### PR TITLE
NativeLSS will redo population if did not complete first time

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
@@ -139,6 +139,9 @@ public class GBPTree<KEY,VALUE> implements Closeable
      */
     public interface Monitor
     {
+        /**
+         * Adapter for {@link Monitor}.
+         */
         class Adaptor implements Monitor
         {
             @Override
@@ -199,7 +202,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
     /**
      * No-op header reader.
      */
-    static final Header.Reader NO_HEADER = (cursor,length) -> {};
+    static final Header.Reader NO_HEADER_READER = (cursor,length) -> {};
 
     /**
      * No-op header writer.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
@@ -202,6 +202,11 @@ public class GBPTree<KEY,VALUE> implements Closeable
     static final Header.Reader NO_HEADER = (cursor,length) -> {};
 
     /**
+     * No-op header writer.
+     */
+    static final Consumer<PageCursor> NO_HEADER_WRITER = pc -> {};
+
+    /**
      * Paged file in a {@link PageCache} providing the means of storage.
      */
     private final PagedFile pagedFile;
@@ -340,12 +345,13 @@ public class GBPTree<KEY,VALUE> implements Closeable
      * @param tentativePageSize page size, i.e. tree node size. Must be less than or equal to that of the page cache.
      * A pageSize of {@code 0} means to use whatever the page cache has (at creation)
      * @param monitor {@link Monitor} for monitoring {@link GBPTree}.
-     * @param headerReader reads header data, previously written using {@link #checkpoint(IOLimiter, Consumer)}
-     * or {@link #close()}
+     * @param headerReader reads header data if indexFile already exists,
+     * previously written using {@link #checkpoint(IOLimiter, Consumer)} or {@link #close()}
+     * @param headerWriter writes header data if indexFile is created as a result of this call.
      * @throws IOException on page cache error
      */
     public GBPTree( PageCache pageCache, File indexFile, Layout<KEY,VALUE> layout, int tentativePageSize,
-            Monitor monitor, Header.Reader headerReader ) throws IOException
+            Monitor monitor, Header.Reader headerReader, Consumer<PageCursor> headerWriter ) throws IOException
     {
         this.indexFile = indexFile;
         this.monitor = monitor;
@@ -363,7 +369,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
             // Create or load state
             if ( created )
             {
-                initializeAfterCreation( layout );
+                initializeAfterCreation( layout, headerWriter );
             }
             else
             {
@@ -396,7 +402,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
         }
     }
 
-    private void initializeAfterCreation( Layout<KEY,VALUE> layout ) throws IOException
+    private void initializeAfterCreation( Layout<KEY,VALUE> layout, Consumer<PageCursor> headerWriter ) throws IOException
     {
         // Initialize meta
         writeMeta( layout, pagedFile );
@@ -419,7 +425,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
         // Initialize free-list
         freeList.initializeAfterCreation();
         changesSinceLastCheckpoint = true;
-        checkpoint( IOLimiter.unlimited() );
+        checkpoint( IOLimiter.unlimited(), headerWriter );
         clean = true;
     }
 
@@ -523,7 +529,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
         // Write/carry over header
         int headerOffset = cursor.getOffset();
         int headerDataOffset = headerOffset + Integer.BYTES; // will contain length of written header data (below)
-        if ( otherState.isValid() )
+        if ( otherState.isValid() || headerWriter != CARRY_OVER_PREVIOUS_HEADER )
         {
             PageCursor previousCursor = pagedFile.io( otherState.pageId(), PagedFile.PF_SHARED_READ_LOCK );
             PageCursorUtil.goTo( previousCursor, "previous state page", otherState.pageId() );

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/FormatCompatibilityTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/FormatCompatibilityTest.java
@@ -49,7 +49,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER;
+import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_READER;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_WRITER;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_MONITOR;
 import static org.neo4j.test.rule.PageCacheRule.config;
@@ -98,7 +98,7 @@ public class FormatCompatibilityTest
         // THEN everything should work, otherwise there has likely been a format change
         PageCache pageCache = pageCacheRule.getPageCache( fsRule.get() );
         try ( GBPTree<MutableLong,MutableLong> tree = new GBPTree<>( pageCache, storeFile, new SimpleLongLayout(), 0,
-                NO_MONITOR, NO_HEADER, NO_HEADER_WRITER ) )
+                NO_MONITOR, NO_HEADER_READER, NO_HEADER_WRITER ) )
         {
             try
             {
@@ -174,7 +174,7 @@ public class FormatCompatibilityTest
     {
         PageCache pageCache = pageCacheRule.getPageCache( fsRule.get() );
         try ( GBPTree<MutableLong,MutableLong> tree = new GBPTree<>( pageCache, storeFile, new SimpleLongLayout(), 0,
-                NO_MONITOR, NO_HEADER, NO_HEADER_WRITER ) )
+                NO_MONITOR, NO_HEADER_READER, NO_HEADER_WRITER ) )
         {
             MutableLong insertKey = new MutableLong();
             MutableLong insertValue = new MutableLong();

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/FormatCompatibilityTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/FormatCompatibilityTest.java
@@ -50,6 +50,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER;
+import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_WRITER;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_MONITOR;
 import static org.neo4j.test.rule.PageCacheRule.config;
 
@@ -96,8 +97,8 @@ public class FormatCompatibilityTest
         // WHEN reading from the tree
         // THEN everything should work, otherwise there has likely been a format change
         PageCache pageCache = pageCacheRule.getPageCache( fsRule.get() );
-        try ( GBPTree<MutableLong,MutableLong> tree =
-                new GBPTree<>( pageCache, storeFile, new SimpleLongLayout(), 0, NO_MONITOR, NO_HEADER ) )
+        try ( GBPTree<MutableLong,MutableLong> tree = new GBPTree<>( pageCache, storeFile, new SimpleLongLayout(), 0,
+                NO_MONITOR, NO_HEADER, NO_HEADER_WRITER ) )
         {
             try
             {
@@ -172,8 +173,8 @@ public class FormatCompatibilityTest
     private void createAndZipTree( File storeFile ) throws IOException
     {
         PageCache pageCache = pageCacheRule.getPageCache( fsRule.get() );
-        try ( GBPTree<MutableLong,MutableLong> tree =
-                new GBPTree<>( pageCache, storeFile, new SimpleLongLayout(), 0, NO_MONITOR, NO_HEADER ) )
+        try ( GBPTree<MutableLong,MutableLong> tree = new GBPTree<>( pageCache, storeFile, new SimpleLongLayout(), 0,
+                NO_MONITOR, NO_HEADER, NO_HEADER_WRITER ) )
         {
             MutableLong insertKey = new MutableLong();
             MutableLong insertValue = new MutableLong();

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyIT.java
@@ -61,6 +61,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.rules.RuleChain.outerRule;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER;
+import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_WRITER;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_MONITOR;
 import static org.neo4j.test.rule.PageCacheRule.config;
 
@@ -106,7 +107,7 @@ public class GBPTreeConcurrencyIT
         PageCache pageCache =
                 pageCacheRule.getPageCache( fs.get(), config().withPageSize( pageSize ).withAccessChecks( true ) );
         return index = new GBPTree<>( pageCache, directory.file( "index" ),
-                layout, 0/*use whatever page cache says*/, monitor, NO_HEADER );
+                layout, 0/*use whatever page cache says*/, monitor, NO_HEADER, NO_HEADER_WRITER );
     }
 
     @After

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyIT.java
@@ -60,7 +60,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.rules.RuleChain.outerRule;
-import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER;
+import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_READER;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_WRITER;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_MONITOR;
 import static org.neo4j.test.rule.PageCacheRule.config;
@@ -107,7 +107,7 @@ public class GBPTreeConcurrencyIT
         PageCache pageCache =
                 pageCacheRule.getPageCache( fs.get(), config().withPageSize( pageSize ).withAccessChecks( true ) );
         return index = new GBPTree<>( pageCache, directory.file( "index" ),
-                layout, 0/*use whatever page cache says*/, monitor, NO_HEADER, NO_HEADER_WRITER );
+                layout, 0/*use whatever page cache says*/, monitor, NO_HEADER_READER, NO_HEADER_WRITER );
     }
 
     @After

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeIT.java
@@ -45,7 +45,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.rules.RuleChain.outerRule;
-import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER;
+import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_READER;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_WRITER;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_MONITOR;
 import static org.neo4j.test.rule.PageCacheRule.config;
@@ -76,7 +76,7 @@ public class GBPTreeIT
     {
         pageCache = pageCacheRule.getPageCache( fs.get(), config().withPageSize( pageSize ).withAccessChecks( true ) );
         return index = new GBPTree<>( pageCache, directory.file( "index" ),
-                layout, 0/*use whatever page cache says*/, monitor, NO_HEADER, NO_HEADER_WRITER );
+                layout, 0/*use whatever page cache says*/, monitor, NO_HEADER_READER, NO_HEADER_WRITER );
     }
 
     @After

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeIT.java
@@ -46,6 +46,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.rules.RuleChain.outerRule;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER;
+import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_WRITER;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_MONITOR;
 import static org.neo4j.test.rule.PageCacheRule.config;
 
@@ -75,7 +76,7 @@ public class GBPTreeIT
     {
         pageCache = pageCacheRule.getPageCache( fs.get(), config().withPageSize( pageSize ).withAccessChecks( true ) );
         return index = new GBPTree<>( pageCache, directory.file( "index" ),
-                layout, 0/*use whatever page cache says*/, monitor, NO_HEADER );
+                layout, 0/*use whatever page cache says*/, monitor, NO_HEADER, NO_HEADER_WRITER );
     }
 
     @After

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryIT.java
@@ -43,7 +43,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.rules.RuleChain.outerRule;
-import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER;
+import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_READER;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_WRITER;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_MONITOR;
 import static org.neo4j.index.internal.gbptree.ThrowingRunnable.throwing;
@@ -382,7 +382,8 @@ public class GBPTreeRecoveryIT
 
     private static GBPTree<MutableLong,MutableLong> createIndex( PageCache pageCache, File file ) throws IOException
     {
-        return new GBPTree<>( pageCache, file, new SimpleLongLayout(), 0, NO_MONITOR, NO_HEADER, NO_HEADER_WRITER );
+        return new GBPTree<>( pageCache, file, new SimpleLongLayout(), 0, NO_MONITOR,
+                NO_HEADER_READER, NO_HEADER_WRITER );
     }
 
     private PageCache createPageCache()

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryIT.java
@@ -44,6 +44,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.rules.RuleChain.outerRule;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER;
+import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_WRITER;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_MONITOR;
 import static org.neo4j.index.internal.gbptree.ThrowingRunnable.throwing;
 import static org.neo4j.io.pagecache.IOLimiter.unlimited;
@@ -381,7 +382,7 @@ public class GBPTreeRecoveryIT
 
     private static GBPTree<MutableLong,MutableLong> createIndex( PageCache pageCache, File file ) throws IOException
     {
-        return new GBPTree<>( pageCache, file, new SimpleLongLayout(), 0, NO_MONITOR, NO_HEADER );
+        return new GBPTree<>( pageCache, file, new SimpleLongLayout(), 0, NO_MONITOR, NO_HEADER, NO_HEADER_WRITER );
     }
 
     private PageCache createPageCache()

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
@@ -73,7 +73,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.rules.RuleChain.outerRule;
-import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER;
+import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_READER;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_WRITER;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_MONITOR;
 import static org.neo4j.index.internal.gbptree.ThrowingRunnable.throwing;
@@ -1261,7 +1261,7 @@ public class GBPTreeTest
         private int pageCachePageSize = 256;
         private int tentativePageSize = 0;
         private Monitor monitor = NO_MONITOR;
-        private Header.Reader headerReader = NO_HEADER;
+        private Header.Reader headerReader = NO_HEADER_READER;
         private Layout<MutableLong,MutableLong> layout = GBPTreeTest.layout;
         private PageCache specificPageCache;
         private Consumer<PageCursor> headerWriter = NO_HEADER_WRITER;

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
@@ -44,6 +44,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
@@ -73,6 +74,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.rules.RuleChain.outerRule;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER;
+import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_WRITER;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_MONITOR;
 import static org.neo4j.index.internal.gbptree.ThrowingRunnable.throwing;
 import static org.neo4j.io.pagecache.IOLimiter.unlimited;
@@ -557,6 +559,50 @@ public class GBPTreeTest
         verifyHeaderDataAfterClose( beforeClose );
     }
 
+    @Test
+    public void mustWriteHeaderOnInitialization() throws Exception
+    {
+        // GIVEN
+        byte[] headerBytes = new byte[12];
+        ThreadLocalRandom.current().nextBytes( headerBytes );
+        Consumer<PageCursor> headerWriter = pc -> pc.putBytes( headerBytes );
+
+        // WHEN
+        try ( GBPTree<MutableLong,MutableLong> ignore = index().with( headerWriter ).build() )
+        {
+        }
+
+        // THEN
+        verifyHeader( headerBytes );
+    }
+
+    @Test
+    public void mustNotOverwriteHeaderOnExistingTree() throws Exception
+    {
+        // GIVEN
+        byte[] expectedBytes = new byte[12];
+        ThreadLocalRandom.current().nextBytes( expectedBytes );
+        Consumer<PageCursor> headerWriter = pc -> pc.putBytes( expectedBytes );
+        try ( GBPTree<MutableLong,MutableLong> ignore = index().with( headerWriter ).build() )
+        {
+        }
+
+        // WHEN
+        byte[] fraudulentBytes = new byte[12];
+        do
+        {
+            ThreadLocalRandom.current().nextBytes( fraudulentBytes );
+        }
+        while ( Arrays.equals( expectedBytes, fraudulentBytes ) );
+
+        try ( GBPTree<MutableLong,MutableLong> ignore = index().with( headerWriter ).build() )
+        {
+        }
+
+        // THEN
+        verifyHeader( expectedBytes );
+    }
+
     private void verifyHeaderDataAfterClose( BiConsumer<GBPTree<MutableLong,MutableLong>,byte[]> beforeClose ) throws IOException
     {
         byte[] expectedHeader = new byte[12];
@@ -568,6 +614,11 @@ public class GBPTreeTest
             beforeClose.accept( index, expectedHeader );
         }
 
+        verifyHeader( expectedHeader );
+    }
+
+    private void verifyHeader( byte[] expectedHeader ) throws IOException
+    {
         // WHEN
         byte[] readHeader = new byte[expectedHeader.length];
         AtomicInteger length = new AtomicInteger();
@@ -1213,6 +1264,7 @@ public class GBPTreeTest
         private Header.Reader headerReader = NO_HEADER;
         private Layout<MutableLong,MutableLong> layout = GBPTreeTest.layout;
         private PageCache specificPageCache;
+        private Consumer<PageCursor> headerWriter = NO_HEADER_WRITER;
 
         private GBPTreeBuilder withPageCachePageSize( int pageSize )
         {
@@ -1250,6 +1302,12 @@ public class GBPTreeTest
             return this;
         }
 
+        public GBPTreeBuilder with( Consumer<PageCursor> headerWriter )
+        {
+            this.headerWriter = headerWriter;
+            return this;
+        }
+
         private GBPTree<MutableLong,MutableLong> build() throws IOException
         {
             PageCache pageCacheToUse;
@@ -1267,7 +1325,8 @@ public class GBPTreeTest
                 pageCacheToUse = specificPageCache;
             }
 
-            return new GBPTree<>( pageCacheToUse, indexFile, layout, tentativePageSize, monitor, headerReader );
+            return new GBPTree<>( pageCacheToUse, indexFile, layout, tentativePageSize, monitor, headerReader,
+                    headerWriter );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreTest.java
@@ -55,6 +55,7 @@ import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.labelscan.LabelScanWriter;
 import org.neo4j.kernel.api.labelscan.NodeLabelRange;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
+import org.neo4j.kernel.impl.api.scan.FullStoreChangeStream;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.storageengine.api.schema.LabelScanReader;
 import org.neo4j.test.rule.RandomRule;
@@ -73,12 +74,13 @@ import static org.neo4j.collection.primitive.PrimitiveLongCollections.EMPTY_LONG
 import static org.neo4j.helpers.collection.Iterators.iterator;
 import static org.neo4j.helpers.collection.Iterators.single;
 import static org.neo4j.kernel.api.labelscan.NodeLabelUpdate.labelChanges;
+import static org.neo4j.kernel.impl.api.scan.FullStoreChangeStream.asStream;
 
 public abstract class LabelScanStoreTest
 {
     private final TestDirectory testDirectory = TestDirectory.testDirectory();
     private final ExpectedException expectedException = ExpectedException.none();
-    private final DefaultFileSystemRule fileSystemRule = new DefaultFileSystemRule();
+    protected final DefaultFileSystemRule fileSystemRule = new DefaultFileSystemRule();
     final RandomRule random = new RandomRule();
 
     @Rule
@@ -90,7 +92,7 @@ public abstract class LabelScanStoreTest
     private LifeSupport life;
     private TrackingMonitor monitor;
     private LabelScanStore store;
-    private File dir;
+    protected File dir;
 
     @Before
     public void clearDir() throws IOException
@@ -101,11 +103,14 @@ public abstract class LabelScanStoreTest
     @After
     public void shutdown()
     {
-        life.shutdown();
+        if ( life != null )
+        {
+            life.shutdown();
+        }
     }
 
     protected abstract LabelScanStore createLabelScanStore( FileSystemAbstraction fileSystemAbstraction,
-            File rootFolder, List<NodeLabelUpdate> existingData, boolean usePersistentStore, boolean readOnly,
+            File rootFolder, FullStoreChangeStream fullStoreChangeStream, boolean usePersistentStore, boolean readOnly,
             LabelScanStore.Monitor monitor );
 
     @Test
@@ -550,7 +555,8 @@ public abstract class LabelScanStoreTest
         life = new LifeSupport();
         monitor = new TrackingMonitor();
 
-        store = createLabelScanStore( fileSystemRule.get(), dir, existingData, usePersistentStore, readOnly, monitor );
+        store = createLabelScanStore( fileSystemRule.get(), dir, asStream( existingData ), usePersistentStore, readOnly,
+                monitor );
         life.add( store );
 
         life.start();
@@ -594,10 +600,13 @@ public abstract class LabelScanStoreTest
         }
     }
 
-    private static class TrackingMonitor extends LabelScanStore.Monitor.Adaptor
+    public static class TrackingMonitor extends LabelScanStore.Monitor.Adaptor
     {
-        boolean initCalled, rebuildingCalled, rebuiltCalled, noIndexCalled;
-        boolean corruptedIndex = false;
+        boolean initCalled;
+        public boolean rebuildingCalled;
+        public boolean rebuiltCalled;
+        public boolean noIndexCalled;
+        public boolean corruptedIndex = false;
 
         @Override
         public void noIndex()
@@ -632,6 +641,11 @@ public abstract class LabelScanStoreTest
         public void init()
         {
             initCalled = true;
+        }
+
+        public void reset()
+        {
+            initCalled = rebuildingCalled = rebuiltCalled = noIndexCalled = corruptedIndex = false;
         }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/impl/labelscan/LabelScanStoreTest.java
@@ -606,7 +606,7 @@ public abstract class LabelScanStoreTest
         public boolean rebuildingCalled;
         public boolean rebuiltCalled;
         public boolean noIndexCalled;
-        public boolean corruptedIndex = false;
+        public boolean corruptedIndex;
 
         @Override
         public void noIndex()
@@ -645,7 +645,11 @@ public abstract class LabelScanStoreTest
 
         public void reset()
         {
-            initCalled = rebuildingCalled = rebuiltCalled = noIndexCalled = corruptedIndex = false;
+            initCalled = false;
+            rebuildingCalled = false;
+            rebuiltCalled = false;
+            noIndexCalled = false;
+            corruptedIndex = false;
         }
     }
 }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStoreTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/labelscan/LuceneLabelScanStoreTest.java
