### PR TITLE
More efficient log rotation checking

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/rotation/LogRotationImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/rotation/LogRotationImpl.java
@@ -49,18 +49,21 @@ public class LogRotationImpl implements LogRotation
          * doing force (think batching of writes), such that it can't see a bad state of the writer
          * even when rotating underlying channels.
          */
-        synchronized ( logFile )
+        if ( logFile.rotationNeeded() )
         {
-            if ( logFile.rotationNeeded() )
+            synchronized ( logFile )
             {
-                try ( LogRotateEvent rotateEvent = logAppendEvent.beginLogRotate() )
+                if ( logFile.rotationNeeded() )
                 {
-                    doRotate();
+                    try ( LogRotateEvent rotateEvent = logAppendEvent.beginLogRotate() )
+                    {
+                        doRotate();
+                    }
+                    return true;
                 }
-                return true;
             }
-            return false;
         }
+        return false;
     }
 
     /**


### PR DESCRIPTION
Merely checking need for log rotation shows up on the radar when profiling,
especially if there are many concurrent committers. When appending there's
a natural selection of one out of all that gets to force the log.
This commit piggy-backs on that decision and lets that thread, and only
that one out of all concurrent committers, to check log rotation.

Also introduced double checked locking for checking need for log rotation
due to a lot of unnecessary hogging of that monitor in most calls,
since log rotation isn't needed very often

These two minor changes improves transaction commit concurrency