### PR TITLE
Removed obsolete KernelExtension service files

### DIFF
--- a/community/jmx/src/main/resources/META-INF/services/org.neo4j.kernel.KernelExtension
+++ b/community/jmx/src/main/resources/META-INF/services/org.neo4j.kernel.KernelExtension
@@ -1,1 +1,0 @@
-org.neo4j.jmx.impl.JmxExtension

--- a/community/kernel/src/test/resources/META-INF/services/org.neo4j.kernel.KernelExtension
+++ b/community/kernel/src/test/resources/META-INF/services/org.neo4j.kernel.KernelExtension
@@ -1,2 +1,0 @@
-org.neo4j.kernel.DummyExtension
-org.neo4j.kernel.OtherExtension

--- a/community/monitor-logging/src/main/resources/META-INF/services/org.neo4j.kernel.KernelExtension
+++ b/community/monitor-logging/src/main/resources/META-INF/services/org.neo4j.kernel.KernelExtension
@@ -1,1 +1,0 @@
-org.neo4j.ext.monitorlogging.MonitorLoggingExtension

--- a/community/shell/src/main/resources/META-INF/services/org.neo4j.kernel.KernelExtension
+++ b/community/shell/src/main/resources/META-INF/services/org.neo4j.kernel.KernelExtension
@@ -1,1 +1,0 @@
-org.neo4j.shell.impl.ShellServerExtension

--- a/enterprise/backup/src/main/resources/META-INF/services/org.neo4j.kernel.KernelExtension
+++ b/enterprise/backup/src/main/resources/META-INF/services/org.neo4j.kernel.KernelExtension
@@ -1,1 +1,0 @@
-org.neo4j.backup.OnlineBackupExtension


### PR DESCRIPTION
The service provider for `KernelExtension` has been removed and replaced by `KernelExtensionFactory`. Theis files are no longer needed.