### PR TITLE
Reduce the probability of getting false positive deadlocks from the Forseti lock manager used by default in Enterprise Edition

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/SimpleBitSet.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/collection/SimpleBitSet.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.util.collection;
 
 import java.util.Arrays;
+import java.util.concurrent.locks.StampedLock;
 
 import org.neo4j.collection.primitive.PrimitiveIntIterable;
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
@@ -27,18 +28,21 @@ import org.neo4j.collection.primitive.PrimitiveIntIterator;
 /**
  * A basic bitset.
  *
- * Space usage: 20bytes + 1 bit per key.
+ * Represented using an automatically expanding long array, with one bit per key.
  *
  * Performance:
  *  * put, remove, contains, size: O(1)
  *  * clear: O(size/64)
  *
  * Concurrency semantics:
- *  * Concurrent writes may lead to data loss.
- *  * Concurrent reads is fine
- *  * Concurrent reads during write is allowed, but bulk put/remove is not atomic.
+ *  * Concurrent writes synchronise and is thread-safe
+ *  * Concurrent reads are thread-safe and will not observe torn writes, but may become
+ *    out of date as soon as the operation returns
+ *  * Concurrent reads during write is thread-safe
+ *  * Bulk operations appear atomic to concurrent readers
+ *  * Only caveat being that the iterator is not thread-safe
  */
-public class SimpleBitSet implements PrimitiveIntIterable
+public class SimpleBitSet extends StampedLock implements PrimitiveIntIterable
 {
     private long[] data;
 
@@ -48,48 +52,67 @@ public class SimpleBitSet implements PrimitiveIntIterable
         int capacity = 1;
         while (capacity < initialCapacity)
             capacity <<= 1;
+        long stamp = writeLock();
         data = new long[capacity];
+        unlockWrite( stamp );
     }
 
     public boolean contains(int key)
     {
         int idx = key >>> 6;
-        return data.length > idx && (data[idx] & ((1L << (key & 63)))) != 0;
+        boolean result;
+        long stamp;
+        do
+        {
+            stamp = tryOptimisticRead();
+            result = data.length > idx && (data[idx] & ((1L << (key & 63)))) != 0;
+        }
+        while ( !validate( stamp ) );
+        return result;
     }
 
     public void put( int key )
     {
+        long stamp = writeLock();
         int idx = key >>> 6;
         ensureCapacity(idx);
         data[idx] = data[idx] | (1L<< (key & 63));
+        unlockWrite( stamp );
     }
 
     public void put( SimpleBitSet other )
     {
+        long stamp = writeLock();
         ensureCapacity( other.data.length - 1 );
         for(int i=0;i<data.length && i<other.data.length;i++)
             data[i] = data[i] | other.data[i];
+        unlockWrite( stamp );
     }
 
     public void remove( int key )
     {
+        long stamp = writeLock();
         int idx = key >>> 6;
         if(data.length > idx)
         {
             data[idx] = data[idx] & ~(1L<< (key & 63));
         }
+        unlockWrite( stamp );
     }
 
     public void remove( SimpleBitSet other )
     {
+        long stamp = writeLock();
         for(int i=0;i<data.length;i++)
             data[i] = data[i] & ~other.data[i];
+        unlockWrite( stamp );
     }
 
     public void clear()
     {
-        for(int i=0;i<data.length;i++)
-            data[i] = 0L;
+        long stamp = writeLock();
+        Arrays.fill( data, 0 );
+        unlockWrite( stamp );
     }
 
     public int size()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/collection/SimpleBitSetTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/collection/SimpleBitSetTest.java
@@ -29,6 +29,8 @@ import static java.util.Arrays.asList;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.TestCase.assertFalse;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
 public class SimpleBitSetTest
@@ -162,4 +164,95 @@ public class SimpleBitSetTest
         assertThat( found, equalTo( asList( 4, 7, 63, 78 ) ));
     }
 
