### PR TITLE
Importer option to disallow cache allocation on heap

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CountsComputer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CountsComputer.java
@@ -58,7 +58,7 @@ public class CountsComputer implements DataInitializer<CountsAccessor.Updater>
                 stores.getNodeStore(), stores.getRelationshipStore(),
                 (int) stores.getLabelTokenStore().getHighId(),
                 (int) stores.getRelationshipTypeTokenStore().getHighId(),
-                NumberArrayFactory.auto( pageCache, stores.getStoreDir() ) );
+                NumberArrayFactory.auto( pageCache, stores.getStoreDir(), true ) );
     }
 
     public CountsComputer( long lastCommittedTransactionId, NodeStore nodes, RelationshipStore relationships,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
@@ -423,7 +423,7 @@ public class StoreMigrator extends AbstractStoreMigrationParticipant
                 int highRelationshipTypeId = (int) neoStores.getRelationshipTypeTokenStore().getHighId();
                 CountsComputer initializer = new CountsComputer(
                         lastTxId, nodeStore, relationshipStore, highLabelId, highRelationshipTypeId,
-                        NumberArrayFactory.auto( pageCache, storeDir ) );
+                        NumberArrayFactory.auto( pageCache, storeDir, true ) );
                 life.add( new CountsTracker(
                         logService.getInternalLogProvider(), fileSystem, pageCache, config, storeFileBase )
                         .setInitializer( initializer ) );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Configuration.java
@@ -163,6 +163,17 @@ public interface Configuration
         return false;
     }
 
