### PR TITLE
TransactionBoundQueryContext no longer creates new statements

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
@@ -314,11 +314,7 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
 
   override def nodeIsDense(node: Long): Boolean = statement.readOperations().nodeIsDense(node)
 
-  private def kernelStatement: KernelStatement =
-    txBridge
-      .getKernelTransactionBoundToThisThread(true)
-      .acquireStatement()
-      .asInstanceOf[KernelStatement]
+  private def kernelStatement = statement.asInstanceOf[KernelStatement]
 
   class NodeOperations extends BaseOperations[Node] {
     def delete(obj: Node) {


### PR DESCRIPTION
Instead always uses the statement passed in. This was a problem because
isDeleted methods created a new statement, but didn't close it in the end.
This was both unnecessary and it created problems due to causing statements
to be open longer than they should, causing e.g. index reader caching
to hold on to cache readers too long.