### PR TITLE
Removed OptionalExpand from compiled runtime

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -132,6 +132,8 @@ Find a shortest path among paths matched using a non-variable length pattern
 Find a combination of a shortest path and a pattern expression
 Filter with AND/OR
 LIMIT 0 should stop side effects
+Id on null
+type on null
 
 //OrderByAcceptance.feature - Unsupported orderability
 ORDER BY nodes should return null results last in ascending order

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -97,7 +97,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     }
   }
 
-  test("should handle optional match of none existant path.") {
+  test("should handle optional match of non-existent path.") {
 
     val n = createLabeledNode("Client")
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -97,6 +97,21 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     }
   }
 
+  test("should handle optional match of none existant path.") {
+
+    val n = createLabeledNode("Client")
+
+    val query =
+      """ MATCH (n:Client)
+        | OPTIONAL MATCH (n)-[rel1:relType]->(n1:label)
+        | OPTIONAL MATCH (n1)-[rel2:relType2]->(n2:label2)
+        | RETURN n, rel1, n1, rel2, n2;
+        |""".stripMargin
+
+    val result = executeWithAllPlannersAndCompatibilityMode(query)
+    result.toList should equal(List(Map("n" -> n, "rel1" -> null, "rel2" -> null, "n1" -> null, "n2" -> null)))
+  }
+
   test("should handle optional paths from graph algo") {
     val a = createNode("A")
     val b = createNode("B")

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProfilerAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProfilerAcceptanceTest.scala
@@ -234,7 +234,7 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
     createNode()
 
     // WHEN
-    val result = profileWithAllPlannersAndRuntimes("MATCH (n) optional match (n)-->(x) return x")
+    val result = profileWithAllPlanners("MATCH (n) optional match (n)-->(x) return x")
 
     // THEN
     assertDbHits(0)(result)("ProduceResults")
@@ -324,7 +324,7 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
 
   test("should support profiling optional match queries") {
     createLabeledNode(Map("x" -> 1), "Label")
-    val result = profileWithAllPlannersAndRuntimes("match (a:Label {x: 1}) optional match (a)-[:REL]->(b) return a.x as A, b.x as B").toList.head
+    val result = profileWithAllPlanners("match (a:Label {x: 1}) optional match (a)-[:REL]->(b) return a.x as A, b.x as B").toList.head
     result("A") should equal(1)
     result("B") should equal(null.asInstanceOf[Int])
   }

--- a/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -560,6 +560,21 @@ Handling non-string operands for CONTAINS
 Handling non-string operands for ENDS WITH
 Returning nested expressions based on list property
 
+Returning label predicate on null node
+`type()` on mixed null and non-null relationships
+`type()` on mixed null and non-null relationships
+`type()` on null relationship
+Return two subgraphs with bound undirected relationship and optional relationship
+Respect predicates on the OPTIONAL MATCH
+Optionally matching self-loops
+Optionally matching self-loops without matches
+OPTIONAL MATCH with previously bound nodes
+OPTIONAL MATCH with labels on the optional end node
+OPTIONAL MATCH and bound nodes
+MATCH and OPTIONAL MATCH on same pattern
+Handling correlated optional matches; first does not match implies second does not match
+Do not fail when predicates on optionally matched and missed nodes are invalid
+
 Many CREATE clauses
 
 Comparing strings and integers using > in an AND'd predicate

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/CodeGeneratorTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/CodeGeneratorTest.scala
@@ -292,26 +292,6 @@ abstract class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTest
     result shouldBe empty
   }
 
