### PR TITLE
Speed up data linking in importer by increasing parallelism, and allowing out-of-order batch transfer

### DIFF
--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/CsvImporter.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/CsvImporter.java
@@ -108,8 +108,8 @@ class CsvImporter implements Importer
         Collector badCollector = badCollector( badOutput, isIgnoringSomething() ? BadCollector.UNLIMITED_TOLERANCE : 0,
                 collect( ignoreBadRelationships, ignoreDuplicateNodes, ignoreExtraColumns ) );
 
-        Configuration configuration = new WrappedBatchImporterConfigurationForNeo4jAdmin( importConfiguration( null, false,
-                databaseConfig ) );
+        Configuration configuration = new WrappedBatchImporterConfigurationForNeo4jAdmin( importConfiguration(
+                null, false, databaseConfig, storeDir ) );
         CsvInput input = new CsvInput(
                 nodeData( inputEncoding, nodesFiles ), defaultFormatNodeFileHeader(),
                 relationshipData( inputEncoding, relationshipsFiles ), defaultFormatRelationshipFileHeader(),

--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -438,7 +438,8 @@ public class ImportTool
                     Converters.toFile(), Validators.REGEX_FILE_EXISTS ) );
             dbConfig = dbConfig.augment( loadDbConfig( args.interpretOption( Options.ADDITIONAL_CONFIG.key(), Converters.optional(),
                     Converters.toFile(), Validators.REGEX_FILE_EXISTS ) ) );
-            configuration = importConfiguration( processors, defaultSettingsSuitableForTests, dbConfig, maxMemory );
+            configuration = importConfiguration(
+                    processors, defaultSettingsSuitableForTests, dbConfig, maxMemory, storeDir );
             input = new CsvInput( nodeData( inputEncoding, nodesFiles ), defaultFormatNodeFileHeader(),
                     relationshipData( inputEncoding, relationshipsFiles ), defaultFormatRelationshipFileHeader(),
                     idType, csvConfiguration( args, defaultSettingsSuitableForTests ), badCollector,
@@ -663,14 +664,14 @@ public class ImportTool
         }
     }
 
-    public static org.neo4j.unsafe.impl.batchimport.Configuration importConfiguration( final Number processors,
-            final boolean defaultSettingsSuitableForTests, final Config dbConfig )
+    public static org.neo4j.unsafe.impl.batchimport.Configuration importConfiguration(
+            Number processors, boolean defaultSettingsSuitableForTests, Config dbConfig, File storeDir )
     {
-        return importConfiguration( processors, defaultSettingsSuitableForTests, dbConfig, null );
+        return importConfiguration( processors, defaultSettingsSuitableForTests, dbConfig, null, storeDir );
     }
 
-    public static org.neo4j.unsafe.impl.batchimport.Configuration importConfiguration( final Number processors,
-            final boolean defaultSettingsSuitableForTests, final Config dbConfig, Long maxMemory )
+    public static org.neo4j.unsafe.impl.batchimport.Configuration importConfiguration(
+            Number processors, boolean defaultSettingsSuitableForTests, Config dbConfig, Long maxMemory, File storeDir )
     {
         return new org.neo4j.unsafe.impl.batchimport.Configuration()
         {
@@ -695,7 +696,14 @@ public class ImportTool
             @Override
             public long maxMemoryUsage()
             {
-                return maxMemory != null ? maxMemory.longValue() : DEFAULT.maxMemoryUsage();
+                return maxMemory != null ? maxMemory : DEFAULT.maxMemoryUsage();
+            }
+
+            @Override
+            public boolean parallelRecordReadsWhenWriting()
+            {
+                return org.neo4j.unsafe.impl.batchimport.Configuration.hintParallelRecordReadsWhenWritingForStoreDir(
+                        storeDir, false );
             }
         };
     }

--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -43,6 +43,7 @@ import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.io.IOUtils;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.logging.LogService;
@@ -702,8 +703,7 @@ public class ImportTool
             @Override
             public boolean parallelRecordReadsWhenWriting()
             {
-                return org.neo4j.unsafe.impl.batchimport.Configuration.hintParallelRecordReadsWhenWritingForStoreDir(
-                        storeDir, false );
+                return FileUtils.highIODevice( storeDir.toPath(), false );
             }
         };
     }

