### PR TITLE
Use specific empty instances instead of unnamed lambdas for common cases

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachine.java
@@ -36,6 +36,8 @@ import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.query.QueryExecutionKernelException;
 
+import static org.neo4j.function.ThrowingAction.noop;
+
 public class TransactionStateMachine implements StatementProcessor
 {
     private static final String BEGIN = "BEGIN";
@@ -187,7 +189,7 @@ public class TransactionStateMachine implements StatementProcessor
                             }
                             if ( spi.isPeriodicCommit( statement ) )
                             {
-                                BoltResultHandle resultHandle = executeQuery( ctx, spi, statement, params, () -> {} );
+                                BoltResultHandle resultHandle = executeQuery( ctx, spi, statement, params, noop() );
                                 ctx.currentResultHandle = resultHandle;
                                 ctx.currentResult = resultHandle.start();
                                 ctx.currentTransaction = null; // Periodic commit will change the current transaction, so

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/ResetFuzzTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/ResetFuzzTest.java
@@ -40,6 +40,7 @@ import org.neo4j.bolt.v1.messaging.BoltResponseMessageHandler;
 import org.neo4j.bolt.v1.messaging.message.RequestMessage;
 import org.neo4j.bolt.v1.runtime.concurrent.ThreadedWorkerFactory;
 import org.neo4j.bolt.v1.runtime.spi.Record;
+import org.neo4j.concurrent.Runnables;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.impl.logging.NullLogService;
@@ -119,7 +120,7 @@ public class ResetFuzzTest
             public void onSuccess( Map metadata ) throws IOException
             {
             }
-        }, () -> {} );
+        }, Runnables.EMPTY_RUNNABLE );
 
         // Test random combinations of messages within a small budget of testing time.
         long deadline = System.currentTimeMillis() + 2 * 1000;

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionRule.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/SessionRule.java
@@ -37,6 +37,7 @@ import org.neo4j.bolt.security.auth.BasicAuthentication;
 import org.neo4j.bolt.v1.runtime.BoltConnectionDescriptor;
 import org.neo4j.bolt.v1.runtime.BoltFactoryImpl;
 import org.neo4j.bolt.v1.runtime.BoltStateMachine;
+import org.neo4j.concurrent.Runnables;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
@@ -122,7 +123,7 @@ class SessionRule implements TestRule
         {
             throw new IllegalStateException( "Cannot access test environment before test is running." );
         }
-        BoltStateMachine connection = boltFactory.newMachine( connectionDescriptor, () -> {}, clock );
+        BoltStateMachine connection = boltFactory.newMachine( connectionDescriptor, Runnables.EMPTY_RUNNABLE, clock );
         runningMachines.add( connection );
         return connection;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
@@ -163,7 +163,7 @@ public class CommunityEditionModule extends EditionModule
 
     protected SchemaWriteGuard createSchemaWriteGuard()
     {
-        return () -> {};
+        return SchemaWriteGuard.ALLOW_ALL_WRITES;
     }
 
     private TokenCreator createRelationshipTypeCreator( Config config, DataSourceManager dataSourceManager,

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputCache.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.neo4j.concurrent.Runnables;
 import org.neo4j.function.ThrowingSupplier;
 import org.neo4j.io.ByteUnit;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -196,7 +197,7 @@ public class InputCache implements Closeable
     {
         if ( !deleteAfterUse )
         {
-            return () -> {};
+            return Runnables.EMPTY_RUNNABLE;
         }
 
         return () ->

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
@@ -50,6 +50,7 @@ import java.util.function.IntPredicate;
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongObjectMap;
 import org.neo4j.collection.primitive.PrimitiveLongSet;
+import org.neo4j.concurrent.Runnables;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.BoundedIterable;
@@ -152,7 +153,6 @@ public class IndexingServiceTest
     public ExpectedException expectedException = ExpectedException.none();
 
     private static final LogMatcherBuilder logMatch = inLog( IndexingService.class );
-    private static final Runnable DO_NOTHING_CALLBACK = () -> {};
     private final int labelId = 7;
     private final int propertyKeyId = 15;
     private final IndexDescriptor index = IndexDescriptorFactory.forLabel( labelId, propertyKeyId );
@@ -345,7 +345,7 @@ public class IndexingServiceTest
 
         life.add( IndexingServiceFactory.createIndexingService( Config.empty(), mock( JobScheduler.class ), providerMap,
                 mock( IndexStoreView.class ), mockLookup, asList( onlineIndex, populatingIndex, failedIndex ),
-                logProvider, IndexingService.NO_MONITOR, DO_NOTHING_CALLBACK ) );
+                logProvider, IndexingService.NO_MONITOR, Runnables.EMPTY_RUNNABLE ) );
 
         when( provider.getInitialState( onlineIndex.getId(), onlineIndex.getIndexDescriptor() ) )
                 .thenReturn( ONLINE );
