### PR TITLE
Empty stream instead of exception for non-existing directory

### DIFF
--- a/community/io/src/test/java/org/neo4j/io/fs/FileSystemAbstractionTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/FileSystemAbstractionTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
+import org.neo4j.function.Predicates;
 import org.neo4j.graphdb.mockfs.CloseTrackingFileSystem;
 import org.neo4j.io.fs.watcher.FileWatcher;
 import org.neo4j.test.rule.TestDirectory;
@@ -382,11 +383,10 @@ public abstract class FileSystemAbstractionTest
     }
 
     @Test
-    public void streamFilesRecursiveMustThrowOnNonExistingBasePath() throws Exception
+    public void streamFilesRecursiveMustReturnEmptyStreamForNonExistingBasePath() throws Exception
     {
         File nonExisting = new File( "nonExisting" );
-        expectedException.expect( NoSuchFileException.class );
-        fsa.streamFilesRecursive( nonExisting );
+        assertFalse( fsa.streamFilesRecursive( nonExisting ).anyMatch( Predicates.alwaysTrue() ) );
     }
 
     @Test

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/GBPTreeUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/GBPTreeUtil.java
@@ -27,6 +27,8 @@ import org.neo4j.index.internal.gbptree.GBPTree;
 import org.neo4j.io.fs.FileHandle;
 import org.neo4j.io.pagecache.PageCache;
 
+import static org.neo4j.function.Predicates.alwaysTrue;
+
 /**
  * Utilities for common operations around a {@link GBPTree}.
  */
@@ -76,8 +78,7 @@ public class GBPTreeUtil
     {
         try
         {
-            storeFileHandle( pageCache, storeFile );
-            return true;
+            return pageCache.getCachedFileSystem().streamFilesRecursive( storeFile ).anyMatch( alwaysTrue() );
         }
         catch ( IOException e )
         {
@@ -87,6 +88,9 @@ public class GBPTreeUtil
 
     private static FileHandle storeFileHandle( PageCache pageCache, File storeFile ) throws IOException
     {
-        return pageCache.getCachedFileSystem().streamFilesRecursive( storeFile ).findFirst().get();
+        return pageCache.getCachedFileSystem()
+                .streamFilesRecursive( storeFile )
+                .findFirst()
+                .orElseThrow( () -> new NoSuchFileException( storeFile.getPath() ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigrator.java
@@ -113,16 +113,9 @@ public class NativeLabelScanStoreMigrator extends AbstractStoreMigrationParticip
 
     private boolean isNativeLabelScanStoreMigrationRequired( File storeDir ) throws IOException
     {
-        try
-        {
-            return pageCache.getCachedFileSystem()
-                    .streamFilesRecursive( new File( storeDir, NativeLabelScanStore.FILE_NAME ) )
-                    .noneMatch( Predicates.alwaysTrue() );
-        }
-        catch ( Exception e )
-        {
-            return true;
-        }
+        return pageCache.getCachedFileSystem()
+                .streamFilesRecursive( new File( storeDir, NativeLabelScanStore.FILE_NAME ) )
+                .noneMatch( Predicates.alwaysTrue() );
     }
 
     private void deleteLuceneLabelIndex( File indexRootDirectory ) throws IOException


### PR DESCRIPTION
Return empty stream instead of throwing an exception in case if the
directory does not exist. This will gonna allow the creation of empty
streams on top of non-existing directories and will allow for example
usage of stream find/match methods instead of catching the exception to
determine the correctness of situation in user code.