### PR TITLE
Use standard TestDirectory as test folder provider for EmbeddedDatabaseRule

### DIFF
--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/AllNodesInStoreExistInLabelIndexTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/AllNodesInStoreExistInLabelIndexTest.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.consistency.checking;
 
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -47,7 +46,6 @@ import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.test.rule.DatabaseRule;
 import org.neo4j.test.rule.EmbeddedDatabaseRule;
 import org.neo4j.test.rule.RandomRule;
-import org.neo4j.test.rule.TestDirectory;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -58,11 +56,8 @@ import static org.neo4j.test.TestLabels.LABEL_TWO;
 
 public class AllNodesInStoreExistInLabelIndexTest
 {
-    @ClassRule
-    public static final TestDirectory dir = TestDirectory.testDirectory();
-
     @Rule
-    public final DatabaseRule db = new EmbeddedDatabaseRule( dir.absolutePath() );
+    public final DatabaseRule db = new EmbeddedDatabaseRule();
 
     @Rule
     public final RandomRule random = new RandomRule();
@@ -74,7 +69,6 @@ public class AllNodesInStoreExistInLabelIndexTest
     private static final double UPDATE_RATIO = 0.2;
     private static final int NODE_COUNT_BASELINE = 10;
 
-    //    @RandomRule.Seed( 1497348748034L )
     @Test
     public void mustReportSuccessfulForConsistentLabelScanStore() throws Exception
     {
@@ -245,16 +239,18 @@ public class AllNodesInStoreExistInLabelIndexTest
     {
         db.restartDatabase( ( fs, directory ) ->
         {
-            fs.deleteFile( dir.file( NativeLabelScanStore.FILE_NAME ) );
-            fs.copyFile( labelIndexFileCopy, dir.file( NativeLabelScanStore.FILE_NAME ) );
+            File storeDir = db.getStoreDir();
+            fs.deleteFile( new File( storeDir, NativeLabelScanStore.FILE_NAME ) );
+            fs.copyFile( labelIndexFileCopy, new File( storeDir, NativeLabelScanStore.FILE_NAME ) );
         } );
     }
 
     private File copyLabelIndexFile() throws IOException
     {
-        File labelIndexFileCopy = dir.file( "label_index_copy" );
+        File storeDir = db.getStoreDir();
+        File labelIndexFileCopy = new File( storeDir, "label_index_copy" );
         db.restartDatabase( ( fs, directory ) ->
-                fs.copyFile( dir.file( NativeLabelScanStore.FILE_NAME ), labelIndexFileCopy ) );
+                fs.copyFile( new File( storeDir, NativeLabelScanStore.FILE_NAME ), labelIndexFileCopy ) );
         return labelIndexFileCopy;
     }
 
@@ -349,7 +345,7 @@ public class AllNodesInStoreExistInLabelIndexTest
         {
             ConsistencyCheckService service = new ConsistencyCheckService();
             Config config = Config.defaults();
-            return service.runFullConsistencyCheck( dir.absolutePath(), config, NONE, log, fsa, true,
+            return service.runFullConsistencyCheck( db.getStoreDir(), config, NONE, log, fsa, true,
                     new CheckConsistencyConfig( config ) );
         }
     }

--- a/community/cypher/cypher/pom.xml
+++ b/community/cypher/cypher/pom.xml
@@ -380,6 +380,10 @@
       <artifactId>jetty-servlet</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
 
   </dependencies>
 

--- a/community/import-tool/pom.xml
+++ b/community/import-tool/pom.xml
@@ -88,7 +88,10 @@ the relevant Commercial Agreement.
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolNumericalFailureTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolNumericalFailureTest.java
@@ -95,7 +95,7 @@ public class ImportToolNumericalFailureTest
     public String expectedError;
 
     @Rule
-    public final EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() ).startLazily();
+    public final EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule().startLazily();
     @Rule
     public final SuppressOutput suppressOutput = SuppressOutput.suppress( SuppressOutput.System.values() );
 

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
@@ -98,7 +98,7 @@ public class ImportToolTest
     private static final IntPredicate TRUE = i -> true;
 
     @Rule
-    public final EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() ).startLazily();
+    public final EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule().startLazily();
     @Rule
     public final RandomRule random = new RandomRule();
     @Rule