@@ -35,14 +35,13 @@ import org.neo4j.kernel.api.impl.index.storage.DirectoryFactory;
 import org.neo4j.kernel.api.impl.index.storage.PartitionedIndexStorage;
 import org.neo4j.kernel.api.impl.labelscan.storestrategy.BitmapDocumentFormat;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
-import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.api.scan.FullStoreChangeStream;
 import org.neo4j.kernel.impl.factory.OperationalMode;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
-import static org.neo4j.kernel.impl.api.scan.FullStoreChangeStream.asStream;
 
 @RunWith( Parameterized.class )
 public class LuceneLabelScanStoreTest extends LabelScanStoreTest
@@ -60,7 +59,7 @@ public class LuceneLabelScanStoreTest extends LabelScanStoreTest
 
     @Override
     protected LabelScanStore createLabelScanStore( FileSystemAbstraction fs, File rootFolder,
-            List<NodeLabelUpdate> existingData, boolean usePersistentStore, boolean readOnly,
+            FullStoreChangeStream fullStoreChangeStream, boolean usePersistentStore, boolean readOnly,
             LabelScanStore.Monitor monitor )
     {
         DirectoryFactory directoryFactory = usePersistentStore ? DirectoryFactory.PERSISTENT : inMemoryDirectoryFactory;
@@ -77,7 +76,7 @@ public class LuceneLabelScanStoreTest extends LabelScanStoreTest
                 .withConfig( config )
                 .withDocumentFormat( documentFormat );
 
-        return new LuceneLabelScanStore( indexBuilder, asStream( existingData ), monitor );
+        return new LuceneLabelScanStore( indexBuilder, fullStoreChangeStream, monitor );
     }
 
     @Override


### PR DESCRIPTION
Before if NativeLabelScanStore was initialised (init) for the first time
without being populated (start), then it would not retry population
job on next start.

Now it will note in GBPTree header that it needs to be rebuilt on next
start and only clean this header after population has completed.

[cl] Fix a problem where Label Index could be seen as online even if population did not complete, for example after migration, effectively creating an inconsistent Label Index.