--- a/community/io/src/main/java/org/neo4j/io/fs/FileUtils.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/FileUtils.java
@@ -383,8 +383,8 @@ public class FileUtils
 
                 Path device = Paths.get( name ).toRealPath(); // Use toRealPath to resolve any symlinks.
                 Path deviceName = device.getName( device.getNameCount() - 1 );
-                Path sysblock = Paths.get( "/sys/block" );
-                Path rotational = sysblock.resolve( deviceName ).resolve( "queue" ).resolve( "rotational" );
+
+                Path rotational = rotationalPathFor( deviceName );
                 if ( Files.exists( rotational ) )
                 {
                     return readFirstCharacter( rotational ) == '0';
@@ -397,8 +397,8 @@ public class FileUtils
                     {
                         len--;
                     }
-                    namePart = namePart.substring( 0, len );
-                    rotational = sysblock.resolve( namePart ).resolve( "queue" ).resolve( "rotational" );
+                    deviceName = Paths.get( namePart.substring( 0, len ) );
+                    rotational = rotationalPathFor( deviceName );
                     if ( Files.exists( rotational ) )
                     {
                         return readFirstCharacter( rotational ) == '0';
@@ -412,6 +412,11 @@ public class FileUtils
         }
 
         return defaultHunch;
+    }
+
+    private static Path rotationalPathFor( Path deviceName )
+    {
+        return Paths.get( "/sys/block" ).resolve( deviceName ).resolve( "queue" ).resolve( "rotational" );
     }
 
     private static int readFirstCharacter( Path file ) throws IOException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
@@ -370,7 +370,15 @@ public class StoreMigrator extends AbstractStoreMigrationParticipant
                 RecordCursors relationshipInputCursors = new RecordCursors( legacyStore );
                 OutputStream badOutput = new BufferedOutputStream( new FileOutputStream( badFile, false ) ) )
         {
-            Configuration importConfig = new Configuration.Overridden( config );
+            Configuration importConfig = new Configuration.Overridden( config )
+            {
+                @Override
+                public boolean parallelRecordReadsWhenWriting()
+                {
+                    return Configuration.hintParallelRecordReadsWhenWritingForStoreDir(
+                            storeDir, super.parallelRecordReadsWhenWriting() );
+                }
+            };
             AdditionalInitialIds additionalInitialIds =
                     readAdditionalIds( lastTxId, lastTxChecksum, lastTxLogVersion, lastTxLogByteOffset );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
@@ -45,6 +45,7 @@ import java.util.stream.StreamSupport;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.io.fs.FileHandle;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.fs.FileUtils;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
@@ -375,8 +376,7 @@ public class StoreMigrator extends AbstractStoreMigrationParticipant
                 @Override
                 public boolean parallelRecordReadsWhenWriting()
                 {
-                    return Configuration.hintParallelRecordReadsWhenWritingForStoreDir(
-                            storeDir, super.parallelRecordReadsWhenWriting() );
+                    return FileUtils.highIODevice( storeDir.toPath(), super.parallelRecordReadsWhenWriting() );
                 }
             };
             AdditionalInitialIds additionalInitialIds =

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
@@ -19,12 +19,6 @@
  */
 package org.neo4j.unsafe.impl.batchimport;
 
-import org.apache.commons.lang3.SystemUtils;
-import org.apache.lucene.util.IOUtils;
-
-import java.io.File;
-import java.io.IOException;
-
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.pagecache.ConfiguringPageCacheFactory;
 import org.neo4j.kernel.impl.util.OsBeanUtil;
@@ -290,24 +284,5 @@ public interface Configuration
 
         double factor = percent / 100D;
         return round( (freePhysicalMemory - Runtime.getRuntime().maxMemory()) * factor );
