### PR TITLE
Comparability of NaN with other numbers

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/predicates/ComparablePredicate.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/predicates/ComparablePredicate.scala
@@ -32,7 +32,11 @@ abstract sealed class ComparablePredicate(val left: Expression, val right: Expre
     val r: Any = right(m)
 
     if (l == null || r == null) None
-    else compareForComparability(None, l, r)(state).map(result => compare(result))
+    else (l, r) match {
+      case (d: Double, _: Number) if d.isNaN => Some(false)
+      case (_:Number, d: Double) if d.isNaN => Some(false)
+      case (_, _) => compareForComparability(None, l, r)(state).map(result => compare(result))
+    }
   }
 
   def sign: String

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/predicates/ComparablePredicate.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/predicates/ComparablePredicate.scala
@@ -33,8 +33,8 @@ abstract sealed class ComparablePredicate(val left: Expression, val right: Expre
 
     if (l == null || r == null) None
     else (l, r) match {
-      case (d: Double, _: Number) if d.isNaN => Some(false)
-      case (_:Number, d: Double) if d.isNaN => Some(false)
+      case (d: Double, _) if d.isNaN => None
+      case (_, d: Double) if d.isNaN => None
       case (_, _) => compareForComparability(None, l, r)(state).map(result => compare(result))
     }
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/ComparablePredicateTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/ComparablePredicateTest.scala
@@ -25,6 +25,7 @@ import org.neo4j.cypher.internal.compatibility.v3_3.runtime.commands.predicates.
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes.QueryStateHelper
 import org.neo4j.cypher.internal.compiler.v3_3.CypherOrdering
 import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.CypherFunSuite
+import org.scalatest.matchers.{MatchResult, Matcher}
 
 class ComparablePredicateTest extends CypherFunSuite {
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -694,6 +694,61 @@ return p""")
     result.toList should equal(List(Map("size" -> 8)))
   }
 
+  test("should handle NaN comparisons correctly") {
+    // Given
+    createNode(Map("x" -> Double.NaN))
+
+    // When
+    val result = executeWithCostPlannerAndInterpretedRuntimeOnly("MATCH (n) RETURN n.x > 0 AS gt, n.x < 0 AS lt, n.x >= 0 AS ge, n.x <= 0 AS le")
+
+    // Then
+    result.toList should equal(List(Map("gt" -> false, "lt" -> false, "le" -> false, "ge" -> false)))
+  }
+
+  test("should handle NaN comparisons with string correctly") {
+    // Given
+    createNode(Map("x" -> Double.NaN))
+
+    // When
+    val result = executeWithCostPlannerAndInterpretedRuntimeOnly("MATCH (n) RETURN n.x > 'a' AS gt, n.x < 'a' AS lt, n.x >= 'a' AS ge, n.x <= 'a' AS le")
+
+    // Then
+    result.toList should equal(List(Map("gt" -> null, "lt" -> null, "le" -> null, "ge" -> null)))
+  }
+
+  test("should handle NaN compared to NaN") {
+    // Given
+    createNode(Map("x" -> Double.NaN))
+
+    // When
+    val result = executeWithCostPlannerAndInterpretedRuntimeOnly("PROFILE MATCH (n) RETURN n.x > n.x AS gt, n.x < n.x AS lt, n.x <= n.x AS le, n.x >= n.x AS ge")
+
+    // Then
+    result.toList should equal(List(Map("gt" -> false, "lt" -> false, "le" -> false, "ge" -> false)))
+  }
+
+  test("should handle NaN null checks correctly") {
+    // Given
+    createNode(Map("x" -> Double.NaN))
+
+    // When
+    val result = executeWithCostPlannerAndInterpretedRuntimeOnly("MATCH (n) RETURN n.x IS NULL AS nu, n.x IS NOT NULL AS nnu")
+
+    // Then
+    result.toList should equal(List(Map("nu" -> false, "nnu" -> true)))
+  }
+
+  test("should handle NaN equality checks correctly") {
+    // Given
+    createNode(Map("x" -> Double.NaN))
+
+    // When
+    val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH (n) RETURN n.x = n.x AS eq, n.x <> n.x as ne")
+
+    // Then
+    result.toList should equal(List(Map("eq" -> false, "ne" -> true)))
+  }
+
   /**
    * Append variable to keys and transform value arrays to lists
    */

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -702,7 +702,7 @@ return p""")
     val result = executeWithCostPlannerAndInterpretedRuntimeOnly("MATCH (n) RETURN n.x > 0 AS gt, n.x < 0 AS lt, n.x >= 0 AS ge, n.x <= 0 AS le")
 
     // Then
-    result.toList should equal(List(Map("gt" -> false, "lt" -> false, "le" -> false, "ge" -> false)))
+    result.toList should equal(List(Map("gt" -> null, "lt" -> null, "le" -> null, "ge" -> null)))
   }
 
   test("should handle NaN comparisons with string correctly") {
@@ -724,7 +724,7 @@ return p""")
     val result = executeWithCostPlannerAndInterpretedRuntimeOnly("PROFILE MATCH (n) RETURN n.x > n.x AS gt, n.x < n.x AS lt, n.x <= n.x AS le, n.x >= n.x AS ge")
 
     // Then
-    result.toList should equal(List(Map("gt" -> false, "lt" -> false, "le" -> false, "ge" -> false)))
+    result.toList should equal(List(Map("gt" -> null, "lt" -> null, "le" -> null, "ge" -> null)))
   }
 
   test("should handle NaN null checks correctly") {


### PR DESCRIPTION
Fixes comparability of Double.NaN

changelog: Updates behaviour of comparisons between NaN and other numbers to follow the standard as described in CIP2016-06-14 (Comparability & Equality).

Instead of following the IEEE-754 standard, which specifies that any comparison against a NaN should return false, the Cypher behaviour is to return NULL.