### PR TITLE
Procedures now close acquired KernelStatements

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/SchemaProcedure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/SchemaProcedure.java
@@ -40,6 +40,7 @@ import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.StatementTokenNameLookup;
 import org.neo4j.kernel.api.constraints.NodePropertyConstraint;
 import org.neo4j.kernel.api.index.IndexDescriptor;
@@ -62,82 +63,90 @@ public class SchemaProcedure
         final Map<String,NodeImpl> nodes = new HashMap<>();
         final Map<String,Set<RelationshipImpl>> relationships = new HashMap<>();
 
-        ReadOperations readOperations = kernelTransaction.acquireStatement().readOperations();
-        StatementTokenNameLookup statementTokenNameLookup = new StatementTokenNameLookup( readOperations );
-
-        try ( Transaction transaction = graphDatabaseAPI.beginTx(); )
+        try ( Statement statement = kernelTransaction.acquireStatement() )
         {
-            // add all labelsInDatabase
-            ResourceIterator<Label> labelsInDatabase = graphDatabaseAPI.getAllLabelsInUse().iterator();
-            while ( labelsInDatabase.hasNext() )
+            ReadOperations readOperations = statement.readOperations();
+            StatementTokenNameLookup statementTokenNameLookup = new StatementTokenNameLookup( readOperations );
+
+            try ( Transaction transaction = graphDatabaseAPI.beginTx(); )
             {
-                Label label = labelsInDatabase.next();
-                Map<String,Object> properties = new HashMap<>();
-
-                Iterator<IndexDescriptor> indexDescriptorIterator =
-                        readOperations.indexesGetForLabel( readOperations.labelGetForName( label.name() ) );
-                ArrayList<String> indexes = new ArrayList<>();
-                while ( indexDescriptorIterator.hasNext() )
+                // add all labelsInDatabase
+                try ( ResourceIterator<Label> labelsInDatabase = graphDatabaseAPI.getAllLabelsInUse().iterator() )
                 {
-                    indexes.add( statementTokenNameLookup
-                            .propertyKeyGetName( indexDescriptorIterator.next().getPropertyKeyId() ) );
-                }
-                properties.put( "indexes", indexes );
+                    while ( labelsInDatabase.hasNext() )
+                    {
+                        Label label = labelsInDatabase.next();
+                        Map<String,Object> properties = new HashMap<>();
 
-                Iterator<NodePropertyConstraint> nodePropertyConstraintIterator =
-                        readOperations.constraintsGetForLabel( readOperations.labelGetForName( label.name() ) );
-                ArrayList<String> constraints = new ArrayList<>();
-                while ( nodePropertyConstraintIterator.hasNext() )
+                        Iterator<IndexDescriptor> indexDescriptorIterator =
+                                readOperations.indexesGetForLabel( readOperations.labelGetForName( label.name() ) );
+                        ArrayList<String> indexes = new ArrayList<>();
+                        while ( indexDescriptorIterator.hasNext() )
+                        {
+                            indexes.add( statementTokenNameLookup
+                                    .propertyKeyGetName( indexDescriptorIterator.next().getPropertyKeyId() ) );
+                        }
+                        properties.put( "indexes", indexes );
+
+                        Iterator<NodePropertyConstraint> nodePropertyConstraintIterator =
+                                readOperations.constraintsGetForLabel( readOperations.labelGetForName( label.name() ) );
+                        ArrayList<String> constraints = new ArrayList<>();
+                        while ( nodePropertyConstraintIterator.hasNext() )
+                        {
+                            constraints
+                                    .add( nodePropertyConstraintIterator.next().userDescription( statementTokenNameLookup ) );
+                        }
+                        properties.put( "constraints", constraints );
+
+                        getOrCreateLabel( label.name(), properties, nodes );
+                    }
+                }
+
+                //add all relationships
+
+                try ( ResourceIterator<RelationshipType> relationshipTypeIterator = graphDatabaseAPI.getAllRelationshipTypesInUse()
+                        .iterator() )
                 {
-                    constraints
-                            .add( nodePropertyConstraintIterator.next().userDescription( statementTokenNameLookup ) );
-                }
-                properties.put( "constraints", constraints );
+                    while ( relationshipTypeIterator.hasNext() )
+                    {
+                        RelationshipType relationshipType = relationshipTypeIterator.next();
+                        String relationshipTypeGetName = relationshipType.name();
+                        int relId = readOperations.relationshipTypeGetForName( relationshipTypeGetName );
+                        ResourceIterator<Label> labelsInUse = graphDatabaseAPI.getAllLabelsInUse().iterator();
 
-                getOrCreateLabel( label.name(), properties, nodes );
+                        List<NodeImpl> startNodes = new LinkedList<>();
+                        List<NodeImpl> endNodes = new LinkedList<>();
+
+                        while ( labelsInUse.hasNext() )
+                        {
+                            Label labelToken = labelsInUse.next();
+                            String labelName = labelToken.name();
+                            Map<String,Object> properties = new HashMap<>();
+                            NodeImpl node = getOrCreateLabel( labelName, properties, nodes );
+                            int labelId = readOperations.labelGetForName( labelName );
+
+                            if ( readOperations.countsForRelationship( labelId, relId, ReadOperations.ANY_LABEL ) > 0 )
+                            {
+                                startNodes.add( node );
+                            }
+                            if ( readOperations.countsForRelationship( ReadOperations.ANY_LABEL, relId, labelId ) > 0 )
+                            {
+                                endNodes.add( node );
+                            }
+                        }
+                        for ( NodeImpl startNode : startNodes )
+                        {
+                            for ( NodeImpl endNode : endNodes )
+                            {
+                                RelationshipImpl relationship =
+                                        addRelationship( startNode, endNode, relationshipTypeGetName, relationships );
+                            }
+                        }
+                    }
+                }
+                transaction.success();
+                return getGraphResult( nodes, relationships );
             }
