### PR TITLE
Make CountsTracker rotation timeout robust against drift

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsTracker.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.impl.store.counts;
 
 import java.io.File;
 import java.io.IOException;
-import java.time.Clock;
 import java.util.Optional;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -47,6 +46,7 @@ import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.register.Register;
 import org.neo4j.time.Clocks;
+import org.neo4j.time.SystemNanoClock;
 
 import static java.lang.String.format;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.counts_store_rotation_timeout;
@@ -87,11 +87,11 @@ public class CountsTracker extends AbstractKeyValueStore<CountsKey>
     public CountsTracker( final LogProvider logProvider, FileSystemAbstraction fs, PageCache pages, Config config,
             File baseFile )
     {
-        this( logProvider, fs, pages, config, baseFile, Clocks.systemClock() );
+        this( logProvider, fs, pages, config, baseFile, Clocks.nanoClock() );
     }
 
     public CountsTracker( final LogProvider logProvider, FileSystemAbstraction fs, PageCache pages, Config config,
-            File baseFile, Clock clock )
+                          File baseFile, SystemNanoClock clock )
     {
         super( fs, pages, baseFile, new RotationMonitor()
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsTrackerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsTrackerTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.time.Clock;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.function.Predicate;
@@ -48,6 +47,7 @@ import org.neo4j.test.rule.Resources;
 import org.neo4j.test.rule.concurrent.ThreadingRule;
 import org.neo4j.time.Clocks;
 import org.neo4j.time.FakeClock;
+import org.neo4j.time.SystemNanoClock;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -405,10 +405,10 @@ public class CountsTrackerTest
 
     private CountsTracker newTracker()
     {
-        return newTracker( Clocks.systemClock() );
+        return newTracker( Clocks.nanoClock() );
     }
 
-    private CountsTracker newTracker( Clock clock )
+    private CountsTracker newTracker( SystemNanoClock clock )
     {
         return new CountsTracker( resourceManager.logProvider(), resourceManager.fileSystem(),
                 resourceManager.pageCache(), Config.empty(), resourceManager.testPath(), clock )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/RotationTimerFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/kvstore/RotationTimerFactoryTest.java
@@ -22,9 +22,6 @@ package org.neo4j.kernel.impl.store.kvstore;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.time.Clock;
-import java.time.Instant;
-import java.time.ZoneOffset;
 import java.util.concurrent.TimeUnit;
 
 import org.neo4j.time.Clocks;
@@ -36,10 +33,10 @@ public class RotationTimerFactoryTest
     public void testTimer() throws Exception
     {
         // GIVEN
-        Clock fixedClock = Clock.fixed( Instant.ofEpochMilli( 10000 ), ZoneOffset.UTC );
+        FakeClock fakeClock = Clocks.fakeClock( 10000 , TimeUnit.MILLISECONDS );
 
         // WHEN
-        RotationTimerFactory timerFactory = new RotationTimerFactory( fixedClock, 1000 );
+        RotationTimerFactory timerFactory = new RotationTimerFactory( fakeClock, 1000 );
         RotationTimerFactory.RotationTimer timer = timerFactory.createTimer();
         RotationTimerFactory.RotationTimer anotherTimer = timerFactory.createTimer();
 
@@ -49,7 +46,7 @@ public class RotationTimerFactoryTest
         Assert.assertNotSame( "Factory should construct different timers", timer, anotherTimer );
 
         // WHEN
-        FakeClock fakeClock = Clocks.fakeClock();
+        fakeClock = Clocks.fakeClock();
         RotationTimerFactory fakeTimerFactory = new RotationTimerFactory( fakeClock, 1000 );
         RotationTimerFactory.RotationTimer fakeTimer = fakeTimerFactory.createTimer();
         fakeClock.forward( 1001, TimeUnit.MILLISECONDS );


### PR DESCRIPTION
Hopefully this will also make the AbstractKeyValueStoreTest less flaky on very resource strained systems, but just to be sure I have also increased the timeout by a factor 10.