### PR TITLE
Refactored several Functional Interfaces to the Specialized Primitive Functional Interfaces

### DIFF
--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/TermsTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/TermsTest.java
@@ -22,7 +22,7 @@ package org.neo4j.causalclustering.core.consensus.log.segmented;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
-import java.util.function.Function;
+import java.util.function.LongUnaryOperator;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -500,11 +500,11 @@ public class TermsTest
         assertTermInRange( from, to, ( index ) -> expectedTerm );
     }
 
-    private void assertTermInRange( long from, long to, Function<Long,Long> expectedTermFunction )
+    private void assertTermInRange( long from, long to, LongUnaryOperator expectedTermFunction )
     {
         for ( long index = from; index < to; index++ )
         {
-            assertEquals( "For index: " + index, (long) expectedTermFunction.apply( index ), terms.get( index ) );
+            assertEquals( "For index: " + index, (long) expectedTermFunction.applyAsLong( index ), terms.get( index ) );
         }
     }
 
@@ -513,11 +513,11 @@ public class TermsTest
         appendRange( from, to, ( index ) -> term );
     }
 
-    private void appendRange( long from, long to, Function<Long,Long> termFunction )
+    private void appendRange( long from, long to, LongUnaryOperator termFunction )
     {
         for ( long index = from; index < to; index++ )
         {
-            terms.append( index, termFunction.apply( index ) );
+            terms.append( index, termFunction.applyAsLong( index ) );
         }
     }
 }

--- a/enterprise/cypher/spec-suite-tools/src/main/java/cypher/feature/parser/matchers/ListMatcher.java
+++ b/enterprise/cypher/spec-suite-tools/src/main/java/cypher/feature/parser/matchers/ListMatcher.java
@@ -21,7 +21,7 @@ package cypher.feature.parser.matchers;
 
 import java.lang.reflect.Array;
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.IntFunction;
 
 public class ListMatcher implements ValueMatcher
 {
@@ -51,7 +51,7 @@ public class ListMatcher implements ValueMatcher
         return false;
     }
 
-    protected boolean sizeAndElements( int length, Function<Integer,Object> resultList )
+    protected boolean sizeAndElements( int length, IntFunction<Object> resultList )
     {
         if ( list.size() == length )
         {

--- a/enterprise/cypher/spec-suite-tools/src/main/java/cypher/feature/parser/matchers/UnorderedListMatcher.java
+++ b/enterprise/cypher/spec-suite-tools/src/main/java/cypher/feature/parser/matchers/UnorderedListMatcher.java
@@ -21,7 +21,7 @@ package cypher.feature.parser.matchers;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.IntFunction;
 
 public class UnorderedListMatcher extends ListMatcher
 {
@@ -31,7 +31,7 @@ public class UnorderedListMatcher extends ListMatcher
     }
 
     @Override
-    protected boolean sizeAndElements( int length, Function<Integer,Object> resultList )
+    protected boolean sizeAndElements( int length, IntFunction<Object> resultList )
     {
         if ( list.size() == length )
         {


### PR DESCRIPTION
Hello,

I am a graduate student at Oregon State University and as a part of my research and subject CS562 Applied Software Engineering project (Study and Refactoring of Functional Interface in Java), I have done various refactoring of the functional interface namely:

> Function<Long,Long> --> LongUnaryOperator

> Function<Integer,Object> --> IntFunction

> Function<Object,Integer> --> ToIntFunction

My project and research deals with the boxing and unboxing of Wrapper Class and the primitive data-types. I want to know that whether the open source community is ready to accept these micro-optimizing refactoring or not.

In the file `TermsTest`,  the Function<Long,Long> is consumed as primitive **long** in the line

> **terms.append( index, termFunction.apply( index ) )** 

and so, Java compiler has to autobox **Long to long**. But using LongUnaryOperator, Java compiler does not have to autobox and because of that we can get better performance results. 

Thank you,
Harshraj Thakor