-
-            //add all relationships
-
-            Iterator<RelationshipType> relationshipTypeIterator =
-                    graphDatabaseAPI.getAllRelationshipTypesInUse().iterator();
-            while ( relationshipTypeIterator.hasNext() )
-            {
-                RelationshipType relationshipType = relationshipTypeIterator.next();
-                String relationshipTypeGetName = relationshipType.name();
-                int relId = readOperations.relationshipTypeGetForName( relationshipTypeGetName );
-                ResourceIterator<Label> labelsInUse = graphDatabaseAPI.getAllLabelsInUse().iterator();
-
-                List<NodeImpl> startNodes = new LinkedList<>();
-                List<NodeImpl> endNodes = new LinkedList<>();
-
-                while ( labelsInUse.hasNext() )
-                {
-                    Label labelToken = labelsInUse.next();
-                    String labelName = labelToken.name();
-                    Map<String,Object> properties = new HashMap<>();
-                    NodeImpl node = getOrCreateLabel( labelName, properties, nodes );
-                    int labelId = readOperations.labelGetForName( labelName );
-
-                    if ( readOperations.countsForRelationship( labelId, relId, ReadOperations.ANY_LABEL ) > 0 )
-                    {
-                        startNodes.add( node );
-                    }
-                    if ( readOperations.countsForRelationship( ReadOperations.ANY_LABEL, relId, labelId ) > 0 )
-                    {
-                        endNodes.add( node );
-                    }
-                }
-                for ( NodeImpl startNode : startNodes )
-                {
-                    for ( NodeImpl endNode : endNodes )
-                    {
-                        RelationshipImpl relationship = addRelationship( startNode, endNode, relationshipTypeGetName, relationships );
-                    }
-                }
-            }
-            transaction.success();
-            return getGraphResult( nodes, relationships );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/TokenProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/TokenProcedures.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.builtinprocs;
 
 import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.schema.IllegalTokenNameException;
 import org.neo4j.kernel.api.exceptions.schema.TooManyLabelsException;
 import org.neo4j.procedure.Context;
