### PR TITLE
Parallel execution of server based tests

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
@@ -52,11 +52,11 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.ListenSocketAddress;
 import org.neo4j.helpers.Service;
 import org.neo4j.kernel.api.bolt.BoltConnectionTracker;
-import org.neo4j.kernel.api.bolt.BoltPortRegister;
 import org.neo4j.kernel.api.security.AuthManager;
 import org.neo4j.kernel.api.security.UserManagerSupplier;
 import org.neo4j.kernel.configuration.BoltConnector;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.configuration.ConnectorPortRegister;
 import org.neo4j.kernel.configuration.ssl.SslPolicyLoader;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
@@ -106,7 +106,7 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
 
         BoltConnectionTracker sessionTracker();
 
-        BoltPortRegister connectionRegister();
+        ConnectorPortRegister connectionRegister();
 
         Clock clock();
 
@@ -144,7 +144,7 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
         BoltFactory boltFactory = life.add( new BoltFactoryImpl( api, dependencies.usageData(),
                 logService, dependencies.txBridge(), authentication, dependencies.sessionTracker(), config ) );
         WorkerFactory workerFactory = createWorkerFactory( boltFactory, scheduler, dependencies, logService, clock );
-        BoltPortRegister connectionRegister = dependencies.connectionRegister();
+        ConnectorPortRegister connectionRegister = dependencies.connectionRegister();
 
         Map<BoltConnector, ProtocolInitializer> connectors = config.enabledBoltConnectors().stream()
                 .collect( Collectors.toMap( Function.identity(), connConfig ->

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/NettyServer.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/NettyServer.java
@@ -35,8 +35,8 @@ import java.util.concurrent.ThreadFactory;
 
 import org.neo4j.helpers.ListenSocketAddress;
 import org.neo4j.helpers.PortBindException;
-import org.neo4j.kernel.api.bolt.BoltPortRegister;
 import org.neo4j.kernel.configuration.BoltConnector;
+import org.neo4j.kernel.configuration.ConnectorPortRegister;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
 /**
@@ -52,7 +52,7 @@ public class NettyServer extends LifecycleAdapter
 
     private final Map<BoltConnector, ProtocolInitializer> bootstrappersMap;
     private final ThreadFactory tf;
-    private final BoltPortRegister connectionRegister;
+    private final ConnectorPortRegister connectionRegister;
     private EventLoopGroup bossGroup;
     private EventLoopGroup selectorGroup;
 
@@ -71,7 +71,7 @@ public class NettyServer extends LifecycleAdapter
      * @param connectorRegister register to keep local address information on all configured connectors
      */
     public NettyServer( ThreadFactory tf, Map<BoltConnector, ProtocolInitializer> initializersMap,
-            BoltPortRegister connectorRegister )
+            ConnectorPortRegister connectorRegister )
     {
         this.bootstrappersMap = initializersMap;
         this.tf = tf;

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/NettyServerTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/NettyServerTest.java
@@ -33,8 +33,8 @@ import org.neo4j.bolt.transport.NettyServer;
 import org.neo4j.helpers.ListenSocketAddress;
 import org.neo4j.helpers.NamedThreadFactory;
 import org.neo4j.helpers.PortBindException;
-import org.neo4j.kernel.api.bolt.BoltPortRegister;
 import org.neo4j.kernel.configuration.BoltConnector;
+import org.neo4j.kernel.configuration.ConnectorPortRegister;
 
 import static org.neo4j.helpers.collection.MapUtil.genericMap;
 
@@ -60,7 +60,7 @@ public class NettyServerTest
             Map<BoltConnector,NettyServer.ProtocolInitializer> initializersMap =
                     genericMap( new BoltConnector( "test" ), protocolOnAddress( address ) );
             new NettyServer( new NamedThreadFactory( "mythreads" ), initializersMap,
-                    new BoltPortRegister() ).start();
+                    new ConnectorPortRegister() ).start();
 
         }
     }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/Neo4jWithSocket.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/Neo4jWithSocket.java
@@ -34,8 +34,8 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.helpers.HostnamePort;
 import org.neo4j.io.fs.FileSystemAbstraction;
-import org.neo4j.kernel.api.bolt.BoltPortRegister;
 import org.neo4j.kernel.configuration.BoltConnector;
+import org.neo4j.kernel.configuration.ConnectorPortRegister;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.rule.TestDirectory;
@@ -52,7 +52,7 @@ public class Neo4jWithSocket extends ExternalResource
     private TestGraphDatabaseFactory graphDatabaseFactory;
     private GraphDatabaseService gdb;
     private File workingDirectory;
-    private BoltPortRegister connectorRegister;
+    private ConnectorPortRegister connectorRegister;
 
     public Neo4jWithSocket( Class<?> testClass )
     {
@@ -150,7 +150,7 @@ public class Neo4jWithSocket extends ExternalResource
         gdb = graphDatabaseFactory.newImpermanentDatabaseBuilder( storeDir ).
                 setConfig( settings ).newGraphDatabase();
         connectorRegister =
-                ((GraphDatabaseAPI) gdb).getDependencyResolver().resolveDependency( BoltPortRegister.class );
+                ((GraphDatabaseAPI) gdb).getDependencyResolver().resolveDependency( ConnectorPortRegister.class );
     }
 
     private Map<String,String> configure( Consumer<Map<String,String>> overrideSettingsFunction ) throws IOException

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConnectorPortRegister.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ConnectorPortRegister.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.api.bolt;
+package org.neo4j.kernel.configuration;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.ConcurrentHashMap;
@@ -27,7 +27,7 @@ import org.neo4j.helpers.HostnamePort;
 /**
  * Connector tracker that keeps information about local address that any configured connector get during bootstrapping.
  */
-public class BoltPortRegister
+public class ConnectorPortRegister
 {
 
     private final ConcurrentHashMap<String,HostnamePort> connectorsInfo = new ConcurrentHashMap<>();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -32,8 +32,8 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemLifecycleAdapter;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.AvailabilityGuard;
-import org.neo4j.kernel.api.bolt.BoltPortRegister;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.configuration.ConnectorPortRegister;
 import org.neo4j.kernel.extension.KernelExtensions;
 import org.neo4j.kernel.extension.UnsatisfiedDependencyStrategies;
 import org.neo4j.kernel.impl.api.LogRotationMonitor;
@@ -209,7 +209,7 @@ public class PlatformModule
         storeCopyCheckPointMutex = new StoreCopyCheckPointMutex();
         dependencies.satisfyDependency( storeCopyCheckPointMutex );
 
-        dependencies.satisfyDependency( new BoltPortRegister() );
+        dependencies.satisfyDependency( new ConnectorPortRegister() );
 
         publishPlatformInfo( dependencies.resolveDependency( UsageData.class ) );
     }

--- a/community/server-plugin-test/pom.xml
+++ b/community/server-plugin-test/pom.xml
@@ -50,17 +50,6 @@ the relevant Commercial Agreement.
     </license>
   </licenses>
 
-  <build>
-    <plugins>
-      <plugin>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <configuration>
-          <forkCount>1</forkCount>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
-
   <dependencies>
     <dependency>
       <groupId>org.neo4j.app</groupId>

--- a/community/server/pom.xml
+++ b/community/server/pom.xml
@@ -320,13 +320,6 @@
   <build>
     <plugins>
 
-      <plugin>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <configuration>
-          <forkCount>1</forkCount>
-        </configuration>
-      </plugin>
-
       <!-- Development execution -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>

--- a/community/server/src/main/java/org/neo4j/server/web/Jetty9WebServer.java
+++ b/community/server/src/main/java/org/neo4j/server/web/Jetty9WebServer.java
@@ -354,14 +354,14 @@ public class Jetty9WebServer implements WebServer
     @Override
     public InetSocketAddress getLocalHttpAddress()
     {
-        return new InetSocketAddress( serverConnector.getHost(), serverConnector.getLocalPort() );
+        return toSocketAddress( serverConnector );
     }
 
     @Override
     public InetSocketAddress getLocalHttpsAddress()
     {
         return Optional.ofNullable( secureServerConnector)
-                        .map( connector -> new InetSocketAddress( connector.getHost(), connector.getLocalPort() ) )
+                        .map( Jetty9WebServer::toSocketAddress )
                         .orElseThrow( () -> new IllegalStateException( "Secure connector is not configured" ) );
     }
 
@@ -538,6 +538,11 @@ public class Jetty9WebServer implements WebServer
         }
     }
 