-  test("label scan + optional expand incoming") {
-  //given
-  val plan = ProduceResult(List("a", "b"),
-                             OptionalExpand(
-                               NodeByLabelScan(IdName("a"), lblName("T1"), Set.empty)(solved), IdName("a"),
-                               SemanticDirection.OUTGOING, Seq.empty, IdName("b"), IdName("r"), ExpandAll,
-                               Seq(HasLabels(varFor("b"), Seq(LabelName("T1")(pos)))(pos)))(solved))
-
-    //when
-    val compiled: InternalExecutionResult = compileAndExecute(plan)
-    //then
-    val result = getNodesFromResult(compiled, "a", "b")
-
-    result should equal(List(
-      Map("a" -> aNode, "b" -> null),
-      Map("a" -> bNode, "b" -> null),
-      Map("a" -> cNode, "b" -> null)
-      ))
-  }
-
   test("label scan + expand both directions") { // MATCH (a:T1)-[r]-(b) RETURN a, b
   //given
   val plan = ProduceResult(List("a", "b"),
@@ -375,54 +355,6 @@ abstract class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTest
     ))
   }
 
-  test("optional expand into self loop") {
-    //given
-    val scanT1 = NodeByLabelScan(IdName("a"), lblName("T1"), Set.empty)(solved)
-    val optionalExpandInto = OptionalExpand(
-      scanT1, IdName("a"), SemanticDirection.OUTGOING,
-      Seq.empty, IdName("a"), IdName("r2"), ExpandInto, Seq(HasLabels(varFor("a"), Seq(LabelName("T2")(pos)))(pos)))(solved)
-
-
-    val plan = ProduceResult(List("a", "r2"), optionalExpandInto)
-
-    //when
-    val compiled = compileAndExecute(plan)
-
-    //then
-    val result = getResult(compiled, "a", "r2")
-
-    result should equal(List(
-      Map("a" -> aNode, "r2" -> null),
-      Map("a" -> bNode, "r2" -> null),
-      Map("a" -> cNode, "r2" -> null)))
-  }
-
-  test("optional expand into on top of expand all") {
-    //given
-    val scanT1 = NodeByLabelScan(IdName("a"), lblName("T1"), Set.empty)(solved)
-    val expandAll = Expand(
-      scanT1, IdName("a"), SemanticDirection.OUTGOING,
-      Seq.empty, IdName("b"), IdName("r1"), ExpandAll)(solved)
-    val optionalExpandInto = OptionalExpand(
-      expandAll, IdName("a"), SemanticDirection.OUTGOING,
-      Seq.empty, IdName("b"), IdName("r2"), ExpandInto, Seq(HasLabels(varFor("b"), Seq(LabelName("T2")(pos)))(pos)))(solved)
-
-
-    val plan = ProduceResult(List("a", "b", "r2"), optionalExpandInto)
-
-    //when
-    val compiled = compileAndExecute(plan)
-
-    //then
-    val result = getResult(compiled, "a", "b", "r2")
-
-    result should equal(List(
-      Map("a" -> aNode, "b" -> dNode, "r2" -> null),
-      Map("a" -> bNode, "b" -> dNode, "r2" -> null),
-      Map("a" -> cNode, "b" -> eNode, "r2" -> null)
-    ))
-  }
-
   test("expand into on top of expand all with relationship types") {
     //given
     val scanT2 = NodeByLabelScan(IdName("a"), lblName("T2"), Set.empty)(solved)
@@ -448,33 +380,7 @@ abstract class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTest
     ))
   }
 