+    @Test
+    public void checkPointOnUnchangedSetMustDoNothing() throws Exception
+    {
+        SimpleBitSet set = new SimpleBitSet( 16 );
+        int key = 10;
+        set.put( key );
+        long checkpoint = 0;
+        checkpoint = set.checkPointAndPut( checkpoint, key );
+        assertThat( set.checkPointAndPut( checkpoint, key ), is( checkpoint ) );
+        assertTrue( set.contains( key ) );
+    }
+
+    @Test
+    public void checkPointOnUnchangedSetButWithDifferentKeyMustUpdateSet() throws Exception
+    {
+        SimpleBitSet set = new SimpleBitSet( 16 );
+        int key = 10;
+        set.put( key );
+        long checkpoint = 0;
+        checkpoint = set.checkPointAndPut( checkpoint, key );
+        assertThat( set.checkPointAndPut( checkpoint, key + 1 ), is( not( checkpoint ) ) );
+        assertTrue( set.contains( key + 1 ) );
+        assertFalse( set.contains( key ) );
+    }
+
+    @Test
+    public void checkPointOnChangedSetMustClearState() throws Exception
+    {
+        SimpleBitSet set = new SimpleBitSet( 16 );
+        int key = 10;
+        set.put( key );
+        long checkpoint = 0;
+        checkpoint = set.checkPointAndPut( checkpoint, key );
+        set.put( key + 1 );
+        assertThat( set.checkPointAndPut( checkpoint, key ), is( not( checkpoint ) ) );
+        assertTrue( set.contains( key ) );
+        assertFalse( set.contains( key + 1 ) );
+    }
+
+    @Test
+    public void checkPointMustBeAbleToExpandCapacity() throws Exception
+    {
+        SimpleBitSet set = new SimpleBitSet( 16 );
+        int key = 10;
+        int key2 = 255;
+        set.put( key );
+        long checkpoint = 0;
+        checkpoint = set.checkPointAndPut( checkpoint, key );
+        assertThat( set.checkPointAndPut( checkpoint, key2 ), is( not( checkpoint ) ) );
+        assertTrue( set.contains( key2 ) );
+        assertFalse( set.contains( key ) );
+    }
+
+    @Test
+    public void modificationsMustTakeWriteLocks() throws Exception
+    {
+        // We can observe that a write lock was taken, by seeing that an optimistic read lock was invalidated.
+        SimpleBitSet set = new SimpleBitSet( 16 );
+        long stamp = set.tryOptimisticRead();
+
+        set.put( 8 );
+        assertFalse( set.validate( stamp ) );
+        stamp = set.tryOptimisticRead();
+
+        set.put( 8 );
+        assertFalse( set.validate( stamp ) );
+        stamp = set.tryOptimisticRead();
+
+        SimpleBitSet other = new SimpleBitSet( 16 );
+        other.put( 3 );
+        set.put( other );
+        assertFalse( set.validate( stamp ) );
+        stamp = set.tryOptimisticRead();
+
+        set.remove( 3 );
+        assertFalse( set.validate( stamp ) );
+        stamp = set.tryOptimisticRead();
+
+        set.remove( 3 );
+        assertFalse( set.validate( stamp ) );
+        stamp = set.tryOptimisticRead();
+
+        other.put( 8 );
+        set.remove( other );
+        assertFalse( set.validate( stamp ) );
+        stamp = set.tryOptimisticRead();
+
+        other.put( 8 );
+        set.remove( other );
+        assertFalse( set.validate( stamp ) );
+    }
 }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ExclusiveLock.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ExclusiveLock.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.impl.enterprise.lock.forseti;
 
+import java.util.Set;
+
 import org.neo4j.kernel.impl.util.collection.SimpleBitSet;
 
 class ExclusiveLock implements ForsetiLockManager.Lock
@@ -46,6 +48,12 @@ class ExclusiveLock implements ForsetiLockManager.Lock
     public String describeWaitList()
     {
         return "ExclusiveLock[" + owner.describeWaitList() + "]";
+    }
+
+    @Override
+    public void collectOwners( Set<ForsetiClient> owners )
+    {
+        owners.add( owner );
     }
 
     @Override

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiLockManager.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiLockManager.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.enterprise.lock.forseti;
 
 import java.util.Map;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ConcurrentMap;
@@ -76,7 +77,7 @@ import org.neo4j.storageengine.api.lock.WaitStrategy;
  * <p/>
  * A.waitlist = [A] U [B] => [A,B]
  * <p/>