+    private static InetSocketAddress toSocketAddress( ServerConnector connector )
+    {
+        return new InetSocketAddress( connector.getHost(), connector.getLocalPort() );
+    }
+
     private static class FilterDefinition
     {
         private final Filter filter;
@@ -558,7 +563,6 @@ public class Jetty9WebServer implements WebServer
         {
             return filter;
         }
-
         String getPathSpec()
         {
             return pathSpec;

--- a/community/server/src/main/java/org/neo4j/server/web/WebServer.java
+++ b/community/server/src/main/java/org/neo4j/server/web/WebServer.java
@@ -23,6 +23,7 @@ import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Server;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -74,4 +75,14 @@ public interface WebServer
     void setDefaultInjectables( Collection<InjectableProvider<?>> defaultInjectables );
 
     void setJettyCreatedCallback( Consumer<Server> callback );
+
+    /**
+     * @return local http connector bind port
+     */
+    InetSocketAddress getLocalHttpAddress();
+
+    /**
+     * @return local https connector bind port
+     */
+    InetSocketAddress getLocalHttpsAddress();
 }

--- a/community/server/src/test/java/org/neo4j/server/BaseBootstrapperTestIT.java
+++ b/community/server/src/test/java/org/neo4j/server/BaseBootstrapperTestIT.java
@@ -78,7 +78,8 @@ public abstract class BaseBootstrapperTestIT extends ExclusiveServerTestBase
                 "-c", configOption( data_directory, tempDir.getRoot().getAbsolutePath() ),
                 "-c", configOption( logs_directory, tempDir.getRoot().getAbsolutePath() ),
                 "-c", "dbms.connector.http.type=HTTP",
-                "-c", "dbms.connector.http.enabled=true"
+                "-c", "dbms.connector.http.enabled=true",
+                "-c", "dbms.connector.http.advertised_address=localhost:0"
         );
 
         // Then
@@ -96,6 +97,7 @@ public abstract class BaseBootstrapperTestIT extends ExclusiveServerTestBase
         properties.putAll( ServerTestUtils.getDefaultRelativeProperties() );
         properties.put( "dbms.connector.http.type", "HTTP" );
         properties.put( "dbms.connector.http.enabled", "true" );
+        properties.put( "dbms.connector.http.advertised_address", "localhost:0" );
         store( properties, configFile );
 
         // When
@@ -117,6 +119,7 @@ public abstract class BaseBootstrapperTestIT extends ExclusiveServerTestBase
         properties.putAll( ServerTestUtils.getDefaultRelativeProperties() );
         properties.put( "dbms.connector.http.type", "HTTP" );
         properties.put( "dbms.connector.http.enabled", "true" );
+        properties.put( "dbms.connector.http.advertised_address", "localhost:0" );
         store( properties, configFile );
 
         // When

--- a/community/server/src/test/java/org/neo4j/server/LegacyIndexIT.java
+++ b/community/server/src/test/java/org/neo4j/server/LegacyIndexIT.java
@@ -37,7 +37,7 @@ import org.neo4j.test.server.HTTP;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.neo4j.server.helpers.CommunityServerBuilder.server;
+import static org.neo4j.server.helpers.CommunityServerBuilder.serverOnRandomPorts;
 import static org.neo4j.test.server.HTTP.RawPayload.quotedJson;
 
 @RunWith( Theories.class )
@@ -58,7 +58,7 @@ public class LegacyIndexIT extends ExclusiveServerTestBase
     @Before
     public void startServer() throws NoSuchAlgorithmException, KeyManagementException, IOException
     {
-        server = server().withHttpsEnabled()
+        server = serverOnRandomPorts().withHttpsEnabled()
                 .withProperty( "dbms.shell.enabled", "false" )
                 .withProperty( "dbms.security.auth_enabled", "false" )
                 .withProperty( ServerSettings.maximum_response_header_size.name(), "5000" )

--- a/community/server/src/test/java/org/neo4j/server/NeoServerJAXRSIT.java
+++ b/community/server/src/test/java/org/neo4j/server/NeoServerJAXRSIT.java
@@ -19,12 +19,12 @@
  */
 package org.neo4j.server;
 
-import java.net.URI;
-
 import org.dummy.web.service.DummyThirdPartyWebService;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.net.URI;
 
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.RelationshipType;
@@ -33,13 +33,11 @@ import org.neo4j.server.helpers.CommunityServerBuilder;
 import org.neo4j.server.helpers.FunctionalTestHelper;
 import org.neo4j.server.helpers.ServerHelper;
 import org.neo4j.server.helpers.Transactor;
-import org.neo4j.server.helpers.UnitOfWork;
 import org.neo4j.server.rest.JaxRsResponse;
 import org.neo4j.server.rest.RestRequest;
 import org.neo4j.test.server.ExclusiveServerTestBase;
 
 import static org.junit.Assert.assertEquals;
-
 import static org.neo4j.server.helpers.FunctionalTestHelper.CLIENT;
 
 public class NeoServerJAXRSIT extends ExclusiveServerTestBase
@@ -76,7 +74,7 @@ public class NeoServerJAXRSIT extends ExclusiveServerTestBase
     @Test
     public void shouldLoadThirdPartyJaxRsClasses() throws Exception
     {
-        server = CommunityServerBuilder.server()
+        server = CommunityServerBuilder.serverOnRandomPorts()
                 .withThirdPartyJaxRsPackage( "org.dummy.web.service",
                         DummyThirdPartyWebService.DUMMY_WEB_SERVICE_MOUNT_POINT )
                 .usingDataDir( folder.directory( name.getMethodName() ).getAbsolutePath() )

--- a/community/server/src/test/java/org/neo4j/server/NeoServerRestartTestCommunityIT.java
+++ b/community/server/src/test/java/org/neo4j/server/NeoServerRestartTestCommunityIT.java
@@ -28,7 +28,8 @@ public class NeoServerRestartTestCommunityIT extends NeoServerRestartTestIT
 {
     protected NeoServer getNeoServer( String customPageSwapperName ) throws IOException
     {
-        CommunityServerBuilder builder = CommunityServerBuilder.server().withProperty( GraphDatabaseSettings
+        CommunityServerBuilder builder = CommunityServerBuilder.serverOnRandomPorts()
+                .withProperty( GraphDatabaseSettings
                 .pagecache_swapper.name(), customPageSwapperName );
         return builder.build();
     }

--- a/community/server/src/test/java/org/neo4j/server/NeoServerRestartTestIT.java
+++ b/community/server/src/test/java/org/neo4j/server/NeoServerRestartTestIT.java
@@ -100,7 +100,6 @@ public abstract class NeoServerRestartTestIT extends ExclusiveServerTestBase
             catch ( Exception e )
             {
                 failure.set( true );
-                e.printStackTrace();
             }
         };
     }

--- a/community/server/src/test/java/org/neo4j/server/RedirectToBrowserTestIT.java
+++ b/community/server/src/test/java/org/neo4j/server/RedirectToBrowserTestIT.java
@@ -63,7 +63,7 @@ public class RedirectToBrowserTestIT extends ExclusiveServerTestBase
                 .TEXT_HTML_TYPE ).get( server.baseUri().toString() );
 
         assertEquals( 303, response.getStatus() );
-        assertEquals( new URI( "http://localhost:7474/browser/" ), response.getLocation() );
+        assertEquals( new URI( server.baseUri() + "browser/" ), response.getLocation() );
         response.close();
     }
 

--- a/community/server/src/test/java/org/neo4j/server/TransactionTimeoutIT.java
+++ b/community/server/src/test/java/org/neo4j/server/TransactionTimeoutIT.java
@@ -34,7 +34,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.neo4j.helpers.collection.MapUtil.map;
 import static org.neo4j.kernel.api.exceptions.Status.Transaction.TransactionNotFound;
-import static org.neo4j.server.helpers.CommunityServerBuilder.server;
+import static org.neo4j.server.helpers.CommunityServerBuilder.serverOnRandomPorts;
 
 public class TransactionTimeoutIT extends ExclusiveServerTestBase
 {
@@ -50,7 +50,8 @@ public class TransactionTimeoutIT extends ExclusiveServerTestBase
     public void shouldHonorReallyLowSessionTimeout() throws Exception
     {
         // Given
-        server = server().withProperty( ServerSettings.transaction_idle_timeout.name(), "1" ).build();
+        server = serverOnRandomPorts()
+                .withProperty( ServerSettings.transaction_idle_timeout.name(), "1" ).build();
         server.start();
 
         String tx = HTTP.POST( txURI(), asList( map( "statement", "CREATE (n)" ) ) ).location();

--- a/community/server/src/test/java/org/neo4j/server/helpers/ServerHelper.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/ServerHelper.java
@@ -23,8 +23,6 @@ import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.InetAddress;
-import java.net.ServerSocket;
 
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -38,6 +36,7 @@ import org.neo4j.server.NeoServer;
 
 public class ServerHelper
 {
+
     private ServerHelper()
     {
     }
@@ -104,34 +103,13 @@ public class ServerHelper
         {
             builder = builder.persistent();
         }
+        builder.onRandomPorts();
         NeoServer server = builder
                 .usingDataDir( path != null ? path.getAbsolutePath() : null )
                 .build();
 
-        checkServerCanStart( server.baseUri().getHost(), server.baseUri().getPort() );
-
         server.start();
         return server;
-    }
-
-    private static void checkServerCanStart( String host, int port ) throws IOException
-    {
-        ServerSocket serverSocket = null;
-        try
-        {
-            serverSocket = new ServerSocket( port, 1, InetAddress.getByName( host ) );
-        }
-        catch ( IOException ex )
-        {
-            throw new RuntimeException( "Unable to start server on " + host + ":" + port, ex );
-        }
-        finally
-        {
-            if ( serverSocket != null )
-            {
-                serverSocket.close();
-            }
-        }
     }
 
     private static void rollbackAllOpenTransactions( NeoServer server )

--- a/community/server/src/test/java/org/neo4j/server/integration/StartupLoggingIT.java
+++ b/community/server/src/test/java/org/neo4j/server/integration/StartupLoggingIT.java
@@ -95,6 +95,7 @@ public class StartupLoggingIT extends ExclusiveServerTestBase
         }
         pairs.add( Pair.of( GraphDatabaseSettings.allow_store_upgrade.name(), Settings.TRUE) );
         pairs.add( Pair.of( new HttpConnector( "http", Encryption.NONE ).type.name(), "HTTP" ) );
+        pairs.add( Pair.of( new HttpConnector( "http", Encryption.NONE ).advertised_address.name(), "localhost:0" ) );
         pairs.add( Pair.of( new HttpConnector( "http", Encryption.NONE ).enabled.name(), Settings.TRUE ) );
         return pairs.toArray( new Pair[pairs.size()] );
     }

