### PR TITLE
Transaction timeout monitor

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -240,6 +240,10 @@ public abstract class GraphDatabaseSettings
     @Description("The maximum time interval of a transaction within which it should be completed.")
     public static final Setting<Long> transaction_timeout = setting( "dbms.transaction.timeout", DURATION, String.valueOf( UNSPECIFIED_TIMEOUT ) );
 
+    @Description("Configures the time interval between transaction monitor checks. Determines how often " +
+            "monitor thread will check transaction for timeout.")
+    public static final Setting<Long> transaction_monitor_check_interval = setting( "dbms.transaction.monitor.check.interval", DURATION, "10s" );
+
     @Description( "The maximum amount of time to wait for running transactions to complete before allowing "
                   + "initiated database shutdown to continue" )
     @Internal

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -242,7 +242,7 @@ public abstract class GraphDatabaseSettings
 
     @Description("Configures the time interval between transaction monitor checks. Determines how often " +
             "monitor thread will check transaction for timeout.")
-    public static final Setting<Long> transaction_monitor_check_interval = setting( "dbms.transaction.monitor.check.interval", DURATION, "10s" );
+    public static final Setting<Long> transaction_monitor_check_interval = setting( "dbms.transaction.monitor.check.interval", DURATION, "5s" );
 
     @Description( "The maximum amount of time to wait for running transactions to complete before allowing "
                   + "initiated database shutdown to continue" )

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -54,6 +54,8 @@ import org.neo4j.kernel.impl.api.DataIntegrityValidatingStatementOperations;
 import org.neo4j.kernel.impl.api.GuardingStatementOperations;
 import org.neo4j.kernel.impl.api.Kernel;
 import org.neo4j.kernel.impl.api.KernelSchemaStateStore;
+import org.neo4j.kernel.impl.api.KernelTransactionMonitorScheduler;
+import org.neo4j.kernel.impl.api.KernelTransactionTimeoutMonitor;
 import org.neo4j.kernel.impl.api.KernelTransactions;
 import org.neo4j.kernel.impl.api.KernelTransactionsSnapshot;
 import org.neo4j.kernel.impl.api.LegacyIndexProviderLookup;
@@ -802,6 +804,8 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
                 transactionCommitProcess, indexConfigStore, legacyIndexProviderLookup, hooks, transactionMonitor, life,
                 tracers, storageEngine, procedures, transactionIdStore, clock, accessCapability ) );
 
+        buildTransactionMonitor( kernelTransactions, clock, config );
+
         final Kernel kernel = new Kernel( kernelTransactions, hooks, databaseHealth, transactionMonitor, procedures,
                 config );
 
@@ -836,6 +840,16 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
                 return fileListing;
             }
         };
