### PR TITLE
Legacy indexes can be read when in read_only mode

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ReadOperations.java
@@ -291,6 +291,24 @@ public interface ReadOperations
     //== LEGACY INDEX OPERATIONS ================
     //===========================================
 
+    /**
+     * @param indexName name of node index to check for existence.
+     * @param customConfiguration if {@code null} the configuration of existing won't be matched, otherwise it will
+     * be matched and a mismatch will throw {@link IllegalArgumentException}.
+     * @return whether or not node legacy index with name {@code indexName} exists.
+     * @throws IllegalArgumentException on index existence with provided mismatching {@code customConfiguration}.
+     */
+    boolean nodeLegacyIndexExists( String indexName, Map<String,String> customConfiguration );
+
+    /**
+     * @param indexName name of relationship index to check for existence.
+     * @param customConfiguration if {@code null} the configuration of existing won't be matched, otherwise it will
+     * be matched and a mismatch will throw {@link IllegalArgumentException}.
+     * @return whether or not relationship legacy index with name {@code indexName} exists.
+     * @throws IllegalArgumentException on index existence with provided mismatching {@code customConfiguration}.
+     */
+    boolean relationshipLegacyIndexExists( String indexName, Map<String,String> customConfiguration );
+
     Map<String, String> nodeLegacyIndexGetConfiguration( String indexName )
             throws LegacyIndexNotFoundKernelException;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/LegacyIndexTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/LegacyIndexTransactionState.java
@@ -38,7 +38,27 @@ public interface LegacyIndexTransactionState extends RecordState
 
     LegacyIndex relationshipChanges( String indexName ) throws LegacyIndexNotFoundKernelException;
 
-    void createIndex( IndexEntityType node, String name, Map<String, String> config );
+    void createIndex( IndexEntityType entityType, String indexName, Map<String, String> config );
 
     void deleteIndex( IndexEntityType entityType, String indexName );
+
+    /**
+     * Checks whether or not index with specific {@code name} exists.
+     * Optionally the specific {@code config} is verified to be matching.
+     *
+     * This method can either return {@code boolean} or {@code throw} exception on:
+     * <ul>
+     * <li>index exists, config is provided and matching => {@code true}</li>
+     * <li>index exists, config is provided and NOT matching => {@code throw exception}</li>
+     * <li>index exists, config is NOT provided => {@code true}</li>
+     * <li>index does NOT exist => {@code false}</li>
+     * </ul>
+     *
+     * @param entityType {@link IndexEntityType} for the index.
+     * @param indexName name of the index.
+     * @param config configuration which must match the existing index, if it exists. {@code null} means
+     * that the configuration doesn't need to be checked.
+     * @return {@code true} if the index with the specific {@code name} and {@code entityType} exists, otherwise {@code false}.
+     */
+    boolean checkIndexExistence( IndexEntityType entityType, String indexName, Map<String, String> config );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CachingLegacyIndexTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/CachingLegacyIndexTransactionState.java
@@ -94,4 +94,10 @@ public class CachingLegacyIndexTransactionState implements LegacyIndexTransactio
     {
         txState.extractCommands( target );
     }
+
+    @Override
+    public boolean checkIndexExistence( IndexEntityType entityType, String indexName, Map<String,String> config )
+    {
+        return txState.checkIndexExistence( entityType, indexName, config );
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -1017,6 +1017,20 @@ public class OperationsFacade
 
     // <Legacy index>
     @Override
+    public boolean nodeLegacyIndexExists( String indexName, Map<String,String> customConfiguration )
+    {
+        statement.assertOpen();
+        return legacyIndexRead().nodeLegacyIndexExists( statement, indexName, customConfiguration );
+    }
+
+    @Override
+    public boolean relationshipLegacyIndexExists( String indexName, Map<String,String> customConfiguration )
+    {
+        statement.assertOpen();
+        return legacyIndexRead().relationshipLegacyIndexExists( statement, indexName, customConfiguration );
+    }
+
+    @Override
     public LegacyIndexHits nodeLegacyIndexGet( String indexName, String key, Object value )
             throws LegacyIndexNotFoundKernelException
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -1448,7 +1448,6 @@ public class StateHandlingStatementOperations implements
         return storeLayer.relationshipTypeCount();
     }
 
-    // <Legacy index>
     @Override
     public <EXCEPTION extends Exception> void relationshipVisit( KernelStatement statement,
             long relId, RelationshipVisitor<EXCEPTION> visitor ) throws EntityNotFoundException, EXCEPTION
@@ -1461,6 +1460,19 @@ public class StateHandlingStatementOperations implements
             }
         }
         storeLayer.relationshipVisit( relId, visitor );
