### PR TITLE
OPTIONAL MATCH now depends on updates

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/OptionalMatchRemoverTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/OptionalMatchRemoverTest.scala
@@ -175,6 +175,13 @@ class OptionalMatchRemoverTest extends CypherFunSuite with LogicalPlanningTestSu
           OPTIONAL MATCH (a)-[r:T1]->(b) WHERE (b)-[:T2]->(:A:B {foo: 'apa', id: 42})
           RETURN DISTINCT b as b""")
 
+  assert_that(
+    """MATCH (a)
+      |OPTIONAL MATCH (a)-[r]->(b)
+      |DELETE r
+      |RETURN DISTINCT a AS a""".stripMargin).
+    is_not_rewritten()
+
   case class RewriteTester(originalQuery: String) {
     def is_rewritten_to(newQuery: String): Unit =
       test(originalQuery) {

--- a/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/MutatingPattern.scala
+++ b/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/MutatingPattern.scala
@@ -20,10 +20,11 @@
 package org.neo4j.cypher.internal.ir.v3_2
 
 import org.neo4j.cypher.internal.frontend.v3_2.SemanticDirection
-import org.neo4j.cypher.internal.frontend.v3_2.ast.{Expression, LabelName, PropertyKeyName, RelTypeName}
+import org.neo4j.cypher.internal.frontend.v3_2.ast._
 
 sealed trait MutatingPattern {
   def coveredIds: Set[IdName]
+  def dependencies: Set[Variable] = Set.empty
 }
 
 sealed trait NoSymbols {
@@ -63,7 +64,9 @@ case class CreateRelationshipPattern(relName: IdName, leftNode: IdName, relType:
   override def coveredIds = Set(relName)
 }
 
-case class DeleteExpression(expression: Expression, forced: Boolean) extends MutatingPattern with NoSymbols
+case class DeleteExpression(expression: Expression, forced: Boolean) extends MutatingPattern with NoSymbols {
+  override def dependencies: Set[Variable] = expression.dependencies
+}
 
 sealed trait MergePattern {
   self : MutatingPattern =>

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -44,7 +44,19 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     val result = executeWithAllPlannersAndCompatibilityMode(query)
 
     result.toSet should equal(Set(Map("d" -> ArrayBuffer(n1)), Map("d" -> ArrayBuffer(n1, n2))))
+  }
 
+  test("OPTIONAL MATCH, DISTINCT and DELETE in an unfortunate combination") {
+    val start = createLabeledNode("Start")
+    createLabeledNode("End")
+    val result = executeWithAllPlannersAndCompatibilityMode(
+      """
+        |MATCH (start:Start),(end:End)
+        |OPTIONAL MATCH (start)-[rel]->(end)
+        |DELETE rel
+        |RETURN DISTINCT start""".stripMargin)
+
+    result.toList should equal(List(Map("start" -> start)))
   }
 
   test("should allow for OPTONAL MATCH with horizon and aggregating function") {


### PR DESCRIPTION
changelog: Fix issue where a combination of `DELETE`, `OPTIONAL MATCH` and `DISTINCT`, caused the query to fail.