### PR TITLE
Appends tree information on exceptions leaving surface

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
@@ -492,7 +492,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
             if ( pageSize > pageCache.pageSize() )
             {
                 throw new MetadataMismatchException(
-                        "Was about to create tree with page size %d" +
+                        "Tried to create tree with page size %d" +
                         ", but page cache used to create it has a smaller page size %d" +
                         " so cannot be created", pageSize, pageCache.pageSize() );
             }
@@ -698,7 +698,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
             if ( pageSize > pageCache.pageSize() )
             {
                 throw new MetadataMismatchException(
-                        " was created with page size %d, but page cache used to open it this time " +
+                        "Tried to create tree with page size %d, but page cache used to open it this time " +
                         "has a smaller page size %d so cannot be opened",
                         pageSize, pageCache.pageSize() );
             }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/MetadataMismatchException.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/MetadataMismatchException.java
@@ -24,13 +24,13 @@ package org.neo4j.index.internal.gbptree;
  */
 public class MetadataMismatchException extends RuntimeException
 {
+    MetadataMismatchException( Throwable cause, String format, Object... args )
+    {
+        super( String.format( format, args ), cause );
+    }
+
     MetadataMismatchException( String format, Object... args )
     {
         super( String.format( format, args ) );
-    }
-
-    MetadataMismatchException( String message )
-    {
-        super( message );
     }
 }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeInconsistencyException.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeInconsistencyException.java
@@ -28,9 +28,4 @@ public class TreeInconsistencyException extends RuntimeException
     {
         super( String.format( format, args ) );
     }
-
-    TreeInconsistencyException( String message )
-    {
-        super( message );
-    }
 }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNode.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNode.java
@@ -104,13 +104,14 @@ class TreeNode<KEY,VALUE>
 
         if ( internalMaxKeyCount < 2 )
         {
-            throw new MetadataMismatchException( "For layout " + layout + " a page size of " + pageSize +
-                    " would only fit " + internalMaxKeyCount + " internal keys, minimum is 2" );
+            throw new MetadataMismatchException(
+                    "For layout %s a page size of %d would only fit %d internal keys, minimum is 2",
+                    layout, pageSize, internalMaxKeyCount );
         }
         if ( leafMaxKeyCount < 2 )
         {
-            throw new MetadataMismatchException( "A page size of " + pageSize + " would only fit " +
-                    leafMaxKeyCount + " leaf keys, minimum is 2" );
+            throw new MetadataMismatchException( "A page size of %d would only fit leaf keys, minimum is 2",
+                    pageSize, leafMaxKeyCount );
         }
     }
 

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
@@ -173,7 +173,6 @@ public class GBPTreeTest
         };
         try ( GBPTree<MutableLong,MutableLong> ignored = index().with( otherLayout ).build() )
         {
-
             fail( "Should not load" );
         }
         catch ( MetadataMismatchException e )

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTest.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
@@ -59,6 +60,9 @@ public class SeekCursorTest
     private static final Supplier<Root> failingRootCatchup = () ->
     {
         throw new AssertionError( "Should not happen" );
+    };
+    private static final Consumer<Throwable> exceptionDecorator = t ->
+    {
     };
 
     private final SimpleIdProvider id = new SimpleIdProvider();
@@ -1238,7 +1242,7 @@ public class SeekCursorTest
         // WHEN
         try ( SeekCursor<MutableLong,MutableLong> cursor = new SeekCursor<>( this.cursor,
                 node, from, to, layout, stableGeneration, unstableGeneration, () -> 0L, failingRootCatchup,
-                unstableGeneration ) )
+                unstableGeneration, exceptionDecorator ) )
         {
             // reading a couple of keys
             assertTrue( cursor.next() );
@@ -1894,7 +1898,8 @@ public class SeekCursorTest
 
         // when
         try ( SeekCursor<MutableLong,MutableLong> seek = new SeekCursor<>( cursor, node, from, to, layout,
-                stableGeneration, unstableGeneration, generationSupplier, rootCatchup, generation - 1 ) )
+                stableGeneration, unstableGeneration, generationSupplier, rootCatchup, generation - 1,
+                exceptionDecorator ) )
         {
             // do nothing
         }
@@ -1950,7 +1955,8 @@ public class SeekCursorTest
         from.setValue( 1L );
         to.setValue( 2L );
         try ( SeekCursor<MutableLong,MutableLong> seek = new SeekCursor<>( cursor, node, from, to, layout,
-                stableGeneration, unstableGeneration, generationSupplier, rootCatchup, unstableGeneration ) )
+                stableGeneration, unstableGeneration, generationSupplier, rootCatchup, unstableGeneration,
+                exceptionDecorator ) )
         {
             // do nothing
         }
@@ -2005,7 +2011,8 @@ public class SeekCursorTest
         from.setValue( 1L );
         to.setValue( 20L );
         try ( SeekCursor<MutableLong,MutableLong> seek = new SeekCursor<>( cursor, node, from, to, layout,
-                stableGeneration - 1, unstableGeneration - 1, generationSupplier, rootCatchup, unstableGeneration ) )
+                stableGeneration - 1, unstableGeneration - 1, generationSupplier, rootCatchup, unstableGeneration,
+                exceptionDecorator ) )
         {
             while ( seek.next() )
             {
@@ -2206,8 +2213,8 @@ public class SeekCursorTest
     {
         from.setValue( fromInclusive );
         to.setValue( toExclusive );
-        return new SeekCursor<>( pageCursor, node, from, to, layout, stableGeneration, unstableGeneration, generationSupplier,
-                failingRootCatchup, unstableGeneration );
+        return new SeekCursor<>( pageCursor, node, from, to, layout, stableGeneration, unstableGeneration,
+                generationSupplier, failingRootCatchup, unstableGeneration , exceptionDecorator );
     }
 
     /**


### PR DESCRIPTION
There are many places where exceptions can be thrown from inside internal
code related to GBPTree and its internals. However the surface of GBPTree
is very small and so the approach is to not pass in tree information into
all internal classes and static methods, but instead decorate exceptions
from the small number of places where these exceptions can leave the
surface. This approach is much less intrusive than the alternative.

This is how it was already, but not the entire surface was covered.
Now also SeekCursor decorates outgoing exceptions.