@@ -386,7 +386,7 @@ public class IndexingServiceTest
         IndexingService indexingService = IndexingServiceFactory.createIndexingService( Config.empty(),
                 mock( JobScheduler.class ), providerMap, storeView, mockLookup,
                 asList( onlineIndex, populatingIndex, failedIndex ), logProvider, IndexingService.NO_MONITOR,
-                DO_NOTHING_CALLBACK );
+                Runnables.EMPTY_RUNNABLE );
 
         when( provider.getInitialState( onlineIndex.getId(), onlineIndex.getIndexDescriptor() ) )
                 .thenReturn( ONLINE );
@@ -977,7 +977,7 @@ public class IndexingServiceTest
 
         life.add( IndexingServiceFactory.createIndexingService( Config.empty(), mock( JobScheduler.class ), providerMap,
                 mock( IndexStoreView.class ), mockLookup, indexes,
-                logProvider, IndexingService.NO_MONITOR, DO_NOTHING_CALLBACK ) );
+                logProvider, IndexingService.NO_MONITOR, Runnables.EMPTY_RUNNABLE ) );
 
         when( mockLookup.propertyKeyGetName( 1 ) ).thenReturn( "prop" );
 
@@ -1025,7 +1025,7 @@ public class IndexingServiceTest
 
         IndexingService indexingService = IndexingServiceFactory.createIndexingService( Config.empty(),
                 mock( JobScheduler.class ), providerMap, storeView, mockLookup, indexes,
-                logProvider, IndexingService.NO_MONITOR, DO_NOTHING_CALLBACK );
+                logProvider, IndexingService.NO_MONITOR, Runnables.EMPTY_RUNNABLE );
         when( storeView.indexSample( anyLong(), any( DoubleLongRegister.class ) ) )
                 .thenReturn( newDoubleLongRegister( 32L, 32L ) );
         when( mockLookup.propertyKeyGetName( 1 ) ).thenReturn( "prop" );
@@ -1238,7 +1238,7 @@ public class IndexingServiceTest
                         loop( iterator( rules ) ),
                         logProvider,
                         monitor,
-                        DO_NOTHING_CALLBACK )
+                        Runnables.EMPTY_RUNNABLE )
         );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexQueryTransactionStateTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.collection.primitive.PrimitiveLongResourceIterator;
+import org.neo4j.graphdb.Resource;
 import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.schema.IndexQuery;
