### PR TITLE
Deprecated AuthProviderOperations.neo4jConfigFile()

### DIFF
--- a/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/api/AuthProviderOperations.java
+++ b/enterprise/auth-plugin-api/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/api/AuthProviderOperations.java
@@ -39,7 +39,12 @@ public interface AuthProviderOperations
      * Returns the path to the Neo4j configuration file if one exists.
      *
      * @return the path to the Neo4j configuration file if one exists
+     *
+     * @deprecated
+     * Settings are recommended to be stored in a separate file. You can use {@link AuthProviderOperations#neo4jHome()}
+     * to resolve your configuration file, e.g. <code>neo4jHome().resolve("conf/myPlugin.conf" );</code>.
      */
+    @Deprecated
     Optional<Path> neo4jConfigFile();
 
     /**

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/PluginRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/plugin/PluginRealm.java
@@ -438,7 +438,7 @@ public class PluginRealm extends AuthorizingRealm implements RealmLifecycle, Shi
         @Override
         public Optional<Path> neo4jConfigFile()
         {
-            return config.getConfigFile();
+            return Optional.empty();
         }
 
         @Override


### PR DESCRIPTION
Deprecated neo4jConfigFile(), custom settings are recommended to be placed in a separate file instead.
You can use `neo4jHome().resolve("conf/myPlugin.conf" )` to get the path of a custom settings file.