### PR TITLE
The importer can now process datasets that are so big that even the external-to-internal ID map cannot fit in memory

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/PackedMultiFieldCache.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/cache/PackedMultiFieldCache.java
@@ -24,7 +24,7 @@ import org.neo4j.unsafe.impl.batchimport.cache.LongArray;
 import org.neo4j.unsafe.impl.batchimport.cache.LongBitsManipulator;
 
 import static org.neo4j.consistency.checking.cache.CacheSlots.ID_SLOT_SIZE;
-import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO_WITHOUT_PAGECACHE;
 
 /**
  * Simply combining a {@link LongArray} with {@link LongBitsManipulator}, so that each long can be split up into
@@ -38,7 +38,7 @@ public class PackedMultiFieldCache
 
     public PackedMultiFieldCache( int... slotSizes )
     {
-        this( AUTO.newDynamicLongArray( 1_000_000, 0 ), slotSizes );
+        this( AUTO_WITHOUT_PAGECACHE.newDynamicLongArray( 1_000_000, 0 ), slotSizes );
     }
 
     public PackedMultiFieldCache( LongArray array, int... slotSizes )

--- a/community/consistency-check/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
@@ -85,7 +85,7 @@ import static org.neo4j.helpers.collection.Iterators.asSet;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.io.ByteUnit.mebiBytes;
 import static org.neo4j.unsafe.impl.batchimport.AdditionalInitialIds.EMPTY;
-import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO_WITHOUT_PAGECACHE;
 import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerators.fromInput;
 import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerators.startingFromTheBeginning;
 import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMappers.longs;
@@ -153,13 +153,13 @@ public class ParallelBatchImporterTest
         return Arrays.<Object[]>asList(
 
                 // synchronous I/O, actual node id input
-                new Object[]{new LongInputIdGenerator(), longs( AUTO ), fromInput(), true},
+                new Object[]{new LongInputIdGenerator(), longs( AUTO_WITHOUT_PAGECACHE ), fromInput(), true},
                 // synchronous I/O, string id input
-                new Object[]{new StringInputIdGenerator(), strings( AUTO ), startingFromTheBeginning(), true},
+                new Object[]{new StringInputIdGenerator(), strings( AUTO_WITHOUT_PAGECACHE ), startingFromTheBeginning(), true},
                 // synchronous I/O, string id input
-                new Object[]{new StringInputIdGenerator(), strings( AUTO ), startingFromTheBeginning(), false},
+                new Object[]{new StringInputIdGenerator(), strings( AUTO_WITHOUT_PAGECACHE ), startingFromTheBeginning(), false},
                 // extra slow parallel I/O, actual node id input
-                new Object[]{new LongInputIdGenerator(), longs( AUTO ), fromInput(), false}
+                new Object[]{new LongInputIdGenerator(), longs( AUTO_WITHOUT_PAGECACHE ), fromInput(), false}
         );
     }
 

--- a/community/import-tool/src/test/java/org/neo4j/tooling/DataGeneratorInput.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/DataGeneratorInput.java
@@ -24,6 +24,7 @@ import org.neo4j.csv.reader.Extractors;
 import org.neo4j.unsafe.impl.batchimport.IdRangeInput.Range;
 import org.neo4j.unsafe.impl.batchimport.InputIterable;
 import org.neo4j.unsafe.impl.batchimport.InputIterator;
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerator;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
 import org.neo4j.unsafe.impl.batchimport.input.Collector;
@@ -122,9 +123,9 @@ public class DataGeneratorInput implements Input
     }
 
     @Override
-    public IdMapper idMapper()
+    public IdMapper idMapper( NumberArrayFactory numberArrayFactory )
     {
-        return idType.idMapper();
+        return idType.idMapper( numberArrayFactory );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CountsComputer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CountsComputer.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.store;
 
+import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.impl.api.CountsAccessor;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
 import org.neo4j.kernel.impl.store.kvstore.DataInitializer;
@@ -35,13 +36,13 @@ public class CountsComputer implements DataInitializer<CountsAccessor.Updater>
 
     private final NumberArrayFactory numberArrayFactory;
 
-    public static void recomputeCounts( NeoStores stores )
+    public static void recomputeCounts( NeoStores stores, PageCache pageCache )
     {
         MetaDataStore metaDataStore = stores.getMetaDataStore();
         CountsTracker counts = stores.getCounts();
         try ( CountsAccessor.Updater updater = counts.reset( metaDataStore.getLastCommittedTransactionId() ) )
         {
-            new CountsComputer( stores ).initialize( updater );
+            new CountsComputer( stores, pageCache ).initialize( updater );
         }
     }
 
@@ -51,13 +52,13 @@ public class CountsComputer implements DataInitializer<CountsAccessor.Updater>
     private final int highRelationshipTypeId;
     private final long lastCommittedTransactionId;
 
-    public CountsComputer( NeoStores stores )
+    public CountsComputer( NeoStores stores, PageCache pageCache )
     {
         this( stores.getMetaDataStore().getLastCommittedTransactionId(),
                 stores.getNodeStore(), stores.getRelationshipStore(),
                 (int) stores.getLabelTokenStore().getHighId(),
                 (int) stores.getRelationshipTypeTokenStore().getHighId(),
-                NumberArrayFactory.autoWithPageCacheFallback( stores.getPageCache(), stores.getStoreDir() ) );
+                NumberArrayFactory.auto( pageCache, stores.getStoreDir() ) );
     }
 
     public CountsComputer( long lastCommittedTransactionId, NodeStore nodes, RelationshipStore relationships,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStores.java
@@ -151,6 +151,11 @@ public class NeoStores implements AutoCloseable
         return storeDir;
     }
 
+    public PageCache getPageCache()
+    {
+        return pageCache;
+    }
+
     private File getStoreFile( String substoreName )
     {
         return new File( neoStoreFileName.getPath() + substoreName );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/NeoStores.java
@@ -151,11 +151,6 @@ public class NeoStores implements AutoCloseable
         return storeDir;
     }
 
-    public PageCache getPageCache()
-    {
-        return pageCache;
-    }
-
     private File getStoreFile( String substoreName )
     {
         return new File( neoStoreFileName.getPath() + substoreName );
@@ -637,7 +632,7 @@ public class NeoStores implements AutoCloseable
             public void initialize( CountsAccessor.Updater updater )
             {
                 log.warn( "Missing counts store, rebuilding it." );
-                new CountsComputer( neoStores ).initialize( updater );
+                new CountsComputer( neoStores, pageCache ).initialize( updater );
                 log.warn( "Counts store rebuild completed." );
             }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
@@ -423,7 +423,7 @@ public class StoreMigrator extends AbstractStoreMigrationParticipant
                 int highRelationshipTypeId = (int) neoStores.getRelationshipTypeTokenStore().getHighId();
                 CountsComputer initializer = new CountsComputer(
                         lastTxId, nodeStore, relationshipStore, highLabelId, highRelationshipTypeId,
-                        NumberArrayFactory.autoWithPageCacheFallback( pageCache, storeDir ) );
+                        NumberArrayFactory.auto( pageCache, storeDir ) );
                 life.add( new CountsTracker(
                         logService.getInternalLogProvider(), fileSystem, pageCache, config, storeFileBase )
                         .setInitializer( initializer ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
@@ -102,6 +102,7 @@ import org.neo4j.unsafe.impl.batchimport.BatchImporter;
 import org.neo4j.unsafe.impl.batchimport.Configuration;
 import org.neo4j.unsafe.impl.batchimport.InputIterable;
 import org.neo4j.unsafe.impl.batchimport.ParallelBatchImporter;
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerators;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMappers;
 import org.neo4j.unsafe.impl.batchimport.input.Collectors;
@@ -421,7 +422,8 @@ public class StoreMigrator extends AbstractStoreMigrationParticipant
                 int highLabelId = (int) neoStores.getLabelTokenStore().getHighId();
                 int highRelationshipTypeId = (int) neoStores.getRelationshipTypeTokenStore().getHighId();
                 CountsComputer initializer = new CountsComputer(
-                        lastTxId, nodeStore, relationshipStore, highLabelId, highRelationshipTypeId );
+                        lastTxId, nodeStore, relationshipStore, highLabelId, highRelationshipTypeId,
+                        NumberArrayFactory.autoWithPageCacheFallback( pageCache, storeDir ) );
                 life.add( new CountsTracker(
                         logService.getInternalLogProvider(), fileSystem, pageCache, config, storeFileBase )
                         .setInitializer( initializer ) );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
@@ -187,6 +187,7 @@ public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvide
     private final Config config;
     private final BatchInserterImpl.BatchSchemaActions actions;
     private final StoreLocker storeLocker;
+    private final PageCache pageCache;
     private boolean labelsTouched;
     private boolean isShutdown;
 
@@ -260,6 +261,7 @@ public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvide
         life.start();
         neoStores = sf.openAllNeoStores( true );
         neoStores.verifyStoreOk();
+        this.pageCache = pageCache;
 
         nodeStore = neoStores.getNodeStore();
         relationshipStore = neoStores.getRelationshipStore();
@@ -526,7 +528,7 @@ public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvide
             throw new UnderlyingStorageException( e );
         }
 
-        CountsComputer.recomputeCounts( neoStores );
+        CountsComputer.recomputeCounts( neoStores, pageCache );
     }
 
     private class InitialNodeLabelCreationVisitor implements Visitor<NodeLabelUpdate, IOException>, Closeable

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -169,7 +169,7 @@ public class ParallelBatchImporter implements BatchImporter
               InputCache inputCache = new InputCache( fileSystem, storeDir, recordFormats, config ) )
         {
             NumberArrayFactory numberArrayFactory =
-                    NumberArrayFactory.autoWithPageCacheFallback( neoStore.getPageCache(), storeDir );
+                    NumberArrayFactory.auto( pageCache, storeDir );
             Collector badCollector = input.badCollector();
             // Some temporary caches and indexes in the import
             IoMonitor writeMonitor = new IoMonitor( neoStore.getIoTracer() );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupCache.java
@@ -28,9 +28,7 @@ import org.neo4j.unsafe.impl.batchimport.cache.LongArray;
 import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 
 import static java.lang.Long.max;
-
 import static org.neo4j.helpers.Format.bytes;
-import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO;
 
 /**
  * Holds information vital for making {@link RelationshipGroupDefragmenter} work the way it does.
@@ -54,7 +52,7 @@ public class RelationshipGroupCache implements Iterable<RelationshipGroupRecord>
     private final ByteArray groupCountCache;
     private final ByteArray cache;
     private final long highNodeId;
-    private final LongArray offsets = AUTO.newDynamicLongArray( 100_000, 0 );
+    private final LongArray offsets;
     private final byte[] scratch = new byte[GROUP_ENTRY_SIZE];
     private long fromNodeId;
     private long toNodeId;
@@ -63,6 +61,7 @@ public class RelationshipGroupCache implements Iterable<RelationshipGroupRecord>
 
     public RelationshipGroupCache( NumberArrayFactory arrayFactory, long maxMemory, long highNodeId )
     {
+        this.offsets = arrayFactory.newDynamicLongArray( 100_000, 0 );
         this.groupCountCache = arrayFactory.newByteArray( highNodeId, new byte[2] );
         this.highNodeId = highNodeId;
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupDefragmenter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupDefragmenter.java
@@ -44,6 +44,9 @@ import static org.neo4j.unsafe.impl.batchimport.staging.ExecutionSupervisors.sup
 public class RelationshipGroupDefragmenter
 {
 
+    private final Configuration config;
+    private final ExecutionMonitor executionMonitor;
+    private final Monitor monitor;
     private final NumberArrayFactory numberArrayFactory;
 
     public interface Monitor
@@ -58,15 +61,11 @@ public class RelationshipGroupDefragmenter
         default void defragmentingNodeRange( long fromNodeId, long toNodeId )
         {   // empty
         }
-
         Monitor EMPTY = new Monitor()
         {   // empty
         };
-    }
 
-    private final Configuration config;
-    private final ExecutionMonitor executionMonitor;
-    private final Monitor monitor;
+    }
 
     public RelationshipGroupDefragmenter( Configuration config, ExecutionMonitor executionMonitor,
                                           NumberArrayFactory numberArrayFactory )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupDefragmenter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupDefragmenter.java
@@ -23,12 +23,12 @@ import org.neo4j.kernel.impl.store.RecordStore;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
 import org.neo4j.unsafe.impl.batchimport.cache.ByteArray;
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 import org.neo4j.unsafe.impl.batchimport.staging.ExecutionMonitor;
 import org.neo4j.unsafe.impl.batchimport.staging.Stage;
 import org.neo4j.unsafe.impl.batchimport.store.BatchingNeoStores;
 
 import static org.neo4j.unsafe.impl.batchimport.Configuration.withBatchSize;
-import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO;
 import static org.neo4j.unsafe.impl.batchimport.staging.ExecutionSupervisors.superviseExecution;
 
 /**
@@ -43,6 +43,9 @@ import static org.neo4j.unsafe.impl.batchimport.staging.ExecutionSupervisors.sup
  */
 public class RelationshipGroupDefragmenter
 {
+
+    private final NumberArrayFactory numberArrayFactory;
+
     public interface Monitor
     {
         /**
@@ -65,22 +68,25 @@ public class RelationshipGroupDefragmenter
     private final ExecutionMonitor executionMonitor;
     private final Monitor monitor;
 
-    public RelationshipGroupDefragmenter( Configuration config, ExecutionMonitor executionMonitor )
+    public RelationshipGroupDefragmenter( Configuration config, ExecutionMonitor executionMonitor,
+                                          NumberArrayFactory numberArrayFactory )
     {
-        this( config, executionMonitor, Monitor.EMPTY );
+        this( config, executionMonitor, Monitor.EMPTY, numberArrayFactory );
     }
 
-    public RelationshipGroupDefragmenter( Configuration config, ExecutionMonitor executionMonitor, Monitor monitor )
+    public RelationshipGroupDefragmenter( Configuration config, ExecutionMonitor executionMonitor, Monitor monitor,
+                                          NumberArrayFactory numberArrayFactory )
     {
         this.config = config;
         this.executionMonitor = executionMonitor;
         this.monitor = monitor;
+        this.numberArrayFactory = numberArrayFactory;
     }
 
     public void run( long memoryWeCanHoldForCertain, BatchingNeoStores neoStore, long highNodeId )
     {
         try ( RelationshipGroupCache groupCache =
-                new RelationshipGroupCache( AUTO, memoryWeCanHoldForCertain, highNodeId ) )
+                new RelationshipGroupCache( numberArrayFactory, memoryWeCanHoldForCertain, highNodeId ) )
         {
             // Read from the temporary relationship group store...
             RecordStore<RelationshipGroupRecord> fromStore = neoStore.getTemporaryRelationshipGroupStore();

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/ChunkedNumberArrayFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/ChunkedNumberArrayFactory.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache;
+
+import static java.lang.Long.min;
+
+/**
+ * Used as part of the fallback strategy for {@link Auto}. Tries to split up fixed-size arrays
+ * ({@link #newLongArray(long, long)} and {@link #newIntArray(long, int)} into smaller chunks where
+ * some can live on heap and some off heap.
+ */
+public class ChunkedNumberArrayFactory extends NumberArrayFactory.Adapter
+{
+    private final NumberArrayFactory delegate;
+
+    public ChunkedNumberArrayFactory()
+    {
+        this( OFF_HEAP, HEAP );
+    }
+
+    public ChunkedNumberArrayFactory( NumberArrayFactory... delegateList )
+    {
+        delegate = new Auto( delegateList );
+    }
+
+    @Override
+    public LongArray newLongArray( long length, long defaultValue, long base )
+    {
+        // Here we want to have the property of a dynamic array which makes some parts of the array
+        // live on heap, some off. At the same time we want a fixed size array. Therefore first create
+        // the array as a dynamic array and make it grow to the requested length.
+        LongArray array = newDynamicLongArray( fractionOf( length ), defaultValue );
+        array.at( length - 1 );
+        return array;
+    }
+
+    @Override
+    public IntArray newIntArray( long length, int defaultValue, long base )
+    {
+        // Here we want to have the property of a dynamic array which makes some parts of the array
+        // live on heap, some off. At the same time we want a fixed size array. Therefore first create
+        // the array as a dynamic array and make it grow to the requested length.
+        IntArray array = newDynamicIntArray( fractionOf( length ), defaultValue );
+        array.at( length - 1 );
+        return array;
+    }
+
+    @Override
+    public ByteArray newByteArray( long length, byte[] defaultValue, long base )
+    {
+        // Here we want to have the property of a dynamic array which makes some parts of the array
+        // live on heap, some off. At the same time we want a fixed size array. Therefore first create
+        // the array as a dynamic array and make it grow to the requested length.
+        ByteArray array = newDynamicByteArray( fractionOf( length ), defaultValue );
+        array.at( length - 1 );
+        return array;
+    }
+
+    private long fractionOf( long length )
+    {
+        int idealChunkCount = 10;
+        if ( length < idealChunkCount )
+        {
+            return length;
+        }
+        int maxArraySize = Integer.MAX_VALUE - Short.MAX_VALUE;
+        return min( length / idealChunkCount, maxArraySize );
+    }
+
+    @Override
+    public IntArray newDynamicIntArray( long chunkSize, int defaultValue )
+    {
+        return new DynamicIntArray( delegate, chunkSize, defaultValue );
+    }
+
+    @Override
+    public LongArray newDynamicLongArray( long chunkSize, long defaultValue )
+    {
+        return new DynamicLongArray( delegate, chunkSize, defaultValue );
+    }
+
+    @Override
+    public ByteArray newDynamicByteArray( long chunkSize, byte[] defaultValue )
+    {
+        return new DynamicByteArray( delegate, chunkSize, defaultValue );
+    }
+
+    @Override
+    public String toString()
+    {
+        return "CHUNKED_FIXED_SIZE";
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/ChunkedNumberArrayFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/ChunkedNumberArrayFactory.java
@@ -28,14 +28,18 @@ import static java.lang.Long.min;
  */
 public class ChunkedNumberArrayFactory extends NumberArrayFactory.Adapter
 {
+    static final int MAGIC_CHUNK_COUNT = 10;
+    // This is a safe bet on the maximum number of items the JVM can store in an array. It is commonly slightly less
+    // than Integer.MAX_VALUE
+    private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - Short.MAX_VALUE;
     private final NumberArrayFactory delegate;
 
-    public ChunkedNumberArrayFactory()
+    ChunkedNumberArrayFactory()
     {
         this( OFF_HEAP, HEAP );
     }
 
-    public ChunkedNumberArrayFactory( NumberArrayFactory... delegateList )
+    ChunkedNumberArrayFactory( NumberArrayFactory... delegateList )
     {
         delegate = new Auto( delegateList );
     }
@@ -43,45 +47,34 @@ public class ChunkedNumberArrayFactory extends NumberArrayFactory.Adapter
     @Override
     public LongArray newLongArray( long length, long defaultValue, long base )
     {
-        // Here we want to have the property of a dynamic array which makes some parts of the array
-        // live on heap, some off. At the same time we want a fixed size array. Therefore first create
-        // the array as a dynamic array and make it grow to the requested length.
-        LongArray array = newDynamicLongArray( fractionOf( length ), defaultValue );
-        array.at( length - 1 );
-        return array;
+        // Here we want to have the property of a dynamic array so that some parts of the array
+        // can live on heap, some off.
+        return newDynamicLongArray( fractionOf( length ), defaultValue );
     }
 
     @Override
     public IntArray newIntArray( long length, int defaultValue, long base )
     {
-        // Here we want to have the property of a dynamic array which makes some parts of the array
-        // live on heap, some off. At the same time we want a fixed size array. Therefore first create
-        // the array as a dynamic array and make it grow to the requested length.
-        IntArray array = newDynamicIntArray( fractionOf( length ), defaultValue );
-        array.at( length - 1 );
-        return array;
+        // Here we want to have the property of a dynamic array so that some parts of the array
+        // can live on heap, some off.
+        return newDynamicIntArray( fractionOf( length ), defaultValue );
     }
 
     @Override
     public ByteArray newByteArray( long length, byte[] defaultValue, long base )
     {
-        // Here we want to have the property of a dynamic array which makes some parts of the array
-        // live on heap, some off. At the same time we want a fixed size array. Therefore first create
-        // the array as a dynamic array and make it grow to the requested length.
-        ByteArray array = newDynamicByteArray( fractionOf( length ), defaultValue );
-        array.at( length - 1 );
-        return array;
+        // Here we want to have the property of a dynamic array so that some parts of the array
+        // can live on heap, some off.
+        return newDynamicByteArray( fractionOf( length ), defaultValue );
     }
 
     private long fractionOf( long length )
     {
-        int idealChunkCount = 10;
-        if ( length < idealChunkCount )
+        if ( length < MAGIC_CHUNK_COUNT )
         {
             return length;
         }
-        int maxArraySize = Integer.MAX_VALUE - Short.MAX_VALUE;
-        return min( length / idealChunkCount, maxArraySize );
+        return min( length / MAGIC_CHUNK_COUNT, MAX_ARRAY_SIZE );
     }
 
     @Override
@@ -105,6 +98,6 @@ public class ChunkedNumberArrayFactory extends NumberArrayFactory.Adapter
     @Override
     public String toString()
     {
-        return "CHUNKED_FIXED_SIZE";
+        return "ChunkedNumberArrayFactory with delegate " + delegate;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicByteArray.java
@@ -37,18 +37,14 @@ public class DynamicByteArray extends DynamicNumberArray<ByteArray> implements B
     }
 
     @Override
-    public void swap( long fromIndex, long toIndex, int numberOfEntries )
+    public void swap( long fromIndex, long toIndex )
     {
-        // Let's just do this the stupid way. There's room for optimization here
-        byte[] intermediary = defaultValue.clone();
-        byte[] transport = defaultValue.clone();
-        for ( int i = 0; i < numberOfEntries; i++ )
-        {
-            get( fromIndex + i, intermediary );
-            get( toIndex + i, transport );
-            set( fromIndex + i, transport );
-            set( toIndex + i, intermediary );
-        }
+        byte[] a = defaultValue.clone();
+        byte[] b = defaultValue.clone();
+        get( fromIndex, a );
+        get( toIndex, b );
+        set( fromIndex, b );
+        set( toIndex, a );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicIntArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicIntArray.java
@@ -49,18 +49,6 @@ public class DynamicIntArray extends DynamicNumberArray<IntArray> implements Int
     }
 
     @Override
-    public void swap( long fromIndex, long toIndex, int numberOfEntries )
-    {
-        // Let's just do this the stupid way. There's room for optimization here
-        for ( int i = 0; i < numberOfEntries; i++ )
-        {
-            int intermediary = get( fromIndex + i );
-            set( fromIndex + i, get( toIndex + i ) );
-            set( toIndex + i, intermediary );
-        }
-    }
-
-    @Override
     protected IntArray addChunk( long chunkSize, long base )
     {
         return factory.newIntArray( chunkSize, defaultValue, base );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicLongArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicLongArray.java
@@ -49,18 +49,6 @@ public class DynamicLongArray extends DynamicNumberArray<LongArray> implements L
     }
 
     @Override
-    public void swap( long fromIndex, long toIndex, int numberOfEntries )
-    {
-        // Let's just do this the stupid way. There's room for optimization here
-        for ( int i = 0; i < numberOfEntries; i++ )
-        {
-            long intermediary = get( fromIndex + i );
-            set( fromIndex + i, get( toIndex + i ) );
-            set( toIndex + i, intermediary );
-        }
-    }
-
-    @Override
     protected LongArray addChunk( long chunkSize, long base )
     {
         return factory.newLongArray( chunkSize, defaultValue, base );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapByteArray.java
@@ -50,12 +50,14 @@ public class HeapByteArray extends HeapNumberArray<ByteArray> implements ByteArr
     }
 
     @Override
-    public void swap( long fromIndex, long toIndex, int numberOfEntries )
+    public void swap( long fromIndex, long toIndex )
     {
-        byte[] intermediary = new byte[numberOfEntries * itemSize];
-        System.arraycopy( array, index( toIndex, 0 ), intermediary, 0, intermediary.length );
-        System.arraycopy( array, index( fromIndex, 0 ), array, index( toIndex, 0 ), intermediary.length );
-        System.arraycopy( intermediary, 0, array, index( fromIndex, 0 ), intermediary.length );
+        byte[] a = defaultValue.clone();
+        byte[] b = defaultValue.clone();
+        get( fromIndex, a );
+        get( toIndex, b );
+        set( fromIndex, b );
+        set( toIndex, a );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapIntArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapIntArray.java
@@ -60,15 +60,4 @@ public class HeapIntArray extends HeapNumberArray<IntArray> implements IntArray
     {
         Arrays.fill( array, defaultValue );
     }
-
-    @Override
-    public void swap( long fromIndex, long toIndex, int numberOfEntries )
-    {
-        for ( int i = 0; i < numberOfEntries; i++ )
-        {
-            int fromValue = get( fromIndex + i );
-            set( fromIndex + i, get( toIndex + i ) );
-            set( toIndex + i, fromValue );
-        }
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapLongArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapLongArray.java
@@ -60,15 +60,4 @@ public class HeapLongArray extends HeapNumberArray<LongArray> implements LongArr
     {
         Arrays.fill( array, defaultValue );
     }
-
-    @Override
-    public void swap( long fromIndex, long toIndex, int numberOfEntries )
-    {
-        for ( int i = 0; i < numberOfEntries; i++ )
-        {
-            long fromValue = get( fromIndex + i );
-            set( fromIndex + i, get( toIndex + i ) );
-            set( toIndex + i, fromValue );
-        }
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/IntArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/IntArray.java
@@ -30,4 +30,16 @@ public interface IntArray extends NumberArray<IntArray>
     int get( long index );
 
     void set( long index, int value );
+
+    @Override
+    default void swap( long fromIndex, long toIndex, int numberOfEntries )
+    {
+        // Let's just do this the stupid way. There's room for optimization here
+        for ( int i = 0; i < numberOfEntries; i++ )
+        {
+            int intermediary = get( fromIndex+i );
+            set( fromIndex+i, get( toIndex+i ) );
+            set( toIndex+i, intermediary );
+        }
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/IntArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/IntArray.java
@@ -32,14 +32,10 @@ public interface IntArray extends NumberArray<IntArray>
     void set( long index, int value );
 
     @Override
-    default void swap( long fromIndex, long toIndex, int numberOfEntries )
+    default void swap( long fromIndex, long toIndex )
     {
-        // Let's just do this the stupid way. There's room for optimization here
-        for ( int i = 0; i < numberOfEntries; i++ )
-        {
-            int intermediary = get( fromIndex+i );
-            set( fromIndex+i, get( toIndex+i ) );
-            set( toIndex+i, intermediary );
-        }
+        int intermediary = get( fromIndex );
+        set( fromIndex, get( toIndex ) );
+        set( toIndex, intermediary );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/LongArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/LongArray.java
@@ -30,4 +30,16 @@ public interface LongArray extends NumberArray<LongArray>
     long get( long index );
 
     void set( long index, long value );
+
+    @Override
+    default void swap( long fromIndex, long toIndex, int numberOfEntries )
+    {
+        // Let's just do this the stupid way. There's room for optimization here
+        for ( int i = 0; i < numberOfEntries; i++ )
+        {
+            long intermediary = get( fromIndex+i );
+            set( fromIndex+i, get( toIndex+i ) );
+            set( toIndex+i, intermediary );
+        }
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/LongArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/LongArray.java
@@ -32,14 +32,10 @@ public interface LongArray extends NumberArray<LongArray>
     void set( long index, long value );
 
     @Override
-    default void swap( long fromIndex, long toIndex, int numberOfEntries )
+    default void swap( long fromIndex, long toIndex )
     {
-        // Let's just do this the stupid way. There's room for optimization here
-        for ( int i = 0; i < numberOfEntries; i++ )
-        {
-            long intermediary = get( fromIndex+i );
-            set( fromIndex+i, get( toIndex+i ) );
-            set( toIndex+i, intermediary );
-        }
+        long intermediary = get( fromIndex );
+        set( fromIndex, get( toIndex ) );
+        set( toIndex, intermediary );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCache.java
@@ -832,16 +832,17 @@ public class NodeRelationshipCache implements MemoryStatsVisitor.Visitable
                 continue;
             }
 
-            ByteArray chunk = array.at( nodeId );
-            for ( int i = 0; i < chunkSize && nodeId < highNodeId; i++, nodeId++ )
+            ByteArray subArray = array.at( nodeId );
+            long subArrayLength = subArray.length();
+            for ( int i = 0; i < subArrayLength && nodeId < highNodeId; i++, nodeId++ )
             {
                 boolean nodeHasChanged =
-                        (NodeType.isDense( nodeTypes ) && nodeIsChanged( chunk, nodeId, denseMask )) ||
-                        (NodeType.isSparse( nodeTypes ) && nodeIsChanged( chunk, nodeId, sparseMask ));
+                        (NodeType.isDense( nodeTypes ) && nodeIsChanged( subArray, nodeId, denseMask )) ||
+                        (NodeType.isSparse( nodeTypes ) && nodeIsChanged( subArray, nodeId, sparseMask ));
 
                 if ( nodeHasChanged && NodeType.matchesDense( nodeTypes, isDense( array, nodeId ) ) )
                 {
-                    visitor.change( nodeId, chunk );
+                    visitor.change( nodeId, subArray );
                 }
             }
         }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArray.java
@@ -34,12 +34,10 @@ public interface NumberArray<N extends NumberArray<N>> extends MemoryStatsVisito
     /**
      * Swaps {@code numberOfEntries} items from {@code fromIndex} to {@code toIndex}, such that
      * {@code fromIndex} and {@code toIndex}, {@code fromIndex+1} and {@code toIndex} a.s.o swaps places.
-     *
-     * @param fromIndex where to start swapping from.
+     *  @param fromIndex where to start swapping from.
      * @param toIndex where to start swapping to.
-     * @param numberOfEntries number of entries to swap, starting from the given from/to indexes.
      */
-    void swap( long fromIndex, long toIndex, int numberOfEntries );
+    void swap( long fromIndex, long toIndex );
 
     /**
      * Sets all values to a default value.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArray.java
@@ -32,8 +32,9 @@ public interface NumberArray<N extends NumberArray<N>> extends MemoryStatsVisito
     long length();
 
     /**
-     * Swaps {@code numberOfEntries} items from {@code fromIndex} to {@code toIndex}, such that
+     * Swaps items from {@code fromIndex} to {@code toIndex}, such that
      * {@code fromIndex} and {@code toIndex}, {@code fromIndex+1} and {@code toIndex} a.s.o swaps places.
+     * The number of items swapped is equal to the length of the default value of the array.
      *  @param fromIndex where to start swapping from.
      * @param toIndex where to start swapping to.
      */

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapByteArray.java
@@ -33,13 +33,12 @@ public class OffHeapByteArray extends OffHeapNumberArray<ByteArray> implements B
     }
 
     @Override
-    public void swap( long fromIndex, long toIndex, int numberOfEntries )
+    public void swap( long fromIndex, long toIndex )
     {
-        int size = numberOfEntries * itemSize;
-        long intermediary = UnsafeUtil.allocateMemory( size );
-        UnsafeUtil.copyMemory( address( fromIndex, 0 ), intermediary, size );
-        UnsafeUtil.copyMemory( address( toIndex, 0 ), address( fromIndex, 0 ), size );
-        UnsafeUtil.copyMemory( intermediary, address( toIndex, 0 ), size );
+        long intermediary = UnsafeUtil.allocateMemory( itemSize );
+        UnsafeUtil.copyMemory( address( fromIndex, 0 ), intermediary, itemSize );
+        UnsafeUtil.copyMemory( address( toIndex, 0 ), address( fromIndex, 0 ), itemSize );
+        UnsafeUtil.copyMemory( intermediary, address( toIndex, 0 ), itemSize );
         UnsafeUtil.free( intermediary );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapIntArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapIntArray.java
@@ -63,18 +63,4 @@ public class OffHeapIntArray extends OffHeapRegularNumberArray<IntArray> impleme
             }
         }
     }
-
-    @Override
-    public void swap( long fromIndex, long toIndex, int numberOfEntries )
-    {
-        long fromAddress = addressOf( fromIndex );
-        long toAddress = addressOf( toIndex );
-
-        for ( int i = 0; i < numberOfEntries; i++, fromAddress += itemSize, toAddress += itemSize )
-        {
-            int fromValue = UnsafeUtil.getInt( fromAddress );
-            UnsafeUtil.putInt( fromAddress, UnsafeUtil.getInt( toAddress ) );
-            UnsafeUtil.putInt( toAddress, fromValue );
-        }
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapLongArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapLongArray.java
@@ -63,18 +63,4 @@ public class OffHeapLongArray extends OffHeapRegularNumberArray<LongArray> imple
             }
         }
     }
-
-    @Override
-    public void swap( long fromIndex, long toIndex, int numberOfEntries )
-    {
-        long fromAddress = addressOf( fromIndex );
-        long toAddress = addressOf( toIndex );
-
-        for ( int i = 0; i < numberOfEntries; i++, fromAddress += itemSize, toAddress += itemSize )
-        {
-            long fromValue = UnsafeUtil.getLong( fromAddress );
-            UnsafeUtil.putLong( fromAddress, UnsafeUtil.getLong( toAddress ) );
-            UnsafeUtil.putLong( toAddress, fromValue );
-        }
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheByteArray.java
@@ -33,10 +33,11 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
 {
     private final byte[] defaultValue;
 
-    public PageCacheByteArray( PagedFile pagedFile, long length, byte[] defaultValue, long base ) throws IOException
+    PageCacheByteArray( PagedFile pagedFile, long length, byte[] defaultValue, long base ) throws IOException
     {
-        // '0' default value means we skip filling it out in super
-        super( pagedFile, defaultValue.length, length, 0, base );
+        // Default value is handled locally in this class, in contrast to its siblings, which lets the superclass
+        // handle it.
+        super( pagedFile, defaultValue.length, length, base );
         this.defaultValue = defaultValue;
         setDefaultValue( -1 );
     }
@@ -167,7 +168,7 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
             {
                 long low4b = cursor.getInt( offset ) & 0xFFFFFFFFL;
                 long high2b = cursor.getShort( offset + Integer.BYTES );
-                result = low4b | (high2b << 32);
+                result = low4b | (high2b << Integer.SIZE);
             }
             while ( cursor.shouldRetry() );
             checkBounds( cursor );
@@ -208,7 +209,7 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
         assert value.length == entrySize;
         long pageId = pageId( index );
         int offset = offset( index );
-        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ); )
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ) )
         {
             cursor.next();
             for ( int i = 0; i < value.length; i++ )
@@ -228,7 +229,7 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
     {
         long pageId = pageId( index );
         offset += offset( index );
-        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ); )
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ) )
         {
             cursor.next();
             cursor.putByte( offset, value );
@@ -245,7 +246,7 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
     {
         long pageId = pageId( index );
         offset += offset( index );
-        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ); )
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ) )
         {
             cursor.next();
             cursor.putShort( offset, value );
@@ -262,7 +263,7 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
     {
         long pageId = pageId( index );
         offset += offset( index );
-        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ); )
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ) )
         {
             cursor.next();
             cursor.putInt( offset, value );
@@ -279,11 +280,11 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
     {
         long pageId = pageId( index );
         offset += offset( index );
-        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ); )
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ) )
         {
             cursor.next();
             cursor.putInt( offset, (int) value );
-            cursor.putShort( offset + Integer.BYTES, (short) (value >>> 32) );
+            cursor.putShort( offset + Integer.BYTES, (short) (value >>> Integer.SIZE) );
             checkBounds( cursor );
         }
         catch ( IOException e )
