### PR TITLE
Use schema state directly to clear it instead of using callback.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationJob.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationJob.java
@@ -28,6 +28,7 @@ import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
+import org.neo4j.kernel.impl.api.SchemaState;
 import org.neo4j.storageengine.api.schema.PopulationProgress;
 
 import static java.lang.Thread.currentThread;
@@ -44,21 +45,16 @@ public class IndexPopulationJob implements Runnable
 {
     private final IndexingService.Monitor monitor;
     private final MultipleIndexPopulator multiPopulator;
-    private final IndexStoreView storeView;
     private final CountDownLatch doneSignal = new CountDownLatch( 1 );
-    private final Runnable schemaStateChangeCallback;
+    private final SchemaState schemaState;
 
     private volatile StoreScan<IndexPopulationFailedKernelException> storeScan;
     private volatile boolean cancelled;
 
-    public IndexPopulationJob( IndexStoreView storeView,
-                               MultipleIndexPopulator multiPopulator,
-                               IndexingService.Monitor monitor,
-                               Runnable schemaStateChangeCallback )
+    public IndexPopulationJob( MultipleIndexPopulator multiPopulator, IndexingService.Monitor monitor, SchemaState schemaState )
     {
         this.multiPopulator = multiPopulator;
-        this.storeView = storeView;
-        this.schemaStateChangeCallback = schemaStateChangeCallback;
+        this.schemaState = schemaState;
         this.monitor = monitor;
     }
 
@@ -118,7 +114,7 @@ public class IndexPopulationJob implements Runnable
 
                 multiPopulator.flipAfterPopulation();
 
-                schemaStateChangeCallback.run();
+                schemaState.clear();
             }
             catch ( Throwable t )
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingServiceFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingServiceFactory.java
@@ -22,12 +22,13 @@ package org.neo4j.kernel.impl.api.index;
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.api.SchemaState;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingController;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingControllerFactory;
 import org.neo4j.kernel.impl.store.record.IndexRule;
