### PR TITLE
Open legacy index in writable mode for non single instance read only environments

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSource.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSource.java
@@ -115,8 +115,8 @@ public class LuceneDataSource extends LifecycleAdapter
     /**
      * Constructs this data source.
      */
-    public LuceneDataSource( File storeDir, Config config, IndexConfigStore indexStore, FileSystemAbstraction
-            fileSystemAbstraction, OperationalMode operationalMode )
+    public LuceneDataSource( File storeDir, Config config, IndexConfigStore indexStore,
+            FileSystemAbstraction fileSystemAbstraction, OperationalMode operationalMode )
     {
         this.storeDir = storeDir;
         this.config = config;

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneIndexImplementation.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneIndexImplementation.java
@@ -32,6 +32,7 @@ import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.TransactionApplier;
+import org.neo4j.kernel.impl.factory.OperationalMode;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.kernel.spi.legacyindex.IndexCommandFactory;
@@ -60,20 +61,22 @@ public class LuceneIndexImplementation extends LifecycleAdapter implements Index
     private final Config config;
     private final Supplier<IndexConfigStore> indexStore;
     private final FileSystemAbstraction fileSystemAbstraction;
+    private final OperationalMode operationalMode;
 
     public LuceneIndexImplementation( File storeDir, Config config, Supplier<IndexConfigStore> indexStore,
-            FileSystemAbstraction fileSystemAbstraction )
+            FileSystemAbstraction fileSystemAbstraction, OperationalMode operationalMode )
     {
         this.storeDir = storeDir;
         this.config = config;
         this.indexStore = indexStore;
         this.fileSystemAbstraction = fileSystemAbstraction;
+        this.operationalMode = operationalMode;
     }
 
     @Override
     public void init() throws Throwable
     {
-        this.dataSource = new LuceneDataSource( storeDir, config, indexStore.get(), fileSystemAbstraction );
+        this.dataSource = new LuceneDataSource( storeDir, config, indexStore.get(), fileSystemAbstraction, operationalMode );
         this.dataSource.init();
     }
 

--- a/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneKernelExtension.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneKernelExtension.java
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
 import org.neo4j.index.impl.lucene.legacy.LuceneIndexImplementation;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.factory.OperationalMode;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.kernel.spi.legacyindex.IndexProviders;
@@ -36,15 +37,17 @@ public class LuceneKernelExtension extends LifecycleAdapter
     private final Supplier<IndexConfigStore> indexStore;
     private final FileSystemAbstraction fileSystemAbstraction;
     private final IndexProviders indexProviders;
+    private final OperationalMode operationalMode;
 
     public LuceneKernelExtension( File storeDir, Config config, Supplier<IndexConfigStore> indexStore,
-            FileSystemAbstraction fileSystemAbstraction, IndexProviders indexProviders )
+            FileSystemAbstraction fileSystemAbstraction, IndexProviders indexProviders, OperationalMode operationalMode )
     {
         this.storeDir = storeDir;
         this.config = config;
         this.indexStore = indexStore;
         this.fileSystemAbstraction = fileSystemAbstraction;
         this.indexProviders = indexProviders;
+        this.operationalMode = operationalMode;
     }
 
     @Override
@@ -52,7 +55,7 @@ public class LuceneKernelExtension extends LifecycleAdapter
     {
 
         LuceneIndexImplementation indexImplementation =
-                new LuceneIndexImplementation( storeDir, config, indexStore, fileSystemAbstraction );
+                new LuceneIndexImplementation( storeDir, config, indexStore, fileSystemAbstraction, operationalMode );
         indexProviders.registerIndexProvider( LuceneIndexImplementation.SERVICE_NAME, indexImplementation );
     }
 

--- a/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneKernelExtensionFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneKernelExtensionFactory.java
@@ -51,6 +51,7 @@ public class LuceneKernelExtensionFactory extends KernelExtensionFactory<LuceneK
                 dependencies.getConfig(),
                 dependencies::getIndexStore,
                 context.fileSystem(),
