### PR TITLE
Migrate to native label index during store upgrade

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/DatabaseMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/DatabaseMigrator.java
@@ -31,6 +31,7 @@ import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
 import org.neo4j.kernel.impl.storemigration.participant.CountsMigrator;
 import org.neo4j.kernel.impl.storemigration.participant.LegacyIndexMigrator;
+import org.neo4j.kernel.impl.storemigration.participant.NativeLabelScanStoreMigrator;
 import org.neo4j.kernel.impl.storemigration.participant.StoreMigrator;
 import org.neo4j.kernel.spi.legacyindex.IndexImplementation;
 import org.neo4j.logging.LogProvider;
@@ -86,11 +87,13 @@ public class DatabaseMigrator
         StoreMigrationParticipant schemaMigrator = schemaIndexProvider.storeMigrationParticipant( fs, pageCache );
         LegacyIndexMigrator legacyIndexMigrator = new LegacyIndexMigrator( fs, indexProviders, logProvider );
         StoreMigrator storeMigrator = new StoreMigrator( fs, pageCache, config, logService );
+        NativeLabelScanStoreMigrator nativeLabelScanStoreMigrator = new NativeLabelScanStoreMigrator( fs, pageCache );
         CountsMigrator countsMigrator = new CountsMigrator( fs, pageCache, config );
 
         storeUpgrader.addParticipant( schemaMigrator );
         storeUpgrader.addParticipant( legacyIndexMigrator );
         storeUpgrader.addParticipant( storeMigrator );
+        storeUpgrader.addParticipant( nativeLabelScanStoreMigrator );
         storeUpgrader.addParticipant( countsMigrator );
         storeUpgrader.migrateIfNeeded( storeDir );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
