### PR TITLE
List properties and index in compiled runtime

### DIFF
--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
@@ -91,7 +91,7 @@ public abstract class CompiledConversionUtils
             DoubleStream stream = (DoubleStream) value;
             return stream.boxed().collect( Collectors.toList() );
         }
-        else if (value.getClass().isArray() )
+        else if ( value.getClass().isArray() )
         {
             int len = Array.getLength( value );
             ArrayList<Object> collection = new ArrayList<>( len );
@@ -131,7 +131,7 @@ public abstract class CompiledConversionUtils
             DoubleStream stream = (DoubleStream) value;
             return stream.boxed().collect( Collectors.toSet() );
         }
-        else if (value.getClass().isArray() )
+        else if ( value.getClass().isArray() )
         {
             int len = Array.getLength( value );
             HashSet<Object> collection = new HashSet<>( len );
@@ -279,7 +279,7 @@ public abstract class CompiledConversionUtils
             Class<?> componentType = value.getClass().getComponentType();
             int length = Array.getLength( value );
 
-            if (componentType.isPrimitive())
+            if ( componentType.isPrimitive() )
             {
                 Object copy = Array.newInstance( componentType, length );
                 //noinspection SuspiciousSystemArraycopy
@@ -291,7 +291,7 @@ public abstract class CompiledConversionUtils
                 Object[] copy = new Object[length];
                 for ( int i = 0; i < length; i++ )
                 {
-                    copy[i] = loadParameter( Array.get(value, i) );
+                    copy[i] = loadParameter( Array.get( value, i ) );
                 }
                 return copy;
             }
@@ -357,12 +357,12 @@ public abstract class CompiledConversionUtils
             // IntStream is only used for list of primitive booleans
             return ((IntStream) anyValue).mapToObj( i -> i != 0 ).collect( Collectors.toList() );
         }
-        else if ( anyValue.getClass().isArray())
+        else if ( anyValue.getClass().isArray() )
         {
             Class<?> componentType = anyValue.getClass().getComponentType();
             int length = Array.getLength( anyValue );
 
-            if (componentType.isPrimitive())
+            if ( componentType.isPrimitive() )
             {
                 Object copy = Array.newInstance( componentType, length );
                 //noinspection SuspiciousSystemArraycopy
@@ -374,7 +374,7 @@ public abstract class CompiledConversionUtils
                 Object[] copy = new Object[length];
                 for ( int i = 0; i < length; i++ )
                 {
-                    copy[i] = materializeAnyResult( nodeManager, Array.get(anyValue, i) );
+                    copy[i] = materializeAnyResult( nodeManager, Array.get( anyValue, i ) );
                 }
                 return copy;
             }
@@ -548,6 +548,212 @@ public abstract class CompiledConversionUtils
             throw new IllegalArgumentException(
                     format( "Can not be converted to long: %s", obj.getClass().getName() ) );
         }
