### PR TITLE
Restore default HA pull interval to 10 seconds

### DIFF
--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -270,7 +270,7 @@ dbms.connector.https.enabled=true
 
 # The interval, in seconds, at which slaves will pull updates from the master. You must comment out
 # the option to disable periodic pulling of updates.
-#ha.pull_interval=10
+ha.pull_interval=10
 
 # Amount of slaves the master will try to push a transaction to upon commit
 # (default is 1). The master will optimistically continue and not fail the


### PR DESCRIPTION
This was changed by mistake in the 3.1.0 release cycle.

The default in the Settings java file is 0 which means
disabled and the default in the conf was always 10 seconds.