### PR TITLE
Mark UnavailableException with the correct status code

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/AvailabilityGuard.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/AvailabilityGuard.java
@@ -29,6 +29,7 @@ import java.util.function.Function;
 import org.neo4j.helpers.Format;
 import org.neo4j.helpers.Listeners;
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.logging.Log;
 
 /**
@@ -43,11 +44,17 @@ public class AvailabilityGuard
     public static final String DATABASE_AVAILABLE_MSG = "Fulfilling of requirement makes database available: ";
     public static final String DATABASE_UNAVAILABLE_MSG = "Requirement makes database unavailable: ";
 
-    public class UnavailableException extends Exception
+    public class UnavailableException extends Exception implements Status.HasStatus
     {
         public UnavailableException( String message )
         {
             super( message );
+        }
+
+        @Override
+        public Status status()
+        {
+            return Status.General.DatabaseUnavailable;
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/CoreAPIAvailabilityGuard.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/CoreAPIAvailabilityGuard.java
@@ -54,7 +54,7 @@ public class CoreAPIAvailabilityGuard
             {
                 throw new DatabaseShutdownException();
             }
-            throw new org.neo4j.graphdb.TransactionFailureException( e.getMessage() );
+            throw new org.neo4j.graphdb.TransactionFailureException( e.getMessage(), e );
         }
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/UnavailableIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/UnavailableIT.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.scenarios;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.causalclustering.discovery.Cluster;
+import org.neo4j.causalclustering.discovery.ClusterMember;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.AvailabilityGuard;
+import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.test.causalclustering.ClusterRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class UnavailableIT
+{
+    @Rule
+    public final ClusterRule clusterRule = new ClusterRule( getClass() ).withNumberOfCoreMembers( 3 );
+
+    private Cluster cluster;
+
+    @Before
+    public void setup() throws Exception
+    {
+        cluster = clusterRule.startCluster();
+    }
+
+    @Test
+    public void shouldReturnUnavailableStatus() throws Exception
+    {
+        // given
+        ClusterMember member = cluster.getCoreMemberById( 1 );
+
+        // when
+        member.database().getDependencyResolver().resolveDependency( AvailabilityGuard.class )
+                .require( () -> "Not doing long operation" );
+
+        // then
+        try ( Transaction tx = member.database().beginTx() )
+        {
+            tx.success();
+            fail();
+        }
+        catch ( Exception e )
+        {
+            assertEquals( Status.General.DatabaseUnavailable, statusCodeOf( e ) );
+        }
+    }
+
+    private Status statusCodeOf( Throwable e )
+    {
+        do
+        {
+            if ( e instanceof Status.HasStatus )
+            {
+                return ((Status.HasStatus) e).status();
+            }
+            e = e.getCause();
+        }
+        while ( e != null );
+
+        return null;
+    }
+}


### PR DESCRIPTION
The intention is for driver software to forget about this server
temporarily when unavailable (until next TTL tick).

Effectively this will mean that a server doing large operations
like a store copy or even shutting down will remove it from
the current set.

The specific status code was already used in the TransactionIdTracker
as well but it should only trigger there in uncommon cases where such
a server is hopelessly behind.