@@ -39,21 +40,30 @@ public class TokenProcedures
     public void createLabel( @Name( "newLabel" ) String newLabel )
             throws IllegalTokenNameException, TooManyLabelsException
     {
-        tx.acquireStatement().tokenWriteOperations().labelGetOrCreateForName( newLabel );
+        try ( Statement statement = tx.acquireStatement() )
+        {
+            statement.tokenWriteOperations().labelGetOrCreateForName( newLabel );
+        }
     }
 
     @Description( "Create a RelationshipType" )
     @Procedure( name = "db.createRelationshipType", mode = WRITE )
     public void createRelationshipType( @Name( "newRelationshipType" ) String newRelationshipType )
             throws IllegalTokenNameException    {
-        tx.acquireStatement().tokenWriteOperations().relationshipTypeGetOrCreateForName( newRelationshipType );
+        try ( Statement statement = tx.acquireStatement() )
+        {
+            statement.tokenWriteOperations().relationshipTypeGetOrCreateForName( newRelationshipType );
+        }
     }
 
     @Description( "Create a Property" )
     @Procedure( name = "db.createProperty", mode = WRITE )
     public void createProperty( @Name( "newProperty" ) String newProperty ) throws IllegalTokenNameException
     {
-        tx.acquireStatement().tokenWriteOperations().propertyKeyGetOrCreateForName( newProperty );
+        try ( Statement statement = tx.acquireStatement() )
+        {
+            statement.tokenWriteOperations().propertyKeyGetOrCreateForName( newProperty );
+        }
     }
 
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/SchemaImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/schema/SchemaImpl.java
@@ -643,7 +643,7 @@ public class SchemaImpl implements Schema
         @Override
         public void assertInOpenTransaction()
         {
-            ctxSupplier.get();
+            ctxSupplier.get().close();
         }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/SchemaProcedureIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/SchemaProcedureIT.java
@@ -131,7 +131,6 @@ public class SchemaProcedureIT extends KernelIntegrationTest
                     contains( equalTo( Label.label( "Person" ) ) ) );
             assertThat( relationships.get( 0 ).getEndNode().getLabels(),
                     contains( equalTo( Label.label( "Location" ) ) ) );
-
         }
     }
 }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
@@ -40,6 +40,7 @@ import org.neo4j.helpers.collection.Pair;
 import org.neo4j.kernel.api.ExecutingQuery;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.KernelTransactionHandle;
+import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.bolt.BoltConnectionTracker;
 import org.neo4j.kernel.api.bolt.ManagedBoltStateMachine;
 import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
@@ -105,7 +106,10 @@ public class EnterpriseBuiltInDbmsProcedures
                             "keys and values to be less than %d, got %d", HARD_CHAR_LIMIT, totalCharSize ) );
         }
 