- * It will do this in a loop, continiously figuring out the union of wait lists for all clients it waits for. The magic
+ * It will do this in a loop, continuously figuring out the union of wait lists for all clients it waits for. The magic
  * then happens whenever one of those clients become blocked on client A. Assuming client B now has to wait for A,
  * it will also perform a union of A's wait list (which is [A,B] at this point):
  * <p/>
@@ -84,6 +85,23 @@ import org.neo4j.storageengine.api.lock.WaitStrategy;
  * <p/>
  * As it performs this union, B will find itself in A's waiting list, and when it does, it has detected a deadlock.
  * <p/>
+ * This algorithm always identifies real deadlocks, but it may also mistakenly identify a deadlock where there is none;
+ * a false positive. For this reason, we have a secondary deadlock verification algorithm that only runs if the
+ * algorithm above found what appears to be a deadlock.
+ * <p/>
+ * The secondary deadlock verification algorithm works like this: Whenever a lock client blocks to wait on a lock, the
+ * lock is stored in the clients `waitsFor` field, and the field is cleared when the client unblocks. Since every lock
+ * track their owners, we now have all the information we need to traverse the waiter/lock-holder dependency graph to
+ * verify that a cycle really does exist.
+ * <p/>
+ * We first collect the owners of the lock that we are blocking upon. From there, we need to find a lock that one of
+ * these lock-owners are waiting on, and have us amongst its owners. So to recap, we collect the immediate owners of
+ * the lock that we are immediately blocked upon, then we collect the set of locks that they are waiting upon, and then
+ * we collect the combined set of owners of <em>those</em> locks, and if we are amongst those, then we consider the
+ * deadlock is real. If we are not amongst those owners, then we take another step out into the graph, collect the next
+ * frontier of locks that are waited upon, and their owners, and then we check again in this new owner set. We continue
+ * traversing the graph like this until we either find ourselves amongst the owners - a deadlock - or we run out of
+ * locks that are being waited upon - no deadlock.
  * <p/>
  * <h2>Future work</h2>
  * <p/>
@@ -121,6 +139,17 @@ public class ForsetiLockManager implements Locks
          * for the lock.
          */
         String describeWaitList();
+
+        /**
+         * Collect the current owners of this lock into the given set. This is used for verifying that apparent
+         * deadlocks really do involve circular wait dependencies.
+         *
+         * Note that the owner set may change while this method is running, and thus it is not guaranteed to reflect any
+         * particular snapshot of the set of lock owners. Furthermore, the set may change arbitrarily after the method
+         * returns, immediately rendering the result outdated.
+         * @param owners The set into which to collect the current owners of this lock.
+         */
+        void collectOwners( Set<ForsetiClient> owners );
     }
 
     /**
@@ -254,8 +283,6 @@ public class ForsetiLockManager implements Locks
         private final AtomicInteger clientIds = new AtomicInteger( 0 );
 
         /** Re-use ids, forseti uses these in arrays, so we want to keep them low and not loose them. */
-        // TODO we could use a synchronised SimpleBitSet instead, since we know that we only care about reusing a
-        // very limited set of integers.
         private final Queue<Integer> unusedIds = new ConcurrentLinkedQueue<>();
         private final ConcurrentMap<Integer,ForsetiClient> clientsById = new ConcurrentHashMap<>();
         private final ConcurrentMap<Long,ForsetiLockManager.Lock>[] lockMaps;

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/SharedLock.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/SharedLock.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.enterprise.lock.forseti;
 
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReferenceArray;
 
@@ -211,6 +212,26 @@ class SharedLock implements ForsetiLockManager.Lock
             }
         }
         return sb.append( "]" ).toString();
