### PR TITLE
Allow execution of shell IT tests in parallel in forked VMs

### DIFF
--- a/community/shell/pom.xml
+++ b/community/shell/pom.xml
@@ -60,12 +60,6 @@ the relevant Commercial Agreement.
   <build>
     <plugins>
       <plugin>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <configuration>
-          <forkCount>1</forkCount>
-        </configuration>
-      </plugin>
-      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>

--- a/community/shell/src/test/java/org/neo4j/shell/AbstractShellIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/AbstractShellIT.java
@@ -132,15 +132,27 @@ public abstract class AbstractShellIT
     {
         if ( remotelyAvailableOnPort == null )
         {
-            remotelyAvailableOnPort = findFreePort();
-            shellServer.makeRemotelyAvailable( remotelyAvailableOnPort, SimpleAppServer.DEFAULT_NAME );
+            int attempts = 0;
+            int port = SimpleAppServer.DEFAULT_PORT;
+            do
+            {
+                try
+                {
+                    shellServer.makeRemotelyAvailable( port, SimpleAppServer.DEFAULT_NAME );
+                    remotelyAvailableOnPort = port;
+                }
+                catch ( Throwable error )
+                {
+                    port++;
+                    attempts++;
+                    if ( attempts == 100 )
+                    {
+                        throw new RuntimeException( "Not able to find free port more them 100 times.", error );
+                    }
+                }
+            }
+            while ( remotelyAvailableOnPort == null );
         }
-    }
-
-    private int findFreePort()
-    {
-        // TODO
-        return SimpleAppServer.DEFAULT_PORT;
     }
 
     protected void restartServer() throws Exception


### PR DESCRIPTION
Try 100 ties to find free port for remote server during execution of IT
tests in shell to allow them to run in parallel and avoid port conflicts.