@@ -357,6 +358,6 @@ public class IndexQueryTransactionStateTest
 
     private static PrimitiveLongResourceIterator asPrimitiveResourceIterator( long... values )
     {
-        return PrimitiveLongCollections.resourceIterator( PrimitiveLongCollections.iterator( values ), () -> {} );
+        return PrimitiveLongCollections.resourceIterator( PrimitiveLongCollections.iterator( values ), Resource.EMPTY );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/StoreCopyCheckPointMutexTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/StoreCopyCheckPointMutexTest.java
@@ -36,6 +36,7 @@ import org.neo4j.test.Barrier;
 import org.neo4j.test.Race;
 import org.neo4j.test.rule.concurrent.OtherThreadRule;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertEquals;
@@ -47,14 +48,11 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-
+import static org.neo4j.function.ThrowingAction.noop;
 import static org.neo4j.test.Race.throwing;
 
 public class StoreCopyCheckPointMutexTest
 {
-    private static final ThrowingAction<IOException> NO_OP = () -> {};
     private static final ThrowingAction<IOException> ASSERT_NOT_CALLED = () -> fail( "Should not be called" );
 
     @Rule
@@ -71,7 +69,7 @@ public class StoreCopyCheckPointMutexTest
         try ( Resource lock = mutex.checkPoint() )
         {
             // WHEN
-            t2.execute( state -> mutex.storeCopy( NO_OP ) );
+            t2.execute( state -> mutex.storeCopy( noop() ) );
 
             // THEN
             t2.get().waitUntilWaiting( details -> details.isAt( StoreCopyCheckPointMutex.class, "storeCopy" ) );
@@ -96,7 +94,7 @@ public class StoreCopyCheckPointMutexTest
     public void storeCopyShouldBlockCheckPoint() throws Exception
     {
         // GIVEN
-        try ( Resource lock = mutex.storeCopy( NO_OP ) )
+        try ( Resource lock = mutex.storeCopy( noop() ) )
         {
             // WHEN
             t2.execute( state -> mutex.checkPoint() );
@@ -110,7 +108,7 @@ public class StoreCopyCheckPointMutexTest
     public void storeCopyShouldHaveTryCheckPointBackOff() throws Exception
     {
         // GIVEN
-        try ( Resource lock = mutex.storeCopy( NO_OP ) )
+        try ( Resource lock = mutex.storeCopy( noop() ) )
         {
             // WHEN
             assertNull( mutex.tryCheckPoint() );
@@ -121,10 +119,10 @@ public class StoreCopyCheckPointMutexTest
     public void storeCopyShouldAllowAnotherStoreCopy() throws Exception
     {
         // GIVEN
-        try ( Resource lock = mutex.storeCopy( NO_OP ) )
+        try ( Resource lock = mutex.storeCopy( noop() ) )
         {
             // WHEN
-            try ( Resource otherLock = mutex.storeCopy( NO_OP ) )
+            try ( Resource otherLock = mutex.storeCopy( noop() ) )
             {
                 // THEN good
             }

--- a/community/kernel/src/test/java/org/neo4j/test/RaceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/test/RaceTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
 
+import org.neo4j.concurrent.Runnables;
+
 import static java.lang.Thread.sleep;
 import static java.util.concurrent.ThreadLocalRandom.current;
 import static org.junit.Assert.assertEquals;
@@ -83,7 +85,7 @@ public class RaceTest
         ControlledBooleanSupplier endCondition3 = spy( new ControlledBooleanSupplier( false ) );
         Race race = new Race().withEndCondition( endCondition1, endCondition2, endCondition3 );
         race.addContestant( () -> endCondition2.set( true ) );
-        race.addContestants( 3, () -> {} );
+        race.addContestants( 3, Runnables.EMPTY_RUNNABLE );
 
         // WHEN
         race.go();

--- a/community/kernel/src/test/java/org/neo4j/test/rule/RecordStorageEngineRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/RecordStorageEngineRule.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.neo4j.concurrent.Runnables;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
@@ -50,7 +51,6 @@ import org.neo4j.kernel.impl.store.id.IdReuseEligibility;
 import org.neo4j.kernel.impl.store.id.configuration.CommunityIdTypeConfigurationProvider;
 import org.neo4j.kernel.impl.store.id.configuration.IdTypeConfigurationProvider;
 import org.neo4j.kernel.impl.util.IdOrderingQueue;
-import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
 import org.neo4j.kernel.impl.util.SynchronizedArrayIdOrderingQueue;
 import org.neo4j.kernel.internal.DatabaseHealth;
@@ -60,6 +60,7 @@ import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLog;
 import org.neo4j.logging.NullLogProvider;
+import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.storageengine.api.TransactionApplicationMode;
 import org.neo4j.test.impl.EphemeralIdGenerator;
 
@@ -115,7 +116,7 @@ public class RecordStorageEngineRule extends ExternalResource
                 IdReuseEligibility.ALWAYS, new CommunityIdTypeConfigurationProvider(), pageCache, fs,
                 NullLogProvider.getInstance(),
                 mock( PropertyKeyTokenHolder.class ), mock( LabelTokenHolder.class ),
-                mock( RelationshipTypeTokenHolder.class ), () -> {}, new StandardConstraintSemantics(),
+                mock( RelationshipTypeTokenHolder.class ), Runnables.EMPTY_RUNNABLE, new StandardConstraintSemantics(),
                 scheduler, mock( TokenNameLookup.class ), new ReentrantLockService(),
                 schemaIndexProvider, IndexingService.NO_MONITOR, databaseHealth,
                 labelScanStoreProvider, legacyIndexProviderLookup, indexConfigStore,

--- a/community/neo4j/src/test/java/schema/MultiIndexPopulationConcurrentUpdatesIT.java
+++ b/community/neo4j/src/test/java/schema/MultiIndexPopulationConcurrentUpdatesIT.java
@@ -34,6 +34,7 @@ import java.util.function.IntPredicate;
 import java.util.stream.Collectors;
 
 import org.neo4j.collection.primitive.PrimitiveLongResourceIterator;
+import org.neo4j.concurrent.Runnables;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
@@ -73,8 +74,8 @@ import org.neo4j.kernel.impl.transaction.state.DefaultSchemaIndexProviderMap;
 import org.neo4j.kernel.impl.transaction.state.DirectIndexUpdates;
 import org.neo4j.kernel.impl.transaction.state.storeview.DynamicIndexStoreView;
 import org.neo4j.kernel.impl.transaction.state.storeview.LabelScanViewNodeStoreScan;
-import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.logging.NullLogProvider;
+import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.test.rule.EmbeddedDatabaseRule;
 
@@ -245,7 +246,7 @@ public class MultiIndexPopulationConcurrentUpdatesIT
 
             indexService = IndexingServiceFactory.createIndexingService( Config.empty(), scheduler,
                     providerMap, storeView, tokenNameLookup, getIndexRules( neoStores ),
-                    NullLogProvider.getInstance(), IndexingService.NO_MONITOR, () -> {} );
+                    NullLogProvider.getInstance(), IndexingService.NO_MONITOR, Runnables.EMPTY_RUNNABLE );
             indexService.start();
 
             IndexRule[] rules = createIndexRules( labelNameIdMap, propertyId );

--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/Runnables.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/Runnables.java
@@ -17,16 +17,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.api;
+package org.neo4j.concurrent;
 
-import org.neo4j.kernel.api.exceptions.InvalidTransactionTypeKernelException;
-
-public interface SchemaWriteGuard
+public class Runnables
 {
-    SchemaWriteGuard ALLOW_ALL_WRITES = () ->
+    public static final Runnable EMPTY_RUNNABLE = () ->
     {
-        // allow all writes
+        // empty
     };
-
-    void assertSchemaWritesAllowed() throws InvalidTransactionTypeKernelException;
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
@@ -315,7 +315,7 @@ public class EnterpriseCoreEditionModule extends EditionModule
 
     private SchemaWriteGuard createSchemaWriteGuard()
     {
-        return () -> {};
+        return SchemaWriteGuard.ALLOW_ALL_WRITES;
     }
 
     private KernelData createKernelData( FileSystemAbstraction fileSystem, PageCache pageCache, File storeDir,

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
@@ -60,6 +60,7 @@ import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.neo4j.bolt.v1.runtime.integration.TransactionIT.createHttpServer;
+import static org.neo4j.concurrent.Runnables.EMPTY_RUNNABLE;
 import static org.neo4j.graphdb.security.AuthorizationViolationException.PERMISSION_DENIED;
 import static org.neo4j.helpers.collection.Iterables.single;
 import static org.neo4j.helpers.collection.MapUtil.map;
@@ -120,7 +121,8 @@ public abstract class BuiltInProceduresInteractionTestBase<S> extends ProcedureI
     {
         final DoubleLatch doubleLatch = new DoubleLatch( 2 );
 
-        ClassWithProcedures.setTestLatch( new ClassWithProcedures.LatchedRunnables( doubleLatch, () -> {}, () -> {} ) );
+        ClassWithProcedures.setTestLatch( new ClassWithProcedures.LatchedRunnables( doubleLatch, EMPTY_RUNNABLE,
+                EMPTY_RUNNABLE ) );
 
         new Thread( () -> assertEmpty( writeSubject, "CALL test.waitForLatch()" ) ).start();
         doubleLatch.startAndWaitForAllToStart();
@@ -1027,7 +1029,8 @@ public abstract class BuiltInProceduresInteractionTestBase<S> extends ProcedureI
     {
         final DoubleLatch doubleLatch = new DoubleLatch( 2 );
 
-        ClassWithProcedures.setTestLatch( new ClassWithProcedures.LatchedRunnables( doubleLatch, () -> {}, () -> {} ) );
+        ClassWithProcedures.setTestLatch(
+                new ClassWithProcedures.LatchedRunnables( doubleLatch, EMPTY_RUNNABLE, EMPTY_RUNNABLE ) );
 
         new Thread( () -> assertFail( writeSubject, "CALL test.waitForLatch()", "Explicitly terminated by the user." ) )
                 .start();


### PR DESCRIPTION
Introduce Runnables with EMPTY_RUNNABLE and use it instead of empty lambdas,
Use ThrowingAction.noop,
use SchemaWriteGuard.ALLOW_ALL_WRITES instead of unnamed implementations