### PR TITLE
Fixed error with setting owningPipe for Distinct

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/commands/expressions/Distinct.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/commands/expressions/Distinct.scala
@@ -33,4 +33,6 @@ case class Distinct(innerAggregator: AggregationExpression, expression: Expressi
   }
 
   override def symbolTableDependencies = innerAggregator.symbolTableDependencies ++ expression.symbolTableDependencies
+
+  override def arguments = Seq(expression, innerAggregator)
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternExpressionImplementationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternExpressionImplementationAcceptanceTest.scala
@@ -195,6 +195,22 @@ class PatternExpressionImplementationAcceptanceTest extends ExecutionEngineFunSu
     }
   }
 
+  test("MATCH (n:FOO) WITH n, COLLECT(DISTINCT { res:CASE WHEN EXISTS ((n)-[:BAR*]->()) THEN 42 END }) as x RETURN n, x") {
+    val node1 = createLabeledNode("FOO")
+    val node2 = createNode()
+    relate(node1, node2, "BAR")
+    val result = executeWithCostPlannerAndInterpretedRuntimeOnly(
+      """
+        |MATCH (n:FOO)
+        |WITH n, COLLECT (DISTINCT{
+        |res:CASE WHEN EXISTS((n)-[:BAR*]->()) THEN 42 END
+        |}) as x RETURN n, x
+      """.stripMargin
+    )
+
+    result.toList should equal(List(Map("n" -> node1, "x" -> List(Map("res" -> 42)))))
+  }
+
   test("case expressions and pattern expressions") {
     val n1 = createLabeledNode(Map("prop" -> 42), "A")
 


### PR DESCRIPTION
Changelog: Fixes bug which materializes as a None.get stacktrace, typically by Cypher queries involving nested distinct/list/map/pattern comprehensions.