### PR TITLE
`KernelIntegrationTest` retain db on restart

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
@@ -129,24 +129,6 @@ public class IndexIT extends KernelIntegrationTest
     }
 
     @Test
-    public void shouldRemoveAConstraintIndexWithoutOwnerInRecovery() throws Exception
-    {
-        // given
-        PropertyAccessor propertyAccessor = mock( PropertyAccessor.class );
-        ConstraintIndexCreator creator = new ConstraintIndexCreator( () -> kernel, indexingService, propertyAccessor, false );
-
-        creator.createConstraintIndex( descriptor );
-
-        // when
-        restartDb();
-
-        // then
-        ReadOperations readOperations = readOperationsInNewTransaction();
-        assertEquals( emptySet(), asSet( readOperations.indexesGetForLabel( labelId ) ) );
-        commit();
-    }
-
-    @Test
     public void shouldDisallowDroppingIndexThatDoesNotExist() throws Exception
     {
         // given

--- a/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresTest.java
@@ -23,6 +23,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.security.AnonymousContext;
@@ -68,7 +69,7 @@ public class AuthProceduresTest extends KernelIntegrationTest
     }
 
     @Override
-    protected TestGraphDatabaseBuilder configure( TestGraphDatabaseBuilder graphDatabaseBuilder )
+    protected GraphDatabaseBuilder configure( GraphDatabaseBuilder graphDatabaseBuilder )
     {
         graphDatabaseBuilder.setConfig( GraphDatabaseSettings.auth_enabled, "true" );
         return graphDatabaseBuilder;

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyConstraintValidationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyConstraintValidationIT.java
@@ -33,7 +33,6 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
@@ -56,8 +55,10 @@ import static org.junit.Assert.fail;
 import static org.neo4j.kernel.api.schema.SchemaDescriptorFactory.forLabel;
 import static org.neo4j.kernel.api.schema.SchemaDescriptorFactory.forRelType;
 import static org.neo4j.kernel.impl.api.integrationtest.PropertyConstraintValidationIT.NodeKeyConstraintValidationIT;
-import static org.neo4j.kernel.impl.api.integrationtest.PropertyConstraintValidationIT.NodePropertyExistenceConstraintValidationIT;
-import static org.neo4j.kernel.impl.api.integrationtest.PropertyConstraintValidationIT.RelationshipPropertyExistenceConstraintValidationIT;
+import static org.neo4j.kernel.impl.api.integrationtest.PropertyConstraintValidationIT
+        .NodePropertyExistenceConstraintValidationIT;
+import static org.neo4j.kernel.impl.api.integrationtest.PropertyConstraintValidationIT
+        .RelationshipPropertyExistenceConstraintValidationIT;
 
 @RunWith( Suite.class )
 @SuiteClasses( {
@@ -321,11 +322,10 @@ public class PropertyConstraintValidationIT
         abstract int entityCount() throws TransactionFailureException;
 
         @Override
-        protected GraphDatabaseService createGraphDatabase( EphemeralFileSystemAbstraction fs )
+        protected GraphDatabaseService createGraphDatabase()
         {
-            return new TestEnterpriseGraphDatabaseFactory()
-                    .setFileSystem( fs )
-                    .newImpermanentDatabaseBuilder()
+            return new TestEnterpriseGraphDatabaseFactory().setFileSystem( fileSystemRule.get() )
+                    .newEmbeddedDatabaseBuilder( testDir.graphDbDir() )
                     .newGraphDatabase();
         }
 


### PR DESCRIPTION
Some extending tests already assume this to be the case.