+    /**
+     * Whether or not to allocate memory for holding the cache on heap. The first alternative is to allocate
+     * off-heap, but if there's no more available memory, but there might be in the heap the importer will
+     * try to allocate chunks of the cache on heap instead. This config control whether or not to allow
+     * this allocation to happen on heap.
+     */
+    default boolean allowCacheAllocationOnHeap()
+    {
+        return true;
+    }
+
     Configuration DEFAULT = new Configuration()
     {
     };

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -169,7 +169,7 @@ public class ParallelBatchImporter implements BatchImporter
               InputCache inputCache = new InputCache( fileSystem, storeDir, recordFormats, config ) )
         {
             NumberArrayFactory numberArrayFactory =
-                    NumberArrayFactory.auto( pageCache, storeDir );
+                    NumberArrayFactory.auto( pageCache, storeDir, config.allowCacheAllocationOnHeap() );
             Collector badCollector = input.badCollector();
             // Some temporary caches and indexes in the import
             IoMonitor writeMonitor = new IoMonitor( neoStore.getIoTracer() );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
@@ -20,12 +20,16 @@
 package org.neo4j.unsafe.impl.batchimport.cache;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.io.pagecache.PageCache;
 
 import static java.lang.String.format;
+import static java.util.Arrays.asList;
+
 import static org.neo4j.helpers.Exceptions.launderedException;
 import static org.neo4j.helpers.Format.bytes;
 import static org.neo4j.unsafe.impl.batchimport.Utils.safeCastLongToInt;
@@ -112,14 +116,37 @@ public interface NumberArrayFactory
     /**
      * {@link Auto} factory which has a page cache backed number array as final fallback, in order to prevent OOM
      * errors.
+     * @param pageCache {@link PageCache} to fallback allocation into, if no more memory is available.
+     * @param dir directory where cached files are placed.
+     * @param allowHeapAllocation whether or not to allow allocation on heap. Otherwise allocation is restricted
+     * to off-heap and the page cache fallback. This to be more in control of available space in the heap at all times.
+     * @return a {@link NumberArrayFactory} which tries to allocation off-heap, then potentially on heap
+     * and lastly falls back to allocating inside the given {@code pageCache}.
      */
-    static NumberArrayFactory auto( PageCache pageCache, File dir )
+    static NumberArrayFactory auto( PageCache pageCache, File dir, boolean allowHeapAllocation )
     {
         PageCachedNumberArrayFactory pagedArrayFactory = new PageCachedNumberArrayFactory( pageCache, dir );
-        ChunkedNumberArrayFactory chunkedArrayFactory = new ChunkedNumberArrayFactory( OFF_HEAP, HEAP,
-                pagedArrayFactory );
-        return new Auto( OFF_HEAP, HEAP, chunkedArrayFactory );
+        ChunkedNumberArrayFactory chunkedArrayFactory = new ChunkedNumberArrayFactory(
+                allocationAlternatives( allowHeapAllocation, pagedArrayFactory ) );
+        return new Auto( allocationAlternatives( allowHeapAllocation, chunkedArrayFactory ) );
     }
+
+    /**
+     * @param allowHeapAllocation whether or not to include heap allocation as an alternative.
+     * @param additional other means of allocation to try after the standard off/on heap alternatives.
+     * @return an array of {@link NumberArrayFactory} with the desired alternatives.
+     */
+    static NumberArrayFactory[] allocationAlternatives( boolean allowHeapAllocation, NumberArrayFactory... additional )
+    {
+        List<NumberArrayFactory> result = new ArrayList<>( asList( OFF_HEAP ) );
+        if ( allowHeapAllocation )
+        {
+            result.add( HEAP );
+        }
+        result.addAll( asList( additional ) );
+        return result.toArray( new NumberArrayFactory[result.size()] );
+    }
+
     /**
      * Looks at available memory and decides where the requested array fits best. Tries to allocate the whole
      * array with the first candidate, falling back to others as needed.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/ByteArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/ByteArrayTest.java
@@ -57,7 +57,7 @@ public class ByteArrayTest extends NumberArrayPageCacheTestSupport
         fixture = prepareDirectoryAndPageCache( ByteArrayTest.class );
         PageCache pageCache = fixture.pageCache;
         File dir = fixture.directory;
-        NumberArrayFactory autoWithPageCacheFallback = auto( pageCache, dir );
+        NumberArrayFactory autoWithPageCacheFallback = auto( pageCache, dir, true );
         NumberArrayFactory pageCacheArrayFactory = new PageCachedNumberArrayFactory( pageCache, dir );
         int chunkSize = LENGTH / ChunkedNumberArrayFactory.MAGIC_CHUNK_COUNT;
         return Arrays.asList(

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/IntArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/IntArrayTest.java
@@ -106,7 +106,7 @@ public class IntArrayTest extends NumberArrayPageCacheTestSupport
         fixture = prepareDirectoryAndPageCache( IntArrayTest.class );
         PageCache pageCache = fixture.pageCache;
         File dir = fixture.directory;
-        NumberArrayFactory autoWithPageCacheFallback = auto( pageCache, dir );
+        NumberArrayFactory autoWithPageCacheFallback = auto( pageCache, dir, true );
         NumberArrayFactory pageCacheArrayFactory = new PageCachedNumberArrayFactory( pageCache, dir );
         return Arrays.asList( HEAP, OFF_HEAP, autoWithPageCacheFallback, pageCacheArrayFactory );
     }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/LongArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/LongArrayTest.java
@@ -106,7 +106,7 @@ public class LongArrayTest extends NumberArrayPageCacheTestSupport
         fixture = prepareDirectoryAndPageCache( LongArrayTest.class );
         PageCache pageCache = fixture.pageCache;
         File dir = fixture.directory;
-        NumberArrayFactory autoWithPageCacheFallback = auto( pageCache, dir );
+        NumberArrayFactory autoWithPageCacheFallback = auto( pageCache, dir, true );
         NumberArrayFactory pageCacheArrayFactory = new PageCachedNumberArrayFactory( pageCache, dir );
         return Arrays.asList( HEAP, OFF_HEAP, autoWithPageCacheFallback, pageCacheArrayFactory );
     }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayTest.java
@@ -77,7 +77,7 @@ public class NumberArrayTest extends NumberArrayPageCacheTestSupport
         factories.put( "OFF_HEAP", OFF_HEAP );
         factories.put( "AUTO_WITHOUT_PAGECACHE", AUTO_WITHOUT_PAGECACHE );
         factories.put( "CHUNKED_FIXED_SIZE", CHUNKED_FIXED_SIZE );
-        factories.put( "autoWithPageCacheFallback", auto( pageCache, dir ) );
+        factories.put( "autoWithPageCacheFallback", auto( pageCache, dir, true ) );
         factories.put( "PageCachedNumberArrayFactory", new PageCachedNumberArrayFactory( pageCache, dir ) );
         for ( Map.Entry<String,NumberArrayFactory> entry : factories.entrySet() )
         {

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheLongArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheLongArrayTest.java
@@ -65,7 +65,7 @@ public class PageCacheLongArrayTest
     {
         PageCache pageCache = pageCacheRule.getPageCache( fs );
         File directory = dir.directory();
-        NumberArrayFactory numberArrayFactory = NumberArrayFactory.auto( pageCache, directory );
+        NumberArrayFactory numberArrayFactory = NumberArrayFactory.auto( pageCache, directory, false );
         try ( LongArray array = numberArrayFactory.newDynamicLongArray( COUNT / 1_000, 0 ) )
         {
             verifyBehaviour( array );


### PR DESCRIPTION
Normally, allocating data arrays for caching in the importer tries off-heap,
falls back to on-heap and then on to additional ways of allocating.
This commit introduces a config option in the import tool to disallow
the on-heap alternative. This to have better control over heap usage
for normal working memory.

Configuration option is e.g. `--cache-on-heap=false`