### PR TITLE
Consistency checker now check label scan store for missing entries

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyCheckTasks.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyCheckTasks.java
@@ -175,9 +175,10 @@ public class ConsistencyCheckTasks
         ConsistencyReporter filteredReporter = multiPass.reporter( NODES );
         if ( checkLabelScanStore )
         {
+            long highId = nativeStores.getNodeStore().getHighId();
             tasks.add( recordScanner( "LabelScanStore",
-                    labelScanStore.allNodeLabelRanges(), new LabelScanDocumentProcessor(
-                            filteredReporter, new LabelScanCheck() ), Stage.SEQUENTIAL_FORWARD,
+                    new GapFreeAllEntriesLabelScanReader( labelScanStore.allNodeLabelRanges(), highId ),
+                    new LabelScanDocumentProcessor( filteredReporter, new LabelScanCheck() ), Stage.SEQUENTIAL_FORWARD,
                     ROUND_ROBIN ) );
         }
         if ( checkIndexes )

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/GapFreeAllEntriesLabelScanReader.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/GapFreeAllEntriesLabelScanReader.java
@@ -66,10 +66,10 @@ class GapFreeAllEntriesLabelScanReader implements AllEntriesLabelScanReader
         private int currentId;
         private boolean first;
 
-        GapFillingIterator( Iterator<NodeLabelRange> iterator, long highId )
+        GapFillingIterator( Iterator<NodeLabelRange> nodeLableRangeIterator, long highId )
         {
             this.highId = highId;
-            this.source = iterator;
+            this.source = nodeLableRangeIterator;
             this.first = true;
         }
 