-                dependencies.getIndexProviders() );
+                dependencies.getIndexProviders(),
+                context.databaseInfo().operationalMode );
     }
 }

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/LuceneCommandApplierTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/LuceneCommandApplierTest.java
@@ -26,9 +26,10 @@ import java.io.File;
 import java.util.Map;
 
 import org.neo4j.graphdb.Node;
-import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.configuration.Settings;
+import org.neo4j.kernel.impl.factory.OperationalMode;
 import org.neo4j.kernel.impl.index.IndexCommand.AddNodeCommand;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.index.IndexDefineCommand;
@@ -39,7 +40,6 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.index.impl.lucene.legacy.LuceneIndexImplementation.EXACT_CONFIG;
 
@@ -61,7 +61,7 @@ public class LuceneCommandApplierTest
         configStore.set( Node.class, indexName, EXACT_CONFIG );
         LuceneDataSource dataSource = life.add( spy( new LuceneDataSource( dir, new Config( stringMap(
                 LuceneDataSource.Configuration.ephemeral.name(), Settings.TRUE ) ),
-                configStore, fs.get() ) ) );
+                configStore, fs.get(), OperationalMode.single ) ) );
 
         try ( LuceneCommandApplier applier = new LuceneCommandApplier( dataSource, false ) )
         {

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSourceTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSourceTest.java
@@ -35,6 +35,7 @@ import org.neo4j.graphdb.index.IndexManager;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.factory.OperationalMode;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.index.IndexEntityType;
 import org.neo4j.kernel.lifecycle.LifeRule;
@@ -74,8 +75,7 @@ public class LuceneDataSourceTest
         stopDataSource();
 
         Config readOnlyConfig = new Config( readOnlyConfig(), GraphDatabaseSettings.class );
-        LuceneDataSource readOnlyDataSource = life.add( new LuceneDataSource( directory.graphDbDir(), readOnlyConfig,
-                indexStore, new DefaultFileSystemAbstraction() ) );
+        LuceneDataSource readOnlyDataSource = life.add( getLuceneDataSource( readOnlyConfig ) );
         assertNotNull( readOnlyDataSource.getIndexSearcher( indexIdentifier ) );
 
         readOnlyDataSource.force();
@@ -89,25 +89,40 @@ public class LuceneDataSourceTest
         stopDataSource();
 
         Config readOnlyConfig = new Config( readOnlyConfig(), GraphDatabaseSettings.class );
-        dataSource = life.add( new LuceneDataSource( directory.graphDbDir(), readOnlyConfig, indexStore, new DefaultFileSystemAbstraction() ) );
+        dataSource = life.add( getLuceneDataSource( readOnlyConfig, OperationalMode.single ) );
         expectedException.expect( IllegalStateException.class );
         expectedException.expectMessage("Index deletion in read only mode is not supported.");
         dataSource.deleteIndex( indexIdentifier, false );
     }
 
     @Test
-    public void useReadOnlyIndexSearcherInReadOnlyMode() throws IOException
+    public void useReadOnlyIndexSearcherInReadOnlyModeForSingleInstance() throws IOException
     {
         IndexIdentifier indexIdentifier = identifier( "foo" );
         prepareIndexesByIdentifiers( indexIdentifier );
         stopDataSource();
 
         Config readOnlyConfig = new Config( readOnlyConfig(), GraphDatabaseSettings.class );
-        dataSource = life.add( new LuceneDataSource( directory.graphDbDir(), readOnlyConfig, indexStore, new DefaultFileSystemAbstraction() ) );
+        dataSource = life.add( getLuceneDataSource( readOnlyConfig, OperationalMode.single ) );
 
         IndexReference indexSearcher = dataSource.getIndexSearcher( indexIdentifier );
         assertTrue( "Read only index reference should be used in read only mode.",
                 ReadOnlyIndexReference.class.isInstance( indexSearcher ) );
+    }
+
+    @Test
+    public void useWritableIndexSearcherInReadOnlyModeForNonSingleInstance() throws IOException
+    {
+        IndexIdentifier indexIdentifier = identifier( "foo" );
+        prepareIndexesByIdentifiers( indexIdentifier );
+        stopDataSource();
+
+        Config readOnlyConfig = new Config( readOnlyConfig(), GraphDatabaseSettings.class );
+        dataSource = life.add( getLuceneDataSource( readOnlyConfig, OperationalMode.ha ) );
+
+        IndexReference indexSearcher = dataSource.getIndexSearcher( indexIdentifier );
+        assertTrue( "Writable index reference should be used in read only mode in ha mode.",
+                WritableIndexReference.class.isInstance( indexSearcher ) );
     }
 
     @Test
