### PR TITLE
Fix outdated javadoc in GraphDatabaseService

### DIFF
--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/GraphDatabaseService.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/GraphDatabaseService.java
@@ -33,7 +33,7 @@ import org.neo4j.graphdb.traversal.TraversalDescription;
  * The main access point to a running Neo4j instance. The most common way to instantiate a {@link GraphDatabaseService}
  * is as follows:
  * <pre>
- * <code>GraphDatabaseService graphDb = new GraphDatabaseFactory().newEmbeddedDatabase( "var/graphDb" );
+ * <code>GraphDatabaseService graphDb = new GraphDatabaseFactory().newEmbeddedDatabase( new File("var/graphDb") );
  * // ... use Neo4j
  * graphDb.{@link #shutdown() shutdown()};</code>
  * </pre>


### PR DESCRIPTION
Update javadoc to use new signature for newEmbeddedDatabase in GraphDatabaseFactory
that takes File now instead of string path.

Fixes neo4j/neo4j-documentation#90