### PR TITLE
Fix broken backwards compatibility with array values

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/ArrayEncoder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/ArrayEncoder.java
@@ -158,13 +158,15 @@ public final class ArrayEncoder
         @Override
         public void beginArray( int size, ArrayType arrayType )
         {
-            builder.append( typeChar( arrayType ) );
+            if ( size > 0 )
+            {
+                builder.append( typeChar( arrayType ) );
+            }
         }
 
         @Override
         public void endArray()
         {
-
         }
 
         private char typeChar( ArrayType arrayType )

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/ArrayEncoderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/ArrayEncoderTest.java
@@ -90,6 +90,7 @@ public class ArrayEncoderTest
         assertEncoding( "D1.0|2.0|3.0|", new int[]{1, 2, 3} );
         assertEncoding( "Ztrue|false|", new boolean[]{true, false} );
         assertEncoding( "LYWxp|YXJl|eW91|b2s=|", new String[]{"ali", "are", "you", "ok"} );
+        assertEncoding( "", new String[]{} );
     }
 
     @Test


### PR DESCRIPTION
The recently introduced value module accidentally changed how property values of empty arrays were encoded in schema indexes. This PR restores the legacy index array encoding, so that migration works again.