### PR TITLE
Configure failsafe system properties by default

### DIFF
--- a/enterprise/causal-clustering/pom.xml
+++ b/enterprise/causal-clustering/pom.xml
@@ -258,15 +258,9 @@
                     <!-- Misha says it is not safe to run tests with more than one thread per JVM -->
                     <!-- He also said he'd fix that! -->
                     <threadCount>1</threadCount>
-                    <reuseForks>true</reuseForks>
-                    <runOrder>random</runOrder>
                     <!-- slowest test class takes up to 10 minutes, so let's cater for that, with contingency -->
                     <parallelTestsTimeoutInSeconds>1200</parallelTestsTimeoutInSeconds>
                     <parallelTestsTimeoutForcedInSeconds>1800</parallelTestsTimeoutForcedInSeconds>
-                    <workingDirectory>${project.build.directory}/FORK_DIRECTORY_${surefire.forkNumber}</workingDirectory>
-                    <systemPropertyVariables>
-                        <port.authority.directory>${user.dir}/target/port-authority-${maven.build.timestamp}</port.authority.directory>
-                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/enterprise/ha/pom.xml
+++ b/enterprise/ha/pom.xml
@@ -216,15 +216,9 @@
           <!-- Misha says it is not safe to run tests with more than one thread per JVM -->
           <!-- He also said he'd fix that! -->
           <threadCount>1</threadCount>
-          <reuseForks>true</reuseForks>
-          <runOrder>random</runOrder>
           <!-- slowest test class takes up to 10 minutes, so let's cater for that, with contingency -->
           <parallelTestsTimeoutInSeconds>1200</parallelTestsTimeoutInSeconds>
           <parallelTestsTimeoutForcedInSeconds>1800</parallelTestsTimeoutForcedInSeconds>
-          <workingDirectory>${project.build.directory}/FORK_DIRECTORY_${surefire.forkNumber}</workingDirectory>
-          <systemPropertyVariables>
-            <port.authority.directory>${user.dir}/target/port-authority-${maven.build.timestamp}</port.authority.directory>
-          </systemPropertyVariables>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
           <runOrder>random</runOrder>
           <systemPropertyVariables>
             <dbms.pagecache.memory.default.override>8m</dbms.pagecache.memory.default.override>
+            <port.authority.directory>${user.dir}/target/port-authority-${maven.build.timestamp}</port.authority.directory>
           </systemPropertyVariables>
         </configuration>
       </plugin>


### PR DESCRIPTION
Cleanup failsafe configuration. Move port.authority property
to common config to avoid the need to reconfigure
failsafe in all modules that use port authority utility (for example metrics module).