### PR TITLE
Unify numeric types conversion utilities. Introduce Numbers.

### DIFF
--- a/community/common/src/main/java/org/neo4j/helpers/Numbers.java
+++ b/community/common/src/main/java/org/neo4j/helpers/Numbers.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.helpers;
+
+public class Numbers
+{
+    public static short safeCastIntToUnsignedShort( int value )
+    {
+        if ( (value & ~0xFFFF) != 0 )
+        {
+            throw new ArithmeticException( getOverflowMessage( value, "unsigned short" ) );
+        }
+        return (short) value;
+    }
+
+    public static int safeCastLongToInt( long value )
+    {
+        if ( (int) value != value )
+        {
+            throw new ArithmeticException( getOverflowMessage( value, Integer.TYPE ) );
+        }
+        return (int) value;
+    }
+
+    public static short safeCastLongToShort( long value )
+    {
+        if ( (short) value != value )
+        {
+            throw new ArithmeticException( getOverflowMessage( value, Short.TYPE ) );
+        }
+        return (short) value;
+    }
+
+    public static byte safeCastLongToByte( long value )
+    {
+        if ( (byte) value != value )
+        {
+            throw new ArithmeticException( getOverflowMessage( value, Byte.TYPE ) );
+        }
+        return (byte) value;
+    }
+
+    public static int unsignedShortToInt( short value )
+    {
+        return value & 0xFFFF;
+    }
+
+    private static String getOverflowMessage( long value, Class clazz )
+    {
+        return getOverflowMessage( value, clazz.getName() );
+    }
+
+    private static String getOverflowMessage( long value, String numericType )
+    {
+        return "Value " + value + " is too big to be represented as " + numericType;
+    }
+}

--- a/community/common/src/test/java/org/neo4j/helpers/NumbersTest.java
+++ b/community/common/src/test/java/org/neo4j/helpers/NumbersTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.helpers;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.helpers.Numbers.safeCastIntToUnsignedShort;
+import static org.neo4j.helpers.Numbers.safeCastLongToByte;
+import static org.neo4j.helpers.Numbers.safeCastLongToInt;
+import static org.neo4j.helpers.Numbers.safeCastLongToShort;
+import static org.neo4j.helpers.Numbers.unsignedShortToInt;
+
+public class NumbersTest
+{
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void failSafeCastLongToInt()
+    {
+        expectedException.expect( ArithmeticException.class );
+        expectedException.expectMessage( "Value 2147483648 is too big to be represented as int" );
+
+        safeCastLongToInt( Integer.MAX_VALUE + 1L );
+    }
+
+    @Test
+    public void failSafeCastLongToShort()
+    {
+        expectedException.expect( ArithmeticException.class );
+        expectedException.expectMessage( "Value 32768 is too big to be represented as short" );
+
+        safeCastLongToShort( Short.MAX_VALUE + 1L );
+    }
+
+    @Test
+    public void failSafeCastIntToUnsignedShort()
+    {
+        expectedException.expect( ArithmeticException.class );
+        expectedException.expectMessage( "Value 131068 is too big to be represented as unsigned short" );
+
+        safeCastIntToUnsignedShort( Short.MAX_VALUE << 1 + 1 );
+    }
+
+    @Test
+    public void failSafeCastLongToByte()
+    {
+        expectedException.expect( ArithmeticException.class );
+        expectedException.expectMessage( "Value 128 is too big to be represented as byte" );
+
+        safeCastLongToByte( Byte.MAX_VALUE + 1 );
+    }
+
+    @Test
+    public void castLongToInt()
+    {
+        assertEquals(1, safeCastLongToInt( 1L ));
+        assertEquals(10, safeCastLongToInt( 10L ));
+        assertEquals(-1, safeCastLongToInt( -1L ));
+        assertEquals(Integer.MAX_VALUE, safeCastLongToInt( Integer.MAX_VALUE ));
+        assertEquals(Integer.MIN_VALUE, safeCastLongToInt( Integer.MIN_VALUE ));
+    }
+
+    @Test
+    public void castLongToShort()
+    {
+        assertEquals(1, safeCastLongToShort( 1L ));
+        assertEquals(10, safeCastLongToShort( 10L ));
+        assertEquals(-1, safeCastLongToShort( -1L ));
+        assertEquals(Short.MAX_VALUE, safeCastLongToShort( Short.MAX_VALUE ));
+        assertEquals(Short.MIN_VALUE, safeCastLongToShort( Short.MIN_VALUE ));
+    }
+
+    @Test
+    public void castIntToUnsighedShort()
+    {
+        assertEquals(1, safeCastIntToUnsignedShort( 1 ));
+        assertEquals(10, safeCastIntToUnsignedShort( 10 ));
+        assertEquals(Short.MAX_VALUE, safeCastIntToUnsignedShort( Short.MAX_VALUE ));
+    }
+
+    @Test
+    public void castLongToByte()
+    {
+        assertEquals(1, safeCastLongToByte( 1L ));
+        assertEquals(10, safeCastLongToByte( 10L ));
+        assertEquals(-1, safeCastLongToByte( -1L ));
+        assertEquals(Byte.MAX_VALUE, safeCastLongToByte( Byte.MAX_VALUE ));
+        assertEquals(Byte.MIN_VALUE, safeCastLongToByte( Byte.MIN_VALUE ));
+    }
+
+    @Test
+    public void castUnsignedShortToInt()
+    {
+        assertEquals( 1, unsignedShortToInt( (short) 1 ) );
+        assertEquals( Short.MAX_VALUE, unsignedShortToInt( Short.MAX_VALUE ) );
+        assertEquals( (Short.MAX_VALUE << 1) | 1, unsignedShortToInt( (short) -1 ) );
+    }
+}

