### PR TITLE
Update Cypher compiler dependency to 3.0.10

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-30.txt
+++ b/community/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-30.txt
@@ -1,8 +1,2 @@
 Standalone call to procedure with argument of type INTEGER accepts value of type FLOAT
   In-query call to procedure with argument of type INTEGER accepts value of type FLOAT
-
-// ReturnAcceptance.feature
-Accessing a list with null should return null
-Accessing a list with null as lower bound should return null
-Accessing a list with null as upper bound should return null
-Accessing a map with null should return null

--- a/community/cypher/cypher/pom.xml
+++ b/community/cypher/cypher/pom.xml
@@ -211,7 +211,7 @@
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-cypher-compiler-3.0</artifactId>
-      <version>3.0.9</version>
+      <version>3.0.10</version>
       <exclusions>
         <exclusion>
           <groupId>org.neo4j</groupId>


### PR DESCRIPTION
After doing this I noticed that the deprecation warnings went through the roof all over the code base (prior 14, now 381). Should we also fix this or what is the procedure?