### PR TITLE
Convenient PageCache rule

### DIFF
--- a/community/io/src/test/java/org/neo4j/test/rule/PageCacheAndDependenciesRule.java
+++ b/community/io/src/test/java/org/neo4j/test/rule/PageCacheAndDependenciesRule.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test.rule;
+
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import java.util.function.Supplier;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
+import org.neo4j.test.rule.fs.FileSystemRule;
+
+/**
+ * Very often when you want a {@link PageCacheRule} you also want {@link TestDirectory} and some {@link FileSystemRule}.
+ * This is tedious to write and apply in the correct order in every test doing this. This rule collects
+ * this threesome into one rule for convenience.
+ */
+public class PageCacheAndDependenciesRule implements TestRule
+{
+    private final RuleChain chain;
+    private final FileSystemRule<? extends FileSystemAbstraction> fs;
+    private final TestDirectory directory;
+    private final PageCacheRule pageCacheRule = new PageCacheRule();
+
+    public PageCacheAndDependenciesRule()
+    {
+        this( () -> new EphemeralFileSystemRule() );
+    }
+
+    /**
+     * @param fsSupplier as {@link Supplier} to make it clear that it is this class that owns the created
+     * {@link FileSystemRule} instance.
+     */
+    public PageCacheAndDependenciesRule( Supplier<FileSystemRule<? extends FileSystemAbstraction>> fsSupplier )
+    {
+        this.fs = fsSupplier.get();
+        this.directory = TestDirectory.testDirectory( fs );
+        this.chain = RuleChain.outerRule( fs ).around( directory ).around( pageCacheRule );
+    }
+
+    @Override
+    public Statement apply( Statement base, Description description )
+    {
+        return chain.apply( base, description );
+    }
+
+    public FileSystemRule<? extends FileSystemAbstraction> fileSystemRule()
+    {
+        return fs;
+    }
+
+    public FileSystemAbstraction fileSystem()
+    {
+        return fs.get();
+    }
+
+    public TestDirectory directory()
+    {
+        return directory;
+    }
+
+    public PageCacheRule pageCacheRule()
+    {
+        return pageCacheRule;
+    }
+
+    public PageCache pageCache()
+    {
+        return pageCacheRule.getPageCache( fs );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/NeoStoreDataSourceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/NeoStoreDataSourceTest.java
@@ -38,6 +38,7 @@ import org.neo4j.kernel.impl.store.id.configuration.CommunityIdTypeConfiguration
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryVersion;
 import org.neo4j.kernel.impl.transaction.log.entry.LogHeader;
+import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.kernel.internal.DatabaseHealth;
 import org.neo4j.kernel.lifecycle.LifecycleException;
 import org.neo4j.logging.AssertableLogProvider;
@@ -48,7 +49,6 @@ import org.neo4j.test.rule.PageCacheRule;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 
-import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -86,9 +86,11 @@ public class NeoStoreDataSourceTest
         {
             DatabaseHealth databaseHealth = new DatabaseHealth( mock( DatabasePanicEventGenerator.class ),
                     NullLogProvider.getInstance().getLog( DatabaseHealth.class ) );
+            Dependencies dependencies = new Dependencies();
+            dependencies.satisfyDependency( databaseHealth );
 
             theDataSource = dsRule.getDataSource( dir.graphDbDir(), fs.get(), pageCacheRule.getPageCache( fs.get() ),
-                    stringMap(), databaseHealth );
+                    dependencies );
 
             databaseHealth.panic( new Throwable() );
 
@@ -110,7 +112,7 @@ public class NeoStoreDataSourceTest
     public void flushOfThePageCacheHappensOnlyOnceDuringShutdown() throws IOException
     {
         PageCache pageCache = spy( pageCacheRule.getPageCache( fs.get() ) );
-        NeoStoreDataSource ds = dsRule.getDataSource( dir.graphDbDir(), fs.get(), pageCache, stringMap() );
+        NeoStoreDataSource ds = dsRule.getDataSource( dir.graphDbDir(), fs.get(), pageCache );
 
         ds.init();
         ds.start();
@@ -125,12 +127,9 @@ public class NeoStoreDataSourceTest
     @Test
     public void flushOfThePageCacheOnShutdownHappensIfTheDbIsHealthy() throws IOException
     {
-        DatabaseHealth health = mock( DatabaseHealth.class );
-        when( health.isHealthy() ).thenReturn( true );
-
         PageCache pageCache = spy( pageCacheRule.getPageCache( fs.get() ) );
 
-        NeoStoreDataSource ds = dsRule.getDataSource( dir.graphDbDir(), fs.get(), pageCache, stringMap(), health );
+        NeoStoreDataSource ds = dsRule.getDataSource( dir.graphDbDir(), fs.get(), pageCache );
 
         ds.init();
         ds.start();
@@ -146,10 +145,11 @@ public class NeoStoreDataSourceTest
     {
         DatabaseHealth health = mock( DatabaseHealth.class );
         when( health.isHealthy() ).thenReturn( false );
-
         PageCache pageCache = spy( pageCacheRule.getPageCache( fs.get() ) );
 
-        NeoStoreDataSource ds = dsRule.getDataSource( dir.graphDbDir(), fs.get(), pageCache, stringMap(), health );
+        Dependencies dependencies = new Dependencies();
+        dependencies.satisfyDependency( health );
+        NeoStoreDataSource ds = dsRule.getDataSource( dir.graphDbDir(), fs.get(), pageCache, dependencies );
 
         ds.init();
         ds.start();
@@ -224,10 +224,11 @@ public class NeoStoreDataSourceTest
         AssertableLogProvider logProvider = new AssertableLogProvider();
         SimpleLogService logService = new SimpleLogService( logProvider, logProvider );
         PageCache pageCache = pageCacheRule.getPageCache( fs.get() );
+        Dependencies dependencies = new Dependencies();
+        dependencies.satisfyDependencies( idGeneratorFactory, idTypeConfigurationProvider, config, logService );
 
-        NeoStoreDataSource dataSource = dsRule.getDataSource( dir.graphDbDir(), fs.get(), idGeneratorFactory,
-                idTypeConfigurationProvider,
-                pageCache, config, mock( DatabaseHealth.class ), logService );
+        NeoStoreDataSource dataSource = dsRule.getDataSource( dir.graphDbDir(), fs.get(),
+                pageCache, dependencies );
 
         try
         {
@@ -256,7 +257,9 @@ public class NeoStoreDataSourceTest
         IOException ex = new IOException( "boom!" );
         doThrow( ex ).when( databaseHealth )
                 .assertHealthy( IOException.class ); // <- this is a trick to simulate a failure during checkpointing
-        NeoStoreDataSource dataSource = dsRule.getDataSource( storeDir, fs, pageCache, emptyMap(), databaseHealth );
+        Dependencies dependencies = new Dependencies();
+        dependencies.satisfyDependencies( databaseHealth );
+        NeoStoreDataSource dataSource = dsRule.getDataSource( storeDir, fs, pageCache, dependencies );
         dataSource.start();
 
         try

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresTest.java
@@ -74,6 +74,7 @@ import org.neo4j.kernel.impl.transaction.log.entry.LogHeader;
 import org.neo4j.kernel.impl.transaction.state.PropertyLoader;
 import org.neo4j.kernel.impl.transaction.state.TransactionRecordState.PropertyReceiver;
 import org.neo4j.kernel.impl.util.ArrayMap;
+import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.storageengine.api.NodeItem;
 import org.neo4j.storageengine.api.PropertyItem;
@@ -867,7 +868,9 @@ public class NeoStoresTest
 
     private void initializeStores( File storeDir, Map<String,String> additionalConfig ) throws IOException
     {
-        ds = dsRule.getDataSource( storeDir, fs.get(), pageCache, additionalConfig );
+        Dependencies dependencies = new Dependencies();
+        dependencies.satisfyDependency( Config.embeddedDefaults( additionalConfig ) );
+        ds = dsRule.getDataSource( storeDir, fs.get(), pageCache, dependencies );
         ds.init();
         ds.start();
 

--- a/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoreDataSourceRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoreDataSourceRule.java
@@ -20,8 +20,7 @@
 package org.neo4j.test.rule;
 
 import java.io.File;
-import java.util.Map;
-
+import java.util.function.Function;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.IOLimiter;
@@ -51,6 +50,7 @@ import org.neo4j.kernel.impl.locking.StatementLocks;
 import org.neo4j.kernel.impl.locking.StatementLocksFactory;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.kernel.impl.logging.SimpleLogService;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.spi.KernelContext;
 import org.neo4j.kernel.impl.spi.SimpleKernelContext;
@@ -61,11 +61,13 @@ import org.neo4j.kernel.impl.store.id.configuration.CommunityIdTypeConfiguration
 import org.neo4j.kernel.impl.store.id.configuration.IdTypeConfigurationProvider;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
 import org.neo4j.kernel.impl.transaction.TransactionMonitor;
+import org.neo4j.kernel.impl.transaction.TransactionStats;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.StoreCopyCheckPointMutex;
 import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.kernel.impl.util.DependenciesProxy;
 import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.kernel.impl.util.UnsatisfiedDependencyException;
 import org.neo4j.kernel.internal.DatabaseHealth;
 import org.neo4j.kernel.internal.TransactionEventHandlers;
 import org.neo4j.kernel.monitoring.Monitors;
@@ -84,36 +86,15 @@ public class NeoStoreDataSourceRule extends ExternalResource
 {
     private NeoStoreDataSource dataSource;
 
-    public NeoStoreDataSource getDataSource( File storeDir, FileSystemAbstraction fs,
-            PageCache pageCache, Map<String,String> additionalConfig, DatabaseHealth databaseHealth )
+    public NeoStoreDataSource getDataSource( File storeDir, FileSystemAbstraction fs, PageCache pageCache )
     {
-        CommunityIdTypeConfigurationProvider idTypeConfigurationProvider =
-                new CommunityIdTypeConfigurationProvider();
-        DefaultIdGeneratorFactory idGeneratorFactory = new DefaultIdGeneratorFactory( fs );
-        NullLogService logService = NullLogService.getInstance();
-        return getDataSource( storeDir, fs, idGeneratorFactory, idTypeConfigurationProvider, pageCache,
-                additionalConfig, databaseHealth, logService );
+        return getDataSource( storeDir, fs, pageCache, new Dependencies() );
     }
 
-    public NeoStoreDataSource getDataSource( File storeDir, FileSystemAbstraction fs,
-            IdGeneratorFactory idGeneratorFactory, IdTypeConfigurationProvider idConfigurationProvider,
-            PageCache pageCache, Map<String, String> additionalConfig, DatabaseHealth databaseHealth,
-            LogService logService )
+    public NeoStoreDataSource getDataSource( File storeDir, FileSystemAbstraction fs, PageCache pageCache,
+            DependencyResolver otherCustomOverriddenDependencies )
     {
-        return getDataSource( storeDir, fs, idGeneratorFactory, idConfigurationProvider, pageCache,
-                Config.embeddedDefaults( additionalConfig ), databaseHealth, logService );
-    }
-
-    public NeoStoreDataSource getDataSource( File storeDir, FileSystemAbstraction fs,
-            IdGeneratorFactory idGeneratorFactory, IdTypeConfigurationProvider idConfigurationProvider,
-            PageCache pageCache, Config config, DatabaseHealth databaseHealth,
-            LogService logService )
-    {
-        if ( dataSource != null )
-        {
-            dataSource.stop();
-            dataSource.shutdown();
-        }
+        shutdownAnyRunning();
 
         StatementLocksFactory locksFactory = mock( StatementLocksFactory.class );
         StatementLocks statementLocks = mock( StatementLocks.class );
@@ -124,16 +105,34 @@ public class NeoStoreDataSourceRule extends ExternalResource
 
         JobScheduler jobScheduler = mock( JobScheduler.class, RETURNS_MOCKS );
         Monitors monitors = new Monitors();
+
+        Dependencies mutableDependencies = new Dependencies( otherCustomOverriddenDependencies );
+        Config config = dependency( mutableDependencies, Config.class, deps -> Config.empty() );
+        LogService logService = dependency( mutableDependencies, LogService.class,
+                deps -> new SimpleLogService( NullLogProvider.getInstance(), NullLogProvider.getInstance() ) );
+        IdGeneratorFactory idGeneratorFactory = dependency( mutableDependencies, IdGeneratorFactory.class,
+                deps -> new DefaultIdGeneratorFactory( fs ) );
+        IdTypeConfigurationProvider idConfigurationProvider = dependency( mutableDependencies,
+                IdTypeConfigurationProvider.class, deps -> new CommunityIdTypeConfigurationProvider() );
+        DatabaseHealth databaseHealth = dependency( mutableDependencies, DatabaseHealth.class,
+                deps -> new DatabaseHealth( mock( DatabasePanicEventGenerator.class ),
+                        NullLogProvider.getInstance().getLog( DatabaseHealth.class ) ) );
+        SystemNanoClock clock = dependency( mutableDependencies, SystemNanoClock.class, deps -> Clocks.nanoClock() );
+        TransactionMonitor transactionMonitor =
+                dependency( mutableDependencies, TransactionMonitor.class, deps -> new TransactionStats() );
+        AvailabilityGuard availabilityGuard = dependency( mutableDependencies, AvailabilityGuard.class,
+                deps -> new AvailabilityGuard( deps.resolveDependency( SystemNanoClock.class ),
+                        NullLog.getInstance() ) );
+
         LabelScanStoreProvider labelScanStoreProvider =
                 nativeLabelScanStoreProvider( storeDir, fs, pageCache, config, logService, monitors );
-        SystemNanoClock clock = Clocks.nanoClock();
         dataSource = new NeoStoreDataSource( storeDir, config, idGeneratorFactory, IdReuseEligibility.ALWAYS,
                 idConfigurationProvider,
                 logService, mock( JobScheduler.class, RETURNS_MOCKS ), mock( TokenNameLookup.class ),
                 dependencyResolverForNoIndexProvider( labelScanStoreProvider ), mock( PropertyKeyTokenHolder.class ),
                 mock( LabelTokenHolder.class ), mock( RelationshipTypeTokenHolder.class ), locksFactory,
                 mock( SchemaWriteGuard.class ), mock( TransactionEventHandlers.class ), IndexingService.NO_MONITOR,
-                fs, mock( TransactionMonitor.class ), databaseHealth,
+                fs, transactionMonitor, databaseHealth,
                 mock( PhysicalLogFile.Monitor.class ), TransactionHeaderInformationFactory.DEFAULT,
                 new StartupStatisticsProvider(), null,
                 new CommunityCommitProcessFactory(), mock( InternalAutoIndexing.class ), pageCache,
@@ -141,10 +140,38 @@ public class NeoStoreDataSourceRule extends ExternalResource
                 new Tracers( "null", NullLog.getInstance(), monitors, jobScheduler ),
                 mock( Procedures.class ),
                 IOLimiter.unlimited(),
-                new AvailabilityGuard( clock, NullLog.getInstance() ), clock,
+                availabilityGuard, clock,
                 new CanWrite(), new StoreCopyCheckPointMutex() );
 
         return dataSource;
+    }
+
+    private <T> T dependency( Dependencies dependencies, Class<T> type,
+            Function<DependencyResolver,T> defaultSupplier )
+    {
+        try
+        {
+            return dependencies.resolveDependency( type );
+        }
+        catch ( IllegalArgumentException | UnsatisfiedDependencyException e )
+        {
+            return dependencies.satisfyDependency( defaultSupplier.apply( dependencies ) );
+        }
+    }
+
+    private void shutdownAnyRunning()
+    {
+        if ( dataSource != null )
+        {
+            dataSource.stop();
+            dataSource.shutdown();
+        }
+    }
+
+    @Override
+    protected void after( boolean successful ) throws Throwable
+    {
+        shutdownAnyRunning();
     }
 
     public static LabelScanStoreProvider nativeLabelScanStoreProvider( File storeDir, FileSystemAbstraction fs,
@@ -171,14 +198,6 @@ public class NeoStoreDataSourceRule extends ExternalResource
         {
             throw launderedException( e );
         }
-    }
-
-    public NeoStoreDataSource getDataSource( File storeDir, FileSystemAbstraction fs,
-            PageCache pageCache, Map<String,String> additionalConfig )
-    {
-        DatabaseHealth databaseHealth = new DatabaseHealth( mock( DatabasePanicEventGenerator.class ),
-                NullLogProvider.getInstance().getLog( DatabaseHealth.class ) );
-        return getDataSource( storeDir, fs, pageCache, additionalConfig, databaseHealth );
     }
 
     private DependencyResolver dependencyResolverForNoIndexProvider( LabelScanStoreProvider labelScanStoreProvider )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpWriterTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpWriterTest.java
@@ -55,7 +55,6 @@ import org.neo4j.test.rule.PageCacheRule;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 
-import static java.util.Collections.emptyMap;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
@@ -156,7 +155,7 @@ public class TransactionLogCatchUpWriterTest
     {
         // create an empty store
         org.neo4j.kernel.impl.store.StoreId storeId;
-        NeoStoreDataSource ds = dsRule.getDataSource( storeDir, fs, pageCache, emptyMap() );
+        NeoStoreDataSource ds = dsRule.getDataSource( storeDir, fs, pageCache );
         try ( Lifespan ignored = new Lifespan( ds ) )
         {
             storeId = ds.getStoreId();


### PR DESCRIPTION
Managing PageCache, FileSystemAbstraction and TestDirectory. This conveniently gathered into one rule instead of creating all thread and doing the RuleChain thing. Now it'll be much more fun writing these tests.

This commit was previously part of #9227 , but got reverted in #9547 so I decided to pull this commit out as a separate PR to get it in.