--- a/community/common/src/test/java/org/neo4j/helpers/NumbersTest.java
+++ b/community/common/src/test/java/org/neo4j/helpers/NumbersTest.java
@@ -97,7 +97,7 @@ public class NumbersTest
     {
         assertEquals(1, safeCastIntToUnsignedShort( 1 ));
         assertEquals(10, safeCastIntToUnsignedShort( 10 ));
-        assertEquals(Short.MAX_VALUE, safeCastIntToUnsignedShort( Short.MAX_VALUE ));
+        assertEquals( -1, safeCastIntToUnsignedShort( (Short.MAX_VALUE << 1) + 1 ) );
     }
 
     @Test

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/MandatoryProperties.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/MandatoryProperties.java
@@ -38,7 +38,8 @@ import org.neo4j.kernel.impl.store.record.ConstraintRule;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.PrimitiveRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
-import org.neo4j.unsafe.impl.batchimport.Utils;
+
+import static org.neo4j.helpers.Numbers.safeCastLongToInt;
 
 public class MandatoryProperties
 {
@@ -89,7 +90,7 @@ public class MandatoryProperties
             for ( long labelId : NodeLabelReader.getListOfLabels( node, storeAccess.getNodeDynamicLabelStore() ) )
             {
                 // labelId _is_ actually an int. A technical detail in the store format has these come in a long[]
-                int[] propertyKeys = nodes.get( Utils.safeCastLongToInt( labelId ) );
+                int[] propertyKeys = nodes.get( safeCastLongToInt( labelId ) );
                 if ( propertyKeys != null )
                 {
                     if ( keys == null )

--- a/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
+++ b/community/csv/src/main/java/org/neo4j/csv/reader/Extractors.java
@@ -26,6 +26,9 @@ import java.util.Map;
 import static java.lang.Character.isWhitespace;
 import static java.lang.reflect.Modifier.isStatic;
 import static org.neo4j.collection.primitive.PrimitiveLongCollections.EMPTY_LONG_ARRAY;
+import static org.neo4j.helpers.Numbers.safeCastLongToByte;
+import static org.neo4j.helpers.Numbers.safeCastLongToInt;
+import static org.neo4j.helpers.Numbers.safeCastLongToShort;
 
 /**
  * Common implementations of {@link Extractor}. Since array values can have a delimiter of user choice that isn't
@@ -1009,32 +1012,5 @@ public class Extractors
         }
 
         return true;
-    }
-
-    private static int safeCastLongToInt( long value )
-    {
-        if ( value > Integer.MAX_VALUE )
-        {
-            throw new UnsupportedOperationException( "Not supported a.t.m" );
-        }
-        return (int) value;
-    }
-
-    private static short safeCastLongToShort( long value )
-    {
-        if ( value > Short.MAX_VALUE )
-        {
-            throw new UnsupportedOperationException( "Not supported a.t.m" );
-        }
-        return (short) value;
-    }
-
-    private static byte safeCastLongToByte( long value )
-    {
-        if ( value > Byte.MAX_VALUE )
-        {
-            throw new UnsupportedOperationException( "Not supported a.t.m" );
-        }
-        return (byte) value;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreSingleNodeCursor.java
@@ -24,6 +24,7 @@ import java.util.function.Consumer;
 import org.neo4j.collection.primitive.PrimitiveIntCollections;
 import org.neo4j.collection.primitive.PrimitiveIntSet;
 import org.neo4j.cursor.Cursor;
+import org.neo4j.helpers.Numbers;
 import org.neo4j.kernel.api.StatementConstants;
 import org.neo4j.kernel.impl.locking.Lock;
 import org.neo4j.kernel.impl.locking.LockService;
@@ -31,12 +32,11 @@ import org.neo4j.kernel.impl.store.NodeLabelsField;
 import org.neo4j.kernel.impl.store.RecordCursors;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.Record;
-import org.neo4j.kernel.impl.util.IoPrimitiveUtils;
 import org.neo4j.storageengine.api.NodeItem;
 
+import static org.neo4j.helpers.Numbers.safeCastLongToInt;
 import static org.neo4j.kernel.impl.locking.LockService.NO_LOCK_SERVICE;
 import static org.neo4j.kernel.impl.store.record.RecordLoad.CHECK;
-import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.safeCastLongToInt;
 
 /**
  * Base cursor for nodes.
@@ -110,7 +110,7 @@ public class StoreSingleNodeCursor implements Cursor<NodeItem>, NodeItem
     public PrimitiveIntSet labels()
     {
         ensureLabels();
-        return PrimitiveIntCollections.asSet( labels, IoPrimitiveUtils::safeCastLongToInt );
+        return PrimitiveIntCollections.asSet( labels, Numbers::safeCastLongToInt );
     }
 
     private void ensureLabels()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/SchemaRuleDeserializer2_0to3_1.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/SchemaRuleDeserializer2_0to3_1.java
@@ -29,7 +29,7 @@ import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
 import org.neo4j.storageengine.api.schema.SchemaRule;
 import org.neo4j.storageengine.api.schema.SchemaRule.Kind;
 
-import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.safeCastLongToInt;
+import static org.neo4j.helpers.Numbers.safeCastLongToInt;
 import static org.neo4j.string.UTF8.getDecodedStringFrom;
 
 /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV2_1.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV2_1.java
@@ -44,13 +44,13 @@ import org.neo4j.kernel.impl.transaction.command.CommandReading.DynamicRecordAdd
 import org.neo4j.storageengine.api.ReadableChannel;
 import org.neo4j.storageengine.api.schema.SchemaRule;
 
+import static org.neo4j.helpers.Numbers.unsignedShortToInt;
 import static org.neo4j.kernel.impl.transaction.command.CommandReading.COLLECTION_DYNAMIC_RECORD_ADDER;
 import static org.neo4j.kernel.impl.transaction.command.CommandReading.PROPERTY_BLOCK_DYNAMIC_RECORD_ADDER;
 import static org.neo4j.kernel.impl.transaction.command.CommandReading.PROPERTY_DELETED_DYNAMIC_RECORD_ADDER;
 import static org.neo4j.kernel.impl.transaction.command.CommandReading.PROPERTY_INDEX_DYNAMIC_RECORD_ADDER;
 import static org.neo4j.kernel.impl.util.Bits.bitFlag;
 import static org.neo4j.kernel.impl.util.Bits.notFlag;
-import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.shortToUnsignedInt;
 
 public class PhysicalLogCommandReaderV2_1 extends BaseCommandReader
 {
@@ -169,7 +169,7 @@ public class PhysicalLogCommandReaderV2_1 extends BaseCommandReader
         {
             throw new IOException( "Illegal in use flag: " + inUseByte );
         }
-        int type = shortToUnsignedInt( channel.getShort() );
+        int type = unsignedShortToInt( channel.getShort() );
         RelationshipGroupRecord record = new RelationshipGroupRecord( id, type );
         record.setInUse( inUse );
         record.setNext( channel.getLong() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV2_2.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV2_2.java
@@ -53,6 +53,7 @@ import org.neo4j.kernel.impl.transaction.command.CommandReading.DynamicRecordAdd
 import org.neo4j.storageengine.api.ReadableChannel;
 import org.neo4j.storageengine.api.schema.SchemaRule;
 
+import static org.neo4j.helpers.Numbers.unsignedShortToInt;
 import static org.neo4j.kernel.impl.transaction.command.CommandReading.COLLECTION_DYNAMIC_RECORD_ADDER;
 import static org.neo4j.kernel.impl.transaction.command.CommandReading.PROPERTY_BLOCK_DYNAMIC_RECORD_ADDER;
 import static org.neo4j.kernel.impl.transaction.command.CommandReading.PROPERTY_DELETED_DYNAMIC_RECORD_ADDER;
@@ -62,7 +63,6 @@ import static org.neo4j.kernel.impl.util.Bits.notFlag;
 import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.read2bLengthAndString;
 import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.read2bMap;
 import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.read3bLengthAndString;
-import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.shortToUnsignedInt;
 
 public class PhysicalLogCommandReaderV2_2 extends BaseCommandReader
 {
@@ -220,7 +220,7 @@ public class PhysicalLogCommandReaderV2_2 extends BaseCommandReader
         {
             throw new IOException( "Illegal in use flag: " + inUseByte );
         }
-        int type = shortToUnsignedInt( channel.getShort() );
+        int type = unsignedShortToInt( channel.getShort() );
         RelationshipGroupRecord record = new RelationshipGroupRecord( id, type );
         record.setInUse( inUse );
         record.setNext( channel.getLong() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV2_2_10.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV2_2_10.java
@@ -53,6 +53,7 @@ import org.neo4j.kernel.impl.transaction.command.CommandReading.DynamicRecordAdd
 import org.neo4j.storageengine.api.ReadableChannel;
 import org.neo4j.storageengine.api.schema.SchemaRule;
 
+import static org.neo4j.helpers.Numbers.unsignedShortToInt;
 import static org.neo4j.kernel.impl.transaction.command.CommandReading.COLLECTION_DYNAMIC_RECORD_ADDER;
 import static org.neo4j.kernel.impl.transaction.command.CommandReading.PROPERTY_BLOCK_DYNAMIC_RECORD_ADDER;
 import static org.neo4j.kernel.impl.transaction.command.CommandReading.PROPERTY_DELETED_DYNAMIC_RECORD_ADDER;
@@ -62,7 +63,6 @@ import static org.neo4j.kernel.impl.util.Bits.notFlag;
 import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.read2bLengthAndString;
 import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.read2bMap;
 import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.read3bLengthAndString;
-import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.shortToUnsignedInt;
 
 public class PhysicalLogCommandReaderV2_2_10 extends BaseCommandReader
 {
@@ -220,7 +220,7 @@ public class PhysicalLogCommandReaderV2_2_10 extends BaseCommandReader
         {
             throw new IOException( "Illegal in use flag: " + inUseByte );
         }
-        int type = shortToUnsignedInt( channel.getShort() );
+        int type = unsignedShortToInt( channel.getShort() );
         RelationshipGroupRecord record = new RelationshipGroupRecord( id, type );
         record.setInUse( inUse );
         record.setNext( channel.getLong() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV2_2_4.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV2_2_4.java
@@ -53,6 +53,7 @@ import org.neo4j.kernel.impl.transaction.command.CommandReading.DynamicRecordAdd
 import org.neo4j.storageengine.api.ReadableChannel;
 import org.neo4j.storageengine.api.schema.SchemaRule;
 
+import static org.neo4j.helpers.Numbers.unsignedShortToInt;
 import static org.neo4j.kernel.impl.transaction.command.CommandReading.COLLECTION_DYNAMIC_RECORD_ADDER;
 import static org.neo4j.kernel.impl.transaction.command.CommandReading.PROPERTY_BLOCK_DYNAMIC_RECORD_ADDER;
 import static org.neo4j.kernel.impl.transaction.command.CommandReading.PROPERTY_DELETED_DYNAMIC_RECORD_ADDER;
@@ -62,7 +63,6 @@ import static org.neo4j.kernel.impl.util.Bits.notFlag;
 import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.read2bLengthAndString;
 import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.read2bMap;
 import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.read3bLengthAndString;
-import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.shortToUnsignedInt;
 
 public class PhysicalLogCommandReaderV2_2_4 extends BaseCommandReader
 {
@@ -220,7 +220,7 @@ public class PhysicalLogCommandReaderV2_2_4 extends BaseCommandReader
         {
             throw new IOException( "Illegal in use flag: " + inUseByte );
         }
-        int type = shortToUnsignedInt( channel.getShort() );
+        int type = unsignedShortToInt( channel.getShort() );
         RelationshipGroupRecord record = new RelationshipGroupRecord( id, type );
         record.setInUse( inUse );
         record.setNext( channel.getLong() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV3_0.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV3_0.java
@@ -53,6 +53,7 @@ import org.neo4j.kernel.impl.transaction.command.CommandReading.DynamicRecordAdd
 import org.neo4j.storageengine.api.ReadableChannel;
 import org.neo4j.storageengine.api.schema.SchemaRule;
 
+import static org.neo4j.helpers.Numbers.unsignedShortToInt;
 import static org.neo4j.kernel.impl.transaction.command.CommandReading.COLLECTION_DYNAMIC_RECORD_ADDER;
 import static org.neo4j.kernel.impl.transaction.command.CommandReading.PROPERTY_BLOCK_DYNAMIC_RECORD_ADDER;
 import static org.neo4j.kernel.impl.transaction.command.CommandReading.PROPERTY_DELETED_DYNAMIC_RECORD_ADDER;
@@ -61,7 +62,6 @@ import static org.neo4j.kernel.impl.util.Bits.bitFlag;
 import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.read2bLengthAndString;
 import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.read2bMap;
 import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.read3bLengthAndString;
-import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.shortToUnsignedInt;
 
 public class PhysicalLogCommandReaderV3_0 extends BaseCommandReader
 {
@@ -211,7 +211,7 @@ public class PhysicalLogCommandReaderV3_0 extends BaseCommandReader
         boolean hasSecondaryUnit = bitFlag( flags, Record.HAS_SECONDARY_UNIT );
         boolean usesFixedReferenceFormat = bitFlag( flags, Record.USES_FIXED_REFERENCE_FORMAT );
 
-        int type = shortToUnsignedInt( channel.getShort() );
+        int type = unsignedShortToInt( channel.getShort() );
         RelationshipGroupRecord record = new RelationshipGroupRecord( id, type );
         record.setInUse( inUse );
         record.setNext( channel.getLong() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV3_0_2.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/command/PhysicalLogCommandReaderV3_0_2.java
@@ -53,6 +53,7 @@ import org.neo4j.kernel.impl.transaction.command.CommandReading.DynamicRecordAdd
 import org.neo4j.storageengine.api.ReadableChannel;
 import org.neo4j.storageengine.api.schema.SchemaRule;
 
+import static org.neo4j.helpers.Numbers.unsignedShortToInt;
 import static org.neo4j.kernel.impl.transaction.command.CommandReading.COLLECTION_DYNAMIC_RECORD_ADDER;
 import static org.neo4j.kernel.impl.transaction.command.CommandReading.PROPERTY_BLOCK_DYNAMIC_RECORD_ADDER;
 import static org.neo4j.kernel.impl.transaction.command.CommandReading.PROPERTY_DELETED_DYNAMIC_RECORD_ADDER;
@@ -61,7 +62,6 @@ import static org.neo4j.kernel.impl.util.Bits.bitFlag;
 import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.read2bLengthAndString;
 import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.read2bMap;
 import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.read3bLengthAndString;
-import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.shortToUnsignedInt;
 
 public class PhysicalLogCommandReaderV3_0_2 extends BaseCommandReader
 {
@@ -211,7 +211,7 @@ public class PhysicalLogCommandReaderV3_0_2 extends BaseCommandReader
         boolean hasSecondaryUnit = bitFlag( flags, Record.HAS_SECONDARY_UNIT );
         boolean usesFixedReferenceFormat = bitFlag( flags, Record.USES_FIXED_REFERENCE_FORMAT );
 
-        int type = shortToUnsignedInt( channel.getShort() );
+        int type = unsignedShortToInt( channel.getShort() );
         RelationshipGroupRecord record = new RelationshipGroupRecord( id, type );
         record.setInUse( inUse );
         record.setNext( channel.getLong() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/IoPrimitiveUtils.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/IoPrimitiveUtils.java
@@ -223,28 +223,4 @@ public abstract class IoPrimitiveUtils
         }
         return new Object[] { propertyValue };
     }
-
-    public static int safeCastLongToInt( long value )
-    {
-        if ( value >= Integer.MAX_VALUE )
-        {
-            throw new IllegalArgumentException( "Casting long value " + value + " to an int would wrap around" );
-        }
-        return (int) value;
-    }
-
-    public static short safeCastIntToUnsignedShort( int value )
-    {
-        if ( (value & ~0xFFFF) != 0 )
-        {
-            throw new IllegalArgumentException(
-                    "Casting int value " + value + " to an unsigned short would wrap around" );
-        }
-        return (short) value;
-    }
-
-    public static int shortToUnsignedInt( short value )
-    {
-        return value & 0xFFFF;
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
@@ -170,10 +170,10 @@ import static org.neo4j.collection.primitive.PrimitiveLongCollections.map;
 import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.logs_directory;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.store_internal_log_path;
+import static org.neo4j.helpers.Numbers.safeCastLongToInt;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.store.NodeLabelsField.parseLabelsField;
 import static org.neo4j.kernel.impl.store.PropertyStore.encodeString;
-import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.safeCastLongToInt;
 
 public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvider
 {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Utils.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Utils.java
@@ -29,33 +29,6 @@ import org.neo4j.unsafe.impl.batchimport.input.SourceInputIterator;
  */
 public class Utils
 {
-    public static int safeCastLongToInt( long value )
-    {
-        if ( value > Integer.MAX_VALUE )
-        {
-            throw new ArithmeticException( getOverflowMessage( value, Integer.TYPE ) );
-        }
-        return (int) value;
-    }
-
-    public static short safeCastLongToShort( long value )
-    {
-        if ( value > Short.MAX_VALUE )
-        {
-            throw new ArithmeticException( getOverflowMessage( value, Short.TYPE ) );
-        }
-        return (short) value;
-    }
-
-    public static byte safeCastLongToByte( long value )
-    {
-        if ( value > Byte.MAX_VALUE )
-        {
-            throw new ArithmeticException( getOverflowMessage( value, Byte.TYPE ) );
-        }
-        return (byte) value;
-    }
-
     public enum CompareType
     {
         EQ, GT, GE, LT, LE, NE
@@ -205,11 +178,6 @@ public class Utils
                 into[t--] = into[i--];
             }
         }
-    }
-
-    private static String getOverflowMessage( long value, Class clazz )
-    {
-        return "Value " + value + " is too big to be represented as " + clazz.getName();
     }
 
     private Utils()

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapNumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapNumberArray.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.unsafe.impl.batchimport.cache;
 
-import static org.neo4j.unsafe.impl.batchimport.Utils.safeCastLongToInt;
+import static org.neo4j.helpers.Numbers.safeCastLongToInt;
 
 /**
  * Base class for common functionality for any {@link NumberArray} where the data lives inside heap.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCache.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCache.java
@@ -33,10 +33,11 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.neo4j.graphdb.Direction;
 import org.neo4j.helpers.collection.PrefetchingIterator;
-import org.neo4j.kernel.impl.util.IoPrimitiveUtils;
 
 import static java.lang.Long.min;
 import static java.lang.Math.toIntExact;
+import static org.neo4j.helpers.Numbers.safeCastIntToUnsignedShort;
+import static org.neo4j.helpers.Numbers.unsignedShortToInt;
 
 /**
  * Caches of parts of node store and relationship group store. A crucial part of batch import where
@@ -622,7 +623,7 @@ public class NodeRelationshipCache implements MemoryStatsVisitor.Visitable
 
         int getTypeId( ByteArray array, long index )
         {
-            return IoPrimitiveUtils.shortToUnsignedInt( array.getShort( index, TYPE_OFFSET ) );
+            return unsignedShortToInt( array.getShort( index, TYPE_OFFSET ) );
         }
 
         /**
@@ -678,7 +679,7 @@ public class NodeRelationshipCache implements MemoryStatsVisitor.Visitable
             long rebasedIndex = rebase( index );
             ByteArray array = this.array.at( rebasedIndex );
             clearIndex( array, rebasedIndex );
-            short shortTypeId = IoPrimitiveUtils.safeCastIntToUnsignedShort( typeId );
+            short shortTypeId = safeCastIntToUnsignedShort( typeId );
             array.setShort( rebasedIndex, TYPE_OFFSET, shortTypeId );
             return index;
         }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
@@ -28,7 +28,7 @@ import org.neo4j.io.pagecache.PageCache;
 import static java.lang.String.format;
 import static org.neo4j.helpers.Exceptions.launderedException;
 import static org.neo4j.helpers.Format.bytes;
-import static org.neo4j.unsafe.impl.batchimport.Utils.safeCastLongToInt;
+import static org.neo4j.helpers.Numbers.safeCastLongToInt;
 
 /**
  * Factory of {@link LongArray}, {@link IntArray} and {@link ByteArray} instances. Users can select in which type of

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
@@ -28,7 +28,6 @@ import org.neo4j.function.Factory;
 import org.neo4j.helpers.progress.ProgressListener;
 import org.neo4j.unsafe.impl.batchimport.InputIterable;
 import org.neo4j.unsafe.impl.batchimport.InputIterator;
-import org.neo4j.unsafe.impl.batchimport.Utils;
 import org.neo4j.unsafe.impl.batchimport.Utils.CompareType;
 import org.neo4j.unsafe.impl.batchimport.cache.IntArray;
 import org.neo4j.unsafe.impl.batchimport.cache.LongArray;
@@ -44,7 +43,7 @@ import org.neo4j.unsafe.impl.batchimport.input.InputException;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.String.format;
-import static org.neo4j.unsafe.impl.batchimport.Utils.safeCastLongToInt;
+import static org.neo4j.helpers.Numbers.safeCastLongToInt;
 import static org.neo4j.unsafe.impl.batchimport.Utils.unsignedCompare;
 import static org.neo4j.unsafe.impl.batchimport.Utils.unsignedDifference;
 import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.ParallelSort.DEFAULT;
@@ -578,7 +577,7 @@ public class EncodingIdMapper implements IdMapper
                 // We cast the collision index to an int here. This means that we can't support > int-range
                 // number of collisions. But that's probably alright since the data structures and
                 // actual collisions values for all these collisions wouldn't fit in a heap anyway.
-                Object inputId = collisionValues.get( Utils.safeCastLongToInt( collisionIndex ) );
+                Object inputId = collisionValues.get( safeCastLongToInt( collisionIndex ) );
                 int detectorIndex = detector.add( inputId, sourceInformation );
                 if ( detectorIndex != -1 )
                 {   // Duplicate

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/IntTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/IntTracker.java
@@ -19,8 +19,9 @@
  */
 package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
 
-import org.neo4j.unsafe.impl.batchimport.Utils;
 import org.neo4j.unsafe.impl.batchimport.cache.IntArray;
+
+import static org.neo4j.helpers.Numbers.safeCastLongToInt;
 
 /**
  * {@link Tracker} capable of keeping {@code int} range values, using {@link IntArray}.
@@ -47,6 +48,6 @@ public class IntTracker extends AbstractTracker<IntArray>
     @Override
     public void set( long index, long value )
     {
-        array.set( index, Utils.safeCastLongToInt( value ) );
+        array.set( index, safeCastLongToInt( value ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/ParallelSort.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/ParallelSort.java
@@ -28,6 +28,7 @@ import org.neo4j.unsafe.impl.batchimport.Utils;
 import org.neo4j.unsafe.impl.batchimport.Utils.CompareType;
 import org.neo4j.unsafe.impl.batchimport.cache.LongArray;
 
+import static org.neo4j.helpers.Numbers.safeCastLongToInt;
 import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.EncodingIdMapper.clearCollision;
 
 /**
@@ -354,7 +355,7 @@ public class ParallelSort
 
             long low = Math.max( start, randomIndex - 5 );
             long high = Math.min( low + 10, end );
-            int length = Utils.safeCastLongToInt( high - low );
+            int length = safeCastLongToInt( high - low );
 
             int j = 0;
             for ( long i = low; i < high; i++, j++ )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityCacher.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityCacher.java
@@ -33,7 +33,7 @@ import org.neo4j.kernel.impl.transaction.log.LogPositionMarker;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogVersionedStoreChannel;
 import org.neo4j.kernel.impl.transaction.log.PositionAwarePhysicalFlushableChannel;
 
-import static org.neo4j.unsafe.impl.batchimport.Utils.safeCastLongToShort;
+import static org.neo4j.helpers.Numbers.safeCastLongToShort;
 import static org.neo4j.unsafe.impl.batchimport.input.InputCache.END_OF_ENTITIES;
 import static org.neo4j.unsafe.impl.batchimport.input.InputCache.END_OF_HEADER;
 import static org.neo4j.unsafe.impl.batchimport.input.InputCache.GROUP_TOKEN;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityReader.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputEntityReader.java
@@ -39,8 +39,8 @@ import org.neo4j.kernel.impl.util.collection.ContinuableArrayCursor;
 import org.neo4j.unsafe.impl.batchimport.InputIterator;
 import org.neo4j.unsafe.impl.batchimport.staging.TicketedProcessing;
 
+import static org.neo4j.helpers.Numbers.safeCastLongToInt;
 import static org.neo4j.kernel.impl.transaction.log.LogVersionBridge.NO_MORE_CHANNELS;
-import static org.neo4j.unsafe.impl.batchimport.Utils.safeCastLongToInt;
 import static org.neo4j.unsafe.impl.batchimport.input.InputCache.END_OF_ENTITIES;
 import static org.neo4j.unsafe.impl.batchimport.input.InputCache.END_OF_HEADER;
 import static org.neo4j.unsafe.impl.batchimport.input.InputCache.GROUP_TOKEN;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/DelayedBufferTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/DelayedBufferTest.java
@@ -42,7 +42,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.neo4j.function.Suppliers.singleton;
-import static org.neo4j.unsafe.impl.batchimport.Utils.safeCastLongToInt;
+import static org.neo4j.helpers.Numbers.safeCastLongToInt;
 
 public class DelayedBufferTest
 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NodeCommandTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NodeCommandTest.java
@@ -50,12 +50,12 @@ import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.neo4j.helpers.Numbers.safeCastLongToInt;
 import static org.neo4j.kernel.impl.store.DynamicNodeLabels.dynamicPointer;
 import static org.neo4j.kernel.impl.store.NodeLabelsField.parseLabelsField;
 import static org.neo4j.kernel.impl.store.ShortArray.LONG;
 import static org.neo4j.kernel.impl.store.record.AbstractBaseRecord.NO_ID;
 import static org.neo4j.kernel.impl.store.record.DynamicRecord.dynamicRecord;
-import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.safeCastLongToInt;
 
 public class NodeCommandTest
 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NodeLabelsFieldTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NodeLabelsFieldTest.java
@@ -58,9 +58,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.neo4j.helpers.Numbers.safeCastLongToInt;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.util.Bits.bits;
-import static org.neo4j.kernel.impl.util.IoPrimitiveUtils.safeCastLongToInt;
 
 public class NodeLabelsFieldTest
 {

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/UtilsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/UtilsTest.java
@@ -19,9 +19,7 @@
  */
 package org.neo4j.unsafe.impl.batchimport;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -43,9 +41,6 @@ import static org.neo4j.unsafe.impl.batchimport.input.InputEntity.NO_PROPERTIES;
 public class UtilsTest
 {
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
     @Test
     public void shouldDetectCollisions() throws Exception
     {
@@ -58,24 +53,6 @@ public class UtilsTest
 
         // THEN
         assertTrue( collides );
-    }
-
-    @Test
-    public void failSafeCastLongToIntOnOverflow()
-    {
-        expectedException.expect( ArithmeticException.class );
-        expectedException.expectMessage( "Value 2147483648 is too big to be represented as int" );
-
-        Utils.safeCastLongToInt( Integer.MAX_VALUE + 1L );
-    }
-
-    @Test
-    public void failSafeCastLongToShortOnOverflow()
-    {
-        expectedException.expect( ArithmeticException.class );
-        expectedException.expectMessage( "Value 32768 is too big to be represented as short" );
-
-        Utils.safeCastLongToShort( Short.MAX_VALUE + 1L );
     }
 
     @Test


### PR DESCRIPTION
Remove duplicated conversions across code base that perform
safe conversion from one numeric type to another. Unify them and cleanup.