-        getCurrentTx().acquireStatement().queryRegistration().setMetaData( data );
+        try ( Statement statement = getCurrentTx().acquireStatement() )
+        {
+            statement.queryRegistration().setMetaData( data );
+        }
     }
 
     private KernelTransaction getCurrentTx()

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/kernel/builtinprocs/ProcedureResourcesIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/kernel/builtinprocs/ProcedureResourcesIT.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.builtinprocs;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.api.proc.ProcedureSignature;
+import org.neo4j.kernel.impl.proc.Procedures;
+import org.neo4j.test.rule.DatabaseRule;
+import org.neo4j.test.rule.EnterpriseDatabaseRule;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class ProcedureResourcesIT
+{
+    @Rule
+    public DatabaseRule db = new EnterpriseDatabaseRule();
+
+    private final String indexDefinition = ":Label(prop)";
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    @After
+    public void tearDown() throws InterruptedException
+    {
+        executor.shutdown();
+        executor.awaitTermination( 5, TimeUnit.SECONDS );
+    }
+
+    @Test
+    public void allProcedures() throws Exception
+    {
+        // given
+        Map<String,List<Object>> allProceduresWithParameters = allProceduresWithParameters();
+
+        // when
+        createIndex();
+        for ( Map.Entry<String,List<Object>> procedureWithParams : allProceduresWithParameters.entrySet() )
+        {
+            // then
+            verifyProcedureCloseAllAcquiredKernelStatements( procedureWithParams.getKey(), procedureWithParams.getValue() );
+            clearDb();
+        }
+    }
+
+    private void verifyProcedureCloseAllAcquiredKernelStatements( String procedureName, List<Object> parameters )
+            throws ExecutionException, InterruptedException
+    {
+        String failureMessage = "Failed on procedure " + procedureName;
+        try ( Transaction outer = db.beginTx() )
+        {
+            String procedureQuery = buildProcedureQuery( procedureName, parameters );
+            exhaust( db.execute( procedureQuery ) ).close();
+            exhaust( db.execute( "MATCH (mo:Label) WHERE mo.prop = 'n/a' RETURN mo" ) ).close();
+            executeInOtherThread( "CREATE(mo:Label) SET mo.prop = 'val' RETURN mo" );
+            Result result = db.execute( "MATCH (mo:Label) WHERE mo.prop = 'val' RETURN mo" );
+            assertTrue( failureMessage, result.hasNext() );
+            Map<String,Object> next = result.next();
+            assertNotNull( failureMessage, next.get( "mo" ) );
+            exhaust( result );
+            result.close();
+            outer.success();
+        }
+    }
+
+    private Result exhaust( Result execute )
+    {
+        while ( execute.hasNext() )
+        {
+            execute.next();
+        }
+        return execute;
+    }
+
+    private void createIndex()
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.execute( "CREATE INDEX ON " + indexDefinition );
+            tx.success();
+        }
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.schema().awaitIndexesOnline( 1, TimeUnit.SECONDS );
+            tx.success();
+        }
+    }
+
+    private String buildProcedureQuery( String procedureName, List<Object> parameters )
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append( "CALL " ).append( procedureName ).append( "(" );
+        boolean first = true;
+        for ( Object parameter : parameters )
+        {
+            if ( !first )
+            {
+                sb.append( "," );
+            }
+            sb.append( parameter );
+            first = false;
+        }
+        sb.append( ")" );
+        return sb.toString();
+    }
+
+    private void clearDb()
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.execute( "MATCH (n) DETACH DELETE n" ).close();
+            tx.success();
+        }
+    }
+
+    private Map<String,List<Object>> allProceduresWithParameters()
+    {
+        Set<ProcedureSignature> allProcedures = db.getDependencyResolver().resolveDependency( Procedures.class ).getAllProcedures();
+        Map<String,List<Object>> allProceduresWithParameters = new HashMap<>();
+        for ( ProcedureSignature procedure : allProcedures )
+        {
+            List<Object> params = paramsFor( procedure );
+            allProceduresWithParameters.put( procedure.name().toString(), params );
+        }
+        return allProceduresWithParameters;
+    }
+
+    private List<Object> paramsFor( ProcedureSignature procedure )
+    {
+        List<Object> parameters = new ArrayList<>();
+        switch ( procedure.name().toString() )
+        {
+        case "db.createProperty":
+            parameters.add( "'propKey'" );
+            break;
+        case "db.resampleIndex":
+            parameters.add( "'" + indexDefinition + "'" );
+            break;
+        case "db.createRelationshipType":
+            parameters.add( "'RelType'" );
+            break;
+        case "dbms.queryJmx":
+            parameters.add( "'*:*'" );
+            break;
+        case "db.awaitIndex":
+            parameters.add( "'" + indexDefinition + "'" );
+            parameters.add( 100 );
+            break;
+        case "db.createLabel":
+            parameters.add( "'OtherLabel'" );
+            break;
+        case "dbms.killQuery":
+            parameters.add( "'query-1234'" );
+            break;
+        case "dbms.killQueries":
+            parameters.add( "['query-1234']" );
+            break;
+        case "dbms.setTXMetaData":
+            parameters.add( "{realUser:'MyMan'}" );
+            break;
+        default:
+        }
+        return parameters;
+    }
+
+    private void executeInOtherThread( String query ) throws ExecutionException, InterruptedException
+    {
+        Future<?> future = executor.submit( () ->
+        {
+            try ( Transaction tx = db.beginTx() )
+            {
+                exhaust( db.execute( query ) );
+                tx.success();
+            }
+        } );
+        future.get();
+    }
+
+}

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/kernel/builtinprocs/ProcedureResourcesIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/kernel/builtinprocs/ProcedureResourcesIT.java
@@ -141,17 +141,12 @@ public class ProcedureResourcesIT
 
     private String buildProcedureQuery( String procedureName, List<Object> parameters )
     {
-        StringBuilder sb = new StringBuilder();
-        StringJoiner joiner = new StringJoiner( "," );
-        sb.append( "CALL " ).append( procedureName ).append( "(" );
+        StringJoiner stringJoiner = new StringJoiner( ",", "CALL " + procedureName + "(", ")" );
         for ( Object parameter : parameters )
         {
-            joiner.add( parameter.toString() );
+            stringJoiner.add( parameter.toString() );
         }
-        sb.append( joiner.toString() );
-        sb.append( ")" );
-        System.out.println( sb.toString() );
-        return sb.toString();
+        return stringJoiner.toString();
     }
 
     private void clearDb()


### PR DESCRIPTION
Verified in test by performing two index reads with
intermediate create. Second read should see result
of create but will not if KernelStatement has leaked,
because Lucene reader from first match will be reused
for second read.