### PR TITLE
[#9052][WIP] Unify two procedure validations

### DIFF
--- a/community/pom.xml
+++ b/community/pom.xml
@@ -68,6 +68,7 @@
     <module>procedure-compiler</module>
     <module>values</module>
     <module>ssl</module>
+    <module>procedure-validation</module>
   </modules>
 
   <licenses>

--- a/community/procedure-validation/LICENSES.txt
+++ b/community/procedure-validation/LICENSES.txt
@@ -1,0 +1,4 @@
+This file contains the full license text of the included third party
+libraries. For an overview of the licenses see the NOTICE.txt file.
+
+

--- a/community/procedure-validation/NOTICE.txt
+++ b/community/procedure-validation/NOTICE.txt
@@ -1,0 +1,27 @@
+Neo4j
+Copyright © 2002-2017 Network Engine for Objects in Lund AB (referred to
+in this notice as "Neo Technology")
+   [http://neotechnology.com]
+
+This product includes software ("Software") developed by Neo Technology.
+
+The copyright in the bundled Neo4j graph database (including the
+Software) is owned by Neo Technology. The Software developed and owned
+by Neo Technology is licensed under the GNU GENERAL PUBLIC LICENSE
+Version 3 (http://www.fsf.org/licensing/licenses/gpl-3.0.html) ("GPL")
+to all third parties and that license, as required by the GPL, is
+included in the LICENSE.txt file.
+
+However, if you have executed an End User Software License and Services
+Agreement or an OEM Software License and Support Services Agreement, or
+another commercial license agreement with Neo Technology or one of its
+affiliates (each, a "Commercial Agreement"), the terms of the license in
+such Commercial Agreement will supersede the GPL and you may use the
+software solely pursuant to the terms of the relevant Commercial
+Agreement.
+
+Full license texts are found in LICENSES.txt.
+
+Third-party licenses
+--------------------
+

--- a/community/procedure-validation/pom.xml
+++ b/community/procedure-validation/pom.xml
@@ -1,0 +1,52 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>org.neo4j</groupId>
+        <artifactId>parent</artifactId>
+        <version>3.3.0-SNAPSHOT</version>
+        <relativePath>../..</relativePath>
+    </parent>
+
+    <properties>
+        <short-name>procedure-validation</short-name>
+        <bundle.namespace>org.neo4j.tooling.procedure</bundle.namespace>
+        <license-text.header>GPL-3-header.txt</license-text.header>
+        <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+        <version-package>tooling.procedure</version-package>
+    </properties>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>procedure-validation</artifactId>
+    <version>3.3.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Neo4j - Procedure Validation Logic</name>
+    <description>Neo4j Stored Procedure validation logic shared between compile-time and runtime validators</description>
+    <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>
+
+    <scm>
+        <connection>scm:git:git://github.com/neo4j/neo4j.git</connection>
+        <developerConnection>scm:git:git@github.com:neo4j/neo4j.git</developerConnection>
+        <url>https://github.com/neo4j/neo4j</url>
+    </scm>
+
+    <licenses>
+        <license>
+            <name>GNU General Public License, Version 3</name>
+            <url>http://www.gnu.org/licenses/gpl-3.0-standalone.html</url>
+            <comments>The software ("Software") developed and owned by Network Engine for
+                Objects in Lund AB (referred to in this notice as "Neo Technology") is
+                licensed under the GNU GENERAL PUBLIC LICENSE Version 3 to all third
+                parties and that license is included below.
+
+                However, if you have executed an End User Software License and Services
+                Agreement or an OEM Software License and Support Services Agreement, or
+                another commercial license agreement with Neo Technology or one of its
+                affiliates (each, a "Commercial Agreement"), the terms of the license in
+                such Commercial Agreement will supersede the GNU GENERAL PUBLIC LICENSE
+                Version 3 and you may use the Software solely pursuant to the terms of
+                the relevant Commercial Agreement.
+            </comments>
+        </license>
+    </licenses>
+
+</project>

--- a/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/ElementTypeValidator.java
+++ b/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/ElementTypeValidator.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.procedure.validation;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.neo4j.procedure.validation.errors.ElementTypeValidationFailure;
+import org.neo4j.procedure.validation.errors.ExtensionValidationFailure;
+import org.neo4j.procedure.validation.functional.ConditionalPredicate;
+import org.neo4j.procedure.validation.model.ElementType;
+
+public class ElementTypeValidator implements Function<ElementType,Optional<ExtensionValidationFailure>>
+{
+    private final ConditionalPredicate<ElementType> isBasicTypeSupported;
+    private final ConditionalPredicate<ElementType> isValidListType;
+    private final ConditionalPredicate<ElementType> isValidMapType;
+
+    public ElementTypeValidator( ConditionalPredicate<ElementType> isBasicTypeSupported,
+            ConditionalPredicate<ElementType> isValidListType, ConditionalPredicate<ElementType> isValidMapType )
+    {
+        this.isBasicTypeSupported = isBasicTypeSupported;
+        this.isValidListType = isValidListType;
+        this.isValidMapType = isValidMapType;
+    }
+
+    @Override
+    public Optional<ExtensionValidationFailure> apply( ElementType elementType )
+    {
+        if ( isValidListType.isApplicableTo( elementType ) )
+        {
+            if ( !isValidListType.test( elementType ) )
+            {
+                return Optional.of( ElementTypeValidationFailure.UNSUPPORTED_TYPE );
+            }
+            return Optional.empty();
+        }
+
+        if ( isValidMapType.isApplicableTo( elementType ) )
+        {
+            if ( !isValidMapType.test( elementType ) )
+            {
+                return Optional.of( ElementTypeValidationFailure.UNSUPPORTED_MAP_TYPE );
+            }
+            return Optional.empty();
+        }
+
+        if ( !isBasicTypeSupported.test( elementType ) )
+        {
+            return Optional.of( ElementTypeValidationFailure.UNSUPPORTED_TYPE );
+        }
+        return Optional.empty();
+    }
+}

--- a/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/ExtensionFieldValidator.java
+++ b/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/ExtensionFieldValidator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.procedure.validation;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.neo4j.procedure.validation.errors.ExtensionFieldValidationFailure;
+import org.neo4j.procedure.validation.errors.ExtensionValidationFailure;
+import org.neo4j.procedure.validation.model.ExtensionField;
+
+public class ExtensionFieldValidator implements Function<ExtensionField,Optional<ExtensionValidationFailure>>
+{
+    @Override
+    public Optional<ExtensionValidationFailure> apply( ExtensionField extensionField )
+    {
+        if ( extensionField.isSynthetic() )
+        {
+            return Optional.empty();
+        }
+
+        if ( !extensionField.isAnnotatedWith( "org.neo4j.procedure.Context" ) )
+        {
+            return Optional.empty();
+        }
+
+        if ( !extensionField.isPublic() || extensionField.isStatic() || extensionField.isFinal() )
+        {
+            return Optional.of( ExtensionFieldValidationFailure.WRONG_MODIFIERS );
+        }
+
+        return Optional.empty();
+    }
+}

--- a/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/ExtensionParameterValidator.java
+++ b/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/ExtensionParameterValidator.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.procedure.validation;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.neo4j.procedure.validation.errors.ExtensionParameterValidationFailure;
+import org.neo4j.procedure.validation.errors.ExtensionValidationFailure;
+import org.neo4j.procedure.validation.model.ElementType;
+import org.neo4j.procedure.validation.model.ExtensionParameter;
+
+public class ExtensionParameterValidator implements Function<ExtensionParameter,Optional<ExtensionValidationFailure>>
+{
+    private final Predicate<ExtensionParameter> hasNameAnnotation;
+    private final Predicate<ExtensionParameter> hasNonEmptyNameAnnotationValue;
+    private final Function<ElementType,Optional<ExtensionValidationFailure>> typeValidator;
+    private final Predicate<List<ExtensionParameter>> defaultValuedParametersAreLast;
+
+    public ExtensionParameterValidator( Predicate<ExtensionParameter> hasNameAnnotation,
+            Predicate<ExtensionParameter> hasNonEmptyNameAnnotationValue,
+            Function<ElementType,Optional<ExtensionValidationFailure>> typeValidator,
+            Predicate<List<ExtensionParameter>> defaultValuedParametersAreLast )
+    {
+        this.hasNameAnnotation = hasNameAnnotation;
+        this.hasNonEmptyNameAnnotationValue = hasNonEmptyNameAnnotationValue;
+        this.typeValidator = typeValidator;
+        this.defaultValuedParametersAreLast = defaultValuedParametersAreLast;
+    }
+
+    @Override
+    public Optional<ExtensionValidationFailure> apply( ExtensionParameter extensionParameter )
+    {
+        if ( !hasNameAnnotation.test( extensionParameter ) )
+        {
+            return Optional.of( ExtensionParameterValidationFailure.MISSING_NAME_ANNOTATION );
+        }
+        if ( !hasNonEmptyNameAnnotationValue.test( extensionParameter ) )
+        {
+            return Optional.of( ExtensionParameterValidationFailure.EMPTY_NAME_ANNOTATION_VALUE );
+        }
+
+        return typeValidator.apply( extensionParameter.getType() );
+
+    }
+
+    public Optional<ExtensionValidationFailure> validateDefaultValuedParameterPosition(
+            List<ExtensionParameter> parameters )
+    {
+        if ( !defaultValuedParametersAreLast.test( parameters ) )
+        {
+            return Optional.of( ExtensionParameterValidationFailure.DEFAULT_VALUE_NOT_FOUND_LAST );
+        }
+        return Optional.empty();
+    }
+}

--- a/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/UserFunctionValidator.java
+++ b/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/UserFunctionValidator.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.procedure.validation;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.neo4j.procedure.validation.errors.ExtensionValidationFailure;
+import org.neo4j.procedure.validation.errors.FunctionValidationFailure;
+import org.neo4j.procedure.validation.functional.OptionalStreams;
+import org.neo4j.procedure.validation.model.ExtensionConstructor;
+import org.neo4j.procedure.validation.model.ExtensionParameter;
+import org.neo4j.procedure.validation.model.ExtensionQualifiedName;
+import org.neo4j.procedure.validation.model.UserFunctionDefinition;
+
+public class UserFunctionValidator implements Function<UserFunctionDefinition,Optional<ExtensionValidationFailure>>
+{
+
+    private final Predicate<ExtensionConstructor> isNoArgConstructor;
+    private final Predicate<ExtensionQualifiedName> hasWhitelistedName;
+    private final Predicate<ExtensionQualifiedName> isRootNamespace;
+    private final ExtensionParameterValidator extensionParameterValidator;
+    private final ElementTypeValidator elementTypeValidator;
+    private final ExtensionFieldValidator extensionFieldValidator;
+
+    public UserFunctionValidator( Predicate<ExtensionConstructor> isNoArgConstructor,
+            Predicate<ExtensionQualifiedName> whitelistedName, Predicate<ExtensionQualifiedName> isRootNamespace,
+            ExtensionParameterValidator extensionParameterValidator, ElementTypeValidator elementTypeValidator,
+            ExtensionFieldValidator extensionFieldValidator )
+    {
+
+        this.isNoArgConstructor = isNoArgConstructor;
+        this.hasWhitelistedName = whitelistedName;
+        this.isRootNamespace = isRootNamespace;
+        this.extensionParameterValidator = extensionParameterValidator;
+        this.elementTypeValidator = elementTypeValidator;
+        this.extensionFieldValidator = extensionFieldValidator;
+    }
+
+    @Override
+    public Optional<ExtensionValidationFailure> apply( UserFunctionDefinition userFunctionDefinition )
+    {
+        ExtensionQualifiedName name = userFunctionDefinition.getName();
+        if ( !isNoArgConstructor.test( userFunctionDefinition.getConstructor() ) )
+        {
+            return Optional.of( FunctionValidationFailure.MISSING_NO_ARG_CONSTRUCTOR );
+        }
+        if ( !hasWhitelistedName.test( name ) )
+        {
+            return Optional.of( FunctionValidationFailure.NOT_WHITELISTED );
+        }
+        if ( !isRootNamespace.test( name ) )
+        {
+            return Optional.of( FunctionValidationFailure.IN_ROOT_NAMESPACE );
+        }
+
+        List<ExtensionParameter> parameters = userFunctionDefinition.getParameters();
+        Optional<ExtensionValidationFailure> parameterFailure =
+                OptionalStreams.flatMap( parameters.stream(), extensionParameterValidator ).findFirst();
+
+        if ( parameterFailure.isPresent() )
+        {
+            return parameterFailure;
+        }
+
+        Optional<ExtensionValidationFailure> defaultValuePositionFailure =
+                extensionParameterValidator.validateDefaultValuedParameterPosition( parameters );
+        if ( defaultValuePositionFailure.isPresent() )
+        {
+            return defaultValuePositionFailure;
+        }
+
+        Optional<ExtensionValidationFailure> returnTypeFailure =
+                elementTypeValidator.apply( userFunctionDefinition.getReturnType() );
+        if ( returnTypeFailure.isPresent() )
+        {
+            return returnTypeFailure;
+        }
+
+        return OptionalStreams.flatMap( userFunctionDefinition.getExtensionFields().stream(), extensionFieldValidator )
+                .findFirst();
+
+    }
+}

--- a/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/errors/ElementTypeValidationFailure.java
+++ b/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/errors/ElementTypeValidationFailure.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.procedure.validation.errors;
+
+public enum ElementTypeValidationFailure implements ExtensionValidationFailure
+{
+    UNSUPPORTED_MAP_TYPE,
+    UNSUPPORTED_TYPE
+}

--- a/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/errors/ExtensionFieldValidationFailure.java
+++ b/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/errors/ExtensionFieldValidationFailure.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.procedure.validation.errors;
+
+public enum ExtensionFieldValidationFailure implements ExtensionValidationFailure
+{
+    WRONG_MODIFIERS
+}

--- a/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/errors/ExtensionParameterValidationFailure.java
+++ b/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/errors/ExtensionParameterValidationFailure.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.procedure.validation.errors;
+
+public enum ExtensionParameterValidationFailure implements ExtensionValidationFailure
+{
+    MISSING_NAME_ANNOTATION,
+    DEFAULT_VALUE_NOT_FOUND_LAST,
+    EMPTY_NAME_ANNOTATION_VALUE
+}

--- a/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/errors/ExtensionValidationFailure.java
+++ b/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/errors/ExtensionValidationFailure.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.procedure.validation.errors;
+
+public interface ExtensionValidationFailure
+{
+}

--- a/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/errors/FunctionValidationFailure.java
+++ b/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/errors/FunctionValidationFailure.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.procedure.validation.errors;
+
+public enum FunctionValidationFailure implements ExtensionValidationFailure
+{
+    NOT_WHITELISTED,
+    IN_ROOT_NAMESPACE,
+    MISSING_NO_ARG_CONSTRUCTOR;
+}

--- a/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/functional/ConditionalPredicate.java
+++ b/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/functional/ConditionalPredicate.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.procedure.validation.functional;
+
+import java.util.function.Predicate;
+
+public interface ConditionalPredicate<T> extends Predicate<T>
+{
+    default boolean isApplicableTo( T value )
+    {
+        return true;
+    }
+}

--- a/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/functional/OptionalStreams.java
+++ b/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/functional/OptionalStreams.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.procedure.validation.functional;
+
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class OptionalStreams
+{
+    private OptionalStreams()
+    {
+        throw new RuntimeException( "static class" );
+    }
+
+    public static <T, U> Stream<U> flatMap( Stream<T> stream, Function<T,Optional<U>> function )
+    {
+        return stream.map( function ).flatMap( option -> option.map( Stream::of ).orElseGet( Stream::empty ) );
+    }
+}

--- a/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/model/ElementType.java
+++ b/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/model/ElementType.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.procedure.validation.model;
+
+public class ElementType
+{
+}

--- a/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/model/ExtensionConstructor.java
+++ b/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/model/ExtensionConstructor.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.procedure.validation.model;
+
+public class ExtensionConstructor
+{
+}

--- a/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/model/ExtensionField.java
+++ b/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/model/ExtensionField.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.procedure.validation.model;
+
+public class ExtensionField
+{
+    public boolean isSynthetic()
+    {
+        return false;
+    }
+
+    public boolean isAnnotatedWith( String className )
+    {
+        return false;
+    }
+
+    public boolean isPublic()
+    {
+        return false;
+    }
+
+    public boolean isStatic()
+    {
+        return false;
+    }
+
+    public boolean isFinal()
+    {
+        return false;
+    }
+}

--- a/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/model/ExtensionParameter.java
+++ b/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/model/ExtensionParameter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.procedure.validation.model;
+
+public class ExtensionParameter
+{
+    private final ElementType type;
+
+    public ExtensionParameter( ElementType type )
+    {
+        this.type = type;
+    }
+
+    public ElementType getType()
+    {
+        return type;
+    }
+}

--- a/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/model/ExtensionQualifiedName.java
+++ b/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/model/ExtensionQualifiedName.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.procedure.validation.model;
+
+public class ExtensionQualifiedName
+{
+
+    private final String namespace;
+    private final String className;
+
+    public ExtensionQualifiedName( String namespace, String className )
+    {
+        this.namespace = namespace;
+        this.className = className;
+    }
+
+    public String getNamespace()
+    {
+        return namespace;
+    }
+
+    public String getClassName()
+    {
+        return className;
+    }
+}

--- a/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/model/UserFunctionDefinition.java
+++ b/community/procedure-validation/src/main/java/org/neo4j/procedure/validation/model/UserFunctionDefinition.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.procedure.validation.model;
+
+import java.util.List;
+
+public class UserFunctionDefinition
+{
+    private final ExtensionConstructor constructor;
+    private final ExtensionQualifiedName name;
+    private final List<ExtensionParameter> parameters;
+    private final ElementType returnType;
+    private final List<ExtensionField> extensionFields;
+
+    public UserFunctionDefinition( ExtensionConstructor constructor, ExtensionQualifiedName name,
+            List<ExtensionParameter> parameters, ElementType returnType, List<ExtensionField> extensionFields )
+    {
+        this.constructor = constructor;
+        this.name = name;
+        this.parameters = parameters;
+        this.returnType = returnType;
+        this.extensionFields = extensionFields;
+    }
+
+    public ExtensionConstructor getConstructor()
+    {
+        return constructor;
+    }
+
+    public ExtensionQualifiedName getName()
+    {
+        return name;
+    }
+
+    public List<ExtensionParameter> getParameters()
+    {
+        return parameters;
+    }
+
+    public ElementType getReturnType()
+    {
+        return returnType;
+    }
+
+    public List<ExtensionField> getExtensionFields()
+    {
+        return extensionFields;
+    }
+}


### PR DESCRIPTION
This commit centralizes the common validation between the
reflective (or runtime) procedure compiler and the compile-time
annotation processor.

The validation workflow is defined once and specific validation
functions are implemented on both sides.