### PR TITLE
Removed unnecessary assertion in UNION

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/convert/plannerQuery/StatementConverters.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/convert/plannerQuery/StatementConverters.scala
@@ -68,7 +68,6 @@ object StatementConverters {
         //UNION requires all queries to return the same variables
         assert(plannedQueries.nonEmpty)
         val returns = plannedQueries.head.returns
-        assert(plannedQueries.forall(_.returns == returns))
 
         UnionQuery(plannedQueries.map(_.build()), distinct, returns, PeriodicCommit(periodicCommitHint))
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LernaeanTestSupport.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LernaeanTestSupport.scala
@@ -149,6 +149,8 @@ trait LernaeanTestSupport extends CypherTestSupport {
 
     def Version3_2: TestConfig = Compiled + Scenarios.CommunityInterpreted + Scenarios.RulePlannerOnLatestVersion
 
+    def AllRulePlanners: TestConfig = Scenarios.Compatibility3_1Rule + Scenarios.Compatibility2_3Rule + Scenarios.RulePlannerOnLatestVersion
+
     def Cost: TestConfig = Compiled + Scenarios.Compatibility3_1Cost + Scenarios.Compatibility2_3Cost + Scenarios.ForcedCostPlanner
 
     def BackwardsCompatibility: TestConfig = Version2_3 + Version3_1

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UnionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UnionAcceptanceTest.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import org.neo4j.cypher._
+
+class UnionAcceptanceTest extends ExecutionEngineFunSuite with LernaeanTestSupport {
+
+  test("Should work when doing union with same return varibles"){
+    createLabeledNode(Map("a" -> "a", "b" -> "b"),"A")
+    createLabeledNode(Map("a" -> "a", "b" -> "b"),"B")
+
+    val query ="""
+                 |MATCH (N:A)
+                 | RETURN
+                 |	N.a as A,
+                 |	N.b as B
+                 |UNION
+                 |
+                 |MATCH (M:B) RETURN
+                 |	M.b as A,
+                 |	M.a as B
+               """.stripMargin
+
+    val result = testWith(Configs.All - Configs.Compiled, query)
+    val expected = List(Map("A" -> "a", "B" -> "b"), Map("A" -> "b", "B" -> "a"))
+
+
+    result.toList should equal(expected)
+
+  }
+
+  test("Should work when doing union with permutated return varibles"){
+    createLabeledNode(Map("a" -> "a", "b" -> "b"),"A")
+    createLabeledNode(Map("a" -> "b", "b" -> "a"),"B")
+
+    val query ="""
+                 |MATCH (N:A)
+                 | RETURN
+                 |	N.a as B,
+                 |	N.b as A
+                 |UNION
+                 |
+                 |MATCH (M:B) RETURN
+                 |	M.b as A,
+                 |	M.a as B
+               """.stripMargin
+
+
+    val result = testWith(Configs.All - Configs.Compiled - Configs.BackwardsCompatibility + Configs.AllRulePlanners, query)
+    val expected = List(Map("A" -> "b", "B" -> "a"), Map("A" -> "a", "B" -> "b"))
+
+
+    result.toList should equal(expected)
+  }
+
+}

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UnionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UnionAcceptanceTest.scala
@@ -23,50 +23,47 @@ import org.neo4j.cypher._
 
 class UnionAcceptanceTest extends ExecutionEngineFunSuite with LernaeanTestSupport {
 
-  test("Should work when doing union with same return varibles"){
-    createLabeledNode(Map("a" -> "a", "b" -> "b"),"A")
-    createLabeledNode(Map("a" -> "a", "b" -> "b"),"B")
+  test("Should work when doing union with same return varibles") {
+    createLabeledNode(Map("a" -> "a", "b" -> "b"), "A")
+    createLabeledNode(Map("a" -> "a", "b" -> "b"), "B")
 
-    val query ="""
-                 |MATCH (N:A)
-                 | RETURN
-                 |	N.a as A,
-                 |	N.b as B
-                 |UNION
-                 |
-                 |MATCH (M:B) RETURN
-                 |	M.b as A,
-                 |	M.a as B
-               """.stripMargin
+    val query =
+    """
+      |MATCH (N:A)
+      |RETURN
+      |N.a as A,
+      |N.b as B
+      |UNION
+      |MATCH (M:B) RETURN
+      |M.b as A,
+      |M.a as B
+    """.stripMargin
 
     val result = testWith(Configs.All - Configs.Compiled, query)
     val expected = List(Map("A" -> "a", "B" -> "b"), Map("A" -> "b", "B" -> "a"))
 
-
     result.toList should equal(expected)
-
   }
 
-  test("Should work when doing union with permutated return varibles"){
-    createLabeledNode(Map("a" -> "a", "b" -> "b"),"A")
-    createLabeledNode(Map("a" -> "b", "b" -> "a"),"B")
+  test("Should work when doing union with permutated return varibles") {
+    createLabeledNode(Map("a" -> "a", "b" -> "b"), "A")
+    createLabeledNode(Map("a" -> "b", "b" -> "a"), "B")
 
-    val query ="""
-                 |MATCH (N:A)
-                 | RETURN
-                 |	N.a as B,
-                 |	N.b as A
-                 |UNION
-                 |
-                 |MATCH (M:B) RETURN
-                 |	M.b as A,
-                 |	M.a as B
-               """.stripMargin
+    val query =
+    """
+      |MATCH (N:A)
+      |RETURN
+      |N.a as B,
+      |N.b as A
+      |UNION
+      |MATCH (M:B) RETURN
+      |M.b as A,
+      |M.a as B
+    """.stripMargin
 
 
     val result = testWith(Configs.All - Configs.Compiled - Configs.BackwardsCompatibility + Configs.AllRulePlanners, query)
     val expected = List(Map("A" -> "b", "B" -> "a"), Map("A" -> "a", "B" -> "b"))
-
 
     result.toList should equal(expected)
   }


### PR DESCRIPTION
When running with cost planner Union now supports that the return variables are permutated.