### PR TITLE
Removes generic and some boxing in RecordAccess

### DIFF
--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -143,6 +143,9 @@ the relevant Commercial Agreement.
             <include>org/neo4j/procedure/*</include>
             <include>org/neo4j/helpers/collection/*</include>
           </includes>
+          <excludes>
+            <exclude>org/neo4j/unsafe/batchinsert/DirectRecordAccess</exclude>
+          </excludes>
         </configuration>
       </plugin>
     </plugins>

--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -145,6 +145,7 @@ the relevant Commercial Agreement.
           </includes>
           <excludes>
             <exclude>org/neo4j/unsafe/batchinsert/DirectRecordAccess</exclude>
+            <exclude>org/neo4j/unsafe/batchinsert/DirectRecordAccessSet</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/Loaders.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/Loaders.java
@@ -39,18 +39,20 @@ import org.neo4j.kernel.impl.store.record.SchemaRecord;
 import org.neo4j.kernel.impl.transaction.state.RecordAccess.Loader;
 import org.neo4j.storageengine.api.schema.SchemaRule;
 
+import static java.lang.Math.toIntExact;
+
 import static org.neo4j.kernel.impl.store.record.RecordLoad.NORMAL;
 
 public class Loaders
 {
-    private final Loader<Long,NodeRecord,Void> nodeLoader;
-    private final Loader<Long,PropertyRecord,PrimitiveRecord> propertyLoader;
-    private final Loader<Long,RelationshipRecord,Void> relationshipLoader;
-    private final Loader<Long,RelationshipGroupRecord,Integer> relationshipGroupLoader;
-    private final Loader<Long,SchemaRecord,SchemaRule> schemaRuleLoader;
-    private final Loader<Integer,PropertyKeyTokenRecord,Void> propertyKeyTokenLoader;
-    private final Loader<Integer,LabelTokenRecord,Void> labelTokenLoader;
-    private final Loader<Integer,RelationshipTypeTokenRecord,Void> relationshipTypeTokenLoader;
+    private final Loader<NodeRecord,Void> nodeLoader;
+    private final Loader<PropertyRecord,PrimitiveRecord> propertyLoader;
+    private final Loader<RelationshipRecord,Void> relationshipLoader;
+    private final Loader<RelationshipGroupRecord,Integer> relationshipGroupLoader;
+    private final Loader<SchemaRecord,SchemaRule> schemaRuleLoader;
+    private final Loader<PropertyKeyTokenRecord,Void> propertyKeyTokenLoader;
+    private final Loader<LabelTokenRecord,Void> labelTokenLoader;
+    private final Loader<RelationshipTypeTokenRecord,Void> relationshipTypeTokenLoader;
 
     public Loaders( NeoStores neoStores )
     {
@@ -85,58 +87,58 @@ public class Loaders
         relationshipTypeTokenLoader = relationshipTypeTokenLoader( relationshipTypeTokenStore );
     }
 
-    public Loader<Long,NodeRecord,Void> nodeLoader()
+    public Loader<NodeRecord,Void> nodeLoader()
     {
         return nodeLoader;
     }
 
-    public Loader<Long,PropertyRecord,PrimitiveRecord> propertyLoader()
+    public Loader<PropertyRecord,PrimitiveRecord> propertyLoader()
     {
         return propertyLoader;
     }
 
-    public Loader<Long,RelationshipRecord,Void> relationshipLoader()
+    public Loader<RelationshipRecord,Void> relationshipLoader()
     {
         return relationshipLoader;
     }
 
-    public Loader<Long,RelationshipGroupRecord,Integer> relationshipGroupLoader()
+    public Loader<RelationshipGroupRecord,Integer> relationshipGroupLoader()
     {
         return relationshipGroupLoader;
     }
 
-    public Loader<Long,SchemaRecord,SchemaRule> schemaRuleLoader()
+    public Loader<SchemaRecord,SchemaRule> schemaRuleLoader()
     {
         return schemaRuleLoader;
     }
 
-    public Loader<Integer,PropertyKeyTokenRecord,Void> propertyKeyTokenLoader()
+    public Loader<PropertyKeyTokenRecord,Void> propertyKeyTokenLoader()
     {
         return propertyKeyTokenLoader;
     }
 
-    public Loader<Integer,LabelTokenRecord,Void> labelTokenLoader()
+    public Loader<LabelTokenRecord,Void> labelTokenLoader()
     {
         return labelTokenLoader;
     }
 
-    public Loader<Integer,RelationshipTypeTokenRecord,Void> relationshipTypeTokenLoader()
+    public Loader<RelationshipTypeTokenRecord,Void> relationshipTypeTokenLoader()
     {
         return relationshipTypeTokenLoader;
     }
 
-    public static Loader<Long,NodeRecord,Void> nodeLoader( final RecordStore<NodeRecord> store )
+    public static Loader<NodeRecord,Void> nodeLoader( final RecordStore<NodeRecord> store )
     {
-        return new Loader<Long,NodeRecord,Void>()
+        return new Loader<NodeRecord,Void>()
         {
             @Override
-            public NodeRecord newUnused( Long key, Void additionalData )
+            public NodeRecord newUnused( long key, Void additionalData )
             {
                 return andMarkAsCreated( new NodeRecord( key ) );
             }
 
             @Override
-            public NodeRecord load( Long key, Void additionalData )
+            public NodeRecord load( long key, Void additionalData )
             {
                 return store.getRecord( key, store.newRecord(), NORMAL );
             }
@@ -155,12 +157,12 @@ public class Loaders
         };
     }
 
-    public static Loader<Long,PropertyRecord,PrimitiveRecord> propertyLoader( final PropertyStore store )
+    public static Loader<PropertyRecord,PrimitiveRecord> propertyLoader( final PropertyStore store )
     {
-        return new Loader<Long,PropertyRecord,PrimitiveRecord>()
+        return new Loader<PropertyRecord,PrimitiveRecord>()
         {
             @Override
-            public PropertyRecord newUnused( Long key, PrimitiveRecord additionalData )
+            public PropertyRecord newUnused( long key, PrimitiveRecord additionalData )
             {
                 PropertyRecord record = new PropertyRecord( key );
                 setOwner( record, additionalData );
@@ -176,7 +178,7 @@ public class Loaders
             }
 
             @Override
-            public PropertyRecord load( Long key, PrimitiveRecord additionalData )
+            public PropertyRecord load( long key, PrimitiveRecord additionalData )
             {
                 PropertyRecord record = store.getRecord( key, store.newRecord(), NORMAL );
                 setOwner( record, additionalData );
@@ -200,19 +202,19 @@ public class Loaders
         };
     }
 
-    public static Loader<Long,RelationshipRecord,Void> relationshipLoader(
+    public static Loader<RelationshipRecord,Void> relationshipLoader(
             final RecordStore<RelationshipRecord> store )
     {
-        return new Loader<Long, RelationshipRecord, Void>()
+        return new Loader<RelationshipRecord, Void>()
         {
             @Override
-            public RelationshipRecord newUnused( Long key, Void additionalData )
+            public RelationshipRecord newUnused( long key, Void additionalData )
             {
                 return andMarkAsCreated( new RelationshipRecord( key ) );
             }
 
             @Override
-            public RelationshipRecord load( Long key, Void additionalData )
+            public RelationshipRecord load( long key, Void additionalData )
             {
                 return store.getRecord( key, store.newRecord(), NORMAL );
             }
@@ -230,13 +232,13 @@ public class Loaders
         };
     }
 
-    public static Loader<Long,RelationshipGroupRecord,Integer> relationshipGroupLoader(
+    public static Loader<RelationshipGroupRecord,Integer> relationshipGroupLoader(
             final RecordStore<RelationshipGroupRecord> store )
     {
-        return new Loader<Long, RelationshipGroupRecord, Integer>()
+        return new Loader<RelationshipGroupRecord, Integer>()
         {
             @Override
-            public RelationshipGroupRecord newUnused( Long key, Integer type )
+            public RelationshipGroupRecord newUnused( long key, Integer type )
             {
                 RelationshipGroupRecord record = new RelationshipGroupRecord( key );
                 record.setType( type );
@@ -244,7 +246,7 @@ public class Loaders
             }
 
             @Override
-            public RelationshipGroupRecord load( Long key, Integer type )
+            public RelationshipGroupRecord load( long key, Integer type )
             {
                 return store.getRecord( key, store.newRecord(), NORMAL );
             }
@@ -262,19 +264,19 @@ public class Loaders
         };
     }
 
-    public static Loader<Long,SchemaRecord,SchemaRule> schemaRuleLoader( final SchemaStore store )
+    public static Loader<SchemaRecord,SchemaRule> schemaRuleLoader( final SchemaStore store )
     {
-        return new Loader<Long, SchemaRecord, SchemaRule>()
+        return new Loader<SchemaRecord, SchemaRule>()
         {
             @Override
-            public SchemaRecord newUnused( Long key, SchemaRule additionalData )
+            public SchemaRecord newUnused( long key, SchemaRule additionalData )
             {
                 // Don't blindly mark as created here since some records may be reused.
                 return new SchemaRecord( store.allocateFrom( additionalData ) );
             }
 
             @Override
-            public SchemaRecord load( Long key, SchemaRule additionalData )
+            public SchemaRecord load( long key, SchemaRule additionalData )
             {
                 return new SchemaRecord( store.getRecords( key, RecordLoad.NORMAL ) );
             }
@@ -296,19 +298,19 @@ public class Loaders
         };
     }
 
-    public static Loader<Integer,PropertyKeyTokenRecord,Void> propertyKeyTokenLoader(
+    public static Loader<PropertyKeyTokenRecord,Void> propertyKeyTokenLoader(
             final RecordStore<PropertyKeyTokenRecord> store )
     {
-        return new Loader<Integer, PropertyKeyTokenRecord, Void>()
+        return new Loader<PropertyKeyTokenRecord, Void>()
         {
             @Override
-            public PropertyKeyTokenRecord newUnused( Integer key, Void additionalData )
+            public PropertyKeyTokenRecord newUnused( long key, Void additionalData )
             {
-                return andMarkAsCreated( new PropertyKeyTokenRecord( key ) );
+                return andMarkAsCreated( new PropertyKeyTokenRecord( toIntExact( key ) ) );
             }
 
             @Override
-            public PropertyKeyTokenRecord load( Integer key, Void additionalData )
+            public PropertyKeyTokenRecord load( long key, Void additionalData )
             {
                 return store.getRecord( key, store.newRecord(), NORMAL );
             }
@@ -327,19 +329,19 @@ public class Loaders
         };
     }
 
-    public static Loader<Integer,LabelTokenRecord,Void> labelTokenLoader(
+    public static Loader<LabelTokenRecord,Void> labelTokenLoader(
             final RecordStore<LabelTokenRecord> store )
     {
-        return new Loader<Integer, LabelTokenRecord, Void>()
+        return new Loader<LabelTokenRecord, Void>()
         {
             @Override
-            public LabelTokenRecord newUnused( Integer key, Void additionalData )
+            public LabelTokenRecord newUnused( long key, Void additionalData )
             {
-                return andMarkAsCreated( new LabelTokenRecord( key ) );
+                return andMarkAsCreated( new LabelTokenRecord( toIntExact( key ) ) );
             }
 
             @Override
-            public LabelTokenRecord load( Integer key, Void additionalData )
+            public LabelTokenRecord load( long key, Void additionalData )
             {
                 return store.getRecord( key, store.newRecord(), NORMAL );
             }
@@ -358,19 +360,19 @@ public class Loaders
         };
     }
 
-    public static Loader<Integer,RelationshipTypeTokenRecord,Void> relationshipTypeTokenLoader(
+    public static Loader<RelationshipTypeTokenRecord,Void> relationshipTypeTokenLoader(
             final RecordStore<RelationshipTypeTokenRecord> store )
     {
-        return new Loader<Integer, RelationshipTypeTokenRecord, Void>()
+        return new Loader<RelationshipTypeTokenRecord, Void>()
         {
             @Override
-            public RelationshipTypeTokenRecord newUnused( Integer key, Void additionalData )
+            public RelationshipTypeTokenRecord newUnused( long key, Void additionalData )
             {
-                return andMarkAsCreated( new RelationshipTypeTokenRecord( key ) );
+                return andMarkAsCreated( new RelationshipTypeTokenRecord( toIntExact( key ) ) );
             }
 
             @Override
-            public RelationshipTypeTokenRecord load( Integer key, Void additionalData )
+            public RelationshipTypeTokenRecord load( long key, Void additionalData )
             {
                 return store.getRecord( key, store.newRecord(), NORMAL );
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyCreator.java
@@ -56,8 +56,8 @@ public class PropertyCreator
     }
 
     public <P extends PrimitiveRecord> void primitiveSetProperty(
-            RecordProxy<Long, P, Void> primitiveRecordChange, int propertyKey, Value value,
-            RecordAccess<Long, PropertyRecord, PrimitiveRecord> propertyRecords )
+            RecordProxy<P, Void> primitiveRecordChange, int propertyKey, Value value,
+            RecordAccess<PropertyRecord, PrimitiveRecord> propertyRecords )
     {
         PropertyBlock block = encodePropertyValue( propertyKey, value );
         P primitive = primitiveRecordChange.forReadingLinkage();
@@ -72,12 +72,12 @@ public class PropertyCreator
         // - (2) (a) occurs and (b) has occurred, but new property block didn't fit
         // - (3) (b) occurs and (a) has occurred
         // - (4) Chain ends
-        RecordProxy<Long, PropertyRecord, PrimitiveRecord> freeHostProxy = null;
-        RecordProxy<Long, PropertyRecord, PrimitiveRecord> existingHostProxy = null;
+        RecordProxy<PropertyRecord, PrimitiveRecord> freeHostProxy = null;
+        RecordProxy<PropertyRecord, PrimitiveRecord> existingHostProxy = null;
         long prop = primitive.getNextProp();
         while ( prop != Record.NO_NEXT_PROPERTY.intValue() ) // <-- (4)
         {
-            RecordProxy<Long, PropertyRecord, PrimitiveRecord> proxy =
+            RecordProxy<PropertyRecord, PrimitiveRecord> proxy =
                     propertyRecords.getOrLoad( prop, primitive );
             PropertyRecord propRecord = proxy.forReadingLinkage();
             assert propRecord.inUse() : propRecord;
@@ -197,13 +197,13 @@ public class PropertyCreator
     }
 
     public long createPropertyChain( PrimitiveRecord owner, Iterator<PropertyBlock> properties,
-            RecordAccess<Long, PropertyRecord, PrimitiveRecord> propertyRecords )
+            RecordAccess<PropertyRecord, PrimitiveRecord> propertyRecords )
     {
         return createPropertyChain( owner, properties, propertyRecords, p -> {} );
     }
 
     public long createPropertyChain( PrimitiveRecord owner, Iterator<PropertyBlock> properties,
-            RecordAccess<Long, PropertyRecord, PrimitiveRecord> propertyRecords,
+            RecordAccess<PropertyRecord, PrimitiveRecord> propertyRecords,
             Consumer<PropertyRecord> createdPropertyRecords )
     {
         if ( properties == null || !properties.hasNext() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyDeleter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyDeleter.java
@@ -36,12 +36,12 @@ public class PropertyDeleter
     }
 
     public void deletePropertyChain( PrimitiveRecord primitive,
-            RecordAccess<Long, PropertyRecord, PrimitiveRecord> propertyRecords )
+            RecordAccess<PropertyRecord, PrimitiveRecord> propertyRecords )
     {
         long nextProp = primitive.getNextProp();
         while ( nextProp != Record.NO_NEXT_PROPERTY.intValue() )
         {
-            RecordProxy<Long, PropertyRecord, PrimitiveRecord> propertyChange =
+            RecordProxy<PropertyRecord, PrimitiveRecord> propertyChange =
                     propertyRecords.getOrLoad( nextProp, primitive );
 
             // TODO forChanging/forReading piggy-backing
@@ -73,8 +73,8 @@ public class PropertyDeleter
      * @param propertyRecords access to records.
      * @return {@code true} if the property was found and removed, otherwise {@code false}.
      */
