### PR TITLE
Handle multiple hints better

### DIFF
--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/OptionalMatchPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/OptionalMatchPlanningIntegrationTest.scala
@@ -25,6 +25,7 @@ import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.plans.{Limit, _}
 import org.neo4j.cypher.internal.frontend.v3_3.SemanticDirection
 import org.neo4j.cypher.internal.frontend.v3_3.ast._
 import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.frontend.v3_3.Foldable._
 import org.neo4j.cypher.internal.ir.v3_3.{IdName, SimplePatternLength}
 
 class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
@@ -34,6 +35,7 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
       cost = {
         case (_: AllNodesScan, _) => 2000000.0
         case (_: NodeByLabelScan, _) => 20.0
+        case (p: Expand, _) if p.findByAllClass[CartesianProduct].nonEmpty => Double.MaxValue
         case (_: Expand, _) => 10.0
         case (_: OuterHashJoin, _) => 20.0
         case (_: SingleRow, _) => 1.0

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/idp/SingleComponentPlannerTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/idp/SingleComponentPlannerTest.scala
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_3.planner.logical.idp
+
+import org.neo4j.cypher.internal.compiler.v3_3.planner.LogicalPlanningTestSupport
+import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.plans._
+import org.neo4j.cypher.internal.compiler.v3_3.spi.PlanContext
+import org.neo4j.cypher.internal.frontend.v3_3.SemanticDirection
+import org.neo4j.cypher.internal.frontend.v3_3.ast._
+import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.ir.v3_3.{IdName, PatternRelationship, QueryGraph, SimplePatternLength}
+
+class SingleComponentPlannerTest extends CypherFunSuite with LogicalPlanningTestSupport with AstConstructionTestSupport {
+  test("plans expands for queries with single pattern rel") {
+    // given
+    val aNode = IdName("a")
+    val bNode = IdName("b")
+    val pattern = PatternRelationship(IdName("r1"), (aNode, bNode), SemanticDirection.OUTGOING, Seq.empty, SimplePatternLength)
+    val qg = QueryGraph(patternRelationships = Set(pattern), patternNodes = Set(aNode, bNode))
+    val aPlan = newMockedLogicalPlan("a")
+    val bPlan = newMockedLogicalPlan("b")
+    implicit val context = newMockedLogicalPlanningContext(planContext = mock[PlanContext])
+
+    // when
+    val logicalPlans = SingleComponentPlanner.planSinglePattern(qg, pattern, Set(aPlan, bPlan))
+
+    // then
+    val plan1 = Expand(aPlan, IdName("a"), SemanticDirection.OUTGOING, Seq.empty, IdName("b"), IdName("r1"), ExpandAll)(solved)
+    val plan2 = Expand(bPlan, IdName("b"), SemanticDirection.INCOMING, Seq.empty, IdName("a"), IdName("r1"), ExpandAll)(solved)
+    assertPlansMatch(Set(plan1, plan2), logicalPlans.toSet)
+  }
+
+  test("plans hashjoins and cartesian product for queries with single pattern rel and multiple index hints") {
+    // given
+    val aNode = IdName("a")
+    val bNode = IdName("b")
+    val pattern = PatternRelationship(IdName("r1"), (aNode, bNode), SemanticDirection.OUTGOING, Seq.empty, SimplePatternLength)
+    val hint1 = UsingIndexHint(varFor("a"), lblName("X"), Seq(PropertyKeyName("p")(pos)))(pos)
+    val hint2 = UsingIndexHint(varFor("b"), lblName("X"), Seq(PropertyKeyName("p")(pos)))(pos)
+    val qg = QueryGraph(patternRelationships = Set(pattern), patternNodes = Set(aNode, bNode), hints = Set(hint1, hint2))
+    val aPlan = newMockedLogicalPlan("a")
+    val bPlan = newMockedLogicalPlan("b")
+    implicit val context = newMockedLogicalPlanningContext(planContext = mock[PlanContext])
+
+    // when
+    val logicalPlans = SingleComponentPlanner.planSinglePattern(qg, pattern, Set(aPlan, bPlan))
+
+    // then
+
+    val plan1 = Expand(aPlan, IdName("a"), SemanticDirection.OUTGOING, Seq.empty, IdName("b"), IdName("r1"), ExpandAll)(solved)
+    val plan2 = Expand(bPlan, IdName("b"), SemanticDirection.INCOMING, Seq.empty, IdName("a"), IdName("r1"), ExpandAll)(solved)
+    val plan3a = NodeHashJoin(Set(bNode), plan1, bPlan)(solved)
+    val plan3b = NodeHashJoin(Set(bNode), bPlan, plan1)(solved)
+    val plan4a = NodeHashJoin(Set(aNode), plan2, aPlan)(solved)
+    val plan4b = NodeHashJoin(Set(aNode), aPlan, plan2)(solved)
+    val plan5 = Expand(CartesianProduct(aPlan, bPlan)(solved), IdName("a"), SemanticDirection.OUTGOING, Seq.empty, IdName("b"), IdName("r1"), ExpandInto)(solved)
+    assertPlansMatch(logicalPlans.toSet, Set(plan1, plan2, plan3a, plan3b, plan4a, plan4b, plan5))
+  }
+
+  test("plans hashjoins and cartesian product for queries with single pattern rel and a join hint") {
+    // given
+    val aNode = IdName("a")
+    val bNode = IdName("b")
+    val pattern = PatternRelationship(IdName("r1"), (aNode, bNode), SemanticDirection.OUTGOING, Seq.empty, SimplePatternLength)
+    val hint = UsingJoinHint(Seq(varFor("a")))(pos)
+    val qg = QueryGraph(patternRelationships = Set(pattern), patternNodes = Set(aNode, bNode), hints = Set(hint))
+    val aPlan = newMockedLogicalPlan("a")
+    val bPlan = newMockedLogicalPlan("b")
+    implicit val context = newMockedLogicalPlanningContext(planContext = mock[PlanContext])
+
+    // when
+    val logicalPlans = SingleComponentPlanner.planSinglePattern(qg, pattern, Set(aPlan, bPlan))
+
+    // then
+    val plan1 = Expand(aPlan, IdName("a"), SemanticDirection.OUTGOING, Seq.empty, IdName("b"), IdName("r1"), ExpandAll)(solved)
+    val plan2 = Expand(bPlan, IdName("b"), SemanticDirection.INCOMING, Seq.empty, IdName("a"), IdName("r1"), ExpandAll)(solved)
+    val plan3a = NodeHashJoin(Set(bNode), plan1, bPlan)(solved)
+    val plan3b = NodeHashJoin(Set(bNode), bPlan, plan1)(solved)
+    val plan4a = NodeHashJoin(Set(aNode), plan2, aPlan)(solved)
+    val plan4b = NodeHashJoin(Set(aNode), aPlan, plan2)(solved)
+    val plan5 = Expand(CartesianProduct(aPlan, bPlan)(solved), IdName("a"), SemanticDirection.OUTGOING, Seq.empty, IdName("b"), IdName("r1"), ExpandInto)(solved)
+    assertPlansMatch(logicalPlans.toSet, Set(plan1, plan2, plan3a, plan3b, plan4a, plan4b, plan5))
+
+    assertPlanSolvesHints(logicalPlans.filter {
+      case join: NodeHashJoin if join.nodes == Set(aNode) => true
+      case _ => false
+    }, hint)
+  }
+
+  test("plans hashjoins and cartesian product for queries with single pattern rel and a join hint on the end node") {
+    // given
+    val aNode = IdName("a")
+    val bNode = IdName("b")
+    val pattern = PatternRelationship(IdName("r1"), (aNode, bNode), SemanticDirection.OUTGOING, Seq.empty, SimplePatternLength)
+    val hint = UsingJoinHint(Seq(varFor("b")))(pos)
+    val qg = QueryGraph(patternRelationships = Set(pattern), patternNodes = Set(aNode, bNode), hints = Set(hint))
+    val aPlan = newMockedLogicalPlan("a")
+    val bPlan = newMockedLogicalPlan("b")
+    implicit val context = newMockedLogicalPlanningContext(planContext = mock[PlanContext])
+
+    // when
+    val logicalPlans = SingleComponentPlanner.planSinglePattern(qg, pattern, Set(aPlan, bPlan))
+
+    // then
+    val plan1 = Expand(aPlan, IdName("a"), SemanticDirection.OUTGOING, Seq.empty, IdName("b"), IdName("r1"), ExpandAll)(solved)
+    val plan2 = Expand(bPlan, IdName("b"), SemanticDirection.INCOMING, Seq.empty, IdName("a"), IdName("r1"), ExpandAll)(solved)
+    val plan3a = NodeHashJoin(Set(bNode), plan1, bPlan)(solved)
+    val plan3b = NodeHashJoin(Set(bNode), bPlan, plan1)(solved)
+    val plan4a = NodeHashJoin(Set(aNode), plan2, aPlan)(solved)
+    val plan4b = NodeHashJoin(Set(aNode), aPlan, plan2)(solved)
+    val plan5 = Expand(CartesianProduct(aPlan, bPlan)(solved), IdName("a"), SemanticDirection.OUTGOING, Seq.empty, IdName("b"), IdName("r1"), ExpandInto)(solved)
+    assertPlansMatch(logicalPlans.toSet, Set(plan1, plan2, plan3a, plan3b, plan4a, plan4b, plan5))
+
+    assertPlanSolvesHints(logicalPlans.filter {
+      case join: NodeHashJoin if join.nodes == Set(bNode) => true
+      case _ => false
+    }, hint)
+  }
+
+  private def assertPlansMatch(expected: Set[LogicalPlan], actualPlans: Set[LogicalPlan]) {
+    actualPlans.foreach(actual => expected should contain(actual))
+    actualPlans.size should be(expected.size)
+  }
+
+  private def assertPlanSolvesHints(plans: Iterable[LogicalPlan], hints: Hint*) {
+    for (h <- hints;
+         p <- plans) {
+      p.solved.lastQueryGraph.hints should contain(h)
+    }
+  }
+}

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/idp/SingleComponentPlannerTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/idp/SingleComponentPlannerTest.scala
@@ -44,7 +44,8 @@ class SingleComponentPlannerTest extends CypherFunSuite with LogicalPlanningTest
     // then
     val plan1 = Expand(aPlan, IdName("a"), SemanticDirection.OUTGOING, Seq.empty, IdName("b"), IdName("r1"), ExpandAll)(solved)
     val plan2 = Expand(bPlan, IdName("b"), SemanticDirection.INCOMING, Seq.empty, IdName("a"), IdName("r1"), ExpandAll)(solved)
-    assertPlansMatch(Set(plan1, plan2), logicalPlans.toSet)
+    val plan3 = Expand(CartesianProduct(aPlan, bPlan)(solved), IdName("a"), SemanticDirection.OUTGOING, Seq.empty, IdName("b"), IdName("r1"), ExpandInto)(solved)
+    assertPlansMatch(Set(plan1, plan2, plan3), logicalPlans.toSet)
   }
 
   test("plans hashjoins and cartesian product for queries with single pattern rel and multiple index hints") {

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/helpers/NonEmptyList.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/helpers/NonEmptyList.scala
@@ -132,6 +132,12 @@ sealed trait NonEmptyList[+T] {
     reverse.mapAndPrependReversedTo[X, X](identity, other)
 
   @tailrec
+  final def containsAnyOf[X >: T](x: X*): Boolean = self match {
+    case Last(elem) => x.contains(elem)
+    case Fby(elem, tail) => x.contains(elem) || tail.containsAnyOf(x:_*)
+  }
+
+  @tailrec
   final def foreach(f: T => Unit): Unit = self match {
     case Last(elem) => f(elem)
     case Fby(elem, tail) => f(elem); tail.foreach(f)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NotificationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NotificationAcceptanceTest.scala
@@ -190,10 +190,10 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
     result.notifications should contain(IndexHintUnfulfillableNotification("Animal", Seq("species")))
   }
 
-  test("should warn when join hint is unfulfilled") {
+  test("should not warn when join hint is used with COST planner") {
     val result = innerExecute( """CYPHER planner=cost EXPLAIN MATCH (a)-->(b) USING JOIN ON b RETURN a, b""")
 
-    result.notifications should equal(Set(JoinHintUnfulfillableNotification(Seq("b"))))
+    result.notifications should not contain JoinHintUnfulfillableNotification(Seq("b"))
   }
 
   test("should not warn when join hint is used with COST planner with EXPLAIN") {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SemanticMergeAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SemanticMergeAcceptanceTest.scala
@@ -21,6 +21,7 @@ package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.internal.frontend.v3_3.SemanticDirection
 import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport, PatternGen, QueryStatisticsTestSupport}
+import org.neo4j.graphdb.{ResourceIterator, Result}
 import org.scalacheck.{Gen, Shrink}
 
 /*
@@ -46,8 +47,10 @@ class SemanticMergeAcceptanceTest
           updateWithBothPlannersAndCompatibilityMode(s"MERGE $patternString")
 
           //find created pattern (cannot return * since everything might be unnamed)
-          val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode(s"MATCH $patternString RETURN 42")
-          result.toList should have size 1
+          val result1: Result = graph.execute(s"MATCH $patternString RETURN 42")
+          hasSingleRow(result1)
+          val result2 = graph.execute(s"CYPHER runtime=interpreted MATCH $patternString RETURN 42")
+          hasSingleRow(result2)
 
           //clean up
           updateWithBothPlannersAndCompatibilityMode(s"MATCH (n) DETACH DELETE n")
@@ -77,6 +80,12 @@ class SemanticMergeAcceptanceTest
         }
       }
     }
+  }
+
+  private def hasSingleRow(in: ResourceIterator[_]) = {
+    in.hasNext should equal(true)
+    in.next()
+    in.hasNext should equal(false)
   }
 
   override protected def numberOfTestRuns: Int = 20

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/compiled_runtime/codegen/LogicalPlanConverter.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/compiled_runtime/codegen/LogicalPlanConverter.scala
@@ -30,6 +30,7 @@ import org.neo4j.cypher.internal.compiler.v3_3.planner.{CantCompileQueryExceptio
 import org.neo4j.cypher.internal.frontend.v3_3.ast.Expression
 import org.neo4j.cypher.internal.frontend.v3_3.helpers.Eagerly.immutableMapValues
 import org.neo4j.cypher.internal.frontend.v3_3.{InternalException, ast, symbols}
+import org.neo4j.cypher.internal.frontend.v3_3.Foldable._
 import org.neo4j.cypher.internal.ir.v3_3.IdName
 import ExpressionConverter.createExpression
 import org.neo4j.cypher.internal.compatibility.v3_3.compiled_runtime.codegen.ir.aggregation.Distinct
@@ -46,6 +47,9 @@ object LogicalPlanConverter {
     case p: Expand => expandAsCodeGenPlan(p)
     case p: OptionalExpand => optionalExpandAsCodeGenPlan(p)
     case p: NodeHashJoin => nodeHashJoinAsCodeGenPlan(p)
+    case p: CartesianProduct if p.findByAllClass[NodeHashJoin].nonEmpty =>
+      throw new CantCompileQueryException(s"This logicalPlan is not yet supported: $logicalPlan")
+
     case p: CartesianProduct => cartesianProductAsCodeGenPlan(p)
     case p: Selection => selectionAsCodeGenPlan(p)
     case p: Top => topAsCodeGenPlan(p)


### PR DESCRIPTION
A cartesian product is planned as an alternative to the expands.
When using multiple hints on the same single hop pattern relationship, the planner will produce joins.