+    }
+
+    @Override
+    public void collectOwners( Set<ForsetiClient> owners )
+    {
+        for ( AtomicReferenceArray<ForsetiClient> ownerArray : clientsHoldingThisLock )
+        {
+            if ( ownerArray != null )
+            {
+                int len = ownerArray.length();
+                for ( int i = 0; i < len; i++ )
+                {
+                    ForsetiClient owner = ownerArray.get( i );
+                    if ( owner != null )
+                    {
+                        owners.add( owner );
+                    }
+                }
+            }
+        }
     }
 
     @Override

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiFalseDeadlockTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiFalseDeadlockTest.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.enterprise.lock.forseti;
+
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+import org.neo4j.concurrent.BinaryLatch;
+import org.neo4j.function.ThrowingAction;
+import org.neo4j.kernel.impl.locking.Locks;
+import org.neo4j.kernel.impl.locking.community.CommunityLockManger;
+import org.neo4j.kernel.impl.util.concurrent.LockWaitStrategies;
+import org.neo4j.storageengine.api.lock.ResourceType;
+import org.neo4j.storageengine.api.lock.WaitStrategy;
+
+@RunWith( Parameterized.class )
+public class ForsetiFalseDeadlockTest
+{
+    public static class Fixture
+    {
+        private final int iterations;
+        private final LockManager lockManager;
+        private final WaitStrategy waitStrategy;
+        private final LockType lockTypeAX;
+        private final LockType lockTypeAY;
+        private final LockType lockTypeBX;
+        private final LockType lockTypeBY;
+
+        Fixture( int iterations,
+                 LockManager lockManager,
+                 WaitStrategy waitStrategy,
+                 LockType lockTypeAX,
+                 LockType lockTypeAY,
+                 LockType lockTypeBX,
+                 LockType lockTypeBY )
+        {
+            this.iterations = iterations;
+            this.lockManager = lockManager;
+            this.waitStrategy = waitStrategy;
+            this.lockTypeAX = lockTypeAX;
+            this.lockTypeAY = lockTypeAY;
+            this.lockTypeBX = lockTypeBX;
+            this.lockTypeBY = lockTypeBY;
+        }
+
+        int iterations()
+        {
+            return iterations;
+        }
+
+        Locks createLockManager( ResourceType resourceType )
+        {
+            return lockManager.create( resourceType );
+        }
+
+        ResourceType createResourceType()
+        {
+            return new ResourceType()
+            {
+                @Override
+                public int typeId()
+                {
+                    return 0;
+                }
+
+                @Override
+                public WaitStrategy waitStrategy()
+                {
+                    return waitStrategy;
+                }
+            };
+        }
+
+        void acquireAX( Locks.Client client, ResourceType resourceType )
+        {
+            lockTypeAX.acquire( client, resourceType, 1 );
+        }
+
+        void releaseAX( Locks.Client client, ResourceType resourceType )
+        {
+            lockTypeAX.release( client, resourceType, 1 );
+        }
+
+        void acquireAY( Locks.Client client, ResourceType resourceType )
+        {
+            lockTypeAY.acquire( client, resourceType, 2 );
+        }
+
+        void releaseAY( Locks.Client client, ResourceType resourceType )
+        {
+            lockTypeAY.release( client, resourceType, 2 );
+        }
+
+        void acquireBX( Locks.Client client, ResourceType resourceType )
+        {
+            lockTypeBX.acquire( client, resourceType, 1 );
+        }
+
+        void releaseBX( Locks.Client client, ResourceType resourceType )
+        {
+            lockTypeBX.release( client, resourceType, 1 );
+        }
+
+        void acquireBY( Locks.Client client, ResourceType resourceType )
+        {
+            lockTypeBY.acquire( client, resourceType, 2 );
+        }
+
+        void releaseBY( Locks.Client client, ResourceType resourceType )
+        {
+            lockTypeBY.release( client, resourceType, 2 );
+        }
+
+        @Override
+        public String toString()
+        {
+            return "iterations=" + iterations +
+                   ", lockManager=" + lockManager +
+                   ", waitStrategy=" + waitStrategy +
+                   ", lockTypeAX=" + lockTypeAX +
+                   ", lockTypeAY=" + lockTypeAY +
+                   ", lockTypeBX=" + lockTypeBX +
+                   ", lockTypeBY=" + lockTypeBY;
+        }
+    }
+
+    public enum LockType
+    {
+        EXCLUSIVE
+                {
+                    @Override
+                    public void acquire( Locks.Client client, ResourceType resourceType, int resource )
+                    {
+                        client.acquireExclusive( resourceType, resource );
+                    }
+
+                    @Override
+                    public void release( Locks.Client client, ResourceType resourceType, int resource )
+                    {
+                        client.releaseExclusive( resourceType, resource );
+                    }
+                },
+        SHARED
+                {
+                    @Override
+                    public void acquire( Locks.Client client, ResourceType resourceType, int resource )
+                    {
+                        client.acquireShared( resourceType, resource );
+                    }
+
+                    @Override
+                    public void release( Locks.Client client, ResourceType resourceType, int resource )
+                    {
+                        client.releaseShared( resourceType, resource );
+                    }
+                };
+
+        public abstract void acquire( Locks.Client client, ResourceType resourceType, int resource );
+
+        public abstract void release( Locks.Client client, ResourceType resourceType, int resource );
+    }
+
+    public enum LockManager
+    {
+        COMMUNITY
+                {
+                    @Override
+                    public Locks create( ResourceType resourceType )
+                    {
+                        return new CommunityLockManger();
+                    }
+                },
+        FORSETI
+                {
+                    @Override
+                    public Locks create( ResourceType resourceType )
+                    {
+                        return new ForsetiLockManager( resourceType );
+                    }
+                };
+
+        public abstract Locks create( ResourceType resourceType );
+    }
+
+    @Parameterized.Parameters( name = "{0}" )
+    public static Iterable<Object[]> parameters()
+    {
+        List<Fixture> fixtures = new ArrayList<>();
+
+        // During development I also had iteration counts 1 and 2 here, but they never found anything, so for actually
+        // running this test, I leave only iteration count 100 enabled.
+        int[] iterations = new int[]{100};
+        LockManager[] lockManagers = LockManager.values();
+        LockWaitStrategies[] lockWaitStrategies = LockWaitStrategies.values();
+        LockType[] lockTypes = LockType.values();
+        for ( LockManager lockManager : lockManagers )
+        {
+            for ( LockWaitStrategies waitStrategy : lockWaitStrategies )
+            {
+                for ( LockType lockTypeAX : lockTypes )
+                {
+                    for ( LockType lockTypeAY : lockTypes )
+                    {
+                        for ( LockType lockTypeBX : lockTypes )
+                        {
+                            for ( LockType lockTypeBY : lockTypes )
+                            {
+                                for ( int iteration : iterations )
+                                {
+                                    fixtures.add( new Fixture(
+                                            iteration, lockManager, waitStrategy,
+                                            lockTypeAX, lockTypeAY, lockTypeBX, lockTypeBY ) );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return fixtures.stream().map( f -> new Object[]{f} ).collect( Collectors.toList() );
+    }
+
+    private static ExecutorService executor = Executors.newCachedThreadPool( r ->
+    {
+        Thread thread = new Thread( r );
+        thread.setDaemon( true );
+        return thread;
+    } );
+
+    public ForsetiFalseDeadlockTest( Fixture fixture )
+    {
+        this.fixture = fixture;
+    }
+
+    private final Fixture fixture;
+
+    /**
+     * This takes a fair bit of time, and we don't want to wait that long. But more importantly, false deadlocks are
+     * still only very unlikely; they are not impossible, though.
+     *
+     * So this test is technically flaky, but the probability is, I think, quite low for the 'mild' test, but it is too
+     * high for this aggressive test. So therefor I have marked it as @Ignored, but I still keep it here for the sake
+     * of this comment, and to allow others to run it and get a feel for the probabilities involved.
+     */
+    @Ignore
+    @Test
+    public void testAggressivelyForFalseDeadlocks() throws Exception
+    {
+        int testRuns = 2000;
+        loopRunTest( testRuns );
+    }
+
+    @Test
+    public void testMildlyForFalseDeadlocks() throws Exception
+    {
+        int testRuns = 10;
+        loopRunTest( testRuns );
+    }
+
+    private void loopRunTest( int testRuns ) throws InterruptedException, java.util.concurrent.ExecutionException
+    {
+        for ( int i = 0; i < testRuns; i++ )
+        {
+            try
+            {
+                runTest();
+            }
+            catch ( Throwable th )
+            {
+                th.addSuppressed( new Exception( "Failed at iteration " + i ) );
+                throw th;
+            }
+        }
+    }
+
+    private void runTest() throws InterruptedException, java.util.concurrent.ExecutionException
+    {
+        int iterations = fixture.iterations();
+        ResourceType resourceType = fixture.createResourceType();
+        Locks manager = fixture.createLockManager( resourceType );
+        try ( Locks.Client a = manager.newClient();
+              Locks.Client b = manager.newClient() )
+        {
+            BinaryLatch startLatch = new BinaryLatch();
+            BlockedCallable callA = new BlockedCallable( startLatch,
+                    () -> workloadA( a, resourceType, iterations ) );
+            BlockedCallable callB = new BlockedCallable( startLatch,
+                    () -> workloadB( b, resourceType, iterations ) );
+
+            Future<Void> futureA = executor.submit( callA );
+            Future<Void> futureB = executor.submit( callB );
+
+            callA.awaitBlocked();
+            callB.awaitBlocked();
+
+            startLatch.release();
+
+            futureA.get();
+            futureB.get();
+        }
+        finally
+        {
+            manager.close();
+        }
+    }
+
+    private void workloadA( Locks.Client a, ResourceType resourceType, int iterations )
+    {
+        for ( int i = 0; i < iterations; i++ )
+        {
+            fixture.acquireAX( a, resourceType );
+            fixture.acquireAY( a, resourceType );
+            fixture.releaseAY( a, resourceType );
+            fixture.releaseAX( a, resourceType );
+        }
+    }
+
+    private void workloadB( Locks.Client b, ResourceType resourceType, int iterations )
+    {
+        for ( int i = 0; i < iterations; i++ )
+        {
+            fixture.acquireBX( b, resourceType );
+            fixture.releaseBX( b, resourceType );
+            fixture.acquireBY( b, resourceType );
+            fixture.releaseBY( b, resourceType );
+        }
+    }
+
+    public static class BlockedCallable implements Callable<Void>
+    {
+        private final BinaryLatch startLatch;
+        private final ThrowingAction<Exception> delegate;
+        private volatile Thread runner;
+
+        BlockedCallable( BinaryLatch startLatch, ThrowingAction<Exception> delegate )
+        {
+            this.startLatch = startLatch;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public Void call() throws Exception
+        {
+            runner = Thread.currentThread();
+            startLatch.await();
+            delegate.apply();
+            return null;
+        }
+
+        void awaitBlocked()
+        {
+            Thread t;
+            do
+            {
+                t = runner;
+            }
+            while ( t == null || t.getState() != Thread.State.WAITING );
+        }
+    }
+}

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiFalseDeadlockTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiFalseDeadlockTest.java
@@ -216,7 +216,7 @@ public class ForsetiFalseDeadlockTest
 
         // During development I also had iteration counts 1 and 2 here, but they never found anything, so for actually
         // running this test, I leave only iteration count 100 enabled.
-        int[] iterations = new int[]{100};
+        int iteration = 100;
         LockManager[] lockManagers = LockManager.values();
         LockWaitStrategies[] lockWaitStrategies = LockWaitStrategies.values();
         LockType[] lockTypes = LockType.values();
@@ -232,12 +232,9 @@ public class ForsetiFalseDeadlockTest
                         {
                             for ( LockType lockTypeBY : lockTypes )
                             {
-                                for ( int iteration : iterations )
-                                {
-                                    fixtures.add( new Fixture(
-                                            iteration, lockManager, waitStrategy,
-                                            lockTypeAX, lockTypeAY, lockTypeBX, lockTypeBY ) );
-                                }
+                                fixtures.add( new Fixture(
+                                        iteration, lockManager, waitStrategy,
+                                        lockTypeAX, lockTypeAY, lockTypeBX, lockTypeBY ) );
                             }
                         }
                     }


### PR DESCRIPTION
Note that false positives are an inherent risk with the Dreadlocks algorithm.
With this change, we still use Dreadlocks for the initial deadlock test, but if
one is found we follow up with a more thorough search of the waiter/lock-holder
dependency graph. Unfortunately, this search is _also_ probabilistic and may
find false positives. However, we only act upon the deadlock result if we have
made at least 10 attempts at grabbing the lock.

The two different deadlock tests, combined requiring 20 consequitive positive
deadlock results, means that the probability of a false positive making it all
the way through, is now considerably lower than it was before.