### PR TITLE
Legacy SSL policy must have client_auth set to NONE

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyLoader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyLoader.java
@@ -160,7 +160,7 @@ public class SslPolicyLoader
         X509Certificate[] keyCertChain = loadCertificateChain( certficateFile );
 
         return new SslPolicy( privateKey, keyCertChain, null, null,
-                ClientAuth.OPTIONAL, InsecureTrustManagerFactory.INSTANCE );
+                ClientAuth.NONE, InsecureTrustManagerFactory.INSTANCE );
     }
 
     private void load( Config config, Log log )


### PR DESCRIPTION
This was the legacy setting. It is unknown exactly why it is
required, but browser web sockets seem to have an issue with it
while regular HTTPS traffic is fine. To be investigated.