### PR TITLE
Use transaction counters to wait for all transactions completion on shutdown

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
@@ -93,13 +93,20 @@ public class Kernel extends LifecycleAdapter implements KernelAPI
     }
 
     @Override
-    public KernelTransaction newTransaction( KernelTransaction.Type type, SecurityContext securityContext, long timeout ) throws
-            TransactionFailureException
+    public KernelTransaction newTransaction( KernelTransaction.Type type, SecurityContext securityContext, long timeout )
+            throws TransactionFailureException
     {
         health.assertHealthy( TransactionFailureException.class );
-        KernelTransaction transaction = transactions.newInstance( type, securityContext, timeout );
         transactionMonitor.transactionStarted();
-        return transaction;
+        try
+        {
+            return transactions.newInstance( type, securityContext, timeout );
+        }
+        catch ( Throwable t )
+        {
+            transactionMonitor.transactionFinished( false, false );
+            throw t;
+        }
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
@@ -66,8 +66,6 @@ import static org.neo4j.kernel.api.security.SecurityContext.AUTH_DISABLED;
 
 public class KernelIT extends KernelIntegrationTest
 {
-    // TODO: Split this into area-specific tests, see PropertyIT.
-
     @Test
     public void mixingBeansApiWithKernelAPI() throws Exception
     {

--- a/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoreDataSourceRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoreDataSourceRule.java
@@ -57,7 +57,7 @@ import org.neo4j.kernel.impl.store.id.IdReuseEligibility;
 import org.neo4j.kernel.impl.store.id.configuration.CommunityIdTypeConfigurationProvider;
 import org.neo4j.kernel.impl.store.id.configuration.IdTypeConfigurationProvider;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
-import org.neo4j.kernel.impl.transaction.TransactionMonitor;
+import org.neo4j.kernel.impl.transaction.TransactionStats;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.internal.DatabaseHealth;
@@ -75,6 +75,7 @@ import static org.neo4j.helpers.collection.MapUtil.stringMap;
 public class NeoStoreDataSourceRule extends ExternalResource
 {
     private NeoStoreDataSource dataSource;
+    private TransactionStats transactionMonitor;
 
     public NeoStoreDataSource getDataSource( File storeDir, FileSystemAbstraction fs,
             PageCache pageCache, Map<String,String> additionalConfig, DatabaseHealth databaseHealth )
@@ -108,13 +109,14 @@ public class NeoStoreDataSourceRule extends ExternalResource
 
         JobScheduler jobScheduler = mock( JobScheduler.class, RETURNS_MOCKS );
         Monitors monitors = new Monitors();
+        transactionMonitor = mock( TransactionStats.class );
         dataSource = new NeoStoreDataSource( storeDir, config, idGeneratorFactory, IdReuseEligibility.ALWAYS,
                 idConfigurationProvider,
                 logService, mock( JobScheduler.class, RETURNS_MOCKS ), mock( TokenNameLookup.class ),
                 dependencyResolverForNoIndexProvider(), mock( PropertyKeyTokenHolder.class ),
                 mock( LabelTokenHolder.class ), mock( RelationshipTypeTokenHolder.class ), locksFactory,
                 mock( SchemaWriteGuard.class ), mock( TransactionEventHandlers.class ), IndexingService.NO_MONITOR,
-                fs, mock( TransactionMonitor.class ), databaseHealth,
+                fs, transactionMonitor, databaseHealth,
                 mock( PhysicalLogFile.Monitor.class ), TransactionHeaderInformationFactory.DEFAULT,
                 new StartupStatisticsProvider(), null,
                 new CommunityCommitProcessFactory(), mock( InternalAutoIndexing.class ), pageCache,
@@ -124,6 +126,11 @@ public class NeoStoreDataSourceRule extends ExternalResource
                 IOLimiter.unlimited(), Clock.systemUTC(), new CanWrite() );
 
         return dataSource;
+    }
+
+    public TransactionStats getTransactionMonitor()
+    {
+        return transactionMonitor;
     }
 
     public NeoStoreDataSource getDataSource( File storeDir, FileSystemAbstraction fs,


### PR DESCRIPTION
Use transaction statistics counters to wait for all transaction to
complete before NeoStoreDataSource will try to acquire transactional log
file lock to prevent deadlock on shutdown

<b>N.B!</b> should be null merged to 3.2 and 3.3.