@@ -84,6 +84,7 @@ class GapFreeAllEntriesLabelScanReader implements AllEntriesLabelScanReader
             int cursor = 0;
             for ( ; cursor < batchSize; cursor++, currentId++ )
             {
+                // First or empty source
                 if ( first || (sourceNodeIds != null && sourceIndex >= sourceNodeIds.length) )
                 {
                     first = false;

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/GapFreeAllEntriesLabelScanReader.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/GapFreeAllEntriesLabelScanReader.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.consistency.checking.full;
+
+import java.util.Iterator;
+
+import org.neo4j.helpers.collection.PrefetchingIterator;
+import org.neo4j.kernel.api.labelscan.AllEntriesLabelScanReader;
+import org.neo4j.kernel.api.labelscan.NodeLabelRange;
+
+class GapFreeAllEntriesLabelScanReader implements AllEntriesLabelScanReader
+{
+    private final AllEntriesLabelScanReader nodeLabelRanges;
+    private final long highId;
+
+    GapFreeAllEntriesLabelScanReader( AllEntriesLabelScanReader nodeLabelRanges, long highId )
+    {
+        this.nodeLabelRanges = nodeLabelRanges;
+        this.highId = highId;
+    }
+
+    @Override
+    public long maxCount()
+    {
+        return nodeLabelRanges.maxCount();
+    }
+
+    @Override
+    public void close() throws Exception
+    {
+        nodeLabelRanges.close();
+    }
+
+    @Override
+    public Iterator<NodeLabelRange> iterator()
+    {
+        return new GapFillingIterator( nodeLabelRanges.iterator(), highId );
+    }
+
+    private static class GapFillingIterator extends PrefetchingIterator<NodeLabelRange>
+    {
+        private static final int BATCH_SIZE = 1_000;
+        private static final long[] EMPTY_LONG_ARRAY = new long[0];
+        private final long highId;
+        private Iterator<NodeLabelRange> source;
+        private NodeLabelRange nextFromSource;
+        private long[] sourceNodeIds;
+        private int sourceIndex;
+        private int currentId;
+        private boolean first;
+
+        GapFillingIterator( Iterator<NodeLabelRange> iterator, long highId )
+        {
+            this.highId = highId;
+            this.source = iterator;
+            this.first = true;
+        }
+
+        @Override
+        protected NodeLabelRange fetchNextOrNull()
+        {
+            long baseId = currentId;
+            int batchSize = BATCH_SIZE;
+            long[] nodes = new long[batchSize];
+            long[][] labels = new long[batchSize][];
+
+            int cursor = 0;
+            for ( ; cursor < batchSize; cursor++, currentId++ )
+            {
+                if ( first || (sourceNodeIds != null && sourceIndex >= sourceNodeIds.length) )
+                {
+                    first = false;
+                    if ( source.hasNext() )
+                    {
+                        nextFromSource = source.next();
+                        sourceNodeIds = nextFromSource.nodes();
+                        sourceIndex = 0;
+                    }
+                    else
+                    {
+                        nextFromSource = null;
+                        sourceNodeIds = null;
+                    }
+                }
+
+                if ( currentId >= highId && sourceNodeIds == null )
+                {
+                    break;
+                }
+
+                nodes[cursor] = currentId;
+                if ( sourceNodeIds != null && sourceNodeIds[sourceIndex] == currentId )
+                {
+                    labels[cursor] = nextFromSource.labels( currentId );
+                    sourceIndex++;
+                }
+                else
+                {
+                    labels[cursor] = EMPTY_LONG_ARRAY;
+                }
+            }
+            return cursor > 0 ? new SimpleNodeLabelRange( baseId, nodes, labels ) : null;
+        }
+
+        private static class SimpleNodeLabelRange extends NodeLabelRange
+        {
+            private final long baseId;
+            private final long[] nodes;
+            private final long[][] labels;
+
+            SimpleNodeLabelRange( long baseId, long[] nodes, long[][] labels )
+            {
+                this.baseId = baseId;
+                this.nodes = nodes;
+                this.labels = labels;
+            }
+
+            @Override
+            public int id()
+            {
+                return (int) baseId;
+            }
+
+            @Override
+            public long[] nodes()
+            {
+                return nodes;
+            }
+
+            @Override
+            public long[] labels( long nodeId )
+            {
+                return labels[(int) (nodeId - baseId)];
+            }
+
+            @Override
+            public String toString()
+            {
+                String rangeString = baseId + "-" + (baseId + nodes.length);
+                String prefix = "NodeLabelRange[idRange=" + rangeString;
+                return toString( prefix, nodes, labels );
+            }
+        }
+    }
+}

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/NodeInUseWithCorrectLabelsCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/NodeInUseWithCorrectLabelsCheck.java
@@ -84,7 +84,7 @@ public class NodeInUseWithCorrectLabelsCheck
                 validateLabelIds( nodeRecord, storeLabels, report );
             }
         }