-  test("optional expand into on top of expand all with relationship types") {
-    //given
-    val scanT2 = NodeByLabelScan(IdName("a"), lblName("T2"), Set.empty)(solved)
-    val expandAll = Expand(
-      scanT2, IdName("a"), SemanticDirection.OUTGOING,
-      Seq(RelTypeName("R2")(pos)), IdName("b"), IdName("r1"), ExpandAll)(solved)
-    val expandInto = OptionalExpand(
-      expandAll, IdName("b"), SemanticDirection.INCOMING,
-      Seq(RelTypeName("R2")(pos)), IdName("a"), IdName("r2"), ExpandInto)(solved)
-
-
-    val plan = ProduceResult(List("a", "b", "r2"), expandInto)
-
-    //when
-    val compiled = compileAndExecute(plan)
-
-    //then
-    val result = getResult(compiled, "a", "b", "r2")
-
-    result should equal(List(
-      Map("a" -> fNode, "b" -> dNode, "r2" -> relMap(14L).relationship),
-      Map("a" -> gNode, "b" -> eNode, "r2" -> relMap(15L).relationship)
-    ))
-  }
-
-
-  test("expand into on top of expand all with a loop") {
+ test("expand into on top of expand all with a loop") {
     //given
     val scanT3 = NodeByLabelScan(IdName("a"), lblName("T3"), Set.empty)(solved)
     val expandAll = Expand(
@@ -496,32 +402,6 @@ abstract class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTest
     result should equal(List(
       Map("a" -> hNode, "b" -> iNode),
       Map("a" -> iNode, "b" -> hNode)
-    ))
-  }
-
-  test("optional expand into on top of expand all with a loop") {
-    //given
-    val scanT3 = NodeByLabelScan(IdName("a"), lblName("T3"), Set.empty)(solved)
-    val expandAll = Expand(
-      scanT3, IdName("a"), SemanticDirection.OUTGOING,
-      Seq(RelTypeName("R3")(pos)), IdName("b"), IdName("r1"), ExpandAll)(solved)
-    val expandInto = OptionalExpand(
-      expandAll, IdName("b"), SemanticDirection.INCOMING,
-      Seq(RelTypeName("R3")(pos)), IdName("a"), IdName("r2"), ExpandInto,
-      Seq(HasLabels(varFor("b"), Seq(LabelName("T2")(pos)))(pos)))(solved)
-
-
-    val plan = ProduceResult(List("a", "b", "r2"), expandInto)
-
-    //when
-    val compiled = compileAndExecute(plan)
-
-    //then
-    val result = getResult(compiled, "a", "b", "r2")
-
-    result should equal(List(
-      Map("a" -> hNode, "b" -> iNode, "r2" -> null),
-      Map("a" -> iNode, "b" -> hNode, "r2" -> null)
     ))
   }
 
@@ -1385,33 +1265,6 @@ abstract class CodeGeneratorTest extends CypherFunSuite with LogicalPlanningTest
     // then
     val result = getResult(compiled, "x")
     result.toList should equal(List(Map("x" -> List(true, false))))
-  }
-
-  test("compare nullable relationships with equals") {
-    //given
-    val scanT1 = NodeByLabelScan(IdName("a"), lblName("T1"), Set.empty)(solved)
-    val expand = Expand(scanT1,
-      from = IdName("a"), SemanticDirection.OUTGOING, Seq.empty,
-      to = IdName("b"), relName = IdName("r1"), ExpandAll)(solved)
-    val optionalExpandInto = OptionalExpand(expand,
-      from = IdName("b"), SemanticDirection.OUTGOING, Seq.empty,
-      to = IdName("a"), IdName("r2"), ExpandInto, Seq(HasLabels(varFor("a"), Seq(LabelName("T2")(pos)))(pos)))(solved)
-
-    val projection = plans.Projection(optionalExpandInto, Map("sameRel" -> Equals(varFor("r1"), varFor("r2"))(pos)))(solved)
-    val plan = ProduceResult(List("sameRel"), projection)
-
-    //when
-    val compiled = compileAndExecute(plan)
-
-    //then
-    val result = getResult(compiled, "sameRel")
-
-    // Since r2 is null the result of equals should be null
-    result should equal(List(
-      Map("sameRel" -> null),
-      Map("sameRel" -> null),
-      Map("sameRel" -> null)
-    ))
   }
 
   test("count with non-nullable literal") {


### PR DESCRIPTION
changelog: Fix issue with the compiled runtimes handling of optional expand when the incoming bound node is null. This change removes support for optional expand entirely from the compiled runtime.