### PR TITLE
Internal restarts no longer break bolt connections

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/LifecycleManagedBoltFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/LifecycleManagedBoltFactory.java
@@ -29,7 +29,6 @@ import org.neo4j.kernel.api.bolt.BoltConnectionTracker;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
-import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
@@ -47,7 +46,6 @@ public class LifecycleManagedBoltFactory extends LifecycleAdapter implements Bol
 
     private QueryExecutionEngine queryExecutionEngine;
     private GraphDatabaseQueryService queryService;
-    private TransactionIdStore transactionIdStore;
     private AvailabilityGuard availabilityGuard;
 
     public LifecycleManagedBoltFactory( GraphDatabaseAPI gds, UsageData usageData, LogService logging,
@@ -74,7 +72,6 @@ public class LifecycleManagedBoltFactory extends LifecycleAdapter implements Bol
         DependencyResolver dependencyResolver = gds.getDependencyResolver();
         queryExecutionEngine = dependencyResolver.resolveDependency( QueryExecutionEngine.class );
         queryService = dependencyResolver.resolveDependency( GraphDatabaseQueryService.class );
-        transactionIdStore = dependencyResolver.resolveDependency( TransactionIdStore.class );
         availabilityGuard = dependencyResolver.resolveDependency( AvailabilityGuard.class );
         life.start();
     }
@@ -95,8 +92,8 @@ public class LifecycleManagedBoltFactory extends LifecycleAdapter implements Bol
     public BoltStateMachine newMachine( String connectionDescriptor, Runnable onClose, Clock clock )
     {
         TransactionStateMachine.SPI transactionSPI =
-                new TransactionStateMachineSPI( gds, txBridge, queryExecutionEngine, transactionIdStore,
-                        availabilityGuard, queryService, clock );
+                new TransactionStateMachineSPI( gds, txBridge, queryExecutionEngine, availabilityGuard, queryService,
+                        clock );
         BoltStateMachine.SPI boltSPI = new BoltStateMachineSPI( connectionDescriptor, usageData,
                 logging, authentication, connectionTracker, transactionSPI );
         return new BoltStateMachine( boltSPI, onClose, Clock.systemUTC() );

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineSPI.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineSPI.java
@@ -63,7 +63,6 @@ class TransactionStateMachineSPI implements TransactionStateMachine.SPI
     TransactionStateMachineSPI( GraphDatabaseAPI db,
                                 ThreadToStatementContextBridge txBridge,
                                 QueryExecutionEngine queryExecutionEngine,
-                                TransactionIdStore transactionIdStoreSupplier,
                                 AvailabilityGuard availabilityGuard,
                                 GraphDatabaseQueryService queryService,
                                 Clock clock )
@@ -71,7 +70,8 @@ class TransactionStateMachineSPI implements TransactionStateMachine.SPI
         this.db = db;
         this.txBridge = txBridge;
         this.queryExecutionEngine = queryExecutionEngine;
-        this.transactionIdTracker = new TransactionIdTracker( transactionIdStoreSupplier, availabilityGuard );
+        this.transactionIdTracker = new TransactionIdTracker(
+                db.getDependencyResolver().provideDependency( TransactionIdStore.class ), availabilityGuard );
         this.contextFactory = Neo4jTransactionalContextFactory.create( queryService, locker );
         this.queryService = queryService;
         this.clock = clock;

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CausalConsistencyIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CausalConsistencyIT.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.causalclustering.scenarios;
 
+import java.util.function.Supplier;
+
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -98,10 +100,10 @@ public class CausalConsistencyIT
 
     private TransactionIdTracker transactionIdTracker( GraphDatabaseAPI database )
     {
-        TransactionIdStore transactionIdStore =
-                database.getDependencyResolver().resolveDependency( TransactionIdStore.class );
+        Supplier<TransactionIdStore> transactionIdStoreSupplier = database.getDependencyResolver().provideDependency(
+                TransactionIdStore.class );
         AvailabilityGuard availabilityGuard =
                 database.getDependencyResolver().resolveDependency( AvailabilityGuard.class );
-        return new TransactionIdTracker( transactionIdStore, availabilityGuard );
+        return new TransactionIdTracker( transactionIdStoreSupplier, availabilityGuard );
     }
 }