--- a/community/server/src/test/java/org/neo4j/server/rest/AbstractRestFunctionalTestBase.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/AbstractRestFunctionalTestBase.java
@@ -32,6 +32,7 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.helpers.collection.Pair;
+import org.neo4j.kernel.configuration.ConnectorPortRegister;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.server.rest.domain.JsonHelper;
 import org.neo4j.server.rest.domain.JsonParseException;
@@ -54,8 +55,6 @@ import static org.neo4j.server.rest.web.Surface.PATH_SCHEMA_INDEX;
 
 public class AbstractRestFunctionalTestBase extends SharedServerTestBase implements GraphHolder
 {
-    protected static final String NODES = "http://localhost:7474/db/data/node/";
-
     @Rule
     public TestData<Map<String,Node>> data = TestData.producedThrough( GraphDescription.createGraphFor( this, true ) );
 
@@ -123,12 +122,12 @@ public class AbstractRestFunctionalTestBase extends SharedServerTestBase impleme
 
     protected static String getDataUri()
     {
-        return "http://localhost:7474/db/data/";
+        return "http://localhost:" + getLocalHttpPort() + "/db/data/";
     }
 
     protected String getDatabaseUri()
     {
-        return "http://localhost:7474/db/";
+        return "http://localhost:" + getLocalHttpPort() + "/db/";
     }
 
     protected String getNodeUri( Node node )
@@ -277,5 +276,12 @@ public class AbstractRestFunctionalTestBase extends SharedServerTestBase impleme
     public String getSchemaConstraintLabelUniquenessPropertyUri( String label, String property )
     {
         return getDataUri() + PATH_SCHEMA_CONSTRAINT + "/" + label + "/uniqueness/" + property;
+    }
+
+    public static int getLocalHttpPort()
+    {
+        ConnectorPortRegister connectorPortRegister = server().getDatabase().getGraph().getDependencyResolver()
+                .resolveDependency( ConnectorPortRegister.class );
+        return connectorPortRegister.getLocalAddress( "http" ).getPort();
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/AutoIndexWithNonDefaultConfigurationThroughRESTAPIIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/AutoIndexWithNonDefaultConfigurationThroughRESTAPIIT.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.server.rest;
 
-import java.io.IOException;
-
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -28,6 +26,8 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
 
 import org.neo4j.server.CommunityNeoServer;
 import org.neo4j.server.helpers.CommunityServerBuilder;
@@ -53,7 +53,7 @@ public class AutoIndexWithNonDefaultConfigurationThroughRESTAPIIT extends Exclus
     @BeforeClass
     public static void allocateServer() throws IOException
     {
-        server = CommunityServerBuilder.server()
+        server = CommunityServerBuilder.serverOnRandomPorts()
                 .usingDataDir( staticFolder.getRoot().getAbsolutePath() )
                 .withAutoIndexingEnabledForNodes( "foo", "bar" )
                 .build();

--- a/community/server/src/test/java/org/neo4j/server/rest/DisableWADLIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/DisableWADLIT.java
@@ -19,13 +19,13 @@
  */
 package org.neo4j.server.rest;
 
-import java.net.URI;
-
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.junit.Test;
+
+import java.net.URI;
 
 import static org.junit.Assert.assertEquals;
 
@@ -34,7 +34,7 @@ public class DisableWADLIT extends AbstractRestFunctionalTestBase
     @Test
     public void should404OnAnyUriEndinginWADL() throws Exception
     {
-        URI nodeUri = new URI( "http://localhost:7474/db/data/application.wadl" );
+        URI nodeUri = new URI( server().baseUri() + "db/data/application.wadl" );
 
         HttpClient httpclient = new DefaultHttpClient();
         try

--- a/community/server/src/test/java/org/neo4j/server/rest/PathsIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/PathsIT.java
@@ -67,7 +67,7 @@ public class PathsIT extends AbstractRestFunctionalTestBase
         String response = gen()
         .expectedStatus( Status.OK.getStatusCode() )
         .payload( getAllShortestPathPayLoad( g ) )
-        .post( "http://localhost:7474/db/data/node/" + a + "/paths" )
+        .post( getServerUri() + "db/data/node/" + a + "/paths" )
         .entity();
         Collection<?> result = (Collection<?>) JsonHelper.readJson( response );
         assertEquals( 2, result.size() );
@@ -105,7 +105,7 @@ public class PathsIT extends AbstractRestFunctionalTestBase
         String response = gen()
         .expectedStatus( Status.OK.getStatusCode() )
         .payload( getAllShortestPathPayLoad( g ) )
-        .post( "http://localhost:7474/db/data/node/" + a + "/path" )
+        .post( getServerUri() + "db/data/node/" + a + "/path" )
         .entity();
         // Get single shortest path
 
@@ -174,7 +174,7 @@ public class PathsIT extends AbstractRestFunctionalTestBase
         long e = nodeId( data.get(), "e" );
         String response = gen().expectedStatus( Status.OK.getStatusCode() )
                 .payload( getAllPathsUsingDijkstraPayLoad( e, false ) )
-                .post( "http://localhost:7474/db/data/node/" + a + "/path" )
+                .post( getServerUri() + "db/data/node/" + a + "/path" )
                 .entity();
         //
         Map<?, ?> path = JsonHelper.jsonToMap( response );
@@ -222,7 +222,7 @@ public class PathsIT extends AbstractRestFunctionalTestBase
         long e = nodeId( data.get(), "e" );
         String response = gen().expectedStatus( Status.OK.getStatusCode() )
                 .payload( getAllPathsUsingDijkstraPayLoad( e, false ) )
-                .post( "http://localhost:7474/db/data/node/" + a + "/paths" )
+                .post( getServerUri() + "db/data/node/" + a + "/paths" )
                 .entity();
         //
         List<Map<String, Object>> list = JsonHelper.jsonToList( response );
@@ -282,7 +282,7 @@ public class PathsIT extends AbstractRestFunctionalTestBase
         String response = gen()
                 .expectedStatus( Status.OK.getStatusCode() )
                 .payload( getAllPathsUsingDijkstraPayLoad( e, false ) )
-                .post( "http://localhost:7474/db/data/node/" + a + "/path" )
+                .post( getServerUri() + "db/data/node/" + a + "/path" )
                 .entity();
 
         Map<?, ?> path = JsonHelper.jsonToMap( response );
@@ -315,7 +315,7 @@ public class PathsIT extends AbstractRestFunctionalTestBase
         String entity = gen()
         .expectedStatus( Status.NOT_FOUND.getStatusCode() )
         .payload( noHitsJson )
-        .post( "http://localhost:7474/db/data/node/" + a + "/path" )
+        .post( getServerUri() + "db/data/node/" + a + "/path" )
         .entity();
         System.out.println( entity );
     }
@@ -328,7 +328,7 @@ public class PathsIT extends AbstractRestFunctionalTestBase
 
     private String nodeUri( final long l )
     {
-        return NODES + l;
+        return getServerUri() + "db/data/node/" + l;
     }
 
     private String getAllShortestPathPayLoad( final long to )
@@ -346,6 +346,11 @@ public class PathsIT extends AbstractRestFunctionalTestBase
         + ( includeDefaultCost ? ", \"default_cost\":1" : "" )
         + ", \"relationships\":{\"type\":\"to\", \"direction\":\"out\"}, \"algorithm\":\"dijkstra\"}";
         return json;
+    }
+
+    private String getServerUri()
+    {
+        return server().baseUri().toString();
     }
 
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/RetrieveRelationshipsFromNodeIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/RetrieveRelationshipsFromNodeIT.java
@@ -98,7 +98,7 @@ public class RetrieveRelationshipsFromNodeIT extends AbstractRestFunctionalDocTe
         HttpClient httpclient = new DefaultHttpClient();
         try
         {
-            HttpGet httpget = new HttpGet( "http://localhost:7474/db/data/relationship/" + likes );
+            HttpGet httpget = new HttpGet( getServerUri() + "db/data/relationship/" + likes );
             httpget.setHeader( "Accept", "application/json" );
             httpget.setHeader( "Host", "dummy.neo4j.org" );
             HttpResponse response = httpclient.execute( httpget );
@@ -109,7 +109,7 @@ public class RetrieveRelationshipsFromNodeIT extends AbstractRestFunctionalDocTe
             System.out.println( entityBody );
 
             assertThat( entityBody, containsString( "http://dummy.neo4j.org/db/data/relationship/" + likes ) );
-            assertThat( entityBody, not( containsString( "localhost:7474" ) ) );
+            assertThat( entityBody, not( containsString( getServerUri() ) ) );
         }
         finally
         {
@@ -123,7 +123,7 @@ public class RetrieveRelationshipsFromNodeIT extends AbstractRestFunctionalDocTe
         HttpClient httpclient = new DefaultHttpClient();
         try
         {
-            HttpGet httpget = new HttpGet( "http://localhost:7474/db/data/relationship/" + likes );
+            HttpGet httpget = new HttpGet( getServerUri() + "db/data/relationship/" + likes );
 
             httpget.setHeader( "Accept", "application/json" );
             HttpResponse response = httpclient.execute( httpget );
@@ -131,7 +131,7 @@ public class RetrieveRelationshipsFromNodeIT extends AbstractRestFunctionalDocTe
 
             String entityBody = IOUtils.toString( entity.getContent(), StandardCharsets.UTF_8 );
 
-            assertThat( entityBody, containsString( "http://localhost:7474/db/data/relationship/" + likes ) );
+            assertThat( entityBody, containsString( getServerUri() + "db/data/relationship/" + likes ) );
         }
         finally
         {
@@ -314,6 +314,11 @@ public class RetrieveRelationshipsFromNodeIT extends AbstractRestFunctionalDocTe
         assertNotNull( entity );
         isLegalJson( entity );
         response.close();
+    }
+
+    private String getServerUri()
+    {
+        return server().baseUri().toString();
     }
 
     private void isLegalJson( String entity ) throws IOException, JsonParseException

--- a/community/server/src/test/java/org/neo4j/server/rest/paging/PagedTraverserIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/paging/PagedTraverserIT.java
@@ -81,7 +81,7 @@ public class PagedTraverserIT extends ExclusiveServerTestBase
     public static void setupServer() throws Exception
     {
         clock = Clocks.fakeClock();
-        server = CommunityServerBuilder.server()
+        server = CommunityServerBuilder.serverOnRandomPorts()
                 .usingDataDir( staticFolder.getRoot().getAbsolutePath() )
                 .withClock( clock )
                 .build();

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/XForwardFilterIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/XForwardFilterIT.java
@@ -62,7 +62,7 @@ public class XForwardFilterIT extends AbstractRestFunctionalTestBase
     public void shouldUseXForwardedHostHeaderWhenPresent() throws Exception
     {
         // when
-        ClientResponse response = client.resource( "http://localhost:7474/db/manage" )
+        ClientResponse response = client.resource( getManageUri() )
                 .accept( APPLICATION_JSON )
                 .header( X_FORWARDED_HOST, "jimwebber.org" )
                 .get( ClientResponse.class );
@@ -77,7 +77,7 @@ public class XForwardFilterIT extends AbstractRestFunctionalTestBase
     public void shouldUseXForwardedProtoHeaderWhenPresent() throws Exception
     {
         // when
-        ClientResponse response = client.resource( "http://localhost:7474/db/manage" )
+        ClientResponse response = client.resource( getManageUri() )
                 .accept( APPLICATION_JSON )
                 .header( X_FORWARDED_PROTO, "https" )
                 .get( ClientResponse.class );
@@ -92,7 +92,7 @@ public class XForwardFilterIT extends AbstractRestFunctionalTestBase
     public void shouldPickFirstXForwardedHostHeaderValueFromCommaOrCommaAndSpaceSeparatedList() throws Exception
     {
         // when
-        ClientResponse response = client.resource( "http://localhost:7474/db/manage" )
+        ClientResponse response = client.resource( getManageUri() )
                 .accept( APPLICATION_JSON )
                 .header( X_FORWARDED_HOST, "jimwebber.org, kathwebber.com,neo4j.org" )
                 .get( ClientResponse.class );
@@ -107,49 +107,49 @@ public class XForwardFilterIT extends AbstractRestFunctionalTestBase
     public void shouldUseBaseUriOnBadXForwardedHostHeader() throws Exception
     {
         // when
-        ClientResponse response = client.resource( "http://localhost:7474/db/manage" )
+        ClientResponse response = client.resource( getManageUri() )
                 .accept( APPLICATION_JSON )
                 .header( X_FORWARDED_HOST, ":bad_URI" )
                 .get( ClientResponse.class );
 
         // then
         String entity = response.getEntity( String.class );
-        assertTrue( entity.contains( "http://localhost:7474" ) );
+        assertTrue( entity.contains( getServerUri() ) );
     }
 
     @Test
     public void shouldUseBaseUriIfFirstAddressInXForwardedHostHeaderIsBad() throws Exception
     {
         // when
-        ClientResponse response = client.resource( "http://localhost:7474/db/manage" )
+        ClientResponse response = client.resource( getManageUri() )
                 .accept( APPLICATION_JSON )
                 .header( X_FORWARDED_HOST, ":bad_URI,good-host" )
                 .get( ClientResponse.class );
 
         // then
         String entity = response.getEntity( String.class );
-        assertTrue( entity.contains( "http://localhost:7474" ) );
+        assertTrue( entity.contains( getServerUri() ) );
     }
 
     @Test
     public void shouldUseBaseUriOnBadXForwardedProtoHeader() throws Exception
     {
         // when
-        ClientResponse response = client.resource( "http://localhost:7474/db/manage" )
+        ClientResponse response = client.resource( getManageUri() )
                 .accept( APPLICATION_JSON )
                 .header( X_FORWARDED_PROTO, "%%%DEFINITELY-NOT-A-PROTO!" )
                 .get( ClientResponse.class );
 
         // then
         String entity = response.getEntity( String.class );
-        assertTrue( entity.contains( "http://localhost:7474" ) );
+        assertTrue( entity.contains( getServerUri() ) );
     }
 
     @Test
     public void shouldUseXForwardedHostAndXForwardedProtoHeadersWhenPresent() throws Exception
     {
         // when
-        ClientResponse response = client.resource( "http://localhost:7474/db/manage" )
+        ClientResponse response = client.resource( getManageUri() )
                 .accept( APPLICATION_JSON )
                 .header( X_FORWARDED_HOST, "jimwebber.org" )
                 .header( X_FORWARDED_PROTO, "https" )
@@ -158,7 +158,7 @@ public class XForwardFilterIT extends AbstractRestFunctionalTestBase
         // then
         String entity = response.getEntity( String.class );
         assertTrue( entity.contains( "https://jimwebber.org" ) );
-        assertFalse( entity.contains( "http://localhost:7474" ) );
+        assertFalse( entity.contains( getServerUri() ) );
     }
 
     @Test
@@ -168,7 +168,7 @@ public class XForwardFilterIT extends AbstractRestFunctionalTestBase
         String jsonString = "{\"statements\" : [{ \"statement\": \"MATCH (n) RETURN n\", " +
                 "\"resultDataContents\":[\"REST\"] }] }";
 
-        ClientResponse response = client.resource( "http://localhost:7474/db/data/transaction" )
+        ClientResponse response = client.resource( getServerUri() + "db/data/transaction" )
                 .accept( APPLICATION_JSON )
                 .header( X_FORWARDED_HOST, "jimwebber.org:2354" )
                 .header( X_FORWARDED_PROTO, "https" )
@@ -178,6 +178,16 @@ public class XForwardFilterIT extends AbstractRestFunctionalTestBase
         // then
         String entity = response.getEntity( String.class );
         assertTrue( entity.contains( "https://jimwebber.org:2354" ) );
-        assertFalse( entity.contains( "http://localhost:7474" ) );
+        assertFalse( entity.contains( getServerUri() ) );
+    }
+
+    private String getManageUri()
+    {
+        return getServerUri() + "db/manage";
+    }
+
+    private String getServerUri()
+    {
+        return server().baseUri().toString();
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/rest/security/CommunityServerTestBase.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/CommunityServerTestBase.java
@@ -45,7 +45,7 @@ public class CommunityServerTestBase extends ExclusiveServerTestBase
 
     protected void startServer( boolean authEnabled ) throws IOException
     {
-        server = CommunityServerBuilder.server()
+        server = CommunityServerBuilder.serverOnRandomPorts()
                 .withProperty( GraphDatabaseSettings.auth_enabled.name(), Boolean.toString( authEnabled ) )
                 .build();
         server.start();

--- a/community/server/src/test/java/org/neo4j/server/rest/security/SecurityRulesIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/SecurityRulesIT.java
@@ -19,13 +19,13 @@
  */
 package org.neo4j.server.rest.security;
 
-import java.net.URI;
-import javax.ws.rs.core.MediaType;
-
 import org.dummy.web.service.DummyThirdPartyWebService;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.net.URI;
+import javax.ws.rs.core.MediaType;
 
 import org.neo4j.kernel.impl.annotations.Documented;
 import org.neo4j.server.CommunityNeoServer;
@@ -80,7 +80,7 @@ public class SecurityRulesIT extends ExclusiveServerTestBase
     public void should401WithBasicChallengeWhenASecurityRuleFails()
             throws Exception
     {
-        server = CommunityServerBuilder.server().withDefaultDatabaseTuning().withSecurityRules(
+        server = CommunityServerBuilder.serverOnRandomPorts().withDefaultDatabaseTuning().withSecurityRules(
                 PermanentlyFailingSecurityRule.class.getCanonicalName() )
                 .usingDataDir( folder.directory( name.getMethodName() ).getAbsolutePath() )
                 .build();
@@ -98,7 +98,7 @@ public class SecurityRulesIT extends ExclusiveServerTestBase
     public void should401WithBasicChallengeIfAnyOneOfTheRulesFails()
             throws Exception
     {
-        server = CommunityServerBuilder.server().withDefaultDatabaseTuning().withSecurityRules(
+        server = CommunityServerBuilder.serverOnRandomPorts().withDefaultDatabaseTuning().withSecurityRules(
                 PermanentlyFailingSecurityRule.class.getCanonicalName(),
                 PermanentlyPassingSecurityRule.class.getCanonicalName() )
                 .usingDataDir( folder.directory( name.getMethodName() ).getAbsolutePath() )
@@ -118,7 +118,7 @@ public class SecurityRulesIT extends ExclusiveServerTestBase
     public void shouldInvokeAllSecurityRules() throws Exception
     {
         // given
-        server = CommunityServerBuilder.server().withDefaultDatabaseTuning().withSecurityRules(
+        server = CommunityServerBuilder.serverOnRandomPorts().withDefaultDatabaseTuning().withSecurityRules(
                 NoAccessToDatabaseSecurityRule.class.getCanonicalName())
                 .usingDataDir( folder.directory( name.getMethodName() ).getAbsolutePath() )
                 .build();
@@ -136,7 +136,7 @@ public class SecurityRulesIT extends ExclusiveServerTestBase
     public void shouldRespondWith201IfAllTheRulesPassWhenCreatingANode()
             throws Exception
     {
-        server = CommunityServerBuilder.server().withDefaultDatabaseTuning().withSecurityRules(
+        server = CommunityServerBuilder.serverOnRandomPorts().withDefaultDatabaseTuning().withSecurityRules(
                 PermanentlyPassingSecurityRule.class.getCanonicalName() )
                 .usingDataDir( folder.directory( name.getMethodName() ).getAbsolutePath() )
                 .build();
@@ -173,7 +173,7 @@ public class SecurityRulesIT extends ExclusiveServerTestBase
             throws Exception
     {
         String mountPoint = "/protected/tree/starts/here" + DummyThirdPartyWebService.DUMMY_WEB_SERVICE_MOUNT_POINT;
-        server = CommunityServerBuilder.server().withDefaultDatabaseTuning()
+        server = CommunityServerBuilder.serverOnRandomPorts().withDefaultDatabaseTuning()
                 .withThirdPartyJaxRsPackage( "org.dummy.web.service",
                         mountPoint )
                 .withSecurityRules(
@@ -211,7 +211,7 @@ public class SecurityRulesIT extends ExclusiveServerTestBase
     {
         String mountPoint = "/protected/wildcard_replacement/x/y/z/something/else/more_wildcard_replacement/a/b/c" +
                 "/final/bit";
-        server = CommunityServerBuilder.server().withDefaultDatabaseTuning()
+        server = CommunityServerBuilder.serverOnRandomPorts().withDefaultDatabaseTuning()
                 .withThirdPartyJaxRsPackage( "org.dummy.web.service",
                         mountPoint )
                 .withSecurityRules(
@@ -237,7 +237,7 @@ public class SecurityRulesIT extends ExclusiveServerTestBase
     public void should403WhenAuthenticatedButForbidden()
             throws Exception
     {
-        server = CommunityServerBuilder.server().withDefaultDatabaseTuning().withSecurityRules(
+        server = CommunityServerBuilder.serverOnRandomPorts().withDefaultDatabaseTuning().withSecurityRules(
                 PermanentlyForbiddenSecurityRule.class.getCanonicalName(),
                 PermanentlyPassingSecurityRule.class.getCanonicalName() )
                 .usingDataDir( folder.directory( name.getMethodName() ).getAbsolutePath() )

--- a/community/server/src/test/java/org/neo4j/server/rest/security/UsersIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/security/UsersIT.java
@@ -148,7 +148,7 @@ public class UsersIT extends ExclusiveServerTestBase
 
     public void startServer( boolean authEnabled ) throws IOException
     {
-        server = CommunityServerBuilder.server()
+        server = CommunityServerBuilder.serverOnRandomPorts()
                 .withProperty( GraphDatabaseSettings.auth_enabled.name(), Boolean.toString( authEnabled ) )
                 .build();
         server.start();

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/DeadlockIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/DeadlockIT.java
@@ -40,7 +40,7 @@ import static org.neo4j.test.server.HTTP.RawPayload.quotedJson;
 
 public class DeadlockIT extends AbstractRestFunctionalTestBase
 {
-    private final HTTP.Builder http = HTTP.withBaseUri( "http://localhost:7474" );
+    private final HTTP.Builder http = HTTP.withBaseUri( server().baseUri() );
 
     @Rule
     public OtherThreadRule<Object> otherThread = new OtherThreadRule<>();
@@ -59,7 +59,7 @@ public class DeadlockIT extends AbstractRestFunctionalTestBase
         }
 
         // When I lock node:First
-        HTTP.Response begin = http.POST( "/db/data/transaction",
+        HTTP.Response begin = http.POST( "db/data/transaction",
                 quotedJson( "{ 'statements': [ { 'statement': 'MATCH (n:First) SET n.prop=1' } ] }" ));
 
         // and I lock node:Second, and wait for a lock on node:First in another transaction
@@ -82,7 +82,7 @@ public class DeadlockIT extends AbstractRestFunctionalTestBase
     {
         return state ->
         {
-            HTTP.Response post = http.POST( "/db/data/transaction",
+            HTTP.Response post = http.POST( "db/data/transaction",
                     quotedJson( "{ 'statements': [ { 'statement': 'MATCH (n:Second) SET n.prop=1' } ] }" ) );
             secondNodeLocked.countDown();
             http.POST( post.location(),

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/QueryResultsSerializationTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/QueryResultsSerializationTest.java
@@ -52,7 +52,7 @@ import static org.neo4j.test.server.HTTP.RawPayload.quotedJson;
 
 public class QueryResultsSerializationTest extends AbstractRestFunctionalTestBase
 {
-    private final HTTP.Builder http = HTTP.withBaseUri( "http://localhost:7474" );
+    private final HTTP.Builder http = HTTP.withBaseUri( server().baseUri() );
 
     private String commitResource;
 
@@ -60,7 +60,7 @@ public class QueryResultsSerializationTest extends AbstractRestFunctionalTestBas
     public void setUp()
     {
         // begin
-        Response begin = http.POST( "/db/data/transaction" );
+        Response begin = http.POST( "db/data/transaction" );
 
         assertThat( begin.status(), equalTo( 201 ) );
         assertHasTxLocation( begin );

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/ReadOnlyIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/ReadOnlyIT.java
@@ -24,7 +24,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.File;
 import java.io.IOException;
 
 import org.neo4j.server.NeoServer;
@@ -39,14 +38,15 @@ import static org.neo4j.test.server.HTTP.RawPayload.quotedJson;
 
 public class ReadOnlyIT extends ExclusiveServerTestBase
 {
-    private final HTTP.Builder http = HTTP.withBaseUri( "http://localhost:7474" );
     private NeoServer readOnlyServer;
+    private HTTP.Builder http;
 
     @Before
     public void setup() throws IOException
     {
         ServerHelper.cleanTheDatabase( readOnlyServer );
         readOnlyServer = ServerHelper.createNonPersistentReadOnlyServer();
+        http = HTTP.withBaseUri( readOnlyServer.baseUri() );
     }
 
     @After
@@ -62,7 +62,7 @@ public class ReadOnlyIT extends ExclusiveServerTestBase
     public void shouldReturnReadOnlyStatusWhenCreatingNodes() throws Exception
     {
         // Given
-        HTTP.Response response = http.POST( "/db/data/transaction/commit",
+        HTTP.Response response = http.POST( "db/data/transaction/commit",
                 quotedJson( "{ 'statements': [ { 'statement': 'CREATE (node)' } ] }" ) );
 
         // Then
@@ -79,7 +79,7 @@ public class ReadOnlyIT extends ExclusiveServerTestBase
     {
         // Given
         // When
-        HTTP.Response response = http.POST( "/db/data/transaction/commit",
+        HTTP.Response response = http.POST( "db/data/transaction/commit",
                 quotedJson( "{ 'statements': [ { 'statement': 'CREATE (node:Node)' } ] }" ) );
 
         // Then

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/RowFormatMetaFieldTestIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/RowFormatMetaFieldTestIT.java
@@ -40,7 +40,7 @@ import static org.neo4j.test.server.HTTP.RawPayload.quotedJson;
 
 public class RowFormatMetaFieldTestIT extends AbstractRestFunctionalTestBase
 {
-    private final HTTP.Builder http = HTTP.withBaseUri( "http://localhost:7474" );
+    private final HTTP.Builder http = HTTP.withBaseUri( server().baseUri() );
 
     private String commitResource;
 
@@ -48,7 +48,7 @@ public class RowFormatMetaFieldTestIT extends AbstractRestFunctionalTestBase
     public void setUp()
     {
         // begin
-        Response begin = http.POST( "/db/data/transaction" );
+        Response begin = http.POST( "db/data/transaction" );
 
         assertThat( begin.status(), equalTo( 201 ) );
         assertHasTxLocation( begin );

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/integration/TransactionIT.java
@@ -66,7 +66,7 @@ import static org.neo4j.test.server.HTTP.RawPayload.rawPayload;
 
 public class TransactionIT extends AbstractRestFunctionalTestBase
 {
-    private final HTTP.Builder http = HTTP.withBaseUri( "http://localhost:7474" );
+    private final HTTP.Builder http = HTTP.withBaseUri( server().baseUri() );
 
     @Test
     public void begin__execute__commit() throws Exception
@@ -74,7 +74,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
         long nodesInDatabaseBeforeTransaction = countNodes();
 
         // begin
-        Response begin = http.POST( "/db/data/transaction" );
+        Response begin = http.POST( "db/data/transaction" );
 
         assertThat( begin.status(), equalTo( 201 ) );
         assertHasTxLocation( begin );
@@ -102,7 +102,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
         long nodesInDatabaseBeforeTransaction = countNodes();
 
         // begin
-        Response begin = http.POST( "/db/data/transaction" );
+        Response begin = http.POST( "db/data/transaction" );
 
         assertThat( begin.status(), equalTo( 201 ) );
         assertHasTxLocation( begin );
@@ -123,7 +123,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
         long nodesInDatabaseBeforeTransaction = countNodes();
 
         // begin
-        Response begin = http.POST( "/db/data/transaction" );
+        Response begin = http.POST( "db/data/transaction" );
 
         assertThat( begin.status(), equalTo( 201 ) );
         assertHasTxLocation( begin );
@@ -146,7 +146,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
         long nodesInDatabaseBeforeTransaction = countNodes();
 
         // begin and execute
-        Response begin = http.POST( "/db/data/transaction",
+        Response begin = http.POST( "db/data/transaction",
                 quotedJson( "{ 'statements': [ { 'statement': 'CREATE (n)' } ] }" ) );
 
         String commitResource = begin.stringFromContent( "commit" );
@@ -168,7 +168,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
 
         // begin and execute
         // given statement is badly escaped and it is a client error, thus tx is rolled back at once
-        Response begin = http.POST( "/db/data/transaction", quotedJson( json ) );
+        Response begin = http.POST( "db/data/transaction", quotedJson( json ) );
 
         String commitResource = begin.stringFromContent( "commit" );
 
@@ -188,7 +188,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
     public void begin__execute__commit__execute() throws Exception
     {
         // begin
-        Response begin = http.POST( "/db/data/transaction" );
+        Response begin = http.POST( "db/data/transaction" );
         String commitResource = begin.stringFromContent( "commit" );
 
         // execute
@@ -211,7 +211,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
         long nodesInDatabaseBeforeTransaction = countNodes();
 
         // begin and execute and commit
-        Response begin = http.POST( "/db/data/transaction/commit",
+        Response begin = http.POST( "db/data/transaction/commit",
                 quotedJson( "{ 'statements': [ { 'statement': 'CREATE (n)' } ] }" ) );
 
         assertThat( begin.status(), equalTo( 200 ) );
@@ -225,7 +225,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
         // begin and execute and commit "resultDataContents":["REST"]
         HTTP.RawPayload payload = quotedJson( "{ 'statements': [ { 'statement': 'CREATE (n {a: 1}) return n', " +
                                               "'resultDataContents' : ['REST'] } ] }" );
-        Response begin = http.POST( "/db/data/transaction/commit", payload );
+        Response begin = http.POST( "db/data/transaction/commit", payload );
 
         assertThat( begin.status(), equalTo( 200 ) );
         JsonNode results = begin.get( "results" );
@@ -248,7 +248,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
                       "\\\"xx file://C:/countries.csvxxx\\\\\" as csvLine MERGE (c:Country { Code: csvLine.Code })\" " +
                       "} ] }";
         // begin and execute and commit
-        Response begin = http.POST( "/db/data/transaction/commit", quotedJson( json ) );
+        Response begin = http.POST( "db/data/transaction/commit", quotedJson( json ) );
 
         assertThat( begin.status(), equalTo( 200 ) );
         assertThat( begin, hasErrors( Status.Request.InvalidFormat ) );
@@ -267,7 +267,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
 
             // begin and execute and commit
             Response response = http.POST(
-                    "/db/data/transaction/commit",
+                    "db/data/transaction/commit",
                     quotedJson( "{ 'statements': [ { 'statement': 'USING PERIODIC COMMIT " + batch + " LOAD CSV FROM " +
                             "\\\"" + url + "\\\" AS line CREATE ()' } ] }" )
             );
@@ -299,7 +299,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
 
             // begin and execute and commit
             Response response = http.POST(
-                    "/db/data/transaction/commit",
+                    "db/data/transaction/commit",
                     quotedJson( "{ 'statements': [ { 'statement': 'USING PERIODIC COMMIT " + batch + " LOAD CSV FROM " +
                             "\\\"" + url + "\\\" AS line CREATE (n {id: 23}) RETURN n' } ] }" )
             );
@@ -335,7 +335,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
 
             // begin and execute and commit
             Response response = http.POST(
-                    "/db/data/transaction/commit",
+                    "db/data/transaction/commit",
                     quotedJson( "{ 'statements': [ { 'statement': 'CYPHER 2.3 USING PERIODIC COMMIT " + batch +
                             " LOAD CSV FROM" + " \\\"" + url + "\\\" AS line CREATE (n {id: 23}) RETURN n' } ] }" )
             );
@@ -359,7 +359,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
         {
             // begin and execute and commit
             Response response = http.POST(
-                    "/db/data/transaction/commit",
+                    "db/data/transaction/commit",
                     quotedJson( "{ 'statements': [ { 'statement': 'USING PERIODIC COMMIT LOAD CSV FROM \\\"" +
                                 url +
                                 "\\\" AS line CREATE (n {id: 23}) RETURN n' }, { 'statement': 'RETURN 1' } ] }" )
@@ -375,7 +375,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
     {
         // begin and execute and commit
         Response response = http.POST(
-                "/db/data/transaction/commit",
+                "db/data/transaction/commit",
                 quotedJson( "{ 'statements': [ { 'statement': 'MATCH n RETURN m' } ] }" )
         );
 
@@ -390,7 +390,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
         {
             // begin and execute and commit
             Response response = http.POST(
-                    "/db/data/transaction/commit",
+                    "db/data/transaction/commit",
                     quotedJson( "{ 'statements': [ { 'statement': 'CREATE ()' }, " +
                                 "{ 'statement': 'USING PERIODIC COMMIT LOAD CSV FROM \\\"" + url + "\\\" AS line " +
                                 "CREATE ()' } ] }" )
@@ -406,7 +406,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
         ServerTestUtils.withCSVFile( 1, url ->
         {
             // begin
-            Response begin = http.POST( "/db/data/transaction" );
+            Response begin = http.POST( "db/data/transaction" );
 
             // execute
             http.POST( begin.location(), quotedJson( "{ 'statements': [ { 'statement': 'CREATE ()' } ] }" ) );
@@ -427,7 +427,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
         {
             // begin and execute
             Response begin = http.POST(
-                    "/db/data/transaction",
+                    "db/data/transaction",
                     quotedJson( "{ 'statements': [ { 'statement': 'USING PERIODIC COMMIT LOAD CSV FROM \\\"" +
                                 url + "\\\" AS line CREATE ()' } ] }" )
             );
@@ -442,7 +442,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
         long nodesInDatabaseBeforeTransaction = countNodes();
 
         // begin
-        Response begin = http.POST( "/db/data/transaction" );
+        Response begin = http.POST( "db/data/transaction" );
 
         String commitResource = begin.stringFromContent( "commit" );
 
@@ -462,7 +462,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
         long nodesInDatabaseBeforeTransaction = countNodes();
 
         // begin
-        Response begin = http.POST( "/db/data/transaction" );
+        Response begin = http.POST( "db/data/transaction" );
 
         String commitResource = begin.stringFromContent( "commit" );
 
@@ -490,7 +490,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
 
         // GIVEN
         long nodesInDatabaseBeforeTransaction = countNodes();
-        Response response = http.POST( "/db/data/transaction/commit",
+        Response response = http.POST( "db/data/transaction/commit",
                 rawPayload( "{ \"statements\" : [{\"statement\" : \"CREATE (n0:DecibelEntity :AlbumGroup{DecibelID : " +
                             "'34a2201b-f4a9-420f-87ae-00a9c691cc5c', Title : 'Dance With Me', " +
                             "ArtistString : 'Ra Ra Riot', MainArtistAlias : 'Ra Ra Riot', " +
@@ -509,7 +509,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
         long id = result.get( "data" ).get( 0 ).get( "row" ).get( 0 ).getLongValue();
 
         // WHEN
-        http.POST( "/db/data/cypher", rawPayload( "{\"query\":\"match (n) where id(n) = " + id + " delete n\"}" ) );
+        http.POST( "db/data/cypher", rawPayload( "{\"query\":\"match (n) where id(n) = " + id + " delete n\"}" ) );
 
         // THEN
         assertThat( countNodes(), equalTo( nodesInDatabaseBeforeTransaction + 1 ) );
@@ -519,7 +519,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
     public void begin__rollback__commit() throws Exception
     {
         // begin
-        Response begin = http.POST( "/db/data/transaction" );
+        Response begin = http.POST( "db/data/transaction" );
 
         assertThat( begin.status(), equalTo( 201 ) );
         assertHasTxLocation( begin );
@@ -539,7 +539,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
     public void begin__rollback__execute() throws Exception
     {
         // begin
-        Response begin = http.POST( "/db/data/transaction" );
+        Response begin = http.POST( "db/data/transaction" );
 
         assertThat( begin.status(), equalTo( 201 ) );
         assertHasTxLocation( begin );
@@ -559,7 +559,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
     public void begin__execute__rollback_concurrently() throws Exception
     {
         // begin
-        final Response begin = http.POST( "/db/data/transaction" );
+        final Response begin = http.POST( "db/data/transaction" );
         assertThat( begin.status(), equalTo( 201 ) );
         assertHasTxLocation( begin );
 
@@ -610,7 +610,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
     @Test
     public void status_codes_should_appear_in_response() throws Exception
     {
-        Response response = http.POST( "/db/data/transaction/commit",
+        Response response = http.POST( "db/data/transaction/commit",
                 quotedJson( "{ 'statements': [ { 'statement': 'RETURN {n}' } ] }" ) );
 
         assertThat( response.status(), equalTo( 200 ) );
@@ -628,7 +628,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
         long initialTerminations = txMonitor.getNumberOfTerminatedTransactions();
 
         // when sending a request and aborting in the middle of receiving the result
-        Socket socket = new Socket( "localhost", 7474 );
+        Socket socket = new Socket( "localhost", getLocalHttpPort() );
         PrintStream out = new PrintStream( socket.getOutputStream() );
 
         String output = quotedJson(
@@ -682,10 +682,10 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
         long initialData = countNodes( "Foo" );
 
         // given
-        http.POST( "/db/data/transaction/commit", singleStatement( "CREATE (n:Foo:Bar)" ) );
+        http.POST( "db/data/transaction/commit", singleStatement( "CREATE (n:Foo:Bar)" ) );
 
         // when
-        Response response = http.POST( "/db/data/transaction/commit", quotedJson(
+        Response response = http.POST( "db/data/transaction/commit", quotedJson(
                 "{ 'statements': [ { 'statement': 'MATCH (n:Foo) RETURN n', 'resultDataContents':['row'," +
                 "'graph'] } ] }" ) );
 
@@ -715,10 +715,10 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
     public void should_serialize_collect_correctly() throws Exception
     {
         // given
-        http.POST( "/db/data/transaction/commit", singleStatement( "CREATE (n:Foo)" ) );
+        http.POST( "db/data/transaction/commit", singleStatement( "CREATE (n:Foo)" ) );
 
         // when
-        Response response = http.POST( "/db/data/transaction/commit", quotedJson(
+        Response response = http.POST( "db/data/transaction/commit", quotedJson(
                 "{ 'statements': [ { 'statement': 'MATCH (n:Foo) RETURN COLLECT(n)' } ] }" ) );
 
         // then
@@ -735,7 +735,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
     @Test
     public void shouldSerializeMapsCorrectlyInRowsFormat() throws Exception
     {
-        Response response = http.POST( "/db/data/transaction/commit", quotedJson(
+        Response response = http.POST( "db/data/transaction/commit", quotedJson(
                 "{ 'statements': [ { 'statement': 'RETURN {one:{two:[true, {three: 42}]}}' } ] }" ) );
 
         // then
@@ -755,7 +755,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
     @Test
     public void shouldSerializeMapsCorrectlyInRestFormat() throws Exception
     {
-        Response response = http.POST( "/db/data/transaction/commit", quotedJson( "{ 'statements': [ { 'statement': " +
+        Response response = http.POST( "db/data/transaction/commit", quotedJson( "{ 'statements': [ { 'statement': " +
                                                                                   "'RETURN {one:{two:[true, {three: " +
                                                                                   "42}]}}', " +
                                                                                   "'resultDataContents':['rest'] } ] " +
@@ -779,7 +779,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
     public void shouldHandleMapParametersCorrectly() throws Exception
     {
         Response response = http.POST(
-                "/db/data/transaction/commit",
+                "db/data/transaction/commit",
                 quotedJson("{ 'statements': [ { 'statement': " +
                         "'WITH {map} AS map RETURN map[0]', 'parameters':{'map':[{'index':0,'name':'a'},{'index':1,'name':'b'}]} } ] }"));
 
@@ -804,7 +804,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
         final String scheme = "http";
 
         // when
-        Response rs = http.POST( "/db/data/transaction/commit", quotedJson(
+        Response rs = http.POST( "db/data/transaction/commit", quotedJson(
                 "{ 'statements': [ { 'statement': 'CREATE (n:Foo:Bar) RETURN n', 'resultDataContents':['rest'] } ] }"
         ) );
 
@@ -839,7 +839,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
 
         // when
         Response rs = http.withHeaders( XForwardUtil.X_FORWARD_HOST_HEADER_KEY, hostname )
-                .POST( "/db/data/transaction/commit", quotedJson(
+                .POST( "db/data/transaction/commit", quotedJson(
                         "{ 'statements': [ { 'statement': 'CREATE (n:Foo:Bar) RETURN n', " +
                         "'resultDataContents':['rest'] } ] }"
                 ) );
@@ -870,7 +870,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
     public void correctStatusCodeWhenUsingHintWithoutAnyIndex() throws Exception
     {
         // begin and execute and commit
-        Response begin = http.POST( "/db/data/transaction/commit",
+        Response begin = http.POST( "db/data/transaction/commit",
                 quotedJson( "{ 'statements': [ { 'statement': " +
                         "'MATCH (n:Test) USING INDEX n:Test(foo) WHERE n.foo = 42 RETURN n.foo' } ] }" ) );
         assertThat( begin, hasErrors( Status.Request.Schema.IndexNotFound ) );
@@ -880,7 +880,7 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
     public void transaction_not_in_response_on_failure() throws Exception
     {
         // begin
-        Response begin = http.POST( "/db/data/transaction" );
+        Response begin = http.POST( "db/data/transaction" );
 
         String commitResource = begin.stringFromContent( "commit" );
 
@@ -908,14 +908,14 @@ public class TransactionIT extends AbstractRestFunctionalTestBase
     public void shouldWorkWhenHittingTheASTCacheInCypher() throws JsonParseException
     {
         // give a cached plan
-        Response response = http.POST( "/db/data/transaction/commit",
+        Response response = http.POST( "db/data/transaction/commit",
                 singleStatement( "MATCH (group:Group {name: \\\"AAA\\\"}) RETURN *" ) );
 
         assertThat( response.status(), equalTo( 200 ) );
         assertThat( response.get( "errors" ).size(), equalTo( 0 ) );
 
         // when we hit the ast cache
-        response = http.POST( "/db/data/transaction/commit",
+        response = http.POST( "db/data/transaction/commit",
                 singleStatement( "MATCH (group:Group {name: \\\"BBB\\\"}) RETURN *" ) );
 
         // then no errors (in particular no NPE)

--- a/community/server/src/test/java/org/neo4j/server/rest/web/integration/CypherOldEndpointIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/integration/CypherOldEndpointIT.java
@@ -31,7 +31,7 @@ import static org.neo4j.test.server.HTTP.RawPayload.quotedJson;
 
 public class CypherOldEndpointIT extends AbstractRestFunctionalTestBase
 {
-    private final HTTP.Builder http = HTTP.withBaseUri( "http://localhost:7474" );
+    private final HTTP.Builder http = HTTP.withBaseUri( server().baseUri() );
 
     @Test
     public void periodicCommitTest() throws Exception
@@ -40,7 +40,7 @@ public class CypherOldEndpointIT extends AbstractRestFunctionalTestBase
         {
             // begin
             HTTP.Response begin = http.POST(
-                    "/db/data/cypher",
+                    "db/data/cypher",
                     quotedJson( "{ 'query': 'USING PERIODIC COMMIT 100 LOAD CSV FROM \\\"" + url + "\\\" AS line CREATE ();' }" )
             );
             assertThat( begin.status(), equalTo( 200 ) );

--- a/community/server/src/test/java/org/neo4j/server/security/auth/AuthorizationDisabledIT.java
+++ b/community/server/src/test/java/org/neo4j/server/security/auth/AuthorizationDisabledIT.java
@@ -41,7 +41,8 @@ public class AuthorizationDisabledIT extends ExclusiveServerTestBase
     public void shouldAllowDisablingAuthorization() throws Exception
     {
         // Given
-        server = CommunityServerBuilder.server().withProperty( GraphDatabaseSettings.auth_enabled.name(), "false" ).build();
+        server = CommunityServerBuilder.serverOnRandomPorts()
+                .withProperty( GraphDatabaseSettings.auth_enabled.name(), "false" ).build();
 
         // When
         server.start();

--- a/community/server/src/test/java/org/neo4j/server/security/auth/AuthorizationWhitelistIT.java
+++ b/community/server/src/test/java/org/neo4j/server/security/auth/AuthorizationWhitelistIT.java
@@ -43,7 +43,8 @@ public class AuthorizationWhitelistIT extends ExclusiveServerTestBase
     {
         // Given
         assumeTrue( browserIsLoaded() );
-        server = CommunityServerBuilder.server().withProperty( GraphDatabaseSettings.auth_enabled.name(), "true" ).build();
+        server = CommunityServerBuilder.serverOnRandomPorts()
+                .withProperty( GraphDatabaseSettings.auth_enabled.name(), "true" ).build();
 
         // When
         server.start();
@@ -57,7 +58,8 @@ public class AuthorizationWhitelistIT extends ExclusiveServerTestBase
     public void shouldNotWhitelistConsoleService() throws Exception
     {
         // Given
-        server = CommunityServerBuilder.server().withProperty( GraphDatabaseSettings.auth_enabled.name(), "true" ).build();
+        server = CommunityServerBuilder.serverOnRandomPorts()
+                .withProperty( GraphDatabaseSettings.auth_enabled.name(), "true" ).build();
 
         // When
         server.start();
@@ -71,7 +73,8 @@ public class AuthorizationWhitelistIT extends ExclusiveServerTestBase
     public void shouldNotWhitelistDB() throws Exception
     {
         // Given
-        server = CommunityServerBuilder.server().withProperty( GraphDatabaseSettings.auth_enabled.name(), "true" ).build();
+        server = CommunityServerBuilder.serverOnRandomPorts()
+                .withProperty( GraphDatabaseSettings.auth_enabled.name(), "true" ).build();
 
         // When
         server.start();

--- a/community/server/src/test/java/org/neo4j/server/web/WebServerDirectoryListingTestIT.java
+++ b/community/server/src/test/java/org/neo4j/server/web/WebServerDirectoryListingTestIT.java
@@ -43,7 +43,8 @@ public class WebServerDirectoryListingTestIT extends ExclusiveServerTestBase
     public void shouldDisallowDirectoryListings() throws Exception
     {
         // Given
-        server = CommunityServerBuilder.server().build();
+        server = CommunityServerBuilder.serverOnRandomPorts()
+                .build();
         server.start();
 
         // When

--- a/community/server/src/test/java/org/neo4j/server/web/logging/HTTPLoggingIT.java
+++ b/community/server/src/test/java/org/neo4j/server/web/logging/HTTPLoggingIT.java
@@ -68,7 +68,7 @@ public class HTTPLoggingIT extends ExclusiveServerTestBase
         String directoryPrefix = testName.getMethodName();
         File logDirectory = testDirectory.directory( directoryPrefix + "-logdir" );
 
-        NeoServer server = CommunityServerBuilder.server().withDefaultDatabaseTuning().persistent()
+        NeoServer server = CommunityServerBuilder.serverOnRandomPorts().withDefaultDatabaseTuning().persistent()
                 .withProperty( ServerSettings.http_logging_enabled.name(), Settings.FALSE )
                 .withProperty( GraphDatabaseSettings.logs_directory.name(), logDirectory.toString() )
                 .usingDataDir( testDirectory.directory( directoryPrefix + "-dbdir" ).getAbsolutePath() )
@@ -103,7 +103,7 @@ public class HTTPLoggingIT extends ExclusiveServerTestBase
         File logDirectory = testDirectory.directory( directoryPrefix + "-logdir" );
         final String query = "?explicitlyEnabled=" + randomString();
 
-        NeoServer server = CommunityServerBuilder.server().withDefaultDatabaseTuning().persistent()
+        NeoServer server = CommunityServerBuilder.serverOnRandomPorts().withDefaultDatabaseTuning().persistent()
                 .withProperty( ServerSettings.http_logging_enabled.name(), Settings.TRUE )
                 .withProperty( GraphDatabaseSettings.logs_directory.name(), logDirectory.getAbsolutePath() )
                 .usingDataDir( testDirectory.directory( directoryPrefix + "-dbdir" ).getAbsolutePath() )

--- a/community/server/src/test/java/org/neo4j/test/server/HTTP.java
+++ b/community/server/src/test/java/org/neo4j/test/server/HTTP.java
@@ -70,9 +70,9 @@ public class HTTP
         return BUILDER.withHeaders( kvPairs );
     }
 
-    public static Builder withBaseUri( String baseUri )
+    public static Builder withBaseUri( URI baseUri )
     {
-        return BUILDER.withBaseUri( baseUri );
+        return BUILDER.withBaseUri( baseUri.toString() );
     }
 
     public static Response POST( String uri )

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedInteraction.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedInteraction.java
@@ -31,9 +31,9 @@ import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.helpers.HostnamePort;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.api.bolt.BoltPortRegister;
 import org.neo4j.kernel.api.security.AuthenticationResult;
 import org.neo4j.kernel.configuration.BoltConnector;
+import org.neo4j.kernel.configuration.ConnectorPortRegister;
 import org.neo4j.kernel.configuration.ssl.LegacySslPolicyConfig;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthManager;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
@@ -51,7 +51,7 @@ public class EmbeddedInteraction implements NeoInteractionLevel<EnterpriseSecuri
     private GraphDatabaseFacade db;
     private EnterpriseAuthManager authManager;
     private FileSystemAbstraction fileSystem;
-    private BoltPortRegister connectorRegister;
+    private ConnectorPortRegister connectorRegister;
 
     EmbeddedInteraction( Map<String, String> config ) throws Throwable
     {
@@ -86,7 +86,7 @@ public class EmbeddedInteraction implements NeoInteractionLevel<EnterpriseSecuri
 
         db = (GraphDatabaseFacade) builder.newGraphDatabase();
         authManager = db.getDependencyResolver().resolveDependency( EnterpriseAuthManager.class );
-        connectorRegister = db.getDependencyResolver().resolveDependency( BoltPortRegister.class );
+        connectorRegister = db.getDependencyResolver().resolveDependency( ConnectorPortRegister.class );
     }
 
     @Override

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/PropertyExistenceConstraintsIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/PropertyExistenceConstraintsIT.java
@@ -292,7 +292,7 @@ public class PropertyExistenceConstraintsIT implements GraphHolder
 
     private String getDataUri()
     {
-        return "http://localhost:7474/db/data/";
+        return server.baseUri() + "db/data/";
     }
 
     public String getSchemaConstraintUri()

--- a/integrationtests/src/test/java/org/neo4j/TransactionTerminationIT.java
+++ b/integrationtests/src/test/java/org/neo4j/TransactionTerminationIT.java
@@ -116,7 +116,7 @@ public class TransactionTerminationIT
                 .newServer() );
 
         GraphDatabaseService db = server.graph();
-        HTTP.Builder http = withBaseUri( server.httpURI().toString() );
+        HTTP.Builder http = withBaseUri( server.httpURI() );
 
         long value1 = 1L;
         long value2 = 2L;

--- a/integrationtests/src/test/java/org/neo4j/server/BatchEndpointIT.java
+++ b/integrationtests/src/test/java/org/neo4j/server/BatchEndpointIT.java
@@ -28,7 +28,6 @@ import org.neo4j.kernel.configuration.ssl.LegacySslPolicyConfig;
 import org.neo4j.server.configuration.ServerSettings;
 
 import static org.junit.Assert.assertEquals;
-
 import static org.neo4j.server.ServerTestUtils.getRelativePath;
 import static org.neo4j.server.ServerTestUtils.getSharedTestTemporaryFolder;
 import static org.neo4j.test.server.HTTP.RawPayload.quotedJson;
@@ -54,7 +53,7 @@ public class BatchEndpointIT
                 "{'method': 'POST', 'to': '/node', 'body': {'age': 1}, 'id': 1} ]";
 
         // When
-        Response response = withBaseUri( neo4j.httpURI().toString() )
+        Response response = withBaseUri( neo4j.httpURI() )
                 .withHeaders( "Content-Type", "application/json" )
                 .POST( "db/data/batch", quotedJson( body ) );
 


### PR DESCRIPTION
Allow server to be started on random http/https port.
Update tests to be able to resolve port on which server is running.
Register http and https connector ports in port register component.