### PR TITLE
Remove blacklisted tests

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
+++ b/community/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
@@ -51,9 +51,3 @@ Explanation of   in-query procedure call
 Pattern expression inside list comprehension
 Get node degree via length of pattern expression
 Get node degree via length of pattern expression that specifies a relationship type
-
-// ReturnAcceptance.feature
-Accessing a list with null should return null
-Accessing a list with null as lower bound should return null
-Accessing a list with null as upper bound should return null
-Accessing a map with null should return null


### PR DESCRIPTION
Since the update of the 2.3 dependency some tests no longer
have to be blacklisted.