### PR TITLE
Fix discovery listen address ignored

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastDiscoveryServiceFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastDiscoveryServiceFactory.java
@@ -50,6 +50,7 @@ public class HazelcastDiscoveryServiceFactory implements DiscoveryServiceFactory
     {
         // tell hazelcast to not phone home
         System.setProperty( "hazelcast.phone.home.enabled", "false" );
+        System.setProperty( "hazelcast.socket.server.bind.any", "false" );
 
         String licenseKey = config.get( CausalClusteringSettings.hazelcast_license_key );
         if ( licenseKey != null )


### PR DESCRIPTION
This was previously fixed by #9086 but it seems the
forward merge was partially botched.