### PR TITLE
Invokes afterRollback on tx event handlers with failing beforeCommit

### DIFF
--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/TransactionEventHandler.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/event/TransactionEventHandler.java
@@ -113,8 +113,9 @@ public interface TransactionEventHandler<T>
      * can provide will require a new transaction to be opened.
      *
      * @param data the changes that were attempted to be committed in this transaction.
-     * @param state the object returned by
-     *            {@link #beforeCommit(TransactionData)}.
+     * @param state the object returned by {@link #beforeCommit(TransactionData)}.
+     * If this handler failed when executing {@link #beforeCommit(TransactionData)} this
+     * {@code state} will be {@code null}.
      */
     // TODO: should this method take a parameter describing WHY the tx failed?
     void afterRollback( TransactionData data, T state );

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/TransactionEventHandlers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/TransactionEventHandlers.java
@@ -124,7 +124,7 @@ public class TransactionEventHandlers
         {
             try
             {
-                handlerStates.add( handler, handler.beforeCommit( txData ) );
+                handlerStates.add( handler ).setState( handler.beforeCommit( txData ) );
             }
             catch ( Throwable t )
             {
@@ -178,11 +178,15 @@ public class TransactionEventHandlers
     public static class HandlerAndState
     {
         private final TransactionEventHandler handler;
-        private final Object state;
+        private Object state;
 
-        public HandlerAndState( TransactionEventHandler<?> handler, Object state )
+        public HandlerAndState( TransactionEventHandler<?> handler )
         {
             this.handler = handler;
+        }
+
+        void setState( Object state )
+        {
             this.state = state;
         }
     }
@@ -215,9 +219,11 @@ public class TransactionEventHandlers
             return error;
         }
 
-        public void add( TransactionEventHandler<?> handler, Object state )
+        public HandlerAndState add( TransactionEventHandler<?> handler )
         {
-            states.add( new HandlerAndState( handler, state ) );
+            HandlerAndState result = new HandlerAndState( handler );
+            states.add( result );
+            return result;
         }
     }
 


### PR DESCRIPTION
Previously only those TransactionEventHandlers with successful call to
beforeCommit would see a call to afterRollback. However such information
may be interesting to all event handlers, even failing ones.

The contractual difference here is that the state argument will be null
in such cases.

Fixes #2660