### PR TITLE
Optional match in compiled runtime now check that nodes exists.

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -97,6 +97,23 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     }
   }
 
+  test("should handle optional match of none existant path.") {
+
+    val n = createLabeledNode("Client")
+
+    val query =
+      """
+        | MATCH (n:Client)
+        | OPTIONAL MATCH (n)-[rel1:relType]->(n1:label)
+        | OPTIONAL MATCH (n1)-[rel2:relType2]->(n2:label2)
+        | RETURN n, rel1, n1, rel2, n2;
+        |""".stripMargin
+
+    val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode(query)
+
+    result.toList should equal(List(Map("n" -> n, "rel1" -> null, "rel2" -> null, "n1" -> null, "n2" -> null)))
+  }
+
   test("should handle optional paths from graph algo") {
     val a = createNode("A")
     val b = createNode("B")

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/HasLabel.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/ir/expressions/HasLabel.scala
@@ -34,12 +34,16 @@ case class HasLabel(nodeVariable: Variable, labelVariable: String, labelName: St
     structure.declarePredicate(localName)
 
     structure.incrementDbHits()
-    if (nodeVariable.nullable)
-      structure.nullableReference(nodeVariable.name, CodeGenType.primitiveNode,
-                                  structure.box(
-                                    structure.hasLabel(nodeVariable.name, labelVariable, localName), CodeGenType.primitiveBool))
+    if (nodeVariable.nullable) {
+      structure.ifNotStatement(structure.equalityExpression(structure.loadVariable(nodeVariable.name),
+        structure.constantExpression(Long.box(-1L)),
+        CodeGenType.primitiveInt)){ inner =>
+        inner.hasLabel(nodeVariable.name, labelVariable, localName)
+      }
+    }
     else
       structure.hasLabel(nodeVariable.name, labelVariable, localName)
+    structure.loadVariable(localName)
   }
 
   override def nullable(implicit context: CodeGenContext) = nodeVariable.nullable

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
@@ -141,7 +141,7 @@ trait MethodStructure[E] {
 
   // db access
   def labelScan(iterVar: String, labelIdVar: String): Unit
-  def hasLabel(nodeVar: String, labelVar: String, predVar: String): E
+  def hasLabel(nodeVar: String, labelVar: String, predVar: String): Unit
   def allNodesScan(iterVar: String): Unit
   def lookupLabelId(labelIdVar: String, labelName: String): Unit
   def lookupLabelIdE(labelName: String): E

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -1270,7 +1270,6 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
     handleKernelExceptions(generator, fields.ro, _finalizers) { inner =>
       val invoke = Expression.invoke(readOperations, nodeHasLabel, inner.load(nodeVar), inner.load(labelVar))
       inner.assign(local, invoke)
-      generator.load(predVar)
     }
   }
 


### PR DESCRIPTION
changelog: Optional match in compiled runtime now checks that nodes exist before checking the label.