### PR TITLE
Don't throw on removing non existent property in batch inserter.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyDeleter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyDeleter.java
@@ -64,12 +64,51 @@ public class PropertyDeleter
         primitive.setNextProp( Record.NO_NEXT_PROPERTY.intValue() );
     }
 
+    /**
+     * Removes property with given {@code propertyKey} from property chain owner by the primitive found in
+     * {@code primitiveProxy} if it exists.
+     *
+     * @param primitiveProxy access to the primitive record pointing to the start of the property chain.
+     * @param propertyKey the property key token id to look for and remove.
+     * @param propertyRecords access to records.
+     * @return {@code true} if the property was found and removed, otherwise {@code false}.
+     */
+    public <P extends PrimitiveRecord> boolean removePropertyIfExists( RecordProxy<Long,P,Void> primitiveProxy,
+            int propertyKey, RecordAccess<Long,PropertyRecord,PrimitiveRecord> propertyRecords )
+    {
+        PrimitiveRecord primitive = primitiveProxy.forReadingData();
+        long propertyId = // propertyData.getId();
+                traverser.findPropertyRecordContaining( primitive, propertyKey, propertyRecords, false );
+        if ( !Record.NO_NEXT_PROPERTY.is( propertyId ) )
+        {
+            removeProperty( primitiveProxy, propertyKey, propertyRecords, primitive, propertyId );
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Removes property with given {@code propertyKey} from property chain owner by the primitive found in
+     * {@code primitiveProxy}.
+     *
+     * @param primitiveProxy access to the primitive record pointing to the start of the property chain.
+     * @param propertyKey the property key token id to look for and remove.
+     * @param propertyRecords access to records.
+     * @throws IllegalStateException if property key was not found in the property chain.
+     */
     public <P extends PrimitiveRecord> void removeProperty( RecordProxy<Long,P,Void> primitiveProxy, int propertyKey,
             RecordAccess<Long,PropertyRecord,PrimitiveRecord> propertyRecords )
     {
         PrimitiveRecord primitive = primitiveProxy.forReadingData();
         long propertyId = // propertyData.getId();
                 traverser.findPropertyRecordContaining( primitive, propertyKey, propertyRecords, true );
+        removeProperty( primitiveProxy, propertyKey, propertyRecords, primitive, propertyId );
+    }
+
+    private <P extends PrimitiveRecord> void removeProperty( RecordProxy<Long,P,Void> primitiveProxy, int propertyKey,
+            RecordAccess<Long,PropertyRecord,PrimitiveRecord> propertyRecords, PrimitiveRecord primitive,
+            long propertyId )
+    {
         RecordProxy<Long, PropertyRecord, PrimitiveRecord> recordChange =
                 propertyRecords.getOrLoad( propertyId, primitive );
         PropertyRecord propRecord = recordChange.forChangingData();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyTraverser.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyTraverser.java
@@ -32,6 +32,19 @@ import org.neo4j.kernel.impl.util.Listener;
 
 public class PropertyTraverser
 {
+    /**
+     * Traverses a property record chain and finds the record containing the property with key {@code propertyKey}.
+     * If none is found and {@code strict} is {@code true} then {@link IllegalStateException} is thrown,
+     * otherwise id value of {@link Record#NO_NEXT_PROPERTY} is returned.
+     *
+     * @param primitive {@link PrimitiveRecord} which is the owner of the chain.
+     * @param propertyKey property key token id to look for.
+     * @param propertyRecords access to records.
+     * @param strict dictates behavior on property key not found. If {@code true} then {@link IllegalStateException}
+     * is thrown, otherwise value of {@link Record#NO_NEXT_PROPERTY} is returned.
+     * @return property record id containing property with the given {@code propertyKey}, otherwise if
+     * {@code strict} is false value of {@link Record#NO_NEXT_PROPERTY}.
+     */
     public long findPropertyRecordContaining( PrimitiveRecord primitive, int propertyKey,
             RecordAccess<Long, PropertyRecord, PrimitiveRecord> propertyRecords, boolean strict )
     {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
@@ -352,7 +352,7 @@ public class BatchInserterImpl implements BatchInserter
     public void removeNodeProperty( long node, String propertyName )
     {
         int propertyKey = getOrCreatePropertyKeyId( propertyName );
-        propertyDeletor.removeProperty( getNodeRecord( node ), propertyKey, recordAccess.getPropertyRecords() );
+        propertyDeletor.removePropertyIfExists( getNodeRecord( node ), propertyKey, recordAccess.getPropertyRecords() );
         flushStrategy.flush();
     }
 
@@ -361,7 +361,7 @@ public class BatchInserterImpl implements BatchInserter
                                             String propertyName )
     {
         int propertyKey = getOrCreatePropertyKeyId( propertyName );
-        propertyDeletor.removeProperty( getRelationshipRecord( relationship ), propertyKey,
+        propertyDeletor.removePropertyIfExists( getRelationshipRecord( relationship ), propertyKey,
                 recordAccess.getPropertyRecords() );
         flushStrategy.flush();
     }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
@@ -1402,6 +1402,35 @@ public class BatchInsertTest
         assertEquals( properties, inserter.getNodeProperties( node ) );
     }
 
+    @Test
+    public void shouldIgnoreRemovingNonExistentNodeProperty() throws Exception
+    {
+        // given
+        BatchInserter inserter = globalInserter;
+        long id = inserter.createNode( Collections.<String,Object>emptyMap() );
+
+        // when
+        inserter.removeNodeProperty( id, "non-existent" );
+
+        // then no exception should be thrown, this mimics GraphDatabaseService behaviour
+    }
+
+    @Test
+    public void shouldIgnoreRemovingNonExistentRelationshipProperty() throws Exception
+    {
+        // given
+        BatchInserter inserter = globalInserter;
+        Map<String,Object> noProperties = Collections.<String,Object>emptyMap();
+        long nodeId1 = inserter.createNode( noProperties );
+        long nodeId2 = inserter.createNode( noProperties );
+        long id = inserter.createRelationship( nodeId1, nodeId2, MyRelTypes.TEST, noProperties );
+
+        // when
+        inserter.removeRelationshipProperty( id, "non-existent" );
+
+        // then no exception should be thrown, this mimics GraphDatabaseService behaviour
+    }
+
     private void createRelationships( BatchInserter inserter, long node, RelationshipType relType,
             int out, int in, int loop )
     {


### PR DESCRIPTION
Doesn't throw on removing non existent property in batch inserter.

This to mimic behavior of GraphDatabaseService. It seems that this behaviour was
changed by accident in a previous version to throw exception instead of
just ignoring.