-        else
+        else if ( indexLabels.length != 0 )
         {
             engine.report().nodeNotInUse( nodeRecord );
         }

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/AllNodesInStoreExistInLabelIndexTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/AllNodesInStoreExistInLabelIndexTest.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.consistency.checking;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.neo4j.consistency.ConsistencyCheckService;
+import org.neo4j.consistency.checking.full.CheckConsistencyConfig;
+import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.helpers.collection.Pair;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.index.labelscan.NativeLabelScanStore;
+import org.neo4j.logging.AssertableLogProvider;
+import org.neo4j.test.rule.DatabaseRule;
+import org.neo4j.test.rule.EmbeddedDatabaseRule;
+import org.neo4j.test.rule.RandomRule;
+import org.neo4j.test.rule.TestDirectory;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.helpers.progress.ProgressMonitorFactory.NONE;
+import static org.neo4j.test.TestLabels.LABEL_ONE;
+import static org.neo4j.test.TestLabels.LABEL_THREE;
+import static org.neo4j.test.TestLabels.LABEL_TWO;
+
+public class AllNodesInStoreExistInLabelIndexTest
+{
+    @ClassRule
+    public static final TestDirectory dir = TestDirectory.testDirectory();
+
+    @Rule
+    public final DatabaseRule db = new EmbeddedDatabaseRule( dir.absolutePath() );
+
+    @Rule
+    public final RandomRule random = new RandomRule();
+
+    private final AssertableLogProvider log = new AssertableLogProvider();
+    private static final Label[] LABEL_ALPHABET = new Label[]{LABEL_ONE, LABEL_TWO, LABEL_THREE};
+    private static final Label EXTRA_LABEL = Label.label( "extra" );
+    private static final double DELETE_RATIO = 0.2;
+    private static final double UPDATE_RATIO = 0.2;
+    private static final int NODE_COUNT_BASELINE = 10;
+
+    //    @RandomRule.Seed( 1497348748034L )
+    @Test
+    public void mustReportSuccessfulForConsistentLabelScanStore() throws Exception
+    {
+        // given
+        someData();
+        db.shutdownAndKeepStore();
+
+        // when
+        ConsistencyCheckService.Result result = fullConsistencyCheck();
+
+        // then
+        assertTrue( "Expected consistency check to succeed", result.isSuccessful() );
+    }
+
+    @Test
+    public void mustReportMissingNode() throws Exception
+    {
+        // given
+        someData();
+        File labelIndexFileCopy = copyLabelIndexFile();
+
+        // when
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.createNode( LABEL_ONE );
+            tx.success();
+        }
+
+        // and
+        replaceLabelIndexWithCopy( labelIndexFileCopy );
+        db.shutdownAndKeepStore();
+
+        // then
+        ConsistencyCheckService.Result result = fullConsistencyCheck();
+        assertFalse( "Expected consistency check to fail", result.isSuccessful() );
+    }
+
+    @Test
+    public void mustReportMissingLabel() throws Exception
+    {
+        // given
+        List<Pair<Long,Label[]>> nodesInStore = someData();
+        File labelIndexFileCopy = copyLabelIndexFile();
+
+        // when
+        try ( Transaction tx = db.beginTx() )
+        {
+            addLabelToExistingNode( nodesInStore );
+            tx.success();
+        }
+
+        // and
+        replaceLabelIndexWithCopy( labelIndexFileCopy );
+        db.shutdownAndKeepStore();
+
+        // then
+        ConsistencyCheckService.Result result = fullConsistencyCheck();
+        assertFalse( "Expected consistency check to fail", result.isSuccessful() );
+    }
+
+    @Test
+    public void mustReportExtraLabelsOnExistingNode() throws Exception
+    {
+        // given
+        List<Pair<Long,Label[]>> nodesInStore = someData();
+        File labelIndexFileCopy = copyLabelIndexFile();
+
+        // when
+        try ( Transaction tx = db.beginTx() )
+        {
+            removeLabelFromExistingNode( nodesInStore );
+            tx.success();
+        }
+
+        // and
+        replaceLabelIndexWithCopy( labelIndexFileCopy );
+        db.shutdownAndKeepStore();
+
+        // then
+        ConsistencyCheckService.Result result = fullConsistencyCheck();
+        assertFalse( "Expected consistency check to fail", result.isSuccessful() );
+    }
+
+    @Test
+    public void mustReportExtraNode() throws Exception
+    {
+        // given
+        List<Pair<Long,Label[]>> nodesInStore = someData();
+        File labelIndexFileCopy = copyLabelIndexFile();
+
+        // when
+        try ( Transaction tx = db.beginTx() )
+        {
+            removeExistingNode( nodesInStore );
+            tx.success();
+        }
+
+        // and
+        replaceLabelIndexWithCopy( labelIndexFileCopy );
+        db.shutdownAndKeepStore();
+
+        // then
+        ConsistencyCheckService.Result result = fullConsistencyCheck();
+        assertFalse( "Expected consistency check to fail", result.isSuccessful() );
+    }
+
+    // Do not remove this, very useful for debugging
+    private void printReport( ConsistencyCheckService.Result result )
+            throws IOException
+    {
+        try
+        {
+            FileInputStream fileInputStream = new FileInputStream( result.reportFile() );
+
+            BufferedReader bufferedReader = new BufferedReader( new InputStreamReader( fileInputStream ) );
+            String line;
+            while ( (line = bufferedReader.readLine()) != null )
+            {
+                System.out.println( line );
+            }
+        }
+        catch ( FileNotFoundException e )
+        {
+            // Fine dont print it then, just report
+            System.out
+                    .println( "FileNotFoundException, might just mean that consistency checker had nothing to report" );
+        }
+    }
+
+    private void removeExistingNode( List<Pair<Long,Label[]>> nodesInStore )
+    {
+        Node node;
+        Label[] labels;
+        do
+        {
+            int targetIndex = random.nextInt( nodesInStore.size() );
+            Pair<Long,Label[]> existingNode = nodesInStore.get( targetIndex );
+            node = db.getNodeById( existingNode.first() );
+            labels = existingNode.other();
+        }
+        while ( labels.length == 0 );
+        node.delete();
+    }
+
+    private void addLabelToExistingNode( List<Pair<Long,Label[]>> nodesInStore )
+    {
+        int targetIndex = random.nextInt( nodesInStore.size() );
+        Pair<Long,Label[]> existingNode = nodesInStore.get( targetIndex );
+        Node node = db.getNodeById( existingNode.first() );
+        node.addLabel( EXTRA_LABEL );
+    }
+
+    private void removeLabelFromExistingNode( List<Pair<Long,Label[]>> nodesInStore )
+    {
+        Pair<Long,Label[]> existingNode;
+        Node node;
+        do
+        {
+            int targetIndex = random.nextInt( nodesInStore.size() );
+            existingNode = nodesInStore.get( targetIndex );
+            node = db.getNodeById( existingNode.first() );
+        }
+        while ( existingNode.other().length == 0 );
+        node.removeLabel( existingNode.other()[0] );
+    }
+
+    private void replaceLabelIndexWithCopy( File labelIndexFileCopy ) throws IOException
+    {
+        db.restartDatabase( ( fs, directory ) ->
+        {
+            fs.deleteFile( dir.file( NativeLabelScanStore.FILE_NAME ) );
+            fs.copyFile( labelIndexFileCopy, dir.file( NativeLabelScanStore.FILE_NAME ) );
+        } );
+    }
+
+    private File copyLabelIndexFile() throws IOException
+    {
+        File labelIndexFileCopy = dir.file( "label_index_copy" );
+        db.restartDatabase( ( fs, directory ) ->
+                fs.copyFile( dir.file( NativeLabelScanStore.FILE_NAME ), labelIndexFileCopy ) );
+        return labelIndexFileCopy;
+    }
+
+    List<Pair<Long,Label[]>> someData()
+    {
+        return someData( 50 );
+    }
+
+    List<Pair<Long,Label[]>> someData( int numberOfModifications )
+    {
+        List<Pair<Long,Label[]>> existingNodes;
+        existingNodes = new ArrayList<>();
+        try ( Transaction tx = db.beginTx() )
+        {
+            randomModifications( existingNodes, numberOfModifications );
+            tx.success();
+        }
+        return existingNodes;
+    }
+
+    private List<Pair<Long,Label[]>> randomModifications( List<Pair<Long,Label[]>> existingNodes,
+            int numberOfModifications )
+    {
+        for ( int i = 0; i < numberOfModifications; i++ )
+        {
+            double selectModification = random.nextDouble();
+            if ( existingNodes.size() < NODE_COUNT_BASELINE || selectModification >= DELETE_RATIO + UPDATE_RATIO )
+            {
+                createNewNode( existingNodes );
+            }
+            else if ( selectModification < DELETE_RATIO )
+            {
+                deleteExistingNode( existingNodes );
+            }
+            else
+            {
+                modifyLabelsOnExistingNode( existingNodes );
+            }
+        }
+        return existingNodes;
+    }
+
+    private void createNewNode( List<Pair<Long,Label[]>> existingNodes )
+    {
+        Label[] labels = randomLabels();
+        Node node = db.createNode( labels );
+        existingNodes.add( Pair.of( node.getId(), labels ) );
+    }
+
+    private void modifyLabelsOnExistingNode( List<Pair<Long,Label[]>> existingNodes )
+    {
+        int targetIndex = random.nextInt( existingNodes.size() );
+        Pair<Long,Label[]> existingPair = existingNodes.get( targetIndex );
+        long nodeId = existingPair.first();
+        Node node = db.getNodeById( nodeId );
+        node.getLabels().forEach( node::removeLabel );
+        Label[] newLabels = randomLabels();
+        for ( Label label : newLabels )
+        {
+            node.addLabel( label );
+        }
+        existingNodes.remove( targetIndex );
+        existingNodes.add( Pair.of( nodeId, newLabels ) );
+    }
+
+    private void deleteExistingNode( List<Pair<Long,Label[]>> existingNodes )
+    {
+        int targetIndex = random.nextInt( existingNodes.size() );
+        Pair<Long,Label[]> existingPair = existingNodes.get( targetIndex );
+        Node node = db.getNodeById( existingPair.first() );
+        node.delete();
+        existingNodes.remove( targetIndex );
+    }
+
+    private Label[] randomLabels()
+    {
+        List<Label> labels = new ArrayList<>( 3 );
+        for ( Label label : LABEL_ALPHABET )
+        {
+            if ( random.nextBoolean() )
+            {
+                labels.add( label );
+            }
+        }
+        return labels.toArray( new Label[labels.size()] );
+    }
+
+    ConsistencyCheckService.Result fullConsistencyCheck()
+            throws ConsistencyCheckIncompleteException, IOException
+    {
+        try ( FileSystemAbstraction fsa = new DefaultFileSystemAbstraction() )
+        {
+            ConsistencyCheckService service = new ConsistencyCheckService();
+            Config config = Config.defaults();
+            return service.runFullConsistencyCheck( dir.absolutePath(), config, NONE, log, fsa, true,
+                    new CheckConsistencyConfig( config ) );
+        }
+    }
+}

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/NodeInUseWithCorrectLabelsCheckTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/NodeInUseWithCorrectLabelsCheckTest.java
@@ -51,13 +51,14 @@ public class NodeInUseWithCorrectLabelsCheckTest
     {
         // given
         int nodeId = 42;
+        long labelId = 7;
 
         ConsistencyReport.LabelScanConsistencyReport report =
                 mock( ConsistencyReport.LabelScanConsistencyReport.class );
         NodeRecord node = notInUse( new NodeRecord( nodeId, false, 0, 0 ) );
 
         // when
-        checker( new long[]{}, true ).checkReference( null, node, engineFor( report ), null );
+        checker( new long[]{labelId}, true ).checkReference( null, node, engineFor( report ), null );
 
         // then
         verify( report ).nodeNotInUse( node );

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/NodeLabelRange.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/labelscan/NodeLabelRange.java
@@ -19,11 +19,40 @@
  */
 package org.neo4j.kernel.api.labelscan;
 
-public interface NodeLabelRange
+public abstract class NodeLabelRange
 {
-    int id();
+    public abstract int id();
 
-    long[] nodes();
+    public abstract long[] nodes();
 
-    long[] labels( long nodeId );
+    public abstract long[] labels( long nodeId );
+
+    public String toString( String prefix, long[] nodes, long[][] labels )
+    {
+        StringBuilder result = new StringBuilder( prefix );
+        result.append( "; {" );
+        for ( int i = 0; i < nodes.length; i++ )
+        {
+            if ( i != 0 )
+            {
+                result.append( ", " );
+            }
+            result.append( "Node[" ).append( nodes[i] ).append( "]: Labels[" );
+            String sep = "";
+            if ( labels[i] != null )
+            {
+                for ( long labelId : labels[i] )
+                {
+                    result.append( sep ).append( labelId );
+                    sep = ", ";
+                }
+            }
+            else
+            {
+                result.append( "null" );
+            }
+            result.append( "]" );
+        }
+        return result.append( "}]" ).toString();
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeAllEntriesLabelScanReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeAllEntriesLabelScanReader.java
@@ -206,7 +206,7 @@ class NativeAllEntriesLabelScanReader implements AllEntriesLabelScanReader
         }
     }
 
-    private static class NativeNodeLabelRange implements NodeLabelRange
+    private static class NativeNodeLabelRange extends NodeLabelRange
     {
         private final long idRange;
         private final long[] nodes;
@@ -253,30 +253,9 @@ class NativeAllEntriesLabelScanReader implements AllEntriesLabelScanReader
         @Override
         public String toString()
         {
-            long lowRange = idRange * RANGE_SIZE;
-            long highRange = (idRange + 1) * RANGE_SIZE;
-            String rangeString = lowRange + "-" + highRange;
-            StringBuilder result = new StringBuilder( "NodeLabelRange[idRange=" ).append( rangeString );
-            result.append( "; {" );
-            for ( int i = 0; i < nodes.length; i++ )
-            {
-                if ( i != 0 )
-                {
-                    result.append( ", " );
-                }
-                result.append( "Node[" ).append( nodes[i] ).append( "]: Labels[" );
-                String sep = "";
-                if ( labels[i] != null )
-                {
-                    for ( long labelId : labels[i] )
-                    {
-                        result.append( sep ).append( labelId );
-                        sep = ", ";
-                    }
-                }
-                result.append( "]" );
-            }
-            return result.append( "}]" ).toString();
+            String rangeString = idRange * RANGE_SIZE + "-" + (idRange + 1) * RANGE_SIZE;
+            String prefix = "NodeLabelRange[idRange=" + rangeString;
+            return toString( prefix, nodes, labels );
         }
     }
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/LuceneNodeLabelRange.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/labelscan/LuceneNodeLabelRange.java
@@ -28,7 +28,7 @@ import java.util.Set;
 import org.neo4j.kernel.api.labelscan.NodeLabelRange;
 
 
-public class LuceneNodeLabelRange implements NodeLabelRange
+public class LuceneNodeLabelRange extends NodeLabelRange
 {
     private final int id;
     private final long[] nodeIds;
@@ -44,24 +44,8 @@ public class LuceneNodeLabelRange implements NodeLabelRange
     @Override
     public String toString()
     {
-        StringBuilder result = new StringBuilder( "NodeLabelRange[docId=" ).append( id );
-        result.append( "; {" );
-        for ( int i = 0; i < nodeIds.length; i++ )
-        {
-            if ( i != 0 )
-            {
-                result.append( ", " );
-            }
-            result.append( "Node[" ).append( nodeIds[i] ).append( "]: Labels[" );
-            String sep = "";
-            for ( long labelId : labelIds[i] )
-            {
-                result.append( sep ).append( labelId );
-                sep = ", ";
-            }
-            result.append( "]" );
-        }
-        return result.append( "}]" ).toString();
+        String prefix = "NodeLabelRange[docId=" + id;
+        return toString( prefix, nodeIds, labelIds );
     }
 
     @Override


### PR DESCRIPTION
Previously, it was only verified that everything in label scan store
was consistent with the real store. It was never checked that
everything in real store was actually in the label scan store.

Verification is done by iterating over all entries in label scan store
and verify content with the store. If some node in the store was not
present in the label index, this would not be reported because this
node would never show up in the iteration over the label scan store.

Now, we wrap the label scan store iterator with a 
`GapFreeAllEntriesLabelScanReader` that produce "node with no labels"
records for all the gaps in the label scan index. So for example if
label scan index contain node 1, 2 and 3 with labels [1,2], [1] and [2] 
respectively, written as: `{[1:1,2],[3:1],[5:2]}`. The gap filling wrapper
will produce a view over the label scan index that also contain node
2 and 4 with no labels: `{[1:1,2],[2:_],[3:1],[4:_],[5:2]}`. In this way
we make sure all node records in the store is verified agains the
label scan store. Note that `[2:_]` is consistent with node 2 not
having any labels or not being in use at all.

[cl] Consistency checker now verifies that all nodes with some label(s) are present in Label Index. Previously it only checked that everything in Label Index aligned with the store.