### PR TITLE
Handle OR with indexes

### DIFF
--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
@@ -25,9 +25,11 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
@@ -70,14 +72,58 @@ public abstract class CompiledConversionUtils
         {
             return Collections.emptyList();
         }
-        if ( value instanceof Collection<?> )
+        else if ( value instanceof Collection<?> )
         {
             return (Collection<?>) value;
         }
-        // TODO: Handle primitive streams
+        else if ( value instanceof LongStream)
+        {
+            LongStream stream = (LongStream) value;
+            return stream.boxed().collect( Collectors.toList());
+        }
+        else if ( value instanceof IntStream )
+        {
+            IntStream stream = (IntStream) value;
+            return stream.boxed().collect( Collectors.toList());
+        }
+        else if ( value instanceof DoubleStream )
+        {
+            DoubleStream stream = (DoubleStream) value;
+            return stream.boxed().collect( Collectors.toList());
+        }
 
         throw new CypherTypeException(
                 "Don't know how to create an iterable out of " + value.getClass().getSimpleName(), null );
+    }
+
+    public static Set<?> toSet( Object value )
+    {
+        if ( value == null )
+        {
+            return Collections.emptySet();
+        }
+        else if ( value instanceof Collection<?> )
+        {
+            return new HashSet<>(  (Collection< ? >) value);
+        }
+        else if ( value instanceof LongStream)
+        {
+            LongStream stream = (LongStream) value;
+            return stream.boxed().collect( Collectors.toSet());
+        }
+        else if ( value instanceof IntStream )
+        {
+            IntStream stream = (IntStream) value;
+            return stream.boxed().collect( Collectors.toSet());
+        }
+        else if ( value instanceof DoubleStream )
+        {
+            DoubleStream stream = (DoubleStream) value;
+            return stream.boxed().collect( Collectors.toSet());
+        }
+
+        throw new CypherTypeException(
+                "Don't know how to create a set out of " + value.getClass().getSimpleName(), null );
     }
 
     public static CompositeKey compositeKey( long... keys )

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/codegen/CompiledConversionUtilsTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/codegen/CompiledConversionUtilsTest.scala
@@ -20,6 +20,7 @@
 package org.neo4j.cypher.internal.codegen
 
 import java.util
+import java.util.stream.{DoubleStream, IntStream, LongStream}
 
 import org.mockito.Mockito.when
 import org.neo4j.cypher.internal.frontend.v3_2.CypherTypeException
@@ -75,6 +76,15 @@ class CompiledConversionUtilsTest extends CypherFunSuite {
 
     //when/then
     theMap(theKey) should equal(theObject)
+  }
+
+  test("should handle toSet") {
+    import scala.collection.JavaConverters._
+    CompiledConversionUtils.toSet(null) should equal(Set.empty.asJava)
+    CompiledConversionUtils.toSet(List(1,1,2,3).asJava) should equal(Set(1,2,3).asJava)
+    CompiledConversionUtils.toSet(IntStream.of(1,2,3,1)) should equal(Set(1,2,3).asJava)
+    CompiledConversionUtils.toSet(LongStream.of(1L,2L,3L,1L)) should equal(Set(1L,2L,3L).asJava)
+    CompiledConversionUtils.toSet(DoubleStream.of(1.1,2.2,3.3,1.1)) should equal(Set(1.1,2.2,3.3).asJava)
   }
 
   val testEquality = Seq(

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -619,7 +619,8 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
     invoke(iterator, method[java.util.Iterator[_], Boolean]("hasNext"))
 
   override def toSet(value: Expression) =
-    createNewInstance(typeRef[util.HashSet[Object]], (typeRef[util.Collection[_]], value))
+    invoke(methodReference(typeRef[CompiledConversionUtils], typeRef[java.util.Set[Object]], "toSet", typeRef[Object]),
+           value)
 
   override def newDistinctSet(name: String, codeGenTypes: Iterable[CodeGenType]) = {
     if (codeGenTypes.size == 1 && codeGenTypes.head.repr == LongType) {


### PR DESCRIPTION
Queries of the form

```
MATCH (n:L) WHERE n.prop = 1 OR n.prop = 3 RETURN n
```

was crashing at runtime in the compiled runtime causing the query
to break.

changelog: Fix problem with the compiled runtime when solving OR predicates using two index seeks.