### PR TITLE
Fix bugs that prevented imports of more than 20 billion nodes from working, in environments where the amount of RAM available to the importer, was close to the amount of RAM required for the import.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapByteArray.java
@@ -32,7 +32,7 @@ public class HeapByteArray extends HeapNumberArray<ByteArray> implements ByteArr
     private final byte[] defaultValue;
     private final boolean defaultValueIsUniform;
 
-    public HeapByteArray( int length, byte[] defaultValue, int base )
+    public HeapByteArray( int length, byte[] defaultValue, long base )
     {
         super( defaultValue.length, base );
         this.length = length;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapIntArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapIntArray.java
@@ -29,7 +29,7 @@ public class HeapIntArray extends HeapNumberArray<IntArray> implements IntArray
     private final int[] array;
     private final int defaultValue;
 
-    public HeapIntArray( int length, int defaultValue, int base )
+    public HeapIntArray( int length, int defaultValue, long base )
     {
         super( 4, base );
         this.defaultValue = defaultValue;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapLongArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapLongArray.java
@@ -29,7 +29,7 @@ public class HeapLongArray extends HeapNumberArray<LongArray> implements LongArr
     private final long[] array;
     private final long defaultValue;
 
-    public HeapLongArray( int length, long defaultValue, int base )
+    public HeapLongArray( int length, long defaultValue, long base )
     {
         super( 8, base );
         this.defaultValue = defaultValue;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
@@ -315,7 +315,8 @@ public interface NumberArrayFactory
 
         private long fractionOf( long length )
         {
-            return min( length / 10, Integer.MAX_VALUE );
+            int maxArraySize = Integer.MAX_VALUE - Short.MAX_VALUE;
+            return min( length / 10, maxArraySize );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
@@ -144,19 +144,19 @@ public interface NumberArrayFactory
         @Override
         public IntArray newIntArray( long length, int defaultValue, long base )
         {
-            return new HeapIntArray( safeCastLongToInt( length ), defaultValue, toIntExact( base ) );
+            return new HeapIntArray( safeCastLongToInt( length ), defaultValue, base );
         }
 
         @Override
         public LongArray newLongArray( long length, long defaultValue, long base )
         {
-            return new HeapLongArray( safeCastLongToInt( length ), defaultValue, toIntExact( base ) );
+            return new HeapLongArray( safeCastLongToInt( length ), defaultValue, base );
         }
 
         @Override
         public ByteArray newByteArray( long length, byte[] defaultValue, long base )
         {
-            return new HeapByteArray( safeCastLongToInt( length ), defaultValue, toIntExact( base ) );
+            return new HeapByteArray( safeCastLongToInt( length ), defaultValue, base );
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactoryTest.java
@@ -21,7 +21,9 @@ package org.neo4j.unsafe.impl.batchimport.cache;
 
 import org.junit.Test;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -140,5 +142,30 @@ public class NumberArrayFactoryTest
         verify( throwingMemoryFactory, times( 1 ) ).newByteArray( eq( KILO ), any( byte[].class ), eq( 0L ) );
         assertTrue( array instanceof HeapByteArray );
         assertEquals( 12345, array.getInt( KILO - 10, 0 ) );
+    }
+
+    @Test
+    public void heapArrayShouldAllowVeryLargeBases() throws Exception
+    {
+        NumberArrayFactory factory = new NumberArrayFactory.Auto( NumberArrayFactory.HEAP );
+        verifyVeryLargeBaseSupport( factory );
+    }
+
+    @Test
+    public void offHeapArrayShouldAllowVeryLargeBases() throws Exception
+    {
+        NumberArrayFactory factory = new NumberArrayFactory.Auto( NumberArrayFactory.OFF_HEAP );
+        verifyVeryLargeBaseSupport( factory );
+    }
+
+    private void verifyVeryLargeBaseSupport( NumberArrayFactory factory )
+    {
+        long base = Integer.MAX_VALUE * 1337L;
+        byte[] into = new byte[1];
+        into[0] = 1;
+        factory.newByteArray( 10, new byte[1], base ).get( base + 1, into );
+        assertThat( into[0], is( (byte) 0 ) );
+        assertThat( factory.newIntArray( 10, 1, base ).get( base + 1 ), is( 1 ) );
+        assertThat( factory.newLongArray( 10, 1, base ).get( base + 1 ), is( 1L ) );
     }
 }


### PR DESCRIPTION
This fixes a couple of bugs that prevent the EncodingIdMappers internal data structures from growing to sufficient capacities in some situations.