### PR TITLE
Fix optional match remover to account for dependencies from `SET ...`

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/OptionalMatchRemover.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/OptionalMatchRemover.scala
@@ -46,7 +46,7 @@ case object OptionalMatchRemover extends PlannerQueryRewriter {
 
       val projectionDeps = (distinctExpressions.values ++ aggregations.values).flatMap(_.dependencies)
       val updateDeps = graph.mutatingPatterns.flatMap(_.dependencies)
-      val dependencies: Set[IdName] = (projectionDeps ++ updateDeps).map(IdName.fromVariable).toSet
+      val dependencies: Set[IdName] = projectionDeps.map(IdName.fromVariable).toSet ++ updateDeps
 
       val optionalMatches = graph.optionalMatches.flatMapWithTail {
         (original: QueryGraph, tail: Seq[QueryGraph]) =>

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/OptionalMatchRemoverTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/OptionalMatchRemoverTest.scala
@@ -182,6 +182,41 @@ class OptionalMatchRemoverTest extends CypherFunSuite with LogicalPlanningTestSu
       |RETURN DISTINCT a AS a""".stripMargin).
     is_not_rewritten()
 
+  assert_that(
+    """MATCH (a)
+      |OPTIONAL MATCH (a)-[r]->(b)
+      |SET b.foo = 1
+      |RETURN DISTINCT a AS a""".stripMargin).
+    is_not_rewritten()
+
+  assert_that(
+    """MATCH (a)
+      |OPTIONAL MATCH (a)-[r]->(b)
+      |SET a.foo = b.foo
+      |RETURN DISTINCT a AS a""".stripMargin).
+    is_not_rewritten()
+
+  assert_that(
+    """MATCH (a)
+      |OPTIONAL MATCH (a)-[r]->(b)
+      |SET r.foo = 1
+      |RETURN DISTINCT a AS a""".stripMargin).
+    is_not_rewritten()
+
+  assert_that(
+    """MATCH (a)
+      |OPTIONAL MATCH (a)-[r]->(b)
+      |SET b:FOO
+      |RETURN DISTINCT a AS a""".stripMargin).
+    is_not_rewritten()
+
+  assert_that(
+    """MATCH (a)-[r1]->(b)
+      |OPTIONAL MATCH (c)<-[r2]-(b)
+      |SET c.foo = 1
+      |RETURN DISTINCT b AS b""".stripMargin).
+    is_not_rewritten()
+
   case class RewriteTester(originalQuery: String) {
     def is_rewritten_to(newQuery: String): Unit =
       test(originalQuery) {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SetAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SetAcceptanceTest.scala
@@ -23,6 +23,23 @@ import org.neo4j.cypher._
 
 class SetAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with NewPlannerTestSupport {
 
+  test("optional match and set") {
+    val n1 = createLabeledNode("L1")
+    val n2 = createLabeledNode("L2")
+    relate(n1, n2, "R1")
+
+    // only fails when returning distinct...
+    val result = executeWithCostPlannerAndInterpretedRuntimeOnly(
+      """
+        |MATCH (n1:L1)-[:R1]->(n2:L2)
+        |OPTIONAL MATCH (n3)<-[r:R2]-(n2)
+        |SET n3.prop = false
+        |RETURN distinct n2
+      """.stripMargin)
+
+    result.toList should be(List(Map("n2" -> n2)))
+  }
+
   test("should be able to set property to collection") {
     // given
     val node = createNode()


### PR DESCRIPTION
The rewriter didn't account for dependencies from `SET` and was removing too often.

Changelog: Fix issue where a combination of SET, OPTIONAL MATCH and DISTINCT, caused the query to fail.