### PR TITLE
Optional lookup filter for number queries

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyAndNodeIndexedCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/PropertyAndNodeIndexedCheck.java
@@ -242,8 +242,8 @@ public class PropertyAndNodeIndexedCheck implements RecordCheck<NodeRecord, Cons
                     Arrays.toString( query ) ), e );
         }
 
-        indexedNodeIds = LookupFilter.exactIndexMatches( propertyReader, indexedNodeIds, query );
-        return indexedNodeIds;
+        return reader.hasFullNumberPrecision()
+                ? indexedNodeIds : LookupFilter.exactIndexMatches( propertyReader, indexedNodeIds, query );
     }
 
     private static boolean nodeHasSchemaProperties(

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/DelegatingIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/DelegatingIndexReader.java
@@ -59,6 +59,12 @@ public class DelegatingIndexReader implements IndexReader
     }
 
     @Override
+    public boolean hasFullNumberPrecision()
+    {
+        return delegate.hasFullNumberPrecision();
+    }
+
+    @Override
     public String toString()
     {
         return delegate.toString();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LookupFilter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LookupFilter.java
@@ -91,10 +91,16 @@ public class LookupFilter
     }
 
     /**
+     * This filter is added on top of index results for schema index implementations that will have
+     * potential false positive hits due to value coersion to double values.
+     * The given {@code indexedNodeIds} will be wrapped in a filter double-checking with the actual
+     * node property values iff the {@link IndexQuery} predicates query for numbers, i.e. where this
+     * coersion problem may be possible.
+     *
      * used in "normal" operation
      */
     public static PrimitiveLongIterator exactIndexMatches( EntityOperations operations, KernelStatement state,
-                                                           PrimitiveLongIterator indexedNodeIds, IndexQuery... predicates )
+            PrimitiveLongIterator indexedNodeIds, IndexQuery... predicates )
     {
         if ( !indexedNodeIds.hasNext() )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -828,7 +828,8 @@ public class StateHandlingStatementOperations implements
          * a fresh reader that isn't associated with the current transaction and hence will not be
          * automatically closed. */
         PrimitiveLongResourceIterator committed = resourceIterator( reader.query( query ), reader );
-        PrimitiveLongIterator exactMatches = LookupFilter.exactIndexMatches( this, state, committed, query );
+        PrimitiveLongIterator exactMatches = reader.hasFullNumberPrecision()
+                ? committed : LookupFilter.exactIndexMatches( this, state, committed, query );
         PrimitiveLongIterator changesFiltered =
                 filterIndexStateChangesForSeek( state, exactMatches, index, OrderedPropertyValues.of( query ) );
         return single( resourceIterator( changesFiltered, committed ), NO_SUCH_NODE );
@@ -841,7 +842,8 @@ public class StateHandlingStatementOperations implements
         StorageStatement storeStatement = state.getStoreStatement();
         IndexReader reader = storeStatement.getIndexReader( index );
         PrimitiveLongIterator committed = reader.query( predicates );
-        PrimitiveLongIterator exactMatches = LookupFilter.exactIndexMatches( this, state, committed, predicates );
+        PrimitiveLongIterator exactMatches = reader.hasFullNumberPrecision()
+                ? committed : LookupFilter.exactIndexMatches( this, state, committed, predicates );
 
         IndexQuery firstPredicate = predicates[0];
         switch ( firstPredicate.type() )

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/IndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/IndexReader.java
@@ -50,6 +50,15 @@ public interface IndexReader extends Resource
      */
     PrimitiveLongIterator query( IndexQuery... predicates ) throws IndexNotApplicableKernelException;
 
+    /**
+     * @return whether or not this reader will only return 100% matching results from {@link #query(IndexQuery...)}
+     * when calling with predicates involving numbers, such as {@link IndexQuery#exact(int, Object)}
+     * w/ a {@link Number} or {@link IndexQuery#range(int, Number, boolean, Number, boolean)}.
+     * If {@code false} is returned this means that the caller of {@link #query(IndexQuery...)} will have to
+     * do additional filtering, double-checking of actual property values, externally.
+     */
+    boolean hasFullNumberPrecision();
+
     IndexReader EMPTY = new IndexReader()
     {
         // Used for checking index correctness
@@ -74,6 +83,12 @@ public interface IndexReader extends Resource
         @Override
         public void close()
         {
+        }
+
+        @Override
+        public boolean hasFullNumberPrecision()
+        {
+            return true;
         }
     };
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/HashBasedIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/HashBasedIndex.java
@@ -291,7 +291,7 @@ class HashBasedIndex extends InMemoryIndexImplementation
     @Override
     public boolean hasFullNumberPrecision()
     {
-        return true;
+        return false;
     }
 
     private interface StringFilter

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/HashBasedIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/HashBasedIndex.java
@@ -288,6 +288,12 @@ class HashBasedIndex extends InMemoryIndexImplementation
         }
     }
 
+    @Override
+    public boolean hasFullNumberPrecision()
+    {
+        return true;
+    }
+
     private interface StringFilter
     {
         boolean test( String s );

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/reader/PartitionedIndexReader.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/reader/PartitionedIndexReader.java
@@ -77,6 +77,12 @@ public class PartitionedIndexReader implements IndexReader
         }
     }
 
+    @Override
+    public boolean hasFullNumberPrecision()
+    {
+        return false;
+    }
+
     private PrimitiveLongIterator innerQuery( IndexReader reader, IndexQuery[] predicates )
     {
         try

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/reader/SimpleIndexReader.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/reader/SimpleIndexReader.java
@@ -56,10 +56,10 @@ import static org.neo4j.kernel.api.schema.index.IndexDescriptor.Type.UNIQUE;
  */
 public class SimpleIndexReader implements IndexReader
 {
-    private PartitionSearcher partitionSearcher;
-    private IndexDescriptor descriptor;
+    private final PartitionSearcher partitionSearcher;
+    private final IndexDescriptor descriptor;
     private final IndexSamplingConfig samplingConfig;
-    private TaskCoordinator taskCoordinator;
+    private final TaskCoordinator taskCoordinator;
 
     public SimpleIndexReader( PartitionSearcher partitionSearcher,
             IndexDescriptor descriptor,
@@ -135,6 +135,12 @@ public class SimpleIndexReader implements IndexReader
             // todo figure out a more specific exception
             throw new RuntimeException( "Index query not supported: " + Arrays.toString( predicates ) );
         }
+    }
+
+    @Override
+    public boolean hasFullNumberPrecision()
+    {
+        return false;
     }
 
     private void assertNotComposite( IndexQuery[] predicates )


### PR DESCRIPTION
Until now index number query results have needed double-checking w/ store
comparing actual values, due to the way Lucene schema index indexes numbers.

iThe native schema index doesn't need this and so it would be unnecessary
to have this filtering when using the native schema index.
Now IndexReader has a new method #hasFullNumberPrecision() which decides
whether or not number index query results must be filtered outside the index.