### PR TITLE
Remove blacklisted tests

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
@@ -62,14 +62,3 @@ Ordering for lists, descending
 
 //SkipLimitAcceptance.feature - Unsupported limit syntax
 Negative parameter for LIMIT should not generate errors
-
-// Long chain of comparison operators
-Long chains of integer comparisons
-Long chains of floating point comparisons
-Long chains of string comparisons
-
-// ReturnAcceptance.feature
-Accessing a list with null should return null
-Accessing a list with null as lower bound should return null
-Accessing a list with null as upper bound should return null
-Accessing a map with null should return null


### PR DESCRIPTION
Since the update of the 2.3 dependency some tests no longer
have to be blacklisted.