@@ -297,7 +298,7 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
     {
         long pageId = pageId( index );
         offset += offset( index );
-        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ); )
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ) )
         {
             cursor.next();
             cursor.putLong( offset, value );
@@ -340,7 +341,7 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
     {
         long pageId = pageId( index );
         offset += offset( index );
-        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ); )
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ) )
         {
             cursor.next();
             cursor.putShort( offset, (short) value );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheByteArray.java
@@ -25,6 +25,10 @@ import java.io.UncheckedIOException;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
 
+import static org.neo4j.io.pagecache.PagedFile.PF_NO_GROW;
+import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_READ_LOCK;
+import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_WRITE_LOCK;
+
 public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implements ByteArray
 {
     private final byte[] defaultValue;
@@ -34,7 +38,7 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
         // '0' default value means we skip filling it out in super
         super( pagedFile, defaultValue.length, length, 0, base );
         this.defaultValue = defaultValue;
-        setDefaultValue( writeCursor( 0 ), -1 );
+        setDefaultValue( -1 );
     }
 
     @Override
@@ -62,9 +66,9 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
     {
         long pageId = pageId( index );
         int offset = offset( index );
-        try
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_READ_LOCK ) )
         {
-            PageCursor cursor = readCursor( pageId );
+            cursor.next();
             do
             {
                 for ( int i = 0; i < into.length; i++ )
@@ -86,9 +90,9 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
     {
         long pageId = pageId( index );
         offset += offset( index );
-        try
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_READ_LOCK ) )
         {
-            PageCursor cursor = readCursor( pageId );
+            cursor.next();
             byte result;
             do
             {
@@ -109,9 +113,9 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
     {
         long pageId = pageId( index );
         offset += offset( index );
-        try
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_READ_LOCK ) )
         {
-            PageCursor cursor = readCursor( pageId );
+            cursor.next();
             short result;
             do
             {
@@ -132,9 +136,9 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
     {
         long pageId = pageId( index );
         offset += offset( index );
-        try
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_READ_LOCK ) )
         {
-            PageCursor cursor = readCursor( pageId );
+            cursor.next();
             int result;
             do
             {
@@ -155,9 +159,9 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
     {
         long pageId = pageId( index );
         offset += offset( index );
-        try
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_READ_LOCK ) )
         {
-            PageCursor cursor = readCursor( pageId );
+            cursor.next();
             long result;
             do
             {
@@ -180,9 +184,9 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
     {
         long pageId = pageId( index );
         offset += offset( index );
-        try
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_READ_LOCK ) )
         {
-            PageCursor cursor = readCursor( pageId );
+            cursor.next();
             long result;
             do
             {
@@ -204,9 +208,9 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
         assert value.length == entrySize;
         long pageId = pageId( index );
         int offset = offset( index );
-        try
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ); )
         {
-            PageCursor cursor = writeCursor( pageId );
+            cursor.next();
             for ( int i = 0; i < value.length; i++ )
             {
                 cursor.putByte( offset + i, value[i] );
@@ -224,9 +228,9 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
     {
         long pageId = pageId( index );
         offset += offset( index );
-        try
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ); )
         {
-            PageCursor cursor = writeCursor( pageId );
+            cursor.next();
             cursor.putByte( offset, value );
             checkBounds( cursor );
         }
@@ -241,9 +245,9 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
     {
         long pageId = pageId( index );
         offset += offset( index );
-        try
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ); )
         {
-            PageCursor cursor = writeCursor( pageId );
+            cursor.next();
             cursor.putShort( offset, value );
             checkBounds( cursor );
         }
@@ -258,9 +262,9 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
     {
         long pageId = pageId( index );
         offset += offset( index );
-        try
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ); )
         {
-            PageCursor cursor = writeCursor( pageId );
+            cursor.next();
             cursor.putInt( offset, value );
             checkBounds( cursor );
         }
@@ -275,9 +279,9 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
     {
         long pageId = pageId( index );
         offset += offset( index );
-        try
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ); )
         {
-            PageCursor cursor = writeCursor( pageId );
+            cursor.next();
             cursor.putInt( offset, (int) value );
             cursor.putShort( offset + Integer.BYTES, (short) (value >>> 32) );
             checkBounds( cursor );
@@ -293,9 +297,9 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
     {
         long pageId = pageId( index );
         offset += offset( index );
-        try
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ); )
         {
-            PageCursor cursor = writeCursor( pageId );
+            cursor.next();
             cursor.putLong( offset, value );
             checkBounds( cursor );
         }
@@ -311,9 +315,9 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
 
         long pageId = pageId( index );
         offset += offset( index );
-        try
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_READ_LOCK ) )
         {
-            PageCursor cursor = readCursor( pageId );
+            cursor.next();
             int result;
             do
             {
@@ -336,9 +340,9 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
     {
         long pageId = pageId( index );
         offset += offset( index );
-        try
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ); )
         {
-            PageCursor cursor = writeCursor( pageId );
+            cursor.next();
             cursor.putShort( offset, (short) value );
             cursor.putByte( offset + Short.BYTES, (byte) (value >>> Short.SIZE) );
             checkBounds( cursor );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheByteArray.java
@@ -1,0 +1,351 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.io.pagecache.PagedFile;
+
+public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implements ByteArray
+{
+    private final byte[] defaultValue;
+
+    public PageCacheByteArray( PagedFile pagedFile, long length, byte[] defaultValue, long base ) throws IOException
+    {
+        // '0' default value means we skip filling it out in super
+        super( pagedFile, defaultValue.length, length, 0, base );
+        this.defaultValue = defaultValue;
+        setDefaultValue( writeCursor( 0 ), -1 );
+    }
+
+    @Override
+    protected void fillPageWithDefaultValue( PageCursor writeCursor, long ignoredDefaultValue, int pageSize )
+    {
+        for ( int i = 0; i < entriesPerPage; i++ )
+        {
+            writeCursor.putBytes( this.defaultValue );
+        }
+    }
+
+    @Override
+    public void swap( long fromIndex, long toIndex )
+    {
+        byte[] a = defaultValue.clone();
+        byte[] b = defaultValue.clone();
+        get( fromIndex, a );
+        get( toIndex, b );
+        set( fromIndex, b );
+        set( toIndex, a );
+    }
+
+    @Override
+    public void get( long index, byte[] into )
+    {
+        long pageId = pageId( index );
+        int offset = offset( index );
+        try
+        {
+            PageCursor cursor = readCursor( pageId );
+            do
+            {
+                for ( int i = 0; i < into.length; i++ )
+                {
+                    into[i] = cursor.getByte( offset + i );
+                }
+            }
+            while ( cursor.shouldRetry() );
+            checkBounds( cursor );
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    @Override
+    public byte getByte( long index, int offset )
+    {
+        long pageId = pageId( index );
+        offset += offset( index );
+        try
+        {
+            PageCursor cursor = readCursor( pageId );
+            byte result;
+            do
+            {
+                result = cursor.getByte( offset );
+            }
+            while ( cursor.shouldRetry() );
+            checkBounds( cursor );
+            return result;
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    @Override
+    public short getShort( long index, int offset )
+    {
+        long pageId = pageId( index );
+        offset += offset( index );
+        try
+        {
+            PageCursor cursor = readCursor( pageId );
+            short result;
+            do
+            {
+                result = cursor.getShort( offset );
+            }
+            while ( cursor.shouldRetry() );
+            checkBounds( cursor );
+            return result;
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    @Override
+    public int getInt( long index, int offset )
+    {
+        long pageId = pageId( index );
+        offset += offset( index );
+        try
+        {
+            PageCursor cursor = readCursor( pageId );
+            int result;
+            do
+            {
+                result = cursor.getInt( offset );
+            }
+            while ( cursor.shouldRetry() );
+            checkBounds( cursor );
+            return result;
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    @Override
+    public long get6ByteLong( long index, int offset )
+    {
+        long pageId = pageId( index );
+        offset += offset( index );
+        try
+        {
+            PageCursor cursor = readCursor( pageId );
+            long result;
+            do
+            {
+                long low4b = cursor.getInt( offset ) & 0xFFFFFFFFL;
+                long high2b = cursor.getShort( offset + Integer.BYTES );
+                result = low4b | (high2b << 32);
+            }
+            while ( cursor.shouldRetry() );
+            checkBounds( cursor );
+            return result;
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    @Override
+    public long getLong( long index, int offset )
+    {
+        long pageId = pageId( index );
+        offset += offset( index );
+        try
+        {
+            PageCursor cursor = readCursor( pageId );
+            long result;
+            do
+            {
+                result = cursor.getLong( offset );
+            }
+            while ( cursor.shouldRetry() );
+            checkBounds( cursor );
+            return result;
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    @Override
+    public void set( long index, byte[] value )
+    {
+        assert value.length == entrySize;
+        long pageId = pageId( index );
+        int offset = offset( index );
+        try
+        {
+            PageCursor cursor = writeCursor( pageId );
+            for ( int i = 0; i < value.length; i++ )
+            {
+                cursor.putByte( offset + i, value[i] );
+            }
+            checkBounds( cursor );
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    @Override
+    public void setByte( long index, int offset, byte value )
+    {
+        long pageId = pageId( index );
+        offset += offset( index );
+        try
+        {
+            PageCursor cursor = writeCursor( pageId );
+            cursor.putByte( offset, value );
+            checkBounds( cursor );
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    @Override
+    public void setShort( long index, int offset, short value )
+    {
+        long pageId = pageId( index );
+        offset += offset( index );
+        try
+        {
+            PageCursor cursor = writeCursor( pageId );
+            cursor.putShort( offset, value );
+            checkBounds( cursor );
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    @Override
+    public void setInt( long index, int offset, int value )
+    {
+        long pageId = pageId( index );
+        offset += offset( index );
+        try
+        {
+            PageCursor cursor = writeCursor( pageId );
+            cursor.putInt( offset, value );
+            checkBounds( cursor );
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    @Override
+    public void set6ByteLong( long index, int offset, long value )
+    {
+        long pageId = pageId( index );
+        offset += offset( index );
+        try
+        {
+            PageCursor cursor = writeCursor( pageId );
+            cursor.putInt( offset, (int) value );
+            cursor.putShort( offset + Integer.BYTES, (short) (value >>> 32) );
+            checkBounds( cursor );
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    @Override
+    public void setLong( long index, int offset, long value )
+    {
+        long pageId = pageId( index );
+        offset += offset( index );
+        try
+        {
+            PageCursor cursor = writeCursor( pageId );
+            cursor.putLong( offset, value );
+            checkBounds( cursor );
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    @Override
+    public int get3ByteInt( long index, int offset )
+    {
+
+        long pageId = pageId( index );
+        offset += offset( index );
+        try
+        {
+            PageCursor cursor = readCursor( pageId );
+            int result;
+            do
+            {
+                int lowWord = cursor.getShort( offset ) & 0xFFFF;
+                byte highByte = cursor.getByte( offset + Short.BYTES );
+                result = lowWord | (highByte << Short.SIZE);
+            }
+            while ( cursor.shouldRetry() );
+            checkBounds( cursor );
+            return result;
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    @Override
+    public void set3ByteInt( long index, int offset, int value )
+    {
+        long pageId = pageId( index );
+        offset += offset( index );
+        try
+        {
+            PageCursor cursor = writeCursor( pageId );
+            cursor.putShort( offset, (short) value );
+            cursor.putByte( offset + Short.BYTES, (byte) (value >>> Short.SIZE) );
+            checkBounds( cursor );
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheIntArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheIntArray.java
@@ -31,9 +31,9 @@ import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_WRITE_LOCK;
 
 public class PageCacheIntArray extends PageCacheNumberArray<IntArray> implements IntArray
 {
-    public PageCacheIntArray( PagedFile pagedFile, long length, long defaultValue, long base ) throws IOException
+    PageCacheIntArray( PagedFile pagedFile, long length, long defaultValue, long base ) throws IOException
     {
-        super( pagedFile, Integer.BYTES, length, defaultValue, base );
+        super( pagedFile, Integer.BYTES, length, defaultValue | defaultValue << Integer.SIZE, base );
     }
 
     @Override
@@ -64,7 +64,7 @@ public class PageCacheIntArray extends PageCacheNumberArray<IntArray> implements
     {
         long pageId = pageId( index );
         int offset = offset( index );
-        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ); )
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ) )
         {
             cursor.next();
             cursor.putInt( offset, value );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheIntArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheIntArray.java
@@ -25,6 +25,10 @@ import java.io.UncheckedIOException;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
 
+import static org.neo4j.io.pagecache.PagedFile.PF_NO_GROW;
+import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_READ_LOCK;
+import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_WRITE_LOCK;
+
 public class PageCacheIntArray extends PageCacheNumberArray<IntArray> implements IntArray
 {
     public PageCacheIntArray( PagedFile pagedFile, long length, long defaultValue, long base ) throws IOException
@@ -37,9 +41,9 @@ public class PageCacheIntArray extends PageCacheNumberArray<IntArray> implements
     {
         long pageId = pageId( index );
         int offset = offset( index );
-        try
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_READ_LOCK ) )
         {
-            PageCursor cursor = readCursor( pageId );
+            cursor.next();
             int result;
             do
             {
@@ -60,9 +64,9 @@ public class PageCacheIntArray extends PageCacheNumberArray<IntArray> implements
     {
         long pageId = pageId( index );
         int offset = offset( index );
-        try
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ); )
         {
-            PageCursor cursor = writeCursor( pageId );
+            cursor.next();
             cursor.putInt( offset, value );
             checkBounds( cursor );
         }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheIntArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheIntArray.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache;
+
+import java.io.IOException;
+
+import org.neo4j.io.pagecache.PagedFile;
+
+import static java.lang.Math.toIntExact;
+
+public class PageCacheIntArray extends PageCacheNumberArray<IntArray> implements IntArray
+{
+    private static final int ENTRY_SIZE = Integer.BYTES;
+    private static final int ENTRIES_PER_PAGE = PAGE_SIZE / ENTRY_SIZE;
+
+    public PageCacheIntArray( PagedFile pagedFile ) throws IOException
+    {
+        super( pagedFile, ENTRIES_PER_PAGE, ENTRY_SIZE );
+    }
+
+    @Override
+    public int get( long index )
+    {
+        long pageId = index / ENTRIES_PER_PAGE;
+        int offset = toIntExact( index % ENTRIES_PER_PAGE ) * ENTRY_SIZE;
+        if ( writeCursor.getCurrentPageId() == pageId )
+        {
+            // We have to read from the write cursor, since the write cursor is on it
+            return writeCursor.getInt( offset );
+        }
+
+        // Go ahead and read from the read cursor
+        try
+        {
+            goTo( readCursor, pageId );
+            int result;
+            do
+            {
+                result = readCursor.getInt( offset );
+            }
+            while ( readCursor.shouldRetry() );
+            checkBounds( readCursor );
+            return result;
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( e );
+        }
+    }
+
+    @Override
+    public void set( long index, int value )
+    {
+        long pageId = index / ENTRIES_PER_PAGE;
+        int offset = toIntExact( index % ENTRIES_PER_PAGE ) * ENTRY_SIZE;
+        try
+        {
+            goTo( writeCursor, pageId );
+            writeCursor.putInt( offset, value );
+            checkBounds( writeCursor );
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( e );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheLongArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheLongArray.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache;
+
+import java.io.IOException;
+
+import org.neo4j.io.pagecache.PagedFile;
+
+import static java.lang.Math.toIntExact;
+
+public class PageCacheLongArray extends PageCacheNumberArray<LongArray> implements LongArray
+{
+    private static final int ENTRY_SIZE = Long.BYTES;
+    private static final int ENTRIES_PER_PAGE = PAGE_SIZE / ENTRY_SIZE;
+
+    public PageCacheLongArray( PagedFile pagedFile ) throws IOException
+    {
+        super( pagedFile, ENTRIES_PER_PAGE, ENTRY_SIZE );
+    }
+
+    @Override
+    public long get( long index )
+    {
+        long pageId = index / ENTRIES_PER_PAGE;
+        int offset = toIntExact( index % ENTRIES_PER_PAGE ) * ENTRY_SIZE;
+        if ( writeCursor.getCurrentPageId() == pageId )
+        {
+            // We have to read from the write cursor, since the write cursor is on it
+            return writeCursor.getLong( offset );
+        }
+
+        // Go ahead and read from the read cursor
+        try
+        {
+            goTo( readCursor, pageId );
+            long result;
+            do
+            {
+                result = readCursor.getLong( offset );
+            }
+            while ( readCursor.shouldRetry() );
+            checkBounds( readCursor );
+            return result;
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( e );
+        }
+    }
+
+    @Override
+    public void set( long index, long value )
+    {
+        long pageId = index / ENTRIES_PER_PAGE;
+        int offset = toIntExact( index % ENTRIES_PER_PAGE ) * ENTRY_SIZE;
+        try
+        {
+            goTo( writeCursor, pageId );
+            writeCursor.putLong( offset, value );
+            checkBounds( writeCursor );
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( e );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheLongArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheLongArray.java
@@ -31,7 +31,7 @@ import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_WRITE_LOCK;
 
 public class PageCacheLongArray extends PageCacheNumberArray<LongArray> implements LongArray
 {
-    public PageCacheLongArray( PagedFile pagedFile, long length, long defaultValue, long base ) throws IOException
+    PageCacheLongArray( PagedFile pagedFile, long length, long defaultValue, long base ) throws IOException
     {
         super( pagedFile, Long.BYTES, length, defaultValue, base );
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheLongArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheLongArray.java
@@ -25,6 +25,10 @@ import java.io.UncheckedIOException;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
 
+import static org.neo4j.io.pagecache.PagedFile.PF_NO_GROW;
+import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_READ_LOCK;
+import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_WRITE_LOCK;
+
 public class PageCacheLongArray extends PageCacheNumberArray<LongArray> implements LongArray
 {
     public PageCacheLongArray( PagedFile pagedFile, long length, long defaultValue, long base ) throws IOException
@@ -37,9 +41,9 @@ public class PageCacheLongArray extends PageCacheNumberArray<LongArray> implemen
     {
         long pageId = pageId( index );
         int offset = offset( index );
-        try
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_READ_LOCK ) )
         {
-            PageCursor cursor = readCursor( pageId );
+            cursor.next();
             long result;
             do
             {
@@ -60,9 +64,9 @@ public class PageCacheLongArray extends PageCacheNumberArray<LongArray> implemen
     {
         long pageId = pageId( index );
         int offset = offset( index );
-        try
+        try ( PageCursor cursor = pagedFile.io( pageId, PF_SHARED_WRITE_LOCK | PF_NO_GROW ) )
         {
-            PageCursor cursor = writeCursor( pageId );
+            cursor.next();
             cursor.putLong( offset, value );
             checkBounds( cursor );
         }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheNumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheNumberArray.java
@@ -20,62 +20,141 @@
 package org.neo4j.unsafe.impl.batchimport.cache;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
 
-import static org.neo4j.io.ByteUnit.kibiBytes;
+import static java.lang.Math.toIntExact;
+import static org.neo4j.io.pagecache.PagedFile.PF_NO_GROW;
+import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_READ_LOCK;
+import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_WRITE_LOCK;
 
+// todo make safe for concurrent access
 public abstract class PageCacheNumberArray<N extends NumberArray<N>> implements NumberArray<N>
 {
-    static final int PAGE_SIZE = (int) kibiBytes( 8 );
-
     protected final PagedFile pagedFile;
-    protected final PageCursor readCursor;
-    protected final PageCursor writeCursor;
-    private final int entriesPerPage;
-    private final int entrySize;
+    protected final int entriesPerPage;
+    protected final int entrySize;
+    private final PageCursor readCursor;
+    private final PageCursor writeCursor;
+    private final long length;
+    private final long defaultValue;
+    private final long base;
+    private boolean closed;
 
-    public PageCacheNumberArray( PagedFile pagedFile, int entriesPerPage, int entrySize ) throws IOException
+    public PageCacheNumberArray( PagedFile pagedFile, int entrySize, long length,
+                                 long defaultValue, long base ) throws IOException
     {
         this.pagedFile = pagedFile;
-        this.entriesPerPage = entriesPerPage;
         this.entrySize = entrySize;
-        this.readCursor = pagedFile.io( 0, PagedFile.PF_SHARED_READ_LOCK );
-        this.writeCursor = pagedFile.io( 0, PagedFile.PF_SHARED_WRITE_LOCK );
+        this.entriesPerPage = pagedFile.pageSize() / entrySize;
+        this.readCursor = pagedFile.io( 0, PF_SHARED_READ_LOCK );
+        this.writeCursor = pagedFile.io( 0, PF_SHARED_WRITE_LOCK | PF_NO_GROW );
+        this.length = length;
+        this.defaultValue = defaultValue;
+        this.base = base;
+
+        try ( PageCursor cursorToSetLength = pagedFile.io( 0, PF_SHARED_WRITE_LOCK ) )
+        {
+            setLength( cursorToSetLength, length );
+        }
+
+        if ( defaultValue != 0 )
+        {
+            setDefaultValue( writeCursor, defaultValue );
+        }
+    }
+
+    private void setLength( PageCursor cursor, long length ) throws IOException
+    {
+        goTo( cursor, ( length - 1 ) / entriesPerPage );
+    }
+
+    protected long pageId( long index )
+    {
+        return rebase( index ) / entriesPerPage;
+    }
+
+    protected int offset( long index )
+    {
+        return toIntExact( rebase( index ) % entriesPerPage ) * entrySize;
+    }
+
+    private long rebase( long index )
+    {
+        return index - base;
+    }
+
+    protected void setDefaultValue( PageCursor writeCursor, long defaultValue ) throws IOException
+    {
+        if ( entrySize == Integer.BYTES )
+        {
+            defaultValue |= defaultValue << 32;
+        }
         goTo( writeCursor, 0 );
+        int pageSize = pagedFile.pageSize();
+        fillPageWithDefaultValue( writeCursor, defaultValue, pageSize );
+        if ( pageId( length - 1 ) > 0 )
+        {
+            try ( PageCursor cursor = pagedFile.io( 1, PF_NO_GROW | PF_SHARED_WRITE_LOCK ) )
+            {
+                while ( cursor.next() )
+                {
+                    writeCursor.copyTo( 0, cursor, 0, pageSize );
+                }
+            }
+        }
+    }
+
+    protected void fillPageWithDefaultValue( PageCursor writeCursor, long defaultValue, int pageSize )
+    {
+        int longsInPage = pageSize / Long.BYTES;
+        for ( int i = 0; i < longsInPage; i++ )
+        {
+            writeCursor.putLong( defaultValue );
+        }
     }
 
     @Override
     public long length()
     {
-        try
-        {
-            return pagedFile.getLastPageId() * entriesPerPage;
-        }
-        catch ( IOException e )
-        {
-            throw new RuntimeException( e );
-        }
+        return length;
     }
 
     @Override
     public void clear()
     {
+        try
+        {
+            setDefaultValue( writeCursor, defaultValue );
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
     }
 
     @Override
     public void close()
     {
-        readCursor.close();
-        writeCursor.close();
+        if ( closed )
+        {
+            return;
+        }
         try
         {
+            readCursor.close();
+            writeCursor.close();
             pagedFile.close();
         }
         catch ( IOException e )
         {
-            throw new RuntimeException( e );
+            throw new UncheckedIOException( e );
+        }
+        finally
+        {
+            closed = true;
         }
     }
 
@@ -99,11 +178,26 @@ public abstract class PageCacheNumberArray<N extends NumberArray<N>> implements 
         }
     }
 
-    protected void goTo( PageCursor cursor, long pageId ) throws IOException
+    protected PageCursor goTo( PageCursor cursor, long pageId ) throws IOException
     {
         if ( !cursor.next( pageId ) )
         {
             throw new IllegalStateException();
         }
+        return cursor;
+    }
+
+    protected PageCursor writeCursor( long pageId ) throws IOException
+    {
+        return goTo( writeCursor, pageId );
+    }
+
+    protected PageCursor readCursor( long pageId ) throws IOException
+    {
+        if ( writeCursor.getCurrentPageId() == pageId )
+        {
+            return writeCursor;
+        }
+        return goTo( readCursor, pageId );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheNumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheNumberArray.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache;
+
+import java.io.IOException;
+
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.io.pagecache.PagedFile;
+
+import static org.neo4j.io.ByteUnit.kibiBytes;
+
+public abstract class PageCacheNumberArray<N extends NumberArray<N>> implements NumberArray<N>
+{
+    static final int PAGE_SIZE = (int) kibiBytes( 8 );
+
+    protected final PagedFile pagedFile;
+    protected final PageCursor readCursor;
+    protected final PageCursor writeCursor;
+    private final int entriesPerPage;
+    private final int entrySize;
+
+    public PageCacheNumberArray( PagedFile pagedFile, int entriesPerPage, int entrySize ) throws IOException
+    {
+        this.pagedFile = pagedFile;
+        this.entriesPerPage = entriesPerPage;
+        this.entrySize = entrySize;
+        this.readCursor = pagedFile.io( 0, PagedFile.PF_SHARED_READ_LOCK );
+        this.writeCursor = pagedFile.io( 0, PagedFile.PF_SHARED_WRITE_LOCK );
+        goTo( writeCursor, 0 );
+    }
+
+    @Override
+    public long length()
+    {
+        try
+        {
+            return pagedFile.getLastPageId() * entriesPerPage;
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( e );
+        }
+    }
+
+    @Override
+    public void clear()
+    {
+    }
+
+    @Override
+    public void close()
+    {
+        readCursor.close();
+        writeCursor.close();
+        try
+        {
+            pagedFile.close();
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( e );
+        }
+    }
+
+    @Override
+    public N at( long index )
+    {
+        return (N) this;
+    }
+
+    @Override
+    public void acceptMemoryStatsVisitor( MemoryStatsVisitor visitor )
+    {
+        visitor.offHeapUsage( length() * entrySize );
+    }
+
+    protected void checkBounds( PageCursor cursor )
+    {
+        if ( cursor.checkAndClearBoundsFlag() )
+        {
+            throw new IllegalStateException();
+        }
+    }
+
+    protected void goTo( PageCursor cursor, long pageId ) throws IOException
+    {
+        if ( !cursor.next( pageId ) )
+        {
+            throw new IllegalStateException();
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCachedNumberArrayFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCachedNumberArrayFactory.java
@@ -29,12 +29,16 @@ import org.neo4j.io.pagecache.PagedFile;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.DELETE_ON_CLOSE;
 
+/**
+ * Factory of page cache backed number arrays.
+ * @see NumberArrayFactory
+ */
 public class PageCachedNumberArrayFactory extends NumberArrayFactory.Adapter
 {
     private final PageCache pageCache;
     private final File storeDir;
 
-    public PageCachedNumberArrayFactory( PageCache pageCache, File storeDir )
+    PageCachedNumberArrayFactory( PageCache pageCache, File storeDir )
     {
         this.pageCache = pageCache;
         this.storeDir = storeDir;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCachedNumberArrayFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCachedNumberArrayFactory.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.io.pagecache.PagedFile;
+
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.DELETE_ON_CLOSE;
+
+public class PageCachedNumberArrayFactory extends NumberArrayFactory.Adapter
+{
+    private final PageCache pageCache;
+    private final File storeDir;
+
+    public PageCachedNumberArrayFactory( PageCache pageCache, File storeDir )
+    {
+        this.pageCache = pageCache;
+        this.storeDir = storeDir;
+    }
+
+    @Override
+    public IntArray newIntArray( long length, int defaultValue, long base )
+    {
+        try
+        {
+            File tempFile = File.createTempFile( "intArray", ".tmp", storeDir );
+            PagedFile pagedFile = pageCache.map( tempFile, pageCache.pageSize(), DELETE_ON_CLOSE, CREATE );
+            return new PageCacheIntArray( pagedFile, length, defaultValue, base );
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    @Override
+    public LongArray newLongArray( long length, long defaultValue, long base )
+    {
+        try
+        {
+            File tempFile = File.createTempFile( "longArray", ".tmp", storeDir );
+            PagedFile pagedFile = pageCache.map( tempFile, pageCache.pageSize(), DELETE_ON_CLOSE, CREATE );
+            return new PageCacheLongArray( pagedFile, length, defaultValue, base );
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+
+    @Override
+    public ByteArray newByteArray( long length, byte[] defaultValue, long base )
+    {
+        try
+        {
+            File tempFile = File.createTempFile( "byteArray", ".tmp", storeDir );
+            PagedFile pagedFile = pageCache.map( tempFile, pageCache.pageSize(), DELETE_ON_CLOSE, CREATE );
+            return new PageCacheByteArray( pagedFile, length, defaultValue, base );
+        }
+        catch ( IOException e )
+        {
+            throw new UncheckedIOException( e );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/AbstractTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/AbstractTracker.java
@@ -43,9 +43,9 @@ abstract class AbstractTracker<ARRAY extends NumberArray> implements Tracker
     }
 
     @Override
-    public void swap( long fromIndex, long toIndex, int count )
+    public void swap( long fromIndex, long toIndex )
     {
-        array.swap( fromIndex, toIndex, count );
+        array.swap( fromIndex, toIndex );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
@@ -397,7 +397,7 @@ public class EncodingIdMapper implements IdMapper
                     if ( dataIndexA > dataIndexB )
                     {
                         // Swap so that lower tracker index means lower data index. TODO Why do we do this?
-                        trackerCache.swap( i, i + 1, 1 );
+                        trackerCache.swap( i, i + 1 );
                     }
 
                     if ( collision != ID_NOT_FOUND )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/ParallelSort.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/ParallelSort.java
@@ -273,7 +273,7 @@ public class ParallelSort
             long li = leftIndex, ri = rightIndex - 2, pi = pivotIndex;
             long pivot = clearCollision( dataCache.get( tracker.get( pi ) ) );
             // save pivot in last index
-            tracker.swap( pi, rightIndex - 1, 1 );
+            tracker.swap( pi, rightIndex - 1 );
             long left = clearCollision( dataCache.get( tracker.get( li ) ) );
             long right = clearCollision( dataCache.get( tracker.get( ri ) ) );
             while ( li < ri )
@@ -288,7 +288,7 @@ public class ParallelSort
                 }
                 else
                 {   // this value is on the wrong side of the pivot, swapping
-                    tracker.swap( li, ri, 1 );
+                    tracker.swap( li, ri );
                     long temp = left;
                     left = right;
                     right = temp;
@@ -300,7 +300,7 @@ public class ParallelSort
                 partingIndex++;
             }
             // restore pivot
-            tracker.swap( rightIndex - 1, partingIndex, 1 );
+            tracker.swap( rightIndex - 1, partingIndex );
             return partingIndex;
         }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Tracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Tracker.java
@@ -48,7 +48,7 @@ public interface Tracker extends MemoryStatsVisitor.Visitable, AutoCloseable
     long get( long index );
 
     /**
-     * Swaps values from {@code fromIndex} to {@code toIndex}, as many items as {@code count} specifies.
+     * Swaps values from {@code fromIndex} to {@code toIndex}.
      *
      * @param fromIndex index to swap from.
      * @param toIndex index to swap to.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Tracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Tracker.java
@@ -52,9 +52,8 @@ public interface Tracker extends MemoryStatsVisitor.Visitable, AutoCloseable
      *
      * @param fromIndex index to swap from.
      * @param toIndex index to swap to.
-     * @param count number of items to swap.
      */
-    void swap( long fromIndex, long toIndex, int count );
+    void swap( long fromIndex, long toIndex );
 
     /**
      * Sets {@code value} at the specified {@code index}.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Input.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Input.java
@@ -21,6 +21,7 @@ package org.neo4j.unsafe.impl.batchimport.input;
 
 import org.neo4j.unsafe.impl.batchimport.BatchImporter;
 import org.neo4j.unsafe.impl.batchimport.InputIterable;
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerator;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
 
@@ -50,8 +51,9 @@ public interface Input
      * @return {@link IdMapper} which will get populated by {@link InputNode#id() input node ids}
      * and later queried by {@link InputRelationship#startNode()} and {@link InputRelationship#endNode()} ids
      * to resolve potentially temporary input node ids to actual node ids in the database.
+     * @param numberArrayFactory The factory for creating data-structures to use for caching internally in the IdMapper.
      */
-    IdMapper idMapper();
+    IdMapper idMapper( NumberArrayFactory numberArrayFactory );
 
     /**
      * @return {@link IdGenerator} which is responsible for generating actual node ids from input node ids.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Inputs.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Inputs.java
@@ -22,6 +22,7 @@ package org.neo4j.unsafe.impl.batchimport.input;
 import java.io.File;
 
 import org.neo4j.unsafe.impl.batchimport.InputIterable;
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerator;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
 import org.neo4j.unsafe.impl.batchimport.input.csv.Configuration;
@@ -58,7 +59,7 @@ public class Inputs
             }
 
             @Override
-            public IdMapper idMapper()
+            public IdMapper idMapper( NumberArrayFactory numberArrayFactory )
             {
                 return idMapper;
             }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInput.java
@@ -25,6 +25,7 @@ import org.neo4j.csv.reader.CharSeeker;
 import org.neo4j.kernel.impl.util.Validators;
 import org.neo4j.unsafe.impl.batchimport.InputIterable;
 import org.neo4j.unsafe.impl.batchimport.InputIterator;
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerator;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
 import org.neo4j.unsafe.impl.batchimport.input.Collector;
@@ -148,9 +149,9 @@ public class CsvInput implements Input
     }
 
     @Override
-    public IdMapper idMapper()
+    public IdMapper idMapper( NumberArrayFactory numberArrayFactory )
     {
-        return idType.idMapper();
+        return idType.idMapper( numberArrayFactory );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/IdType.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/IdType.java
@@ -21,13 +21,12 @@ package org.neo4j.unsafe.impl.batchimport.input.csv;
 
 import org.neo4j.csv.reader.Extractor;
 import org.neo4j.csv.reader.Extractors;
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerator;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerators;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMappers;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
-
-import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO;
 
 /**
  * Defines different types that input ids can come in. Enum names in here are user facing.
@@ -49,9 +48,9 @@ public enum IdType
         }
 
         @Override
-        public IdMapper idMapper()
+        public IdMapper idMapper( NumberArrayFactory numberArrayFactory )
         {
-            return IdMappers.strings( AUTO );
+            return IdMappers.strings( numberArrayFactory );
         }
 
         @Override
@@ -74,9 +73,9 @@ public enum IdType
         }
 
         @Override
-        public IdMapper idMapper()
+        public IdMapper idMapper( NumberArrayFactory numberArrayFactory )
         {
-            return IdMappers.longs( AUTO );
+            return IdMappers.longs( numberArrayFactory );
         }
 
         @Override
@@ -99,7 +98,7 @@ public enum IdType
         }
 
         @Override
-        public IdMapper idMapper()
+        public IdMapper idMapper( NumberArrayFactory numberArrayFactory )
         {
             return IdMappers.actual();
         }
@@ -118,7 +117,7 @@ public enum IdType
         this.idsAreExternal = idsAreExternal;
     }
 
-    public abstract IdMapper idMapper();
+    public abstract IdMapper idMapper( NumberArrayFactory numberArrayFactory );
 
     public abstract IdGenerator idGenerator();
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
@@ -283,6 +283,11 @@ public class BatchingNeoStores implements AutoCloseable, MemoryStatsVisitor.Visi
         return neoStores.getCounts();
     }
 
+    public PageCache getPageCache()
+    {
+        return pageCache;
+    }
+
     @Override
     public void close() throws IOException
     {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
@@ -283,11 +283,6 @@ public class BatchingNeoStores implements AutoCloseable, MemoryStatsVisitor.Visi
         return neoStores.getCounts();
     }
 
-    public PageCache getPageCache()
-    {
-        return pageCache;
-    }
-
     @Override
     public void close() throws IOException
     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsComputerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsComputerTest.java
@@ -55,6 +55,7 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.rule.PageCacheRule;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.kernel.impl.store.counts.keys.CountsKeyFactory.nodeKey;
@@ -327,7 +328,8 @@ public class CountsComputerTest
             int highLabelId = (int) neoStores.getLabelTokenStore().getHighId();
             int highRelationshipTypeId = (int) neoStores.getRelationshipTypeTokenStore().getHighId();
             CountsComputer countsComputer = new CountsComputer(
-                    lastCommittedTransactionId, nodeStore, relationshipStore, highLabelId, highRelationshipTypeId );
+                    lastCommittedTransactionId, nodeStore, relationshipStore, highLabelId, highRelationshipTypeId,
+                    NumberArrayFactory.AUTO );
             CountsTracker countsTracker = createCountsTracker();
             life.add( countsTracker.setInitializer( countsComputer ) );
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsComputerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/counts/CountsComputerTest.java
@@ -329,7 +329,7 @@ public class CountsComputerTest
             int highRelationshipTypeId = (int) neoStores.getRelationshipTypeTokenStore().getHighId();
             CountsComputer countsComputer = new CountsComputer(
                     lastCommittedTransactionId, nodeStore, relationshipStore, highLabelId, highRelationshipTypeId,
-                    NumberArrayFactory.AUTO );
+                    NumberArrayFactory.AUTO_WITHOUT_PAGECACHE );
             CountsTracker countsTracker = createCountsTracker();
             life.add( countsTracker.setInitializer( countsComputer ) );
         }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsProcessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsProcessorTest.java
@@ -87,7 +87,7 @@ public class RelationshipCountsProcessorTest
         when( nodeLabelCache.get( eq( client ), eq( 4L ), any( int[].class ) ) ).thenReturn( new int[]{} );
 
         RelationshipCountsProcessor countsProcessor = new RelationshipCountsProcessor( nodeLabelCache, labels,
-                relationTypes, countsUpdater, NumberArrayFactory.AUTO );
+                relationTypes, countsUpdater, NumberArrayFactory.AUTO_WITHOUT_PAGECACHE );
 
         countsProcessor.process( 1, 0, 3 );
         countsProcessor.process( 2, 1, 4 );

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupDefragmenterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupDefragmenterTest.java
@@ -59,6 +59,7 @@ import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.neo4j.kernel.impl.store.record.RecordLoad.CHECK;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO;
 
 @RunWith( Parameterized.class )
 public class RelationshipGroupDefragmenterTest
@@ -192,7 +193,7 @@ public class RelationshipGroupDefragmenterTest
     {
         Monitor monitor = mock( Monitor.class );
         RelationshipGroupDefragmenter defragmenter = new RelationshipGroupDefragmenter( CONFIG,
-                ExecutionMonitors.invisible(), monitor );
+                ExecutionMonitors.invisible(), monitor, AUTO );
 
         // Calculation below correlates somewhat to calculation in RelationshipGroupDefragmenter.
         // Anyway we verify below that we exercise the multi-pass bit, which is what we want

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupDefragmenterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipGroupDefragmenterTest.java
@@ -59,7 +59,7 @@ import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.neo4j.kernel.impl.store.record.RecordLoad.CHECK;
-import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO_WITHOUT_PAGECACHE;
 
 @RunWith( Parameterized.class )
 public class RelationshipGroupDefragmenterTest
@@ -193,7 +193,7 @@ public class RelationshipGroupDefragmenterTest
     {
         Monitor monitor = mock( Monitor.class );
         RelationshipGroupDefragmenter defragmenter = new RelationshipGroupDefragmenter( CONFIG,
-                ExecutionMonitors.invisible(), monitor, AUTO );
+                ExecutionMonitors.invisible(), monitor, AUTO_WITHOUT_PAGECACHE );
 
         // Calculation below correlates somewhat to calculation in RelationshipGroupDefragmenter.
         // Anyway we verify below that we exercise the multi-pass bit, which is what we want

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/ByteArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/ByteArrayTest.java
@@ -39,10 +39,10 @@ import org.neo4j.io.pagecache.PageCache;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO_WITHOUT_PAGECACHE;
 import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.HEAP;
 import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.OFF_HEAP;
-import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.autoWithPageCacheFallback;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.auto;
 
 @RunWith( Parameterized.class )
 public class ByteArrayTest extends NumberArrayPageCacheTestSupport
@@ -57,16 +57,16 @@ public class ByteArrayTest extends NumberArrayPageCacheTestSupport
         fixture = prepareDirectoryAndPageCache( ByteArrayTest.class );
         PageCache pageCache = fixture.pageCache;
         File dir = fixture.directory;
-        NumberArrayFactory autoWithPageCacheFallback = autoWithPageCacheFallback( pageCache, dir );
+        NumberArrayFactory autoWithPageCacheFallback = auto( pageCache, dir );
         NumberArrayFactory pageCacheArrayFactory = new PageCachedNumberArrayFactory( pageCache, dir );
-        int chunkSize = LENGTH / 10;
+        int chunkSize = LENGTH / ChunkedNumberArrayFactory.MAGIC_CHUNK_COUNT;
         return Arrays.asList(
                 () -> HEAP.newByteArray( LENGTH, DEFAULT ),
                 () -> HEAP.newDynamicByteArray( chunkSize, DEFAULT ),
                 () -> OFF_HEAP.newByteArray( LENGTH, DEFAULT ),
                 () -> OFF_HEAP.newDynamicByteArray( chunkSize, DEFAULT ),
-                () -> AUTO.newByteArray( LENGTH, DEFAULT ),
-                () -> AUTO.newDynamicByteArray( chunkSize, DEFAULT ),
+                () -> AUTO_WITHOUT_PAGECACHE.newByteArray( LENGTH, DEFAULT ),
+                () -> AUTO_WITHOUT_PAGECACHE.newDynamicByteArray( chunkSize, DEFAULT ),
                 () -> autoWithPageCacheFallback.newByteArray( LENGTH, DEFAULT ),
                 () -> autoWithPageCacheFallback.newDynamicByteArray( chunkSize, DEFAULT ),
                 () -> pageCacheArrayFactory.newByteArray( LENGTH, DEFAULT ),

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/ByteArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/ByteArrayTest.java
@@ -20,6 +20,7 @@
 package org.neo4j.unsafe.impl.batchimport.cache;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,27 +28,56 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 
+import org.neo4j.io.pagecache.PageCache;
+
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.HEAP;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.OFF_HEAP;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.autoWithPageCacheFallback;
 
 @RunWith( Parameterized.class )
-public class ByteArrayTest
+public class ByteArrayTest extends NumberArrayPageCacheTestSupport
 {
     private static final byte[] DEFAULT = new byte[25];
+    private static final int LENGTH = 1_000;
+    private static Fixture fixture;
 
     @Parameters
-    public static Collection<Supplier<ByteArray>> data()
+    public static Collection<Supplier<ByteArray>> data() throws IOException
     {
+        fixture = prepareDirectoryAndPageCache( ByteArrayTest.class );
+        PageCache pageCache = fixture.pageCache;
+        File dir = fixture.directory;
+        NumberArrayFactory autoWithPageCacheFallback = autoWithPageCacheFallback( pageCache, dir );
+        NumberArrayFactory pageCacheArrayFactory = new PageCachedNumberArrayFactory( pageCache, dir );
+        int chunkSize = LENGTH / 10;
         return Arrays.asList(
-                () -> NumberArrayFactory.HEAP.newByteArray( 1_000, DEFAULT ),
-                () -> NumberArrayFactory.HEAP.newDynamicByteArray( 100, DEFAULT ),
-                () -> NumberArrayFactory.OFF_HEAP.newByteArray( 1_000, DEFAULT ),
-                () -> NumberArrayFactory.OFF_HEAP.newDynamicByteArray( 100, DEFAULT ),
-                () -> NumberArrayFactory.AUTO.newByteArray( 1_000, DEFAULT ),
-                () -> NumberArrayFactory.AUTO.newDynamicByteArray( 100, DEFAULT ) );
+                () -> HEAP.newByteArray( LENGTH, DEFAULT ),
+                () -> HEAP.newDynamicByteArray( chunkSize, DEFAULT ),
+                () -> OFF_HEAP.newByteArray( LENGTH, DEFAULT ),
+                () -> OFF_HEAP.newDynamicByteArray( chunkSize, DEFAULT ),
+                () -> AUTO.newByteArray( LENGTH, DEFAULT ),
+                () -> AUTO.newDynamicByteArray( chunkSize, DEFAULT ),
+                () -> autoWithPageCacheFallback.newByteArray( LENGTH, DEFAULT ),
+                () -> autoWithPageCacheFallback.newDynamicByteArray( chunkSize, DEFAULT ),
+                () -> pageCacheArrayFactory.newByteArray( LENGTH, DEFAULT ),
+                () -> pageCacheArrayFactory.newDynamicByteArray( chunkSize, DEFAULT )
+        );
+    }
+
+    @AfterClass
+    public static void closeFixture() throws Exception
+    {
+        fixture.close();
     }
 
     @Parameter
@@ -69,19 +99,58 @@ public class ByteArrayTest
     @Test
     public void shouldSetAndGetBasicTypes() throws Exception
     {
-        // WHEN
-        array.setByte( 0, 0, (byte) 123 );
-        array.setShort( 0, 1, (short) 1234 );
-        array.setInt( 0, 5, 12345 );
-        array.setLong( 0, 9, Long.MAX_VALUE - 100 );
-        array.set3ByteInt( 0, 17, 76767 );
+        int index = 0;
+        byte[] actualBytes = new byte[DEFAULT.length];
+        byte[] expectedBytes = new byte[actualBytes.length];
+        ThreadLocalRandom.current().nextBytes( actualBytes );
 
-        // THEN
-        assertEquals( (byte) 123, array.getByte( 0, 0 ) );
-        assertEquals( (short) 1234, array.getShort( 0, 1 ) );
-        assertEquals( 12345, array.getInt( 0, 5 ) );
-        assertEquals( Long.MAX_VALUE - 100, array.getLong( 0, 9 ) );
-        assertEquals( 76767, array.get3ByteInt( 0, 17 ) );
+        int len = LENGTH - 1; // subtract one because we access TWO elements.
+        for ( int i = 0; i < len; i++ )
+        {
+            try
+            {
+                // WHEN
+                setSimpleValues( index );
+                setArray( index + 1, actualBytes );
+
+                // THEN
+                verifySimpleValues( index );
+                verifyArray( index + 1, actualBytes, expectedBytes );
+            }
+            catch ( Throwable throwable )
+            {
+                throw new AssertionError( "Failure at index " + i, throwable );
+            }
+        }
+    }
+
+    private void setSimpleValues( int index )
+    {
+        array.setByte( index, 0, (byte) 123 );
+        array.setShort( index, 1, (short) 1234 );
+        array.setInt( index, 5, 12345 );
+        array.setLong( index, 9, Long.MAX_VALUE - 100 );
+        array.set3ByteInt( index, 17, 76767 );
+    }
+
+    private void setArray( int index, byte[] bytes )
+    {
+        array.set( index, bytes );
+    }
+
+    private void verifySimpleValues( int index )
+    {
+        assertEquals( (byte) 123, array.getByte( index, 0 ) );
+        assertEquals( (short) 1234, array.getShort( index, 1 ) );
+        assertEquals( 12345, array.getInt( index, 5 ) );
+        assertEquals( Long.MAX_VALUE - 100, array.getLong( index, 9 ) );
+        assertEquals( 76767, array.get3ByteInt( index, 17 ) );
+    }
+
+    private void verifyArray( int index, byte[] actualBytes, byte[] scratchBuffer )
+    {
+        array.get( index, scratchBuffer );
+        assertArrayEquals( actualBytes, scratchBuffer );
     }
 
     @Test
@@ -94,5 +163,15 @@ public class ByteArrayTest
         // THEN
         assertEquals( -1L, array.get6ByteLong( 10, 2 ) );
         assertEquals( -1L, array.get6ByteLong( 10, 8 ) );
+    }
+
+    @Test
+    public void shouldHandleMultipleCallsToClose() throws Exception
+    {
+        // WHEN
+        array.close();
+
+        // THEN should also work
+        array.close();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicIntArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicIntArrayTest.java
@@ -30,7 +30,7 @@ public class DynamicIntArrayTest
     {
         // GIVEN
         int defaultValue = 0;
-        IntArray array = NumberArrayFactory.AUTO.newDynamicIntArray( 10, defaultValue );
+        IntArray array = NumberArrayFactory.AUTO_WITHOUT_PAGECACHE.newDynamicIntArray( 10, defaultValue );
         array.set( 4, 5 );
 
         // WHEN
@@ -44,7 +44,7 @@ public class DynamicIntArrayTest
     public void shouldChunksAsNeeded() throws Exception
     {
         // GIVEN
-        IntArray array = NumberArrayFactory.AUTO.newDynamicIntArray( 10, 0 );
+        IntArray array = NumberArrayFactory.AUTO_WITHOUT_PAGECACHE.newDynamicIntArray( 10, 0 );
 
         // WHEN
         long index = 243;

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicLongArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicLongArrayTest.java
@@ -30,7 +30,7 @@ public class DynamicLongArrayTest
     {
         // GIVEN
         long defaultValue = 0;
-        LongArray array = NumberArrayFactory.AUTO.newDynamicLongArray( 10, defaultValue );
+        LongArray array = NumberArrayFactory.AUTO_WITHOUT_PAGECACHE.newDynamicLongArray( 10, defaultValue );
         array.set( 4, 5 );
 
         // WHEN
@@ -44,7 +44,7 @@ public class DynamicLongArrayTest
     public void shouldChunksAsNeeded() throws Exception
     {
         // GIVEN
-        LongArray array = NumberArrayFactory.AUTO.newDynamicLongArray( 10, 0 );
+        LongArray array = NumberArrayFactory.AUTO_WITHOUT_PAGECACHE.newDynamicLongArray( 10, 0 );
 
         // WHEN
         long index = 243;

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/IntArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/IntArrayTest.java
@@ -20,21 +20,31 @@
 package org.neo4j.unsafe.impl.batchimport.cache;
 
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Random;
 
+import org.neo4j.io.pagecache.PageCache;
+
 import static java.lang.System.currentTimeMillis;
 import static org.junit.Assert.assertEquals;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.HEAP;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.OFF_HEAP;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.autoWithPageCacheFallback;
 
 @RunWith( Parameterized.class )
-public class IntArrayTest
+public class IntArrayTest extends NumberArrayPageCacheTestSupport
 {
+    private static Fixture fixture;
+
     @Test
     public void shouldHandleSomeRandomSetAndGet() throws Exception
     {
@@ -62,29 +72,49 @@ public class IntArrayTest
                 assertEquals( "Seed:" + seed, expected[index], array.get( index ) );
                 break;
             default: // swap
-                int items = Math.min( random.nextInt( 10 ) + 1, length - index );
-                int toIndex = (index + length / 2) % (length - items);
-                array.swap( index, toIndex, items );
-                swap( expected, index, toIndex, items );
+                int toIndex = random.nextInt( length );
+                array.swap( index, toIndex );
+                swap( expected, index, toIndex );
                 break;
             }
         }
     }
 
-    private void swap( long[] expected, int fromIndex, int toIndex, int items )
+    @Test
+    public void shouldHandleMultipleCallsToClose() throws Exception
     {
-        for ( int i = 0; i < items; i++ )
-        {
-            long fromValue = expected[fromIndex + i];
-            expected[fromIndex + i] = expected[toIndex + i];
-            expected[toIndex + i] = fromValue;
-        }
+        // GIVEN
+        NumberArray<?> array = newArray( 10, -1 );
+
+        // WHEN
+        array.close();
+
+        // THEN should also work
+        array.close();
+    }
+
+    private void swap( long[] expected, int fromIndex, int toIndex )
+    {
+        long fromValue = expected[fromIndex];
+        expected[fromIndex] = expected[toIndex];
+        expected[toIndex] = fromValue;
     }
 
     @Parameters
-    public static Collection<NumberArrayFactory> data()
+    public static Collection<NumberArrayFactory> data() throws IOException
     {
-        return Arrays.asList( NumberArrayFactory.HEAP, NumberArrayFactory.OFF_HEAP );
+        fixture = prepareDirectoryAndPageCache( IntArrayTest.class );
+        PageCache pageCache = fixture.pageCache;
+        File dir = fixture.directory;
+        NumberArrayFactory autoWithPageCacheFallback = autoWithPageCacheFallback( pageCache, dir );
+        NumberArrayFactory pageCacheArrayFactory = new PageCachedNumberArrayFactory( pageCache, dir );
+        return Arrays.asList( HEAP, OFF_HEAP, autoWithPageCacheFallback, pageCacheArrayFactory );
+    }
+
+    @AfterClass
+    public static void closeFixture() throws Exception
+    {
+        fixture.close();
     }
 
     public IntArrayTest( NumberArrayFactory factory )

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/IntArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/IntArrayTest.java
@@ -38,7 +38,7 @@ import static java.lang.System.currentTimeMillis;
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.HEAP;
 import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.OFF_HEAP;
-import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.autoWithPageCacheFallback;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.auto;
 
 @RunWith( Parameterized.class )
 public class IntArrayTest extends NumberArrayPageCacheTestSupport
@@ -106,7 +106,7 @@ public class IntArrayTest extends NumberArrayPageCacheTestSupport
         fixture = prepareDirectoryAndPageCache( IntArrayTest.class );
         PageCache pageCache = fixture.pageCache;
         File dir = fixture.directory;
-        NumberArrayFactory autoWithPageCacheFallback = autoWithPageCacheFallback( pageCache, dir );
+        NumberArrayFactory autoWithPageCacheFallback = auto( pageCache, dir );
         NumberArrayFactory pageCacheArrayFactory = new PageCachedNumberArrayFactory( pageCache, dir );
         return Arrays.asList( HEAP, OFF_HEAP, autoWithPageCacheFallback, pageCacheArrayFactory );
     }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/LongArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/LongArrayTest.java
@@ -38,7 +38,7 @@ import static java.lang.System.currentTimeMillis;
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.HEAP;
 import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.OFF_HEAP;
-import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.autoWithPageCacheFallback;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.auto;
 
 @RunWith( Parameterized.class )
 public class LongArrayTest extends NumberArrayPageCacheTestSupport
@@ -106,7 +106,7 @@ public class LongArrayTest extends NumberArrayPageCacheTestSupport
         fixture = prepareDirectoryAndPageCache( LongArrayTest.class );
         PageCache pageCache = fixture.pageCache;
         File dir = fixture.directory;
-        NumberArrayFactory autoWithPageCacheFallback = autoWithPageCacheFallback( pageCache, dir );
+        NumberArrayFactory autoWithPageCacheFallback = auto( pageCache, dir );
         NumberArrayFactory pageCacheArrayFactory = new PageCachedNumberArrayFactory( pageCache, dir );
         return Arrays.asList( HEAP, OFF_HEAP, autoWithPageCacheFallback, pageCacheArrayFactory );
     }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NodeLabelsCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NodeLabelsCacheTest.java
@@ -36,7 +36,7 @@ public class NodeLabelsCacheTest
     public void shouldCacheSmallSetOfLabelsPerNode() throws Exception
     {
         // GIVEN
-        NodeLabelsCache cache = new NodeLabelsCache( NumberArrayFactory.AUTO, 5, CHUNK_SIZE );
+        NodeLabelsCache cache = new NodeLabelsCache( NumberArrayFactory.AUTO_WITHOUT_PAGECACHE, 5, CHUNK_SIZE );
         NodeLabelsCache.Client client = cache.newClient();
         long nodeId = 0;
 
@@ -54,7 +54,7 @@ public class NodeLabelsCacheTest
     {
         // GIVEN
         int highLabelId = 1000;
-        NodeLabelsCache cache = new NodeLabelsCache( NumberArrayFactory.AUTO, highLabelId, CHUNK_SIZE );
+        NodeLabelsCache cache = new NodeLabelsCache( NumberArrayFactory.AUTO_WITHOUT_PAGECACHE, highLabelId, CHUNK_SIZE );
         NodeLabelsCache.Client client = cache.newClient();
         long nodeId = 0;
 
@@ -73,7 +73,7 @@ public class NodeLabelsCacheTest
     {
         // GIVEN a really weird scenario where we have 5000 different labels
         int highLabelId = 1_000;
-        NodeLabelsCache cache = new NodeLabelsCache( NumberArrayFactory.AUTO, highLabelId, 1_000_000 );
+        NodeLabelsCache cache = new NodeLabelsCache( NumberArrayFactory.AUTO_WITHOUT_PAGECACHE, highLabelId, 1_000_000 );
         NodeLabelsCache.Client client = cache.newClient();
         int numberOfNodes = 100_000;
         int[][] expectedLabels = new int[numberOfNodes][];
@@ -97,7 +97,7 @@ public class NodeLabelsCacheTest
     public void shouldEndTargetArrayWithMinusOne() throws Exception
     {
         // GIVEN
-        NodeLabelsCache cache = new NodeLabelsCache( NumberArrayFactory.AUTO, 10 );
+        NodeLabelsCache cache = new NodeLabelsCache( NumberArrayFactory.AUTO_WITHOUT_PAGECACHE, 10 );
         NodeLabelsCache.Client client = cache.newClient();
         cache.put( 10, new long[] { 5, 6, 7, 8 } );
 
@@ -117,7 +117,7 @@ public class NodeLabelsCacheTest
     public void shouldReturnEmptyArrayForNodeWithNoLabelsAndNoLabelsWhatsoever() throws Exception
     {
         // GIVEN
-        NodeLabelsCache cache = new NodeLabelsCache( NumberArrayFactory.AUTO, 0 );
+        NodeLabelsCache cache = new NodeLabelsCache( NumberArrayFactory.AUTO_WITHOUT_PAGECACHE, 0 );
         NodeLabelsCache.Client client = cache.newClient();
 
         // WHEN
@@ -134,7 +134,7 @@ public class NodeLabelsCacheTest
         // GIVEN
         int highLabelId = 10, numberOfNodes = 100;
         int[][] expectedLabels = new int[numberOfNodes][];
-        NodeLabelsCache cache = new NodeLabelsCache( NumberArrayFactory.AUTO, highLabelId );
+        NodeLabelsCache cache = new NodeLabelsCache( NumberArrayFactory.AUTO_WITHOUT_PAGECACHE, highLabelId );
         for ( int i = 0; i < numberOfNodes; i++ )
         {
             cache.put( i, asLongArray( expectedLabels[i] = randomLabels( random.nextInt( 5 ), highLabelId ) ) );

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCacheTest.java
@@ -87,7 +87,7 @@ public class NodeRelationshipCacheTest
     public void shouldReportCorrectNumberOfDenseNodes() throws Exception
     {
         // GIVEN
-        cache = new NodeRelationshipCache( NumberArrayFactory.AUTO, 5, 100, base );
+        cache = new NodeRelationshipCache( NumberArrayFactory.AUTO_WITHOUT_PAGECACHE, 5, 100, base );
         cache.setHighNodeId( 26 );
         increment( cache, 2, 10 );
         increment( cache, 5, 2 );
@@ -133,7 +133,7 @@ public class NodeRelationshipCacheTest
     public void shouldObserveFirstRelationshipAsEmptyInEachDirection() throws Exception
     {
         // GIVEN
-        cache = new NodeRelationshipCache( NumberArrayFactory.AUTO, 1, 100, base );
+        cache = new NodeRelationshipCache( NumberArrayFactory.AUTO_WITHOUT_PAGECACHE, 1, 100, base );
         int nodes = 100;
         int typeId = 5;
         Direction[] directions = Direction.values();
@@ -170,7 +170,7 @@ public class NodeRelationshipCacheTest
     public void shouldResetCountAfterGetOnDenseNodes() throws Exception
     {
         // GIVEN
-        cache = new NodeRelationshipCache( NumberArrayFactory.AUTO, 1, 100, base );
+        cache = new NodeRelationshipCache( NumberArrayFactory.AUTO_WITHOUT_PAGECACHE, 1, 100, base );
         long nodeId = 0;
         int typeId = 3;
         cache.setHighNodeId( 1 );

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayPageCacheTestSupport.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayPageCacheTestSupport.java
@@ -35,7 +35,6 @@ public class NumberArrayPageCacheTestSupport
         DefaultFileSystemAbstraction fileSystem = new DefaultFileSystemAbstraction();
         TestDirectory testDirectory = TestDirectory.testDirectory( testClass, fileSystem );
         File dir = testDirectory.prepareDirectoryForTest( "test" );
-        fileSystem.mkdirs( dir );
         PageCache pageCache = StandalonePageCacheFactory.createPageCache( fileSystem );
         return new Fixture( pageCache, fileSystem, dir );
     }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayPageCacheTestSupport.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayPageCacheTestSupport.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.io.pagecache.impl.muninn.StandalonePageCacheFactory;
+import org.neo4j.test.rule.TestDirectory;
+
+public class NumberArrayPageCacheTestSupport
+{
+    public static Fixture prepareDirectoryAndPageCache( Class<?> testClass ) throws IOException
+    {
+        DefaultFileSystemAbstraction fileSystem = new DefaultFileSystemAbstraction();
+        TestDirectory testDirectory = TestDirectory.testDirectory( testClass, fileSystem );
+        File dir = testDirectory.prepareDirectoryForTest( "test" );
+        fileSystem.mkdirs( dir );
+        PageCache pageCache = StandalonePageCacheFactory.createPageCache( fileSystem );
+        return new Fixture( pageCache, fileSystem, dir );
+    }
+
+    public static class Fixture implements AutoCloseable
+    {
+        public final PageCache pageCache;
+        public final FileSystemAbstraction fileSystem;
+        public final File directory;
+
+        private Fixture( PageCache pageCache, FileSystemAbstraction fileSystem, File directory )
+        {
+            this.pageCache = pageCache;
+            this.fileSystem = fileSystem;
+            this.directory = directory;
+        }
+
+        @Override
+        public void close() throws Exception
+        {
+            pageCache.close();
+            fileSystem.close();
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayTest.java
@@ -40,11 +40,11 @@ import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.test.rule.RandomRule;
 
 import static org.junit.Assert.assertEquals;
-import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO_WITHOUT_PAGECACHE;
 import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.CHUNKED_FIXED_SIZE;
 import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.HEAP;
 import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.OFF_HEAP;
-import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.autoWithPageCacheFallback;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.auto;
 
 @RunWith( Parameterized.class )
 public class NumberArrayTest extends NumberArrayPageCacheTestSupport
@@ -75,9 +75,9 @@ public class NumberArrayTest extends NumberArrayPageCacheTestSupport
         Map<String,NumberArrayFactory> factories = new HashMap<>();
         factories.put( "HEAP", HEAP );
         factories.put( "OFF_HEAP", OFF_HEAP );
-        factories.put( "AUTO", AUTO );
+        factories.put( "AUTO_WITHOUT_PAGECACHE", AUTO_WITHOUT_PAGECACHE );
         factories.put( "CHUNKED_FIXED_SIZE", CHUNKED_FIXED_SIZE );
-        factories.put( "autoWithPageCacheFallback", autoWithPageCacheFallback( pageCache, dir ) );
+        factories.put( "autoWithPageCacheFallback", auto( pageCache, dir ) );
         factories.put( "PageCachedNumberArrayFactory", new PageCachedNumberArrayFactory( pageCache, dir ) );
         for ( Map.Entry<String,NumberArrayFactory> entry : factories.entrySet() )
         {

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheByteArrayConcurrencyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheByteArrayConcurrencyTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache;
+
+import java.io.IOException;
+
+import org.neo4j.io.pagecache.PagedFile;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class PageCacheByteArrayConcurrencyTest extends PageCacheNumberArrayConcurrencyTest
+{
+    @Override
+    protected Runnable wholeFileRacer( NumberArray array, int contestant )
+    {
+        return new WholeFileRacer( (ByteArray) array );
+    }
+
+    @Override
+    protected Runnable fileRangeRacer( NumberArray array, int contestant )
+    {
+        return new FileRangeRacer( (ByteArray) array, contestant );
+    }
+
+    @Override
+    protected ByteArray getNumberArray( PagedFile file ) throws IOException
+    {
+        return new PageCacheByteArray( file, COUNT, new byte[]{-1, -1, -1, -1}, 0 );
+    }
+
+    private class WholeFileRacer implements Runnable
+    {
+        private ByteArray array;
+
+        WholeFileRacer( ByteArray array )
+        {
+            this.array = array;
+        }
+
+        @Override
+        public void run()
+        {
+            for ( int o = 0; o < LAPS; o++ )
+            {
+                for ( int i = 0; i < COUNT; i++ )
+                {
+                    byte[] value = {1, 2, 3, 4};
+                    array.set( i, value );
+                    byte[] actual = new byte[4];
+                    array.get( i, actual );
+                    assertArrayEquals( value, actual );
+                }
+            }
+        }
+    }
+
+    private class FileRangeRacer implements Runnable
+    {
+        private ByteArray array;
+        private int contestant;
+
+        FileRangeRacer( ByteArray array, int contestant )
+        {
+            this.array = array;
+            this.contestant = contestant;
+        }
+
+        @Override
+        public void run()
+        {
+            for ( int o = 0; o < LAPS; o++ )
+            {
+                for ( int i = contestant; i < COUNT; i += CONTESTANTS )
+                {
+                    byte[] value = new byte[4];
+                    byte[] actual = new byte[4];
+                    random.nextBytes( value );
+                    array.set( i, value );
+                    array.get( i, actual );
+                    assertArrayEquals( value, actual );
+                }
+            }
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheIntArrayConcurrencyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheIntArrayConcurrencyTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache;
+
+import java.io.IOException;
+
+import org.neo4j.io.pagecache.PagedFile;
+
+import static org.junit.Assert.assertEquals;
+
+public class PageCacheIntArrayConcurrencyTest extends PageCacheNumberArrayConcurrencyTest
+{
+    @Override
+    protected Runnable wholeFileRacer( NumberArray array, int contestant )
+    {
+        return new WholeFileRacer( (PageCacheIntArray) array );
+    }
+
+    @Override
+    protected Runnable fileRangeRacer( NumberArray array, int contestant )
+    {
+        return new FileRangeRacer( (PageCacheIntArray) array, contestant );
+    }
+
+    @Override
+    protected PageCacheIntArray getNumberArray( PagedFile file ) throws IOException
+    {
+        return new PageCacheIntArray( file, COUNT, 0, 0 );
+    }
+
+    private class WholeFileRacer implements Runnable
+    {
+        private IntArray array;
+
+        WholeFileRacer( IntArray array )
+        {
+            this.array = array;
+        }
+
+        @Override
+        public void run()
+        {
+            for ( int o = 0; o < LAPS; o++ )
+            {
+                for ( int i = 0; i < COUNT; i++ )
+                {
+                    array.set( i, i );
+                    assertEquals( i, array.get( i ) );
+                }
+            }
+        }
+    }
+
+    private class FileRangeRacer implements Runnable
+    {
+        private IntArray array;
+        private int contestant;
+
+        FileRangeRacer( IntArray array, int contestant )
+        {
+            this.array = array;
+            this.contestant = contestant;
+        }
+
+        @Override
+        public void run()
+        {
+            for ( int o = 0; o < LAPS; o++ )
+            {
+                for ( int i = contestant; i < COUNT; i += CONTESTANTS )
+                {
+                    int value = random.nextInt();
+                    array.set( i, value );
+                    assertEquals( value, array.get( i ) );
+                }
+            }
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheLongArrayConcurrencyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheLongArrayConcurrencyTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache;
+
+import java.io.IOException;
+
+import org.neo4j.io.pagecache.PagedFile;
+
+import static org.junit.Assert.assertEquals;
+
+public class PageCacheLongArrayConcurrencyTest extends PageCacheNumberArrayConcurrencyTest
+{
+    @Override
+    protected Runnable wholeFileRacer( NumberArray array, int contestant )
+    {
+        return new WholeFileRacer( (PageCacheLongArray) array );
+    }
+
+    @Override
+    protected Runnable fileRangeRacer( NumberArray array, int contestant )
+    {
+        return new FileRangeRacer( (PageCacheLongArray) array, contestant );
+    }
+
+    @Override
+    protected PageCacheLongArray getNumberArray( PagedFile file ) throws IOException
+    {
+        return new PageCacheLongArray( file, COUNT, 0, 0 );
+    }
+
+    private class WholeFileRacer implements Runnable
+    {
+        private LongArray array;
+
+        WholeFileRacer( LongArray array )
+        {
+            this.array = array;
+        }
+
+        @Override
+        public void run()
+        {
+
+            for ( int o = 0; o < LAPS; o++ )
+            {
+                for ( long i = 0; i < COUNT; i++ )
+                {
+                    array.set( i, i );
+                    assertEquals( i, array.get( i ) );
+                }
+            }
+        }
+    }
+
+    private class FileRangeRacer implements Runnable
+    {
+        private LongArray array;
+        private int contestant;
+
+        FileRangeRacer( LongArray array, int contestant )
+        {
+            this.array = array;
+            this.contestant = contestant;
+        }
+
+        @Override
+        public void run()
+        {
+
+            for ( int o = 0; o < LAPS; o++ )
+            {
+                for ( long i = contestant; i < COUNT; i += CONTESTANTS )
+                {
+                    long value = random.nextLong();
+                    array.set( i, value );
+                    assertEquals( value, array.get( i ) );
+                }
+            }
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheLongArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheLongArrayTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.nio.file.StandardOpenOption;
+
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.io.pagecache.PageSwapperFactory;
+import org.neo4j.io.pagecache.impl.SingleFilePageSwapperFactory;
+import org.neo4j.io.pagecache.impl.muninn.MuninnPageCache;
+import org.neo4j.io.pagecache.tracing.PageCacheTracer;
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier;
+import org.neo4j.test.rule.RandomRule;
+import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+import static java.lang.System.currentTimeMillis;
+
+import static org.neo4j.io.ByteUnit.mebiBytes;
+import static org.neo4j.unsafe.impl.batchimport.cache.PageCacheNumberArray.PAGE_SIZE;
+
+public class PageCacheLongArrayTest
+{
+    private static final int COUNT = 100_000_000;
+
+    private final DefaultFileSystemRule fs = new DefaultFileSystemRule();
+    private final TestDirectory dir = TestDirectory.testDirectory();
+    private final RandomRule random = new RandomRule();
+
+    @Rule
+    public final RuleChain ruleChain = RuleChain.outerRule( fs ).around( dir ).around( random );
+
+    @Test
+    public void shouldTest() throws Exception
+    {
+        PageSwapperFactory swapper = new SingleFilePageSwapperFactory();
+        swapper.setFileSystemAbstraction( fs );
+        int pageSize = (int) mebiBytes( 1 );
+        try ( PageCache pageCache = new MuninnPageCache( swapper, 1_000, pageSize, PageCacheTracer.NULL,
+                PageCursorTracerSupplier.NULL );
+              LongArray array = new PageCacheLongArray( pageCache.map( dir.file( "file" ), pageSize,
+                StandardOpenOption.CREATE, StandardOpenOption.WRITE, StandardOpenOption.READ,
+                StandardOpenOption.DELETE_ON_CLOSE ) ) )
+        {
+            test( array );
+        }
+    }
+
+    @Test
+    public void shouldSKjdks() throws Exception
+    {
+        LongArray array = NumberArrayFactory.AUTO.newDynamicLongArray( PAGE_SIZE / Long.BYTES, 0 );
+        test( array );
+    }
+
+    private void test( LongArray array )
+    {
+        long time = currentTimeMillis();
+        for ( int i = 0; i < COUNT; i++ )
+        {
+            array.set( i, i );
+        }
+        long insertTime = currentTimeMillis() - time;
+        time = currentTimeMillis();
+        for ( int i = 0; i < COUNT; i++ )
+        {
+            array.get( i );
+        }
+        long scanTime = currentTimeMillis() - time;
+
+        int stride = 12_345_678;
+        int next = random.nextInt( COUNT );
+        time = currentTimeMillis();
+        for ( int i = 0; i < COUNT; i++ )
+        {
+            array.get( next );
+            next = (next + stride) % COUNT;
+        }
+        long randomTime = currentTimeMillis() - time;
+
+        System.out.println( "insert:" + insertTime + ", scan:" + scanTime + ", random:" + randomTime );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheLongArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheLongArrayTest.java
@@ -53,6 +53,7 @@ public class PageCacheLongArrayTest
     {
         PageCache pageCache = pageCacheRule.getPageCache( fs );
         PagedFile file = pageCache.map( dir.file( "file" ), pageCache.pageSize(), CREATE, DELETE_ON_CLOSE );
+
         try ( LongArray array = new PageCacheLongArray( file, COUNT, 0, 0 ) )
         {
             verifyBehaviour( array );
@@ -64,7 +65,7 @@ public class PageCacheLongArrayTest
     {
         PageCache pageCache = pageCacheRule.getPageCache( fs );
         File directory = dir.directory();
-        NumberArrayFactory numberArrayFactory = NumberArrayFactory.autoWithPageCacheFallback( pageCache, directory );
+        NumberArrayFactory numberArrayFactory = NumberArrayFactory.auto( pageCache, directory );
         try ( LongArray array = numberArrayFactory.newDynamicLongArray( COUNT / 1_000, 0 ) )
         {
             verifyBehaviour( array );

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheNumberArrayConcurrencyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheNumberArrayConcurrencyTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.io.IOException;
+import java.util.function.BiFunction;
+
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.test.Race;
+import org.neo4j.test.rule.PageCacheRule;
+import org.neo4j.test.rule.RandomRule;
+import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.DELETE_ON_CLOSE;
+
+public abstract class PageCacheNumberArrayConcurrencyTest
+{
+    protected static final int COUNT = 100;
+    protected static final int LAPS = 2_000;
+    protected static final int CONTESTANTS = 10;
+
+    private final DefaultFileSystemRule fs = new DefaultFileSystemRule();
+    private final TestDirectory dir = TestDirectory.testDirectory();
+    protected final RandomRule random = new RandomRule();
+    private final PageCacheRule pageCacheRule = new PageCacheRule();
+
+    @Rule
+    public final RuleChain ruleChain = RuleChain.outerRule( fs ).around( dir ).around( random ).around( pageCacheRule );
+
+    @Test
+    public void shouldHandleConcurrentAccessToSameData() throws Throwable
+    {
+        doRace( this::wholeFileRacer );
+    }
+
+    @Test
+    public void shouldHandleConcurrentAccessToDifferentData() throws Throwable
+    {
+        doRace( this::fileRangeRacer );
+    }
+
+    private void doRace( BiFunction<NumberArray,Integer,Runnable> contestantCreator ) throws Throwable
+    {
+        PageCache pageCache = pageCacheRule.getPageCache( fs );
+        PagedFile file = pageCache.map( dir.file( "file" ), pageCache.pageSize(), CREATE, DELETE_ON_CLOSE );
+        Race race = new Race();
+        try ( NumberArray array = getNumberArray( file ) )
+        {
+            for ( int i = 0; i < CONTESTANTS; i++ )
+            {
+                race.addContestant( contestantCreator.apply( array, i ) );
+            }
+            race.go();
+
+        }
+    }
+
+    protected abstract Runnable fileRangeRacer( NumberArray array, int contestant );
+
+    protected abstract NumberArray getNumberArray( PagedFile file ) throws IOException;
+
+    protected abstract Runnable wholeFileRacer( NumberArray array, int contestant );
+
+}

--- a/community/neo4j/src/test/java/schema/MultipleIndexPopulationStressIT.java
+++ b/community/neo4j/src/test/java/schema/MultipleIndexPopulationStressIT.java
@@ -62,6 +62,7 @@ import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 import org.neo4j.unsafe.impl.batchimport.BatchImporter;
 import org.neo4j.unsafe.impl.batchimport.InputIterable;
 import org.neo4j.unsafe.impl.batchimport.ParallelBatchImporter;
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerator;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerators;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
@@ -384,7 +385,7 @@ public class MultipleIndexPopulationStressIT
         }
 
         @Override
-        public IdMapper idMapper()
+        public IdMapper idMapper( NumberArrayFactory numberArrayFactory )
         {
             return IdMappers.actual();
         }

--- a/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/NodeCountInputs.java
+++ b/stresstests/src/test/java/org/neo4j/kernel/stresstests/transaction/checkpoint/NodeCountInputs.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.stresstests.transaction.checkpoint;
 
 import org.neo4j.unsafe.impl.batchimport.InputIterable;
 import org.neo4j.unsafe.impl.batchimport.InputIterator;
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerator;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerators;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
@@ -103,7 +104,7 @@ public class NodeCountInputs implements Input
     }
 
     @Override
-    public IdMapper idMapper()
+    public IdMapper idMapper( NumberArrayFactory numberArrayFactory )
     {
         return IdMappers.actual();
     }


### PR DESCRIPTION
- [x] Make the page cache backed NumberArray implementations safe to access concurrently by multiple threads.