### PR TITLE
Invokes afterRollback on tx event handlers with failing beforeCommit

### DIFF
--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/TransactionEventHandler.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/TransactionEventHandler.java
@@ -113,8 +113,9 @@ public interface TransactionEventHandler<T>
      * can provide will require a new transaction to be opened.
      *
      * @param data the changes that were attempted to be committed in this transaction.
-     * @param state the object returned by
-     *            {@link #beforeCommit(TransactionData)}.
+     * @param state the object returned by {@link #beforeCommit(TransactionData)}.
+     * If this handler failed when executing {@link #beforeCommit(TransactionData)} this
+     * {@code state} will be {@code null}.
      */
     // TODO: should this method take a parameter describing WHY the tx failed?
     void afterRollback( TransactionData data, T state );

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/TransactionEventHandlers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/TransactionEventHandlers.java
@@ -24,7 +24,6 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArraySet;
 
 import org.neo4j.graphdb.Node;
@@ -125,7 +124,7 @@ public class TransactionEventHandlers
         {
             try
             {
-                handlerStates.add( handler, handler.beforeCommit( txData ) );
+                handlerStates.add( handler ).setState( handler.beforeCommit( txData ) );
             }
             catch ( Throwable t )
             {
@@ -179,11 +178,15 @@ public class TransactionEventHandlers
     public static class HandlerAndState
     {
         private final TransactionEventHandler handler;
-        private final Object state;
+        private Object state;
 
-        public HandlerAndState( TransactionEventHandler<?> handler, Object state )
+        public HandlerAndState( TransactionEventHandler<?> handler )
         {
             this.handler = handler;
+        }
+
+        void setState( Object state )
+        {
             this.state = state;
         }
     }
@@ -216,9 +219,11 @@ public class TransactionEventHandlers
             return error;
         }
 
-        public void add( TransactionEventHandler<?> handler, Object state )
+        public HandlerAndState add( TransactionEventHandler<?> handler )
         {
-            states.add( new HandlerAndState( handler, state ) );
+            HandlerAndState result = new HandlerAndState( handler );
+            states.add( result );
+            return result;
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TestTransactionEvents.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TestTransactionEvents.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
@@ -45,6 +46,7 @@ import org.neo4j.graphdb.event.PropertyEntry;
 import org.neo4j.graphdb.event.TransactionData;
 import org.neo4j.graphdb.event.TransactionEventHandler;
 import org.neo4j.graphdb.schema.IndexDefinition;
+import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.impl.MyRelTypes;
 import org.neo4j.test.TestLabels;
 import org.neo4j.test.rule.DatabaseRule;
@@ -492,11 +494,17 @@ public class TestTransactionEvents
         @Override
         public T beforeCommit( TransactionData data ) throws Exception
         {
-            if ( willFail )
+            try
             {
-                throw new Exception( "Just failing commit, that's all" );
+                return source.beforeCommit( data );
             }
-            return source.beforeCommit( data );
+            finally
+            {
+                if ( willFail )
+                {
+                    throw new Exception( "Just failing commit, that's all" );
+                }
+            }
         }
     }
 
@@ -1124,6 +1132,47 @@ public class TestTransactionEvents
         assertThat( deletedToString.get(), containsString( format( "(%d)", endNode.getId() ) ) );
     }
 
+    @Test
+    public void shouldGetCallToAfterRollbackEvenIfBeforeCommitFailed() throws Exception
+    {
+        // given
+        CapturingEventHandler<Integer> firstWorkingHandler = new CapturingEventHandler<>( () -> 5 );
+        String failureMessage = "Massive fail";
+        CapturingEventHandler<Integer> faultyHandler = new CapturingEventHandler<>( () ->
+        {
+            throw new RuntimeException( failureMessage );
+        } );
+        CapturingEventHandler<Integer> otherWorkingHandler = new CapturingEventHandler<>( () -> 10 );
+        dbRule.registerTransactionEventHandler( firstWorkingHandler );
+        dbRule.registerTransactionEventHandler( faultyHandler );
+        dbRule.registerTransactionEventHandler( otherWorkingHandler );
+
+        boolean failed = false;
+        try ( Transaction tx = dbRule.beginTx() )
+        {
+            // when
+            dbRule.createNode();
+            tx.success();
+        }
+        catch ( Exception e )
+        {
+            assertTrue( Exceptions.contains( e, failureMessage, RuntimeException.class ) );
+            failed = true;
+        }
+        assertTrue( failed );
+
+        // then
+        assertTrue( firstWorkingHandler.beforeCommitCalled );
+        assertTrue( firstWorkingHandler.afterRollbackCalled );
+        assertEquals( 5, firstWorkingHandler.afterRollbackState.intValue() );
+        assertTrue( faultyHandler.beforeCommitCalled );
+        assertTrue( faultyHandler.afterRollbackCalled );
+        assertNull( faultyHandler.afterRollbackState );
+        assertTrue( otherWorkingHandler.beforeCommitCalled );
+        assertTrue( otherWorkingHandler.afterRollbackCalled );
+        assertEquals( 10, otherWorkingHandler.afterRollbackState.intValue() );
+    }
+
     private Node createNode( String... properties )
     {
         try ( Transaction tx = dbRule.beginTx() )
@@ -1249,6 +1298,42 @@ public class TestTransactionEvents
             this.startNode = relationship.getStartNode();
             this.type = relationship.getType().name();
             this.endNode = relationship.getEndNode();
+        }
+    }
+
+    static class CapturingEventHandler<T> implements TransactionEventHandler<T>
+    {
+        private final Supplier<T> stateSource;
+        boolean beforeCommitCalled;
+        boolean afterCommitCalled;
+        T afterCommitState;
+        boolean afterRollbackCalled;
+        T afterRollbackState;
+
+        CapturingEventHandler( Supplier<T> stateSource )
+        {
+            this.stateSource = stateSource;
+        }
+
+        @Override
+        public T beforeCommit( TransactionData data ) throws Exception
+        {
+            beforeCommitCalled = true;
+            return stateSource.get();
+        }
+
+        @Override
+        public void afterCommit( TransactionData data, T state )
+        {
+            afterCommitCalled = true;
+            afterCommitState = state;
+        }
+
+        @Override
+        public void afterRollback( TransactionData data, T state )
+        {
+            afterRollbackCalled = true;
+            afterRollbackState = state;
         }
     }
 }


### PR DESCRIPTION
Previously only those TransactionEventHandlers with successful call to
beforeCommit would see a call to afterRollback. However such information
may be interesting to all event handlers, even failing ones.

The contractual difference here is that the state argument will be null
in such cases.

Fixes #2660