-    }
-
-    static boolean hintParallelRecordReadsWhenWritingForStoreDir( File storeDir, boolean defaultValue )
-    {
-        try
-        {
-            // The idea is that we can do more IO in parallel if we use flash storage, and that we shouldn't do
-            // parallel IO with a spinning disk because then the additional seeks would hurt us.
-            // Most macs have flash storage, so assume true for them. IOUtils.spins implementation is Linux specific,
-            // and would only return true for that OS if it can detect a spinning storage medium (which we negate).
-            // If IOUtils cannot make an accurate detection, then it assumes true, which means that we by default
-            // assume that we are NOT on flash storage.
-            return SystemUtils.IS_OS_MAC
-                   || !IOUtils.spins( storeDir.toPath() );
-        }
-        catch ( IOException e )
-        {
-            return defaultValue;
-        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
@@ -19,6 +19,12 @@
  */
 package org.neo4j.unsafe.impl.batchimport;
 
+import org.apache.commons.lang3.SystemUtils;
+import org.apache.lucene.util.IOUtils;
+
+import java.io.File;
+import java.io.IOException;
+
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.pagecache.ConfiguringPageCacheFactory;
 import org.neo4j.kernel.impl.util.OsBeanUtil;
@@ -27,7 +33,6 @@ import org.neo4j.unsafe.impl.batchimport.staging.Step;
 
 import static java.lang.Math.min;
 import static java.lang.Math.round;
-
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.dense_node_threshold;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
 import static org.neo4j.io.ByteUnit.gibiBytes;
@@ -285,5 +290,24 @@ public interface Configuration
 
         double factor = percent / 100D;
         return round( (freePhysicalMemory - Runtime.getRuntime().maxMemory()) * factor );
+    }
+
+    static boolean hintParallelRecordReadsWhenWritingForStoreDir( File storeDir, boolean defaultValue )
+    {
+        try
+        {
+            // The idea is that we can do more IO in parallel if we use flash storage, and that we shouldn't do
+            // parallel IO with a spinning disk because then the additional seeks would hurt us.
+            // Most macs have flash storage, so assume true for them. IOUtils.spins implementation is Linux specific,
+            // and would only return true for that OS if it can detect a spinning storage medium (which we negate).
+            // If IOUtils cannot make an accurate detection, then it assumes true, which means that we by default
+            // assume that we are NOT on flash storage.
+            return SystemUtils.IS_OS_MAC
+                   || !IOUtils.spins( storeDir.toPath() );
+        }
+        catch ( IOException e )
+        {
+            return defaultValue;
+        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/AbstractStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/AbstractStep.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.LongPredicate;
 
+import org.neo4j.concurrent.WorkSync;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.impl.util.MovingAverage;
 import org.neo4j.unsafe.impl.batchimport.Configuration;
@@ -47,6 +48,7 @@ public abstract class AbstractStep<T> implements Step<T>
     private volatile String name;
     @SuppressWarnings( "rawtypes" )
     protected volatile Step downstream;
+    protected volatile WorkSync<Downstream,SendDownstream> downstreamWorkSync;
     private volatile boolean endOfUpstream;
     protected volatile Throwable panic;
     private volatile boolean completed;
@@ -167,6 +169,8 @@ public abstract class AbstractStep<T> implements Step<T>
     {
         assert downstream != this;
         this.downstream = downstream;
+        //noinspection unchecked
+        this.downstreamWorkSync = new WorkSync<>( new Downstream( (Step<Object>) downstream, doneBatches ) );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Downstream.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Downstream.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.staging;
+
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicLong;
+
+class Downstream
+{
+    private static final java.util.Comparator<TicketedBatch> TICKETED_BATCH_COMPARATOR =
+            ( a, b ) -> Long.compare( b.ticket, a.ticket );
+
+    private final Step<Object> downstream;
+    private final AtomicLong doneBatches;
+    private final ArrayList<TicketedBatch> batches;
+    private long lastSendTicket = -1;
+
+    public Downstream( Step<Object> downstream, AtomicLong doneBatches )
+    {
+        this.downstream = downstream;
+        this.doneBatches = doneBatches;
+        batches = new ArrayList<>();
+    }
+
+    public long send()
+    {
+        // Sort in reverse, so the elements we want to send first are at the end.
+        batches.sort( TICKETED_BATCH_COMPARATOR );
+        long idleTimeSum = 0;
+        long batchesDone = 0;
+
+        for ( int i = batches.size() - 1; i >= 0 ; i-- )
+        {
+            TicketedBatch batch = batches.get( i );
+            if ( batch.ticket == lastSendTicket + 1 )
+            {
+                batches.remove( i );
+                lastSendTicket = batch.ticket;
+                idleTimeSum += downstream.receive( batch.ticket, batch.batch );
+                batchesDone++;
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        doneBatches.getAndAdd( batchesDone );
+        return idleTimeSum;
+    }
+
+    public void queue( TicketedBatch batch )
+    {
+        // Check that this is not a marker to flush the downstream.
+        if ( batch.ticket != -1 && batch.batch != null )
+        {
+            batches.add( batch );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Downstream.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Downstream.java
@@ -32,14 +32,14 @@ class Downstream
     private final ArrayList<TicketedBatch> batches;
     private long lastSendTicket = -1;
 
-    public Downstream( Step<Object> downstream, AtomicLong doneBatches )
+    Downstream( Step<Object> downstream, AtomicLong doneBatches )
     {
         this.downstream = downstream;
         this.doneBatches = doneBatches;
         batches = new ArrayList<>();
     }
 
-    public long send()
+    long send()
     {
         // Sort in reverse, so the elements we want to send first are at the end.
         batches.sort( TICKETED_BATCH_COMPARATOR );
@@ -66,7 +66,7 @@ class Downstream
         return idleTimeSum;
     }
 
-    public void queue( TicketedBatch batch )
+    void queue( TicketedBatch batch )
     {
         // Check that this is not a marker to flush the downstream.
         if ( batch.ticket != -1 && batch.batch != null )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/DynamicProcessorAssigner.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/DynamicProcessorAssigner.java
@@ -51,7 +51,7 @@ public class DynamicProcessorAssigner extends ExecutionMonitor.Adapter
 
     public DynamicProcessorAssigner( Configuration config )
     {
-        super( 500, MILLISECONDS );
+        super( 100, MILLISECONDS );
         this.config = config;
         this.availableProcessors = config.maxNumberOfProcessors();
     }
@@ -83,7 +83,6 @@ public class DynamicProcessorAssigner extends ExecutionMonitor.Adapter
         Pair<Step<?>,Float> bottleNeck = execution.stepsOrderedBy( Keys.avg_processing_time, false ).iterator().next();
         Step<?> bottleNeckStep = bottleNeck.first();
         long doneBatches = batches( bottleNeckStep );
-        int usedPermits = 0;
         if ( bottleNeck.other() > 1.0f &&
              batchesPassedSinceLastChange( bottleNeckStep, doneBatches ) >= config.movingAverageSize() )
         {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProcessorStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProcessorStep.java
@@ -25,13 +25,11 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.neo4j.concurrent.AsyncApply;
 import org.neo4j.unsafe.impl.batchimport.Configuration;
 import org.neo4j.unsafe.impl.batchimport.executor.DynamicTaskExecutor;
-import org.neo4j.unsafe.impl.batchimport.executor.ParkStrategy;
 import org.neo4j.unsafe.impl.batchimport.executor.TaskExecutor;
 import org.neo4j.unsafe.impl.batchimport.stats.StatsProvider;
 
 import static java.lang.System.currentTimeMillis;
 import static java.lang.System.nanoTime;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.neo4j.unsafe.impl.batchimport.executor.DynamicTaskExecutor.DEFAULT_PARK_STRATEGY;
 
 /**
@@ -54,7 +52,6 @@ public abstract class ProcessorStep<T> extends AbstractStep<T>
     // Time stamp for when we processed the last queued batch received from upstream.
     // Useful for tracking how much time we spend waiting for batches from upstream.
     private final AtomicLong lastBatchEndTime = new AtomicLong();
-    private final ParkStrategy park = new ParkStrategy.Park( 1, MILLISECONDS );
 
     protected ProcessorStep( StageControl control, String name, Configuration config, int maxProcessors,
             StatsProvider... additionalStatsProviders )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/SendDownstream.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/SendDownstream.java
@@ -29,7 +29,7 @@ class SendDownstream implements Work<Downstream,SendDownstream>
     private TicketedBatch head;
     private TicketedBatch tail;
 
-    public SendDownstream( long ticket, Object batch, LongAdder downstreamIdleTime )
+    SendDownstream( long ticket, Object batch, LongAdder downstreamIdleTime )
     {
         this.downstreamIdleTime = downstreamIdleTime;
         TicketedBatch b = new TicketedBatch( ticket, batch );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/SendDownstream.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/SendDownstream.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.staging;
+
+import java.util.concurrent.atomic.LongAdder;
+
+import org.neo4j.concurrent.Work;
+
+class SendDownstream implements Work<Downstream,SendDownstream>
+{
+    private final LongAdder downstreamIdleTime;
+    private TicketedBatch head;
+    private TicketedBatch tail;
+
+    public SendDownstream( long ticket, Object batch, LongAdder downstreamIdleTime )
+    {
+        this.downstreamIdleTime = downstreamIdleTime;
+        TicketedBatch b = new TicketedBatch( ticket, batch );
+        head = b;
+        tail = b;
+    }
+
+    @Override
+    public SendDownstream combine( SendDownstream work )
+    {
+        tail.next = work.head;
+        tail = work.tail;
+        return this;
+    }
+
+    @Override
+    public void apply( Downstream downstream ) throws Exception
+    {
+        TicketedBatch next = head;
+        do
+        {
+            downstream.queue( next );
+            next = next.next;
+        }
+        while ( next != null );
+        downstreamIdleTime.add( downstream.send() );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/TicketedBatch.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/TicketedBatch.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.staging;
+
+class TicketedBatch
+{
+    final long ticket;
+    final Object batch;
+    TicketedBatch next;
+
+    TicketedBatch( long ticket, Object batch )
+    {
+        this.ticket = ticket;
+        this.batch = batch;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/FileUtilsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/FileUtilsTest.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.util;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -27,6 +28,7 @@ import org.junit.rules.RuleChain;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.test.rule.TestDirectory;
@@ -36,6 +38,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 import static org.neo4j.io.fs.FileUtils.pathToFileAfterMove;
 
 public class FileUtilsTest
@@ -217,6 +220,28 @@ public class FileUtilsTest
         File to   = new File( "/a/b" );
 
         assertThat( pathToFileAfterMove( from, to, file ).getPath(), is( path( "/a/b/d/f" ) ) );
+    }
+
+    @Test
+    public void allMacsHaveHighIO() throws Exception
+    {
+        assumeTrue( SystemUtils.IS_OS_MAC );
+        assertTrue( FileUtils.highIODevice( Paths.get( "." ), false ) );
+    }
+
+    @Test
+    public void windowsNeverHaveHighIO() throws Exception
+    {
+        // Future work: Maybe we should do like on Mac and assume true on Windows as well?
+        assumeTrue( SystemUtils.IS_OS_WINDOWS );
+        assertFalse( FileUtils.highIODevice( Paths.get( "." ), false ) );
+    }
+
+    @Test
+    public void onLinuxDevShmHasHighIO() throws Exception
+    {
+        assumeTrue( SystemUtils.IS_OS_LINUX );
+        assertTrue( FileUtils.highIODevice( Paths.get( "/dev/shm" ), false ) );
     }
 
     private File directory( String name )


### PR DESCRIPTION
Between certain steps, batches are required to be handed over in-order. Previously, this was ensured by letting steps wait for their turn to deliver their batches. This prevented a lot of parallelism, and hence `parallelRecordReadsWhenWriting` was `false` by default, meaning only a single thread would process those steps to avoid the turn waiting.

Now, a `WorkSync` is inserted in between the steps, and is used to sort the batches before their hand-over. This means the delivering step can now deliver batches out-of-order, which in turn makes it profitable to run it in parallel.