--- a/integrationtests/src/test/java/org/neo4j/ha/BoltHAIT.java
+++ b/integrationtests/src/test/java/org/neo4j/ha/BoltHAIT.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.ha;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.driver.v1.AccessMode;
+import org.neo4j.driver.v1.AuthTokens;
+import org.neo4j.driver.v1.Driver;
+import org.neo4j.driver.v1.GraphDatabase;
+import org.neo4j.driver.v1.Record;
+import org.neo4j.driver.v1.Session;
+import org.neo4j.driver.v1.Transaction;
+import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
+import org.neo4j.kernel.impl.ha.ClusterManager;
+import org.neo4j.test.ha.ClusterRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.driver.v1.Values.parameters;
+import static org.neo4j.kernel.impl.ha.ClusterManager.clusterOfSize;
+import static org.neo4j.kernel.impl.ha.ClusterManager.entireClusterSeesMemberAsNotAvailable;
+import static org.neo4j.kernel.impl.ha.ClusterManager.masterSeesMembers;
+
+public class BoltHAIT
+{
+    @Rule
+    public final ClusterRule clusterRule = new ClusterRule( getClass() ).withCluster( clusterOfSize( 3 ) );
+
+    @Test
+    public void shouldContinueServingBoltRequestsBetweenInteralRestarts() throws Throwable
+    {
+        // given
+        /*
+         * Interestingly, it is enough to simply start a slave and then direct sessions to it. The problem seems
+         * to arise immediately, since simply from startup to being into SLAVE at least one internal restart happens
+         * and that seems sufficient to break the bolt server.
+         * However, that would make the test really weird, so we'll start the cluster, make sure we can connect and
+         * then isolate the slave, make it shutdown internally, then have it rejoin and it will switch to slave.
+         * At the end of this process, it must still be possible to open and execute transactions against the instance.
+         */
+        ClusterManager.ManagedCluster cluster = clusterRule.startCluster();
+        HighlyAvailableGraphDatabase slave1 = cluster.getAnySlave();
+
+        Driver driver = GraphDatabase.driver( cluster.getBoltAddress( slave1 ),
+                AuthTokens.basic( "neo4j", "neo4j" ) );
+
+        /*
+         * We'll use a bookmark to enforce use of kernel internals by the bolt server, to make sure that parts that are
+         * switched during an internal restart are actually refreshed. Technically, this is not necessary, since the
+         * bolt server makes such use for every request. But this puts a nice bow on top of it.
+         */
+        String lastBookmark;
+
+        try ( Session session = driver.session() )
+        {
+            try ( Transaction tx = session.beginTransaction() )
+            {
+                tx.run( "CREATE (person:Person {name: {name}, title: {title}})",
+                        parameters( "name", "Webber", "title", "Mr" ) );
+                tx.success();
+            }
+            lastBookmark = session.lastBookmark();
+        }
+
+        // when
+        ClusterManager.RepairKit slaveFailRK = cluster.fail( slave1 );
+
+        cluster.await( entireClusterSeesMemberAsNotAvailable( slave1 ) );
+        slaveFailRK.repair();
+        cluster.await( masterSeesMembers( 3 ) );
+
+        // then
+        try ( Session session = driver.session( AccessMode.READ ) )
+        {
+            try ( Transaction tx = session.beginTransaction( lastBookmark ) )
+            {
+                Record record = tx.run( "MATCH (n:Person) RETURN COUNT(*) AS count" ).next();
+                tx.success();
+                assertEquals( 1, record.get( "count" ).asInt() );
+            }
+        }
+    }
+}


### PR DESCRIPTION
The Bolt server was not properly refreshing internal components
 it got access to and this caused internal restarts to try and
 access TransactionIdStore after it was closed, leading to errors
 about the neostore file being closed.
Passing instead a Supplier of the same solves the issue.

This is a partial backport of https://github.com/neo4j/neo4j/pull/9114