### PR TITLE
Improves BoltHAIT and supporting test code

### DIFF
--- a/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterRule.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterRule.java
@@ -19,18 +19,18 @@
  */
 package org.neo4j.test.ha;
 
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.rules.ExternalResource;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 import java.util.function.IntFunction;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.ExternalResource;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 
 import org.neo4j.cluster.client.Cluster;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -129,6 +129,12 @@ public class ClusterRule extends ExternalResource implements ClusterBuilder<Clus
     public ClusterRule withInstanceConfig( Map<String,IntFunction<String>> commonConfig )
     {
         return set( clusterManagerBuilder.withInstanceConfig( commonConfig ) );
+    }
+
+    @Override
+    public ClusterRule withBolt( int port )
+    {
+        return set( clusterManagerBuilder.withBolt( port ) );
     }
 
     @Override


### PR DESCRIPTION
The previous attempt at BoltHAIT suffered from two problems. One was that
 some operations can legitimately throw exceptions that should be ignored.
 The test now expects these and retries accordingly, removing occasional
 failures.
The other was that BOLT was not properly enabled and while it happened to
 work in 3.1 (because the bolt settings across all instances used a different
 identifier for the group compared to what was set in the instance setting),
 3.2 and subsequent branches would fail with bolt server not being active.
 The test cluster code now properly expects explicit activation of bolt which
 overrides the defaults.