### PR TITLE
Removes annoying unit test warnings

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/CompositeIndexAccessorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/CompositeIndexAccessorCompatibility.java
@@ -76,6 +76,7 @@ public abstract class CompositeIndexAccessorCompatibility extends IndexAccessorC
 
     // This behaviour is expected by General indexes
 
+    @Ignore( "Not a test. This is a compatibility suite" )
     public static class General extends CompositeIndexAccessorCompatibility
     {
         public General( IndexProviderCompatibilityTestSuite testSuite )
@@ -106,6 +107,7 @@ public abstract class CompositeIndexAccessorCompatibility extends IndexAccessorC
 
     // This behaviour is expected by Unique indexes
 
+    @Ignore( "Not a test. This is a compatibility suite" )
     public static class Unique extends CompositeIndexAccessorCompatibility
     {
         public Unique( IndexProviderCompatibilityTestSuite testSuite )

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/CompositeIndexPopulatorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/CompositeIndexPopulatorCompatibility.java
@@ -52,6 +52,7 @@ public class CompositeIndexPopulatorCompatibility extends IndexProviderCompatibi
         super( testSuite, descriptor );
     }
 
+    @Ignore( "Not a test. This is a compatibility suite" )
     public static class General extends CompositeIndexPopulatorCompatibility
     {
         public General( IndexProviderCompatibilityTestSuite testSuite )
@@ -82,6 +83,7 @@ public class CompositeIndexPopulatorCompatibility extends IndexProviderCompatibi
         }
     }
 
+    @Ignore( "Not a test. This is a compatibility suite" )
     public static class Unique extends CompositeIndexPopulatorCompatibility
     {
         String value1 = "value1";

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/SimpleIndexAccessorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/SimpleIndexAccessorCompatibility.java
@@ -123,6 +123,7 @@ public abstract class SimpleIndexAccessorCompatibility extends IndexAccessorComp
 
     // This behaviour is expected by General indexes
 
+    @Ignore( "Not a test. This is a compatibility suite" )
     public static class General extends SimpleIndexAccessorCompatibility
     {
         public General( IndexProviderCompatibilityTestSuite testSuite )
@@ -241,6 +242,7 @@ public abstract class SimpleIndexAccessorCompatibility extends IndexAccessorComp
 
     // This behaviour is expected by Unique indexes
 
+    @Ignore( "Not a test. This is a compatibility suite" )
     public static class Unique extends SimpleIndexAccessorCompatibility
     {
         public Unique( IndexProviderCompatibilityTestSuite testSuite )

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/SimpleIndexPopulatorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/SimpleIndexPopulatorCompatibility.java
@@ -136,6 +136,7 @@ public class SimpleIndexPopulatorCompatibility extends IndexProviderCompatibilit
         accessor.close();
     }
 
+    @Ignore( "Not a test. This is a compatibility suite" )
     public static class General extends SimpleIndexPopulatorCompatibility
     {
         public General( IndexProviderCompatibilityTestSuite testSuite )
@@ -165,6 +166,7 @@ public class SimpleIndexPopulatorCompatibility extends IndexProviderCompatibilit
         }
     }
 
+    @Ignore( "Not a test. This is a compatibility suite" )
     public static class Unique extends SimpleIndexPopulatorCompatibility
     {
         public Unique( IndexProviderCompatibilityTestSuite testSuite )


### PR DESCRIPTION
From composite indexing compatibility suites, by doing what we do with
compatibility test suite participants - marking them as ignored with a
note saying just that. The tests are run from its compatibility test anyway.