@@ -118,7 +133,7 @@ public class LuceneDataSourceTest
         stopDataSource();
 
         Config readOnlyConfig = new Config( readOnlyConfig(), GraphDatabaseSettings.class );
-        dataSource = life.add( new LuceneDataSource( directory.graphDbDir(), readOnlyConfig, indexStore, new DefaultFileSystemAbstraction() ) );
+        dataSource = life.add( getLuceneDataSource( readOnlyConfig ) );
 
         IndexReference indexSearcher = dataSource.getIndexSearcher( indexIdentifier );
         IndexReference indexSearcher2 = dataSource.getIndexSearcher( indexIdentifier );
@@ -133,7 +148,7 @@ public class LuceneDataSourceTest
     public void testShouldReturnIndexWriterFromLRUCache() throws Throwable
     {
         Config config = new Config( config(), GraphDatabaseSettings.class );
-        dataSource = life.add( new LuceneDataSource( directory.graphDbDir(), config, indexStore, new DefaultFileSystemAbstraction() ) );
+        dataSource = life.add( getLuceneDataSource( config ) );
         IndexIdentifier identifier = identifier( "foo" );
         IndexWriter writer = dataSource.getIndexSearcher( identifier ).getWriter();
         assertSame( writer, dataSource.getIndexSearcher( identifier ).getWriter() );
@@ -143,7 +158,7 @@ public class LuceneDataSourceTest
     public void testShouldReturnIndexSearcherFromLRUCache() throws Throwable
     {
         Config config = new Config( config(), GraphDatabaseSettings.class );
-        dataSource = life.add( new LuceneDataSource( directory.graphDbDir(), config, indexStore, new DefaultFileSystemAbstraction() ) );
+        dataSource = life.add( getLuceneDataSource( config ) );
         IndexIdentifier identifier = identifier( "foo" );
         IndexReference searcher = dataSource.getIndexSearcher( identifier );
         assertSame( searcher, dataSource.getIndexSearcher( identifier ) );
@@ -158,7 +173,7 @@ public class LuceneDataSourceTest
         Map<String, String> configMap = config();
         configMap.put( GraphDatabaseSettings.lucene_searcher_cache_size.name(), "2" );
         Config config = new Config( configMap, GraphDatabaseSettings.class );
-        dataSource = life.add( new LuceneDataSource( directory.graphDbDir(), config, indexStore, new DefaultFileSystemAbstraction() ) );
+        dataSource = life.add( getLuceneDataSource( config ) );
         IndexIdentifier fooIdentifier = identifier( "foo" );
         IndexIdentifier barIdentifier = identifier( "bar" );
         IndexIdentifier bazIdentifier = identifier( "baz" );
@@ -177,7 +192,7 @@ public class LuceneDataSourceTest
         Map<String, String> configMap = config();
         configMap.put( GraphDatabaseSettings.lucene_searcher_cache_size.name(), "2" );
         Config config = new Config( configMap, GraphDatabaseSettings.class );
-        dataSource = life.add( new LuceneDataSource( directory.graphDbDir(), config, indexStore, new DefaultFileSystemAbstraction() ) );
+        dataSource = life.add( getLuceneDataSource( config ) );
         IndexIdentifier fooIdentifier = identifier( "foo" );
         IndexIdentifier barIdentifier = identifier( "bar" );
         IndexIdentifier bazIdentifier = identifier( "baz" );
@@ -198,7 +213,7 @@ public class LuceneDataSourceTest
         Map<String, String> configMap = config();
         configMap.put( GraphDatabaseSettings.lucene_searcher_cache_size.name(), "2" );
         Config config = new Config( configMap, GraphDatabaseSettings.class );
-        dataSource = life.add( new LuceneDataSource( directory.graphDbDir(), config, indexStore, new DefaultFileSystemAbstraction() ) );
+        dataSource = life.add( getLuceneDataSource( config ) );
         IndexIdentifier fooIdentifier = identifier( "foo" );
         IndexIdentifier barIdentifier = identifier( "bar" );
         IndexIdentifier bazIdentifier = identifier( "baz" );
@@ -222,7 +237,7 @@ public class LuceneDataSourceTest
         Map<String, String> configMap = config();
         configMap.put( GraphDatabaseSettings.lucene_searcher_cache_size.name(), "2" );
         Config config = new Config( configMap, GraphDatabaseSettings.class );
-        dataSource = life.add( new LuceneDataSource( directory.graphDbDir(), config, indexStore, new DefaultFileSystemAbstraction() ) );
+        dataSource = life.add( getLuceneDataSource( config ) );
         IndexIdentifier fooIdentifier = identifier( "foo" );
         IndexIdentifier barIdentifier = identifier( "bar" );
         IndexIdentifier bazIdentifier = identifier( "baz" );
@@ -247,7 +262,7 @@ public class LuceneDataSourceTest
     private void prepareIndexesByIdentifiers( IndexIdentifier indexIdentifier )
     {
         Config config = new Config( config(), GraphDatabaseSettings.class );
-        dataSource = life.add( new LuceneDataSource( directory.graphDbDir(), config, indexStore, new DefaultFileSystemAbstraction() ) );
+        dataSource = life.add( getLuceneDataSource( config ) );
         dataSource.getIndexSearcher( indexIdentifier );
         dataSource.force();
     }
@@ -269,4 +284,14 @@ public class LuceneDataSourceTest
         return new IndexIdentifier( IndexEntityType.Node, name );
     }
 
+    private LuceneDataSource getLuceneDataSource( Config config )
+    {
+        return getLuceneDataSource( config, OperationalMode.unknown );
+    }
+
+    private LuceneDataSource getLuceneDataSource( Config config, OperationalMode operationalMode )
+    {
+        return new LuceneDataSource( directory.graphDbDir(), config, indexStore,
+                new DefaultFileSystemAbstraction(), operationalMode );
+    }
 }

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/ReadOnlyIndexReferenceFactoryTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/ReadOnlyIndexReferenceFactoryTest.java
@@ -33,6 +33,7 @@ import org.neo4j.graphdb.index.IndexManager;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.factory.OperationalMode;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.index.IndexEntityType;
 import org.neo4j.test.CleanupRule;
