### PR TITLE
Wait for open calls to finish on index drop and close

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/ContractCheckingIndexProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/ContractCheckingIndexProxyTest.java
@@ -22,15 +22,20 @@ package org.neo4j.kernel.impl.api.index;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.test.DoubleLatch;
+import org.neo4j.test.ThreadTestUtils;
 
 import static org.neo4j.kernel.impl.api.index.SchemaIndexTestHelper.mockIndexProxy;
 
 public class ContractCheckingIndexProxyTest
 {
+    private static final long TEST_TIMEOUT = 10_000;
+
     @Test( expected = /* THEN */ IllegalStateException.class )
     public void shouldNotCreateIndexTwice() throws IOException
     {
@@ -219,11 +224,11 @@ public class ContractCheckingIndexProxyTest
         }
     }
 
-    @Test( expected = /* THEN */ IllegalStateException.class )
-    public void shouldNotCloseWhileUpdating() throws IOException
+    @Test( timeout = TEST_TIMEOUT)
+    public void closeWaitForUpdateToFinish() throws IOException, InterruptedException
     {
         // GIVEN
-        final DoubleLatch latch = new DoubleLatch();
+        CountDownLatch latch = new CountDownLatch( 1 );
         final IndexProxy inner = new IndexProxyAdapter()
         {
             @Override
@@ -233,15 +238,23 @@ public class ContractCheckingIndexProxyTest
             }
         };
         final IndexProxy outer = newContractCheckingIndexProxy( inner );
+        Thread actionThread = createActionThread( outer::close );
         outer.start();
 
         // WHEN
-        runInSeparateThread( () ->
-        {
-            try (IndexUpdater updater = outer.newUpdater( IndexUpdateMode.ONLINE ))
+        Thread updaterThread = runInSeparateThread( () -> {
+            try ( IndexUpdater updater = outer.newUpdater( IndexUpdateMode.ONLINE ) )
             {
                 updater.process( null );
-                latch.startAndWaitForAllToStartAndFinish();
+                try
+                {
+                    actionThread.start();
+                    latch.await();
+                }
+                catch ( InterruptedException e )
+                {
+                    throw new RuntimeException( e );
+                }
             }
             catch ( IndexEntryConflictException e )
             {
@@ -249,45 +262,46 @@ public class ContractCheckingIndexProxyTest
             }
         } );
 
-        try
-        {
-            latch.waitForAllToStart();
-            outer.close();
-        }
-        finally
-        {
-            latch.finish();
-        }
+        ThreadTestUtils.awaitThreadState( actionThread, 5_000, Thread.State.TIMED_WAITING );
+        latch.countDown();
+        updaterThread.join();
+        actionThread.join();
     }
 
-    @Test( expected = /* THEN */ IllegalStateException.class )
-    public void shouldNotCloseWhileForcing() throws IOException
+    @Test( timeout = TEST_TIMEOUT )
+    public void closeWaitForForceToComplete() throws Exception
     {
         // GIVEN
-        final DoubleLatch latch = new DoubleLatch();
+        CountDownLatch latch = new CountDownLatch( 1 );
+        AtomicReference<Thread> actionThreadReference = new AtomicReference<>();
         final IndexProxy inner = new IndexProxyAdapter()
         {
             @Override
             public void force()
             {
-                latch.startAndWaitForAllToStartAndFinish();
+                try
+                {
+                    actionThreadReference.get().start();
+                    latch.await();
+                }
+                catch ( Exception e )
+                {
+                  throw new RuntimeException( e );
+                }
             }
         };
-        final IndexProxy outer = newContractCheckingIndexProxy( inner );
+        IndexProxy outer = newContractCheckingIndexProxy( inner );
+        Thread actionThread = createActionThread( outer::close );
+        actionThreadReference.set( actionThread );
+
         outer.start();
+        Thread thread = runInSeparateThread( outer::force );
 
-        // WHEN
-        runInSeparateThread( () -> outer.force() );
+        ThreadTestUtils.awaitThreadState( actionThread, 5_000, Thread.State.TIMED_WAITING );
+        latch.countDown();
 
-        try
-        {
-            latch.waitForAllToStart();
-            outer.close();
-        }
-        finally
-        {
-            latch.finish();
-        }
+        thread.join();
+        actionThread.join();
     }
 
     private interface ThrowingRunnable
@@ -295,19 +309,25 @@ public class ContractCheckingIndexProxyTest
         void run() throws IOException;
     }
 
-    private void runInSeparateThread( final ThrowingRunnable action )
+    private Thread runInSeparateThread( final ThrowingRunnable action )
     {
-        new Thread( () ->
-        {
-            try
-            {
-                action.run();
-            }
-            catch ( IOException e )
-            {
-                throw new RuntimeException( e );
-            }
-        } ).start();
+        Thread thread = createActionThread( action );
+        thread.start();
+        return thread;
+    }
+
+    private Thread createActionThread( ThrowingRunnable action )
+    {
+        return new Thread( () -> {
+                try
+                {
+                    action.run();
+                }
+                catch ( IOException e )
+                {
+                    throw new RuntimeException( e );
+                }
+            } );
     }
 
     private ContractCheckingIndexProxy newContractCheckingIndexProxy( IndexProxy inner )


### PR DESCRIPTION
Currently any concurrent open call to index will cause exception to be throw,
that will cause database panic.
To relax current state a bit and do minimal changes to a way how we handle
state in contract checking index we will wait now for all open calls to finish
before performing drop or close operations.