### PR TITLE
Update TraversalAStar.java

### DIFF
--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/TraversalAStar.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/TraversalAStar.java
@@ -93,7 +93,7 @@ public class TraversalAStar implements PathFinder<WeightedPath>
     @Override
     public Iterable<WeightedPath> findAllPaths( Node start, final Node end )
     {
-        return Iterables.asIterable( findSinglePath( start, end ) );
+        return findPaths( start, end, true );
     }
 
     @Override


### PR DESCRIPTION
Hi,

I currently use neo4j and the TraversalAStar algorithm (I need to have a state so I can't use A* implementation). I found that find findAllPaths returning always one path. is there any reason ? I can write some tests later if it's possible to change this behavior.

Thanks,

Arnaud