+    }
+
+    private void buildTransactionMonitor( KernelTransactions kernelTransactions, Clock clock, Config config )
+    {
+        KernelTransactionTimeoutMonitor kernelTransactionTimeoutMonitor =
+                new KernelTransactionTimeoutMonitor( kernelTransactions, clock, logService );
+        KernelTransactionMonitorScheduler transactionMonitorScheduler =
+                new KernelTransactionMonitorScheduler( kernelTransactionTimeoutMonitor, scheduler,
+                        config.get( GraphDatabaseSettings.transaction_monitor_check_interval ) );
+        life.add( transactionMonitorScheduler );
     }
 
     // We do this last to ensure no one is cheating with dependency access

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransactionHandle.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransactionHandle.java
@@ -54,6 +54,12 @@ public interface KernelTransactionHandle
     long startTime();
 
     /**
+     * Underlying transaction specific timeout. In case if timeout is 0 - transaction does not have a timeout.
+     * @return transaction timeout in milliseconds, <b>0 in case if transaction does not have a timeout<b/>
+     */
+    long timeoutMillis();
+
+    /**
      * Check if the underlying transaction is open.
      *
      * @return {@code true} if the underlying transaction ({@link KernelTransaction#close()} was not called),

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandle.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationHandle.java
@@ -40,6 +40,7 @@ class KernelTransactionImplementationHandle implements KernelTransactionHandle
     private final long lastTransactionIdWhenStarted;
     private final long lastTransactionTimestampWhenStarted;
     private final long startTime;
+    private final long timeoutMillis;
     private final KernelTransactionImplementation tx;
     private final SecurityContext securityContext;
     private final Status terminationReason;
@@ -51,6 +52,7 @@ class KernelTransactionImplementationHandle implements KernelTransactionHandle
         this.lastTransactionIdWhenStarted = tx.lastTransactionIdWhenStarted();
         this.lastTransactionTimestampWhenStarted = tx.lastTransactionTimestampWhenStarted();
         this.startTime = tx.startTime();
+        this.timeoutMillis = tx.timeout();
         this.securityContext = tx.securityContext();
         this.terminationReason = tx.getReasonIfTerminated();
         this.executingQueries = tx.executingQueries();
@@ -73,6 +75,12 @@ class KernelTransactionImplementationHandle implements KernelTransactionHandle
     public long startTime()
     {
         return startTime;
+    }
+
+    @Override
+    public long timeoutMillis()
+    {
+        return timeoutMillis;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionMonitorScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionMonitorScheduler.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+import static org.neo4j.kernel.impl.util.JobScheduler.Groups.transactionTimeoutMonitor;
+
+public class KernelTransactionMonitorScheduler extends LifecycleAdapter
+{
+    private final KernelTransactionTimeoutMonitor kernelTransactionTimeoutMonitor;
+    private final JobScheduler scheduler;
+    private final long checkIntervalMillis;
+    private JobScheduler.JobHandle monitorJobHandle;
+
+    public KernelTransactionMonitorScheduler( KernelTransactionTimeoutMonitor kernelTransactionTimeoutMonitor,
+            JobScheduler scheduler, long checkIntervalMillis )
+    {
+        this.kernelTransactionTimeoutMonitor = kernelTransactionTimeoutMonitor;
+        this.scheduler = scheduler;
+        this.checkIntervalMillis = checkIntervalMillis;
+    }
+
+    @Override
+    public void start() throws Throwable
+    {
+        monitorJobHandle = scheduler.scheduleRecurring( transactionTimeoutMonitor, kernelTransactionTimeoutMonitor,
+                checkIntervalMillis, TimeUnit.MILLISECONDS );
+    }
+
+    @Override
+    public void stop() throws Throwable
+    {
+        monitorJobHandle.cancel( true );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionMonitorScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionMonitorScheduler.java
@@ -44,13 +44,19 @@ public class KernelTransactionMonitorScheduler extends LifecycleAdapter
     @Override
     public void start() throws Throwable
     {
-        monitorJobHandle = scheduler.scheduleRecurring( transactionTimeoutMonitor, kernelTransactionTimeoutMonitor,
-                checkIntervalMillis, TimeUnit.MILLISECONDS );
+        if (checkIntervalMillis > 0)
+        {
+            monitorJobHandle = scheduler.scheduleRecurring( transactionTimeoutMonitor, kernelTransactionTimeoutMonitor,
+                    checkIntervalMillis, TimeUnit.MILLISECONDS );
+        }
     }
 
     @Override
     public void stop() throws Throwable
     {
-        monitorJobHandle.cancel( true );
+        if ( monitorJobHandle != null )
+        {
+            monitorJobHandle.cancel( true );
+        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitor.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import java.time.Clock;
+import java.util.Set;
+
+import org.neo4j.kernel.api.KernelTransactionHandle;
+import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.logging.Log;
+
+/**
+ * Transaction monitor that check transactions with a configured timeout for expiration.
+ * In case if transaction timed out it will be terminated.
+ */
+public class KernelTransactionTimeoutMonitor implements Runnable
+{
+    private final KernelTransactions kernelTransactions;
+    private final Clock clock;
+    private final Log log;
+
+    public KernelTransactionTimeoutMonitor( KernelTransactions kernelTransactions, Clock clock, LogService logService )
+    {
+        this.kernelTransactions = kernelTransactions;
+        this.clock = clock;
+        this.log = logService.getInternalLog( KernelTransactionTimeoutMonitor.class );
+    }
+
+    @Override
+    public void run()
+    {
+        Set<KernelTransactionHandle> activeTransactions = kernelTransactions.activeTransactions();
+        long now = clock.millis();
+        for ( KernelTransactionHandle activeTransaction : activeTransactions )
+        {
+            long transactionTimeoutMillis = activeTransaction.timeoutMillis();
+            if ( transactionTimeoutMillis > 0 )
+            {
+                if ( isTransactionExpired( activeTransaction, now, transactionTimeoutMillis ) )
+                {
+                    if ( activeTransaction.markForTermination( Status.Transaction.TransactionTimedOut ) )
+                    {
+                        log.warn( "Transaction %s timeout.", activeTransaction );
+                    }
+                }
+            }
+        }
+    }
+
+    private boolean isTransactionExpired( KernelTransactionHandle activeTransaction, long nowMillis,
+            long transactionTimeoutMillis )
+    {
+        return nowMillis > (activeTransaction.startTime() + transactionTimeoutMillis);
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/JobScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/JobScheduler.java
@@ -171,6 +171,11 @@ public interface JobScheduler extends Lifecycle
          * Native security.
          */
         public static Group nativeSecurity = new Group( "NativeSecurity", POOLED );
+
+        /**
+         * Kernel transaction timeout monitor.
+         */
+        public static Group transactionTimeoutMonitor = new Group( "TransactionTimeoutMonitor", POOLED );
     }
 
     interface JobHandle

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionMonitorSchedulerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionMonitorSchedulerTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.kernel.impl.util.JobScheduler;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+public class KernelTransactionMonitorSchedulerTest
+{
+
+    private final JobScheduler scheduler = mock( JobScheduler.class );
+    private final KernelTransactionTimeoutMonitor transactionTimeoutMonitor = mock( KernelTransactionTimeoutMonitor.class );
+
+    @Test
+    public void scheduleRecurringMonitorJobIfConfigured() throws Throwable
+    {
+        KernelTransactionMonitorScheduler transactionMonitorScheduler = createMonitorScheduler(1);
+        transactionMonitorScheduler.start();
+
+        verify( scheduler).scheduleRecurring( JobScheduler.Groups.transactionTimeoutMonitor, transactionTimeoutMonitor, 1, TimeUnit
+                .MILLISECONDS  );
+    }
+
+    @Test
+    public void doNotScheduleMonitorJobIfDisabled() throws Throwable
+    {
+        KernelTransactionMonitorScheduler transactionMonitorScheduler = createMonitorScheduler( 0 );
+        transactionMonitorScheduler.start();
+
+        verifyZeroInteractions( scheduler);
+    }
+
+    private KernelTransactionMonitorScheduler createMonitorScheduler( long checkInterval )
+    {
+        return new KernelTransactionMonitorScheduler( transactionTimeoutMonitor, scheduler, checkInterval );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitorIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitorIT.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.security.SecurityContext;
+import org.neo4j.kernel.impl.coreapi.InternalTransaction;
+import org.neo4j.test.rule.DatabaseRule;
+import org.neo4j.test.rule.EmbeddedDatabaseRule;
+
+public class KernelTransactionTimeoutMonitorIT
+{
+    @Rule
+    public DatabaseRule database = new EmbeddedDatabaseRule()
+            .withSetting( GraphDatabaseSettings.transaction_monitor_check_interval, "100ms" );
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private static final int NODE_ID = 0;
+    private ExecutorService executor;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        executor = Executors.newSingleThreadExecutor();
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        executor.shutdown();
+    }
+
+    @Test( timeout = 30_000 )
+    public void terminateExpiredTransaction() throws Exception
+    {
+        try ( Transaction transaction = database.beginTx() )
+        {
+            database.createNode();
+            transaction.success();
+        }
+
+        expectedException.expectMessage( "The transaction has been terminated." );
+
+        try ( Transaction transaction = database.beginTx() )
+        {
+            Node nodeById = database.getNodeById( NODE_ID );
+            nodeById.setProperty( "a", "b" );
+            executor.submit( startAnotherTransaction() ).get();
+        }
+    }
+
+    private Runnable startAnotherTransaction()
+    {
+        return () -> {
+            try ( InternalTransaction transaction = database
+                    .beginTransaction( KernelTransaction.Type.implicit, SecurityContext.AUTH_DISABLED, 1,
+                            TimeUnit.SECONDS ) )
+            {
+                Node node = database.getNodeById( NODE_ID );
+                node.setProperty( "c", "d" );
+            }
+        };
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitorSchedulerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitorSchedulerTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.kernel.impl.util.JobScheduler;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.neo4j.kernel.impl.util.JobScheduler.Groups.transactionTimeoutMonitor;
+
+public class KernelTransactionTimeoutMonitorSchedulerTest
+{
+
+    private final KernelTransactionTimeoutMonitor transactionMonitor = mock( KernelTransactionTimeoutMonitor.class );
+    private final JobScheduler jobScheduler = mock( JobScheduler.class );
+
+    @Test
+    public void startJobTransactionMonitor() throws Throwable
+    {
+        JobScheduler.JobHandle jobHandle = Mockito.mock( JobScheduler.JobHandle.class );
+        when( jobScheduler.scheduleRecurring( eq(transactionTimeoutMonitor), eq( transactionMonitor), anyLong(),
+                any(TimeUnit.class) )).thenReturn( jobHandle );
+
+        KernelTransactionMonitorScheduler monitorScheduler =
+                new KernelTransactionMonitorScheduler( transactionMonitor, jobScheduler, 7 );
+
+        monitorScheduler.start();
+        verify(jobScheduler).scheduleRecurring( transactionTimeoutMonitor, transactionMonitor,
+                7, TimeUnit.MILLISECONDS );
+
+        monitorScheduler.stop();
+        verify( jobHandle ).cancel( true );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitorTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.kernel.api.KernelTransactionHandle;
+import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.impl.logging.SimpleLogService;
+import org.neo4j.logging.AssertableLogProvider;
+import org.neo4j.time.Clocks;
+import org.neo4j.time.FakeClock;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class KernelTransactionTimeoutMonitorTest
+{
+    private static final int EXPECTED_REUSE_COUNT = 2;
+    private KernelTransactions kernelTransactions;
+    private FakeClock fakeClock;
+    private AssertableLogProvider logProvider;
+    private LogService logService;
+
+    @Before
+    public void setUp()
+    {
+        kernelTransactions = mock( KernelTransactions.class );
+        fakeClock = Clocks.fakeClock();
+        logProvider = new AssertableLogProvider();
+        logService = new SimpleLogService( logProvider, logProvider );
+    }
+
+    @Test
+    public void terminateExpiredTransactions() throws Exception
+    {
+        HashSet<KernelTransactionHandle> transactions = new HashSet<>();
+        KernelTransactionImplementation tx1 = prepareTxMock( 1, 3 );
+        KernelTransactionImplementation tx2 = prepareTxMock( 1, 8 );
+        KernelTransactionImplementationHandle handle1 = new KernelTransactionImplementationHandle( tx1 );
+        KernelTransactionImplementationHandle handle2 = new KernelTransactionImplementationHandle( tx2 );
+        transactions.add( handle1 );
+        transactions.add( handle2 );
+
+        when( kernelTransactions.activeTransactions()).thenReturn( transactions );
+
+        KernelTransactionTimeoutMonitor transactionMonitor = buildTransactionMonitor();
+
+        fakeClock.forward( 3, TimeUnit.MILLISECONDS );
+        transactionMonitor.run();
+
+        verify( tx1, never() ).markForTermination( Status.Transaction.TransactionTimedOut );
+        verify( tx2, never() ).markForTermination( Status.Transaction.TransactionTimedOut );
+        logProvider.assertNoMessagesContaining( "timeout" );
+
+        fakeClock.forward( 2, TimeUnit.MILLISECONDS );
+        transactionMonitor.run();
+
+        verify( tx1 ).markForTermination( EXPECTED_REUSE_COUNT, Status.Transaction.TransactionTimedOut );
+        verify( tx2, never() ).markForTermination( Status.Transaction.TransactionTimedOut );
+        logProvider.assertContainsLogCallContaining( "timeout" );
+
+        logProvider.clear();
+        fakeClock.forward( 10, TimeUnit.MILLISECONDS );
+        transactionMonitor.run();
+
+        verify( tx2 ).markForTermination( EXPECTED_REUSE_COUNT, Status.Transaction.TransactionTimedOut );
+        logProvider.assertContainsLogCallContaining( "timeout" );
+    }
+
+    @Test
+    public void skipTransactionWithoutTimeout() throws Exception
+    {
+        HashSet<KernelTransactionHandle> transactions = new HashSet<>();
+        KernelTransactionImplementation tx1 = prepareTxMock( 3, 0 );
+        KernelTransactionImplementation tx2 = prepareTxMock( 4, 0 );
+        KernelTransactionImplementationHandle handle1 = new KernelTransactionImplementationHandle( tx1 );
+        KernelTransactionImplementationHandle handle2 = new KernelTransactionImplementationHandle( tx2 );
+        transactions.add( handle1 );
+        transactions.add( handle2 );
+
+        when( kernelTransactions.activeTransactions()).thenReturn( transactions );
+
+        KernelTransactionTimeoutMonitor transactionMonitor = buildTransactionMonitor();
+
+        fakeClock.forward( 300, TimeUnit.MILLISECONDS );
+        transactionMonitor.run();
+
+        verify( tx1, never() ).markForTermination( Status.Transaction.TransactionTimedOut );
+        verify( tx2, never() ).markForTermination( Status.Transaction.TransactionTimedOut );
+        logProvider.assertNoMessagesContaining( "timeout" );
+    }
+
+    private KernelTransactionTimeoutMonitor buildTransactionMonitor()
+    {
+        return new KernelTransactionTimeoutMonitor( kernelTransactions, fakeClock, logService );
+    }
+
+    private KernelTransactionImplementation prepareTxMock( long startMillis, long timeoutMillis )
+    {
+        KernelTransactionImplementation transaction = mock( KernelTransactionImplementation.class );
+        when( transaction.startTime() ).thenReturn( startMillis );
+        when( transaction.getReuseCount() ).thenReturn( EXPECTED_REUSE_COUNT );
+        when( transaction.timeout() ).thenReturn( timeoutMillis );
+        when( transaction.markForTermination( EXPECTED_REUSE_COUNT, Status.Transaction.TransactionTimedOut ) ).thenReturn( true );
+        return transaction;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TestKernelTransactionHandle.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TestKernelTransactionHandle.java
@@ -60,6 +60,12 @@ public class TestKernelTransactionHandle implements KernelTransactionHandle
     }
 
     @Override
+    public long timeoutMillis()
+    {
+        return tx.timeout();
+    }
+
+    @Override
     public boolean isOpen()
     {
         return tx.isOpen();


### PR DESCRIPTION
Introduce kernel transaction timeout monitor thread,
that will run in the background and will mark timed out transactions
as terminated in addition to existent execution guard checker.