### PR TITLE
Check validity of snapshot filesets based on `segments` files

### DIFF
--- a/community/neo4j/src/test/java/org/neo4j/index/backup/IndexBackupIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/backup/IndexBackupIT.java
@@ -45,7 +45,6 @@ import org.neo4j.test.rule.EmbeddedDatabaseRule;
 import org.neo4j.test.rule.RandomRule;
 
 import static java.lang.String.format;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -146,20 +145,25 @@ public class IndexBackupIT
     private void compareSnapshotFiles( Set<String> firstSnapshotFileNames, Set<String> secondSnapshotFileNames,
             FileSystemAbstraction fileSystem )
     {
-        assertThat(
-                format( "Should have at least %d modified index files. Snapshot files  are: %s", NUMBER_OF_INDEXES + 1,
-                        firstSnapshotFileNames ), firstSnapshotFileNames,
-                hasSize( greaterThanOrEqualTo( NUMBER_OF_INDEXES + 1 ) ) );
-        for ( String fileName : firstSnapshotFileNames )
+        Set<String> firstSnapshotIndexesSegments = firstSnapshotFileNames.stream()
+                        .filter( this::segmentsFilePredicate )
+                        .collect( Collectors.toSet() );
+        Set<String> secondSnapshotIndexesSegments = secondSnapshotFileNames.stream()
+                .filter( this::segmentsFilePredicate )
+                .collect( Collectors.toSet() );
+        assertThat( format( "Should have %d modified index segment files. Snapshot segment files are: %s",
+                        NUMBER_OF_INDEXES, firstSnapshotIndexesSegments ), firstSnapshotIndexesSegments,
+                hasSize( NUMBER_OF_INDEXES ) );
+        for ( String fileName : firstSnapshotIndexesSegments )
         {
-            assertFalse( "Snapshot fileset should not have files from another snapshot set." +
-                            describeFileSets( firstSnapshotFileNames, secondSnapshotFileNames ),
-                    secondSnapshotFileNames.contains( fileName ) );
+            assertFalse( "Snapshot segments fileset should not have files from another snapshot set." +
+                            describeFileSets( firstSnapshotIndexesSegments, secondSnapshotIndexesSegments ),
+                    secondSnapshotIndexesSegments.contains( fileName ) );
             String path = FilenameUtils.getFullPath( fileName );
             assertTrue( "Snapshot should contain files for index in path: " + path + "." +
-                            describeFileSets( firstSnapshotFileNames, secondSnapshotFileNames ),
-                    secondSnapshotFileNames.stream().anyMatch( name -> name.startsWith( path ) ) );
-            assertTrue( format( "Snapshot file '%s' should exist.", fileName ),
+                            describeFileSets( firstSnapshotIndexesSegments, secondSnapshotIndexesSegments ),
+                    secondSnapshotIndexesSegments.stream().anyMatch( name -> name.startsWith( path ) ) );
+            assertTrue( format( "Snapshot segment file '%s' should exist.", fileName ),
                     fileSystem.fileExists( new File( fileName ) ) );
         }
     }
@@ -248,5 +252,10 @@ public class IndexBackupIT
     private DependencyResolver getDatabaseResolver()
     {
         return database.getDependencyResolver();
+    }
+
+    private boolean segmentsFilePredicate( String fileName )
+    {
+        return fileName.contains( "segments_" );
     }
 }


### PR DESCRIPTION
Remove expectation of lucene label scan store to be included into set of
lucene indexes that we expect to have snapshots for.
Check snapshots validity based on segments file as an indicator what
index commit was used for particular index snapshot.