### PR TITLE
Remove disabling of logs in core topology service

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
@@ -170,7 +170,6 @@ class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopol
         c.setProperty( MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "10" );
         c.setProperty( INITIAL_MIN_CLUSTER_SIZE.getName(),
                 String.valueOf( minimumClusterSizeThatCanTolerateOneFaultForExpectedClusterSize() ) );
-        c.setProperty( LOGGING_TYPE.getName(), "none" );
 
         c.setNetworkConfig( networkConfig );
 


### PR DESCRIPTION
This is already controlled by a system property in the
hazelcast discovery service factory.