--- a/community/kernel/src/test/java/org/neo4j/graphdb/ConsistentPropertyReadsIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/ConsistentPropertyReadsIT.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertTrue;
 public class ConsistentPropertyReadsIT
 {
     @Rule
-    public DatabaseRule db = new EmbeddedDatabaseRule( getClass() );
+    public DatabaseRule db = new EmbeddedDatabaseRule();
 
     @Test
     public void shouldReadConsistentPropertyValues() throws Throwable

--- a/community/kernel/src/test/java/org/neo4j/graphdb/NativeLabelScanStoreChaosIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/NativeLabelScanStoreChaosIT.java
@@ -42,7 +42,7 @@ import static org.neo4j.helpers.collection.Iterators.asSet;
  */
 public class NativeLabelScanStoreChaosIT
 {
-    private final DatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() );
+    private final DatabaseRule dbRule = new EmbeddedDatabaseRule();
     private final RandomRule randomRule = new RandomRule();
     @Rule
     public final RuleChain ruleChain = RuleChain.outerRule( randomRule ).around( dbRule );

--- a/community/kernel/src/test/java/org/neo4j/graphdb/NativeLabelScanStoreStartupIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/NativeLabelScanStoreStartupIT.java
@@ -47,7 +47,7 @@ public class NativeLabelScanStoreStartupIT
     private static final Label LABEL = Label.label( "testLabel" );
 
     @Rule
-    public final DatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() );
+    public final DatabaseRule dbRule = new EmbeddedDatabaseRule();
     @Rule
     public final RandomRule random = new RandomRule();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/BigStoreIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/BigStoreIT.java
@@ -70,7 +70,7 @@ public class BigStoreIT implements RelationshipType
         }
     };
     @Rule
-    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( BigStoreIT.class );
+    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule();
 
     @Before
     public void doBefore()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListingTest.java
