### PR TITLE
NativeLabelScanReader supports multiple open iterators

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIterator.java
@@ -62,7 +62,14 @@ class LabelScanValueIterator extends PrimitiveLongCollections.PrimitiveLongBaseI
      */
     private long prevRange = -1;
 
+    /**
+     * Remove provided cursor from this collection when iterator is exhausted.
+     */
     private final Collection<RawCursor<Hit<LabelScanKey,LabelScanValue>,IOException>> toRemoveFromWhenExhausted;
+
+    /**
+     * Indicate provided cursor has been closed.
+     */
     private boolean closed;
 
     LabelScanValueIterator( RawCursor<Hit<LabelScanKey,LabelScanValue>,IOException> cursor,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanReader.java
@@ -135,13 +135,10 @@ class NativeLabelScanReader implements LabelScanReader
 
     private void ensureOpenCursorsClosed() throws IOException
     {
-        if ( !openCursors.isEmpty() )
+        for ( RawCursor<Hit<LabelScanKey,LabelScanValue>,IOException> cursor : openCursors )
         {
-            for ( RawCursor<Hit<LabelScanKey,LabelScanValue>,IOException> cursor : openCursors )
-            {
-                cursor.close();
-            }
-            openCursors.clear();
+            cursor.close();
         }
+        openCursors.clear();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIteratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIteratorTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.labelscan;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashSet;
+
+import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.cursor.RawCursor;
+import org.neo4j.index.internal.gbptree.Hit;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class LabelScanValueIteratorTest
+{
+    @Test
+    public void shouldCloseExhaustedCursors() throws Exception
+    {
+        // GIVEN
+        RawCursor<Hit<LabelScanKey,LabelScanValue>,IOException> cursor = mock( RawCursor.class );
+        when( cursor.next() ).thenReturn( false );
+        Collection<RawCursor<Hit<LabelScanKey,LabelScanValue>,IOException>> toRemoveFrom = new HashSet<>();
+        LabelScanValueIterator iterator = new LabelScanValueIterator( cursor, toRemoveFrom );
+        verify( cursor, times( 0 ) ).close();
+
+        // WHEN
+        exhaust( iterator );
+        verify( cursor, times( 1 ) ).close();
+
+        // retrying to get more items from the first one should not close it again
+        iterator.hasNext();
+        verify( cursor, times( 1 ) ).close();
+    }
+
+    private void exhaust( PrimitiveLongIterator iterator )
+    {
+        while ( iterator.hasNext() )
+        {
+            iterator.next();
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIteratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIteratorTest.java
@@ -29,6 +29,7 @@ import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.cursor.RawCursor;
 import org.neo4j.index.internal.gbptree.Hit;
 
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -53,6 +54,9 @@ public class LabelScanValueIteratorTest
         // retrying to get more items from the first one should not close it again
         iterator.hasNext();
         verify( cursor, times( 1 ) ).close();
+
+        // and set should be empty
+        assertTrue( toRemoveFrom.isEmpty() );
     }
 
     private void exhaust( PrimitiveLongIterator iterator )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanWriterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanWriterTest.java
@@ -23,6 +23,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -38,9 +39,11 @@ import org.neo4j.index.internal.gbptree.Writer;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 import org.neo4j.test.rule.RandomRule;
 
-import static java.lang.Integer.max;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
+
+import static java.lang.Integer.max;
+
 import static org.neo4j.collection.primitive.PrimitiveLongCollections.EMPTY_LONG_ARRAY;
 import static org.neo4j.collection.primitive.PrimitiveLongCollections.asArray;
 import static org.neo4j.kernel.impl.index.labelscan.NativeLabelScanStoreIT.flipRandom;
@@ -78,7 +81,7 @@ public class NativeLabelScanWriterTest
         for ( int i = 0; i < LABEL_COUNT; i++ )
         {
             long[] expectedNodeIds = nodesWithLabel( expected, i );
-            long[] actualNodeIds = asArray( new LabelScanValueIterator( inserter.nodesFor( i ) ) );
+            long[] actualNodeIds = asArray( new LabelScanValueIterator( inserter.nodesFor( i ), new ArrayList<>() ) );
             assertArrayEquals( "For label " + i, expectedNodeIds, actualNodeIds );
         }
     }


### PR DESCRIPTION
previously opening a new iterator closed the previous, because that's
how the API was interpreted to work. New use cases would benefit from
multiple concurrent iterators opened, so this commit adds that.