### PR TITLE
Limit and aggregation cannot be combined

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -152,3 +152,6 @@ Accessing a list with null should return null
 Accessing a list with null as lower bound should return null
 Accessing a list with null as upper bound should return null
 Accessing a map with null should return null
+
+//SkipLimitAcceptance.feature
+Combining LIMIT and aggregation

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/SkipLimitAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/SkipLimitAcceptance.feature
@@ -54,3 +54,19 @@ Feature: SkipLimitAcceptance.feature
       LIMIT -1
       """
     Then a SyntaxError should be raised at compile time: NegativeIntegerArgument
+
+  Scenario: Combining LIMIT and aggregation
+    And having executed:
+      """
+      CREATE (s:Person {name: 'Steven'})
+      """
+    When executing query:
+      """
+      MATCH (p:Person)
+      WITH p LIMIT 1
+      RETURN count(p) AS count
+      """
+    Then the result should be, in order:
+      | count |
+      |   1   |
+    And no side effects


### PR DESCRIPTION
In the compiled runtime aggregation and limit are not playing nice
with each other, disable all queries that combine limit and aggregation
to be run  on the compiled runtime for now.

changelog: Fix for queries combining limit and aggregation in the compiled runtime.