### PR TITLE
Close statement in node relationships iterable's

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipConversion.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipConversion.java
@@ -33,6 +33,7 @@ public class RelationshipConversion implements RelationshipVisitor<RuntimeExcept
     RelationshipIterator iterator;
     Statement statement;
     private Relationship next;
+    private boolean closed;
 
     public RelationshipConversion( NodeProxy.NodeActions actions )
     {
@@ -48,7 +49,12 @@ public class RelationshipConversion implements RelationshipVisitor<RuntimeExcept
     @Override
     public boolean hasNext()
     {
-        return iterator.hasNext();
+        boolean hasNext = iterator.hasNext();
+        if ( !hasNext )
+        {
+            close();
+        }
+        return hasNext;
     }
 
     @Override
@@ -73,6 +79,10 @@ public class RelationshipConversion implements RelationshipVisitor<RuntimeExcept
     @Override
     public void close()
     {
-        statement.close();
+        if ( !closed )
+        {
+            statement.close();
+            closed = true;
+        }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipConversionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipConversionTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.core;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.neo4j.kernel.api.Statement;
+import org.neo4j.kernel.impl.api.RelationshipVisitor;
+import org.neo4j.kernel.impl.api.store.RelationshipIterator;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class RelationshipConversionTest
+{
+
+    private NodeProxy.NodeActions nodeActions = mock( NodeProxy.NodeActions.class );
+    private Statement statement = mock( Statement.class );
+    private RelationshipConversion relationshipConversion;
+
+    @Before
+    public void setUp()
+    {
+        relationshipConversion = new RelationshipConversion( nodeActions );
+        relationshipConversion.statement = statement;
+    }
+
+    @Test
+    public void closeStatementOnClose() throws Exception
+    {
+        relationshipConversion.close();
+
+        verify( statement ).close();
+    }
+
+    @Test
+    public void closeStatementWhenIterationIsOver()
+    {
+        relationshipConversion.iterator = new ArrayRelationshipVisitor( new long[]{1L, 8L} );
+
+        assertTrue( relationshipConversion.hasNext() );
+        relationshipConversion.next();
+        verify( statement, never() ).close();
+
+        assertTrue( relationshipConversion.hasNext() );
+        relationshipConversion.next();
+        verify( statement, never() ).close();
+
+        assertFalse( relationshipConversion.hasNext() );
+        verify( statement ).close();
+    }
+
+    @Test
+    public void closeStatementOnlyOnce()
+    {
+        relationshipConversion.iterator = new ArrayRelationshipVisitor( new long[]{1L} );
+
+        assertTrue( relationshipConversion.hasNext() );
+        relationshipConversion.next();
+        assertFalse( relationshipConversion.hasNext() );
+        assertFalse( relationshipConversion.hasNext() );
+        assertFalse( relationshipConversion.hasNext() );
+        assertFalse( relationshipConversion.hasNext() );
+        relationshipConversion.close();
+        relationshipConversion.close();
+
+        verify( statement ).close();
+    }
+
+    private static class ArrayRelationshipVisitor extends RelationshipIterator.BaseIterator
+    {
+        private final long[] ids;
+        private int position;
+
+        ArrayRelationshipVisitor(long[] ids)
+        {
+            this.ids = ids;
+        }
+
+        @Override
+        protected boolean fetchNext()
+        {
+            return ids.length > position && next( ids[position++] );
+        }
+
+        @Override
+        public <EXCEPTION extends Exception> boolean relationshipVisit( long relationshipId,
+                RelationshipVisitor<EXCEPTION> visitor ) throws EXCEPTION
+        {
+            visitor.visit( relationshipId, 1, 1L, 1L );
+            return false;
+        }
+    }
+}

--- a/community/neo4j/src/test/java/org/neo4j/index/IndexFreshDataReadIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/IndexFreshDataReadIT.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.EmbeddedDatabaseRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.neo4j.helpers.collection.MapUtil.map;
+
+public class IndexFreshDataReadIT
+{
+    @Rule
+    public EmbeddedDatabaseRule databaseRule = new EmbeddedDatabaseRule();
+
+    private ExecutorService executor = Executors.newCachedThreadPool();
+
+    @After
+    public void setUp() throws Exception
+    {
+        executor.shutdown();
+    }
+
+    @Test
+    public void readLatestIndexDataAfterUsingExhaustedNodeRelationshipIterator() throws Exception
+    {
+        try ( Transaction transaction = databaseRule.beginTx() )
+        {
+            addStaffMember( "Fry" );
+            assertEquals( 1, countStaff().intValue() );
+
+            Node fry = databaseRule.getNodeById( 0 );
+            Iterable<Relationship> fryRelationships = fry.getRelationships();
+            assertFalse( fryRelationships.iterator().hasNext() );
+
+            addStaffMember( "Lila" );
+            assertEquals( 2, countStaff().intValue() );
+
+            addStaffMember( "Bender" );
+            assertEquals( 3, countStaff().intValue() );
+        }
+    }
+
+    private void addStaffMember( String name ) throws InterruptedException, java.util.concurrent.ExecutionException
+    {
+        executor.submit( new CreateNamedNodeTask( name ) ).get();
+    }
+
+    private Number countStaff()
+    {
+        try ( Result countResult = databaseRule.execute( "MATCH (n:staff) return count(n.name) as count" ) )
+        {
+            return (Number) countResult.columnAs( "count" ).next();
+        }
+    }
+
+    private class CreateNamedNodeTask implements Runnable
+    {
+        private final String name;
+
+        CreateNamedNodeTask(String name)
+        {
+            this.name = name;
+        }
+
+        @Override
+        public void run()
+        {
+            try ( Transaction transaction = databaseRule.beginTx() )
+            {
+                databaseRule.execute( "CREATE (n:staff {name:{name}})", map( "name", name ) );
+                transaction.success();
+            }
+        }
+    }
+}


### PR DESCRIPTION
According to Node interface getRelationships* methods should return
relationship iterable's as result. In the same time, NodeProxy methods
always return ResourceIterables for corresponding calls.
As result, acquired statements will never be never released
and that will cause all sort of side effects with obsolete lucene index readers
that will be cached till the end of the transaction.
With changes introduced in this PR, the statement will be closed but
only in case if iterator of provided iterable was exhausted.