### PR TITLE
Add additional procedures to access transaction metadata

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/QueryRegistryOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/QueryRegistryOperations.java
@@ -42,6 +42,13 @@ public interface QueryRegistryOperations
     void setMetaData( Map<String,Object> data );
 
     /**
+     * Gets associated meta data.
+     *
+     * @return the meta data
+     */
+    Map<String,Object> getMetaData();
+
+    /**
      * List of all currently running stream in this transaction. An user can have multiple stream running
      * simultaneously on the same transaction.
      */

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -23,6 +23,7 @@ import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -179,7 +180,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         this.storageStatement = storeLayer.newStatement();
         this.currentStatement =
                 new KernelStatement( this, this, storageStatement, procedures, accessCapability, lockTracer );
-        this.userMetaData = Collections.emptyMap();
+        this.userMetaData = new HashMap<>();
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -1301,6 +1301,13 @@ public class OperationsFacade
     }
 
     @Override
+    public Map<String,Object> getMetaData()
+    {
+        statement.assertOpen();
+        return statement.getTransaction().getMetaData();
+    }
+
+    @Override
     public Stream<ExecutingQuery> executingQueries()
     {
         statement.assertOpen();

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
@@ -54,7 +54,6 @@ import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
-import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.neo4j.function.ThrowingFunction.catchThrown;
@@ -67,8 +66,6 @@ import static org.neo4j.procedure.Mode.DBMS;
 @SuppressWarnings( "unused" )
 public class EnterpriseBuiltInDbmsProcedures
 {
-    private static final int HARD_CHAR_LIMIT = 2048;
-
     @Context
     public DependencyResolver resolver;
 
@@ -84,20 +81,20 @@ public class EnterpriseBuiltInDbmsProcedures
     public void setTXMetaData( @Name( value = "data" ) Map<String,Object> data )
     {
         securityContext.assertCredentialsNotExpired();
-        int totalCharSize = data.entrySet().stream()
-                .mapToInt( e -> e.getKey().length() + e.getValue().toString().length() )
-                .sum();
-
-        if ( totalCharSize >= HARD_CHAR_LIMIT )
-        {
-            throw new IllegalArgumentException(
-                    format( "Invalid transaction meta-data, expected the total number of chars for " +
-                            "keys and values to be less than %d, got %d", HARD_CHAR_LIMIT, totalCharSize ) );
-        }
-
         try ( Statement statement = getCurrentTx().acquireStatement() )
         {
             statement.queryRegistration().setMetaData( data );
+        }
+    }
+
+    @Description( "Provides attached transaction metadata." )
+    @Procedure( name = "dbms.getTXMetaData", mode = DBMS )
+    public Stream<MetadataResult> getTXMetaData()
+    {
+        securityContext.assertCredentialsNotExpired();
+        try ( Statement statement = getCurrentTx().acquireStatement() )
+        {
+            return Stream.of( statement.queryRegistration().getMetaData() ).map( MetadataResult::new );
         }
     }
 
@@ -526,6 +523,16 @@ public class EnterpriseBuiltInDbmsProcedures
         {
             this.username = username;
             this.connectionCount = connectionCount;
+        }
+    }
+
+    public static class MetadataResult
+    {
+        public final Map<String,Object> metadata;
+
+        MetadataResult( Map<String,Object> metadata )
+        {
+            this.metadata = metadata;
         }
     }
 }

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -63,6 +63,7 @@ import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.logging.Log;
+import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.util.Collections.singletonList;
@@ -90,6 +91,27 @@ public class ProcedureIT
     public ExpectedException exception = ExpectedException.none();
 
     private GraphDatabaseService db;
+
+    @Before
+    public void setUp() throws IOException
+    {
+        exceptionsInProcedure.clear();
+        new JarBuilder().createJarFor( plugins.newFile( "myProcedures.jar" ), ClassWithProcedures.class );
+        new JarBuilder().createJarFor( plugins.newFile( "myFunctions.jar" ), ClassWithFunctions.class );
+        db = new TestEnterpriseGraphDatabaseFactory()
+                .newImpermanentDatabaseBuilder()
+                .setConfig( plugin_dir, plugins.getRoot().getAbsolutePath() )
+                .newGraphDatabase();
+    }
+
+    @After
+    public void tearDown()
+    {
+        if ( this.db != null )
+        {
+            this.db.shutdown();
+        }
+    }
 
     @Test
     public void shouldCallProcedureWithParameterMap() throws Throwable
@@ -1190,27 +1212,6 @@ public class ProcedureIT
         //Then
         exception.expect( TransactionFailureException.class );
         result.next();
-    }
-
-    @Before
-    public void setUp() throws IOException
-    {
-        exceptionsInProcedure.clear();
-        new JarBuilder().createJarFor( plugins.newFile( "myProcedures.jar" ), ClassWithProcedures.class );
-        new JarBuilder().createJarFor( plugins.newFile( "myFunctions.jar" ), ClassWithFunctions.class );
-        db = new TestGraphDatabaseFactory()
-                .newImpermanentDatabaseBuilder()
-                .setConfig( plugin_dir, plugins.getRoot().getAbsolutePath() )
-                .newGraphDatabase();
-    }
-
-    @After
-    public void tearDown()
-    {
-        if ( this.db != null )
-        {
-            this.db.shutdown();
-        }
     }
 
     public static class Output


### PR DESCRIPTION
Add additional standard procedure `dbms.getTXMetaData` to access transactional metadata.
Provide demo usage example as test.