### PR TITLE
Reduces peak memory required by importer by 40%

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CalculateDenseNodesStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/CalculateDenseNodesStep.java
@@ -21,60 +21,43 @@ package org.neo4j.unsafe.impl.batchimport;
 
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeRelationshipCache;
-import org.neo4j.unsafe.impl.batchimport.input.Collector;
-import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
 import org.neo4j.unsafe.impl.batchimport.staging.ForkedProcessorStep;
 import org.neo4j.unsafe.impl.batchimport.staging.StageControl;
-
-import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper.ID_NOT_FOUND;
 
 /**
  * Increments counts for each visited relationship, once for start node and once for end node
  * (unless for loops). This to be able to determine which nodes are dense before starting to import relationships.
  */
-public class CalculateDenseNodesStep extends ForkedProcessorStep<Batch<InputRelationship,RelationshipRecord>>
+public class CalculateDenseNodesStep extends ForkedProcessorStep<RelationshipRecord[]>
 {
     private final NodeRelationshipCache cache;
-    private final Collector badCollector;
 
-    public CalculateDenseNodesStep( StageControl control, Configuration config, NodeRelationshipCache cache,
-            Collector badCollector )
+    public CalculateDenseNodesStep( StageControl control, Configuration config, NodeRelationshipCache cache )
     {
         super( control, "CALCULATE", config );
         this.cache = cache;
-        this.badCollector = badCollector;
     }
 
     @Override
-    protected void forkedProcess( int id, int processors, Batch<InputRelationship,RelationshipRecord> batch )
+    protected void forkedProcess( int id, int processors, RelationshipRecord[] batch )
     {
-        for ( int i = 0, idIndex = 0; i < batch.input.length; i++ )
+        for ( int i = 0; i < batch.length; i++ )
         {
-            InputRelationship relationship = batch.input[i];
-            long startNodeId = batch.ids[idIndex++];
-            long endNodeId = batch.ids[idIndex++];
-            processNodeId( id, processors, startNodeId, relationship, relationship.startNode() );
-            if ( startNodeId != endNodeId ||                 // avoid counting loops twice
-                 startNodeId == ID_NOT_FOUND ) // although always collect bad relationships
+            RelationshipRecord relationship = batch[i];
+            long startNodeId = relationship.getFirstNode();
+            long endNodeId = relationship.getSecondNode();
+            processNodeId( id, processors, startNodeId );
+            if ( startNodeId != endNodeId ) // avoid counting loops twice
             {
                 // Loops only counts as one
-                processNodeId( id, processors, endNodeId, relationship, relationship.endNode() );
+                processNodeId( id, processors, endNodeId );
             }
         }
     }
 
-    private void processNodeId( int id, int processors, long nodeId,
-            InputRelationship relationship, Object inputId )
+    private void processNodeId( int id, int processors, long nodeId )
     {
-        if ( nodeId == ID_NOT_FOUND )
-        {
-            if ( id == MAIN )
-            {
-                // Only let the processor with id=0 (which always exists) report the bad relationships
-                badCollector.collectBadRelationship( relationship, inputId );
-            }
-        }
-        else if ( nodeId % processors == id )
+        if ( nodeId % processors == id )
         {
             cache.incrementCount( nodeId );
         }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeDegreeCountStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeDegreeCountStage.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import static org.neo4j.unsafe.impl.batchimport.RecordIdIterator.forwards;
+import static org.neo4j.unsafe.impl.batchimport.staging.Step.ORDER_SEND_DOWNSTREAM;
+
+import org.neo4j.kernel.impl.store.RelationshipStore;
+import org.neo4j.unsafe.impl.batchimport.cache.NodeRelationshipCache;
+import org.neo4j.unsafe.impl.batchimport.staging.BatchFeedStep;
+import org.neo4j.unsafe.impl.batchimport.staging.ReadRecordsStep;
+import org.neo4j.unsafe.impl.batchimport.staging.Stage;
+
+/**
+ * Goes through {@link RelationshipStore} and increments counts per start/end node,
+ * calling {@link NodeRelationshipCache#incrementCount(long)}. This is in preparation of linking relationships.
+ */
+public class NodeDegreeCountStage extends Stage
+{
+    public NodeDegreeCountStage( Configuration config, RelationshipStore store, NodeRelationshipCache cache )
+    {
+        super( "Node Degrees", config, ORDER_SEND_DOWNSTREAM );
+        add( new BatchFeedStep( control(), config, forwards( 0, store.getHighId(), config ), store.getRecordSize()) );
+        add( new ReadRecordsStep<>( control(), config, false, store, null ) );
+        add( new CalculateDenseNodesStep( control(), config, cache ) );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeStage.java
@@ -60,18 +60,15 @@ import static org.neo4j.unsafe.impl.batchimport.staging.Step.ORDER_SEND_DOWNSTRE
  */
 public class NodeStage extends Stage
 {
-    private final NodeRelationshipCache cache;
     private final NodeStore nodeStore;
 
     public NodeStage( Configuration config, IoMonitor writeMonitor,
             InputIterable<InputNode> nodes, IdMapper idMapper, IdGenerator idGenerator,
             BatchingNeoStores neoStore, InputCache inputCache, LabelScanStore labelScanStore,
             EntityStoreUpdaterStep.Monitor storeUpdateMonitor,
-            NodeRelationshipCache cache,
             StatsProvider memoryUsage ) throws IOException
     {
         super( "Nodes", config, ORDER_SEND_DOWNSTREAM );
-        this.cache = cache;
         add( new InputIteratorBatcherStep<>( control(), config, nodes.iterator(), InputNode.class, t -> true ) );
         if ( !nodes.supportsMultiplePasses() )
         {
@@ -86,14 +83,5 @@ public class NodeStage extends Stage
         add( new LabelScanStorePopulationStep( control(), config, labelScanStore ) );
         add( new EntityStoreUpdaterStep<>( control(), config, nodeStore, propertyStore, writeMonitor,
                 storeUpdateMonitor ) );
-    }
-
-    @Override
-    public void close()
-    {
-        // At this point we know how many nodes we have, so we tell the cache that instead of having the
-        // cache keeping track of that in a the face of concurrent updates.
-        cache.setHighNodeId( nodeStore.getHighId() );
-        super.close();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipStage.java
@@ -26,7 +26,6 @@ import org.neo4j.kernel.impl.store.RelationshipStore;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.store.record.PropertyRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
-import org.neo4j.unsafe.impl.batchimport.cache.NodeRelationshipCache;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
 import org.neo4j.unsafe.impl.batchimport.input.Collector;
 import org.neo4j.unsafe.impl.batchimport.input.Input;
@@ -62,7 +61,7 @@ public class RelationshipStage extends Stage
 
     public RelationshipStage( Configuration config, IoMonitor writeMonitor,
             InputIterable<InputRelationship> relationships, IdMapper idMapper,
-            Collector badCollector, InputCache inputCache, NodeRelationshipCache cache,
+            Collector badCollector, InputCache inputCache,
             BatchingNeoStores neoStore, EntityStoreUpdaterStep.Monitor storeUpdateMonitor ) throws IOException
     {
         super( "Relationships", config, ORDER_SEND_DOWNSTREAM );
@@ -78,8 +77,8 @@ public class RelationshipStage extends Stage
         add( typer = new RelationshipTypeCheckerStep( control(), config, neoStore.getRelationshipTypeRepository() ) );
         add( new AssignRelationshipIdBatchStep( control(), config, 0 ) );
         add( new RelationshipPreparationStep( control(), config, idMapper ) );
-        add( new RelationshipRecordPreparationStep( control(), config, neoStore.getRelationshipTypeRepository() ) );
-        add( new CalculateDenseNodesStep( control(), config, cache, badCollector ) );
+        add( new RelationshipRecordPreparationStep( control(), config,
+                neoStore.getRelationshipTypeRepository(), badCollector ) );
         add( new PropertyEncoderStep<>( control(), config, neoStore.getPropertyKeyRepository(), propertyStore ) );
         add( new EntityStoreUpdaterStep<>( control(), config, relationshipStore, propertyStore,
                 writeMonitor, storeUpdateMonitor ) );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/BadCollector.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/BadCollector.java
@@ -76,7 +76,7 @@ public class BadCollector implements Collector
     }
 
     @Override
-    public void collectBadRelationship( final InputRelationship relationship, final Object specificValue )
+    public synchronized void collectBadRelationship( final InputRelationship relationship, final Object specificValue )
     {
         checkTolerance( BAD_RELATIONSHIPS, new RelationshipsProblemReporter( relationship, specificValue ) );
     }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/CalculateDenseNodesStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/CalculateDenseNodesStepTest.java
@@ -21,19 +21,18 @@ package org.neo4j.unsafe.impl.batchimport;
 
 import org.junit.Test;
 
+import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeRelationshipCache;
-import org.neo4j.unsafe.impl.batchimport.input.Collector;
-import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
 import org.neo4j.unsafe.impl.batchimport.staging.StageControl;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
+import static org.neo4j.kernel.impl.store.record.Record.NULL_REFERENCE;
 import static org.neo4j.unsafe.impl.batchimport.Configuration.DEFAULT;
-import static org.neo4j.unsafe.impl.batchimport.input.InputEntity.NO_PROPERTIES;
 
 public class CalculateDenseNodesStepTest
 {
@@ -43,17 +42,18 @@ public class CalculateDenseNodesStepTest
         // GIVEN
         NodeRelationshipCache cache = mock( NodeRelationshipCache.class );
         try ( CalculateDenseNodesStep step = new CalculateDenseNodesStep( mock( StageControl.class ),
-                DEFAULT, cache, mock( Collector.class ) ) )
+                DEFAULT, cache ) )
         {
             step.processors( 4 );
             step.start( 0 );
 
             // WHEN
-            Batch<InputRelationship,RelationshipRecord> batch = batch(
-                    relationship( 1, 5 ),
-                    relationship( 3, 10 ),
-                    relationship( 2, 2 ), // <-- the loop
-                    relationship( 4, 1 ) );
+            long id = 0;
+            RelationshipRecord[] batch = batch(
+                    relationship( id++, 1, 5 ),
+                    relationship( id++, 3, 10 ),
+                    relationship( id++, 2, 2 ), // <-- the loop
+                    relationship( id++, 4, 1 ) );
             step.receive( 0, batch );
             step.endOfUpstream();
             while ( !step.isCompleted() )
@@ -71,77 +71,15 @@ public class CalculateDenseNodesStepTest
         }
     }
 
-    @Test
-    public void shouldCollectBadRelationships() throws Exception
+    private static RelationshipRecord[] batch( RelationshipRecord... relationships )
     {
-        // GIVEN
-        NodeRelationshipCache cache = mock( NodeRelationshipCache.class );
-        Collector collector = mock( Collector.class );
-        try ( CalculateDenseNodesStep step = new CalculateDenseNodesStep( mock( StageControl.class ),
-                DEFAULT, cache, collector ) )
-        {
-            step.processors( 4 );
-            step.start( 0 );
-
-            // WHEN
-            Batch<InputRelationship,RelationshipRecord> batch = batch(
-                    relationship( 1, 5 ),
-                    relationship( 3, 10 ),
-                    relationship( "a", 2, -1, 2 ),     // <-- bad relationship with missing start node
-                    relationship( 2, "b", 2, -1 ),     // <-- bad relationship with missing end node
-                    relationship( "c", "d", -1, -1 ) );// <-- bad relationship with missing start and end node
-            step.receive( 0, batch );
-            step.endOfUpstream();
-            while ( !step.isCompleted() )
-            {
-                //wait
-            }
-
-            // THEN
-            verify( collector, times( 1 ) ).collectBadRelationship( any( InputRelationship.class ), eq( "a" ) );
-            verify( collector, times( 1 ) ).collectBadRelationship( any( InputRelationship.class ), eq( "b" ) );
-            verify( collector, times( 1 ) ).collectBadRelationship( any( InputRelationship.class ), eq( "c" ) );
-            verify( collector, times( 1 ) ).collectBadRelationship( any( InputRelationship.class ), eq( "d" ) );
-        }
+        return relationships;
     }
 
-    private Batch<InputRelationship,RelationshipRecord> batch( Data... relationships )
+    private static RelationshipRecord relationship( long id, long startNodeId, long endNodeId )
     {
-        Batch<InputRelationship,RelationshipRecord> batch = new Batch<>( new InputRelationship[relationships.length] );
-        batch.ids = new long[relationships.length * 2];
-        for ( int i = 0; i < relationships.length; i++ )
-        {
-            batch.input[i] = new InputRelationship( "test", i, i, NO_PROPERTIES, null, relationships[i].startNode,
-                    relationships[i].endNode, "TYPE", null );
-            batch.ids[i * 2] = relationships[i].startNodeId;
-            batch.ids[i * 2 + 1] = relationships[i].endNodeId;
-        }
-        return batch;
-    }
-
-    private static Data relationship( Object startNode, Object endNode, long startNodeId, long endNodeId )
-    {
-        return new Data( startNode, endNode, startNodeId, endNodeId );
-    }
-
-    private static Data relationship( long startNodeId, long endNodeId )
-    {
-        return new Data( startNodeId, endNodeId, startNodeId, endNodeId );
-    }
-
-    private static class Data
-    {
-        private final long startNodeId;
-        private final long endNodeId;
-        private final Object startNode;
-        private final Object endNode;
-
-        Data( Object startNode, Object endNode, long startNodeId, long endNodeId )
-        {
-            this.startNode = startNode;
-            this.endNode = endNode;
-            this.startNodeId = startNodeId;
-            this.endNodeId = endNodeId;
-        }
+        return new RelationshipRecord( id ).initialize( true, Record.NO_NEXT_PROPERTY.longValue(),
+                startNodeId, endNodeId, 0, NULL_REFERENCE.longValue(), NULL_REFERENCE.longValue(),
+                NULL_REFERENCE.longValue(), NULL_REFERENCE.longValue(), false, false );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipRecordPreparationStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipRecordPreparationStepTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.impl.store.record.RelationshipRecord;
+import org.neo4j.unsafe.impl.batchimport.input.Collector;
+import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
+import org.neo4j.unsafe.impl.batchimport.staging.DeadEndStep;
+import org.neo4j.unsafe.impl.batchimport.staging.StageControl;
+import org.neo4j.unsafe.impl.batchimport.store.BatchingTokenRepository.BatchingRelationshipTypeTokenRepository;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import static org.neo4j.unsafe.impl.batchimport.Configuration.DEFAULT;
+import static org.neo4j.unsafe.impl.batchimport.input.InputEntity.NO_PROPERTIES;
+
+public class RelationshipRecordPreparationStepTest
+{
+    @Test
+    public void shouldCollectBadRelationships() throws Exception
+    {
+        Collector collector = mock( Collector.class );
+        StageControl control = mock( StageControl.class );
+        try ( RelationshipRecordPreparationStep step = new RelationshipRecordPreparationStep(
+                control, DEFAULT, mock( BatchingRelationshipTypeTokenRepository.class ), collector ) )
+        {
+            DeadEndStep end = new DeadEndStep( control );
+            end.start( 0 );
+            step.setDownstream( end );
+            step.start( 0 );
+
+            // WHEN
+            Batch<InputRelationship,RelationshipRecord> batch = batch(
+                    relationship( 1, 5 ),
+                    relationship( 3, 10 ),
+                    relationship( "a", 2, -1, 2 ),     // <-- bad relationship with missing start node
+                    relationship( 2, "b", 2, -1 ),     // <-- bad relationship with missing end node
+                    relationship( "c", "d", -1, -1 ) );// <-- bad relationship with missing start and end node
+            step.receive( 0, batch );
+            step.endOfUpstream();
+            while ( !step.isCompleted() )
+            {
+                //wait
+            }
+
+            // THEN
+            verify( collector, times( 1 ) ).collectBadRelationship( any( InputRelationship.class ), eq( "a" ) );
+            verify( collector, times( 1 ) ).collectBadRelationship( any( InputRelationship.class ), eq( "b" ) );
+            verify( collector, times( 1 ) ).collectBadRelationship( any( InputRelationship.class ), eq( "c" ) );
+            verify( collector, times( 1 ) ).collectBadRelationship( any( InputRelationship.class ), eq( "d" ) );
+        }
+    }
+
+    private static Batch<InputRelationship,RelationshipRecord> batch( Data... relationships )
+    {
+        Batch<InputRelationship,RelationshipRecord> batch = new Batch<>( new InputRelationship[relationships.length] );
+        batch.ids = new long[relationships.length * 2];
+        for ( int i = 0; i < relationships.length; i++ )
+        {
+            batch.input[i] = new InputRelationship( "test", i, i, NO_PROPERTIES, null, relationships[i].startNode,
+                    relationships[i].endNode, "TYPE", null );
+            batch.ids[i * 2] = relationships[i].startNodeId;
+            batch.ids[i * 2 + 1] = relationships[i].endNodeId;
+        }
+        return batch;
+    }
+
+    private static Data relationship( Object startNode, Object endNode, long startNodeId, long endNodeId )
+    {
+        return new Data( startNode, endNode, startNodeId, endNodeId );
+    }
+
+    private static Data relationship( long startNodeId, long endNodeId )
+    {
+        return new Data( startNodeId, endNodeId, startNodeId, endNodeId );
+    }
+
+    private static class Data
+    {
+        private final long startNodeId;
+        private final long endNodeId;
+        private final Object startNode;
+        private final Object endNode;
+
+        Data( Object startNode, Object endNode, long startNodeId, long endNodeId )
+        {
+            this.startNode = startNode;
+            this.endNode = endNode;
+            this.startNodeId = startNodeId;
+            this.endNodeId = endNodeId;
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/DeadEndStep.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/DeadEndStep.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.staging;
+
+import org.neo4j.unsafe.impl.batchimport.Configuration;
+
+public class DeadEndStep extends ProcessorStep<Object>
+{
+    public DeadEndStep( StageControl control )
+    {
+        super( control, "END", Configuration.DEFAULT, 1 );
+    }
+
+    @Override
+    protected void process( Object batch, BatchSender sender ) throws Throwable
+    {
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/ForkedProcessorStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/ForkedProcessorStepTest.java
@@ -267,19 +267,6 @@ public class ForkedProcessorStepTest
         }
     }
 
-    private static class DeadEndStep extends ProcessorStep<Object>
-    {
-        DeadEndStep( StageControl control )
-        {
-            super( control, "END", Configuration.DEFAULT, 1 );
-        }
-
-        @Override
-        protected void process( Object batch, BatchSender sender ) throws Throwable
-        {
-        }
-    }
-
     private static class TrackingStep implements Step<Batch>
     {
         private final AtomicLong received = new AtomicLong();


### PR DESCRIPTION
by separating import logic so that IdMapper and NodeRelationshipCache aren't
used at the same time. For this to work one additional stage is introduced
before relationship linking that goes through the imported relationship records
and counts node degrees.

Typically this separation reduces the peak memory usage by 40%.

main author: @SRaghuram