### PR TITLE
Optimisations for the ParallelBatchImporter

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ForkedProcessorStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ForkedProcessorStep.java
@@ -151,7 +151,7 @@ public abstract class ForkedProcessorStep<T> extends AbstractStep<T>
     @SuppressWarnings( "unchecked" )
     void sendDownstream( Unit unit )
     {
-        downstreamIdleTime.addAndGet( downstream.receive( unit.ticket, unit.batch ) );
+        downstreamIdleTime.add( downstream.receive( unit.ticket, unit.batch ) );
     }
 
     // One unit of work. Contains the batch along with ticket and meta state during processing such

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ForkedProcessorStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ForkedProcessorStep.java
@@ -28,8 +28,8 @@ import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 import static java.lang.Integer.max;
 import static java.lang.Integer.min;
 import static java.lang.System.nanoTime;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
-
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 import static org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.getFieldOffset;
 
 /**
@@ -48,17 +48,18 @@ public abstract class ForkedProcessorStep<T> extends AbstractStep<T>
     protected static final int MAIN = 0;
     private final long COMPLETED_PROCESSORS_OFFSET = getFieldOffset( Unit.class, "completedProcessors" );
     private final long PROCESSING_TIME_OFFSET = getFieldOffset( Unit.class, "processingTime" );
-    private static final ParkStrategy PARK = new ParkStrategy.Park( 10, MILLISECONDS );
+    private static final ParkStrategy PARK = new ParkStrategy.Park( IS_OS_WINDOWS ? 10_000 : 500, MICROSECONDS );
 
     private final Object[] forkedProcessors;
     private volatile int numberOfForkedProcessors;
     private final Unit noop = new Unit( -1, null, 0 );
     private final AtomicReference<Unit> head = new AtomicReference<>( noop );
     private final AtomicReference<Unit> tail = new AtomicReference<>( noop );
-    private final Thread downstreamSender = new CompletedBatchesSender();
+    private final Thread downstreamSender;
     private volatile int numberOfProcessors = 1;
     private final int maxProcessors;
-    private Thread receiverThread;
+    private final int maxQueueLength;
+    private volatile Thread receiverThread;
 
     protected ForkedProcessorStep( StageControl control, String name, Configuration config )
     {
@@ -67,6 +68,8 @@ public abstract class ForkedProcessorStep<T> extends AbstractStep<T>
         this.forkedProcessors = new Object[this.maxProcessors];
 
         applyProcessorCount();
+        downstreamSender = new CompletedBatchesSender( name + " [CompletedBatchSender]" );
+        maxQueueLength = 200 + maxProcessors;
     }
 
     private void applyProcessorCount()
@@ -118,32 +121,25 @@ public abstract class ForkedProcessorStep<T> extends AbstractStep<T>
     @Override
     public long receive( long ticket, T batch )
     {
+        long time = nanoTime();
         applyProcessorCount();
-        while ( head.get().ticket - tail.get().ticket >= maxProcessors - 1 )
+        while ( head.get().ticket - tail.get().ticket >= maxQueueLength )
         {
             PARK.park( receiverThread = Thread.currentThread() );
         }
 
         queuedBatches.incrementAndGet();
         Unit unit = new Unit( ticket, batch, numberOfForkedProcessors );
-        long time = nanoTime();
 
         // [old head] [unit]
         //               ^
         //              head
-        Unit myHead;
-        do
-        {
-            myHead = head.get();
-        }
-        while ( !head.compareAndSet( myHead, unit ) );
+        Unit myHead = head.getAndSet( unit );
 
         // [old head] -next-> [unit]
         myHead.next = unit;
 
-        long queueTime = nanoTime() - time;
-
-        return queueTime;
+        return nanoTime() - time;
     }
 
     protected abstract void forkedProcess( int id, int processors, T batch ) throws Throwable;
@@ -168,7 +164,9 @@ public abstract class ForkedProcessorStep<T> extends AbstractStep<T>
         // Updated when a ForkedProcessor have processed this unit.
         // Atomic since changed by UnsafeUtil#getAndAddInt/Long.
         // Volatile since read by CompletedBatchesSender.
+        @SuppressWarnings( "unused" )
         private volatile int completedProcessors;
+        @SuppressWarnings( "unused" )
         private volatile long processingTime;
 
         // Volatile since assigned by thread enqueueing this unit after changing head of the queue.
@@ -206,6 +204,11 @@ public abstract class ForkedProcessorStep<T> extends AbstractStep<T>
      */
     private final class CompletedBatchesSender extends Thread
     {
+        public CompletedBatchesSender( String name )
+        {
+            super( name );
+        }
+
         @Override
         public void run()
         {
@@ -229,9 +232,10 @@ public abstract class ForkedProcessorStep<T> extends AbstractStep<T>
                 }
                 else
                 {
-                    if ( receiverThread != null )
+                    Thread receiver = ForkedProcessorStep.this.receiverThread;
+                    if ( receiver != null )
                     {
-                        PARK.unpark( receiverThread );
+                        PARK.unpark( receiver );
                     }
                     PARK.park( this );
                 }
@@ -276,7 +280,7 @@ public abstract class ForkedProcessorStep<T> extends AbstractStep<T>
                         }
                         else
                         {
-                            // The id of this processor is less than that of the next unit's expected max.
+                            // The id of this processor is greater than that of the next unit's expected max.
                             // This means that the number of assigned processors to this step has decreased
                             // and that this processor have reached the end of its life.
                             break;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ForkedProcessorStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ForkedProcessorStep.java
@@ -204,7 +204,7 @@ public abstract class ForkedProcessorStep<T> extends AbstractStep<T>
      */
     private final class CompletedBatchesSender extends Thread
     {
-        public CompletedBatchesSender( String name )
+        CompletedBatchesSender( String name )
         {
             super( name );
         }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Processing.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Processing.java
@@ -23,8 +23,6 @@ import java.util.function.LongPredicate;
 
 import org.neo4j.unsafe.impl.batchimport.executor.ParkStrategy;
 
-import static java.lang.System.nanoTime;
-
 public class Processing
 {
     private Processing()
@@ -38,16 +36,14 @@ public class Processing
      * @param goal to feed into the {@code goalPredicate}.
      * @param healthCheck to check as to not continue waiting if not passing.
      * @param park {@link ParkStrategy} for each tiny little wait.
-     * @return how long time was spent in here, in nanos.
      */
-    public static long await( LongPredicate goalPredicate, long goal, Runnable healthCheck, ParkStrategy park )
+    public static void await( LongPredicate goalPredicate, long goal, Runnable healthCheck, ParkStrategy park )
     {
         if ( goalPredicate.test( goal ) )
         {
-            return 0;
+            return;
         }
 
-        long startTime = nanoTime();
         for ( int i = 0; i < 1_000_000 && !goalPredicate.test( goal ); i++ )
         {   // Busy loop a while
         }
@@ -58,6 +54,5 @@ public class Processing
             park.park( thread );
             healthCheck.run();
         }
-        return nanoTime() - startTime;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProcessorStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProcessorStep.java
@@ -126,7 +126,7 @@ public abstract class ProcessorStep<T> extends AbstractStep<T>
             long lastBatchEnd = lastBatchEndTime.get();
             if ( lastBatchEnd != 0 )
             {
-                upstreamIdleTime.addAndGet( currentTimeMillis() - lastBatchEnd );
+                upstreamIdleTime.add( currentTimeMillis() - lastBatchEnd );
             }
         }
     }
@@ -164,7 +164,7 @@ public abstract class ProcessorStep<T> extends AbstractStep<T>
         {
             await( rightDoneTicket, ticket, healthChecker, park );
         }
-        downstreamIdleTime.addAndGet( downstream.receive( ticket, batch ) );
+        downstreamIdleTime.add( downstream.receive( ticket, batch ) );
         doneBatches.incrementAndGet();
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProducerStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProducerStep.java
@@ -76,7 +76,7 @@ public abstract class ProducerStep extends AbstractStep<Void> implements StatsPr
     protected void sendDownstream( Object batch )
     {
         long time = downstream.receive( doneBatches.getAndIncrement(), batch );
-        downstreamIdleTime.addAndGet( time );
+        downstreamIdleTime.add( time );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/PageCacheFlusher.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/PageCacheFlusher.java
@@ -37,6 +37,7 @@ class PageCacheFlusher extends Thread
 
     PageCacheFlusher( PageCache pageCache )
     {
+        super( "PageCacheFlusher" );
         this.pageCache = pageCache;
     }
 

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/executor/DynamicTaskExecutorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/executor/DynamicTaskExecutorTest.java
@@ -29,7 +29,6 @@ import org.neo4j.helpers.Exceptions;
 import org.neo4j.test.Barrier;
 import org.neo4j.test.DoubleLatch;
 import org.neo4j.test.OtherThreadExecutor;
-import org.neo4j.test.OtherThreadExecutor.WorkerCommand;
 import org.neo4j.test.Race;
 import org.neo4j.test.rule.RepeatRule;
 import org.neo4j.test.rule.RepeatRule.Repeat;


### PR DESCRIPTION
This seems to make the transfer of batches into ForkedProcessorSteps about 15-20 times faster. The impact of this is particularly clear on the running time of the `mustNotDetachProcessorsFromBatchChains` test.

changelog: Speed up data linking in importer by increasing parallelism, and allowing out-of-order batch transfer. The linking of data used to account for about half the time of an import, importing the raw unlinked data the other half). Now it typically accounts for far less than that.