### PR TITLE
Make whitelist config for Browser not edition dependent

### DIFF
--- a/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
+++ b/community/server/src/main/java/org/neo4j/server/configuration/ServerSettings.java
@@ -172,6 +172,10 @@ public class ServerSettings implements LoadableConfig
     @Description( "Commands to be run when Neo4j Browser successfully connects to this server. Separate multiple commands with semi-colon." )
     public static final Setting<String> browser_postConnectCmd = setting( "browser.post_connect_cmd", STRING, "" );
 
+    @SuppressWarnings("unused") // accessed from the browser
+    @Description( "Whitelist of hosts for the Neo4j Browser to be allowed to fetch content from." )
+    public static final Setting<String> browser_remoteContentHostnameWhitelist = setting( "browser.remote_content_hostname_whitelist", STRING, "guides.neo4j.com,localhost");
+
     @Description( "SSL policy name." )
     public static final Setting<String> ssl_policy = setting( "https.ssl_policy", STRING, LEGACY_POLICY_NAME );
 

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseServerSettings.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseServerSettings.java
@@ -45,10 +45,6 @@ public class EnterpriseServerSettings implements LoadableConfig
     public static final Setting<Boolean> browser_retainConnectionCredentials = setting( "browser.retain_connection_credentials", BOOLEAN, TRUE );
 
     @SuppressWarnings("unused") // accessed from the browser
-    @Description( "Whitelist of hosts for the Neo4j Browser to be allowed to fetch content from." )
-    public static final Setting<String> browser_remoteContentHostnameWhitelist = setting( "browser.remote_content_hostname_whitelist", STRING, "http://guides.neo4j.com,https://guides.neo4j.com,http://localhost,https://localhost" );
-
-    @SuppressWarnings("unused") // accessed from the browser
     @Description( "Configure the policy for outgoing Neo4j Browser connections." )
     public static final Setting<Boolean> browser_allowOutgoingBrowserConnections = setting( "browser.allow_outgoing_connections", BOOLEAN, TRUE );
 }


### PR DESCRIPTION
Moved from EnterpriseServerSettings -> ServerSettings (browser.remote_content_hostname_whitelist)