### PR TITLE
Remove channels on core topology change

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/ChannelExpiryService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/ChannelExpiryService.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.neo4j.causalclustering.discovery.CoreServerInfo;
+import org.neo4j.causalclustering.discovery.CoreTopology;
+import org.neo4j.causalclustering.discovery.CoreTopologyService;
+import org.neo4j.causalclustering.discovery.Difference;
+import org.neo4j.causalclustering.discovery.TopologyDifference;
+import org.neo4j.causalclustering.messaging.ChannelExpiryListener;
+
+class ChannelExpiryService implements CoreTopologyService.Listener
+{
+    private final List<ChannelExpiryListener> listeners = new ArrayList<>();
+
+    void addChannelExpiryListener( ChannelExpiryListener listener )
+    {
+        listeners.add( listener );
+    }
+
+    @Override
+    public void onCoreTopologyChange( CoreTopology oldCoreTopology, CoreTopology newCoreTopology )
+    {
+        TopologyDifference<Difference<CoreServerInfo>> difference = newCoreTopology.difference( oldCoreTopology );
+
+        for ( Difference<CoreServerInfo> coreServerInfo : difference.removed() )
+        {
+            for ( ChannelExpiryListener listener : listeners )
+            {
+                listener.onChannelExpiry( coreServerInfo.getServer().getRaftServer() );
+            }
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
@@ -209,6 +209,10 @@ public class EnterpriseCoreEditionModule extends EditionModule
                 logProvider, platformModule.monitors, maxQueueSize );
         life.add( raftSender );
 
+        ChannelExpiryService channelExpiryService = new ChannelExpiryService();
+        channelExpiryService.addChannelExpiryListener( raftSender );
+        topologyService.addCoreTopologyListener( channelExpiryService );
+
         final MessageLogger<MemberId> messageLogger = createMessageLogger( config, life, identityModule.myself() );
 
         RaftOutbound raftOutbound = new RaftOutbound( topologyService, raftSender, clusteringModule.clusterIdentity(),
@@ -382,4 +386,5 @@ public class EnterpriseCoreEditionModule extends EditionModule
     {
         EnterpriseEditionModule.setupEnterpriseSecurityModule( platformModule, procedures );
     }
+
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopology.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopology.java
@@ -72,18 +72,18 @@ public class CoreTopology
         return format( "{clusterId=%s, bootstrappable=%s, coreMembers=%s}", clusterId, canBeBootstrapped(), coreMembers );
     }
 
-    TopologyDifference difference( CoreTopology other )
+    public TopologyDifference<Difference<CoreServerInfo>> difference( CoreTopology other )
     {
         Set<MemberId> members = coreMembers.keySet();
         Set<MemberId> otherMembers = other.coreMembers.keySet();
 
-        Set<Difference> added = otherMembers.stream().filter( m -> !members.contains( m ) )
+        Set<Difference<CoreServerInfo>> added = otherMembers.stream().filter( m -> !members.contains( m ) )
                 .map( memberId -> Difference.asDifference( other, memberId ) ).collect( toSet() );
 
-        Set<Difference> removed = members.stream().filter( m -> !otherMembers.contains( m ) )
+        Set<Difference<CoreServerInfo>> removed = members.stream().filter( m -> !otherMembers.contains( m ) )
                 .map( memberId -> Difference.asDifference( CoreTopology.this, memberId ) ).collect( toSet() );
 
-        return new TopologyDifference( added, removed );
+        return new TopologyDifference<>( added, removed );
     }
 
     public Optional<MemberId> anyCoreMemberId()

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyListenerService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyListenerService.java
@@ -31,11 +31,11 @@ class CoreTopologyListenerService
         listeners.add( listener );
     }
 
-    void notifyListeners( CoreTopology coreTopology )
+    void notifyListeners( CoreTopology oldCoreTopology, CoreTopology newCoreTopology )
     {
         for ( CoreTopologyService.Listener listener : listeners )
         {
-            listener.onCoreTopologyChange( coreTopology );
+            listener.onCoreTopologyChange( oldCoreTopology, newCoreTopology);
         }
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/CoreTopologyService.java
@@ -41,6 +41,6 @@ public interface CoreTopologyService extends TopologyService
 
     interface Listener
     {
-        void onCoreTopologyChange( CoreTopology coreTopology );
+        void onCoreTopologyChange( CoreTopology oldCoreTopology, CoreTopology newCoreTopology );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/Difference.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/Difference.java
@@ -21,25 +21,30 @@ package org.neo4j.causalclustering.discovery;
 
 import org.neo4j.causalclustering.identity.MemberId;
 
-class Difference
+public class Difference<T>
 {
     private MemberId memberId;
-    private CatchupServerAddress server;
+    private T server;
 
-    private Difference( MemberId memberId, CatchupServerAddress server )
+    private Difference( MemberId memberId, T server )
     {
         this.memberId = memberId;
         this.server = server;
     }
 
-    static Difference asDifference( CoreTopology topology, MemberId memberId )
+    static Difference<CoreServerInfo> asDifference( CoreTopology topology, MemberId memberId )
     {
-        return new Difference( memberId, topology.find( memberId ).orElse( null ) );
+        return new Difference<>( memberId, topology.find( memberId ).orElse( null ) );
     }
 
-    static Difference asDifference( ReadReplicaTopology topology, MemberId memberId )
+    static Difference<ReadReplicaInfo> asDifference( ReadReplicaTopology topology, MemberId memberId )
     {
-        return new Difference( memberId, topology.find( memberId ).orElse( null ) );
+        return new Difference<>( memberId, topology.find( memberId ).orElse( null ) );
+    }
+
+    public T getServer()
+    {
+        return server;
     }
 
     @Override

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RaftCoreTopologyConnector.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RaftCoreTopologyConnector.java
@@ -47,9 +47,9 @@ public class RaftCoreTopologyConnector extends LifecycleAdapter implements CoreT
     }
 
     @Override
-    public synchronized void onCoreTopologyChange( CoreTopology coreTopology )
+    public synchronized void onCoreTopologyChange( CoreTopology oldCoreTopology, CoreTopology newCoreTopology )
     {
-        Set<MemberId> targetMembers = coreTopology.members().keySet();
+        Set<MemberId> targetMembers = oldCoreTopology.members().keySet();
         raftMachine.setTargetMembershipSet( targetMembers );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ReadReplicaTopology.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/ReadReplicaTopology.java
@@ -29,9 +29,6 @@ import org.neo4j.causalclustering.identity.MemberId;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toSet;
 
-import static org.neo4j.causalclustering.discovery.Difference.asDifference;
-
-
 public class ReadReplicaTopology
 {
     static final ReadReplicaTopology EMPTY = new ReadReplicaTopology( emptyMap() );
@@ -76,17 +73,17 @@ public class ReadReplicaTopology
         }
     }
 
-    TopologyDifference difference( ReadReplicaTopology other )
+    TopologyDifference<Difference<ReadReplicaInfo>> difference( ReadReplicaTopology other )
     {
         Set<MemberId> members = readReplicaMembers.keySet();
         Set<MemberId> otherMembers = other.readReplicaMembers.keySet();
 
-        Set<Difference> added = otherMembers.stream().filter( m -> !members.contains( m ) )
-                .map( memberId -> asDifference( other, memberId ) ).collect( toSet() );
+        Set<Difference<ReadReplicaInfo>> added = otherMembers.stream().filter( m -> !members.contains( m ) )
+                .map( memberId -> Difference.asDifference( other, memberId ) ).collect( toSet() );
 
-        Set<Difference> removed = members.stream().filter( m -> !otherMembers.contains( m ) )
-                .map( memberId -> asDifference( ReadReplicaTopology.this, memberId ) ).collect( toSet() );
+        Set<Difference<ReadReplicaInfo>> removed = members.stream().filter( m -> !otherMembers.contains( m ) )
+                .map( memberId -> Difference.asDifference( ReadReplicaTopology.this, memberId ) ).collect( toSet() );
 
-        return new TopologyDifference( added, removed );
+        return new TopologyDifference<>( added, removed );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/ChannelExpiryListener.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/ChannelExpiryListener.java
@@ -17,39 +17,11 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.causalclustering.discovery;
+package org.neo4j.causalclustering.messaging;
 
-import java.util.Set;
+import org.neo4j.helpers.AdvertisedSocketAddress;
 
-public class TopologyDifference<T>
+public interface ChannelExpiryListener
 {
-    private Set<T> added;
-    private Set<T> removed;
-
-    TopologyDifference( Set<T> added, Set<T> removed )
-    {
-        this.added = added;
-        this.removed = removed;
-    }
-
-    public  Set<T> added()
-    {
-        return added;
-    }
-
-    public Set<T> removed()
-    {
-        return removed;
-    }
-
-    boolean hasChanges()
-    {
-        return added.size() > 0 || removed.size() > 0;
-    }
-
-    @Override
-    public String toString()
-    {
-        return String.format( "{added=%s, removed=%s}", added, removed );
-    }
+    void onChannelExpiry( AdvertisedSocketAddress advertisedSocketAddress );
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreTopologyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreTopologyTest.java
@@ -48,7 +48,7 @@ public class CoreTopologyTest
         CoreTopology topology = new CoreTopology( new ClusterId( UUID.randomUUID() ), true, coreMembers );
 
         // when
-        TopologyDifference diff =  topology.difference(topology);
+        TopologyDifference<Difference<CoreServerInfo>> diff =  topology.difference(topology);
 
         // then
         assertThat( diff.added().size(), Matchers.equalTo( 0 ) );
@@ -74,7 +74,7 @@ public class CoreTopologyTest
         CoreTopology topology = new CoreTopology( new ClusterId( UUID.randomUUID() ), true, initialMembers );
 
         // when
-        TopologyDifference diff =  topology.difference(new CoreTopology( new ClusterId( UUID.randomUUID() ), true, newMembers ));
+        TopologyDifference<Difference<CoreServerInfo>> diff =  topology.difference(new CoreTopology( new ClusterId( UUID.randomUUID() ), true, newMembers ));
 
         // then
         assertThat( diff.added().size(), Matchers.equalTo( 1 ) );
@@ -98,7 +98,7 @@ public class CoreTopologyTest
         CoreTopology topology = new CoreTopology( new ClusterId( UUID.randomUUID() ), true, initialMembers );
 
         // when
-        TopologyDifference diff =  topology.difference(new CoreTopology( new ClusterId( UUID.randomUUID() ), true, newMembers ));
+        TopologyDifference<Difference<CoreServerInfo>> diff =  topology.difference(new CoreTopology( new ClusterId( UUID.randomUUID() ), true, newMembers ));
 
         // then
         assertThat( diff.added().size(), Matchers.equalTo( 0 ) );
@@ -121,7 +121,7 @@ public class CoreTopologyTest
         CoreTopology topology = new CoreTopology( new ClusterId( UUID.randomUUID() ), true, initialMembers );
 
         // when
-        TopologyDifference diff =  topology.difference(new CoreTopology( new ClusterId( UUID.randomUUID() ), true, newMembers ));
+        TopologyDifference<Difference<CoreServerInfo>> diff =  topology.difference(new CoreTopology( new ClusterId( UUID.randomUUID() ), true, newMembers ));
 
         // then
         assertThat( diff.added().size(), Matchers.equalTo( 2 ) );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryCoreClient.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryCoreClient.java
@@ -55,7 +55,7 @@ class SharedDiscoveryCoreClient extends LifecycleAdapter implements CoreTopology
     public synchronized void addCoreTopologyListener( Listener listener )
     {
         listeners.add( listener );
-        listener.onCoreTopologyChange( coreTopology );
+        listener.onCoreTopologyChange( coreTopology, coreTopology);
     }
 
     @Override
@@ -101,11 +101,12 @@ class SharedDiscoveryCoreClient extends LifecycleAdapter implements CoreTopology
 
     synchronized void onCoreTopologyChange( CoreTopology coreTopology )
     {
+        CoreTopology oldCoreTopology = this.coreTopology;
         log.info( "Notified of core topology change " + coreTopology );
         this.coreTopology = coreTopology;
         for ( Listener listener : listeners )
         {
-            listener.onCoreTopologyChange( coreTopology );
+            listener.onCoreTopologyChange( oldCoreTopology, coreTopology );
         }
     }
 


### PR DESCRIPTION
At the moment if a server goes away and comes back
with the same hostname but different underlying IP
address we won't be able to do any Raft communication
with it anymore because we cache the channel in SenderService.

This commit adds ChannelExpiryService which translates
core topology change events -> channel expired events that
the SenderService can react to