### PR TITLE
Add preliminary syntax for RETURN GRAPH

### DIFF
--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/SyntaxExceptionCreator.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/SyntaxExceptionCreator.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_3
 
-import org.neo4j.cypher.internal.frontend.v3_3.{CypherException, InputPosition, SemanticError, SyntaxException}
+import org.neo4j.cypher.internal.frontend.v3_3.{CypherException, InputPosition, SemanticErrorDef, SyntaxException}
 
 class SyntaxExceptionCreator(queryText: String, preParserOffset: Option[InputPosition]) extends ((String, InputPosition) => CypherException) {
   override def apply(message: String, position: InputPosition): CypherException = {
@@ -29,6 +29,6 @@ class SyntaxExceptionCreator(queryText: String, preParserOffset: Option[InputPos
 }
 
 object SyntaxExceptionCreator {
-  def throwOnError(mkException: SyntaxExceptionCreator): (Seq[SemanticError]) => Unit =
-    (errors: Seq[SemanticError]) => errors.foreach(e => throw mkException(e.msg, e.position))
+  def throwOnError(mkException: SyntaxExceptionCreator): (Seq[SemanticErrorDef]) => Unit =
+    (errors: Seq[SemanticErrorDef]) => errors.foreach(e => throw mkException(e.msg, e.position))
 }

--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/phases/CompilerContext.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/phases/CompilerContext.scala
@@ -25,7 +25,7 @@ import org.neo4j.cypher.internal.compiler.v3_3._
 import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.{Metrics, QueryGraphSolver}
 import org.neo4j.cypher.internal.compiler.v3_3.spi.PlanContext
 import org.neo4j.cypher.internal.frontend.v3_3.phases.{BaseContext, CompilationPhaseTracer, InternalNotificationLogger, Monitors}
-import org.neo4j.cypher.internal.frontend.v3_3.{CypherException, InputPosition, SemanticError}
+import org.neo4j.cypher.internal.frontend.v3_3.{CypherException, InputPosition, SemanticErrorDef}
 
 class CompilerContext(val exceptionCreator: (String, InputPosition) => CypherException,
                       val tracer: CompilationPhaseTracer,
@@ -39,7 +39,7 @@ class CompilerContext(val exceptionCreator: (String, InputPosition) => CypherExc
                       val debugOptions: Set[String],
                       val clock: Clock) extends BaseContext {
 
-  override def errorHandler: (Seq[SemanticError]) => Unit =
-    (errors: Seq[SemanticError]) => errors.foreach(e => throw exceptionCreator(e.msg, e.position))
+  override def errorHandler =
+    (errors: Seq[SemanticErrorDef]) => errors.foreach(e => throw exceptionCreator(e.msg, e.position))
 
 }

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/ResolveTokensTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/ResolveTokensTest.scala
@@ -41,7 +41,7 @@ class ResolveTokensTest extends CypherFunSuite {
         SingleQuery(Seq(
           Match(
             false,
-            Pattern(Seq(EveryPath(NodePattern(Some(Variable("n")), Seq(), None)))),
+            Pattern(_, Seq(EveryPath(NodePattern(Some(Variable("n")), Seq(), None)))),
             Seq(),
             Some(Where(Equals(Property(Variable("n"), pkToken), StringLiteral("Resolved"))))
           ),
@@ -64,7 +64,7 @@ class ResolveTokensTest extends CypherFunSuite {
         SingleQuery(Seq(
           Match(
             false,
-            Pattern(Seq(EveryPath(NodePattern(Some(Variable("n")), Seq(), None)))),
+            Pattern(_, Seq(EveryPath(NodePattern(Some(Variable("n")), Seq(), None)))),
             Seq(),
             Some(Where(Equals(Property(Variable("n"), pkToken), StringLiteral("Unresolved"))))
           ),
@@ -87,7 +87,7 @@ class ResolveTokensTest extends CypherFunSuite {
       SingleQuery(Seq(
         Match(
           false,
-          Pattern(Seq(EveryPath(NodePattern(Some(Variable("n")), Seq(), None)))),
+          Pattern(_, Seq(EveryPath(NodePattern(Some(Variable("n")), Seq(), None)))),
           Seq(),
           Some(Where(HasLabels(Variable("n"), Seq(labelToken))))
         ),
@@ -110,7 +110,7 @@ class ResolveTokensTest extends CypherFunSuite {
       SingleQuery(Seq(
         Match(
           false,
-          Pattern(Seq(EveryPath(NodePattern(Some(Variable("n")), Seq(), None)))),
+          Pattern(_, Seq(EveryPath(NodePattern(Some(Variable("n")), Seq(), None)))),
           Seq(),
           Some(Where(HasLabels(Variable("n"), Seq(labelToken))))
         ),
@@ -133,7 +133,7 @@ class ResolveTokensTest extends CypherFunSuite {
       SingleQuery(Seq(
         Match(
           false,
-          Pattern(Seq(EveryPath(RelationshipChain(
+          Pattern(_, Seq(EveryPath(RelationshipChain(
             NodePattern(None, Seq(), None),
             RelationshipPattern(None, Seq(relTypeToken), None, None, SemanticDirection.OUTGOING, _),
             NodePattern(None, Seq(), None)
@@ -160,7 +160,7 @@ class ResolveTokensTest extends CypherFunSuite {
       SingleQuery(Seq(
         Match(
           false,
-          Pattern(Seq(EveryPath(RelationshipChain(
+          Pattern(_, Seq(EveryPath(RelationshipChain(
             NodePattern(None, Seq(), None),
             RelationshipPattern(None, Seq(relTypeToken), None, None, SemanticDirection.OUTGOING, _),
             NodePattern(None, Seq(), None)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ErrorMessagesTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ErrorMessagesTest.scala
@@ -126,7 +126,7 @@ class ErrorMessagesTest extends ExecutionEngineFunSuite with CypherSerializer {
   test("badMatch5") {
     expectSyntaxError(
       "match (p) where id(p) = 2 match p[:likes]->dude return dude.name",
-      "Invalid input '[': expected an identifier character, whitespace, '=', node labels, a property map, " +
+      "Invalid input '[': expected an identifier character, whitespace, \":=\", '=', node labels, a property map, " +
         "a relationship pattern, ',', USING, WHERE, LOAD CSV, LOAD GRAPH, EMIT GRAPH, START, MATCH, UNWIND, MERGE, CREATE, SET, DELETE, REMOVE, FOREACH, WITH, " +
         "CALL, RETURN GRAPH, RETURN, UNION, ';' or end of input (line 1, column 34 (offset: 33))",
       33

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ErrorMessagesTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ErrorMessagesTest.scala
@@ -35,7 +35,7 @@ class ErrorMessagesTest extends ExecutionEngineFunSuite with CypherSerializer {
   test("noReturnColumns") {
     expectError(
       "match (s) where id(s) = 0 return",
-      "Unexpected end of input: expected whitespace, DISTINCT, '*' or an expression (line 1, column 33 (offset: 32))"
+      "Unexpected end of input: expected whitespace, GRAPH, DISTINCT, '*' or an expression (line 1, column 33 (offset: 32))"
     )
   }
 
@@ -128,7 +128,7 @@ class ErrorMessagesTest extends ExecutionEngineFunSuite with CypherSerializer {
       "match (p) where id(p) = 2 match p[:likes]->dude return dude.name",
       "Invalid input '[': expected an identifier character, whitespace, '=', node labels, a property map, " +
         "a relationship pattern, ',', USING, WHERE, LOAD CSV, LOAD GRAPH, EMIT GRAPH, START, MATCH, UNWIND, MERGE, CREATE, SET, DELETE, REMOVE, FOREACH, WITH, " +
-        "CALL, RETURN, UNION, ';' or end of input (line 1, column 34 (offset: 33))",
+        "CALL, RETURN GRAPH, RETURN, UNION, ';' or end of input (line 1, column 34 (offset: 33))",
       33
     )
   }

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/SemanticCheck.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/SemanticCheck.scala
@@ -21,11 +21,11 @@ package org.neo4j.cypher.internal.frontend.v3_3
 
 object SemanticCheckResult {
   val success: SemanticCheck = SemanticCheckResult(_, Vector())
-  def error(state: SemanticState, error: SemanticError): SemanticCheckResult = SemanticCheckResult(state, Vector(error))
-  def error(state: SemanticState, error: Option[SemanticError]): SemanticCheckResult = SemanticCheckResult(state, error.toVector)
+  def error(state: SemanticState, error: SemanticErrorDef): SemanticCheckResult = SemanticCheckResult(state, Vector(error))
+  def error(state: SemanticState, error: Option[SemanticErrorDef]): SemanticCheckResult = SemanticCheckResult(state, error.toVector)
 }
 
-case class SemanticCheckResult(state: SemanticState, errors: Seq[SemanticError])
+case class SemanticCheckResult(state: SemanticState, errors: Seq[SemanticErrorDef])
 
 trait SemanticChecking {
   protected def when(condition: Boolean)(check: => SemanticCheck): SemanticCheck = state =>

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/SemanticChecker.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/SemanticChecker.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.frontend.v3_3
 import org.neo4j.cypher.internal.frontend.v3_3.ast.Statement
 
 object SemanticChecker {
-  def check(statement: Statement, onError: Seq[SemanticError] => Unit): SemanticState = {
+  def check(statement: Statement, onError: Seq[SemanticErrorDef] => Unit): SemanticState = {
 
     val SemanticCheckResult(semanticState, semanticErrors) = statement.semanticCheck(SemanticState.clean)
 

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/SemanticError.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/SemanticError.scala
@@ -19,4 +19,16 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_3
 
-case class SemanticError(msg: String, position: InputPosition, references: InputPosition*)
+sealed trait SemanticErrorDef {
+  def msg: String
+  def position: InputPosition
+  def references: Seq[InputPosition]
+}
+
+final case class SemanticError(msg: String, position: InputPosition, references: InputPosition*) extends SemanticErrorDef
+
+final case class UnsupportedOpenCypher(clause: String, position: InputPosition) extends SemanticErrorDef {
+
+  override val msg: String = s"The referenced clause $clause is not supported by Neo4j"
+  override val references = Seq.empty
+}

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/Clause.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/Clause.scala
@@ -71,7 +71,7 @@ case class LoadGraph(graphUrl: Expression)(val position: InputPosition) extends 
   override def semanticCheck: SemanticCheck =
     graphUrl.semanticCheck(Expression.SemanticContext.Simple) chain
       graphUrl.expectType(CTString.covariant) chain
-      UnsupportedOpenCypher(name, position)
+      ClauseError(name, position)
 }
 
 case class EmitGraph(graphName: Expression)(val position: InputPosition) extends Clause with SemanticChecking {
@@ -80,7 +80,7 @@ case class EmitGraph(graphName: Expression)(val position: InputPosition) extends
   override def semanticCheck: SemanticCheck =
     graphName.semanticCheck(Expression.SemanticContext.Simple) chain
       graphName.expectType(CTString.covariant) chain
-      UnsupportedOpenCypher(name, position)
+      ClauseError(name, position)
 }
 
 case class ReturnGraph(graphName: Option[Expression])(val position: InputPosition) extends Clause with SemanticChecking {
@@ -89,7 +89,7 @@ case class ReturnGraph(graphName: Option[Expression])(val position: InputPositio
   override def semanticCheck: SemanticCheck =
     graphName.semanticCheck(Expression.SemanticContext.Simple) chain
       graphName.expectType(CTString.covariant) chain
-      UnsupportedOpenCypher(name, position)
+      ClauseError(name, position)
 }
 
 case class Start(items: Seq[StartItem], where: Option[Where])(val position: InputPosition) extends Clause {

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/Clause.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/Clause.scala
@@ -71,7 +71,7 @@ case class LoadGraph(graphUrl: Expression)(val position: InputPosition) extends 
   override def semanticCheck: SemanticCheck =
     graphUrl.semanticCheck(Expression.SemanticContext.Simple) chain
       graphUrl.expectType(CTString.covariant) chain
-      SemanticError("LOAD GRAPH is not supported by Neo4j", position)
+      UnsupportedOpenCypher(name, position)
 }
 
 case class EmitGraph(graphName: Expression)(val position: InputPosition) extends Clause with SemanticChecking {
@@ -80,7 +80,7 @@ case class EmitGraph(graphName: Expression)(val position: InputPosition) extends
   override def semanticCheck: SemanticCheck =
     graphName.semanticCheck(Expression.SemanticContext.Simple) chain
       graphName.expectType(CTString.covariant) chain
-      SemanticError("EMIT GRAPH is not supported by Neo4j", position)
+      UnsupportedOpenCypher(name, position)
 }
 
 case class Start(items: Seq[StartItem], where: Option[Where])(val position: InputPosition) extends Clause {
@@ -406,10 +406,10 @@ sealed trait ProjectionClause extends HorizonClause with SemanticChecking {
   }
 
   // use an empty state when checking skip & limit, as these have entirely isolated context
-  private def checkSkip: SemanticState => Seq[SemanticError] =
+  private def checkSkip: SemanticState => Seq[SemanticErrorDef] =
     s => skip.semanticCheck(SemanticState.clean).errors
 
-  private def checkLimit: SemanticState => Seq[SemanticError] =
+  private def checkLimit: SemanticState => Seq[SemanticErrorDef] =
     s => limit.semanticCheck(SemanticState.clean).errors
 
   private def ignoreErrors(inner: SemanticCheck): SemanticCheck =

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/Clause.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/Clause.scala
@@ -83,6 +83,15 @@ case class EmitGraph(graphName: Expression)(val position: InputPosition) extends
       UnsupportedOpenCypher(name, position)
 }
 
+case class ReturnGraph(graphName: Option[Expression])(val position: InputPosition) extends Clause with SemanticChecking {
+  override def name = "RETURN GRAPH"
+
+  override def semanticCheck: SemanticCheck =
+    graphName.semanticCheck(Expression.SemanticContext.Simple) chain
+      graphName.expectType(CTString.covariant) chain
+      UnsupportedOpenCypher(name, position)
+}
+
 case class Start(items: Seq[StartItem], where: Option[Where])(val position: InputPosition) extends Clause {
   override def name = "START"
 

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/Pattern.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/Pattern.scala
@@ -61,11 +61,14 @@ object Pattern {
       resultMap.values.toSet
     }
   }
+
+  /** Constructs an anonymous pattern (no named graphlet). */
+  def apply(parts: Seq[PatternPart])(p: InputPosition): Pattern = Pattern(None, parts)(p)
 }
 
 import org.neo4j.cypher.internal.frontend.v3_3.ast.Pattern._
 
-case class Pattern(patternParts: Seq[PatternPart])(val position: InputPosition) extends ASTNode with ASTParticle {
+case class Pattern(graphlet: Option[Variable], patternParts: Seq[PatternPart])(val position: InputPosition) extends ASTNode with ASTParticle {
 
   lazy val length = this.fold(0) {
     case RelationshipChain(_, _, _) => _ + 1
@@ -75,7 +78,13 @@ case class Pattern(patternParts: Seq[PatternPart])(val position: InputPosition) 
   def semanticCheck(ctx: SemanticContext): SemanticCheck =
     patternParts.foldSemanticCheck(_.declareVariables(ctx)) chain
       patternParts.foldSemanticCheck(_.semanticCheck(ctx)) chain
-      ensureNoDuplicateRelationships(this, ctx)
+      ensureNoDuplicateRelationships(this, ctx) chain
+      checkGraphlet
+
+  private def checkGraphlet: SemanticCheck = graphlet match {
+    case None => SemanticCheckResult.success
+    case Some(g) => g.declare(CTGraphlet) chain PatternError("Graphlet patterns are not supported by Neo4j", g.position)
+  }
 
   private def ensureNoDuplicateRelationships(pattern: Pattern, ctx: SemanticContext): SemanticCheck = {
     findDuplicateRelationships(pattern).foldLeft(SemanticCheckResult.success) {

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/Query.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/Query.scala
@@ -105,6 +105,7 @@ case class SingleQuery(clauses: Seq[Clause])(val position: InputPosition) extend
     val lastError = lastPair.last match {
       case _: UpdateClause => None
       case _: Return => None
+      case _: ReturnGraph => None
       case _: CallClause if clauses.size == 1 => None
       case clause =>
         Some(SemanticError(s"Query cannot conclude with ${clause.name} (must be RETURN or an update clause)", clause.position))

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/package.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/package.scala
@@ -35,47 +35,47 @@ package object v3_3 {
   // Allows joining of two (SemanticState => SemanticCheckResult) funcs together (using then)
   implicit def chainableSemanticCheck(check: SemanticCheck): ChainableSemanticCheck = new ChainableSemanticCheck(check)
 
-  // Allows joining of a (SemanticState => SemanticCheckResult) func to a (SemanticState => Either[SemanticError, SemanticState]) func
-  implicit def chainableSemanticEitherFunc(func: SemanticState => Either[SemanticError, SemanticState]): ChainableSemanticCheck = new ChainableSemanticCheck(func)
+  // Allows joining of a (SemanticState => SemanticCheckResult) func to a (SemanticState => Either[SemanticErrorDef, SemanticState]) func
+  implicit def chainableSemanticEitherFunc(func: SemanticState => Either[SemanticErrorDef, SemanticState]): ChainableSemanticCheck = new ChainableSemanticCheck(func)
 
-  // Allows joining of a (SemanticState => SemanticCheckResult) func to a (SemanticState => Seq[SemanticError]) func
-  implicit def chainableSemanticErrorsFunc(func: SemanticState => Seq[SemanticError]): ChainableSemanticCheck = new ChainableSemanticCheck(func)
+  // Allows joining of a (SemanticState => SemanticCheckResult) func to a (SemanticState => Seq[SemanticErrorDef]) func
+  implicit def chainableSemanticErrorDefsFunc(func: SemanticState => Seq[SemanticErrorDef]): ChainableSemanticCheck = new ChainableSemanticCheck(func)
 
-  // Allows joining of a (SemanticState => SemanticCheckResult) func to a (SemanticState => Option[SemanticError]) func
-  implicit def chainableSemanticOptionFunc(func: SemanticState => Option[SemanticError]): ChainableSemanticCheck = new ChainableSemanticCheck(func)
+  // Allows joining of a (SemanticState => SemanticCheckResult) func to a (SemanticState => Option[SemanticErrorDef]) func
+  implicit def chainableSemanticOptionFunc(func: SemanticState => Option[SemanticErrorDef]): ChainableSemanticCheck = new ChainableSemanticCheck(func)
 
-  // Allows using a (SemanticState => Either[SemanticError, SemanticState]) func, where a (SemanticState => SemanticCheckResult) func is expected
-  implicit def liftSemanticEitherFunc(func: SemanticState => Either[SemanticError, SemanticState]): SemanticCheck = state => {
+  // Allows using a (SemanticState => Either[SemanticErrorDef, SemanticState]) func, where a (SemanticState => SemanticCheckResult) func is expected
+  implicit def liftSemanticEitherFunc(func: SemanticState => Either[SemanticErrorDef, SemanticState]): SemanticCheck = state => {
     func(state).fold(error => SemanticCheckResult.error(state, error), s => SemanticCheckResult.success(s))
   }
 
-  // Allows using a (SemanticState => Seq[SemanticError]) func, where a (SemanticState => SemanticCheckResult) func is expected
-  implicit def liftSemanticErrorsFunc(func: SemanticState => Seq[SemanticError]): SemanticCheck = state => {
+  // Allows using a (SemanticState => Seq[SemanticErrorDef]) func, where a (SemanticState => SemanticCheckResult) func is expected
+  implicit def liftSemanticErrorDefsFunc(func: SemanticState => Seq[SemanticErrorDef]): SemanticCheck = state => {
     SemanticCheckResult(state, func(state))
   }
 
-  // Allows using a (SemanticState => Option[SemanticError]) func, where a (SemanticState => SemanticCheckResult) func is expected
-  implicit def liftSemanticErrorFunc(func: SemanticState => Option[SemanticError]): SemanticCheck = state => {
+  // Allows using a (SemanticState => Option[SemanticErrorDef]) func, where a (SemanticState => SemanticCheckResult) func is expected
+  implicit def liftSemanticErrorDefFunc(func: SemanticState => Option[SemanticErrorDef]): SemanticCheck = state => {
     SemanticCheckResult.error(state, func(state))
   }
 
-  // Allows using a sequence of SemanticError, where a (SemanticState => SemanticCheckResult) func is expected
-  implicit def liftSemanticErrors(errors: Seq[SemanticError]): SemanticCheck = SemanticCheckResult(_, errors)
+  // Allows using a sequence of SemanticErrorDef, where a (SemanticState => SemanticCheckResult) func is expected
+  implicit def liftSemanticErrorDefs(errors: Seq[SemanticErrorDef]): SemanticCheck = SemanticCheckResult(_, errors)
 
-  // Allows using a single SemanticError, where a (SemanticState => SemanticCheckResult) func is expected
-  implicit def liftSemanticError(error: SemanticError): SemanticCheck = SemanticCheckResult.error(_, error)
+  // Allows using a single SemanticErrorDef, where a (SemanticState => SemanticCheckResult) func is expected
+  implicit def liftSemanticErrorDef(error: SemanticErrorDef): SemanticCheck = SemanticCheckResult.error(_, error)
 
-  // Allows using an optional SemanticError, where a (SemanticState => SemanticCheckResult) func is expected
-  implicit def liftSemanticErrorOption(error: Option[SemanticError]): SemanticCheck = SemanticCheckResult.error(_, error)
+  // Allows using an optional SemanticErrorDef, where a (SemanticState => SemanticCheckResult) func is expected
+  implicit def liftSemanticErrorDefOption(error: Option[SemanticErrorDef]): SemanticCheck = SemanticCheckResult.error(_, error)
 
-  // Allows starting with a sequence of SemanticError, and joining to a (SemanticState => SemanticCheckResult) func (using then)
-  implicit def liftSemanticErrorsAndChain(errors: Seq[SemanticError]): ChainableSemanticCheck = liftSemanticErrors(errors)
+  // Allows starting with a sequence of SemanticErrorDef, and joining to a (SemanticState => SemanticCheckResult) func (using then)
+  implicit def liftSemanticErrorDefsAndChain(errors: Seq[SemanticErrorDef]): ChainableSemanticCheck = liftSemanticErrorDefs(errors)
 
-  // Allows starting with a single SemanticError, and joining to a (SemanticState => SemanticCheckResult) func (using then)
-  implicit def liftSemanticErrorAndChain(error: SemanticError): ChainableSemanticCheck = liftSemanticError(error)
+  // Allows starting with a single SemanticErrorDef, and joining to a (SemanticState => SemanticCheckResult) func (using then)
+  implicit def liftSemanticErrorDefAndChain(error: SemanticErrorDef): ChainableSemanticCheck = liftSemanticErrorDef(error)
 
-  // Allows starting with an optional SemanticError, and joining to a (SemanticState => SemanticCheckResult) func (using then)
-  implicit def liftSemanticErrorOptionAndChain(error: Option[SemanticError]): ChainableSemanticCheck = liftSemanticErrorOption(error)
+  // Allows starting with an optional SemanticErrorDef, and joining to a (SemanticState => SemanticCheckResult) func (using then)
+  implicit def liftSemanticErrorDefOptionAndChain(error: Option[SemanticErrorDef]): ChainableSemanticCheck = liftSemanticErrorDefOption(error)
 
   // Allows folding a semantic checking func over a collection
   implicit def optionSemanticChecking[A](option: Option[A]): OptionSemanticChecking[A] = new OptionSemanticChecking(option)

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/package.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/package.scala
@@ -22,6 +22,8 @@ package org.neo4j.cypher.internal.frontend
 import org.neo4j.cypher.internal.frontend.v3_3.helpers.NonEmptyList
 import org.neo4j.cypher.internal.frontend.v3_3.symbols.TypeSpec
 
+import scala.language.implicitConversions
+
 package object v3_3 {
   type Rewriter = (AnyRef => AnyRef)
 
@@ -31,16 +33,16 @@ package object v3_3 {
   type TypeGenerator = SemanticState => TypeSpec
 
   // Allows joining of two (SemanticState => SemanticCheckResult) funcs together (using then)
-  implicit def chainableSemanticCheck(check: SemanticCheck) = new ChainableSemanticCheck(check)
+  implicit def chainableSemanticCheck(check: SemanticCheck): ChainableSemanticCheck = new ChainableSemanticCheck(check)
 
   // Allows joining of a (SemanticState => SemanticCheckResult) func to a (SemanticState => Either[SemanticError, SemanticState]) func
-  implicit def chainableSemanticEitherFunc(func: SemanticState => Either[SemanticError, SemanticState]) = new ChainableSemanticCheck(func)
+  implicit def chainableSemanticEitherFunc(func: SemanticState => Either[SemanticError, SemanticState]): ChainableSemanticCheck = new ChainableSemanticCheck(func)
 
   // Allows joining of a (SemanticState => SemanticCheckResult) func to a (SemanticState => Seq[SemanticError]) func
-  implicit def chainableSemanticErrorsFunc(func: SemanticState => Seq[SemanticError]) = new ChainableSemanticCheck(func)
+  implicit def chainableSemanticErrorsFunc(func: SemanticState => Seq[SemanticError]): ChainableSemanticCheck = new ChainableSemanticCheck(func)
 
   // Allows joining of a (SemanticState => SemanticCheckResult) func to a (SemanticState => Option[SemanticError]) func
-  implicit def chainableSemanticOptionFunc(func: SemanticState => Option[SemanticError]) = new ChainableSemanticCheck(func)
+  implicit def chainableSemanticOptionFunc(func: SemanticState => Option[SemanticError]): ChainableSemanticCheck = new ChainableSemanticCheck(func)
 
   // Allows using a (SemanticState => Either[SemanticError, SemanticState]) func, where a (SemanticState => SemanticCheckResult) func is expected
   implicit def liftSemanticEitherFunc(func: SemanticState => Either[SemanticError, SemanticState]): SemanticCheck = state => {
@@ -76,13 +78,13 @@ package object v3_3 {
   implicit def liftSemanticErrorOptionAndChain(error: Option[SemanticError]): ChainableSemanticCheck = liftSemanticErrorOption(error)
 
   // Allows folding a semantic checking func over a collection
-  implicit def optionSemanticChecking[A](option: Option[A]) = new OptionSemanticChecking(option)
+  implicit def optionSemanticChecking[A](option: Option[A]): OptionSemanticChecking[A] = new OptionSemanticChecking(option)
 
-  implicit def traversableOnceSemanticChecking[A](traversable: TraversableOnce[A]) = new TraversableOnceSemanticChecking(traversable)
+  implicit def traversableOnceSemanticChecking[A](traversable: TraversableOnce[A]): TraversableOnceSemanticChecking[A] = new TraversableOnceSemanticChecking(traversable)
 
   // Allows calling semanticCheck on an optional SemanticCheckable object
-  implicit def semanticCheckableOption[A <: SemanticCheckable](option: Option[A]) = new SemanticCheckableOption(option)
+  implicit def semanticCheckableOption[A <: SemanticCheckable](option: Option[A]): SemanticCheckableOption[A] = new SemanticCheckableOption(option)
 
   // Allows calling semanticCheck on a traversable sequence of SemanticCheckable objects
-  implicit def semanticCheckableTraversableOnce[A <: SemanticCheckable](traversable: TraversableOnce[A]) = new SemanticCheckableTraversableOnce(traversable)
+  implicit def semanticCheckableTraversableOnce[A <: SemanticCheckable](traversable: TraversableOnce[A]): SemanticCheckableTraversableOnce[A] = new SemanticCheckableTraversableOnce(traversable)
 }

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/parser/Clauses.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/parser/Clauses.scala
@@ -52,6 +52,10 @@ trait Clauses extends Parser
       (ast.EmitGraph(_))
   }
 
+  def ReturnGraph: Rule1[ast.ReturnGraph] = rule("RETURN GRAPH") {
+    keyword("RETURN GRAPH") ~~ optional(Expression) ~~>> (ast.ReturnGraph(_))
+  }
+
   def Start: Rule1[ast.Start] = rule("START") {
     group(
       keyword("START") ~~ oneOrMore(StartPoint, separator = CommaSep) ~~ optional(Where)

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/parser/Clauses.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/parser/Clauses.scala
@@ -71,7 +71,7 @@ trait Clauses extends Parser
 
   def Merge: Rule1[ast.Merge] = rule("MERGE") {
     group(
-      group(keyword("MERGE") ~~ PatternPart) ~~>> (p => ast.Pattern(Seq(p))) ~~ zeroOrMore(MergeAction, separator = WS)
+      group(keyword("MERGE") ~~ PatternPart) ~~>> (p => ast.Pattern(None, Seq(p))) ~~ zeroOrMore(MergeAction, separator = WS)
     ) ~~>> (ast.Merge(_, _))
   }
 

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/parser/Patterns.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/parser/Patterns.scala
@@ -37,7 +37,7 @@ trait Patterns extends Parser
   with Base {
 
   def Pattern: Rule1[ast.Pattern] = rule("a pattern") {
-    oneOrMore(PatternPart, separator = CommaSep) ~~>> (ast.Pattern(_))
+    optional(Variable ~~ operator(":=")) ~~ oneOrMore(PatternPart, separator = CommaSep) ~~>> (ast.Pattern(_, _))
   }
 
   def PatternPart: Rule1[ast.PatternPart] = rule("a pattern") (

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/parser/Query.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/parser/Query.scala
@@ -62,6 +62,7 @@ trait Query extends Parser
     | Foreach
     | With
     | Call
+    | ReturnGraph
     | Return
     | Pragma
   )

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/phases/BaseContext.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/phases/BaseContext.scala
@@ -19,12 +19,12 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_3.phases
 
-import org.neo4j.cypher.internal.frontend.v3_3.{CypherException, InputPosition, SemanticError}
+import org.neo4j.cypher.internal.frontend.v3_3.{CypherException, InputPosition, SemanticErrorDef}
 
 trait BaseContext {
   def tracer: CompilationPhaseTracer
   def notificationLogger: InternalNotificationLogger
   def exceptionCreator: (String, InputPosition) => CypherException
   def monitors: Monitors
-  def errorHandler: (Seq[SemanticError] => Unit)
+  def errorHandler: (Seq[SemanticErrorDef] => Unit)
 }

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/symbols/GraphletType.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/symbols/GraphletType.scala
@@ -17,24 +17,15 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.frontend.v3_3
+package org.neo4j.cypher.internal.frontend.v3_3.symbols
 
-sealed trait SemanticErrorDef {
-  def msg: String
-  def position: InputPosition
-  def references: Seq[InputPosition]
+object GraphletType {
+  val instance = new GraphletType() {
+    val parentType = CTAny
+    override val toString = "Graphlet"
+    override val toNeoTypeString = "GRAPHLET?"
+
+  }
 }
 
-final case class SemanticError(msg: String, position: InputPosition, references: InputPosition*) extends SemanticErrorDef
-
-sealed trait UnsupportedOpenCypher extends SemanticErrorDef
-
-final case class ClauseError(clause: String, position: InputPosition) extends UnsupportedOpenCypher {
-
-  override val msg: String = s"The referenced clause $clause is not supported by Neo4j"
-  override def references = Seq.empty
-}
-
-final case class PatternError(msg: String, position: InputPosition) extends UnsupportedOpenCypher {
-  override def references = Seq.empty
-}
+sealed abstract class GraphletType extends CypherType

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/symbols/package.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/symbols/package.scala
@@ -32,6 +32,7 @@ package object symbols {
   val CTPoint: PointType = PointType.instance
   val CTGeometry: GeometryType = GeometryType.instance
   val CTPath: PathType = PathType.instance
+  val CTGraphlet: GraphletType = GraphletType.instance
   def CTList(inner: CypherType): ListType = ListType(inner)
 
   implicit def invariantTypeSpec(that: CypherType): TypeSpec = that.invariant

--- a/community/cypher/frontend-3.3/src/test/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/PatternComprehensionTest.scala
+++ b/community/cypher/frontend-3.3/src/test/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/PatternComprehensionTest.scala
@@ -56,8 +56,7 @@ class PatternComprehensionTest extends CypherFunSuite with AstConstructionTestSu
 
     val result = expression.semanticCheck(Expression.SemanticContext.Simple)(SemanticState.clean)
 
-    val errors: Seq[SemanticError] = result.errors
-    errors shouldBe Seq(SemanticError("Variable `missing` not defined", pos))
+    result.errors shouldBe Seq(SemanticError("Variable `missing` not defined", pos))
   }
 
   test("inner filter using missing identifier reports error") {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MultipleGraphsAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MultipleGraphsAcceptanceTest.scala
@@ -54,4 +54,20 @@ class MultipleGraphsAcceptanceTest extends ExecutionEngineFunSuite with NewPlann
       executeWithAllPlanners(query)
     }
   }
+
+  test("matching single graphlet") {
+    val query = "MATCH g := (:A)-->(:B) RETURN g"
+
+    a [SyntaxException] shouldBe thrownBy {
+      executeWithAllPlanners(query)
+    }
+  }
+
+  test("matching multi-pattern graphlet") {
+    val query = "MATCH g := (:A)-->(:B), (:C)-[:T]-(:D) RETURN g"
+
+    a [SyntaxException] shouldBe thrownBy {
+      executeWithAllPlanners(query)
+    }
+  }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MultipleGraphsAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MultipleGraphsAcceptanceTest.scala
@@ -21,7 +21,7 @@ package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport, SyntaxException}
 
-class OpenCypherAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
+class MultipleGraphsAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
 
   test("load graph") {
     val query = "LOAD GRAPH 'test' RETURN 1"
@@ -33,6 +33,22 @@ class OpenCypherAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTe
 
   test("emit graph") {
     val query = "MATCH ()--() EMIT GRAPH 'test' RETURN *"
+
+    a[SyntaxException] shouldBe thrownBy {
+      executeWithAllPlanners(query)
+    }
+  }
+
+  test("return named graph") {
+    val query = "MATCH ()--() RETURN GRAPH 'test'"
+
+    a[SyntaxException] shouldBe thrownBy {
+      executeWithAllPlanners(query)
+    }
+  }
+
+  test("return anonymous graph") {
+    val query = "MATCH ()--() RETURN GRAPH"
 
     a[SyntaxException] shouldBe thrownBy {
       executeWithAllPlanners(query)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SemanticErrorAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SemanticErrorAcceptanceTest.scala
@@ -40,6 +40,20 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
     )
   }
 
+  test("return named graph should generate error") {
+    executeAndEnsureError(
+      "MATCH ()--() RETURN GRAPH 'test'",
+      "The referenced clause RETURN GRAPH is not supported by Neo4j (line 1, column 27 (offset: 26))"
+    )
+  }
+
+  test("return anonymous graph should generate error") {
+    executeAndEnsureError(
+      "MATCH ()--() RETURN GRAPH",
+      "The referenced clause RETURN GRAPH is not supported by Neo4j (line 1, column 26 (offset: 25))"
+    )
+  }
+
   test("return node that's not there") {
     executeAndEnsureError(
       "match (n) where id(n) = 0 return bar",

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SemanticErrorAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SemanticErrorAcceptanceTest.scala
@@ -54,6 +54,20 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
     )
   }
 
+  test("Matching graphlets") {
+    executeAndEnsureError(
+      "MATCH g := (:A)-->(:B) RETURN g",
+      "Graphlet patterns are not supported by Neo4j (line 1, column 7 (offset: 6))"
+    )
+  }
+
+  test("Matching disconnected graphlet") {
+    executeAndEnsureError(
+      "MATCH g := (:A)-->(:B), (:C)-[:T]-(:D) RETURN g",
+      "Graphlet patterns are not supported by Neo4j (line 1, column 7 (offset: 6))"
+    )
+  }
+
   test("return node that's not there") {
     executeAndEnsureError(
       "match (n) where id(n) = 0 return bar",

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SemanticErrorAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SemanticErrorAcceptanceTest.scala
@@ -29,14 +29,14 @@ class SemanticErrorAcceptanceTest extends ExecutionEngineFunSuite {
   test("load graph should generate error") {
     executeAndEnsureError(
       "LOAD GRAPH 'test' RETURN 1",
-      "LOAD GRAPH is not supported by Neo4j (line 1, column 12 (offset: 11))"
+      "The referenced clause LOAD GRAPH is not supported by Neo4j (line 1, column 12 (offset: 11))"
     )
   }
 
   test("emit graph should generate error") {
     executeAndEnsureError(
       "MATCH ()--() EMIT GRAPH 'test' RETURN *",
-      "EMIT GRAPH is not supported by Neo4j (line 1, column 25 (offset: 24))"
+      "The referenced clause EMIT GRAPH is not supported by Neo4j (line 1, column 25 (offset: 24))"
     )
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SyntaxExceptionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SyntaxExceptionAcceptanceTest.scala
@@ -153,7 +153,7 @@ class SyntaxExceptionAcceptanceTest extends ExecutionEngineFunSuite {
   test("should raise error when missing return columns") {
     test(
       "match (s) return",
-      "Unexpected end of input: expected whitespace, DISTINCT, '*' or an expression (line 1, column 17)"
+      "Unexpected end of input: expected whitespace, GRAPH, DISTINCT, '*' or an expression (line 1, column 17)"
     )
   }
 


### PR DESCRIPTION
Also makes using these preliminary Cypher constructs generate a different type of error, in order for another implementation to separate them properly.