### PR TITLE
Improve bookmark waiting

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MetaDataStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MetaDataStore.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.store;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.OpenOption;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.neo4j.helpers.collection.Visitor;
@@ -785,6 +786,14 @@ public class MetaDataStore extends CommonAbstractStore<MetaDataRecord,NoStoreHea
         assertNotClosed();
         checkInitialized( lastCommittingTxField.get() );
         return lastClosedTx.getHighestGapFreeNumber();
+    }
+
+    @Override
+    public void awaitClosedTransactionId( long txId, long timeoutMillis ) throws TimeoutException, InterruptedException
+    {
+        assertNotClosed();
+        checkInitialized( lastCommittingTxField.get() );
+        lastClosedTx.await( txId, timeoutMillis );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadOnlyTransactionIdStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadOnlyTransactionIdStore.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.transaction.log;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.TimeoutException;
 
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.impl.store.MetaDataStore;
@@ -89,6 +90,12 @@ public class ReadOnlyTransactionIdStore implements TransactionIdStore
     public long getLastClosedTransactionId()
     {
         return transactionId;
+    }
+
+    @Override
+    public void awaitClosedTransactionId( long txId, long timeoutMillis ) throws InterruptedException, TimeoutException
+    {
+        throw new UnsupportedOperationException( "Not implemented" );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionIdStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionIdStore.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.impl.transaction.log;
 
+import java.util.concurrent.TimeoutException;
+
 import org.neo4j.kernel.impl.store.TransactionId;
 
 import static org.neo4j.kernel.impl.transaction.log.entry.LogHeader.LOG_HEADER_SIZE;
@@ -107,6 +109,16 @@ public interface TransactionIdStore
      * @return highest seen gap-free {@link #transactionClosed(long, long, long) closed transaction id}.
      */
     long getLastClosedTransactionId();
+
+    /**
+     * Awaits gap-free {@link #transactionClosed(long, long, long) closed transaction id}.
+     *
+     * @param txId the awaited transaction id.
+     * @param timeoutMillis the time to wait for it.
+     * @throws InterruptedException interrupted.
+     * @throws TimeoutException timed out.
+     */
+    void awaitClosedTransactionId( long txId, long timeoutMillis ) throws InterruptedException, TimeoutException;
 
     /**
      * Returns transaction information about the last committed transaction, i.e.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/OutOfOrderSequence.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/OutOfOrderSequence.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.impl.util;
 
+import java.util.concurrent.TimeoutException;
+
 /**
  * The thinking behind an out-of-order sequence is that, to the outside, there's one "last number"
  * which will never be decremented between times of looking at it. It can move in bigger strides
@@ -48,6 +50,14 @@ public interface OutOfOrderSequence
      * @return {@code long[]} with the highest offered gap-free number and its meta data.
      */
     long[] get();
+
+    /**
+     * Waits for the specified number (gap-free).
+     *
+     * @param awaitedNumber the awaited number.
+     * @param timeoutMillis the maximum time to wait in milliseconds.
+     */
+    void await( long awaitedNumber, long timeoutMillis ) throws TimeoutException, InterruptedException;
 
     /**
      * @return the highest gap-free number, without its meta data.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/DeadSimpleTransactionIdStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/DeadSimpleTransactionIdStore.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.transaction;
 
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -98,6 +99,12 @@ public class DeadSimpleTransactionIdStore implements TransactionIdStore
     public long getLastClosedTransactionId()
     {
         return closedTransactionId.getHighestGapFreeNumber();
+    }
+
+    @Override
+    public void awaitClosedTransactionId( long txId, long timeoutMillis ) throws InterruptedException, TimeoutException
+    {
+        throw new UnsupportedOperationException( "Not implemented" );
     }
 
     @Override


### PR DESCRIPTION
Bookmark waiting was previously based on polling and now instead
uses wait/notify primitives. This is implemented in the AQOOS
which now supports waiting for a closed transaction id.

The highestGapFreeNumber is now also volatile so that visibility
is ensured. This is not necessary for the new bookmark waiting, but
potentially for other uses.

The tests for the TransactionIdTracker were also improved to remove
cluttering boilerplate and make it more of a unit test rather than
a mocked up messy gray box of integration.