-    public <P extends PrimitiveRecord> boolean removePropertyIfExists( RecordProxy<Long,P,Void> primitiveProxy,
-            int propertyKey, RecordAccess<Long,PropertyRecord,PrimitiveRecord> propertyRecords )
+    public <P extends PrimitiveRecord> boolean removePropertyIfExists( RecordProxy<P,Void> primitiveProxy,
+            int propertyKey, RecordAccess<PropertyRecord,PrimitiveRecord> propertyRecords )
     {
         PrimitiveRecord primitive = primitiveProxy.forReadingData();
         long propertyId = // propertyData.getId();
@@ -96,8 +96,8 @@ public class PropertyDeleter
      * @param propertyRecords access to records.
      * @throws IllegalStateException if property key was not found in the property chain.
      */
-    public <P extends PrimitiveRecord> void removeProperty( RecordProxy<Long,P,Void> primitiveProxy, int propertyKey,
-            RecordAccess<Long,PropertyRecord,PrimitiveRecord> propertyRecords )
+    public <P extends PrimitiveRecord> void removeProperty( RecordProxy<P,Void> primitiveProxy, int propertyKey,
+            RecordAccess<PropertyRecord,PrimitiveRecord> propertyRecords )
     {
         PrimitiveRecord primitive = primitiveProxy.forReadingData();
         long propertyId = // propertyData.getId();
@@ -105,11 +105,11 @@ public class PropertyDeleter
         removeProperty( primitiveProxy, propertyKey, propertyRecords, primitive, propertyId );
     }
 
-    private <P extends PrimitiveRecord> void removeProperty( RecordProxy<Long,P,Void> primitiveProxy, int propertyKey,
-            RecordAccess<Long,PropertyRecord,PrimitiveRecord> propertyRecords, PrimitiveRecord primitive,
+    private <P extends PrimitiveRecord> void removeProperty( RecordProxy<P,Void> primitiveProxy, int propertyKey,
+            RecordAccess<PropertyRecord,PrimitiveRecord> propertyRecords, PrimitiveRecord primitive,
             long propertyId )
     {
-        RecordProxy<Long, PropertyRecord, PrimitiveRecord> recordChange =
+        RecordProxy<PropertyRecord, PrimitiveRecord> recordChange =
                 propertyRecords.getOrLoad( propertyId, primitive );
         PropertyRecord propRecord = recordChange.forChangingData();
         if ( !propRecord.inUse() )
@@ -148,8 +148,8 @@ public class PropertyDeleter
     }
 
     private <P extends PrimitiveRecord> void unlinkPropertyRecord( PropertyRecord propRecord,
-            RecordAccess<Long,PropertyRecord,PrimitiveRecord> propertyRecords,
-            RecordProxy<Long, P, Void> primitiveRecordChange )
+            RecordAccess<PropertyRecord,PrimitiveRecord> propertyRecords,
+            RecordProxy<P, Void> primitiveRecordChange )
     {
         P primitive = primitiveRecordChange.forReadingLinkage();
         assert traverser.assertPropertyChain( primitive, propertyRecords );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyTraverser.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/PropertyTraverser.java
@@ -46,7 +46,7 @@ public class PropertyTraverser
      * {@code strict} is false value of {@link Record#NO_NEXT_PROPERTY}.
      */
     public long findPropertyRecordContaining( PrimitiveRecord primitive, int propertyKey,
-            RecordAccess<Long, PropertyRecord, PrimitiveRecord> propertyRecords, boolean strict )
+            RecordAccess<PropertyRecord, PrimitiveRecord> propertyRecords, boolean strict )
     {
         long propertyRecordId = primitive.getNextProp();
         while ( !Record.NO_NEXT_PROPERTY.is( propertyRecordId ) )
@@ -70,7 +70,7 @@ public class PropertyTraverser
     }
 
     public void getPropertyChain( long nextProp,
-            RecordAccess<Long, PropertyRecord, PrimitiveRecord> propertyRecords,
+            RecordAccess<PropertyRecord, PrimitiveRecord> propertyRecords,
             Listener<PropertyBlock> collector )
     {
         while ( nextProp != Record.NO_NEXT_PROPERTY.intValue() )
@@ -85,7 +85,7 @@ public class PropertyTraverser
     }
 
     public boolean assertPropertyChain( PrimitiveRecord primitive,
-            RecordAccess<Long, PropertyRecord, PrimitiveRecord> propertyRecords )
+            RecordAccess<PropertyRecord, PrimitiveRecord> propertyRecords )
     {
         List<PropertyRecord> toCheck = new LinkedList<>();
         long nextIdToFetch = primitive.getNextProp();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordAccess.java
@@ -22,7 +22,7 @@ package org.neo4j.kernel.impl.transaction.state;
 /**
  * Provides access to records, both for reading and for writing.
  */
-public interface RecordAccess<KEY,RECORD,ADDITIONAL>
+public interface RecordAccess<RECORD,ADDITIONAL>
 {
     /**
      * Gets an already loaded record, or loads it as part of this call if it wasn't. The {@link RecordProxy}
@@ -34,14 +34,14 @@ public interface RecordAccess<KEY,RECORD,ADDITIONAL>
      * @param additionalData additional data to put in the record after loaded.
      * @return a {@link RecordProxy} for the record for {@code key}.
      */
-    RecordProxy<KEY, RECORD, ADDITIONAL> getOrLoad( KEY key, ADDITIONAL additionalData );
+    RecordProxy<RECORD, ADDITIONAL> getOrLoad( long key, ADDITIONAL additionalData );
 
-    RecordProxy<KEY, RECORD, ADDITIONAL> getIfLoaded( KEY key );
+    RecordProxy<RECORD, ADDITIONAL> getIfLoaded( long key );
 
     @Deprecated
-    void setTo( KEY key, RECORD newRecord, ADDITIONAL additionalData );
+    void setTo( long key, RECORD newRecord, ADDITIONAL additionalData );
 
-    RecordProxy<KEY,RECORD,ADDITIONAL> setRecord( KEY key, RECORD record, ADDITIONAL additionalData );
+    RecordProxy<RECORD,ADDITIONAL> setRecord( long key, RECORD record, ADDITIONAL additionalData );
 
     /**
      * Creates a new record with the given {@code key}. Any {@code additionalData} is set in the
@@ -51,7 +51,7 @@ public interface RecordAccess<KEY,RECORD,ADDITIONAL>
      * @param additionalData additional data to put in the record after loaded.
      * @return a {@link RecordProxy} for the record for {@code key}.
      */
-    RecordProxy<KEY, RECORD, ADDITIONAL> create( KEY key, ADDITIONAL additionalData );
+    RecordProxy<RECORD, ADDITIONAL> create( long key, ADDITIONAL additionalData );
 
     /**
      * Closes the record access.
@@ -60,15 +60,15 @@ public interface RecordAccess<KEY,RECORD,ADDITIONAL>
 
     int changeSize();
 
-    Iterable<RecordProxy<KEY,RECORD,ADDITIONAL>> changes();
+    Iterable<RecordProxy<RECORD,ADDITIONAL>> changes();
 
     /**
      * A proxy for a record that encapsulates load/store actions to take, knowing when the underlying record is
      * requested for reading or for writing.
      */
-    interface RecordProxy<KEY, RECORD, ADDITIONAL>
+    interface RecordProxy<RECORD, ADDITIONAL>
     {
-        KEY getKey();
+        long getKey();
 
         RECORD forChangingLinkage();
 
@@ -90,11 +90,11 @@ public interface RecordAccess<KEY,RECORD,ADDITIONAL>
     /**
      * Hook for loading and creating records.
      */
-    interface Loader<KEY,RECORD,ADDITIONAL>
+    interface Loader<RECORD,ADDITIONAL>
     {
-        RECORD newUnused( KEY key, ADDITIONAL additionalData );
+        RECORD newUnused( long key, ADDITIONAL additionalData );
 
-        RECORD load( KEY key, ADDITIONAL additionalData );
+        RECORD load( long key, ADDITIONAL additionalData );
 
         void ensureHeavy( RECORD record );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordAccessSet.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordAccessSet.java
@@ -32,21 +32,21 @@ import org.neo4j.storageengine.api.schema.SchemaRule;
 
 public interface RecordAccessSet
 {
-    RecordAccess<Long, NodeRecord, Void> getNodeRecords();
+    RecordAccess<NodeRecord, Void> getNodeRecords();
 
-    RecordAccess<Long, PropertyRecord, PrimitiveRecord> getPropertyRecords();
+    RecordAccess<PropertyRecord, PrimitiveRecord> getPropertyRecords();
 
-    RecordAccess<Long, RelationshipRecord, Void> getRelRecords();
+    RecordAccess<RelationshipRecord, Void> getRelRecords();
 
-    RecordAccess<Long, RelationshipGroupRecord, Integer> getRelGroupRecords();
+    RecordAccess<RelationshipGroupRecord, Integer> getRelGroupRecords();
 
-    RecordAccess<Long, SchemaRecord, SchemaRule> getSchemaRuleChanges();
+    RecordAccess<SchemaRecord, SchemaRule> getSchemaRuleChanges();
 
-    RecordAccess<Integer, PropertyKeyTokenRecord, Void> getPropertyKeyTokenChanges();
+    RecordAccess<PropertyKeyTokenRecord, Void> getPropertyKeyTokenChanges();
 
-    RecordAccess<Integer, LabelTokenRecord, Void> getLabelTokenChanges();
+    RecordAccess<LabelTokenRecord, Void> getLabelTokenChanges();
 
-    RecordAccess<Integer, RelationshipTypeTokenRecord, Void> getRelationshipTypeTokenChanges();
+    RecordAccess<RelationshipTypeTokenRecord, Void> getRelationshipTypeTokenChanges();
 
     boolean hasChanges();
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordChangeSet.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordChangeSet.java
@@ -34,14 +34,14 @@ import org.neo4j.storageengine.api.schema.SchemaRule;
 
 public class RecordChangeSet implements RecordAccessSet
 {
-    private final RecordAccess<Long, NodeRecord, Void> nodeRecords;
-    private final RecordAccess<Long, PropertyRecord, PrimitiveRecord> propertyRecords;
-    private final RecordAccess<Long, RelationshipRecord, Void> relRecords;
-    private final RecordAccess<Long, RelationshipGroupRecord, Integer> relGroupRecords;
-    private final RecordAccess<Long, SchemaRecord, SchemaRule> schemaRuleChanges;
-    private final RecordAccess<Integer, PropertyKeyTokenRecord, Void> propertyKeyTokenChanges;
-    private final RecordAccess<Integer, LabelTokenRecord, Void> labelTokenChanges;
-    private final RecordAccess<Integer, RelationshipTypeTokenRecord, Void> relationshipTypeTokenChanges;
+    private final RecordAccess<NodeRecord, Void> nodeRecords;
+    private final RecordAccess<PropertyRecord, PrimitiveRecord> propertyRecords;
+    private final RecordAccess<RelationshipRecord, Void> relRecords;
+    private final RecordAccess<RelationshipGroupRecord, Integer> relGroupRecords;
+    private final RecordAccess<SchemaRecord, SchemaRule> schemaRuleChanges;
+    private final RecordAccess<PropertyKeyTokenRecord, Void> propertyKeyTokenChanges;
+    private final RecordAccess<LabelTokenRecord, Void> labelTokenChanges;
+    private final RecordAccess<RelationshipTypeTokenRecord, Void> relationshipTypeTokenChanges;
     private final IntCounter changeCounter = new IntCounter();
 
     public RecordChangeSet( Loaders loaders )
@@ -57,14 +57,14 @@ public class RecordChangeSet implements RecordAccessSet
     }
 
     public RecordChangeSet(
-            Loader<Long,NodeRecord,Void> nodeLoader,
-            Loader<Long,PropertyRecord,PrimitiveRecord> propertyLoader,
-            Loader<Long,RelationshipRecord,Void> relationshipLoader,
-            Loader<Long,RelationshipGroupRecord,Integer> relationshipGroupLoader,
-            Loader<Long,SchemaRecord,SchemaRule> schemaRuleLoader,
-            Loader<Integer,PropertyKeyTokenRecord,Void> propertyKeyTokenLoader,
-            Loader<Integer,LabelTokenRecord,Void> labelTokenLoader,
-            Loader<Integer,RelationshipTypeTokenRecord,Void> relationshipTypeTokenLoader )
+            Loader<NodeRecord,Void> nodeLoader,
+            Loader<PropertyRecord,PrimitiveRecord> propertyLoader,
+            Loader<RelationshipRecord,Void> relationshipLoader,
+            Loader<RelationshipGroupRecord,Integer> relationshipGroupLoader,
+            Loader<SchemaRecord,SchemaRule> schemaRuleLoader,
+            Loader<PropertyKeyTokenRecord,Void> propertyKeyTokenLoader,
+            Loader<LabelTokenRecord,Void> labelTokenLoader,
+            Loader<RelationshipTypeTokenRecord,Void> relationshipTypeTokenLoader )
     {
         this.nodeRecords = new RecordChanges<>( nodeLoader, changeCounter );
         this.propertyRecords = new RecordChanges<>( propertyLoader, changeCounter );
@@ -77,49 +77,49 @@ public class RecordChangeSet implements RecordAccessSet
     }
 
     @Override
-    public RecordAccess<Long, NodeRecord, Void> getNodeRecords()
+    public RecordAccess<NodeRecord, Void> getNodeRecords()
     {
         return nodeRecords;
     }
 
     @Override
-    public RecordAccess<Long, PropertyRecord, PrimitiveRecord> getPropertyRecords()
+    public RecordAccess<PropertyRecord, PrimitiveRecord> getPropertyRecords()
     {
         return propertyRecords;
     }
 
     @Override
-    public RecordAccess<Long, RelationshipRecord, Void> getRelRecords()
+    public RecordAccess<RelationshipRecord, Void> getRelRecords()
     {
         return relRecords;
     }
 
     @Override
-    public RecordAccess<Long, RelationshipGroupRecord, Integer> getRelGroupRecords()
+    public RecordAccess<RelationshipGroupRecord, Integer> getRelGroupRecords()
     {
         return relGroupRecords;
     }
 
     @Override
-    public RecordAccess<Long, SchemaRecord, SchemaRule> getSchemaRuleChanges()
+    public RecordAccess<SchemaRecord, SchemaRule> getSchemaRuleChanges()
     {
         return schemaRuleChanges;
     }
 
     @Override
-    public RecordAccess<Integer, PropertyKeyTokenRecord, Void> getPropertyKeyTokenChanges()
+    public RecordAccess<PropertyKeyTokenRecord, Void> getPropertyKeyTokenChanges()
     {
         return propertyKeyTokenChanges;
     }
 
     @Override
-    public RecordAccess<Integer, LabelTokenRecord, Void> getLabelTokenChanges()
+    public RecordAccess<LabelTokenRecord, Void> getLabelTokenChanges()
     {
         return labelTokenChanges;
     }
 
     @Override
-    public RecordAccess<Integer, RelationshipTypeTokenRecord, Void> getRelationshipTypeTokenChanges()
+    public RecordAccess<RelationshipTypeTokenRecord, Void> getRelationshipTypeTokenChanges()
     {
         return relationshipTypeTokenChanges;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordChanges.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordChanges.java
@@ -31,11 +31,8 @@ import org.neo4j.kernel.impl.util.statistics.LocalIntCounter;
  * deciding when to make a record heavy and when to consider it changed for inclusion in the
  * transaction as a command.
  *
- * @author Mattias Persson
- *
- * @param <KEY>
- * @param <RECORD>
- * @param <ADDITIONAL>
+ * @param <RECORD> type of record
+ * @param <ADDITIONAL> additional payload
  */
 public class RecordChanges<RECORD,ADDITIONAL> implements RecordAccess<RECORD,ADDITIONAL>
 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordChanges.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RecordChanges.java
@@ -37,13 +37,13 @@ import org.neo4j.kernel.impl.util.statistics.LocalIntCounter;
  * @param <RECORD>
  * @param <ADDITIONAL>
  */
-public class RecordChanges<KEY,RECORD,ADDITIONAL> implements RecordAccess<KEY,RECORD,ADDITIONAL>
+public class RecordChanges<RECORD,ADDITIONAL> implements RecordAccess<RECORD,ADDITIONAL>
 {
-    private Map<KEY, RecordProxy<KEY,RECORD,ADDITIONAL>> recordChanges = new HashMap<>();
-    private final Loader<KEY,RECORD,ADDITIONAL> loader;
+    private Map<Long, RecordProxy<RECORD,ADDITIONAL>> recordChanges = new HashMap<>();
+    private final Loader<RECORD,ADDITIONAL> loader;
     private final IntCounter changeCounter;
 
-    public RecordChanges( Loader<KEY,RECORD,ADDITIONAL> loader, IntCounter globalCounter )
+    public RecordChanges( Loader<RECORD,ADDITIONAL> loader, IntCounter globalCounter )
     {
         this.loader = loader;
         this.changeCounter = new LocalIntCounter( globalCounter );
@@ -58,15 +58,15 @@ public class RecordChanges<KEY,RECORD,ADDITIONAL> implements RecordAccess<KEY,RE
     }
 
     @Override
-    public RecordProxy<KEY, RECORD, ADDITIONAL> getIfLoaded( KEY key )
+    public RecordProxy<RECORD, ADDITIONAL> getIfLoaded( long key )
     {
         return recordChanges.get( key );
     }
 
     @Override
-    public RecordProxy<KEY, RECORD, ADDITIONAL> getOrLoad( KEY key, ADDITIONAL additionalData )
+    public RecordProxy<RECORD, ADDITIONAL> getOrLoad( long key, ADDITIONAL additionalData )
     {
-        RecordProxy<KEY, RECORD, ADDITIONAL> result = recordChanges.get( key );
+        RecordProxy<RECORD, ADDITIONAL> result = recordChanges.get( key );
         if ( result == null )
         {
             RECORD record = loader.load( key, additionalData );
@@ -76,15 +76,15 @@ public class RecordChanges<KEY,RECORD,ADDITIONAL> implements RecordAccess<KEY,RE
     }
 
     @Override
-    public void setTo( KEY key, RECORD newRecord, ADDITIONAL additionalData )
+    public void setTo( long key, RECORD newRecord, ADDITIONAL additionalData )
     {
         setRecord( key, newRecord, additionalData );
     }
 
     @Override
-    public RecordProxy<KEY,RECORD,ADDITIONAL> setRecord( KEY key, RECORD record, ADDITIONAL additionalData )
+    public RecordProxy<RECORD,ADDITIONAL> setRecord( long key, RECORD record, ADDITIONAL additionalData )
     {
-        RecordChange<KEY, RECORD, ADDITIONAL> recordChange =
+        RecordChange<RECORD, ADDITIONAL> recordChange =
                 new RecordChange<>( recordChanges, changeCounter, key, record, loader, false, additionalData );
         recordChanges.put( key, recordChange );
         return recordChange;
@@ -112,7 +112,7 @@ public class RecordChanges<KEY,RECORD,ADDITIONAL> implements RecordAccess<KEY,RE
     }
 
     @Override
-    public RecordProxy<KEY, RECORD, ADDITIONAL> create( KEY key, ADDITIONAL additionalData )
+    public RecordProxy<RECORD, ADDITIONAL> create( long key, ADDITIONAL additionalData )
     {
         if ( recordChanges.containsKey( key ) )
         {
@@ -120,34 +120,34 @@ public class RecordChanges<KEY,RECORD,ADDITIONAL> implements RecordAccess<KEY,RE
         }
 
         RECORD record = loader.newUnused( key, additionalData );
-        RecordChange<KEY,RECORD,ADDITIONAL> change =
+        RecordChange<RECORD,ADDITIONAL> change =
                 new RecordChange<>( recordChanges, changeCounter, key, record, loader, true, additionalData );
         recordChanges.put( key, change );
         return change;
     }
 
     @Override
-    public Iterable<RecordProxy<KEY,RECORD,ADDITIONAL>> changes()
+    public Iterable<RecordProxy<RECORD,ADDITIONAL>> changes()
     {
         return Iterables.filter( RecordProxy::isChanged, recordChanges.values() );
     }
 
-    public static class RecordChange<KEY,RECORD,ADDITIONAL> implements RecordProxy<KEY, RECORD, ADDITIONAL>
+    public static class RecordChange<RECORD,ADDITIONAL> implements RecordProxy<RECORD, ADDITIONAL>
     {
-        private final Map<KEY,RecordProxy<KEY,RECORD,ADDITIONAL>> allChanges;
+        private final Map<Long,RecordProxy<RECORD,ADDITIONAL>> allChanges;
         private final IntCounter changeCounter;
-        private final Loader<KEY,RECORD,ADDITIONAL> loader;
+        private final Loader<RECORD,ADDITIONAL> loader;
 
         private final ADDITIONAL additionalData;
         private final RECORD record;
         private final boolean created;
-        private final KEY key;
+        private final long key;
 
         private RECORD before;
         private boolean changed;
 
-        public RecordChange( Map<KEY,RecordProxy<KEY,RECORD,ADDITIONAL>> allChanges, IntCounter changeCounter, KEY key,
-                RECORD record, Loader<KEY,RECORD,ADDITIONAL> loader, boolean created, ADDITIONAL additionalData )
+        public RecordChange( Map<Long,RecordProxy<RECORD,ADDITIONAL>> allChanges, IntCounter changeCounter, long key,
+                RECORD record, Loader<RECORD,ADDITIONAL> loader, boolean created, ADDITIONAL additionalData )
         {
             this.allChanges = allChanges;
             this.changeCounter = changeCounter;
@@ -165,7 +165,7 @@ public class RecordChanges<KEY,RECORD,ADDITIONAL> implements RecordAccess<KEY,RE
         }
 
         @Override
-        public KEY getKey()
+        public long getKey()
         {
             return key;
         }
@@ -188,7 +188,7 @@ public class RecordChanges<KEY,RECORD,ADDITIONAL> implements RecordAccess<KEY,RE
             ensureHasBeforeRecordImage();
             if ( !this.changed )
             {
-                RecordProxy<KEY,RECORD,ADDITIONAL> previous = this.allChanges.put( key, this );
+                RecordProxy<RECORD,ADDITIONAL> previous = this.allChanges.put( key, this );
 
                 if ( previous == null || !previous.isChanged() )
                 {
@@ -246,6 +246,7 @@ public class RecordChanges<KEY,RECORD,ADDITIONAL> implements RecordAccess<KEY,RE
             }
         }
 
+        @Override
         public boolean isCreated()
         {
             return created;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipCreator.java
@@ -75,8 +75,8 @@ public class RelationshipCreator
     }
 
     private void convertNodeToDenseIfNecessary( NodeRecord node,
-            RecordAccess<Long, RelationshipRecord, Void> relRecords,
-            RecordAccess<Long, RelationshipGroupRecord, Integer> relGroupRecords, ResourceLocker locks )
+            RecordAccess<RelationshipRecord, Void> relRecords,
+            RecordAccess<RelationshipGroupRecord, Integer> relGroupRecords, ResourceLocker locks )
     {
         if ( node.isDense() )
         {
@@ -85,7 +85,7 @@ public class RelationshipCreator
         long relId = node.getNextRel();
         if ( relId != Record.NO_NEXT_RELATIONSHIP.intValue() )
         {
-            RecordProxy<Long, RelationshipRecord, Void> relChange = relRecords.getOrLoad( relId, null );
+            RecordProxy<RelationshipRecord, Void> relChange = relRecords.getOrLoad( relId, null );
             RelationshipRecord rel = relChange.forReadingLinkage();
             if ( relCount( node.getId(), rel ) >= denseNodeThreshold )
             {
@@ -101,8 +101,8 @@ public class RelationshipCreator
 
     private void connectRelationship( NodeRecord firstNode,
             NodeRecord secondNode, RelationshipRecord rel,
-            RecordAccess<Long, RelationshipRecord, Void> relRecords,
-            RecordAccess<Long, RelationshipGroupRecord, Integer> relGroupRecords, ResourceLocker locks )
+            RecordAccess<RelationshipRecord, Void> relRecords,
+            RecordAccess<RelationshipGroupRecord, Integer> relGroupRecords, ResourceLocker locks )
     {
         // Assertion interpreted: if node is a normal node and we're trying to create a
         // relationship that we already have as first rel for that node --> error
@@ -155,8 +155,8 @@ public class RelationshipCreator
     }
 
     private void connectRelationshipToDenseNode( NodeRecord node, RelationshipRecord rel,
-            RecordAccess<Long, RelationshipRecord, Void> relRecords,
-            RecordAccess<Long, RelationshipGroupRecord, Integer> relGroupRecords, ResourceLocker locks )
+            RecordAccess<RelationshipRecord, Void> relRecords,
+            RecordAccess<RelationshipGroupRecord, Integer> relGroupRecords, ResourceLocker locks )
     {
         RelationshipGroupRecord group =
                 relGroupGetter.getOrCreateRelationshipGroup( node, rel.getType(), relGroupRecords ).forChangingData();
@@ -168,14 +168,14 @@ public class RelationshipCreator
     }
 
     private void connect( NodeRecord node, RelationshipRecord rel,
-            RecordAccess<Long, RelationshipRecord, Void> relRecords, ResourceLocker locks )
+            RecordAccess<RelationshipRecord, Void> relRecords, ResourceLocker locks )
     {
         connect( node.getId(), node.getNextRel(), rel, relRecords, locks );
     }
 
     private void convertNodeToDenseNode( NodeRecord node, RelationshipRecord firstRel,
-            RecordAccess<Long, RelationshipRecord, Void> relRecords,
-            RecordAccess<Long, RelationshipGroupRecord, Integer> relGroupRecords, ResourceLocker locks )
+            RecordAccess<RelationshipRecord, Void> relRecords,
+            RecordAccess<RelationshipGroupRecord, Integer> relGroupRecords, ResourceLocker locks )
     {
         node.setDense( true );
         node.setNextRel( Record.NO_NEXT_RELATIONSHIP.intValue() );
@@ -195,7 +195,7 @@ public class RelationshipCreator
     }
 
     private void connect( long nodeId, long firstRelId, RelationshipRecord rel,
-            RecordAccess<Long, RelationshipRecord, Void> relRecords, ResourceLocker locks )
+            RecordAccess<RelationshipRecord, Void> relRecords, ResourceLocker locks )
     {
         long newCount = 1;
         if ( firstRelId != Record.NO_NEXT_RELATIONSHIP.intValue() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipDeleter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipDeleter.java
@@ -69,7 +69,7 @@ public class RelationshipDeleter
     }
 
     private void disconnect( RelationshipRecord rel, RelationshipConnection pointer,
-            RecordAccess<Long, RelationshipRecord, Void> relChanges, ResourceLocker locks )
+            RecordAccess<RelationshipRecord, Void> relChanges, ResourceLocker locks )
     {
         long otherRelId = pointer.otherSide().get( rel );
         if ( otherRelId == Record.NO_NEXT_RELATIONSHIP.intValue() )
@@ -101,9 +101,9 @@ public class RelationshipDeleter
     private void updateNodesForDeletedRelationship( RelationshipRecord rel, RecordAccessSet recordChanges,
             ResourceLocker locks )
     {
-        RecordProxy<Long, NodeRecord, Void> startNodeChange =
+        RecordProxy<NodeRecord, Void> startNodeChange =
                 recordChanges.getNodeRecords().getOrLoad( rel.getFirstNode(), null );
-        RecordProxy<Long, NodeRecord, Void> endNodeChange =
+        RecordProxy<NodeRecord, Void> endNodeChange =
                 recordChanges.getNodeRecords().getOrLoad( rel.getSecondNode(), null );
 
         NodeRecord startNode = recordChanges.getNodeRecords().getOrLoad( rel.getFirstNode(), null ).forReadingLinkage();
@@ -122,7 +122,7 @@ public class RelationshipDeleter
         }
         else
         {
-            RecordProxy<Long, RelationshipGroupRecord, Integer> groupChange =
+            RecordProxy<RelationshipGroupRecord, Integer> groupChange =
                     relGroupGetter.getRelationshipGroup( startNode, rel.getType(),
                             recordChanges.getRelGroupRecords() ).group();
             assert groupChange != null : "Relationship group " + rel.getType() + " should have existed here";
@@ -156,7 +156,7 @@ public class RelationshipDeleter
         }
         else
         {
-            RecordProxy<Long, RelationshipGroupRecord, Integer> groupChange =
+            RecordProxy<RelationshipGroupRecord, Integer> groupChange =
                     relGroupGetter.getRelationshipGroup( endNode, rel.getType(),
                             recordChanges.getRelGroupRecords() ).group();
             DirectionWrapper dir = DirectionIdentifier.wrapDirection( rel, endNode );
@@ -183,7 +183,7 @@ public class RelationshipDeleter
     }
 
     private boolean decrementTotalRelationshipCount( long nodeId, RelationshipRecord rel, long firstRelId,
-            RecordAccess<Long, RelationshipRecord, Void> relRecords, ResourceLocker locks )
+            RecordAccess<RelationshipRecord, Void> relRecords, ResourceLocker locks )
     {
         if ( firstRelId == Record.NO_PREV_RELATIONSHIP.intValue() )
         {
@@ -208,9 +208,9 @@ public class RelationshipDeleter
         return false;
     }
 
-    private void deleteGroup( RecordProxy<Long, NodeRecord, Void> nodeChange,
+    private void deleteGroup( RecordProxy<NodeRecord, Void> nodeChange,
                               RelationshipGroupRecord group,
-                              RecordAccess<Long, RelationshipGroupRecord, Integer> relGroupRecords )
+                              RecordAccess<RelationshipGroupRecord, Integer> relGroupRecords )
     {
         long previous = group.getPrev();
         long next = group.getNext();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipGroupGetter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/RelationshipGroupGetter.java
@@ -35,12 +35,12 @@ public class RelationshipGroupGetter
     }
 
     public RelationshipGroupPosition getRelationshipGroup( NodeRecord node, int type,
-            RecordAccess<Long, RelationshipGroupRecord, Integer> relGroupRecords )
+            RecordAccess<RelationshipGroupRecord, Integer> relGroupRecords )
     {
         long groupId = node.getNextRel();
         long previousGroupId = Record.NO_NEXT_RELATIONSHIP.intValue();
-        RecordProxy<Long, RelationshipGroupRecord, Integer> previous = null;
-        RecordProxy<Long, RelationshipGroupRecord, Integer> current;
+        RecordProxy<RelationshipGroupRecord, Integer> previous = null;
+        RecordProxy<RelationshipGroupRecord, Integer> current;
         while ( groupId != Record.NO_NEXT_RELATIONSHIP.intValue() )
         {
             current = relGroupRecords.getOrLoad( groupId, null );
@@ -62,11 +62,11 @@ public class RelationshipGroupGetter
         return new RelationshipGroupPosition( previous, null );
     }
 
-    public RecordProxy<Long, RelationshipGroupRecord, Integer> getOrCreateRelationshipGroup(
-            NodeRecord node, int type, RecordAccess<Long, RelationshipGroupRecord, Integer> relGroupRecords  )
+    public RecordProxy<RelationshipGroupRecord, Integer> getOrCreateRelationshipGroup(
+            NodeRecord node, int type, RecordAccess<RelationshipGroupRecord, Integer> relGroupRecords  )
     {
         RelationshipGroupPosition existingGroup = getRelationshipGroup( node, type, relGroupRecords );
-        RecordProxy<Long, RelationshipGroupRecord, Integer> change = existingGroup.group();
+        RecordProxy<RelationshipGroupRecord, Integer> change = existingGroup.group();
         if ( change == null )
         {
             assert node.isDense() : "Node " + node + " should have been dense at this point";
@@ -78,7 +78,7 @@ public class RelationshipGroupGetter
             record.setOwningNode( node.getId() );
 
             // Attach it...
-            RecordProxy<Long, RelationshipGroupRecord, Integer> closestPreviousChange = existingGroup.closestPrevious();
+            RecordProxy<RelationshipGroupRecord, Integer> closestPreviousChange = existingGroup.closestPrevious();
             if ( closestPreviousChange != null )
             {   // ...after the closest previous one
                 RelationshipGroupRecord closestPrevious = closestPreviousChange.forChangingLinkage();
@@ -104,22 +104,22 @@ public class RelationshipGroupGetter
 
     public static class RelationshipGroupPosition
     {
-        private final RecordProxy<Long, RelationshipGroupRecord, Integer> closestPrevious;
-        private final RecordProxy<Long, RelationshipGroupRecord, Integer> group;
+        private final RecordProxy<RelationshipGroupRecord, Integer> closestPrevious;
+        private final RecordProxy<RelationshipGroupRecord, Integer> group;
 
-        public RelationshipGroupPosition( RecordProxy<Long, RelationshipGroupRecord, Integer> closestPrevious,
-                RecordProxy<Long, RelationshipGroupRecord, Integer> group )
+        public RelationshipGroupPosition( RecordProxy<RelationshipGroupRecord, Integer> closestPrevious,
+                RecordProxy<RelationshipGroupRecord, Integer> group )
         {
             this.closestPrevious = closestPrevious;
             this.group = group;
         }
 
-        public RecordProxy<Long, RelationshipGroupRecord, Integer> group()
+        public RecordProxy<RelationshipGroupRecord, Integer> group()
         {
             return group;
         }
 
-        public RecordProxy<Long, RelationshipGroupRecord, Integer> closestPrevious()
+        public RecordProxy<RelationshipGroupRecord, Integer> closestPrevious()
         {
             return closestPrevious;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TokenCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TokenCreator.java
@@ -38,7 +38,7 @@ public class TokenCreator<R extends TokenRecord, T extends Token>
         this.store = store;
     }
 
-    public void createToken( String name, int id, RecordAccess<Integer, R,Void> recordAccess )
+    public void createToken( String name, int id, RecordAccess<R,Void> recordAccess )
     {
         R record = recordAccess.create( id, null ).forChangingData();
         record.setInUse( true );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordState.java
@@ -93,7 +93,7 @@ public class TransactionRecordState implements RecordState
     private final PropertyCreator propertyCreator;
     private final PropertyDeleter propertyDeleter;
 
-    private RecordChanges<Long,NeoStoreRecord, Void> neoStoreRecord;
+    private RecordChanges<NeoStoreRecord, Void> neoStoreRecord;
     private boolean prepared;
 
     public TransactionRecordState( NeoStores neoStores, IntegrityValidator integrityValidator,
@@ -138,16 +138,16 @@ public class TransactionRecordState implements RecordState
         int noOfCommands = recordChangeSet.changeSize() +
                            (neoStoreRecord != null ? neoStoreRecord.changeSize() : 0);
 
-        for ( RecordProxy<Integer, LabelTokenRecord, Void> record : recordChangeSet.getLabelTokenChanges().changes() )
+        for ( RecordProxy<LabelTokenRecord, Void> record : recordChangeSet.getLabelTokenChanges().changes() )
         {
             commands.add( new Command.LabelTokenCommand( record.getBefore(), record.forReadingLinkage() ) );
         }
-        for ( RecordProxy<Integer, RelationshipTypeTokenRecord, Void> record :
+        for ( RecordProxy<RelationshipTypeTokenRecord, Void> record :
             recordChangeSet.getRelationshipTypeTokenChanges().changes() )
         {
             commands.add( new Command.RelationshipTypeTokenCommand( record.getBefore(), record.forReadingLinkage() ) );
         }
-        for ( RecordProxy<Integer, PropertyKeyTokenRecord, Void> record :
+        for ( RecordProxy<PropertyKeyTokenRecord, Void> record :
             recordChangeSet.getPropertyKeyTokenChanges().changes() )
         {
             commands.add( new Command.PropertyKeyTokenCommand( record.getBefore(), record.forReadingLinkage() ) );
@@ -160,7 +160,7 @@ public class TransactionRecordState implements RecordState
         {
             nodeCommands = new Command[recordChangeSet.getNodeRecords().changeSize()];
             int i = 0;
-            for ( RecordProxy<Long, NodeRecord, Void> change : recordChangeSet.getNodeRecords().changes() )
+            for ( RecordProxy<NodeRecord, Void> change : recordChangeSet.getNodeRecords().changes() )
             {
                 NodeRecord record = prepared( change, nodeStore );
                 integrityValidator.validateNodeRecord( record );
@@ -174,7 +174,7 @@ public class TransactionRecordState implements RecordState
         {
             relCommands = new Command[recordChangeSet.getRelRecords().changeSize()];
             int i = 0;
-            for ( RecordProxy<Long, RelationshipRecord, Void> change : recordChangeSet.getRelRecords().changes() )
+            for ( RecordProxy<RelationshipRecord, Void> change : recordChangeSet.getRelRecords().changes() )
             {
                 relCommands[i++] = new Command.RelationshipCommand( change.getBefore(),
                         prepared( change, relationshipStore ) );
@@ -187,7 +187,7 @@ public class TransactionRecordState implements RecordState
         {
             propCommands = new Command[recordChangeSet.getPropertyRecords().changeSize()];
             int i = 0;
-            for ( RecordProxy<Long, PropertyRecord, PrimitiveRecord> change :
+            for ( RecordProxy<PropertyRecord, PrimitiveRecord> change :
                 recordChangeSet.getPropertyRecords().changes() )
             {
                 propCommands[i++] = new Command.PropertyCommand( change.getBefore(),
@@ -201,7 +201,7 @@ public class TransactionRecordState implements RecordState
         {
             relGroupCommands = new Command[recordChangeSet.getRelGroupRecords().changeSize()];
             int i = 0;
-            for ( RecordProxy<Long, RelationshipGroupRecord, Integer> change :
+            for ( RecordProxy<RelationshipGroupRecord, Integer> change :
                 recordChangeSet.getRelGroupRecords().changes() )
             {
                 if ( change.isCreated() && !change.forReadingLinkage().inUse() )
@@ -243,12 +243,12 @@ public class TransactionRecordState implements RecordState
 
         if ( neoStoreRecord != null )
         {
-            for ( RecordProxy<Long,NeoStoreRecord, Void> change : neoStoreRecord.changes() )
+            for ( RecordProxy<NeoStoreRecord, Void> change : neoStoreRecord.changes() )
             {
                 commands.add( new Command.NeoStoreCommand( change.getBefore(), change.forReadingData() ) );
             }
         }
-        for ( RecordProxy<Long, SchemaRecord, SchemaRule> change : recordChangeSet.getSchemaRuleChanges().changes() )
+        for ( RecordProxy<SchemaRecord, SchemaRule> change : recordChangeSet.getSchemaRuleChanges().changes() )
         {
             integrityValidator.validateSchemaRule( change.getAdditionalData() );
             commands.add( new Command.SchemaRuleCommand(
@@ -261,7 +261,7 @@ public class TransactionRecordState implements RecordState
     }
 
     private <RECORD extends AbstractBaseRecord> RECORD prepared(
-            RecordProxy<?,RECORD,?> proxy, RecordStore<RECORD> store )
+            RecordProxy<RECORD,?> proxy, RecordStore<RECORD> store )
     {
         RECORD after = proxy.forReadingLinkage();
         store.prepareForCommit( after );
@@ -337,7 +337,7 @@ public class TransactionRecordState implements RecordState
      */
     public void relRemoveProperty( long relId, int propertyKey )
     {
-        RecordProxy<Long, RelationshipRecord, Void> rel = recordChangeSet.getRelRecords().getOrLoad( relId, null );
+        RecordProxy<RelationshipRecord, Void> rel = recordChangeSet.getRelRecords().getOrLoad( relId, null );
         propertyDeleter.removeProperty( rel, propertyKey, recordChangeSet.getPropertyRecords() );
     }
 
@@ -350,7 +350,7 @@ public class TransactionRecordState implements RecordState
      */
     public void nodeRemoveProperty( long nodeId, int propertyKey )
     {
-        RecordProxy<Long, NodeRecord, Void> node = recordChangeSet.getNodeRecords().getOrLoad( nodeId, null );
+        RecordProxy<NodeRecord, Void> node = recordChangeSet.getNodeRecords().getOrLoad( nodeId, null );
         propertyDeleter.removeProperty( node, propertyKey, recordChangeSet.getPropertyRecords() );
     }
 
@@ -364,7 +364,7 @@ public class TransactionRecordState implements RecordState
      */
     public void relChangeProperty( long relId, int propertyKey, Value value )
     {
-        RecordProxy<Long, RelationshipRecord, Void> rel = recordChangeSet.getRelRecords().getOrLoad( relId, null );
+        RecordProxy<RelationshipRecord, Void> rel = recordChangeSet.getRelRecords().getOrLoad( relId, null );
         propertyCreator.primitiveSetProperty( rel, propertyKey, value, recordChangeSet.getPropertyRecords() );
     }
 
@@ -377,7 +377,7 @@ public class TransactionRecordState implements RecordState
      */
     public void nodeChangeProperty( long nodeId, int propertyKey, Value value )
     {
-        RecordProxy<Long, NodeRecord, Void> node = recordChangeSet.getNodeRecords().getOrLoad( nodeId, null );
+        RecordProxy<NodeRecord, Void> node = recordChangeSet.getNodeRecords().getOrLoad( nodeId, null );
         propertyCreator.primitiveSetProperty( node, propertyKey, value, recordChangeSet.getPropertyRecords() );
     }
 
@@ -390,7 +390,7 @@ public class TransactionRecordState implements RecordState
      */
     public void relAddProperty( long relId, int propertyKey, Value value )
     {
-        RecordProxy<Long, RelationshipRecord, Void> rel = recordChangeSet.getRelRecords().getOrLoad( relId, null );
+        RecordProxy<RelationshipRecord, Void> rel = recordChangeSet.getRelRecords().getOrLoad( relId, null );
         propertyCreator.primitiveSetProperty( rel, propertyKey, value, recordChangeSet.getPropertyRecords() );
     }
 
@@ -402,7 +402,7 @@ public class TransactionRecordState implements RecordState
      */
     public void nodeAddProperty( long nodeId, int propertyKey, Value value )
     {
-        RecordProxy<Long, NodeRecord, Void> node = recordChangeSet.getNodeRecords().getOrLoad( nodeId, null );
+        RecordProxy<NodeRecord, Void> node = recordChangeSet.getNodeRecords().getOrLoad( nodeId, null );
         propertyCreator.primitiveSetProperty( node, propertyKey, value, recordChangeSet.getPropertyRecords() );
     }
 
@@ -495,21 +495,21 @@ public class TransactionRecordState implements RecordState
 
     private static final CommandSorter COMMAND_SORTER = new CommandSorter();
 
-    private RecordProxy<Long,NeoStoreRecord, Void> getOrLoadNeoStoreRecord()
+    private RecordProxy<NeoStoreRecord, Void> getOrLoadNeoStoreRecord()
     {
         // TODO Move this neo store record thingie into RecordAccessSet
         if ( neoStoreRecord == null )
         {
-            neoStoreRecord = new RecordChanges<>( new RecordChanges.Loader<Long,NeoStoreRecord, Void>()
+            neoStoreRecord = new RecordChanges<>( new RecordChanges.Loader<NeoStoreRecord, Void>()
             {
                 @Override
-                public NeoStoreRecord newUnused( Long key, Void additionalData )
+                public NeoStoreRecord newUnused( long key, Void additionalData )
                 {
                     throw new UnsupportedOperationException();
                 }
 
                 @Override
-                public NeoStoreRecord load( Long key, Void additionalData )
+                public NeoStoreRecord load( long key, Void additionalData )
                 {
                     return metaDataStore.graphPropertyRecord();
                 }
@@ -561,7 +561,7 @@ public class TransactionRecordState implements RecordState
      */
     public void graphRemoveProperty( int propertyKey )
     {
-        RecordProxy<Long,NeoStoreRecord, Void> recordChange = getOrLoadNeoStoreRecord();
+        RecordProxy<NeoStoreRecord, Void> recordChange = getOrLoadNeoStoreRecord();
         propertyDeleter.removeProperty( recordChange, propertyKey, recordChangeSet.getPropertyRecords() );
     }
 
@@ -578,7 +578,7 @@ public class TransactionRecordState implements RecordState
 
     public void dropSchemaRule( SchemaRule rule )
     {
-        RecordProxy<Long, SchemaRecord, SchemaRule> change =
+        RecordProxy<SchemaRecord, SchemaRule> change =
                 recordChangeSet.getSchemaRuleChanges().getOrLoad( rule.getId(), rule );
         SchemaRecord records = change.forChangingData();
         for ( DynamicRecord record : records )
@@ -590,12 +590,12 @@ public class TransactionRecordState implements RecordState
     public void changeSchemaRule( SchemaRule rule, SchemaRule updatedRule )
     {
         //Read the current record
-        RecordProxy<Long,SchemaRecord,SchemaRule> change = recordChangeSet.getSchemaRuleChanges()
+        RecordProxy<SchemaRecord,SchemaRule> change = recordChangeSet.getSchemaRuleChanges()
                 .getOrLoad( rule.getId(), rule );
         SchemaRecord records = change.forReadingData();
 
         //Register the change of the record
-        RecordProxy<Long,SchemaRecord,SchemaRule> recordChange = recordChangeSet.getSchemaRuleChanges()
+        RecordProxy<SchemaRecord,SchemaRule> recordChange = recordChangeSet.getSchemaRuleChanges()
                 .setRecord( rule.getId(), records, updatedRule );
         SchemaRecord dynamicRecords = recordChange.forChangingData();
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/DirectRecordAccessSet.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/DirectRecordAccessSet.java
@@ -39,13 +39,13 @@ import org.neo4j.storageengine.api.schema.SchemaRule;
 
 public class DirectRecordAccessSet implements RecordAccessSet
 {
-    private final DirectRecordAccess<Long, NodeRecord, Void> nodeRecords;
-    private final DirectRecordAccess<Long, PropertyRecord, PrimitiveRecord> propertyRecords;
-    private final DirectRecordAccess<Long, RelationshipRecord, Void> relationshipRecords;
-    private final DirectRecordAccess<Long, RelationshipGroupRecord, Integer> relationshipGroupRecords;
-    private final DirectRecordAccess<Integer, PropertyKeyTokenRecord, Void> propertyKeyTokenRecords;
-    private final DirectRecordAccess<Integer, RelationshipTypeTokenRecord, Void> relationshipTypeTokenRecords;
-    private final DirectRecordAccess<Integer, LabelTokenRecord, Void> labelTokenRecords;
+    private final DirectRecordAccess<NodeRecord, Void> nodeRecords;
+    private final DirectRecordAccess<PropertyRecord, PrimitiveRecord> propertyRecords;
+    private final DirectRecordAccess<RelationshipRecord, Void> relationshipRecords;
+    private final DirectRecordAccess<RelationshipGroupRecord, Integer> relationshipGroupRecords;
+    private final DirectRecordAccess<PropertyKeyTokenRecord, Void> propertyKeyTokenRecords;
+    private final DirectRecordAccess<RelationshipTypeTokenRecord, Void> relationshipTypeTokenRecords;
+    private final DirectRecordAccess<LabelTokenRecord, Void> labelTokenRecords;
     private final DirectRecordAccess[] all;
 
     public DirectRecordAccessSet( NeoStores neoStores )
@@ -89,49 +89,49 @@ public class DirectRecordAccessSet implements RecordAccessSet
     }
 
     @Override
-    public RecordAccess<Long, NodeRecord, Void> getNodeRecords()
+    public RecordAccess<NodeRecord, Void> getNodeRecords()
     {
         return nodeRecords;
     }
 
     @Override
-    public RecordAccess<Long, PropertyRecord, PrimitiveRecord> getPropertyRecords()
+    public RecordAccess<PropertyRecord, PrimitiveRecord> getPropertyRecords()
     {
         return propertyRecords;
     }
 
     @Override
-    public RecordAccess<Long, RelationshipRecord, Void> getRelRecords()
+    public RecordAccess<RelationshipRecord, Void> getRelRecords()
     {
         return relationshipRecords;
     }
 
     @Override
-    public RecordAccess<Long, RelationshipGroupRecord, Integer> getRelGroupRecords()
+    public RecordAccess<RelationshipGroupRecord, Integer> getRelGroupRecords()
     {
         return relationshipGroupRecords;
     }
 
     @Override
-    public RecordAccess<Long, SchemaRecord, SchemaRule> getSchemaRuleChanges()
+    public RecordAccess<SchemaRecord, SchemaRule> getSchemaRuleChanges()
     {
         throw new UnsupportedOperationException( "Not needed. Implement if needed" );
     }
 
     @Override
-    public RecordAccess<Integer, PropertyKeyTokenRecord, Void> getPropertyKeyTokenChanges()
+    public RecordAccess<PropertyKeyTokenRecord, Void> getPropertyKeyTokenChanges()
     {
         return propertyKeyTokenRecords;
     }
 
     @Override
-    public RecordAccess<Integer, LabelTokenRecord, Void> getLabelTokenChanges()
+    public RecordAccess<LabelTokenRecord, Void> getLabelTokenChanges()
     {
         return labelTokenRecords;
     }
 
     @Override
-    public RecordAccess<Integer, RelationshipTypeTokenRecord, Void> getRelationshipTypeTokenChanges()
+    public RecordAccess<RelationshipTypeTokenRecord, Void> getRelationshipTypeTokenChanges()
     {
         return relationshipTypeTokenRecords;
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
@@ -160,7 +160,6 @@ import org.neo4j.storageengine.api.Token;
 import org.neo4j.storageengine.api.schema.SchemaRule;
 import org.neo4j.unsafe.batchinsert.BatchInserter;
 import org.neo4j.unsafe.batchinsert.BatchRelationship;
-import org.neo4j.unsafe.batchinsert.DirectRecordAccessSet;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
@@ -363,7 +363,7 @@ public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvide
     @Override
     public void setNodeProperty( long node, String propertyName, Object propertyValue )
     {
-        RecordProxy<Long,NodeRecord,Void> nodeRecord = getNodeRecord( node );
+        RecordProxy<NodeRecord,Void> nodeRecord = getNodeRecord( node );
         setPrimitiveProperty( nodeRecord, propertyName, propertyValue );
 
         flushStrategy.flush();
@@ -372,7 +372,7 @@ public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvide
     @Override
     public void setRelationshipProperty( long relationship, String propertyName, Object propertyValue )
     {
-        RecordProxy<Long,RelationshipRecord,Void> relationshipRecord = getRelationshipRecord( relationship );
+        RecordProxy<RelationshipRecord,Void> relationshipRecord = getRelationshipRecord( relationship );
         setPrimitiveProperty( relationshipRecord, propertyName, propertyValue );
 
         flushStrategy.flush();
@@ -402,11 +402,11 @@ public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvide
         return new IndexCreatorImpl( actions, label );
     }
 
-    private void setPrimitiveProperty( RecordProxy<Long,? extends PrimitiveRecord,Void> primitiveRecord,
+    private void setPrimitiveProperty( RecordProxy<? extends PrimitiveRecord,Void> primitiveRecord,
             String propertyName, Object propertyValue )
     {
         int propertyKey = getOrCreatePropertyKeyId( propertyName );
-        RecordAccess<Long,PropertyRecord,PrimitiveRecord> propertyRecords = recordAccess.getPropertyRecords();
+        RecordAccess<PropertyRecord,PrimitiveRecord> propertyRecords = recordAccess.getPropertyRecords();
 
         propertyCreator.primitiveSetProperty( primitiveRecord, propertyKey, Values.of( propertyValue ), propertyRecords );
     }
@@ -1083,7 +1083,7 @@ public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvide
         return id;
     }
 
-    private RecordProxy<Long,NodeRecord,Void> getNodeRecord( long id )
+    private RecordProxy<NodeRecord,Void> getNodeRecord( long id )
     {
         if ( id < 0 || id >= nodeStore.getHighId() )
         {
@@ -1092,7 +1092,7 @@ public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvide
         return recordAccess.getNodeRecords().getOrLoad( id, null );
     }
 
-    private RecordProxy<Long,RelationshipRecord,Void> getRelationshipRecord( long id )
+    private RecordProxy<RelationshipRecord,Void> getRelationshipRecord( long id )
     {
         if ( id < 0 || id >= relationshipStore.getHighId() )
         {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/DirectRecordAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/DirectRecordAccess.java
@@ -17,10 +17,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.unsafe.batchinsert;
+package org.neo4j.unsafe.batchinsert.internal;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -234,7 +233,7 @@ public class DirectRecordAccess<RECORD extends AbstractBaseRecord,ADDITIONAL>
         }
 
         List<DirectRecordProxy> directRecordProxies = new ArrayList<>( batch.values() );
-        Collections.sort(directRecordProxies, ( o1, o2 ) -> Long.compare( -o1.getKey(), o2.getKey() ) );
+        directRecordProxies.sort( ( o1, o2 ) -> Long.compare( -o1.getKey(), o2.getKey() ) );
         for ( DirectRecordProxy proxy : directRecordProxies )
         {
             proxy.store();

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/DirectRecordAccessSet.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/DirectRecordAccessSet.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.unsafe.batchinsert;
+package org.neo4j.unsafe.batchinsert.internal;
 
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.PropertyStore;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingPropertyRecordAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingPropertyRecordAccess.java
@@ -25,13 +25,13 @@ import org.neo4j.kernel.impl.store.record.PropertyRecord;
 /**
  * {@link BatchingRecordAccess} for {@link PropertyRecord property records}.
  */
-public class BatchingPropertyRecordAccess extends BatchingRecordAccess<Long,PropertyRecord, PrimitiveRecord>
+public class BatchingPropertyRecordAccess extends BatchingRecordAccess<PropertyRecord, PrimitiveRecord>
 {
     @Override
-    protected PropertyRecord createRecord( Long key, PrimitiveRecord additionalData )
+    protected PropertyRecord createRecord( long key, PrimitiveRecord additionalData )
     {
         return additionalData != null
-                ? new PropertyRecord( key.longValue(), additionalData )
-                : new PropertyRecord( key.longValue() );
+                ? new PropertyRecord( key, additionalData )
+                : new PropertyRecord( key );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingRecordAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingRecordAccess.java
@@ -23,7 +23,6 @@ import java.util.Collection;
 
 import org.neo4j.helpers.collection.IterableWrapper;
 import org.neo4j.kernel.impl.transaction.state.RecordAccess;
-import org.neo4j.kernel.impl.transaction.state.RecordChanges;
 import org.neo4j.kernel.impl.transaction.state.TransactionRecordState;
 import org.neo4j.kernel.impl.util.collection.ArrayCollection;
 
@@ -32,33 +31,33 @@ import org.neo4j.kernel.impl.util.collection.ArrayCollection;
  * Mostly here as a bridge between a batch importer and existing record logic in {@link TransactionRecordState}
  * and friends.
  */
-public abstract class BatchingRecordAccess<KEY,RECORD,ADDITIONAL> implements RecordAccess<KEY,RECORD,ADDITIONAL>
+public abstract class BatchingRecordAccess<RECORD,ADDITIONAL> implements RecordAccess<RECORD,ADDITIONAL>
 {
-    private final Collection<RecordProxy<KEY,RECORD,ADDITIONAL>> proxies = new ArrayCollection<>( 1000 );
+    private final Collection<RecordProxy<RECORD,ADDITIONAL>> proxies = new ArrayCollection<>( 1000 );
 
     @Override
-    public RecordProxy<KEY,RECORD,ADDITIONAL> getOrLoad( KEY key, ADDITIONAL additionalData )
+    public RecordProxy<RECORD,ADDITIONAL> getOrLoad( long key, ADDITIONAL additionalData )
     {
         throw new UnsupportedOperationException( "We only support creations here" );
     }
 
     @Override
-    public RecordProxy<KEY,RECORD,ADDITIONAL> create( KEY key, ADDITIONAL additionalData )
+    public RecordProxy<RECORD,ADDITIONAL> create( long key, ADDITIONAL additionalData )
     {
         RECORD record = createRecord( key, additionalData );
-        BatchingRecordProxy<KEY,RECORD,ADDITIONAL> proxy = new BatchingRecordProxy<>( key, record, additionalData );
+        BatchingRecordProxy<RECORD,ADDITIONAL> proxy = new BatchingRecordProxy<>( key, record, additionalData );
         proxies.add( proxy );
         return proxy;
     }
 
-    protected abstract RECORD createRecord( KEY key, ADDITIONAL additionalData );
+    protected abstract RECORD createRecord( long key, ADDITIONAL additionalData );
 
     public Iterable<RECORD> records()
     {
-        return new IterableWrapper<RECORD,RecordProxy<KEY,RECORD,ADDITIONAL>>( proxies )
+        return new IterableWrapper<RECORD,RecordProxy<RECORD,ADDITIONAL>>( proxies )
         {
             @Override
-            protected RECORD underlyingObjectToObject( RecordProxy<KEY,RECORD,ADDITIONAL> object )
+            protected RECORD underlyingObjectToObject( RecordProxy<RECORD,ADDITIONAL> object )
             {
                 return object.forReadingLinkage();
             }
@@ -66,19 +65,19 @@ public abstract class BatchingRecordAccess<KEY,RECORD,ADDITIONAL> implements Rec
     }
 
     @Override
-    public RecordProxy<KEY,RECORD,ADDITIONAL> getIfLoaded( KEY key )
+    public RecordProxy<RECORD,ADDITIONAL> getIfLoaded( long key )
     {
         throw new UnsupportedOperationException( "Not supported" );
     }
 
     @Override
-    public void setTo( KEY key, RECORD newRecord, ADDITIONAL additionalData )
+    public void setTo( long key, RECORD newRecord, ADDITIONAL additionalData )
     {
         throw new UnsupportedOperationException( "Not supported" );
     }
 
     @Override
-    public RecordProxy<KEY,RECORD,ADDITIONAL> setRecord( KEY key, RECORD record, ADDITIONAL additionalData )
+    public RecordProxy<RECORD,ADDITIONAL> setRecord( long key, RECORD record, ADDITIONAL additionalData )
     {
         throw new UnsupportedOperationException( "Not supported" );
     }
@@ -90,7 +89,7 @@ public abstract class BatchingRecordAccess<KEY,RECORD,ADDITIONAL> implements Rec
     }
 
     @Override
-    public Iterable<RecordProxy<KEY,RECORD,ADDITIONAL>> changes()
+    public Iterable<RecordProxy<RECORD,ADDITIONAL>> changes()
     {
         return proxies;
     }
@@ -101,13 +100,13 @@ public abstract class BatchingRecordAccess<KEY,RECORD,ADDITIONAL> implements Rec
         proxies.clear();
     }
 
-    public static class BatchingRecordProxy<KEY,RECORD,ADDITIONAL> implements RecordProxy<KEY,RECORD,ADDITIONAL>
+    public static class BatchingRecordProxy<RECORD,ADDITIONAL> implements RecordProxy<RECORD,ADDITIONAL>
     {
-        private final KEY key;
+        private final long key;
         private final RECORD record;
         private final ADDITIONAL additional;
 
-        private BatchingRecordProxy( KEY key, RECORD record, ADDITIONAL additional )
+        private BatchingRecordProxy( long key, RECORD record, ADDITIONAL additional )
         {
             this.key = key;
             this.record = record;
@@ -115,7 +114,7 @@ public abstract class BatchingRecordAccess<KEY,RECORD,ADDITIONAL> implements Rec
         }
 
         @Override
-        public KEY getKey()
+        public long getKey()
         {
             return key;
         }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingTokenRepository.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingTokenRepository.java
@@ -38,6 +38,7 @@ import org.neo4j.storageengine.api.Token;
 import org.neo4j.values.storable.Values;
 
 import static java.lang.Math.max;
+import static java.lang.Math.toIntExact;
 
 /**
  * Batching version of a {@link TokenStore} where tokens can be created and retrieved, but only persisted
@@ -165,12 +166,12 @@ public abstract class BatchingTokenRepository<RECORD extends TokenRecord, TOKEN 
     public void close()
     {
         // Batch-friendly record access
-        BatchingRecordAccess<Integer, RECORD, Void> recordAccess = new BatchingRecordAccess<Integer, RECORD, Void>()
+        BatchingRecordAccess<RECORD, Void> recordAccess = new BatchingRecordAccess<RECORD, Void>()
         {
             @Override
-            protected RECORD createRecord( Integer key, Void additionalData )
+            protected RECORD createRecord( long key, Void additionalData )
             {
-                return BatchingTokenRepository.this.createRecord( key );
+                return BatchingTokenRepository.this.createRecord( toIntExact( key ) );
             }
         };
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PropertyCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PropertyCreatorTest.java
@@ -32,7 +32,7 @@ import org.neo4j.kernel.impl.store.record.PropertyRecord;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.transaction.state.RecordAccess.Loader;
 import org.neo4j.kernel.impl.transaction.state.RecordAccess.RecordProxy;
-import org.neo4j.unsafe.batchinsert.DirectRecordAccess;
+import org.neo4j.unsafe.batchinsert.internal.DirectRecordAccess;
 import org.neo4j.unsafe.impl.batchimport.store.BatchingIdSequence;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PropertyCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PropertyCreatorTest.java
@@ -50,7 +50,7 @@ public class PropertyCreatorTest
     // The RecordAccess will take on the role of both store and tx state and the PropertyCreator
     // will know no difference
     @SuppressWarnings( "unchecked" )
-    private final RecordAccess<Long,PropertyRecord,PrimitiveRecord> records =
+    private final RecordAccess<PropertyRecord,PrimitiveRecord> records =
             new DirectRecordAccess<>( mock( RecordStore.class ), new PropertyRecordLoader() );
     private final MyPrimitiveProxy primitive = new MyPrimitiveProxy();
 
@@ -313,7 +313,7 @@ public class PropertyCreatorTest
         return new ExpectedRecord( properties );
     }
 
-    private static class MyPrimitiveProxy implements RecordProxy<Long,NodeRecord,Void>
+    private static class MyPrimitiveProxy implements RecordProxy<NodeRecord,Void>
     {
         private final NodeRecord record = new NodeRecord( 5 );
         private boolean changed;
@@ -324,7 +324,7 @@ public class PropertyCreatorTest
         }
 
         @Override
-        public Long getKey()
+        public long getKey()
         {
             return record.getId();
         }
@@ -380,18 +380,18 @@ public class PropertyCreatorTest
         }
     }
 
-    private static class PropertyRecordLoader implements Loader<Long,PropertyRecord,PrimitiveRecord>
+    private static class PropertyRecordLoader implements Loader<PropertyRecord,PrimitiveRecord>
     {
-        private final Loader<Long,PropertyRecord,PrimitiveRecord> actual = Loaders.propertyLoader( null );
+        private final Loader<PropertyRecord,PrimitiveRecord> actual = Loaders.propertyLoader( null );
 
         @Override
-        public PropertyRecord newUnused( Long key, PrimitiveRecord additionalData )
+        public PropertyRecord newUnused( long key, PrimitiveRecord additionalData )
         {
             return actual.newUnused( key, additionalData );
         }
 
         @Override
-        public PropertyRecord load( Long key, PrimitiveRecord additionalData )
+        public PropertyRecord load( long key, PrimitiveRecord additionalData )
         {
             return null;
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RecordChangesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RecordChangesTest.java
@@ -28,17 +28,16 @@ import static org.junit.Assert.assertThat;
 
 public class RecordChangesTest
 {
-
-    private final RecordAccess.Loader<Object, Object, Object> loader = new RecordAccess.Loader<Object, Object, Object>()
+    private final RecordAccess.Loader<Object, Object> loader = new RecordAccess.Loader<Object, Object>()
     {
         @Override
-        public Object newUnused( Object o, Object additionalData )
+        public Object newUnused( long o, Object additionalData )
         {
             return o;
         }
 
         @Override
-        public Object load( Object o, Object additionalData )
+        public Object load( long o, Object additionalData )
         {
             return o;
         }
@@ -60,16 +59,15 @@ public class RecordChangesTest
     public void shouldCountChanges() throws Exception
     {
         // Given
-        RecordChanges<Object, Object, Object> change = new RecordChanges<>( loader, new IntCounter() );
+        RecordChanges<Object, Object> change = new RecordChanges<>( loader, new IntCounter() );
 
         // When
-        change.getOrLoad( "K1", null ).forChangingData();
-        change.getOrLoad( "K1", null ).forChangingData();
-        change.getOrLoad( "K2", null ).forChangingData();
-        change.getOrLoad( "K3", null ).forReadingData();
+        change.getOrLoad( 1, null ).forChangingData();
+        change.getOrLoad( 1, null ).forChangingData();
+        change.getOrLoad( 2, null ).forChangingData();
+        change.getOrLoad( 3, null ).forReadingData();
 
         // Then
-        assertThat(change.changeSize(), equalTo(2));
+        assertThat( change.changeSize(), equalTo( 2 ) );
     }
-
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipCreatorTest.java
@@ -52,7 +52,7 @@ import org.neo4j.storageengine.api.lock.ResourceType;
 import org.neo4j.storageengine.api.schema.SchemaRule;
 import org.neo4j.test.rule.DatabaseRule;
 import org.neo4j.test.rule.ImpermanentDatabaseRule;
-import org.neo4j.unsafe.batchinsert.DirectRecordAccessSet;
+import org.neo4j.unsafe.batchinsert.internal.DirectRecordAccessSet;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipCreatorTest.java
@@ -147,49 +147,49 @@ public class RelationshipCreatorTest
         }
 
         @Override
-        public RecordAccess<Long, NodeRecord, Void> getNodeRecords()
+        public RecordAccess<NodeRecord, Void> getNodeRecords()
         {
             return delegate.getNodeRecords();
         }
 
         @Override
-        public RecordAccess<Long, PropertyRecord, PrimitiveRecord> getPropertyRecords()
+        public RecordAccess<PropertyRecord, PrimitiveRecord> getPropertyRecords()
         {
             return delegate.getPropertyRecords();
         }
 
         @Override
-        public RecordAccess<Long, RelationshipRecord, Void> getRelRecords()
+        public RecordAccess<RelationshipRecord, Void> getRelRecords()
         {
             return relRecords;
         }
 
         @Override
-        public RecordAccess<Long, RelationshipGroupRecord, Integer> getRelGroupRecords()
+        public RecordAccess<RelationshipGroupRecord, Integer> getRelGroupRecords()
         {
             return delegate.getRelGroupRecords();
         }
 
         @Override
-        public RecordAccess<Long, SchemaRecord, SchemaRule> getSchemaRuleChanges()
+        public RecordAccess<SchemaRecord, SchemaRule> getSchemaRuleChanges()
         {
             return delegate.getSchemaRuleChanges();
         }
 
         @Override
-        public RecordAccess<Integer, PropertyKeyTokenRecord, Void> getPropertyKeyTokenChanges()
+        public RecordAccess<PropertyKeyTokenRecord, Void> getPropertyKeyTokenChanges()
         {
             return delegate.getPropertyKeyTokenChanges();
         }
 
         @Override
-        public RecordAccess<Integer, LabelTokenRecord, Void> getLabelTokenChanges()
+        public RecordAccess<LabelTokenRecord, Void> getLabelTokenChanges()
         {
             return delegate.getLabelTokenChanges();
         }
 
         @Override
-        public RecordAccess<Integer, RelationshipTypeTokenRecord, Void> getRelationshipTypeTokenChanges()
+        public RecordAccess<RelationshipTypeTokenRecord, Void> getRelationshipTypeTokenChanges()
         {
             return delegate.getRelationshipTypeTokenChanges();
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipGroupGetterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipGroupGetterTest.java
@@ -80,7 +80,7 @@ public class RelationshipGroupGetterTest
             NodeRecord node = new NodeRecord( 0, true, group_2.getId(), -1 );
 
             // WHEN trying to find relationship group 7
-            RecordAccess<Long, RelationshipGroupRecord, Integer> access =
+            RecordAccess<RelationshipGroupRecord, Integer> access =
                     new DirectRecordAccess<>( store, Loaders.relationshipGroupLoader( store ) );
             RelationshipGroupPosition result = groupGetter.getRelationshipGroup( node, 7, access );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipGroupGetterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipGroupGetterTest.java
@@ -38,7 +38,7 @@ import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.rule.PageCacheRule;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
-import org.neo4j.unsafe.batchinsert.DirectRecordAccess;
+import org.neo4j.unsafe.batchinsert.internal.DirectRecordAccess;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TrackingRecordAccess.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TrackingRecordAccess.java
@@ -22,25 +22,25 @@ package org.neo4j.kernel.impl.transaction.state;
 import org.neo4j.helpers.collection.IterableWrapper;
 import org.neo4j.kernel.impl.transaction.state.RelationshipCreatorTest.Tracker;
 
-public class TrackingRecordAccess<RECORD, ADDITIONAL> implements RecordAccess<Long, RECORD, ADDITIONAL>
+public class TrackingRecordAccess<RECORD, ADDITIONAL> implements RecordAccess<RECORD, ADDITIONAL>
 {
-    private final RecordAccess<Long, RECORD, ADDITIONAL> delegate;
+    private final RecordAccess<RECORD, ADDITIONAL> delegate;
     private final Tracker tracker;
 
-    public TrackingRecordAccess( RecordAccess<Long, RECORD, ADDITIONAL> delegate, Tracker tracker )
+    public TrackingRecordAccess( RecordAccess<RECORD, ADDITIONAL> delegate, Tracker tracker )
     {
         this.delegate = delegate;
         this.tracker = tracker;
     }
 
     @Override
-    public RecordProxy<Long, RECORD, ADDITIONAL> getOrLoad( Long key, ADDITIONAL additionalData )
+    public RecordProxy<RECORD, ADDITIONAL> getOrLoad( long key, ADDITIONAL additionalData )
     {
         return new TrackingRecordProxy<>( delegate.getOrLoad( key, additionalData ), false, tracker );
     }
 
     @Override
-    public RecordProxy<Long, RECORD, ADDITIONAL> create( Long key, ADDITIONAL additionalData )
+    public RecordProxy<RECORD, ADDITIONAL> create( long key, ADDITIONAL additionalData )
     {
         return new TrackingRecordProxy<>( delegate.create( key, additionalData ), true, tracker );
     }
@@ -52,20 +52,20 @@ public class TrackingRecordAccess<RECORD, ADDITIONAL> implements RecordAccess<Lo
     }
 
     @Override
-    public RecordProxy<Long,RECORD,ADDITIONAL> getIfLoaded( Long key )
+    public RecordProxy<RECORD,ADDITIONAL> getIfLoaded( long key )
     {
-        RecordProxy<Long,RECORD,ADDITIONAL> actual = delegate.getIfLoaded( key );
+        RecordProxy<RECORD,ADDITIONAL> actual = delegate.getIfLoaded( key );
         return actual == null ? null : new TrackingRecordProxy<>( actual, false, tracker );
     }
 
     @Override
-    public void setTo( Long key, RECORD newRecord, ADDITIONAL additionalData )
+    public void setTo( long key, RECORD newRecord, ADDITIONAL additionalData )
     {
         delegate.setTo( key, newRecord, additionalData );
     }
 
     @Override
-    public RecordProxy<Long,RECORD,ADDITIONAL> setRecord( Long key, RECORD record, ADDITIONAL additionalData )
+    public RecordProxy<RECORD,ADDITIONAL> setRecord( long key, RECORD record, ADDITIONAL additionalData )
     {
         return delegate.setRecord( key, record, additionalData );
     }
@@ -77,14 +77,14 @@ public class TrackingRecordAccess<RECORD, ADDITIONAL> implements RecordAccess<Lo
     }
 
     @Override
-    public Iterable<RecordProxy<Long,RECORD,ADDITIONAL>> changes()
+    public Iterable<RecordProxy<RECORD,ADDITIONAL>> changes()
     {
-        return new IterableWrapper<RecordProxy<Long,RECORD,ADDITIONAL>,RecordProxy<Long,RECORD,ADDITIONAL>>(
+        return new IterableWrapper<RecordProxy<RECORD,ADDITIONAL>,RecordProxy<RECORD,ADDITIONAL>>(
                 delegate.changes() )
         {
             @Override
-            protected RecordProxy<Long,RECORD,ADDITIONAL> underlyingObjectToObject(
-                    RecordProxy<Long,RECORD,ADDITIONAL> actual )
+            protected RecordProxy<RECORD,ADDITIONAL> underlyingObjectToObject(
+                    RecordProxy<RECORD,ADDITIONAL> actual )
             {
                 return new TrackingRecordProxy<>( actual, false, tracker );
             }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TrackingRecordProxy.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TrackingRecordProxy.java
@@ -22,14 +22,14 @@ package org.neo4j.kernel.impl.transaction.state;
 import org.neo4j.kernel.impl.transaction.state.RecordAccess.RecordProxy;
 import org.neo4j.kernel.impl.transaction.state.RelationshipCreatorTest.Tracker;
 
-public class TrackingRecordProxy<RECORD, ADDITIONAL> implements RecordProxy<Long, RECORD, ADDITIONAL>
+public class TrackingRecordProxy<RECORD, ADDITIONAL> implements RecordProxy<RECORD, ADDITIONAL>
 {
-    private final RecordProxy<Long, RECORD, ADDITIONAL> delegate;
+    private final RecordProxy<RECORD, ADDITIONAL> delegate;
     private final Tracker tracker;
     private final boolean created;
     private boolean changed;
 
-    public TrackingRecordProxy( RecordProxy<Long, RECORD, ADDITIONAL> delegate, boolean created, Tracker tracker )
+    public TrackingRecordProxy( RecordProxy<RECORD, ADDITIONAL> delegate, boolean created, Tracker tracker )
     {
         this.delegate = delegate;
         this.created = created;
@@ -38,7 +38,7 @@ public class TrackingRecordProxy<RECORD, ADDITIONAL> implements RecordProxy<Long
     }
 
     @Override
-    public Long getKey()
+    public long getKey()
     {
         return delegate.getKey();
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordStateTest.java
@@ -158,14 +158,14 @@ public class TransactionRecordStateTest
         }
     }
 
-    private static RecordProxy<Long, RelationshipGroupRecord, Integer> getRelationshipGroup(
+    private static RecordProxy<RelationshipGroupRecord, Integer> getRelationshipGroup(
             RecordChangeSet recordChangeSet, NodeRecord node, int type )
     {
         long groupId = node.getNextRel();
         long previousGroupId = Record.NO_NEXT_RELATIONSHIP.intValue();
         while ( groupId != Record.NO_NEXT_RELATIONSHIP.intValue() )
         {
-            RecordProxy<Long, RelationshipGroupRecord, Integer> change =
+            RecordProxy<RelationshipGroupRecord, Integer> change =
                     recordChangeSet.getRelGroupRecords().getOrLoad( groupId, type );
             RelationshipGroupRecord record = change.forReadingData();
             record.setPrev( previousGroupId ); // not persistent so not a "change"

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/WriteTransactionCommandOrderingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/WriteTransactionCommandOrderingTest.java
@@ -135,15 +135,15 @@ public class WriteTransactionCommandOrderingTest
     {
         RecordChangeSet recordChangeSet = mock( RecordChangeSet.class );
 
-        RecordChanges<Integer,LabelTokenRecord,Void> labelTokenChanges = mock( RecordChanges.class );
-        RecordChanges<Integer,RelationshipTypeTokenRecord,Void> relationshipTypeTokenChanges =
+        RecordChanges<LabelTokenRecord,Void> labelTokenChanges = mock( RecordChanges.class );
+        RecordChanges<RelationshipTypeTokenRecord,Void> relationshipTypeTokenChanges =
                 mock( RecordChanges.class );
-        RecordChanges<Integer,PropertyKeyTokenRecord,Void> propertyKeyTokenChanges = mock( RecordChanges.class );
-        RecordChanges<Long,NodeRecord,Void> nodeRecordChanges = mock( RecordChanges.class );
-        RecordChanges<Long,RelationshipRecord,Void> relationshipRecordChanges = mock( RecordChanges.class );
-        RecordChanges<Long,PropertyRecord,PrimitiveRecord> propertyRecordChanges = mock( RecordChanges.class );
-        RecordChanges<Long,RelationshipGroupRecord,Integer> relationshipGroupChanges = mock( RecordChanges.class );
-        RecordChanges<Long,SchemaRecord,SchemaRule> schemaRuleChanges = mock( RecordChanges.class );
+        RecordChanges<PropertyKeyTokenRecord,Void> propertyKeyTokenChanges = mock( RecordChanges.class );
+        RecordChanges<NodeRecord,Void> nodeRecordChanges = mock( RecordChanges.class );
+        RecordChanges<RelationshipRecord,Void> relationshipRecordChanges = mock( RecordChanges.class );
+        RecordChanges<PropertyRecord,PrimitiveRecord> propertyRecordChanges = mock( RecordChanges.class );
+        RecordChanges<RelationshipGroupRecord,Integer> relationshipGroupChanges = mock( RecordChanges.class );
+        RecordChanges<SchemaRecord,SchemaRule> schemaRuleChanges = mock( RecordChanges.class );
 
         when( recordChangeSet.getLabelTokenChanges() ).thenReturn( labelTokenChanges );
         when( recordChangeSet.getRelationshipTypeTokenChanges() ).thenReturn( relationshipTypeTokenChanges );
@@ -154,19 +154,19 @@ public class WriteTransactionCommandOrderingTest
         when( recordChangeSet.getRelGroupRecords() ).thenReturn( relationshipGroupChanges );
         when( recordChangeSet.getSchemaRuleChanges() ).thenReturn( schemaRuleChanges );
 
-        List<RecordProxy<Long,NodeRecord,Void>> nodeChanges = new LinkedList<>();
+        List<RecordProxy<NodeRecord,Void>> nodeChanges = new LinkedList<>();
 
-        RecordChange<Long,NodeRecord,Void> deletedNode = mock( RecordChange.class );
+        RecordChange<NodeRecord,Void> deletedNode = mock( RecordChange.class );
         when( deletedNode.getBefore() ).thenReturn( inUseNode() );
         when( deletedNode.forReadingLinkage() ).thenReturn( missingNode() );
         nodeChanges.add( deletedNode );
 
-        RecordChange<Long,NodeRecord,Void> createdNode = mock( RecordChange.class );
+        RecordChange<NodeRecord,Void> createdNode = mock( RecordChange.class );
         when( createdNode.getBefore() ).thenReturn( missingNode() );
         when( createdNode.forReadingLinkage() ).thenReturn( createdNode() );
         nodeChanges.add( createdNode );
 
-        RecordChange<Long,NodeRecord,Void> updatedNode = mock( RecordChange.class );
+        RecordChange<NodeRecord,Void> updatedNode = mock( RecordChange.class );
         when( updatedNode.getBefore() ).thenReturn( inUseNode() );
         when( updatedNode.forReadingLinkage() ).thenReturn( inUseNode() );
         nodeChanges.add( updatedNode );

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchedFlushStrategyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchedFlushStrategyTest.java
@@ -22,8 +22,6 @@ package org.neo4j.unsafe.batchinsert.internal;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import org.neo4j.unsafe.batchinsert.DirectRecordAccessSet;
-
 public class BatchedFlushStrategyTest
 {
 


### PR DESCRIPTION
The key was generified and boxed all the way simply to distinguish between
long/int, which is completely unnecessary. Now it just uses long everywhere
and runs toIntExact in places where an int is expected. Saves memory as
well as cluttery code.