@@ -56,7 +56,7 @@ import static org.neo4j.helpers.collection.Iterators.asResourceIterator;
 public class NeoStoreFileListingTest
 {
     @Rule
-    public EmbeddedDatabaseRule db = new EmbeddedDatabaseRule( getClass() );
+    public EmbeddedDatabaseRule db = new EmbeddedDatabaseRule();
     private NeoStoreDataSource neoStoreDataSource;
     private static final String[] STANDARD_STORE_DIR_FILES = new String[]{
             "index",

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/storeview/NeoStoreIndexStoreViewTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/storeview/NeoStoreIndexStoreViewTest.java
@@ -71,7 +71,7 @@ import static org.neo4j.helpers.collection.Iterators.asSet;
 public class NeoStoreIndexStoreViewTest
 {
     @Rule
-    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() );
+    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule();
 
     private final Map<Long, Lock> lockMocks = new HashMap<>();
     private final Label label = Label.label( "Person" );

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/BatchInsertionIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/BatchInsertionIT.java
@@ -44,7 +44,7 @@ import static org.neo4j.helpers.collection.MapUtil.map;
 public class BatchInsertionIT
 {
     @Rule
-    public final EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( BatchInsertionIT.class ).startLazily();
+    public final EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule().startLazily();
     @Rule
     public final DefaultFileSystemRule fileSystemRule = new DefaultFileSystemRule();
 

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintCreationIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintCreationIT.java
@@ -41,7 +41,7 @@ import static org.junit.Assert.fail;
 public class ConstraintCreationIT
 {
     @Rule
-    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( ConstraintCreationIT.class );
+    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule();
 
     private static final Label LABEL = Label.label( "label1" );
     private static final String INDEX_IDENTIFIER = "1";

--- a/community/neo4j/src/test/java/files/TestNoFileDescriptorLeaks.java
+++ b/community/neo4j/src/test/java/files/TestNoFileDescriptorLeaks.java
@@ -41,7 +41,7 @@ public class TestNoFileDescriptorLeaks
     private static final AtomicInteger counter = new AtomicInteger();
 
     @Rule
-    public EmbeddedDatabaseRule db = new EmbeddedDatabaseRule( TestNoFileDescriptorLeaks.class );
+    public EmbeddedDatabaseRule db = new EmbeddedDatabaseRule();
 
     @BeforeClass
     public static void beforeClass()

--- a/community/neo4j/src/test/java/org/neo4j/index/backup/IndexBackupIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/backup/IndexBackupIT.java
@@ -59,7 +59,7 @@ public class IndexBackupIT
     @Rule
     public RandomRule randomRule = new RandomRule();
     @Rule
-    public EmbeddedDatabaseRule database = new EmbeddedDatabaseRule( getClass() );
+    public EmbeddedDatabaseRule database = new EmbeddedDatabaseRule();
     private CheckPointer checkPointer;
     private IndexingService indexingService;
     private FileSystemAbstraction fileSystem;

--- a/community/neo4j/src/test/java/synchronization/TestStartTransactionDuringLogRotation.java
+++ b/community/neo4j/src/test/java/synchronization/TestStartTransactionDuringLogRotation.java
@@ -46,7 +46,7 @@ import org.neo4j.test.rule.concurrent.OtherThreadRule;
 public class TestStartTransactionDuringLogRotation
 {
     @Rule
-    public DatabaseRule db = new EmbeddedDatabaseRule( getClass() )
+    public DatabaseRule db = new EmbeddedDatabaseRule()
     {
         @Override
         protected GraphDatabaseBuilder newBuilder( GraphDatabaseFactory factory )

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
@@ -127,7 +127,7 @@ public class BackupServiceIT
 
     private final DefaultFileSystemRule fileSystemRule = new DefaultFileSystemRule();
     private final TestDirectory target = TestDirectory.testDirectory();
-    private final EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() ).startLazily();
+    private final EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule().startLazily();
     private final SuppressOutput suppressOutput = SuppressOutput.suppressAll();
     private final PageCacheRule pageCacheRule = new PageCacheRule();
 

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupToolIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupToolIT.java
@@ -49,7 +49,7 @@ public class BackupToolIT
     @Rule
     public ExpectedException expected = ExpectedException.none();
     @Rule
-    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() ).startLazily();
+    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule().startLazily();
 
     private DefaultFileSystemAbstraction fs;
     private PageCache pageCache;

--- a/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandIT.java
@@ -59,7 +59,7 @@ public class OnlineBackupCommandIT
     @ClassRule
     public static final TestDirectory testDirectory = TestDirectory.testDirectory();
 
-    private final EmbeddedDatabaseRule db = new EmbeddedDatabaseRule( testDirectory.directory( "db" ) ).startLazily();
+    private final EmbeddedDatabaseRule db = new EmbeddedDatabaseRule().startLazily();
 
     @Rule
     public final RuleChain ruleChain = RuleChain.outerRule( SuppressOutput.suppressAll() ).around( db );

--- a/enterprise/cypher/cypher/pom.xml
+++ b/enterprise/cypher/cypher/pom.xml
@@ -363,6 +363,10 @@
       <artifactId>jetty-servlet</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
 
   </dependencies>
 

--- a/enterprise/deferred-locks/pom.xml
+++ b/enterprise/deferred-locks/pom.xml
@@ -104,6 +104,10 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
 
   </dependencies>
 

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiServiceLoadingTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiServiceLoadingTest.java
@@ -34,7 +34,7 @@ import static org.hamcrest.core.IsInstanceOf.instanceOf;
 public class ForsetiServiceLoadingTest
 {
     @Rule
-    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( getClass() ).startLazily();
+    public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule().startLazily();
 
     @Test
     public void shouldUseForsetiAsDefaultLockManager() throws Exception

--- a/enterprise/management/pom.xml
+++ b/enterprise/management/pom.xml
@@ -89,6 +89,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-kernel</artifactId>
       <version>${project.version}</version>

--- a/enterprise/management/src/test/java/org/neo4j/management/ManagementBeansTest.java
+++ b/enterprise/management/src/test/java/org/neo4j/management/ManagementBeansTest.java
@@ -19,11 +19,11 @@
  */
 package org.neo4j.management;
 
-import java.util.Map;
-
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
+
+import java.util.Map;
 
 import org.neo4j.jmx.Kernel;
 import org.neo4j.jmx.Primitives;
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertTrue;
 public class ManagementBeansTest
 {
     @ClassRule
-    public static EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule( ManagementBeansTest.class );
+    public static EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule();
     private static GraphDatabaseAPI graphDb;
 
     @BeforeClass

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceRecordFormatIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/consistency/ConsistencyCheckServiceRecordFormatIT.java
@@ -20,7 +20,6 @@
 package org.neo4j.consistency;
 
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -48,18 +47,13 @@ import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.FormattedLogProvider;
 import org.neo4j.test.rule.EmbeddedDatabaseRule;
 import org.neo4j.test.rule.SuppressOutput;
-import org.neo4j.test.rule.TestDirectory;
 
 import static org.junit.Assert.assertTrue;
 
 @RunWith( Parameterized.class )
 public class ConsistencyCheckServiceRecordFormatIT
 {
-    @ClassRule
-    public static final TestDirectory dir = TestDirectory.testDirectory();
-
-    private final File storeDir = dir.directory( "db" );
-    private final EmbeddedDatabaseRule db = new EmbeddedDatabaseRule( storeDir ).startLazily();
+    private final EmbeddedDatabaseRule db = new EmbeddedDatabaseRule().startLazily();
 
     @Rule
     public final RuleChain ruleChain = RuleChain.outerRule( SuppressOutput.suppressAll() ).around( db );


### PR DESCRIPTION
Use standard TestDirectory rule to provide test directory required for
embedded database, instead of yet another custom implementation of TemporaryFolder rule.
Remove redundant class constructor argument.
Cleanup.