+    }
+
+    //In the store we only support primitives, String, and arrays thereof.
+    //In cypher we must make an effort to transform Cypher lists to appropriate arrays whenever
+    //we are using sending values down to the store or to an index.
+    public static Object makeValueNeoSafe( Object object )
+    {
+        if ( object == null )
+        {
+            return null;
+        }
+        if ( hasSafeType( object ) )
+        {
+            return object;
+        }
+        else if ( object instanceof Object[] )
+        {
+            return safeArray( (Object[]) object );
+        }
+        else if ( object instanceof List<?> )
+        {
+            return safeArray( (List<?>) object );
+        }
+        throw new CypherTypeException( "Property values can only be primitive types or arrays thereof", null );
+    }
+
+    private static Object safeArray( Object[] array )
+    {
+        if ( array.length == 0 )
+        {
+            return new String[0];
+        }
+        else
+        {
+            Class<?> type = array[0].getClass();
+            for ( int i = 1; i < array.length; i++ )
+            {
+                type = mergeType( type, array[i].getClass() );
+            }
+
+            Object safeArray = Array.newInstance( type, array.length );
+            for ( int i = 0; i < array.length; i++ )
+            {
+                Array.set( safeArray, i, castIt( array[i], type ) );
+            }
+            return safeArray;
+        }
+    }
+
+    private static Object safeArray( List<?> list )
+    {
+        if ( list.size() == 0 )
+        {
+            return new String[0];
+        }
+        else
+        {
+            Class<?> type = null;
+            for ( Object o : list )
+            {
+                if ( type == null )
+                {
+                    type = o.getClass();
+                }
+                else
+                {
+                    type = mergeType( type, o.getClass() );
+                }
+            }
+
+            Object safeArray = Array.newInstance( type, list.size() );
+            int i = 0;
+            for ( Object o : list )
+            {
+                Array.set( safeArray, i++, castIt( o, type ) );
+            }
+            return safeArray;
+        }
+    }
+
+    private static Object castIt( Object value, Class<?> type )
+    {
+        if ( value instanceof Number )
+        {
+            Number number = (Number) value;
+            if ( type == Long.class )
+            {
+                return number.longValue();
+            }
+            else if ( type == Integer.class )
+            {
+                return number.intValue();
+            }
+            else if ( type == Short.class )
+            {
+                return number.shortValue();
+            }
+            else if ( type == Byte.class )
+            {
+                return number.byteValue();
+            }
+            else if ( type == Float.class )
+            {
+                return number.floatValue();
+            }
+            else if ( type == Double.class )
+            {
+                return number.doubleValue();
+            }
+            else
+            {
+                throw new CypherTypeException( "Cannot handle numbers of type " + type.getName(), null );
+            }
+        }
+        else
+        {
+            return value;
+        }
+    }
+
+    private static boolean hasSafeType( Object value )
+    {
+        if ( value instanceof String )
+        {
+            return true;
+        }
+        else if ( value instanceof Long )
+        {
+            return true;
+        }
+        else if ( value instanceof Integer )
+        {
+            return true;
+        }
+        else if ( value instanceof Boolean )
+        {
+            return true;
+        }
+        else if ( value instanceof Double )
+        {
+            return true;
+        }
+        else if ( value instanceof Float )
+        {
+            return true;
+        }
+        else if ( value instanceof Short )
+        {
+            return true;
+        }
+        else if ( value instanceof Byte )
+        {
+            return true;
+        }
+        else if ( value.getClass().isArray() && value.getClass().getComponentType().isPrimitive() )
+        {
+            return true;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    static Class<?> mergeType( Class<?> type1, Class<?> type2 )
+    {
+        if ( type1 == String.class && type2 == String.class )
+        {
+            return String.class;
+        }
+        else if ( type1 == Boolean.class && type2 == Boolean.class )
+        {
+            return Boolean.class;
+        }
+        else if ( type1 == Character.class && type2 == Character.class )
+        {
+            return Character.class;
+        }
+        else if ( Number.class.isAssignableFrom( type1 ) && Number.class.isAssignableFrom( type2 ) )
+        {
+            if ( type1 == Double.class || type2 == Double.class )
+            {
+                return Double.class;
+            }
+            else if ( type1 == Float.class || type2 == Float.class )
+            {
+                return Float.class;
+            }
+            else if ( type1 == Long.class || type2 == Long.class )
+            {
+                return Long.class;
+            }
+            else if ( type1 == Integer.class || type2 == Integer.class )
+            {
+                return Integer.class;
+            }
+            else if ( type1 == Short.class || type2 == Short.class )
+            {
+                return Short.class;
+            }
+            else if ( type1 == Byte.class || type2 == Byte.class )
+            {
+                return Byte.class;
+            }
+        }
+        throw new CypherTypeException( "Property values can only be primitive types or arrays thereof", null );
     }
 
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekAcceptanceTest.scala
@@ -307,6 +307,20 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with NewPlanne
     result.toList should contain theSameElementsAs List(Map("root" -> root1), Map("root" -> root2), Map("root" -> root3))
   }
 
+  test("should handle list properties in index") {
+    // Given
+    graph.createIndex("L", "prop")
+    val node1 = createLabeledNode(Map("prop" -> Array(1,2,3)), "L")
+    val node2 = createLabeledNode(Map("prop" -> Array(3,2,1)), "L")
+
+    // When
+    val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH (n:L) WHERE n.prop = [1,2,3] RETURN n")
+
+    // Then
+    result.toList should equal(List(Map("n" -> node1)))
+    result should useOperationTimes("NodeIndexSeek", 1)
+  }
+
   private def setUpDatabaseForTests() {
     updateWithBothPlannersAndCompatibilityMode(
       """CREATE (architect:Matrix { name:'The Architect' }),

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekAcceptanceTest.scala
@@ -321,6 +321,20 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with NewPlanne
     result should useOperationTimes("NodeIndexSeek", 1)
   }
 
+  test("should handle list properties in unique index") {
+    // Given
+    graph.createConstraint("L", "prop")
+    val node1 = createLabeledNode(Map("prop" -> Array(1,2,3)), "L")
+    val node2 = createLabeledNode(Map("prop" -> Array(3,2,1)), "L")
+
+    // When
+    val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH (n:L) WHERE n.prop = [1,2,3] RETURN n")
+
+    // Then
+    result.toList should equal(List(Map("n" -> node1)))
+    result should useOperationTimes("NodeUniqueIndexSeek", 1)
+  }
+
   private def setUpDatabaseForTests() {
     updateWithBothPlannersAndCompatibilityMode(
       """CREATE (architect:Matrix { name:'The Architect' }),

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/spi/MethodStructure.scala
@@ -163,7 +163,6 @@ trait MethodStructure[E] {
   def relationshipGetPropertyForVar(nodeIdVar: String, propIdVar: String, propValueVar: String): Unit
   def lookupPropertyKey(propName: String, propVar: String)
   def indexSeek(iterVar: String, descriptorVar: String, value: E, codeGenType: CodeGenType): Unit
-  def indexUniqueSeek(name: String, descriptorVar: String, value: E, codeGenType: CodeGenType): Unit
   def relType(relIdVar: String, typeVar: String): Unit
   def newIndexDescriptor(descriptorVar: String, labelVar: String, propKeyVar: String): Unit
   def createRelExtractor(extractorName: String): Unit

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -1370,20 +1370,6 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
     }
   }
 
-  override def indexUniqueSeek(nodeVar: String, descriptorVar: String, value: Expression, codeGenType: CodeGenType) = {
-    val predicate = generator.declare(typeRef[IndexQuery.ExactPredicate], s"${nodeVar}Query")
-    val local = generator.declare(typeRef[Long], nodeVar)
-    val boxedValue = if (codeGenType.isPrimitive) Expression.box(value) else value
-    handleKernelExceptions(generator, fields.ro, _finalizers) { body =>
-      val descriptor = body.load(descriptorVar)
-      val schema = invoke(descriptor, method[IndexDescriptor, LabelSchemaDescriptor]("schema"))
-      val propertyKeyId = invoke(schema, method[LabelSchemaDescriptor, Int]("getPropertyId"))
-      body.assign(predicate, invoke(indexQueryExact, propertyKeyId, boxedValue))
-      body.assign(local, invoke(readOperations, indexQuery, descriptor,
-        newArray(typeRef[IndexQuery.ExactPredicate], predicate)))
-    }
-  }
-
   def token(t: Int) = Expression.constant(t)
 
   def wildCardToken = Expression.constant(-1)

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -1357,7 +1357,9 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
   override def indexSeek(iterVar: String, descriptorVar: String, value: Expression, codeGenType: CodeGenType) = {
     val predicate = generator.declare(typeRef[IndexQuery], s"${iterVar}Query")
     val local = generator.declare(typeRef[PrimitiveLongIterator], iterVar)
-    val boxedValue = if (codeGenType.isPrimitive) Expression.box(value) else value
+    val boxedValue =
+      if (codeGenType.isPrimitive) Expression.box(value)
+      else invoke(methodReference(typeRef[CompiledConversionUtils], typeRef[Object], "makeValueNeoSafe", typeRef[Object]), value)
     handleKernelExceptions(generator, fields.ro, _finalizers) { body =>
       val descriptor = body.load(descriptorVar)
       val schema = invoke(descriptor, method[IndexDescriptor, LabelSchemaDescriptor]("schema"))


### PR DESCRIPTION
The compiled runtime wasn't doing the conversion from Cypher lists
to arrays supported by the stores (primitive arrays and String arrays),
before trying to access the index. This lead to errors when trying to
access nodes with array properties from Cypher, e.g.

```
MATCH (n:L) WHERE n.prop = [1,2,3] RETURN n
```

failed whenever there was an index on `:L(prop)`.

changelog: Fix an error that occurred for queries trying to query for an indexed list property in the compiled runtime. 