### PR TITLE
Add additional procedures to access transaction metadata

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/QueryRegistryOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/QueryRegistryOperations.java
@@ -42,6 +42,13 @@ public interface QueryRegistryOperations
     void setMetaData( Map<String,Object> data );
 
     /**
+     * Gets associated meta data.
+     *
+     * @return the meta data
+     */
+    Map<String,Object> getMetaData();
+
+    /**
      * List of all currently running stream in this transaction. An user can have multiple stream running
      * simultaneously on the same transaction.
      */

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -23,6 +23,7 @@ import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -179,7 +180,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         this.storageStatement = storeLayer.newStatement();
         this.currentStatement =
                 new KernelStatement( this, this, storageStatement, procedures, accessCapability, lockTracer );
-        this.userMetaData = Collections.emptyMap();
+        this.userMetaData = new HashMap<>();
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -1294,6 +1294,13 @@ public class OperationsFacade
     }
 
     @Override
+    public Map<String,Object> getMetaData()
+    {
+        statement.assertOpen();
+        return statement.getTransaction().getMetaData();
+    }
+
+    @Override
     public Stream<ExecutingQuery> executingQueries()
     {
         statement.assertOpen();

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
@@ -53,6 +53,7 @@ import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
+import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.neo4j.function.ThrowingFunction.catchThrown;
@@ -65,6 +66,8 @@ import static org.neo4j.procedure.Mode.DBMS;
 @SuppressWarnings( "unused" )
 public class EnterpriseBuiltInDbmsProcedures
 {
+    private static final int HARD_CHAR_LIMIT = 2048;
+
     @Context
     public DependencyResolver resolver;
 
@@ -80,6 +83,17 @@ public class EnterpriseBuiltInDbmsProcedures
     public void setTXMetaData( @Name( value = "data" ) Map<String,Object> data )
     {
         securityContext.assertCredentialsNotExpired();
+        int totalCharSize = data.entrySet().stream()
+                .mapToInt( e -> e.getKey().length() + e.getValue().toString().length() )
+                .sum();
+
+        if ( totalCharSize >= HARD_CHAR_LIMIT )
+        {
+            throw new IllegalArgumentException(
+                    format( "Invalid transaction meta-data, expected the total number of chars for " +
+                            "keys and values to be less than %d, got %d", HARD_CHAR_LIMIT, totalCharSize ) );
+        }
+
         try ( Statement statement = getCurrentTx().acquireStatement() )
         {
             statement.queryRegistration().setMetaData( data );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
@@ -647,7 +647,7 @@ public abstract class BuiltInProceduresInteractionTestBase<S> extends ProcedureI
         {
             String testValue = "testValue";
             String testKey = "test";
-            localGraph.execute( "CALL dbms.setTXMetaData", map( "data", map( testKey, testValue ) ) );
+            localGraph.execute( "CALL dbms.setTXMetaData({" + testKey + ":'" + testValue + "'})" );
             Map<String,Object> metadata =
                     (Map<String,Object>) localGraph.execute( "CALL dbms.getTXMetaData " ).next().get( "metadata" );
             assertEquals( testValue, metadata.get( testKey ) );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -39,9 +38,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.enterprise.builtinprocs.QueryId;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles;
 import org.neo4j.test.Barrier;
 import org.neo4j.test.DoubleLatch;
@@ -58,6 +59,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.neo4j.bolt.v1.runtime.integration.TransactionIT.createHttpServer;
 import static org.neo4j.graphdb.security.AuthorizationViolationException.PERMISSION_DENIED;
@@ -638,17 +640,38 @@ public abstract class BuiltInProceduresInteractionTestBase<S> extends ProcedureI
     }
 
     @Test
-    public void shouldFailOnTooLargeTXMetaData() throws Throwable
+    public void readUpdatedMetadataValue() throws Exception
     {
-        ArrayList<String> list = new ArrayList<>();
-        for ( int i = 0; i < 200; i++ )
+        GraphDatabaseFacade localGraph = neo.getLocalGraph();
+        try ( Transaction transaction = localGraph.beginTx() )
         {
-            list.add( format( "key%d: '0123456789'", i ) );
+            String testValue = "testValue";
+            String testKey = "test";
+            localGraph.execute( "CALL dbms.setTXMetaData", map( "data", map( testKey, testValue ) ) );
+            Map<String,Object> metadata =
+                    (Map<String,Object>) localGraph.execute( "CALL dbms.getTXMetaData " ).next().get( "metadata" );
+            assertEquals( testValue, metadata.get( testKey ) );
         }
-        String longMetaDataMap = "{" + String.join( ", ", list ) + "}";
-        assertFail( writeSubject, "CALL dbms.setTXMetaData( " + longMetaDataMap + " )",
-            "Invalid transaction meta-data, expected the total number of chars for keys and values to be " +
-            "less than 2048, got 3090" );
+    }
+
+    @Test
+    public void readEmptyMetadataInOtherTransaction()
+    {
+        String testValue = "testValue";
+        String testKey = "test";
+        GraphDatabaseFacade localGraph = neo.getLocalGraph();
+        try ( Transaction transaction = localGraph.beginTx() )
+        {
+            localGraph.execute( "CALL dbms.setTXMetaData", map( "data", map( testKey, testValue ) ) );
+            transaction.success();
+        }
+
+        try ( Transaction ignored = localGraph.beginTx() )
+        {
+            Map<String,Object> metadata =
+                    (Map<String,Object>) localGraph.execute( "CALL dbms.getTXMetaData " ).next().get( "metadata" );
+            assertNull( metadata.get( testKey ) );
+        }
     }
 
     //---------- procedure guard -----------

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -63,6 +63,7 @@ import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.logging.Log;
+import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.util.Collections.singletonList;
@@ -90,6 +91,27 @@ public class ProcedureIT
     public ExpectedException exception = ExpectedException.none();
 
     private GraphDatabaseService db;
+
+    @Before
+    public void setUp() throws IOException
+    {
+        exceptionsInProcedure.clear();
+        new JarBuilder().createJarFor( plugins.newFile( "myProcedures.jar" ), ClassWithProcedures.class );
+        new JarBuilder().createJarFor( plugins.newFile( "myFunctions.jar" ), ClassWithFunctions.class );
+        db = new TestEnterpriseGraphDatabaseFactory()
+                .newImpermanentDatabaseBuilder()
+                .setConfig( plugin_dir, plugins.getRoot().getAbsolutePath() )
+                .newGraphDatabase();
+    }
+
+    @After
+    public void tearDown()
+    {
+        if ( this.db != null )
+        {
+            this.db.shutdown();
+        }
+    }
 
     @Test
     public void shouldCallProcedureWithParameterMap() throws Throwable
@@ -1186,27 +1208,6 @@ public class ProcedureIT
         //Then
         exception.expect( TransactionFailureException.class );
         result.next();
-    }
-
-    @Before
-    public void setUp() throws IOException
-    {
-        exceptionsInProcedure.clear();
-        new JarBuilder().createJarFor( plugins.newFile( "myProcedures.jar" ), ClassWithProcedures.class );
-        new JarBuilder().createJarFor( plugins.newFile( "myFunctions.jar" ), ClassWithFunctions.class );
-        db = new TestGraphDatabaseFactory()
-                .newImpermanentDatabaseBuilder()
-                .setConfig( plugin_dir, plugins.getRoot().getAbsolutePath() )
-                .newGraphDatabase();
-    }
-
-    @After
-    public void tearDown()
-    {
-        if ( this.db != null )
-        {
-            this.db.shutdown();
-        }
     }
 
     public static class Output


### PR DESCRIPTION
changelog: Add additional standard procedure dbms.getTXMetaData to access transactional metadata.