### PR TITLE
Some memory improvements around IdMapper

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 
 import org.neo4j.helpers.Exceptions;
 
+import static java.lang.Long.min;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 
@@ -315,7 +316,7 @@ public interface NumberArrayFactory
 
         private long fractionOf( long length )
         {
-            return length / 10;
+            return min( length / 10, Integer.MAX_VALUE );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/AbstractTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/AbstractTracker.java
@@ -29,8 +29,6 @@ import org.neo4j.unsafe.impl.batchimport.cache.NumberArray;
  */
 abstract class AbstractTracker<ARRAY extends NumberArray> implements Tracker
 {
-    static final int DEFAULT_VALUE = -1;
-
     protected ARRAY array;
 
     protected AbstractTracker( ARRAY array )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/BigIdTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/BigIdTracker.java
@@ -19,14 +19,16 @@
  */
 package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
 
-import org.neo4j.unsafe.impl.batchimport.cache.LongArray;
+import org.neo4j.unsafe.impl.batchimport.cache.ByteArray;
 
 /**
- * {@link Tracker} capable of keeping {@code long} range values, using {@link LongArray}.
+ * {@link Tracker} capable of keeping 6B range values, using {@link ByteArray}.
  */
-public class LongTracker extends AbstractTracker<LongArray>
+public class BigIdTracker extends AbstractTracker<ByteArray>
 {
-    public LongTracker( LongArray array )
+    static final byte[] DEFAULT_VALUE = new byte[] {-1, -1, -1, -1, -1, -1};
+
+    public BigIdTracker( ByteArray array )
     {
         super( array );
     }
@@ -34,12 +36,12 @@ public class LongTracker extends AbstractTracker<LongArray>
     @Override
     public long get( long index )
     {
-        return array.get( index );
+        return array.get6ByteLong( index, 0 );
     }
 
     @Override
     public void set( long index, long value )
     {
-        array.set( index, value );
+        array.set6ByteLong( index, 0, value );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/IntTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/IntTracker.java
@@ -28,6 +28,8 @@ import org.neo4j.unsafe.impl.batchimport.cache.IntArray;
  */
 public class IntTracker extends AbstractTracker<IntArray>
 {
+    static final int DEFAULT_VALUE = -1;
+
     public IntTracker( IntArray array )
     {
         super( array );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/TrackerFactories.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/TrackerFactories.java
@@ -21,7 +21,6 @@ package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
 
 import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 
-import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.AbstractTracker.DEFAULT_VALUE;
 
 /**
  * Common {@link TrackerFactory} implementations.
@@ -39,8 +38,8 @@ public class TrackerFactories
             public Tracker create( NumberArrayFactory arrayFactory, long size )
             {
                 return size > Integer.MAX_VALUE
-                        ? new LongTracker( arrayFactory.newLongArray( size, DEFAULT_VALUE ) )
-                        : new IntTracker( arrayFactory.newIntArray( size, DEFAULT_VALUE ) );
+                        ? new BigIdTracker( arrayFactory.newByteArray( size, BigIdTracker.DEFAULT_VALUE ) )
+                        : new IntTracker( arrayFactory.newIntArray( size, IntTracker.DEFAULT_VALUE ) );
             }
         };
     }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapperTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapperTest.java
@@ -628,8 +628,8 @@ public class EncodingIdMapperTest
         public Tracker create( NumberArrayFactory arrayFactory, long size )
         {
             return System.currentTimeMillis() % 2 == 0
-                    ? new IntTracker( arrayFactory.newIntArray( size, AbstractTracker.DEFAULT_VALUE ) )
-                    : new LongTracker( arrayFactory.newLongArray( size, AbstractTracker.DEFAULT_VALUE ) );
+                    ? new IntTracker( arrayFactory.newIntArray( size, IntTracker.DEFAULT_VALUE ) )
+                    : new BigIdTracker( arrayFactory.newByteArray( size, BigIdTracker.DEFAULT_VALUE ) );
         }
     };
 


### PR DESCRIPTION
changelog: Fixes issue where large import would try to allocate array larger than Integer.MAX_VALUE and fail. IdMapper memory usage slightly reduced for large imports too.