-import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.logging.LogProvider;
+import org.neo4j.scheduler.JobScheduler;
 
 /**
  * Factory to create {@link IndexingService}
@@ -46,7 +47,7 @@ public class IndexingServiceFactory
                                           Iterable<IndexRule> indexRules,
                                           LogProvider logProvider,
                                           IndexingService.Monitor monitor,
-                                          Runnable schemaStateChangeCallback )
+                                          SchemaState schemaState )
     {
         if ( providerMap == null || providerMap.getDefaultProvider() == null )
         {
@@ -65,7 +66,7 @@ public class IndexingServiceFactory
                 new IndexProxyCreator( samplingConfig, storeView, providerMap, tokenNameLookup, logProvider );
 
         return new IndexingService( proxySetup, providerMap, indexMapRef, storeView, indexRules,
-                indexSamplingController, tokenNameLookup, scheduler, schemaStateChangeCallback,
+                indexSamplingController, tokenNameLookup, scheduler, schemaState,
                 multiPopulatorFactory, logProvider, monitor );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/BridgingCacheAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/cache/BridgingCacheAccess.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.cache;
 
+import org.neo4j.kernel.impl.api.SchemaState;
 import org.neo4j.kernel.impl.api.store.SchemaCache;
 import org.neo4j.kernel.impl.core.CacheAccessBackDoor;
 import org.neo4j.kernel.impl.core.LabelTokenHolder;
@@ -31,18 +32,18 @@ import org.neo4j.storageengine.api.schema.SchemaRule;
 public class BridgingCacheAccess implements CacheAccessBackDoor
 {
     private final SchemaCache schemaCache;
-    private final Runnable schemaStateChangeCallback;
+    private final SchemaState schemaState;
     private final PropertyKeyTokenHolder propertyKeyTokenHolder;
     private final RelationshipTypeTokenHolder relationshipTypeTokenHolder;
     private final LabelTokenHolder labelTokenHolder;
 
-    public BridgingCacheAccess( SchemaCache schemaCache, Runnable schemaStateChangeCallback,
+    public BridgingCacheAccess( SchemaCache schemaCache, SchemaState schemaState,
             PropertyKeyTokenHolder propertyKeyTokenHolder,
             RelationshipTypeTokenHolder relationshipTypeTokenHolder,
             LabelTokenHolder labelTokenHolder )
     {
         this.schemaCache = schemaCache;
-        this.schemaStateChangeCallback = schemaStateChangeCallback;
+        this.schemaState = schemaState;
         this.propertyKeyTokenHolder = propertyKeyTokenHolder;
         this.relationshipTypeTokenHolder = relationshipTypeTokenHolder;
         this.labelTokenHolder = labelTokenHolder;
@@ -58,7 +59,7 @@ public class BridgingCacheAccess implements CacheAccessBackDoor
     public void removeSchemaRuleFromCache( long id )
     {
         schemaCache.removeSchemaRule( id );
-        schemaStateChangeCallback.run();
+        schemaState.clear();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
@@ -51,6 +51,7 @@ import org.neo4j.kernel.impl.api.KernelTransactionsSnapshot;
 import org.neo4j.kernel.impl.api.LegacyBatchIndexApplier;
 import org.neo4j.kernel.impl.api.LegacyIndexApplierLookup;
 import org.neo4j.kernel.impl.api.LegacyIndexProviderLookup;
+import org.neo4j.kernel.impl.api.SchemaState;
 import org.neo4j.kernel.impl.api.TransactionApplier;
 import org.neo4j.kernel.impl.api.TransactionApplierFacade;
 import org.neo4j.kernel.impl.api.index.IndexingService;
@@ -58,8 +59,8 @@ import org.neo4j.kernel.impl.api.index.IndexingServiceFactory;
 import org.neo4j.kernel.impl.api.index.IndexingUpdateService;
 import org.neo4j.kernel.impl.api.index.PropertyPhysicalToLogicalConverter;
 import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
-import org.neo4j.kernel.impl.api.store.StorageLayer;
 import org.neo4j.kernel.impl.api.store.SchemaCache;
+import org.neo4j.kernel.impl.api.store.StorageLayer;
 import org.neo4j.kernel.impl.api.store.StoreStatement;
 import org.neo4j.kernel.impl.cache.BridgingCacheAccess;
 import org.neo4j.kernel.impl.constraints.ConstraintSemantics;
@@ -104,12 +105,12 @@ import org.neo4j.kernel.impl.transaction.state.storeview.DynamicIndexStoreView;
 import org.neo4j.kernel.impl.transaction.state.storeview.NeoStoreIndexStoreView;
 import org.neo4j.kernel.impl.util.DependencySatisfier;
 import org.neo4j.kernel.impl.util.IdOrderingQueue;
-import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.kernel.info.DiagnosticsManager;
 import org.neo4j.kernel.internal.DatabaseHealth;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.spi.legacyindex.IndexImplementation;
 import org.neo4j.logging.LogProvider;
+import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.storageengine.api.CommandReaderFactory;
 import org.neo4j.storageengine.api.CommandsToApply;
 import org.neo4j.storageengine.api.StorageCommand;
@@ -147,7 +148,7 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
     private final LabelScanStore labelScanStore;
     private final DefaultSchemaIndexProviderMap schemaIndexProviderMap;
     private final LegacyIndexApplierLookup legacyIndexApplierLookup;
-    private final Runnable schemaStateChangeCallback;
+    private final SchemaState schemaState;
     private final SchemaStorage schemaStorage;
     private final ConstraintSemantics constraintSemantics;
     private final IdOrderingQueue legacyIndexTransactionOrdering;
@@ -181,7 +182,7 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
             PropertyKeyTokenHolder propertyKeyTokenHolder,
             LabelTokenHolder labelTokens,
             RelationshipTypeTokenHolder relationshipTypeTokens,
-            Runnable schemaStateChangeCallback,
+            SchemaState schemaState,
             ConstraintSemantics constraintSemantics,
             JobScheduler scheduler,
             TokenNameLookup tokenNameLookup,
@@ -198,7 +199,7 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
         this.propertyKeyTokenHolder = propertyKeyTokenHolder;
         this.relationshipTypeTokenHolder = relationshipTypeTokens;
         this.labelTokenHolder = labelTokens;
-        this.schemaStateChangeCallback = schemaStateChangeCallback;
+        this.schemaState = schemaState;
         this.scheduler = scheduler;
         this.lockService = lockService;
         this.databaseHealth = databaseHealth;
@@ -225,10 +226,10 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
             indexingService = IndexingServiceFactory.createIndexingService( config, scheduler, schemaIndexProviderMap,
                     indexStoreView, tokenNameLookup,
                     Iterators.asList( new SchemaStorage( neoStores.getSchemaStore() ).indexesGetAll() ), logProvider,
-                    indexingServiceMonitor, schemaStateChangeCallback );
+                    indexingServiceMonitor, schemaState );
 
             integrityValidator = new IntegrityValidator( neoStores, indexingService );
-            cacheAccess = new BridgingCacheAccess( schemaCache, schemaStateChangeCallback,
+            cacheAccess = new BridgingCacheAccess( schemaCache, schemaState,
                     propertyKeyTokenHolder, relationshipTypeTokens, labelTokens );
 
             storeStatementSupplier = storeStatementSupplier( neoStores );
@@ -311,8 +312,8 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
                     relationshipCreator, relationshipDeleter, propertyCreator, propertyDeleter );
 
             // Visit transaction state and populate these record state objects
-            TxStateVisitor txStateVisitor = new TransactionToRecordStateVisitor( recordState,
-                    schemaStateChangeCallback, schemaStorage, constraintSemantics, schemaIndexProviderMap );
+            TxStateVisitor txStateVisitor = new TransactionToRecordStateVisitor( recordState, schemaState,
+                    schemaStorage, constraintSemantics, schemaIndexProviderMap );
             CountsRecordState countsRecordState = new CountsRecordState();
             txStateVisitor = constraintSemantics.decorateTxStateVisitor(
                     storeLayer,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/TransactionToRecordStateVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/TransactionToRecordStateVisitor.java
@@ -33,6 +33,7 @@ import org.neo4j.kernel.api.schema.constaints.IndexBackedConstraintDescriptor;
 import org.neo4j.kernel.api.schema.constaints.NodeKeyConstraintDescriptor;
 import org.neo4j.kernel.api.schema.constaints.UniquenessConstraintDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
+import org.neo4j.kernel.impl.api.SchemaState;
 import org.neo4j.kernel.impl.api.index.SchemaIndexProviderMap;
 import org.neo4j.kernel.impl.constraints.ConstraintSemantics;
 import org.neo4j.kernel.impl.store.SchemaStorage;
@@ -45,17 +46,17 @@ public class TransactionToRecordStateVisitor extends TxStateVisitor.Adapter
 {
     private boolean clearSchemaState;
     private final TransactionRecordState recordState;
-    private final Runnable schemaStateChangeCallback;
+    private final SchemaState schemaState;
     private final SchemaStorage schemaStorage;
     private final ConstraintSemantics constraintSemantics;
     private final SchemaIndexProviderMap schemaIndexProviderMap;
 
-    public TransactionToRecordStateVisitor( TransactionRecordState recordState, Runnable schemaStateChangeCallback,
+    public TransactionToRecordStateVisitor( TransactionRecordState recordState, SchemaState schemaState,
                                             SchemaStorage schemaStorage, ConstraintSemantics constraintSemantics,
                                             SchemaIndexProviderMap schemaIndexProviderMap )
     {
         this.recordState = recordState;
-        this.schemaStateChangeCallback = schemaStateChangeCallback;
+        this.schemaState = schemaState;
         this.schemaStorage = schemaStorage;
         this.constraintSemantics = constraintSemantics;
         this.schemaIndexProviderMap = schemaIndexProviderMap;
@@ -68,7 +69,7 @@ public class TransactionToRecordStateVisitor extends TxStateVisitor.Adapter
         {
             if ( clearSchemaState )
             {
-                schemaStateChangeCallback.run();
+                schemaState.clear();
             }
         }
         finally

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
@@ -632,7 +632,7 @@ public class IndexPopulationJobTest
         flipper.setFlipTarget( mock( IndexProxyFactory.class ) );
 
         MultipleIndexPopulator multiPopulator = new MultipleIndexPopulator( storeView, logProvider );
-        IndexPopulationJob job = new IndexPopulationJob( storeView, multiPopulator, NO_MONITOR, stateHolder::clear );
+        IndexPopulationJob job = new IndexPopulationJob( multiPopulator, NO_MONITOR, stateHolder );
         job.addPopulator( populator, indexId, descriptor, PROVIDER_DESCRIPTOR,
                 format( ":%s(%s)", FIRST.name(), name ), flipper, failureDelegateFactory );
         return job;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
@@ -73,6 +73,7 @@ import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.api.SchemaState;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingController;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingMode;
@@ -153,6 +154,7 @@ public class IndexingServiceTest
     public ExpectedException expectedException = ExpectedException.none();
 
     private static final LogMatcherBuilder logMatch = inLog( IndexingService.class );
+    private final SchemaState schemaState = mock( SchemaState.class );
     private final int labelId = 7;
     private final int propertyKeyId = 15;
     private final IndexDescriptor index = IndexDescriptorFactory.forLabel( labelId, propertyKeyId );
@@ -345,7 +347,7 @@ public class IndexingServiceTest
 
         life.add( IndexingServiceFactory.createIndexingService( Config.empty(), mock( JobScheduler.class ), providerMap,
                 mock( IndexStoreView.class ), mockLookup, asList( onlineIndex, populatingIndex, failedIndex ),
-                logProvider, IndexingService.NO_MONITOR, Runnables.EMPTY_RUNNABLE ) );
+                logProvider, IndexingService.NO_MONITOR, schemaState ) );
 
         when( provider.getInitialState( onlineIndex.getId(), onlineIndex.getIndexDescriptor() ) )
                 .thenReturn( ONLINE );
@@ -386,7 +388,7 @@ public class IndexingServiceTest
         IndexingService indexingService = IndexingServiceFactory.createIndexingService( Config.empty(),
                 mock( JobScheduler.class ), providerMap, storeView, mockLookup,
                 asList( onlineIndex, populatingIndex, failedIndex ), logProvider, IndexingService.NO_MONITOR,
-                Runnables.EMPTY_RUNNABLE );
+                schemaState );
 
         when( provider.getInitialState( onlineIndex.getId(), onlineIndex.getIndexDescriptor() ) )
                 .thenReturn( ONLINE );
@@ -976,8 +978,8 @@ public class IndexingServiceTest
         }
 
         life.add( IndexingServiceFactory.createIndexingService( Config.empty(), mock( JobScheduler.class ), providerMap,
-                mock( IndexStoreView.class ), mockLookup, indexes,
-                logProvider, IndexingService.NO_MONITOR, Runnables.EMPTY_RUNNABLE ) );
+                mock( IndexStoreView.class ), mockLookup, indexes, logProvider, IndexingService.NO_MONITOR,
+                schemaState ) );
 
         when( mockLookup.propertyKeyGetName( 1 ) ).thenReturn( "prop" );
 
@@ -1025,7 +1027,7 @@ public class IndexingServiceTest
 
         IndexingService indexingService = IndexingServiceFactory.createIndexingService( Config.empty(),
                 mock( JobScheduler.class ), providerMap, storeView, mockLookup, indexes,
-                logProvider, IndexingService.NO_MONITOR, Runnables.EMPTY_RUNNABLE );
+                logProvider, IndexingService.NO_MONITOR, schemaState );
         when( storeView.indexSample( anyLong(), any( DoubleLongRegister.class ) ) )
                 .thenReturn( newDoubleLongRegister( 32L, 32L ) );
         when( mockLookup.propertyKeyGetName( 1 ) ).thenReturn( "prop" );
@@ -1238,7 +1240,7 @@ public class IndexingServiceTest
                         loop( iterator( rules ) ),
                         logProvider,
                         monitor,
-                        Runnables.EMPTY_RUNNABLE )
+                        schemaState )
         );
     }
 
@@ -1404,7 +1406,7 @@ public class IndexingServiceTest
         return new IndexingService( mock( IndexProxyCreator.class ), mock( SchemaIndexProviderMap.class ),
                 indexMapReference, mock( IndexStoreView.class ), Collections.emptyList(),
                 mock( IndexSamplingController.class ), mock( TokenNameLookup.class ),
-                mock( JobScheduler.class ), mock( Runnable.class ), mock( MultiPopulatorFactory.class ),
+                mock( JobScheduler.class ), mock( SchemaState.class ), mock( MultiPopulatorFactory.class ),
                 NullLogProvider.getInstance(), IndexingService.NO_MONITOR );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/test/rule/RecordStorageEngineRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/RecordStorageEngineRule.java
@@ -34,6 +34,7 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.BatchTransactionApplierFacade;
 import org.neo4j.kernel.impl.api.KernelTransactionsSnapshot;
 import org.neo4j.kernel.impl.api.LegacyIndexProviderLookup;
+import org.neo4j.kernel.impl.api.SchemaState;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.scan.LabelScanStoreProvider;
 import org.neo4j.kernel.impl.constraints.ConstraintSemantics;
@@ -116,7 +117,7 @@ public class RecordStorageEngineRule extends ExternalResource
                 IdReuseEligibility.ALWAYS, new CommunityIdTypeConfigurationProvider(), pageCache, fs,
                 NullLogProvider.getInstance(),
                 mock( PropertyKeyTokenHolder.class ), mock( LabelTokenHolder.class ),
-                mock( RelationshipTypeTokenHolder.class ), Runnables.EMPTY_RUNNABLE, new StandardConstraintSemantics(),
+                mock( RelationshipTypeTokenHolder.class ), mock( SchemaState.class ), new StandardConstraintSemantics(),
                 scheduler, mock( TokenNameLookup.class ), new ReentrantLockService(),
                 schemaIndexProvider, IndexingService.NO_MONITOR, databaseHealth,
                 labelScanStoreProvider, legacyIndexProviderLookup, indexConfigStore,
@@ -200,7 +201,7 @@ public class RecordStorageEngineRule extends ExternalResource
                 IdTypeConfigurationProvider idTypeConfigurationProvider,
                 PageCache pageCache, FileSystemAbstraction fs, LogProvider logProvider,
                 PropertyKeyTokenHolder propertyKeyTokenHolder, LabelTokenHolder labelTokens,
-                RelationshipTypeTokenHolder relationshipTypeTokens, Runnable schemaStateChangeCallback,
+                RelationshipTypeTokenHolder relationshipTypeTokens, SchemaState schemaState,
                 ConstraintSemantics constraintSemantics, JobScheduler scheduler,
                 TokenNameLookup tokenNameLookup, LockService lockService,
                 SchemaIndexProvider indexProvider,
@@ -214,7 +215,7 @@ public class RecordStorageEngineRule extends ExternalResource
         {
             super( storeDir, config, idGeneratorFactory, eligibleForReuse, idTypeConfigurationProvider,
                     pageCache, fs, logProvider, propertyKeyTokenHolder,
-                    labelTokens, relationshipTypeTokens, schemaStateChangeCallback, constraintSemantics, scheduler,
+                    labelTokens, relationshipTypeTokens, schemaState, constraintSemantics, scheduler,
                     tokenNameLookup, lockService, indexProvider, indexingServiceMonitor, databaseHealth,
                     labelScanStoreProvider,
                     legacyIndexProviderLookup, indexConfigStore, legacyIndexTransactionOrdering,

--- a/community/neo4j/src/test/java/schema/MultiIndexPopulationConcurrentUpdatesIT.java
+++ b/community/neo4j/src/test/java/schema/MultiIndexPopulationConcurrentUpdatesIT.java
@@ -55,6 +55,7 @@ import org.neo4j.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.api.SchemaState;
 import org.neo4j.kernel.impl.api.index.IndexProxy;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.api.index.IndexingServiceFactory;
@@ -246,7 +247,7 @@ public class MultiIndexPopulationConcurrentUpdatesIT
 
             indexService = IndexingServiceFactory.createIndexingService( Config.empty(), scheduler,
                     providerMap, storeView, tokenNameLookup, getIndexRules( neoStores ),
-                    NullLogProvider.getInstance(), IndexingService.NO_MONITOR, Runnables.EMPTY_RUNNABLE );
+                    NullLogProvider.getInstance(), IndexingService.NO_MONITOR, getSchemaState() );
             indexService.start();
 
             IndexRule[] rules = createIndexRules( labelNameIdMap, propertyId );
@@ -369,19 +370,24 @@ public class MultiIndexPopulationConcurrentUpdatesIT
         return recordStorageEngine.testAccessNeoStores();
     }
 
+    private SchemaState getSchemaState()
+    {
+        return embeddedDatabase.resolveDependency( SchemaState.class );
+    }
+
     private ThreadToStatementContextBridge getTransactionStatementContextBridge()
     {
-        return embeddedDatabase.getDependencyResolver().resolveDependency( ThreadToStatementContextBridge.class );
+        return embeddedDatabase.resolveDependency( ThreadToStatementContextBridge.class );
     }
 
     private SchemaIndexProvider getSchemaIndexProvider()
     {
-        return embeddedDatabase.getDependencyResolver().resolveDependency( SchemaIndexProvider.class );
+        return embeddedDatabase.resolveDependency( SchemaIndexProvider.class );
     }
 
     private JobScheduler getJobScheduler()
     {
-        return embeddedDatabase.getDependencyResolver().resolveDependency( JobScheduler.class );
+        return embeddedDatabase.resolveDependency( JobScheduler.class );
     }
 
     private class DynamicIndexStoreViewWrapper extends DynamicIndexStoreView


### PR DESCRIPTION
Propagate schema state to perform operations directly instead of passing
Runnable callback.