### PR TITLE
Removes port setting from TestOnlineBackupExtension

### DIFF
--- a/enterprise/backup/src/test/java/org/neo4j/backup/TestOnlineBackupExtension.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/TestOnlineBackupExtension.java
@@ -38,8 +38,6 @@ public class TestOnlineBackupExtension extends KernelExtensionFactoryContractTes
         if ( shouldLoad )
         {
             configuration.put( OnlineBackupSettings.online_backup_enabled.name(), Settings.TRUE );
-            configuration.put( OnlineBackupSettings.online_backup_server.name(), ":" +
-                    (BackupServer.DEFAULT_PORT + instance) );
         }
         return configuration;
     }


### PR DESCRIPTION
so that the default range is used, instead of a specific port which
may be bound by another test.