### PR TITLE
Put import tool logs inside logs directory

### DIFF
--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -76,6 +76,7 @@ import org.neo4j.unsafe.impl.batchimport.input.csv.IdType;
 import org.neo4j.unsafe.impl.batchimport.staging.ExecutionMonitors;
 
 import static java.nio.charset.Charset.defaultCharset;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.logs_directory;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.store_internal_log_path;
 import static org.neo4j.helpers.Exceptions.launderedException;
 import static org.neo4j.helpers.Format.bytes;
@@ -505,11 +506,11 @@ public class ImportTool
         boolean success;
         LifeSupport life = new LifeSupport();
 
-        File internalLogFile = dbConfig.get( store_internal_log_path );
+        File internalLogFile = dbConfig.with( stringMap( logs_directory.name(), logsDir.getCanonicalPath() ) )
+                .get( store_internal_log_path );
         LogService logService = life.add( StoreLogService.withInternalLog( internalLogFile ).build( fs ) );
 
         life.start();
-        //TODO: add file watcher here?
         BatchImporter importer = new ParallelBatchImporter( storeDir,
                 fs,
                 configuration,


### PR DESCRIPTION
Update way how path of import tool logs is constructed.
Before logs directory was missed and log file endup inside what ever
directory was current for importer.
This PR fix that behaviour and by put log file inside directory
defined by `logs_directory` setting.

Cleanup import tool tests