@@ -89,7 +90,7 @@ public class ReadOnlyIndexReferenceFactoryTest
         indexStore = new IndexConfigStore( storeDir, fileSystemAbstraction );
         indexStore.set( Node.class, INDEX_NAME, MapUtil.stringMap( IndexManager.PROVIDER, "lucene", "type", "fulltext" ) );
         LuceneDataSource luceneDataSource = new LuceneDataSource( storeDir, new Config( MapUtil.stringMap() ),
-                indexStore, fileSystemAbstraction );
+                indexStore, fileSystemAbstraction, OperationalMode.single );
         try
         {
             luceneDataSource.init();

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/RecoveryTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/RecoveryTest.java
@@ -38,6 +38,7 @@ import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.factory.OperationalMode;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.test.DatabaseRule;
 import org.neo4j.test.EmbeddedDatabaseRule;
@@ -166,7 +167,7 @@ public class RecoveryTest
         FileSystemAbstraction fileSystem = new DefaultFileSystemAbstraction();
         Config config = new Config( MapUtil.stringMap(), GraphDatabaseSettings.class );
         LuceneDataSource ds = new LuceneDataSource( storeDir, config, new IndexConfigStore( storeDir, fileSystem ),
-                fileSystem );
+                fileSystem, OperationalMode.single );
         ds.start();
         ds.stop();
     }


### PR DESCRIPTION
Open legacy indexes in a writable mode for all read only environments
except single instance. We need to allow indexes to be writable since
they need to be updated during catch up updates.