### PR TITLE
Add a `WorkSync.applyAsync` method for asynchronous application of work

### DIFF
--- a/community/primitive-collections/src/main/java/org/neo4j/concurrent/AsyncApply.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/concurrent/AsyncApply.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.concurrent;
+
+import java.util.concurrent.ExecutionException;
+
+/**
+ * The past or future application of work submitted asynchronously to a {@link WorkSync}.
+ */
+public interface AsyncApply
+{
+    /**
+     * Await the application of the work submitted to a {@link WorkSync}.
+     * <p>
+     * If the work is already done, then this method with return immediately.
+     * <p>
+     * If the work has not been done, then this method will attempt to grab the {@code WorkSync} lock to complete the
+     * work, or block to wait for another thread to complete the work on behalf of the current thread.
+     *
+     * @throws ExecutionException if this thread ends up performing the work, and an exception is thrown from the
+     * attempt to apply the work.
+     */
+    void await() throws ExecutionException;
+}

--- a/community/primitive-collections/src/test/java/org/neo4j/concurrent/WorkSyncTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/concurrent/WorkSyncTest.java
@@ -449,7 +449,7 @@ public class WorkSyncTest
     }
 
     @Test
-    public void asyncWorkDoneInAnotherThreadThatThrowsMustRememberException() throws Exception // TODO!!!
+    public void asyncWorkThatThrowsInAwaitMustRememberException() throws Exception
     {
         Future<Void> stuckAtSemaphore = makeWorkStuckAtSemaphore( 1 );
 


### PR DESCRIPTION
The asynchronous work might be done in the submitting thread, or in any other
thread that interacts with the given `WorkSync`.

The submitting of asynchronous work will never block. All blocking is deferred
to the `AsyncApply.await` method. This method must be called before the work
can be expected to have been applied, and then only if it does not throw an
exception.

Additionaly, if the work ends up being applied in a different thread, then any
thrown exception will only propagate to that thread. The `AsyncApply`
insteances will still be marked as done, but there will be no way to tell if
the application was successful or exceptional.

If the work submitters require such information to be propagated, then they
must encode such propagation infrastructure into the work itself.