@@ -39,8 +39,6 @@ import org.neo4j.kernel.internal.Version;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 
-import static java.lang.String.format;
-
 /**
  * A migration process to migrate {@link StoreMigrationParticipant migration participants}, if there's
  * need for it, before the database fully starts. Participants can
@@ -203,14 +201,12 @@ public class StoreUpgrader
     {
         try
         {
-            int index = 1;
             for ( StoreMigrationParticipant participant : participants )
             {
                 Section section = progressMonitor.startSection( participant.getName() );
                 participant.migrate( storeDir, migrationDirectory, section, versionToMigrateFrom,
                         upgradableDatabase.currentVersion() );
                 section.completed();
-                index++;
             }
         }
         catch ( IOException | UncheckedIOException e )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigrator.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.storemigration.participant;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
+import org.neo4j.kernel.impl.api.index.IndexStoreView;
+import org.neo4j.kernel.impl.api.scan.FullLabelStream;
+import org.neo4j.kernel.impl.index.labelscan.NativeLabelScanStore;
+import org.neo4j.kernel.impl.store.NeoStores;
+import org.neo4j.kernel.impl.store.StoreFactory;
+import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
+import org.neo4j.kernel.impl.transaction.state.storeview.NeoStoreIndexStoreView;
+import org.neo4j.kernel.lifecycle.Lifespan;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.NullLogProvider;
+
+import static org.neo4j.kernel.impl.locking.LockService.NO_LOCK_SERVICE;
+import static org.neo4j.kernel.impl.store.format.RecordFormatSelector.selectForVersion;
+
+public class NativeLabelScanStoreMigrator extends AbstractStoreMigrationParticipant
+{
+    private final FileSystemAbstraction fileSystem;
+    private final PageCache pageCache;
+    private boolean nativeLabelScanStoreMigrated;
+
+    public NativeLabelScanStoreMigrator( FileSystemAbstraction fileSystem, PageCache pageCache )
+    {
+        super( "Native label scan index" );
+        this.fileSystem = fileSystem;
+        this.pageCache = pageCache;
+    }
+
+    @Override
+    public void migrate( File storeDir, File migrationDir, MigrationProgressMonitor.Section progressMonitor,
+            String versionToMigrateFrom, String versionToMigrateTo ) throws IOException
+    {
+        if ( migrateNativeLabelScanStore( storeDir ) )
+        {
+            StoreFactory storeFactory = getStoreFactory( storeDir, versionToMigrateFrom );
+            try ( NeoStores neoStores = storeFactory.openAllNeoStores();
+                    Lifespan lifespan = new Lifespan() )
+            {
+                progressMonitor.start( neoStores.getNodeStore().getNumberOfIdsInUse() );
+                NativeLabelScanStore nativeLabelScanStore = getNativeLabelScanStore( migrationDir, progressMonitor, neoStores );
+                lifespan.add( nativeLabelScanStore );
+            }
+            nativeLabelScanStoreMigrated = true;
+        }
+    }
+
+    @Override
+    public void moveMigratedFiles( File migrationDir, File storeDir, String versionToUpgradeFrom,
+            String versionToMigrateTo ) throws IOException
+    {
+        if ( nativeLabelScanStoreMigrated )
+        {
+            File nativeLabelIndex = new File( migrationDir, NativeLabelScanStore.FILE_NAME );
+            fileSystem.moveToDirectory( nativeLabelIndex, storeDir );
+            deleteLuceneLabelIndex( getLuceneStoreDirectory( storeDir ) );
+        }
+    }
+
+    private NativeLabelScanStore getNativeLabelScanStore( File migrationDir,
+            MigrationProgressMonitor.Section progressMonitor, NeoStores neoStores )
+    {
+        NeoStoreIndexStoreView neoStoreIndexStoreView = new NeoStoreIndexStoreView( NO_LOCK_SERVICE, neoStores );
+        return new NativeLabelScanStore( pageCache, migrationDir,
+                new MonitoredFullLabelStream( neoStoreIndexStoreView, progressMonitor ), false, new Monitors(),
+                RecoveryCleanupWorkCollector.IMMEDIATE );
+    }
+
+    private StoreFactory getStoreFactory( File storeDir, String versionToMigrateFrom )
+    {
+        return new StoreFactory( storeDir, pageCache, fileSystem,
+                        selectForVersion( versionToMigrateFrom ), NullLogProvider.getInstance() );
+    }
+
+    private boolean migrateNativeLabelScanStore( File storeDir )
+    {
+        return !fileSystem.fileExists( new File( storeDir, NativeLabelScanStore.FILE_NAME ) );
+    }
+
+    private void deleteLuceneLabelIndex( File indexRootDirectory ) throws IOException
+    {
+        fileSystem.deleteRecursively( indexRootDirectory );
+    }
+
+    private static File getLuceneStoreDirectory( File storeRootDir )
+    {
+        return new File( new File( new File( storeRootDir, "schema" ), "label" ), "lucene" );
+    }
+
+    private class MonitoredFullLabelStream extends FullLabelStream
+    {
+
+        private final MigrationProgressMonitor.Section progressMonitor;
+
+        MonitoredFullLabelStream( IndexStoreView indexStoreView, MigrationProgressMonitor.Section progressMonitor )
+        {
+            super( indexStoreView );
+            this.progressMonitor = progressMonitor;
+        }
+
+        @Override
+        public boolean visit( NodeLabelUpdate update ) throws IOException
+        {
+            boolean visit = super.visit( update );
+            progressMonitor.progress( 1 );
+            return visit;
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/SchemaIndexMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/SchemaIndexMigrator.java
@@ -70,7 +70,6 @@ public class SchemaIndexMigrator extends AbstractStoreMigrationParticipant
         {
             deleteIndexes( schemaIndexDirectory );
         }
-        deleteIndexes( getLuceneStoreDirectory( storeDir ) );
     }
 
     private void deleteIndexes( File indexRootDirectory ) throws IOException
@@ -78,8 +77,4 @@ public class SchemaIndexMigrator extends AbstractStoreMigrationParticipant
         fileSystem.deleteRecursively( indexRootDirectory );
     }
 
-    static File getLuceneStoreDirectory( File storeRootDir )
-    {
-        return new File( new File( new File( storeRootDir, "schema" ), "label" ), "lucene" );
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
@@ -129,10 +129,6 @@ import static org.neo4j.unsafe.impl.batchimport.staging.ExecutionSupervisors.wit
  */
 public class StoreMigrator extends AbstractStoreMigrationParticipant
 {
-    // Developers: There is a benchmark, storemigrator-benchmark, that generates large stores and benchmarks
-    // the upgrade process. Please utilize that when writing upgrade code to ensure the code is fast enough to
-    // complete upgrades in a reasonable time period.
-
     private static final char TX_LOG_COUNTERS_SEPARATOR = 'A';
     public static final String CUSTOM_IO_EXCEPTION_MESSAGE =
             "Migrating this version is not supported for custom IO configurations.";

--- a/community/kernel/src/main/java/org/neo4j/kernel/monitoring/Monitors.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/monitoring/Monitors.java
@@ -58,7 +58,7 @@ import static org.neo4j.helpers.collection.Iterables.asArray;
  */
 public class Monitors
 {
-    public static final AtomicBoolean FALSE = new AtomicBoolean( false );
+    private static final AtomicBoolean FALSE = new AtomicBoolean( false );
 
     public interface Monitor
     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigratorTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.storemigration.participant;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Paths;
+
+import org.neo4j.collection.primitive.PrimitiveLongCollections;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.fs.StoreChannel;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.impl.api.scan.FullStoreChangeStream;
+import org.neo4j.kernel.impl.index.labelscan.NativeLabelScanStore;
+import org.neo4j.kernel.impl.store.MetaDataStore;
+import org.neo4j.kernel.impl.store.format.standard.StandardV2_3;
+import org.neo4j.kernel.impl.store.format.standard.StandardV3_2;
+import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
+import org.neo4j.kernel.lifecycle.Lifespan;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.test.rule.PageCacheRule;
+import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+
+import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class NativeLabelScanStoreMigratorTest
+{
+    private final TestDirectory testDirectory = TestDirectory.testDirectory();
+    private final DefaultFileSystemRule fileSystemRule = new DefaultFileSystemRule();
+    private final PageCacheRule pageCacheRule = new PageCacheRule();
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule( testDirectory ).around( fileSystemRule ).around( pageCacheRule );
+
+    private File storeDir;
+    private File nativeLabelIndex;
+    private File migrationDir;
+    private File luceneLabelScanStore;
+
+    private final MigrationProgressMonitor.Section progressMonitor = mock( MigrationProgressMonitor.Section.class );
+
+    private FileSystemAbstraction fileSystem;
+    private PageCache pageCache;
+    private NativeLabelScanStoreMigrator indexMigrator;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        storeDir = testDirectory.directory( "store" );
+        nativeLabelIndex = new File( storeDir, NativeLabelScanStore.FILE_NAME );
+        migrationDir = testDirectory.directory( "migrationDir" );
+        luceneLabelScanStore = storeDir.toPath().resolve( Paths.get( "schema", "label", "lucene" ) ).toFile();
+
+        fileSystem = fileSystemRule.get();
+        pageCache = pageCacheRule.getPageCache( fileSystemRule );
+        indexMigrator = new NativeLabelScanStoreMigrator( fileSystem, pageCache );
+        fileSystem.mkdirs( luceneLabelScanStore );
+    }
+
+    @Test
+    public void skipMigrationIfNativeIndexExist() throws Exception
+    {
+        ByteBuffer sourceBuffer = writeNativeIndexFile( nativeLabelIndex, new byte[]{1, 2, 3} );
+
+        indexMigrator.migrate( storeDir, migrationDir, progressMonitor, StandardV3_2.STORE_VERSION, StandardV3_2.STORE_VERSION );
+        indexMigrator.moveMigratedFiles( migrationDir, storeDir, StandardV3_2.STORE_VERSION, StandardV3_2.STORE_VERSION );
+
+        ByteBuffer resultBuffer = readFileContent( nativeLabelIndex, 3 );
+        assertEquals( sourceBuffer, resultBuffer );
+        assertTrue( fileSystem.fileExists( luceneLabelScanStore ) );
+    }
+
+    @Test
+    public void luceneLabelIndexRemovedAfterSuccessfulMigration() throws IOException
+    {
+        prepareEmpty23Database();
+
+        indexMigrator.migrate( storeDir, migrationDir, progressMonitor, StandardV2_3.STORE_VERSION, StandardV3_2.STORE_VERSION );
+        indexMigrator.moveMigratedFiles( migrationDir, storeDir, StandardV2_3.STORE_VERSION, StandardV3_2.STORE_VERSION );
+
+        assertFalse( fileSystem.fileExists( luceneLabelScanStore ) );
+    }
+
+    @Test
+    public void moveCreatedNativeLabelIndexBackToStoreDirectory() throws IOException
+    {
+        prepareEmpty23Database();
+        indexMigrator.migrate( storeDir, migrationDir, progressMonitor, StandardV2_3.STORE_VERSION, StandardV3_2.STORE_VERSION );
+        File migrationNativeIndex = new File( migrationDir, NativeLabelScanStore.FILE_NAME );
+        ByteBuffer migratedFileContent = writeNativeIndexFile( migrationNativeIndex, new byte[]{5, 4, 3, 2, 1} );
+
+        indexMigrator.moveMigratedFiles( migrationDir, storeDir, StandardV2_3.STORE_VERSION, StandardV3_2.STORE_VERSION );
+
+        ByteBuffer movedNativeIndex = readFileContent( nativeLabelIndex, 5 );
+        assertEquals( migratedFileContent, movedNativeIndex );
+    }
+
+    @Test
+    public void populateNativeLabelScanIndexDuringMigration() throws IOException
+    {
+        prepare32DatabaseWithNodes();
+        indexMigrator.migrate( storeDir, migrationDir, progressMonitor, StandardV3_2.STORE_VERSION, StandardV3_2.STORE_VERSION );
+        indexMigrator.moveMigratedFiles( migrationDir, storeDir, StandardV2_3.STORE_VERSION, StandardV3_2.STORE_VERSION );
+
+        try ( Lifespan lifespan = new Lifespan() )
+        {
+            NativeLabelScanStore labelScanStore =
+                    new NativeLabelScanStore( pageCache, storeDir, FullStoreChangeStream.EMPTY, true, new Monitors(),
+                            RecoveryCleanupWorkCollector.NULL );
+            lifespan.add( labelScanStore );
+            for ( int labelId = 0; labelId < 10; labelId++ )
+            {
+                int nodeCount = PrimitiveLongCollections.count( labelScanStore.newReader().nodesWithLabel( labelId ) );
+                assertEquals( format( "Expected to see only one node for label %d but was %d.", labelId, nodeCount ),
+                        1, nodeCount );
+            }
+        }
+    }
+
+    @Test
+    public void reportProgressOnNativeIndexPopulation() throws IOException
+    {
+        prepare32DatabaseWithNodes();
+        indexMigrator.migrate( storeDir, migrationDir, progressMonitor, StandardV3_2.STORE_VERSION, StandardV3_2.STORE_VERSION );
+        indexMigrator.moveMigratedFiles( migrationDir, storeDir, StandardV2_3.STORE_VERSION, StandardV3_2.STORE_VERSION );
+
+        verify( progressMonitor ).start( 10 );
+        verify( progressMonitor, times( 10 ) ).progress( 1 );
+    }
+
+    private ByteBuffer writeNativeIndexFile( File file, byte[] content ) throws IOException
+    {
+        ByteBuffer sourceBuffer = ByteBuffer.wrap( content );
+        storeFileContent( file, sourceBuffer );
+        sourceBuffer.flip();
+        return sourceBuffer;
+    }
+
+    private void prepare32DatabaseWithNodes()
+    {
+        GraphDatabaseService embeddedDatabase = new TestGraphDatabaseFactory().newEmbeddedDatabase( storeDir );
+        try
+        {
+            try ( Transaction transaction = embeddedDatabase.beginTx() )
+            {
+                for ( int i = 0; i < 10; i++ )
+                {
+                    embeddedDatabase.createNode( Label.label( "label" + i ) );
+                }
+                transaction.success();
+            }
+        }
+        finally
+        {
+            embeddedDatabase.shutdown();
+        }
+        fileSystem.deleteFile( nativeLabelIndex );
+    }
+
+    private void prepareEmpty23Database() throws IOException
+    {
+        new TestGraphDatabaseFactory().newEmbeddedDatabase( storeDir ).shutdown();
+        fileSystem.deleteFile( nativeLabelIndex );
+        MetaDataStore.setRecord( pageCache, new File( storeDir, MetaDataStore.DEFAULT_NAME ), MetaDataStore.Position
+                .STORE_VERSION, MetaDataStore.versionStringToLong( StandardV2_3.STORE_VERSION ) );
+    }
+
+    private ByteBuffer readFileContent( File nativeLabelIndex, int length ) throws IOException
+    {
+        try ( StoreChannel storeChannel = fileSystem.open( nativeLabelIndex, "r" ) )
+        {
+            ByteBuffer readBuffer = ByteBuffer.allocate( length );
+            //noinspection StatementWithEmptyBody
+            while ( readBuffer.hasRemaining() && storeChannel.read( readBuffer ) > 0 )
+            {
+                // read till the end of store channel
+            }
+            readBuffer.flip();
+            return readBuffer;
+        }
+    }
+
+    private void storeFileContent( File nativeLabelIndex, ByteBuffer sourceBuffer ) throws IOException
+    {
+        try ( StoreChannel storeChannel = fileSystem.create( nativeLabelIndex ) )
+        {
+            storeChannel.write( sourceBuffer );
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/SchemaIndexMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/SchemaIndexMigratorTest.java
@@ -56,6 +56,5 @@ public class SchemaIndexMigratorTest
         migrator.moveMigratedFiles( migrationDir, storeDir, StandardV2_3.STORE_VERSION, StandardV3_0.STORE_VERSION );
 
         verify( fs ).deleteRecursively( schemaIndexProvider.getSchemaIndexStoreDirectory( storeDir ) );
-        verify( fs ).deleteRecursively( SchemaIndexMigrator.getLuceneStoreDirectory( storeDir ) );
     }
 }


### PR DESCRIPTION
Add additional migrator participant that will create and populate
native label index as part of store upgrade if it does not exist yet.
Migrator is fully integrated into upgrade procedure: it's separate migration step
and support population progress reporting.