### PR TITLE
Allows OnlineBackup to be run with a custom OutputStream for logging

### DIFF
--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackup.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackup.java
@@ -20,6 +20,7 @@
 package org.neo4j.backup;
 
 import java.io.File;
+import java.io.OutputStream;
 
 import org.neo4j.backup.BackupService.BackupOutcome;
 import org.neo4j.kernel.configuration.Config;
@@ -40,6 +41,7 @@ public class OnlineBackup
     private boolean forensics;
     private BackupService.BackupOutcome outcome;
     private long timeoutMillis = BackupClient.BIG_READ_TIMEOUT;
+    private OutputStream out = System.out;
 
     /**
      * Factory method for this class. The OnlineBackup instance returned will perform backup operations against the
@@ -98,7 +100,7 @@ public class OnlineBackup
      */
     public OnlineBackup backup( File targetDirectory )
     {
-        outcome = new BackupService().doIncrementalBackupOrFallbackToFull( hostNameOrIp, port, targetDirectory,
+        outcome = new BackupService( out ).doIncrementalBackupOrFallbackToFull( hostNameOrIp, port, targetDirectory,
                 getConsistencyCheck( true ), defaultConfig(), timeoutMillis, forensics );
         return this;
     }
@@ -132,7 +134,7 @@ public class OnlineBackup
      */
     public OnlineBackup backup( File targetDirectory, boolean verification )
     {
-        outcome = new BackupService().doIncrementalBackupOrFallbackToFull( hostNameOrIp, port, targetDirectory,
+        outcome = new BackupService( out ).doIncrementalBackupOrFallbackToFull( hostNameOrIp, port, targetDirectory,
                 getConsistencyCheck( verification ), defaultConfig(), timeoutMillis, forensics );
         return this;
     }
@@ -165,7 +167,7 @@ public class OnlineBackup
      */
     public OnlineBackup backup( File targetDirectory, Config tuningConfiguration )
     {
-        outcome = new BackupService().doIncrementalBackupOrFallbackToFull( hostNameOrIp, port, targetDirectory,
+        outcome = new BackupService( out ).doIncrementalBackupOrFallbackToFull( hostNameOrIp, port, targetDirectory,
                 getConsistencyCheck( true ), tuningConfiguration, timeoutMillis, forensics );
         return this;
     }
@@ -201,7 +203,7 @@ public class OnlineBackup
      */
     public OnlineBackup backup( File targetDirectory, Config tuningConfiguration, boolean verification )
     {
-        outcome = new BackupService().doIncrementalBackupOrFallbackToFull( hostNameOrIp, port, targetDirectory,
+        outcome = new BackupService( out ).doIncrementalBackupOrFallbackToFull( hostNameOrIp, port, targetDirectory,
                 getConsistencyCheck( verification ), tuningConfiguration, timeoutMillis, forensics );
         return this;
     }
@@ -221,6 +223,12 @@ public class OnlineBackup
         return this;
     }
 
+    public OnlineBackup withOutput( OutputStream out )
+    {
+        this.out = out;
+        return this;
+    }
+
     /**
      * Performs a full backup storing the resulting database at the given directory. The server contacted is the one
      * configured in the factory method used to obtain this instance. At the end of the backup, a verification phase
@@ -236,7 +244,7 @@ public class OnlineBackup
     @Deprecated
     public OnlineBackup full( String targetDirectory )
     {
-        outcome = new BackupService().doFullBackup( hostNameOrIp, port, new File( targetDirectory ),
+        outcome = new BackupService( out ).doFullBackup( hostNameOrIp, port, new File( targetDirectory ),
                 getConsistencyCheck( true ), defaultConfig(), timeoutMillis, forensics );
         return this;
     }
@@ -257,7 +265,7 @@ public class OnlineBackup
     @Deprecated
     public OnlineBackup full( String targetDirectory, boolean verification )
     {
-        outcome = new BackupService().doFullBackup( hostNameOrIp, port, new File( targetDirectory ),
+        outcome = new BackupService( out ).doFullBackup( hostNameOrIp, port, new File( targetDirectory ),
                 getConsistencyCheck( verification ), defaultConfig(), timeoutMillis, forensics );
         return this;
     }
@@ -280,7 +288,7 @@ public class OnlineBackup
     @Deprecated
     public OnlineBackup full( String targetDirectory, boolean verification, Config tuningConfiguration )
     {
-        outcome = new BackupService().doFullBackup( hostNameOrIp, port, new File( targetDirectory ),
+        outcome = new BackupService( out ).doFullBackup( hostNameOrIp, port, new File( targetDirectory ),
                 getConsistencyCheck( verification ), tuningConfiguration, timeoutMillis, forensics );
         return this;
     }
@@ -301,7 +309,7 @@ public class OnlineBackup
     @Deprecated
     public OnlineBackup incremental( String targetDirectory )
     {
-        outcome = new BackupService().doIncrementalBackup( hostNameOrIp, port, new File( targetDirectory ),
+        outcome = new BackupService( out ).doIncrementalBackup( hostNameOrIp, port, new File( targetDirectory ),
                 getConsistencyCheck( false ), timeoutMillis, defaultConfig() );
         return this;
     }
@@ -323,7 +331,7 @@ public class OnlineBackup
     @Deprecated
     public OnlineBackup incremental( String targetDirectory, boolean verification )
     {
-        outcome = new BackupService().doIncrementalBackup( hostNameOrIp, port, new File( targetDirectory ),
+        outcome = new BackupService( out ).doIncrementalBackup( hostNameOrIp, port, new File( targetDirectory ),
                 getConsistencyCheck( verification ), timeoutMillis, defaultConfig() );
         return this;
     }
@@ -344,7 +352,7 @@ public class OnlineBackup
     @Deprecated
     public OnlineBackup incremental( GraphDatabaseAPI targetDb )
     {
-        outcome = new BackupService().doIncrementalBackup( hostNameOrIp, port, targetDb, timeoutMillis );
+        outcome = new BackupService( out ).doIncrementalBackup( hostNameOrIp, port, targetDb, timeoutMillis );
         return this;
     }
 


### PR DESCRIPTION
So far OnlineBackup has defaulted to directing output to the console
 which, while making sense as a standalone tool, it also clutters the
 output when run in tests. This is prominent when BackupLoad is used
 and it also has resulted in test failures because of a slightly
 changed behaviour in new versions of the Surefire plugin.
Using this functionality in BackupStoreCopyInteractionStressTesting
 should reduce the console output and the problems related to that.