### PR TITLE
Importer uses correct page cache in caching arrays

### DIFF
--- a/community/consistency-check/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
@@ -178,7 +178,7 @@ public class ParallelBatchImporterTest
         // GIVEN
         ExecutionMonitor processorAssigner = eagerRandomSaturation( config.maxNumberOfProcessors() );
         final BatchImporter inserter = new ParallelBatchImporter( directory.graphDbDir(),
-                fileSystemRule.get(), config, NullLogService.getInstance(),
+                fileSystemRule.get(), null, config, NullLogService.getInstance(),
                 processorAssigner, EMPTY, Config.empty(), getFormat() );
 
         boolean successful = false;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCachedNumberArrayFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCachedNumberArrayFactory.java
@@ -22,6 +22,7 @@ package org.neo4j.unsafe.impl.batchimport.cache;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Objects;
 
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PagedFile;
@@ -40,6 +41,7 @@ public class PageCachedNumberArrayFactory extends NumberArrayFactory.Adapter
 
     PageCachedNumberArrayFactory( PageCache pageCache, File storeDir )
     {
+        Objects.requireNonNull( pageCache );
         this.pageCache = pageCache;
         this.storeDir = storeDir;
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
@@ -357,4 +357,9 @@ public class BatchingNeoStores implements AutoCloseable, MemoryStatsVisitor.Visi
     {
         visitor.offHeapUsage( (long) pageCache.maxCachedPages() * pageCache.pageSize() );
     }
+
+    public PageCache getPageCache()
+    {
+        return pageCache;
+    }
 }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ImportPanicIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ImportPanicIT.java
@@ -79,7 +79,7 @@ public class ImportPanicIT
     public void shouldExitAndThrowExceptionOnPanic() throws Exception
     {
         // GIVEN
-        BatchImporter importer = new ParallelBatchImporter( directory.absolutePath(), fs, Configuration.DEFAULT,
+        BatchImporter importer = new ParallelBatchImporter( directory.absolutePath(), fs, null, Configuration.DEFAULT,
                 NullLogService.getInstance(), ExecutionMonitors.invisible(), AdditionalInitialIds.EMPTY,
                 Config.empty(), StandardV3_0.RECORD_FORMATS );
         Iterable<DataFactory<InputNode>> nodeData =

--- a/community/neo4j/src/test/java/schema/MultipleIndexPopulationStressIT.java
+++ b/community/neo4j/src/test/java/schema/MultipleIndexPopulationStressIT.java
@@ -301,7 +301,7 @@ public class MultipleIndexPopulationStressIT
         RecordFormats recordFormats =
                 RecordFormatSelector.selectForConfig( config, NullLogProvider.getInstance() );
         BatchImporter importer = new ParallelBatchImporter( directory.graphDbDir(), fileSystemRule.get(),
-                DEFAULT, NullLogService.getInstance(), ExecutionMonitors.invisible(), EMPTY, config, recordFormats );
+                null, DEFAULT, NullLogService.getInstance(), ExecutionMonitors.invisible(), EMPTY, config, recordFormats );
         importer.doImport( new RandomDataInput( count ) );
     }
 


### PR DESCRIPTION
Previously the normal use case of the ParallelBatchImporter would result in
a null PageCache given to PagedCachedNumberArrayFactory and would result in
NPE when allocation got to the point of allocating into it.

Now the page cache use by BatchingNeoStores, be it the external page cache
given to the PBI, or otherwise the one constructed by itself will be passed
to that factory.