+    }
+
+    // <Legacy index>
+    @Override
+    public boolean nodeLegacyIndexExists( KernelStatement statement, String indexName, Map<String,String> customConfiguration )
+    {
+        return statement.legacyIndexTxState().checkIndexExistence( IndexEntityType.Node, indexName, customConfiguration );
+    }
+
+    @Override
+    public boolean relationshipLegacyIndexExists( KernelStatement statement, String indexName, Map<String,String> customConfiguration )
+    {
+        return statement.legacyIndexTxState().checkIndexExistence( IndexEntityType.Relationship, indexName, customConfiguration );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/LegacyIndexReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/LegacyIndexReadOperations.java
@@ -27,6 +27,26 @@ import org.neo4j.kernel.impl.api.KernelStatement;
 
 public interface LegacyIndexReadOperations
 {
+    /**
+     * @param statement {@link KernelStatement} to use for state.
+     * @param indexName name of node index to check for existence.
+     * @param customConfiguration if {@code null} the configuration of existing won't be matched, otherwise it will
+     * be matched and a mismatch will throw {@link IllegalArgumentException}.
+     * @return whether or not node legacy index with name {@code indexName} exists.
+     * @throws IllegalArgumentException on index existence with provided mismatching {@code customConfiguration}.
+     */
+    boolean nodeLegacyIndexExists( KernelStatement statement, String indexName, Map<String,String> customConfiguration );
+
+    /**
+     * @param statement {@link KernelStatement} to use for state.
+     * @param indexName name of relationship index to check for existence.
+     * @param customConfiguration if {@code null} the configuration of existing won't be matched, otherwise it will
+     * be matched and a mismatch will throw {@link IllegalArgumentException}.
+     * @return whether or not relationship legacy index with name {@code indexName} exists.
+     * @throws IllegalArgumentException on index existence with provided mismatching {@code customConfiguration}.
+     */
+    boolean relationshipLegacyIndexExists( KernelStatement statement, String indexName, Map<String,String> customConfiguration );
+
     Map<String, String> nodeLegacyIndexGetConfiguration( KernelStatement statement, String indexName )
             throws LegacyIndexNotFoundKernelException;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/IndexProviderImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/IndexProviderImpl.java
@@ -46,10 +46,13 @@ public class IndexProviderImpl implements IndexProvider
     {
         try ( Statement statement = transactionBridge.get() )
         {
-            // There's a sub-o-meta thing here where we create index config,
-            // and the index will itself share the same IndexConfigStore as us and pick up and use
-            // that. We should pass along config somehow with calls.
-            statement.dataWriteOperations().nodeLegacyIndexCreateLazily( indexName, customConfiguration );
+            if ( !statement.readOperations().nodeLegacyIndexExists( indexName, customConfiguration ) )
+            {
+                // There's a sub-o-meta thing here where we create index config,
+                // and the index will itself share the same IndexConfigStore as us and pick up and use
+                // that. We should pass along config somehow with calls.
+                statement.dataWriteOperations().nodeLegacyIndexCreateLazily( indexName, customConfiguration );
+            }
             return new LegacyIndexProxy<>( indexName, LegacyIndexProxy.Type.NODE, gds, transactionBridge );
         }
         catch ( InvalidTransactionTypeKernelException e )
@@ -64,10 +67,13 @@ public class IndexProviderImpl implements IndexProvider
     {
         try ( Statement statement = transactionBridge.get() )
         {
-            // There's a sub-o-meta thing here where we create index config,
-            // and the index will itself share the same IndexConfigStore as us and pick up and use
-            // that. We should pass along config somehow with calls.
-            statement.dataWriteOperations().relationshipLegacyIndexCreateLazily( indexName, customConfiguration );
+            if ( !statement.readOperations().relationshipLegacyIndexExists( indexName, customConfiguration ) )
+            {
+                // There's a sub-o-meta thing here where we create index config,
+                // and the index will itself share the same IndexConfigStore as us and pick up and use
+                // that. We should pass along config somehow with calls.
+                statement.dataWriteOperations().relationshipLegacyIndexCreateLazily( indexName, customConfiguration );
+            }
             return new RelationshipLegacyIndexProxy( indexName, gds, transactionBridge );
         }
         catch ( InvalidTransactionTypeKernelException e )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/LegacyIndexStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/LegacyIndexStore.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.index;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -126,7 +125,7 @@ public class LegacyIndexStore
         return Collections.unmodifiableMap( configToUse );
     }
 
-    private void assertConfigMatches( IndexImplementation indexProvider, String indexName,
+    public static void assertConfigMatches( IndexImplementation indexProvider, String indexName,
                                       Map<String, String> storedConfig, Map<String, String> suppliedConfig )
     {
         if ( suppliedConfig != null && !indexProvider.configMatches( storedConfig, suppliedConfig ) )

--- a/community/kernel/src/test/java/org/neo4j/test/rule/DatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/DatabaseRule.java
@@ -61,6 +61,8 @@ import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.kernel.impl.store.StoreId;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 
+import static org.neo4j.helpers.collection.MapUtil.stringMap;
+
 public abstract class DatabaseRule extends ExternalResource implements GraphDatabaseAPI
 {
     private GraphDatabaseBuilder databaseBuilder;
@@ -329,10 +331,11 @@ public abstract class DatabaseRule extends ExternalResource implements GraphData
         return database;
     }
 
-    public synchronized void ensureStarted()
+    public synchronized void ensureStarted( String... additionalConfig )
     {
         if ( database == null )
         {
+            applyConfigChanges( additionalConfig );
             database = (GraphDatabaseAPI) databaseBuilder.newGraphDatabase();
             storeDir = database.getStoreDir();
             statementSupplier = resolveDependency( ThreadToStatementContextBridge.class );
@@ -369,18 +372,24 @@ public abstract class DatabaseRule extends ExternalResource implements GraphData
         };
     }
 
-    public GraphDatabaseAPI restartDatabase() throws IOException
+    public GraphDatabaseAPI restartDatabase( String... configChanges ) throws IOException
     {
-        return restartDatabase( RestartAction.EMPTY );
+        return restartDatabase( RestartAction.EMPTY, configChanges );
     }
 
-    public GraphDatabaseAPI restartDatabase( RestartAction action ) throws IOException
+    public GraphDatabaseAPI restartDatabase( RestartAction action, String... configChanges ) throws IOException
     {
         FileSystemAbstraction fs = resolveDependency( FileSystemAbstraction.class );
         database.shutdown();
         action.run( fs, new File( storeDir ) );
         database = null;
+        applyConfigChanges( configChanges );
         return getGraphDatabaseAPI();
+    }
+
+    private void applyConfigChanges( String[] configChanges )
+    {
+        databaseBuilder.setConfig( stringMap( configChanges ) );
     }
 
     @Override

--- a/community/neo4j/src/test/java/org/neo4j/index/AccessLegacyIndexReadOnlyIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/AccessLegacyIndexReadOnlyIT.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.graphdb.index.Index;
+import org.neo4j.graphdb.security.WriteOperationsNotAllowedException;
+import org.neo4j.kernel.impl.MyRelTypes;
+import org.neo4j.test.rule.DatabaseRule;
+import org.neo4j.test.rule.EmbeddedDatabaseRule;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import static java.lang.Boolean.TRUE;
+
+public class AccessLegacyIndexReadOnlyIT
+{
+    @Rule
+    public final DatabaseRule db = new EmbeddedDatabaseRule().startLazily();
+
+    @Test
+    public void shouldListAndReadLegacyIndexesForReadOnlyDb() throws Exception
+    {
+        // given a db with some nodes and populated legacy indexes
+        db.ensureStarted();
+        String key = "key";
+        try ( Transaction tx = db.beginTx() )
+        {
+            Index<Node> nodeIndex = db.index().forNodes( "NODE" );
+            Index<Relationship> relationshipIndex = db.index().forRelationships( "RELATIONSHIP" );
+
+            for ( int i = 0; i < 10; i++ )
+            {
+                Node node = db.createNode();
+                Relationship relationship = node.createRelationshipTo( node, MyRelTypes.TEST );
+                nodeIndex.add( node, key, String.valueOf( i ) );
+                relationshipIndex.add( relationship, key, String.valueOf( i ) );
+            }
+            tx.success();
+        }
+
+        // when restarted as read-only
+        db.restartDatabase( GraphDatabaseSettings.read_only.name(), TRUE.toString() );
+        try ( Transaction tx = db.beginTx() )
+        {
+            Index<Node> nodeIndex = db.index().forNodes( db.index().nodeIndexNames()[0] );
+            Index<Relationship> relationshipIndex = db.index().forRelationships( db.index().relationshipIndexNames()[0] );
+
+            // then try and read the indexes
+            for ( int i = 0; i < 10; i++ )
+            {
+                assertNotNull( nodeIndex.get( key, String.valueOf( i ) ).getSingle() );
+                assertNotNull( relationshipIndex.get( key, String.valueOf( i ) ).getSingle() );
+            }
+            tx.success();
+        }
+    }
+
+    @Test
+    public void shouldNotCreateIndexesForReadOnlyDb() throws Exception
+    {
+        // given
+        db.ensureStarted( GraphDatabaseSettings.read_only.name(), TRUE.toString() );
+
+        // when
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.index().forNodes( "NODE" );
+            fail( "Should've failed" );
+        }
+        catch ( WriteOperationsNotAllowedException e )
+        {
+            // then good
+        }
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.index().forRelationships( "RELATIONSHIP" );
+            fail( "Should've failed" );
+        }
+        catch ( WriteOperationsNotAllowedException e )
+        {
+            // then good
+        }
+    }
+}


### PR DESCRIPTION
Previously simply getting a handle to a legacy index would have the transaction
think that it needed write access, by mistake. This is now changed so that
first the existence of the index is checked with only read requirement and then
if it doesn't gets escalated to create-and-get it.