### PR TITLE
Add compatibility constructor to LuceneKernelExtension

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneKernelExtension.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneKernelExtension.java
@@ -40,6 +40,12 @@ public class LuceneKernelExtension extends LifecycleAdapter
     private final OperationalMode operationalMode;
 
     public LuceneKernelExtension( File storeDir, Config config, Supplier<IndexConfigStore> indexStore,
+            FileSystemAbstraction fileSystemAbstraction, IndexProviders indexProviders )
+    {
+        this( storeDir, config, indexStore, fileSystemAbstraction, indexProviders, OperationalMode.single );
+    }
+
+    public LuceneKernelExtension( File storeDir, Config config, Supplier<IndexConfigStore> indexStore,
             FileSystemAbstraction fileSystemAbstraction, IndexProviders indexProviders, OperationalMode operationalMode )
     {
         this.storeDir = storeDir;


### PR DESCRIPTION
Add compatibility constructor to LuceneKernelExtension that will always
construct LuceneKernelExtension in 'single' OperationalMode.