### PR TITLE
Add possibility to track not closed kernel statements

### DIFF
--- a/community/collections/src/main/java/org/neo4j/helpers/collection/LimitingResourceIterable.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/LimitingResourceIterable.java
@@ -19,18 +19,17 @@
  */
 package org.neo4j.helpers.collection;
 
-import java.util.Iterator;
+import org.neo4j.graphdb.ResourceIterable;
+import org.neo4j.graphdb.ResourceIterator;
 
 /**
- * Limits the amount of items returned by an {@link Iterable}, or rather
- * {@link Iterator}s spawned from it.
- *
- * @author Mattias Persson
+ * Limits the amount of items returned by an {@link ResourceIterable}, or rather
+ * {@link ResourceIterator}s spawned from it.
  *
  * @param <T> the type of items in this {@link Iterable}.
- * @see LimitingIterator
+ * @see LimitingResourceIterator
  */
-public class LimitingIterable<T> implements Iterable<T>
+public class LimitingResourceIterable<T> implements ResourceIterable<T>
 {
     private final Iterable<T> source;
     private final int limit;
@@ -42,15 +41,15 @@ public class LimitingIterable<T> implements Iterable<T>
      * @param source the source of items.
      * @param limit the limit, i.e. the max number of items to return.
      */
-    public LimitingIterable( Iterable<T> source, int limit )
+    public LimitingResourceIterable( ResourceIterable<T> source, int limit )
     {
         this.source = source;
         this.limit = limit;
     }
 
     @Override
-    public Iterator<T> iterator()
+    public ResourceIterator<T> iterator()
     {
-        return new LimitingIterator<T>( source.iterator(), limit );
+        return new LimitingResourceIterator<T>( Iterators.asResourceIterator( source.iterator() ), limit );
     }
 }

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/LimitingResourceIterator.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/LimitingResourceIterator.java
@@ -21,6 +21,8 @@ package org.neo4j.helpers.collection;
 
 import java.util.Iterator;
 
+import org.neo4j.graphdb.ResourceIterator;
+
 /**
  * Limits the amount of items returned by an {@link Iterator}.
  *
@@ -28,10 +30,10 @@ import java.util.Iterator;
  *
  * @param <T> the type of items in this {@link Iterator}.
  */
-public class LimitingIterator<T> extends PrefetchingIterator<T>
+public class LimitingResourceIterator<T> extends PrefetchingResourceIterator<T>
 {
     private int returned;
-    private final Iterator<T> source;
+    private final ResourceIterator<T> source;
     private final int limit;
 
     /**
@@ -42,7 +44,7 @@ public class LimitingIterator<T> extends PrefetchingIterator<T>
      * @param source the source of items.
      * @param limit the limit, i.e. the max number of items to return.
      */
-    public LimitingIterator( Iterator<T> source, int limit )
+    public LimitingResourceIterator( ResourceIterator<T> source, int limit )
     {
         this.source = source;
         this.limit = limit;
@@ -72,5 +74,11 @@ public class LimitingIterator<T> extends PrefetchingIterator<T>
     public boolean limitReached()
     {
         return returned == limit;
+    }
+
+    @Override
+    public void close()
+    {
+        source.close();
     }
 }

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/MappingResourceIterator.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/MappingResourceIterator.java
@@ -17,31 +17,39 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.shell.impl;
+package org.neo4j.helpers.collection;
 
-import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.Relationship;
-import org.neo4j.graphdb.ResourceIterable;
-import org.neo4j.helpers.collection.MappingResourceIterator;
+import org.neo4j.graphdb.ResourceIterator;
 
-public class RelationshipToNodeIterable extends MappingResourceIterator<Node, Relationship>
+public abstract class MappingResourceIterator<T, S> implements ResourceIterator<T>
 {
-    private final Node fromNode;
+    private ResourceIterator<S> sourceIterator;
 
-    private RelationshipToNodeIterable( ResourceIterable<Relationship> iterableToWrap, Node fromNode )
+    public MappingResourceIterator( ResourceIterator<S> sourceResourceIterator )
     {
-        super( iterableToWrap.iterator() );
-        this.fromNode = fromNode;
+        this.sourceIterator = sourceResourceIterator;
+    }
+
+    protected abstract T map( S object );
+
+    public boolean hasNext()
+    {
+        return sourceIterator.hasNext();
+    }
+
+    public T next()
+    {
+        return map( sourceIterator.next() );
+    }
+
+    public void remove()
+    {
+        sourceIterator.remove();
     }
 
     @Override
-    protected Node map( Relationship rel )
+    public void close()
     {
-        return rel.getOtherNode( fromNode );
-    }
-
-    public static MappingResourceIterator<Node,Relationship> wrap( ResourceIterable<Relationship> relationships, Node fromNode )
-    {
-        return new RelationshipToNodeIterable( relationships, fromNode );
+        sourceIterator.close();
     }
 }

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/NestingResourceIterator.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/NestingResourceIterator.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.helpers.collection;
+
+import java.util.Iterator;
+
+import org.neo4j.graphdb.ResourceIterator;
+
+public abstract class NestingResourceIterator<T, U> extends PrefetchingResourceIterator<T>
+{
+    private final Iterator<U> source;
+    private ResourceIterator<T> currentNestedIterator;
+    private U currentSurfaceItem;
+
+    public NestingResourceIterator( Iterator<U> source )
+    {
+        this.source = source;
+    }
+
+    protected abstract ResourceIterator<T> createNestedIterator( U item );
+
+    @Override
+    protected T fetchNextOrNull()
+    {
+        if ( currentNestedIterator == null ||
+                !currentNestedIterator.hasNext() )
+        {
+            while ( source.hasNext() )
+            {
+                currentSurfaceItem = source.next();
+                close();
+                currentNestedIterator = createNestedIterator( currentSurfaceItem );
+                if ( currentNestedIterator.hasNext() )
+                {
+                    break;
+                }
+            }
+        }
+        return currentNestedIterator != null && currentNestedIterator.hasNext() ? currentNestedIterator.next() : null;
+    }
+
+    @Override
+    public void close()
+    {
+        if ( currentNestedIterator != null )
+        {
+            currentNestedIterator.close();
+        }
+    }
+}

--- a/community/collections/src/main/java/org/neo4j/helpers/collection/ResourceClosingIterator.java
+++ b/community/collections/src/main/java/org/neo4j/helpers/collection/ResourceClosingIterator.java
@@ -27,12 +27,12 @@ import org.neo4j.graphdb.ResourceIterator;
 
 public abstract class ResourceClosingIterator<T, V> implements ResourceIterator<V>
 {
-    public static <T> ResourceIterator<T> newResourceIterator( Resource resource, Iterator<T> iterator )
+    public static <R> ResourceIterator<R> newResourceIterator( Resource resource, Iterator<R> iterator )
     {
-        return new ResourceClosingIterator<T,T>( resource, iterator )
+        return new ResourceClosingIterator<R,R>( resource, iterator )
         {
             @Override
-            public T map( T elem )
+            public R map( R elem )
             {
                 return elem;
             }

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionEngineTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionEngineTest.java
@@ -73,9 +73,16 @@ public class ExecutionEngineTest
             String query = "RETURN { key : 'Value' , collectionKey: [{ inner: 'Map1' }, { inner: 'Map2' }]}";
             TransactionalContext tc = createTransactionContext( graph, tx, query );
             result = executionEngine.executeQuery( query, NO_PARAMS, tc );
+
+            verifyResult( result );
+
+            result.close();
             tx.success();
         }
+    }
 
+    private void verifyResult( Result result )
+    {
         Map firstRowValue = (Map) result.next().values().iterator().next();
         assertThat( firstRowValue.get( "key" ), is( "Value" ) );
         List theList = (List) firstRowValue.get( "collectionKey" );

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
@@ -31,9 +31,8 @@ import org.neo4j.cypher.internal.spi.v3_3.{TransactionBoundPlanContext, Transact
 import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService
 import org.neo4j.graphdb._
 import org.neo4j.graphdb.config.Setting
-import org.neo4j.kernel.api.KernelAPI
 import org.neo4j.kernel.api.proc._
-import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge
+import org.neo4j.kernel.api.{KernelAPI, Statement}
 import org.neo4j.kernel.{GraphDatabaseQueryService, monitoring}
 import org.neo4j.test.TestGraphDatabaseFactory
 import org.scalatest.matchers.{MatchResult, Matcher}
@@ -258,13 +257,11 @@ trait GraphDatabaseTestSupport extends CypherTestSupport with GraphIcing {
     func
   }
 
-  def statement = graph.getDependencyResolver.resolveDependency(classOf[ThreadToStatementContextBridge]).get()
-
   def kernelMonitors = graph.getDependencyResolver.resolveDependency(classOf[monitoring.Monitors])
 
   def kernelAPI = graph.getDependencyResolver.resolveDependency(classOf[KernelAPI])
 
-  def planContext: PlanContext = {
+  def planContext(statement: Statement): PlanContext = {
     val tc = mock[TransactionalContextWrapper]
     when(tc.statement).thenReturn(statement)
     when(tc.readOperations).thenReturn(statement.readOperations())

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/CypherCompilerAstCacheAcceptanceTest.scala
@@ -110,6 +110,7 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
                                                     noTracing, Set.empty)
       val context = TransactionalContextWrapper(graph.transactionalContext(query = query -> Map.empty))
       parsedQuery.plan(context, noTracing)
+      context.close(true)
     }
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/AllShortestPathsPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/AllShortestPathsPipeTest.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v3_3
 import org.neo4j.cypher.GraphDatabaseFunSuite
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.commands.{ShortestPath, SingleNode}
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes.{FakePipe, ShortestPathPipe}
-import org.neo4j.cypher.internal.compiler.v3_3.QueryStateHelper.queryStateFrom
+import org.neo4j.cypher.internal.compiler.v3_3.QueryStateHelper.withQueryState
 import org.neo4j.cypher.internal.frontend.v3_3.SemanticDirection
 import org.neo4j.cypher.internal.frontend.v3_3.symbols._
 import org.neo4j.graphdb.Node
@@ -40,7 +40,9 @@ class AllShortestPathsPipeTest extends GraphDatabaseFunSuite {
                                                      SemanticDirection.BOTH, allowZeroLength = false, Some(15),
                                                      single = false, relIterator = None))()
     graph.withTx { tx =>
-      pipe.createResults(queryStateFrom(graph, tx)).toList.map(m => m("p").asInstanceOf[PathValue])
+      withQueryState(graph, tx, Map.empty, {queryState =>
+        pipe.createResults(queryState).toList.map(m => m("p").asInstanceOf[PathValue])
+      })
     }
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/QueryStateHelper.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/QueryStateHelper.scala
@@ -50,7 +50,7 @@ object QueryStateHelper {
     newWith(db = db, query = queryContext, params = params)
   }
 
-  def withQueryState[T](db: GraphDatabaseQueryService, tx: InternalTransaction, params: Map[String, Any] = Map.empty, f: (QueryState) => T)  = {
+  def withQueryState[T](db: GraphDatabaseQueryService, tx: InternalTransaction, params: Map[String, AnyValue] = Map.empty, f: (QueryState) => T)  = {
     val queryState = queryStateFrom(db, tx, params)
     try {
       f(queryState)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/QueryStateHelper.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/QueryStateHelper.scala
@@ -50,5 +50,15 @@ object QueryStateHelper {
     newWith(db = db, query = queryContext, params = params)
   }
 
+  def withQueryState[T](db: GraphDatabaseQueryService, tx: InternalTransaction, params: Map[String, Any] = Map.empty, f: (QueryState) => T)  = {
+    val queryState = queryStateFrom(db, tx, params)
+    try {
+      f(queryState)
+    } finally {
+      queryState.query.transactionalContext.close(true)
+    }
+
+  }
+
   def countStats(q: QueryState) = q.withQueryContext(query = new UpdateCountingQueryContext(q.query))
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/QueryStateTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/QueryStateTestSupport.scala
@@ -30,8 +30,9 @@ trait QueryStateTestSupport {
   def withQueryState[T](f: QueryState => T) = {
     val tx = graph.beginTransaction(KernelTransaction.Type.explicit, AUTH_DISABLED)
     try {
-      val queryState = QueryStateHelper.queryStateFrom(graph, tx)
-      f(queryState)
+      QueryStateHelper.withQueryState(graph, tx, Map.empty, queryState => {
+        f(queryState)
+      })
     } finally {
       tx.close()
     }
@@ -40,8 +41,11 @@ trait QueryStateTestSupport {
   def withCountsQueryState[T](f: QueryState => T) = {
     val tx = graph.beginTransaction(KernelTransaction.Type.explicit, AUTH_DISABLED)
     try {
-      val queryState = QueryStateHelper.countStats(QueryStateHelper.queryStateFrom(graph, tx))
-      f(queryState)
+      QueryStateHelper.withQueryState(graph, tx, Map.empty, queryState =>
+        {
+          val state = QueryStateHelper.countStats(queryState)
+          f(state)
+        })
     } finally {
       tx.close()
     }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/SingleShortestPathPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/SingleShortestPathPipeTest.scala
@@ -22,6 +22,7 @@ package org.neo4j.cypher.internal.compiler.v3_3
 import org.neo4j.cypher.GraphDatabaseFunSuite
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.commands.{ShortestPath, SingleNode}
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes.{FakePipe, ShortestPathPipe}
+import org.neo4j.cypher.internal.compiler.v3_3.QueryStateHelper.withQueryState
 import org.neo4j.cypher.internal.frontend.v3_3.SemanticDirection
 import org.neo4j.cypher.internal.frontend.v3_3.symbols._
 import org.neo4j.graphdb.Node
@@ -53,7 +54,9 @@ class SingleShortestPathPipeTest extends GraphDatabaseFunSuite {
 
     val pipe = ShortestPathPipe(source, path)()
     graph.withTx { tx =>
-      pipe.createResults(QueryStateHelper.queryStateFrom(graph, tx)).next()("p").asInstanceOf[PathValue]
+      withQueryState(graph, tx, Map.empty, { queryState =>
+        pipe.createResults(queryState).next()("p").asInstanceOf[PathValue]
+      })
     }
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundPlanContextTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundPlanContextTest.scala
@@ -70,6 +70,7 @@ class TransactionBoundPlanContextTest extends CypherFunSuite {
       }
     }
 
+    transactionalContext.close(true)
     transaction.close()
   }
 
@@ -101,6 +102,7 @@ class TransactionBoundPlanContextTest extends CypherFunSuite {
     statistics.cardinalityByLabelsAndRelationshipType(
       None, Some(RelTypeId(0)), None) should equal(Cardinality(100))
 
+    transactionalContext.close(true)
     transaction.close()
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundQueryContextTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundQueryContextTest.scala
@@ -131,6 +131,7 @@ class TransactionBoundQueryContextTest extends CypherFunSuite {
     iteratorA.toList should equal(iteratorB.toList)
     2 should equal(iterable.size)
 
+    transactionalContext.close(true)
     tx.success()
     tx.close()
   }
@@ -146,6 +147,7 @@ class TransactionBoundQueryContextTest extends CypherFunSuite {
     context.getImportURL(new URL("file:///tmp/foo/data.csv")) should equal(Right(new URL("file:///tmp/foo/data.csv")))
     context.getImportURL(new URL("jar:file:/tmp/blah.jar!/tmp/foo/data.csv")) should equal(Left("loading resources via protocol 'jar' is not permitted"))
 
+    transactionalContext.close(true)
     tx.success()
     tx.close()
   }
@@ -163,6 +165,7 @@ class TransactionBoundQueryContextTest extends CypherFunSuite {
     context.getImportURL(new URL("http://localhost:7474/data.csv")) should equal (Right(new URL("http://localhost:7474/data.csv")))
     context.getImportURL(new URL("file:///tmp/foo/data.csv")) should equal (Left("configuration property 'dbms.security.allow_csv_import_from_file_urls' is false"))
 
+    transactionalContext.close(true)
     tx.success()
     tx.close()
   }
@@ -187,6 +190,7 @@ class TransactionBoundQueryContextTest extends CypherFunSuite {
     val accesses = tracer.getPageCacheHits + tracer.getPageCacheMisses
     assertThat(Long.box(accesses), greaterThan(Long.box(1L)))
 
+    transactionalContext.close(true)
     tx.close()
   }
 

--- a/community/graph-algo/pom.xml
+++ b/community/graph-algo/pom.xml
@@ -13,6 +13,9 @@
     <bundle.namespace>org.neo4j.graphalgo</bundle.namespace>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <test.runner.jvm.settings.additional>
+      -Dorg.neo4j.kernel.impl.api.KernelStatement.trackStatements=false
+    </test.runner.jvm.settings.additional>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/ancestor/AncestorsUtil.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/ancestor/AncestorsUtil.java
@@ -19,13 +19,14 @@
  */
 package org.neo4j.graphalgo.impl.ancestor;
 
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PathExpander;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.helpers.collection.Iterators;
 
 import static org.neo4j.graphdb.traversal.BranchState.NO_STATE;
 import static org.neo4j.graphdb.traversal.Paths.singleNodePath;
@@ -68,13 +69,15 @@ public class AncestorsUtil
     {
         LinkedList<Node> ancestors = new LinkedList<Node>();
         ancestors.add( node );
-        Iterator<Relationship> relIterator = expander.expand( singleNodePath( node ), NO_STATE ).iterator();
+        ResourceIterator<Relationship> relIterator =
+                Iterators.asResourceIterator( expander.expand( singleNodePath( node ), NO_STATE ).iterator() );
         while ( relIterator.hasNext() )
         {
             Relationship rel = relIterator.next();
             node = rel.getOtherNode( node );
             ancestors.add( node );
-            relIterator = expander.expand( singleNodePath( node ), NO_STATE ).iterator();
+            relIterator.close();
+            relIterator = Iterators.asResourceIterator( expander.expand( singleNodePath( node ), NO_STATE ).iterator() );
         }
         return ancestors;
     }
@@ -96,15 +99,18 @@ public class AncestorsUtil
                     return;
                 }
             }
-            Iterator<Relationship> relIt = expander.expand( singleNodePath( currentNode ), NO_STATE ).iterator();
-            if ( relIt.hasNext() )
+            try ( ResourceIterator<Relationship> relIt = Iterators.asResourceIterator(
+                    expander.expand( singleNodePath( currentNode ), NO_STATE ).iterator() ) )
             {
-                Relationship rel = relIt.next();
-                currentNode = rel.getOtherNode( currentNode );
-            }
-            else
-            {
-                currentNode = null;
+                if ( relIt.hasNext() )
+                {
+                    Relationship rel = relIt.next();
+                    currentNode = rel.getOtherNode( currentNode );
+                }
+                else
+                {
+                    currentNode = null;
+                }
             }
         }
     }

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/DijkstraBidirectional.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/DijkstraBidirectional.java
@@ -46,6 +46,7 @@ import org.neo4j.graphdb.traversal.TraversalDescription;
 import org.neo4j.graphdb.traversal.TraversalMetadata;
 import org.neo4j.graphdb.traversal.Traverser;
 import org.neo4j.graphdb.traversal.Uniqueness;
+import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.impl.util.NoneStrictMath;
 
 import static org.neo4j.graphdb.Direction.OUTGOING;
@@ -174,7 +175,7 @@ public class DijkstraBidirectional implements PathFinder<WeightedPath>
             if ( NoneStrictMath.compare( thisState + otherSideShortest.doubleValue(), shortestSoFar.doubleValue(), epsilon ) > 0 &&
                  stopAfterLowestCost )
             {
-                return Collections.emptyList();
+                return Iterables.resourceIterable( Collections.emptyList() );
             }
             return source.expand( path, state );
         }

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/DijkstraBidirectional.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/DijkstraBidirectional.java
@@ -21,8 +21,6 @@ package org.neo4j.graphalgo.impl.path;
 
 import org.apache.commons.lang3.mutable.MutableDouble;
 
-import java.util.Collections;
-
 import org.neo4j.graphalgo.CostEvaluator;
 import org.neo4j.graphalgo.PathFinder;
 import org.neo4j.graphalgo.WeightedPath;
@@ -175,7 +173,7 @@ public class DijkstraBidirectional implements PathFinder<WeightedPath>
             if ( NoneStrictMath.compare( thisState + otherSideShortest.doubleValue(), shortestSoFar.doubleValue(), epsilon ) > 0 &&
                  stopAfterLowestCost )
             {
-                return Iterables.resourceIterable( Collections.emptyList() );
+                return Iterables.emptyResourceIterable();
             }
             return source.expand( path, state );
         }

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/TraversalAStar.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/TraversalAStar.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.graphalgo.impl.path;
 
-import java.util.Iterator;
-
 import org.neo4j.graphalgo.CostEvaluator;
 import org.neo4j.graphalgo.EstimateEvaluator;
 import org.neo4j.graphalgo.PathFinder;
@@ -33,6 +31,7 @@ import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PathExpander;
+import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.graphdb.traversal.InitialBranchState;
 import org.neo4j.graphdb.traversal.TraversalBranch;
 import org.neo4j.graphdb.traversal.TraversalDescription;
@@ -40,6 +39,7 @@ import org.neo4j.graphdb.traversal.TraversalMetadata;
 import org.neo4j.graphdb.traversal.Traverser;
 import org.neo4j.graphdb.traversal.Uniqueness;
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.helpers.collection.Iterators;
 
 import static org.neo4j.graphdb.traversal.Evaluators.includeWhereEndNodeIs;
 import static org.neo4j.graphdb.traversal.InitialBranchState.NO_STATE;
@@ -102,7 +102,7 @@ public class TraversalAStar implements PathFinder<WeightedPath>
         return Iterables.firstOrNull( findPaths( start, end, false ) );
     }
 
-    private Iterable<WeightedPath> findPaths( Node start, Node end, boolean multiplePaths )
+    private ResourceIterable<WeightedPath> findPaths( Node start, Node end, boolean multiplePaths )
     {
         PathInterest interest;
         if ( multiplePaths )
@@ -122,7 +122,8 @@ public class TraversalAStar implements PathFinder<WeightedPath>
                 new SelectorFactory( end, interest ) )
                 .evaluator( includeWhereEndNodeIs( end ) )
                 .traverse( start );
-        return () -> new WeightedPathIterator( lastTraverser.iterator(), costEvaluator, stopAfterLowestWeight );
+        return Iterators.asResourceIterable(
+                new WeightedPathIterator( lastTraverser.iterator(), costEvaluator, stopAfterLowestWeight ) );
     }
 
     @Override

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/TraversalPathFinder.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/TraversalPathFinder.java
@@ -25,7 +25,7 @@ import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.traversal.TraversalMetadata;
 import org.neo4j.graphdb.traversal.Traverser;
 import org.neo4j.helpers.collection.Iterables;
-import org.neo4j.helpers.collection.LimitingIterable;
+import org.neo4j.helpers.collection.LimitingResourceIterable;
 
 public abstract class TraversalPathFinder implements PathFinder<Path>
 {
@@ -47,7 +47,7 @@ public abstract class TraversalPathFinder implements PathFinder<Path>
     {
         lastTraverser = instantiateTraverser( start, end );
         Integer maxResultCount = maxResultCount();
-        return maxResultCount != null ? new LimitingIterable<Path>( lastTraverser, maxResultCount ) : lastTraverser;
+        return maxResultCount != null ? new LimitingResourceIterable<>( lastTraverser, maxResultCount ) : lastTraverser;
     }
 
     protected abstract Traverser instantiateTraverser( Node start, Node end );

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/Dijkstra.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/shortestpath/Dijkstra.java
@@ -35,6 +35,9 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.ResourceIterable;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.helpers.collection.Iterables;
 
 /**
  * Dijkstra class. This class can be used to perform shortest path computations
@@ -312,100 +315,93 @@ public class Dijkstra<CostType> implements
                 // Otherwise, follow all edges from this node
                 for ( RelationshipType costRelationType : costRelationTypes )
                 {
-                    for ( Relationship relationship : currentNode.getRelationships(
-                            costRelationType, getDirection() ) )
+                    ResourceIterable<Relationship> relationships = Iterables.asResourceIterable(
+                            currentNode.getRelationships( costRelationType, getDirection() ) );
+                    try ( ResourceIterator<Relationship> iterator = relationships.iterator() )
                     {
-                        if ( limitReached() )
+                        while ( iterator.hasNext() )
                         {
-                            break;
-                        }
-                        ++numberOfTraversedRelationShips;
-                        // Target node
-                        Node target = relationship.getOtherNode( currentNode );
-                        // Find out if an eventual path would go in the opposite
-                        // direction of the edge
-                        boolean backwardsEdge = relationship.getEndNode().equals(
-                                currentNode )
-                                                ^ backwards;
-                        CostType newCost = costAccumulator.addCosts(
-                                currentCost, costEvaluator.getCost(
-                                        relationship,
-                                        backwardsEdge ? Direction.INCOMING
-                                                : Direction.OUTGOING ) );
-                        // Already done with target node?
-                        if ( myDistances.containsKey( target ) )
-                        {
-                            // Have we found a better cost for a node which is
-                            // already
-                            // calculated?
-                            if ( costComparator.compare(
-                                    myDistances.get( target ), newCost ) > 0 )
+                            Relationship relationship = iterator.next();
+                            if ( limitReached() )
                             {
-                                throw new RuntimeException(
-                                        "Cycle with negative costs found." );
+                                break;
                             }
-                            // Equally good path found?
-                            else if ( calculateAllShortestPaths
-                                      && costComparator.compare(
-                                              myDistances.get( target ),
-                                              newCost ) == 0 )
+                            ++numberOfTraversedRelationShips;
+                            // Target node
+                            Node target = relationship.getOtherNode( currentNode );
+                            // Find out if an eventual path would go in the opposite
+                            // direction of the edge
+                            boolean backwardsEdge = relationship.getEndNode().equals( currentNode ) ^ backwards;
+                            CostType newCost = costAccumulator.addCosts( currentCost, costEvaluator
+                                    .getCost( relationship, backwardsEdge ? Direction.INCOMING : Direction.OUTGOING ) );
+                            // Already done with target node?
+                            if ( myDistances.containsKey( target ) )
                             {
-                                // Put it in predecessors
-                                List<Relationship> myPredecessors = predecessors.get( currentNode );
-                                // Dont do it if this relation is already in
-                                // predecessors (other direction)
-                                if ( myPredecessors == null
-                                     || !myPredecessors.contains( relationship ) )
+                                // Have we found a better cost for a node which is
+                                // already
+                                // calculated?
+                                if ( costComparator.compare( myDistances.get( target ), newCost ) > 0 )
                                 {
-                                    List<Relationship> predList = predecessors.get( target );
-                                    if ( predList == null )
+                                    throw new RuntimeException( "Cycle with negative costs found." );
+                                }
+                                // Equally good path found?
+                                else if ( calculateAllShortestPaths &&
+                                        costComparator.compare( myDistances.get( target ), newCost ) == 0 )
+                                {
+                                    // Put it in predecessors
+                                    List<Relationship> myPredecessors = predecessors.get( currentNode );
+                                    // Dont do it if this relation is already in
+                                    // predecessors (other direction)
+                                    if ( myPredecessors == null || !myPredecessors.contains( relationship ) )
                                     {
-                                        // This only happens if we get back to
-                                        // the
-                                        // start node, which is just bogus
-                                    }
-                                    else
-                                    {
-                                        predList.add( relationship );
+                                        List<Relationship> predList = predecessors.get( target );
+                                        if ( predList == null )
+                                        {
+                                            // This only happens if we get back to
+                                            // the
+                                            // start node, which is just bogus
+                                        }
+                                        else
+                                        {
+                                            predList.add( relationship );
+                                        }
                                     }
                                 }
+                                continue;
                             }
-                            continue;
-                        }
-                        // Have we found a better cost for this node?
-                        if ( !mySeen.containsKey( target )
-                             || costComparator.compare( mySeen.get( target ),
-                                     newCost ) > 0 )
-                        {
-                            // Put it in the queue
-                            if ( !mySeen.containsKey( target ) )
+                            // Have we found a better cost for this node?
+                            if ( !mySeen.containsKey( target ) ||
+                                    costComparator.compare( mySeen.get( target ), newCost ) > 0 )
                             {
-                                queue.insertValue( target, newCost );
+                                // Put it in the queue
+                                if ( !mySeen.containsKey( target ) )
+                                {
+                                    queue.insertValue( target, newCost );
+                                }
+                                // or update the entry. (It is important to keep
+                                // these
+                                // cases apart to limit the size of the queue)
+                                else
+                                {
+                                    queue.decreaseValue( target, newCost );
+                                }
+                                // Update it
+                                mySeen.put( target, newCost );
+                                // Put it in predecessors
+                                List<Relationship> predList = new LinkedList<Relationship>();
+                                predList.add( relationship );
+                                predecessors.put( target, predList );
                             }
-                            // or update the entry. (It is important to keep
-                            // these
-                            // cases apart to limit the size of the queue)
-                            else
+                            // Have we found an equal cost for (additonal path to)
+                            // this
+                            // node?
+                            else if ( calculateAllShortestPaths &&
+                                    costComparator.compare( mySeen.get( target ), newCost ) == 0 )
                             {
-                                queue.decreaseValue( target, newCost );
+                                // Put it in predecessors
+                                List<Relationship> predList = predecessors.get( target );
+                                predList.add( relationship );
                             }
-                            // Update it
-                            mySeen.put( target, newCost );
-                            // Put it in predecessors
-                            List<Relationship> predList = new LinkedList<Relationship>();
-                            predList.add( relationship );
-                            predecessors.put( target, predList );
-                        }
-                        // Have we found an equal cost for (additonal path to)
-                        // this
-                        // node?
-                        else if ( calculateAllShortestPaths
-                                  && costComparator.compare(
-                                          mySeen.get( target ), newCost ) == 0 )
-                        {
-                            // Put it in predecessors
-                            List<Relationship> predList = predecessors.get( target );
-                            predList.add( relationship );
                         }
                     }
                 }

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/WeightedPathImpl.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/WeightedPathImpl.java
@@ -108,4 +108,10 @@ public class WeightedPathImpl implements WeightedPath
     {
         return path.iterator();
     }
+
+    @Override
+    public void close()
+    {
+        path.close();
+    }
 }

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/WeightedPathImpl.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/WeightedPathImpl.java
@@ -109,9 +109,4 @@ public class WeightedPathImpl implements WeightedPath
         return path.iterator();
     }
 
-    @Override
-    public void close()
-    {
-        path.close();
-    }
 }

--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/WeightedPathIterator.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/util/WeightedPathIterator.java
@@ -19,37 +19,36 @@
  */
 package org.neo4j.graphalgo.impl.util;
 
-import java.util.Iterator;
-
 import org.neo4j.graphalgo.CostEvaluator;
 import org.neo4j.graphalgo.WeightedPath;
 import org.neo4j.graphdb.Path;
-import org.neo4j.helpers.collection.PrefetchingIterator;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.helpers.collection.PrefetchingResourceIterator;
 import org.neo4j.kernel.impl.util.NoneStrictMath;
 
-public class WeightedPathIterator extends PrefetchingIterator<WeightedPath>
+public class WeightedPathIterator extends PrefetchingResourceIterator<WeightedPath>
 {
-    private final Iterator<Path> paths;
+    private final ResourceIterator<Path> paths;
     private final CostEvaluator<Double> costEvaluator;
     private Double foundWeight;
     private int foundTotal;
     private final double epsilon;
     private final PathInterest interest;
 
-    public WeightedPathIterator( Iterator<Path> paths, CostEvaluator<Double> costEvaluator,
+    public WeightedPathIterator( ResourceIterator<Path> paths, CostEvaluator<Double> costEvaluator,
             boolean stopAfterLowestWeight )
     {
         this( paths, costEvaluator, NoneStrictMath.EPSILON, stopAfterLowestWeight );
     }
 
-    public WeightedPathIterator( Iterator<Path> paths, CostEvaluator<Double> costEvaluator,
+    public WeightedPathIterator( ResourceIterator<Path> paths, CostEvaluator<Double> costEvaluator,
             double epsilon, boolean stopAfterLowestWeight )
     {
         this( paths, costEvaluator, epsilon, stopAfterLowestWeight ? PathInterestFactory.allShortest( epsilon ) :
                                                                      PathInterestFactory.all( epsilon ) );
     }
 
-    public WeightedPathIterator( Iterator<Path> paths, CostEvaluator<Double> costEvaluator,
+    public WeightedPathIterator( ResourceIterator<Path> paths, CostEvaluator<Double> costEvaluator,
             double epsilon, PathInterest interest )
     {
         this.paths = paths;
@@ -77,5 +76,11 @@ public class WeightedPathIterator extends PrefetchingIterator<WeightedPath>
         }
         foundWeight = path.weight();
         return path;
+    }
+
+    @Override
+    public void close()
+    {
+        paths.close();
     }
 }

--- a/community/graph-algo/src/test/java/common/Neo4jAlgoTestCase.java
+++ b/community/graph-algo/src/test/java/common/Neo4jAlgoTestCase.java
@@ -35,7 +35,9 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertEquals;
@@ -154,17 +156,23 @@ public abstract class Neo4jAlgoTestCase
     public void assertPaths( Iterable<? extends Path> paths, List<String> pathDefs )
     {
         List<String> unexpectedDefs = new ArrayList<String>();
-        for ( Path path : paths )
+        try ( ResourceIterator<? extends Path> iterator = Iterators.asResourceIterator( paths.iterator() ) )
         {
-            String pathDef = getPathDef( path );
-            int index = pathDefs.indexOf( pathDef );
-            if ( index != -1 )
+            while ( iterator.hasNext() )
             {
-                pathDefs.remove( index );
-            }
-            else
-            {
-                unexpectedDefs.add( getPathDef( path ) );
+                Path path = iterator.next();
+
+                String pathDef = getPathDef( path );
+                int index = pathDefs.indexOf( pathDef );
+                if ( index != -1 )
+                {
+                    pathDefs.remove( index );
+                }
+                else
+                {
+                    unexpectedDefs.add( getPathDef( path ) );
+                }
+                path.close();
             }
         }
         assertTrue( "These unexpected paths were found: " + unexpectedDefs +

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/ancestor/AncestorTestCase.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/ancestor/AncestorTestCase.java
@@ -49,6 +49,18 @@ public class AncestorTestCase implements GraphHolder
     public TestData<Map<String,Node>> data = TestData.producedThrough( GraphDescription.createGraphFor( this, true ) );
     private static GraphDatabaseService gdb;
 
+    @BeforeClass
+    public static void before()
+    {
+        gdb = new TestGraphDatabaseFactory().newImpermanentDatabase();
+    }
+
+    @AfterClass
+    public static void after()
+    {
+        gdb.shutdown();
+    }
+
     @Test
     @Graph( { "root contains child1", "child1 contains child11",
             "child1 contains child12", "root contains child2",
@@ -133,16 +145,6 @@ public class AncestorTestCase implements GraphHolder
         return gdb;
     }
 
-    @BeforeClass
-    public static void before()
-    {
-        gdb = new TestGraphDatabaseFactory().newImpermanentDatabase();
-    }
-    @AfterClass
-    public static void after()
-    {
-        gdb.shutdown();
-    }
     enum Rels implements RelationshipType
     {
         contains

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/path/TestShortestPath.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/path/TestShortestPath.java
@@ -76,30 +76,39 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         final Label F = Label.label( "F" );
         final RelationshipType relType = RelationshipType.withName( "TO" );
         recursiveSnowFlake( null, 0, 4, 5, new Label[]{A, B, C, D, E}, relType );
-        final Node a = graphDb.findNodes( A ).next();
-        final ResourceIterator<Node> allE = graphDb.findNodes( E );
-        while ( allE.hasNext() )
+        Node a = getNodeByLabel( A );
+        try ( ResourceIterator<Node> allE = graphDb.findNodes( E ) )
         {
-            final Node e = allE.next();
-            final Node f = graphDb.createNode( F );
-            f.createRelationshipTo( e, relType );
+            while ( allE.hasNext() )
+            {
+                final Node e = allE.next();
+                final Node f = graphDb.createNode( F );
+                f.createRelationshipTo( e, relType );
+            }
         }
         final CountingPathExpander countingPathExpander =
                 new CountingPathExpander( PathExpanders.forTypeAndDirection( relType, Direction.OUTGOING ) );
-        final ShortestPath shortestPath =
-                new ShortestPath( Integer.MAX_VALUE, countingPathExpander, Integer.MAX_VALUE );
-        final ResourceIterator<Node> allF = graphDb.findNodes( F );
-        final long start = System.currentTimeMillis();
-        while ( allF.hasNext() )
+        final ShortestPath shortestPath = new ShortestPath( Integer.MAX_VALUE, countingPathExpander, Integer.MAX_VALUE );
+        try ( ResourceIterator<Node> allF = graphDb.findNodes( F ) )
         {
-            final Node f = allF.next();
-            shortestPath.findAllPaths( a, f );
+            while ( allF.hasNext() )
+            {
+                final Node f = allF.next();
+                shortestPath.findAllPaths( a, f );
+            }
         }
-        final long totalTime = System.currentTimeMillis() - start;
         assertEquals(
                 "There are 625 different end nodes. The algorithm should start one traversal for each such node. " +
                         "That is 625*2 visited nodes if traversal is interrupted correctly.", 1250,
                 countingPathExpander.nodesVisited.intValue() );
+    }
+
+    private Node getNodeByLabel( Label label )
+    {
+        try ( ResourceIterator<Node> iterator = graphDb.findNodes( label ) )
+        {
+            return iterator.next();
+        }
     }
 
     private void recursiveSnowFlake( Node parent, int level, final int desiredLevel, final int branchingFactor,

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/DijkstraTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/DijkstraTest.java
@@ -65,13 +65,15 @@ public class DijkstraTest extends Neo4jAlgoTestCase
 
         // WHEN
         PathFinder<WeightedPath> finder = factory.dijkstra( PathExpanders.allTypesAndDirections() );
-        WeightedPath path = finder.findSinglePath( start, start );
+        try ( WeightedPath path = finder.findSinglePath( start, start ) )
+        {
 
-        // THEN
-        assertNotNull( path );
-        assertEquals( start, path.startNode() );
-        assertEquals( start, path.endNode() );
-        assertEquals( 0, path.length() );
+            // THEN
+            assertNotNull( path );
+            assertEquals( start, path.startNode() );
+            assertEquals( start, path.endNode() );
+            assertEquals( 0, path.length() );
+        }
     }
 
     @Test

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestExactDepthPathFinder.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestExactDepthPathFinder.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.graphalgo.path;
 
+import common.Neo4jAlgoTestCase;
 import org.junit.Test;
 
 import org.neo4j.graphalgo.GraphAlgoFactory;
@@ -29,7 +30,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.PathExpander;
 import org.neo4j.graphdb.PathExpanders;
-import common.Neo4jAlgoTestCase;
+
 import static org.junit.Assert.assertNotNull;
 
 public class TestExactDepthPathFinder extends Neo4jAlgoTestCase
@@ -64,9 +65,11 @@ public class TestExactDepthPathFinder extends Neo4jAlgoTestCase
     {
         createGraph();
         PathFinder<Path> finder = newFinder();
-        Path path = finder.findSinglePath( graph.getNode( "SOURCE" ), graph.getNode( "TARGET" ) );
-        assertNotNull( path );
-        assertPathDef( path, "SOURCE", "z", "9", "0", "TARGET" );
+        try ( Path path = finder.findSinglePath( graph.getNode( "SOURCE" ), graph.getNode( "TARGET" ) ) )
+        {
+            assertNotNull( path );
+            assertPathDef( path, "SOURCE", "z", "9", "0", "TARGET" );
+        }
     }
 
     @Test

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/Node.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/Node.java
@@ -78,7 +78,9 @@ public interface Node extends Entity
      * are attached to this node, an empty iterable will be returned.
      *
      * @return all relationships attached to this node
+     * @deprecated this method should return {@link ResourceIterable} instead
      */
+    @Deprecated
     Iterable<Relationship> getRelationships();
 
     /**
@@ -99,7 +101,9 @@ public interface Node extends Entity
      * @param types the given relationship type(s)
      * @return all relationships of the given type(s) that are attached to this
      *         node
+     * @deprecated this method should return {@link ResourceIterable} instead
      */
+    @Deprecated
     Iterable<Relationship> getRelationships( RelationshipType... types );
 
     /**
@@ -112,7 +116,9 @@ public interface Node extends Entity
      * @param direction the direction of the relationships to return.
      * @return all relationships of the given type(s) that are attached to this
      *         node
+     * @deprecated this method should return {@link ResourceIterable} instead
      */
+    @Deprecated
     Iterable<Relationship> getRelationships( Direction direction, RelationshipType... types );
 
     /**
@@ -156,7 +162,9 @@ public interface Node extends Entity
      *            {@link Relationship#getEndNode() end node}
      * @return all relationships with the given direction that are attached to
      *         this node
+     * @deprecated this method should return {@link ResourceIterable} instead
      */
+    @Deprecated
     Iterable<Relationship> getRelationships( Direction dir );
 
     /**
@@ -191,7 +199,9 @@ public interface Node extends Entity
      *            {@link Relationship#getEndNode() end node}
      * @return all relationships attached to this node that match the given type
      *         and direction
+     * @deprecated this method should return {@link ResourceIterable} instead
      */
+    @Deprecated
     Iterable<Relationship> getRelationships( RelationshipType type, Direction dir );
 
     /**

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/Node.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/Node.java
@@ -78,9 +78,7 @@ public interface Node extends Entity
      * are attached to this node, an empty iterable will be returned.
      *
      * @return all relationships attached to this node
-     * @deprecated this method should return {@link ResourceIterable} instead
      */
-    @Deprecated
     Iterable<Relationship> getRelationships();
 
     /**
@@ -101,9 +99,7 @@ public interface Node extends Entity
      * @param types the given relationship type(s)
      * @return all relationships of the given type(s) that are attached to this
      *         node
-     * @deprecated this method should return {@link ResourceIterable} instead
      */
-    @Deprecated
     Iterable<Relationship> getRelationships( RelationshipType... types );
 
     /**
@@ -116,9 +112,7 @@ public interface Node extends Entity
      * @param direction the direction of the relationships to return.
      * @return all relationships of the given type(s) that are attached to this
      *         node
-     * @deprecated this method should return {@link ResourceIterable} instead
      */
-    @Deprecated
     Iterable<Relationship> getRelationships( Direction direction, RelationshipType... types );
 
     /**
@@ -162,9 +156,7 @@ public interface Node extends Entity
      *            {@link Relationship#getEndNode() end node}
      * @return all relationships with the given direction that are attached to
      *         this node
-     * @deprecated this method should return {@link ResourceIterable} instead
      */
-    @Deprecated
     Iterable<Relationship> getRelationships( Direction dir );
 
     /**
@@ -199,9 +191,7 @@ public interface Node extends Entity
      *            {@link Relationship#getEndNode() end node}
      * @return all relationships attached to this node that match the given type
      *         and direction
-     * @deprecated this method should return {@link ResourceIterable} instead
      */
-    @Deprecated
     Iterable<Relationship> getRelationships( RelationshipType type, Direction dir );
 
     /**

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/Path.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/Path.java
@@ -30,7 +30,7 @@ import java.util.Iterator;
  * position of the traverser is represented by each such path. The current
  * node in such a traversal is reached via {@link Path#endNode()}.
  */
-public interface Path extends Iterable<PropertyContainer>
+public interface Path extends Iterable<PropertyContainer>, Resource
 {
     /**
      * Returns the start node of this path. It's also the first node returned
@@ -130,4 +130,10 @@ public interface Path extends Iterable<PropertyContainer>
      * @see Iterable#iterator()
      */
     Iterator<PropertyContainer> iterator();
+
+    @Override
+    default void close()
+    {
+        // empty
+    }
 }

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/PathExpander.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/PathExpander.java
@@ -39,7 +39,9 @@ public interface PathExpander<STATE>
      * the children of this branch. If state isn't altered the children
      * of this path will see the state of the parent.
      * @return the relationships to return for the {@code path}.
+     * @deprecated should return {@link ResourceIterable}
      */
+    @Deprecated
     Iterable<Relationship> expand( Path path, BranchState<STATE> state );
 
     /**

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/PathExpander.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/PathExpander.java
@@ -39,9 +39,7 @@ public interface PathExpander<STATE>
      * the children of this branch. If state isn't altered the children
      * of this path will see the state of the parent.
      * @return the relationships to return for the {@code path}.
-     * @deprecated should return {@link ResourceIterable}
      */
-    @Deprecated
     Iterable<Relationship> expand( Path path, BranchState<STATE> state );
 
     /**

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/impl/StandardExpander.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/impl/StandardExpander.java
@@ -36,14 +36,18 @@ import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.PathExpander;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.ResourceIterable;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.traversal.BranchState;
 import org.neo4j.helpers.collection.ArrayIterator;
 import org.neo4j.helpers.collection.FilteringIterator;
-import org.neo4j.helpers.collection.IteratorWrapper;
-import org.neo4j.helpers.collection.NestingIterator;
+import org.neo4j.helpers.collection.MappingResourceIterator;
+import org.neo4j.helpers.collection.NestingResourceIterator;
 
 import static java.util.Arrays.asList;
 import static org.neo4j.graphdb.traversal.Paths.singleNodePath;
+import static org.neo4j.helpers.collection.Iterators.asResourceIterator;
+import static org.neo4j.helpers.collection.ResourceClosingIterator.newResourceIterator;
 
 public abstract class StandardExpander implements PathExpander
 {
@@ -51,7 +55,7 @@ public abstract class StandardExpander implements PathExpander
     {
     }
 
-    abstract static class StandardExpansion<T> implements Iterable<T>
+    abstract static class StandardExpansion<T> implements ResourceIterable<T>
     {
         final StandardExpander expander;
         final Path path;
@@ -154,7 +158,7 @@ public abstract class StandardExpander implements PathExpander
         }
 
         @Override
-        public Iterator<Relationship> iterator()
+        public ResourceIterator<Relationship> iterator()
         {
             return expander.doExpand( path, state );
         }
@@ -186,13 +190,14 @@ public abstract class StandardExpander implements PathExpander
         }
 
         @Override
-        public Iterator<Node> iterator()
+        public ResourceIterator<Node> iterator()
         {
             final Node node = path.endNode();
-            return new IteratorWrapper<Node, Relationship>( expander.doExpand( path, state ) )
+
+            return new MappingResourceIterator<Node, Relationship>( expander.doExpand( path, state ) )
             {
                 @Override
-                protected Node underlyingObjectToObject( Relationship rel )
+                protected Node map( Relationship rel )
                 {
                     return rel.getOtherNode( node );
                 }
@@ -221,9 +226,9 @@ public abstract class StandardExpander implements PathExpander
         }
 
         @Override
-        Iterator<Relationship> doExpand( Path path, BranchState state )
+        ResourceIterator<Relationship> doExpand( Path path, BranchState state )
         {
-            return path.endNode().getRelationships( direction ).iterator();
+            return asResourceIterator( path.endNode().getRelationships( direction ).iterator() );
         }
 
         @Override
@@ -235,7 +240,7 @@ public abstract class StandardExpander implements PathExpander
         @Override
         public StandardExpander remove( RelationshipType type )
         {
-            Map<String, Exclusion> exclude = new HashMap<String, Exclusion>();
+            Map<String, Exclusion> exclude = new HashMap<>();
             exclude.put( type.name(), Exclusion.ALL );
             return new ExcludingExpander( Exclusion.include( direction ), exclude );
         }
@@ -365,15 +370,16 @@ public abstract class StandardExpander implements PathExpander
         }
 
         @Override
-        Iterator<Relationship> doExpand( Path path, BranchState state )
+        ResourceIterator<Relationship> doExpand( Path path, BranchState state )
         {
             final Node node = path.endNode();
-            return new FilteringIterator<>( node.getRelationships().iterator(), rel ->
+            ResourceIterator<Relationship> resourceIterator = asResourceIterator( node.getRelationships().iterator() );
+            return newResourceIterator( resourceIterator, new FilteringIterator<>( resourceIterator, rel ->
             {
                 Exclusion exclude = exclusion.get( rel.getType().name() );
                 exclude = (exclude == null) ? defaultExclusion : exclude;
                 return exclude.accept( node, rel );
-            } );
+            } ) );
         }
 
         @Override
@@ -396,14 +402,13 @@ public abstract class StandardExpander implements PathExpander
                     }
                     else
                     {
-                        newExclusion = new HashMap<String, Exclusion>(
-                                exclusion );
+                        newExclusion = new HashMap<>( exclusion );
                         newExclusion.remove( type.name() );
                     }
                 }
                 else
                 {
-                    newExclusion = new HashMap<String, Exclusion>( exclusion );
+                    newExclusion = new HashMap<>( exclusion );
                     newExclusion.put( type.name(), excluded );
                 }
             }
@@ -418,8 +423,7 @@ public abstract class StandardExpander implements PathExpander
             {
                 return this;
             }
-            Map<String, Exclusion> newExclusion = new HashMap<String, Exclusion>(
-                    exclusion );
+            Map<String, Exclusion> newExclusion = new HashMap<>( exclusion );
             newExclusion.put( type.name(), Exclusion.ALL );
             return new ExcludingExpander( defaultExclusion, newExclusion );
         }
@@ -433,7 +437,7 @@ public abstract class StandardExpander implements PathExpander
         @Override
         public StandardExpander reverse()
         {
-            Map<String, Exclusion> newExclusion = new HashMap<String, Exclusion>();
+            Map<String, Exclusion> newExclusion = new HashMap<>();
             for ( Map.Entry<String, Exclusion> entry : exclusion.entrySet() )
             {
                 newExclusion.put( entry.getKey(), entry.getValue().reversed() );
@@ -490,23 +494,22 @@ public abstract class StandardExpander implements PathExpander
         }
 
         @Override
-        Iterator<Relationship> doExpand( Path path, BranchState state )
+        ResourceIterator<Relationship> doExpand( Path path, BranchState state )
         {
             final Node node = path.endNode();
             if ( directions.length == 1 )
             {
                 DirectionAndTypes direction = directions[0];
-                return node.getRelationships( direction.direction, direction.types ).iterator();
+                return asResourceIterator( node.getRelationships( direction.direction, direction.types ).iterator() );
             }
             else
             {
-                return new NestingIterator<Relationship, DirectionAndTypes>( new ArrayIterator<DirectionAndTypes>(
-                        directions ) )
+                return new NestingResourceIterator<Relationship, DirectionAndTypes>( new ArrayIterator<>( directions ) )
                 {
                     @Override
-                    protected Iterator<Relationship> createNestedIterator( DirectionAndTypes item )
+                    protected ResourceIterator<Relationship> createNestedIterator( DirectionAndTypes item )
                     {
-                        return node.getRelationships( item.direction, item.types ).iterator();
+                        return asResourceIterator( node.getRelationships( item.direction, item.types ).iterator() );
                     }
                 };
             }
@@ -582,9 +585,10 @@ public abstract class StandardExpander implements PathExpander
         }
 
         @Override
-        Iterator<Relationship> doExpand( final Path path, BranchState state )
+        ResourceIterator<Relationship> doExpand( final Path path, BranchState state )
         {
-            return new FilteringIterator<>( expander.doExpand( path, state ), item ->
+            ResourceIterator<Relationship> resourceIterator = expander.doExpand( path, state );
+            return newResourceIterator( resourceIterator, new FilteringIterator<>( resourceIterator, item ->
             {
                 Path extendedPath = ExtendedPath.extend( path, item );
                 for ( Filter filter : filters )
@@ -595,7 +599,7 @@ public abstract class StandardExpander implements PathExpander
                     }
                 }
                 return true;
-            } );
+            } ) );
         }
 
         @Override
@@ -656,9 +660,9 @@ public abstract class StandardExpander implements PathExpander
         }
 
         @Override
-        Iterator<Relationship> doExpand( Path path, BranchState state )
+        ResourceIterator<Relationship> doExpand( Path path, BranchState state )
         {
-            return expander.expand( path, state ).iterator();
+            return asResourceIterator( expander.expand( path, state ).iterator() );
         }
 
         @Override
@@ -793,7 +797,7 @@ public abstract class StandardExpander implements PathExpander
         }
     }
 
-    abstract Iterator<Relationship> doExpand( Path path, BranchState state );
+    abstract ResourceIterator<Relationship> doExpand( Path path, BranchState state );
 
     @Override
     public final String toString()
@@ -843,8 +847,7 @@ public abstract class StandardExpander implements PathExpander
 
     public static StandardExpander create( RelationshipType type, Direction dir )
     {
-        Map<Direction, RelationshipType[]> types =
-                new EnumMap<Direction, RelationshipType[]>( Direction.class );
+        Map<Direction, RelationshipType[]> types = new EnumMap<>( Direction.class );
         types.put( dir, new RelationshipType[]{type} );
         return new RegularExpander( types );
     }
@@ -867,7 +870,7 @@ public abstract class StandardExpander implements PathExpander
         tempMap.get( Direction.INCOMING ).removeAll( both );
 
         // Convert into a final map
-        Map<Direction, RelationshipType[]> map = new EnumMap<Direction, RelationshipType[]>( Direction.class );
+        Map<Direction, RelationshipType[]> map = new EnumMap<>( Direction.class );
         for ( Map.Entry<Direction, Collection<RelationshipType>> entry : tempMap.entrySet() )
         {
             if ( !entry.getValue().isEmpty() )
@@ -880,8 +883,7 @@ public abstract class StandardExpander implements PathExpander
 
     private static Map<Direction, Collection<RelationshipType>> temporaryTypeMap()
     {
-        Map<Direction, Collection<RelationshipType>> map = new EnumMap<Direction,
-                Collection<RelationshipType>>( Direction.class );
+        Map<Direction, Collection<RelationshipType>> map = new EnumMap<>( Direction.class );
         for ( Direction direction : Direction.values() )
         {
             map.put( direction, new ArrayList<>() );
@@ -892,11 +894,10 @@ public abstract class StandardExpander implements PathExpander
     private static Map<Direction, Collection<RelationshipType>> temporaryTypeMapFrom( Map<Direction,
             RelationshipType[]> typeMap )
     {
-        Map<Direction, Collection<RelationshipType>> map = new EnumMap<Direction,
-                Collection<RelationshipType>>( Direction.class );
+        Map<Direction, Collection<RelationshipType>> map = new EnumMap<>( Direction.class );
         for ( Direction direction : Direction.values() )
         {
-            ArrayList<RelationshipType> types = new ArrayList<RelationshipType>();
+            ArrayList<RelationshipType> types = new ArrayList<>();
             map.put( direction, types );
             RelationshipType[] existing = typeMap.get( direction );
             if ( existing != null )

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/LevelSelectorOrderer.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/LevelSelectorOrderer.java
@@ -76,12 +76,29 @@ public class LevelSelectorOrderer extends AbstractSelectorOrderer<LevelSelectorO
         TraversalBranch otherBranch = otherState.branch;
         if ( otherBranch != null )
         {
+            closeBranch( branch );
             otherState.branch = null;
             return otherBranch;
         }
 
         otherBranch = otherSelector.next( metadata );
-        return otherBranch != null ? otherBranch : branch;
+        if ( otherBranch != null )
+        {
+            closeBranch( branch );
+            return otherBranch;
+        }
+        else
+        {
+            return branch;
+        }
+    }
+
+    private void closeBranch( TraversalBranch branch )
+    {
+        if ( branch != null )
+        {
+            branch.close();
+        }
     }
 
     static class Entry

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/LevelSelectorOrderer.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/traversal/LevelSelectorOrderer.java
@@ -76,7 +76,6 @@ public class LevelSelectorOrderer extends AbstractSelectorOrderer<LevelSelectorO
         TraversalBranch otherBranch = otherState.branch;
         if ( otherBranch != null )
         {
-            closeBranch( branch );
             otherState.branch = null;
             return otherBranch;
         }
@@ -84,20 +83,11 @@ public class LevelSelectorOrderer extends AbstractSelectorOrderer<LevelSelectorO
         otherBranch = otherSelector.next( metadata );
         if ( otherBranch != null )
         {
-            closeBranch( branch );
             return otherBranch;
         }
         else
         {
             return branch;
-        }
-    }
-
-    private void closeBranch( TraversalBranch branch )
-    {
-        if ( branch != null )
-        {
-            branch.close();
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -243,6 +243,11 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         this.success = true;
     }
 
+    boolean isSuccess()
+    {
+        return success;
+    }
+
     @Override
     public void failure()
     {
@@ -398,7 +403,12 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     {
         assertTransactionOpen();
         closed = true;
+        notifyListeners( txId );
         closeCurrentStatementIfAny();
+    }
+
+    private void notifyListeners( long txId )
+    {
         for ( CloseListener closeListener : closeListeners )
         {
             closeListener.notify( txId );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TokenAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TokenAccess.java
@@ -133,7 +133,7 @@ public abstract class TokenAccess<R>
         final TokenAccess<T> access;
         final Iterator<Token> tokens;
 
-        TokenIterator( Statement statement, TokenAccess<T> access )
+        private TokenIterator( Statement statement, TokenAccess<T> access )
         {
             this.statement = statement;
             this.access = access;
@@ -161,6 +161,7 @@ public abstract class TokenAccess<R>
                             return access.token( token );
                         }
                     }
+                    close();
                     return null;
                 }
             };
@@ -173,7 +174,15 @@ public abstract class TokenAccess<R>
                 @Override
                 protected T fetchNextOrNull()
                 {
-                    return tokens.hasNext() ? access.token( tokens.next() ) : null;
+                    if ( tokens.hasNext() )
+                    {
+                        return access.token( tokens.next() );
+                    }
+                    else
+                    {
+                        close();
+                        return null;
+                    }
                 }
             };
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -475,7 +475,15 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI
                 @Override
                 protected Relationship fetchNextOrNull()
                 {
-                    return ids.hasNext() ? new RelationshipProxy( relActions, ids.next() ) : null;
+                    if ( ids.hasNext() )
+                    {
+                        return new RelationshipProxy( relActions, ids.next() );
+                    }
+                    else
+                    {
+                        close();
+                        return null;
+                    }
                 }
             };
         };

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/query/Neo4jTransactionalContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/query/Neo4jTransactionalContext.java
@@ -170,6 +170,7 @@ public class Neo4jTransactionalContext implements TransactionalContext
 
         // (1) Unbind current transaction
         QueryRegistryOperations oldQueryRegistryOperations = statement.queryRegistration();
+        Statement oldStatement = statement;
         InternalTransaction oldTransaction = transaction;
         KernelTransaction oldKernelTx = txBridge.getKernelTransactionBoundToThisThread( true );
         txBridge.unbindTransactionFromCurrentThread();
@@ -186,6 +187,7 @@ public class Neo4jTransactionalContext implements TransactionalContext
         oldQueryRegistryOperations.unregisterExecutingQuery( executingQuery );
         try
         {
+            oldStatement.close();
             oldTransaction.success();
             oldTransaction.close();
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/BidirectionalTraversalDescriptionImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/BidirectionalTraversalDescriptionImpl.java
@@ -143,9 +143,20 @@ public class BidirectionalTraversalDescriptionImpl implements BidirectionalTrave
     @Override
     public Traverser traverse( final Iterable<Node> startNodes, final Iterable<Node> endNodes )
     {
-        return new DefaultTraverser( () -> new BidirectionalTraverserIterator(
-                statementFactory.get(), start, end, sideSelector, collisionPolicy, collisionEvaluator, maxDepth,
-                startNodes, endNodes ) );
+        return new DefaultTraverser( () ->
+        {
+            Resource resource = statementFactory.get();
+            try
+            {
+                return new BidirectionalTraverserIterator( resource, start, end, sideSelector, collisionPolicy,
+                        collisionEvaluator, maxDepth, startNodes, endNodes );
+            }
+            catch ( Exception e )
+            {
+                resource.close();
+                throw e;
+            }
+        } );
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/BidirectionalTraversalDescriptionImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/BidirectionalTraversalDescriptionImpl.java
@@ -146,15 +146,21 @@ public class BidirectionalTraversalDescriptionImpl implements BidirectionalTrave
         return new DefaultTraverser( () ->
         {
             Resource resource = statementFactory.get();
+            boolean success = false;
             try
             {
-                return new BidirectionalTraverserIterator( resource, start, end, sideSelector, collisionPolicy,
-                        collisionEvaluator, maxDepth, startNodes, endNodes );
+                BidirectionalTraverserIterator iterator =
+                        new BidirectionalTraverserIterator( resource, start, end, sideSelector, collisionPolicy,
+                                collisionEvaluator, maxDepth, startNodes, endNodes );
+                success = true;
+                return iterator;
             }
-            catch ( Exception e )
+            finally
             {
-                resource.close();
-                throw e;
+                if ( !success )
+                {
+                    resource.close();
+                }
             }
         } );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/BidirectionalTraverserIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/BidirectionalTraverserIterator.java
@@ -161,19 +161,8 @@ class BidirectionalTraverserIterator extends AbstractTraverserIterator
                 if ( foundPaths.hasNext() )
                 {
                     numberOfPathsReturned++;
-                    // not sure we need to close result here
-                    result.close();
-                    Path next = foundPaths.next();
-                    return next;
+                    return foundPaths.next();
                 }
-                else
-                {
-                    result.close();
-                }
-            }
-            else
-            {
-                result.close();
             }
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/BidirectionalTraverserIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/BidirectionalTraverserIterator.java
@@ -161,9 +161,19 @@ class BidirectionalTraverserIterator extends AbstractTraverserIterator
                 if ( foundPaths.hasNext() )
                 {
                     numberOfPathsReturned++;
+                    // not sure we need to close result here
+                    result.close();
                     Path next = foundPaths.next();
                     return next;
                 }
+                else
+                {
+                    result.close();
+                }
+            }
+            else
+            {
+                result.close();
             }
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/MonoDirectionalTraverserIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/MonoDirectionalTraverserIterator.java
@@ -73,6 +73,10 @@ class MonoDirectionalTraverserIterator extends AbstractTraverserIterator
                 numberOfPathsReturned++;
                 return result;
             }
+            else
+            {
+                result.close();
+            }
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/MonoDirectionalTraverserIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/MonoDirectionalTraverserIterator.java
@@ -73,10 +73,6 @@ class MonoDirectionalTraverserIterator extends AbstractTraverserIterator
                 numberOfPathsReturned++;
                 return result;
             }
-            else
-            {
-                result.close();
-            }
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/TraversalBranchImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/TraversalBranchImpl.java
@@ -88,8 +88,7 @@ class TraversalBranchImpl implements TraversalBranch
         }
         else
         {
-            closeRelationships();
-            relationships = Iterators.emptyResourceIterator();
+            resetRelationships();
         }
     }
 
@@ -144,8 +143,7 @@ class TraversalBranchImpl implements TraversalBranch
                 context.unnecessaryRelationshipTraversed();
             }
         }
-        relationships.close();
-        relationships = Iterators.emptyResourceIterator();
+        resetRelationships();
         return null;
     }
 
@@ -157,24 +155,16 @@ class TraversalBranchImpl implements TraversalBranch
     @Override
     public void prune()
     {
-        closeRelationships();
-        relationships = Iterators.emptyResourceIterator();
+        resetRelationships();
     }
 
-    @Override
-    public void close()
-    {
-        //TODO: not sure its a right place to close parent
-        parent.close();
-        closeRelationships();
-    }
-
-    private void closeRelationships()
+    private void resetRelationships()
     {
         if ( relationships != null )
         {
             relationships.close();
         }
+        relationships = Iterators.emptyResourceIterator();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/TraversalBranchWithState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/TraversalBranchWithState.java
@@ -19,15 +19,15 @@
  */
 package org.neo4j.kernel.impl.traversal;
 
-import java.util.Iterator;
-
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PathExpander;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.traversal.BranchState;
 import org.neo4j.graphdb.traversal.InitialBranchState;
 import org.neo4j.graphdb.traversal.TraversalBranch;
 import org.neo4j.graphdb.traversal.TraversalContext;
+import org.neo4j.helpers.collection.Iterators;
 
 public class TraversalBranchWithState extends TraversalBranchImpl implements BranchState
 {
@@ -65,10 +65,10 @@ public class TraversalBranchWithState extends TraversalBranchImpl implements Bra
     }
 
     @Override
-    protected Iterator<Relationship> expandRelationshipsWithoutChecks( PathExpander expander )
+    protected ResourceIterator<Relationship> expandRelationshipsWithoutChecks( PathExpander expander )
     {
-        Iterable<Relationship> iterable = expander.expand( this, this );
-        return iterable.iterator();
+        Iterable expandIterable = expander.expand( this, this );
+        return Iterators.asResourceIterator( expandIterable.iterator() );
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/graphdb/DenseNodeIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/DenseNodeIT.java
@@ -30,6 +30,7 @@ import org.neo4j.test.rule.ImpermanentDatabaseRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.helpers.collection.Iterables.single;
+import static org.neo4j.helpers.collection.Iterators.asResourceIterator;
 
 public class DenseNodeIT
 {
@@ -246,13 +247,17 @@ public class DenseNodeIT
     private void deleteRelationshipsFromNode( Node root, int numberOfRelationships )
     {
         int deleted = 0;
-        for ( Relationship relationship : root.getRelationships() )
+        try ( ResourceIterator<Relationship> iterator = asResourceIterator( root.getRelationships().iterator() ) )
         {
-            relationship.delete();
-            deleted++;
-            if ( deleted == numberOfRelationships )
+            while ( iterator.hasNext() )
             {
-                break;
+                Relationship relationship = iterator.next();
+                relationship.delete();
+                deleted++;
+                if ( deleted == numberOfRelationships )
+                {
+                    break;
+                }
             }
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/graphdb/IndexingAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/IndexingAcceptanceTest.java
@@ -489,9 +489,9 @@ public class IndexingAcceptanceTest
 
         // WHEN
         PrimitiveLongSet found = Primitive.longSet();
-        try ( Transaction tx = db.beginTx() )
+        try ( Transaction tx = db.beginTx();
+              Statement statement = getStatement( (GraphDatabaseAPI) db ) )
         {
-            Statement statement = getStatement( (GraphDatabaseAPI) db );
             ReadOperations ops = statement.readOperations();
             IndexDescriptor descriptor = indexDescriptor( ops, index );
             int propertyKeyId = descriptor.schema().getPropertyId();
@@ -517,11 +517,13 @@ public class IndexingAcceptanceTest
         {
             expected.add( createNode( db, map( "name", "Carlchen" ), LABEL1 ).getId() );
             createNode( db, map( "name", "Karla" ), LABEL1 );
-            Statement statement = getStatement( (GraphDatabaseAPI) db );
-            ReadOperations readOperations = statement.readOperations();
-            IndexDescriptor descriptor = indexDescriptor( readOperations, index );
-            int propertyKeyId = descriptor.schema().getPropertyId();
-            found.addAll( readOperations.indexQuery( descriptor, stringPrefix( propertyKeyId, "Carl" ) ) );
+            try ( Statement statement = getStatement( (GraphDatabaseAPI) db ) )
+            {
+                ReadOperations readOperations = statement.readOperations();
+                IndexDescriptor descriptor = indexDescriptor( readOperations, index );
+                int propertyKeyId = descriptor.schema().getPropertyId();
+                found.addAll( readOperations.indexQuery( descriptor, stringPrefix( propertyKeyId, "Carl" ) ) );
+            }
         }
         // THEN
         assertThat( found, equalTo( expected ) );
@@ -548,11 +550,13 @@ public class IndexingAcceptanceTest
                 db.getNodeById( id ).delete();
                 expected.remove( id );
             }
-            Statement statement = getStatement( (GraphDatabaseAPI) db );
-            ReadOperations readOperations = statement.readOperations();
-            IndexDescriptor descriptor = indexDescriptor( readOperations, index );
-            int propertyKeyId = descriptor.schema().getPropertyId();
-            found.addAll( readOperations.indexQuery( descriptor, stringPrefix( propertyKeyId, "Karl" ) ) );
+            try ( Statement statement = getStatement( (GraphDatabaseAPI) db ) )
+            {
+                ReadOperations readOperations = statement.readOperations();
+                IndexDescriptor descriptor = indexDescriptor( readOperations, index );
+                int propertyKeyId = descriptor.schema().getPropertyId();
+                found.addAll( readOperations.indexQuery( descriptor, stringPrefix( propertyKeyId, "Karl" ) ) );
+            }
         }
         // THEN
         assertThat( found, equalTo( expected ) );
@@ -588,11 +592,13 @@ public class IndexingAcceptanceTest
                 db.getNodeById( id ).setProperty( "name", "X" + id );
                 expected.remove( id );
             }
-            Statement statement = getStatement( (GraphDatabaseAPI) db );
-            ReadOperations readOperations = statement.readOperations();
-            IndexDescriptor descriptor = indexDescriptor( readOperations, index );
-            int propertyKeyId = descriptor.schema().getPropertyId();
-            found.addAll( readOperations.indexQuery( descriptor, stringPrefix( propertyKeyId, prefix ) ) );
+            try ( Statement statement = getStatement( (GraphDatabaseAPI) db ) )
+            {
+                ReadOperations readOperations = statement.readOperations();
+                IndexDescriptor descriptor = indexDescriptor( readOperations, index );
+                int propertyKeyId = descriptor.schema().getPropertyId();
+                found.addAll( readOperations.indexQuery( descriptor, stringPrefix( propertyKeyId, prefix ) ) );
+            }
         }
         // THEN
         assertThat( found, equalTo( expected ) );

--- a/community/kernel/src/test/java/org/neo4j/graphdb/NativeLabelScanStoreStartupIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/NativeLabelScanStoreStartupIT.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.io.pagecache.IOLimiter;
+import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.impl.labelscan.LabelScanStoreTest;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.labelscan.LabelScanWriter;
@@ -106,9 +107,12 @@ public class NativeLabelScanStoreStartupIT
         try ( Transaction transaction = dbRule.beginTx() )
         {
             node = dbRule.createNode( LABEL);
-            labelId = dbRule.getDependencyResolver().resolveDependency( ThreadToStatementContextBridge.class )
-                    .getKernelTransactionBoundToThisThread( true )
-                    .acquireStatement().readOperations().labelGetForName( LABEL.name() );
+            try ( Statement statement = dbRule.getDependencyResolver()
+                    .resolveDependency( ThreadToStatementContextBridge.class )
+                    .getKernelTransactionBoundToThisThread( true ).acquireStatement() )
+            {
+                labelId = statement.readOperations().labelGetForName( LABEL.name() );
+            }
             transaction.success();
         }
         return node;

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/SchemaProcedureIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/SchemaProcedureIT.java
@@ -64,6 +64,7 @@ public class SchemaProcedureIT extends KernelIntegrationTest
 
         // Then
         assertThat( asList( stream ), contains( equalTo( new Object[]{new ArrayList<>(), new ArrayList<>()} ) ) );
+        commit();
     }
 
     @Test
@@ -102,6 +103,7 @@ public class SchemaProcedureIT extends KernelIntegrationTest
             assertEquals( Arrays.asList( "CONSTRAINT ON ( person:Person ) ASSERT person.age IS UNIQUE" ),
                     nodes.get( 0 ).getAllProperties().get( "constraints" ) );
         }
+        commit();
     }
 
     @Test
@@ -136,5 +138,6 @@ public class SchemaProcedureIT extends KernelIntegrationTest
             assertThat( relationships.get( 0 ).getEndNode().getLabels(),
                     contains( equalTo( Label.label( "Location" ) ) ) );
         }
+        commit();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/counts/CompositeCountsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/counts/CompositeCountsTest.java
@@ -393,47 +393,50 @@ public class CompositeCountsTest
      */
     private long countsForRelationship( Label start, RelationshipType type, Label end )
     {
-        ReadOperations read = statementSupplier.get().readOperations();
-        int startId;
-        int typeId;
-        int endId;
-        // start
-        if ( start == null )
+        try ( Statement statement = statementSupplier.get() )
         {
-            startId = ReadOperations.ANY_LABEL;
-        }
-        else
-        {
-            if ( KeyReadOperations.NO_SUCH_LABEL == (startId = read.labelGetForName( start.name() )) )
+            ReadOperations read = statement.readOperations();
+            int startId;
+            int typeId;
+            int endId;
+            // start
+            if ( start == null )
             {
-                return 0;
+                startId = ReadOperations.ANY_LABEL;
             }
-        }
-        // type
-        if ( type == null )
-        {
-            typeId = ReadOperations.ANY_RELATIONSHIP_TYPE;
-        }
-        else
-        {
-            if ( KeyReadOperations.NO_SUCH_LABEL == (typeId = read.relationshipTypeGetForName( type.name() )) )
+            else
             {
-                return 0;
+                if ( KeyReadOperations.NO_SUCH_LABEL == (startId = read.labelGetForName( start.name() )) )
+                {
+                    return 0;
+                }
             }
-        }
-        // end
-        if ( end == null )
-        {
-            endId = ReadOperations.ANY_LABEL;
-        }
-        else
-        {
-            if ( KeyReadOperations.NO_SUCH_LABEL == (endId = read.labelGetForName( end.name() )) )
+            // type
+            if ( type == null )
             {
-                return 0;
+                typeId = ReadOperations.ANY_RELATIONSHIP_TYPE;
             }
+            else
+            {
+                if ( KeyReadOperations.NO_SUCH_LABEL == (typeId = read.relationshipTypeGetForName( type.name() )) )
+                {
+                    return 0;
+                }
+            }
+            // end
+            if ( end == null )
+            {
+                endId = ReadOperations.ANY_LABEL;
+            }
+            else
+            {
+                if ( KeyReadOperations.NO_SUCH_LABEL == (endId = read.labelGetForName( end.name() )) )
+                {
+                    return 0;
+                }
+            }
+            return read.countsForRelationship( startId, typeId, endId );
         }
-        return read.countsForRelationship( startId, typeId, endId );
     }
 
     private Supplier<Statement> statementSupplier;

--- a/community/kernel/src/test/java/org/neo4j/kernel/counts/NodeCountsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/counts/NodeCountsTest.java
@@ -47,6 +47,15 @@ public class NodeCountsTest
     @Rule
     public final ThreadingRule threading = new ThreadingRule();
 
+    private Supplier<Statement> statementSupplier;
+
+    @Before
+    public void setUp()
+    {
+        statementSupplier = db.getGraphDatabaseAPI().getDependencyResolver()
+                .resolveDependency( ThreadToStatementContextBridge.class );
+    }
+
     @Test
     public void shouldReportNumberOfNodesInAnEmptyGraph() throws Exception
     {
@@ -203,15 +212,9 @@ public class NodeCountsTest
 
     private long countsForNode()
     {
-        return statementSupplier.get().readOperations().countsForNode( ReadOperations.ANY_LABEL );
-    }
-
-    private Supplier<Statement> statementSupplier;
-
-    @Before
-    public void exposeGuts()
-    {
-        statementSupplier = db.getGraphDatabaseAPI().getDependencyResolver()
-                              .resolveDependency( ThreadToStatementContextBridge.class );
+        try ( Statement statement = statementSupplier.get() )
+        {
+            return statement.readOperations().countsForNode( ReadOperations.ANY_LABEL );
+        }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/AbstractNeo4jTestCase.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/AbstractNeo4jTestCase.java
@@ -24,8 +24,6 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
 
 import java.io.File;
 import java.io.IOException;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelStatementTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelStatementTest.java
@@ -64,7 +64,14 @@ public class KernelStatementTest
         statement.acquire();
 
         // when
-        statement.forceClose();
+        try
+        {
+            statement.forceClose();
+        }
+        catch ( KernelStatement.StatementNotClosedException ignored )
+        {
+            // ignore
+        }
 
         // then
         verify( storeStatement ).release();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTest.java
@@ -54,10 +54,9 @@ public class KernelTest
         ThreadToStatementContextBridge stmtBridge =
                 db.getDependencyResolver().resolveDependency( ThreadToStatementContextBridge.class );
 
-        try ( Transaction ignored = db.beginTx() )
+        try ( Transaction ignored = db.beginTx();
+                Statement statement = stmtBridge.get() )
         {
-            Statement statement = stmtBridge.get();
-
             try
             {
                 statement.schemaWriteOperations().uniquePropertyConstraintCreate( forLabel( 1, 1 ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementLifecycleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementLifecycleTest.java
@@ -62,7 +62,14 @@ public class StatementLifecycleTest
         statement.acquire();
 
         // when
-        statement.forceClose();
+        try
+        {
+            statement.forceClose();
+        }
+        catch ( KernelStatement.StatementNotClosedException ignored )
+        {
+            //ignored
+        }
 
         // then
         verify( storageStatement ).release();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexCRUDIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexCRUDIT.java
@@ -39,6 +39,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexEntryUpdate;
@@ -89,9 +90,10 @@ public class IndexCRUDIT
         Node node = createNode( map( indexProperty, value1, otherProperty, otherValue ), myLabel );
 
         // Then, for now, this should trigger two NodePropertyUpdates
-        try ( Transaction tx = db.beginTx() )
+        try ( Transaction tx = db.beginTx();
+                Statement statement = ctxSupplier.get() )
         {
-            ReadOperations readOperations = ctxSupplier.get().readOperations();
+            ReadOperations readOperations = statement.readOperations();
             int propertyKey1 = readOperations.propertyKeyGetForName( indexProperty );
             int label = readOperations.labelGetForName( myLabel.name() );
             LabelSchemaDescriptor descriptor = SchemaDescriptorFactory.forLabel( label, propertyKey1 );
@@ -129,9 +131,10 @@ public class IndexCRUDIT
         }
 
         // THEN
-        try ( Transaction tx = db.beginTx() )
+        try ( Transaction tx = db.beginTx();
+              Statement statement = ctxSupplier.get() )
         {
-            ReadOperations readOperations = ctxSupplier.get().readOperations();
+            ReadOperations readOperations = statement.readOperations();
             int propertyKey1 = readOperations.propertyKeyGetForName( indexProperty );
             int label = readOperations.labelGetForName( myLabel.name() );
             LabelSchemaDescriptor descriptor = SchemaDescriptorFactory.forLabel( label, propertyKey1 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
@@ -226,6 +226,7 @@ public class IndexIT extends KernelIntegrationTest
             assertEquals( "Unable to drop index on :label[" + labelId + "](property[" + propertyKeyId + "]): " +
                           "No such INDEX ON :label[" + labelId + "](property[" + propertyKeyId + "]).", e.getMessage() );
         }
+        commit();
     }
 
     @Test
@@ -253,6 +254,7 @@ public class IndexIT extends KernelIntegrationTest
             assertEquals( "Label '" + LABEL + "' and property '" + PROPERTY_KEY + "' have a unique constraint defined" +
                           " on them, so an index is already created that matches this.", e.getMessage() );
         }
+        commit();
     }
 
     @Test
@@ -311,6 +313,7 @@ public class IndexIT extends KernelIntegrationTest
         ReadOperations readOperations = readOperationsInNewTransaction();
         List<IndexDescriptor> indexes = Iterators.asList( readOperations.indexesGetAll() );
         assertThat( indexes, containsInAnyOrder( index1, index2 ) );
+        commit();
     }
 
     private Runnable createIndex( GraphDatabaseAPI db, Label label, String propertyKey )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsIT.java
@@ -138,17 +138,19 @@ public class IndexStatisticsIT
 
     private int labelId( Label alien )
     {
-        try ( Transaction ignore = db.beginTx() )
+        try ( Transaction ignore = db.beginTx();
+              Statement statement = statement() )
         {
-            return statement().readOperations().labelGetForName( alien.name() );
+            return statement.readOperations().labelGetForName( alien.name() );
         }
     }
 
     private int pkId( String propertyName )
     {
-        try ( Transaction ignore = db.beginTx() )
+        try ( Transaction ignore = db.beginTx();
+              Statement statement = statement() )
         {
-            return statement().readOperations().propertyKeyGetForName( propertyName );
+            return statement.readOperations().propertyKeyGetForName( propertyName );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
@@ -184,6 +184,7 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
                         "Get relationship from manual index. Replaces `START r=relationship:relIndex(key = 'A')`"
                 } )
         ) );
+        commit();
     }
 
     @Test
@@ -215,6 +216,8 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
         // Then
         assertThat( asList( stream ), contains( equalTo( new Object[]{"Neo4j Kernel",
                 singletonList( Version.getNeo4jVersion() ), "community"} ) ) );
+
+        commit();
     }
 
     @Test
@@ -252,5 +255,6 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
                 new Object[]{"INDEX ON :Age(foo)", "ONLINE", "node_unique_property"},
                 new Object[]{"INDEX ON :Person(foo)", "ONLINE", "node_label_property"}
         ) );
+        commit();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
@@ -70,7 +70,6 @@ import static org.neo4j.kernel.api.security.SecurityContext.AUTH_DISABLED;
 
 public class KernelIT extends KernelIntegrationTest
 {
-    // TODO: Split this into area-specific tests, see PropertyIT.
 
     @Test
     public void mixingBeansApiWithKernelAPI() throws Exception
@@ -170,9 +169,9 @@ public class KernelIT extends KernelIntegrationTest
         }
 
         // THEN
-        try ( Transaction tx = db.beginTx() )
+        try ( Transaction tx = db.beginTx();
+              Statement statement = statementContextSupplier.get() )
         {
-            Statement statement = statementContextSupplier.get();
             try
             {
                 statement.readOperations().nodeHasLabel( node.getId(), labelId );
@@ -190,24 +189,28 @@ public class KernelIT extends KernelIntegrationTest
     {
         Transaction tx = db.beginTx();
 
-        Statement statement = statementContextSupplier.get();
-
-        // WHEN
+        int labelId1;
+        int labelId2;
         Node node = db.createNode();
-        int labelId1 = statement.tokenWriteOperations().labelGetOrCreateForName( "labello1" );
-        int labelId2 = statement.tokenWriteOperations().labelGetOrCreateForName( "labello2" );
-        statement.dataWriteOperations().nodeAddLabel( node.getId(), labelId1 );
-        statement.dataWriteOperations().nodeAddLabel( node.getId(), labelId2 );
-        statement.dataWriteOperations().nodeRemoveLabel( node.getId(), labelId2 );
-        statement.close();
+        try ( Statement statement = statementContextSupplier.get() )
+        {
+            // WHEN
+            labelId1 = statement.tokenWriteOperations().labelGetOrCreateForName( "labello1" );
+            labelId2 = statement.tokenWriteOperations().labelGetOrCreateForName( "labello2" );
+            statement.dataWriteOperations().nodeAddLabel( node.getId(), labelId1 );
+            statement.dataWriteOperations().nodeAddLabel( node.getId(), labelId2 );
+            statement.dataWriteOperations().nodeRemoveLabel( node.getId(), labelId2 );
+        }
         tx.success();
         tx.close();
 
         // THEN
         tx = db.beginTx();
-        statement = statementContextSupplier.get();
-        assertEquals( PrimitiveIntCollections.asSet( new int[]{labelId1} ),
-                PrimitiveIntCollections.asSet( statement.readOperations().nodeGetLabels( node.getId() ) ) );
+        try ( Statement statement = statementContextSupplier.get() )
+        {
+            assertEquals( PrimitiveIntCollections.asSet( new int[]{labelId1} ),
+                    PrimitiveIntCollections.asSet( statement.readOperations().nodeGetLabels( node.getId() ) ) );
+        }
         tx.close();
     }
 
@@ -307,17 +310,22 @@ public class KernelIT extends KernelIntegrationTest
         // GIVEN
         Transaction tx = db.beginTx();
         Node node = db.createNode();
-        Statement statement = statementContextSupplier.get();
-        int labelId = statement.tokenWriteOperations().labelGetOrCreateForName( "mylabel" );
-        statement.dataWriteOperations().nodeAddLabel( node.getId(), labelId );
-        statement.close();
+        int labelId;
+        try ( Statement statement = statementContextSupplier.get() )
+        {
+            labelId = statement.tokenWriteOperations().labelGetOrCreateForName( "mylabel" );
+            statement.dataWriteOperations().nodeAddLabel( node.getId(), labelId );
+        }
         tx.success();
         tx.close();
 
         // WHEN
         tx = db.beginTx();
-        statement = statementContextSupplier.get();
-        boolean added = statement.dataWriteOperations().nodeAddLabel( node.getId(), labelId );
+        boolean added;
+        try ( Statement statement = statementContextSupplier.get() )
+        {
+            added = statement.dataWriteOperations().nodeAddLabel( node.getId(), labelId );
+        }
         tx.close();
 
         // THEN
@@ -330,16 +338,21 @@ public class KernelIT extends KernelIntegrationTest
         // GIVEN
         Transaction tx = db.beginTx();
         Node node = db.createNode();
-        Statement statement = statementContextSupplier.get();
-        int labelId = statement.tokenWriteOperations().labelGetOrCreateForName( "mylabel" );
-        statement.close();
+        int labelId;
+        try ( Statement statement = statementContextSupplier.get() )
+        {
+            labelId = statement.tokenWriteOperations().labelGetOrCreateForName( "mylabel" );
+        }
         tx.success();
         tx.close();
 
         // WHEN
         tx = db.beginTx();
-        statement = statementContextSupplier.get();
-        boolean added = statement.dataWriteOperations().nodeAddLabel( node.getId(), labelId );
+        boolean added;
+        try ( Statement statement = statementContextSupplier.get() )
+        {
+            added = statement.dataWriteOperations().nodeAddLabel( node.getId(), labelId );
+        }
         tx.close();
 
         // THEN
@@ -352,17 +365,22 @@ public class KernelIT extends KernelIntegrationTest
         // GIVEN
         Transaction tx = db.beginTx();
         Node node = db.createNode();
-        Statement statement = statementContextSupplier.get();
-        int labelId = statement.tokenWriteOperations().labelGetOrCreateForName( "mylabel" );
-        statement.dataWriteOperations().nodeAddLabel( node.getId(), labelId );
-        statement.close();
+        int labelId;
+        try ( Statement statement = statementContextSupplier.get() )
+        {
+            labelId = statement.tokenWriteOperations().labelGetOrCreateForName( "mylabel" );
+            statement.dataWriteOperations().nodeAddLabel( node.getId(), labelId );
+        }
         tx.success();
         tx.close();
 
         // WHEN
         tx = db.beginTx();
-        statement = statementContextSupplier.get();
-        boolean removed = statement.dataWriteOperations().nodeRemoveLabel( node.getId(), labelId );
+        boolean removed;
+        try ( Statement statement = statementContextSupplier.get() )
+        {
+            removed = statement.dataWriteOperations().nodeRemoveLabel( node.getId(), labelId );
+        }
 
         // THEN
         assertTrue( "Should have been removed now", removed );
@@ -375,16 +393,21 @@ public class KernelIT extends KernelIntegrationTest
         // GIVEN
         Transaction tx = db.beginTx();
         Node node = db.createNode();
-        Statement statement = statementContextSupplier.get();
-        int labelId = statement.tokenWriteOperations().labelGetOrCreateForName( "mylabel" );
-        statement.close();
+        int labelId;
+        try ( Statement statement = statementContextSupplier.get() )
+        {
+            labelId = statement.tokenWriteOperations().labelGetOrCreateForName( "mylabel" );
+        }
         tx.success();
         tx.close();
 
         // WHEN
         tx = db.beginTx();
-        statement = statementContextSupplier.get();
-        boolean removed = statement.dataWriteOperations().nodeRemoveLabel( node.getId(), labelId );
+        boolean removed;
+        try ( Statement statement = statementContextSupplier.get() )
+        {
+            removed = statement.dataWriteOperations().nodeRemoveLabel( node.getId(), labelId );
+        }
 
         // THEN
         assertFalse( "Shouldn't have been removed now", removed );
@@ -457,10 +480,13 @@ public class KernelIT extends KernelIntegrationTest
 
         // WHEN
         tx = db.beginTx();
-        Statement statement = statementContextSupplier.get();
-        int labelId = statement.readOperations().labelGetForName( label.name() );
-        PrimitiveLongIterator nodes = statement.readOperations().nodesGetForLabel( labelId );
-        Set<Long> nodeSet = PrimitiveLongCollections.toSet( nodes );
+        Set<Long> nodeSet;
+        try ( Statement statement = statementContextSupplier.get() )
+        {
+            int labelId = statement.readOperations().labelGetForName( label.name() );
+            PrimitiveLongIterator nodes = statement.readOperations().nodesGetForLabel( labelId );
+            nodeSet = PrimitiveLongCollections.toSet( nodes );
+        }
         tx.success();
         tx.close();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/LabelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/LabelIT.java
@@ -60,6 +60,7 @@ public class LabelIT extends KernelIntegrationTest
         // then
         assertThat( asCollection( labelIdsAfterCommit ),
                 hasItems( new Token( "label1", label1Id ), new Token( "label2", label2Id ) ) );
+        commit();
     }
 
     @Test
@@ -82,5 +83,6 @@ public class LabelIT extends KernelIntegrationTest
 
         // And then the node should have the label
         assertTrue( readOperationsInNewTransaction().nodeHasLabel( node, label ) );
+        commit();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/PropertyIT.java
@@ -37,8 +37,6 @@ import static junit.framework.TestCase.fail;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -66,6 +64,8 @@ public class PropertyIT extends KernelIntegrationTest
 
         // THEN
         readOperations.nodeGetProperty( nodeId, propertyKeyId );
+
+        commit();
     }
 
     @Test
@@ -90,6 +90,7 @@ public class PropertyIT extends KernelIntegrationTest
 
         // THEN
         assertEquals( value, readOperations.nodeGetProperty( nodeId, propertyKeyId ) );
+        commit();
     }
 
     @Test
@@ -114,6 +115,7 @@ public class PropertyIT extends KernelIntegrationTest
         // THEN
         ReadOperations readOperations = readOperationsInNewTransaction();
         assertThat( readOperations.nodeGetProperty( nodeId, propertyKeyId ), equalTo( Values.NO_VALUE ) );
+        commit();
     }
 
     @Test
@@ -146,6 +148,7 @@ public class PropertyIT extends KernelIntegrationTest
         // THEN
         ReadOperations readOperations = readOperationsInNewTransaction();
         assertThat( readOperations.nodeGetProperty( nodeId, propertyKeyId ), equalTo( Values.NO_VALUE ) );
+        commit();
     }
 
     @Test
@@ -186,6 +189,7 @@ public class PropertyIT extends KernelIntegrationTest
             assertThat( readOperations.nodeGetProperty( nodeId, propertyKeyId ), equalTo( newValue ) );
             assertThat( toList( readOperations.nodeGetPropertyKeys( nodeId ) ),
                     equalTo( Collections.singletonList( propertyKeyId ) ) );
+            commit();
         }
     }
 
@@ -209,6 +213,7 @@ public class PropertyIT extends KernelIntegrationTest
 
             // THEN
             assertTrue( "Return no property if removing missing", result == NO_VALUE );
+            commit();
         }
     }
 
@@ -235,6 +240,7 @@ public class PropertyIT extends KernelIntegrationTest
         // THEN
         assertThat( readOperations.nodeHasProperty( nodeId, propertyKeyId ), is( true ) );
         assertThat( readOperations.nodeGetProperty( nodeId, propertyKeyId ), not( equalTo( Values.NO_VALUE ) ) );
+        commit();
     }
 
     @Test
@@ -259,6 +265,7 @@ public class PropertyIT extends KernelIntegrationTest
         // THEN
         assertThat( readOperations.nodeHasProperty( nodeId, propertyKeyId ), is( false ) );
         assertThat( readOperations.nodeGetProperty( nodeId, propertyKeyId ), equalTo( Values.NO_VALUE ) );
+        commit();
     }
 
     @Test
@@ -279,6 +286,7 @@ public class PropertyIT extends KernelIntegrationTest
         ReadOperations readOperations = readOperationsInNewTransaction();
         assertThat( readOperations.nodeHasProperty( nodeId, propertyKeyId ), is( false ) );
         assertThat( readOperations.nodeGetProperty( nodeId, propertyKeyId ), equalTo( Values.NO_VALUE ) );
+        commit();
     }
 
     @Test
@@ -299,6 +307,7 @@ public class PropertyIT extends KernelIntegrationTest
         // THEN
         ReadOperations readOperations = readOperationsInNewTransaction();
         assertEquals( 42, readOperations.nodeGetProperty( nodeId, propertyId ).asObject() );
+        commit();
     }
 
     @Test
@@ -326,6 +335,7 @@ public class PropertyIT extends KernelIntegrationTest
         // then
         assertThat( asCollection( propIdsAfterCommit ),
                 hasItems( new Token( "prop1", prop1 ), new Token( "prop2", prop2 ) ) );
+        commit();
     }
 
     @Test
@@ -349,6 +359,7 @@ public class PropertyIT extends KernelIntegrationTest
         {
             assertThat( e.getMessage(), equalTo( "Unable to load NODE with id " + node + "." ) );
         }
+        commit();
     }
 
     @Test
@@ -375,6 +386,7 @@ public class PropertyIT extends KernelIntegrationTest
         {
             assertThat( e.getMessage(), equalTo( "Unable to load RELATIONSHIP with id " + rel + "." ) );
         }
+        commit();
     }
 
     @Test
@@ -401,6 +413,7 @@ public class PropertyIT extends KernelIntegrationTest
         // then
         ReadOperations readOperations = readOperationsInNewTransaction();
         assertThat( readOperations.nodeGetProperty( node, prop ), equalTo( Values.NO_VALUE ) );
+        commit();
     }
 
     @Test
@@ -430,6 +443,7 @@ public class PropertyIT extends KernelIntegrationTest
         // then
         ReadOperations readOperations = readOperationsInNewTransaction();
         assertThat( readOperations.relationshipGetProperty( rel, prop ), equalTo( Values.NO_VALUE ) );
+        commit();
     }
 }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/RelationshipIT.java
@@ -108,6 +108,7 @@ public class RelationshipIT extends KernelIntegrationTest
 
         assertRels( readOperations.nodeGetRelationships( refNode, OUTGOING, new int[]{relType1, relType2} ),
                 fromRefToOther1, fromRefToOther2, fromRefToThird, fromRefToRef );
+        commit();
     }
 
     @Test
@@ -142,6 +143,7 @@ public class RelationshipIT extends KernelIntegrationTest
             // Then
             assertRels( statement.readOperations().nodeGetRelationships( refNode, BOTH ), fromRefToOther2, localTxRel);
             assertRelsInSeparateTx( refNode, BOTH, fromRefToOther1, fromRefToOther2);
+            commit();
         }
     }
 
@@ -193,6 +195,7 @@ public class RelationshipIT extends KernelIntegrationTest
 
         // Then the node should still load the real rels
         assertRels( stmt.nodeGetRelationships( refNode, Direction.BOTH, new int[]{relTypeTheNodeDoesUse} ), rels );
+        commit();
     }
 
     private void assertRelsInSeparateTx( final long refNode, final Direction both, final long ... longs ) throws
@@ -200,9 +203,10 @@ public class RelationshipIT extends KernelIntegrationTest
     {
         assertTrue( otherThread.execute( state ->
         {
-            try ( Transaction tx = db.beginTx() )
+            try ( Transaction tx = db.beginTx();
+                    Statement statement = statementContextSupplier.get() )
             {
-                ReadOperations stmt = statementContextSupplier.get().readOperations();
+                ReadOperations stmt = statement.readOperations();
                 assertRels( stmt.nodeGetRelationships( refNode, both ), longs );
             }
             return true;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintValidationIT.java
@@ -68,6 +68,7 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         {
             assertThat( e.getUserMessage( tokenLookup( statement ) ), containsString( "`key1` = 'value1'" ) );
         }
+        commit();
     }
 
     @Test
@@ -120,6 +121,7 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         {
             assertThat( e.getUserMessage( tokenLookup( statement ) ), containsString( "`key1` = 1" ) );
         }
+        commit();
     }
 
     @Test
@@ -144,6 +146,7 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         {
             assertThat( e.getUserMessage( tokenLookup( statement ) ), containsString( "`key1` = 'value1'" ) );
         }
+        commit();
     }
 
     @Test
@@ -226,6 +229,7 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         {
             assertThat( e.getUserMessage( tokenLookup( statement ) ), containsString( "`key1` = 'value2'" ) );
         }
+        commit();
     }
 
     @Test
@@ -241,6 +245,7 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         statement.dataWriteOperations().nodeSetProperty( node, key, Values.of( "value1" ) );
 
         // then should not throw exception
+        commit();
     }
 
     @Test
@@ -256,6 +261,7 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
         statement.dataWriteOperations().nodeAddLabel( node, label );
 
         // then should not throw exception
+        commit();
     }
 
     @Test
@@ -305,6 +311,7 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
 
         // then I should find the original node
         assertThat( readOps.nodeGetFromUniqueIndexSeek( idx, exact( propId, Values.of( 1 ) ) ), equalTo( ourNode ) );
+        commit();
     }
 
     @Test
@@ -331,6 +338,7 @@ public class UniquenessConstraintValidationIT extends KernelIntegrationTest
 
         // then I should find the original node
         assertThat( readOps.nodeGetFromUniqueIndexSeek( idx, exact( propId, Values.of( 1 ) ) ), equalTo( ourNode ));
+        commit();
     }
 
     private TokenNameLookup tokenLookup( Statement statement )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorageLayerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorageLayerTest.java
@@ -30,7 +30,6 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
@@ -98,32 +97,34 @@ public abstract class StorageLayerTest
 
     protected int labelId( Label label )
     {
-        try ( Transaction ignored = db.beginTx() )
+        try ( Transaction ignored = db.beginTx();
+                Statement statement = statement() )
         {
-            return readOps().labelGetForName( label.name() );
+            return statement.readOperations().labelGetForName( label.name() );
         }
     }
 
     protected int relationshipTypeId( RelationshipType type )
     {
-        try ( Transaction ignored = db.beginTx() )
+        try ( Transaction ignored = db.beginTx();
+                Statement statement = statement() )
         {
-            return readOps().relationshipTypeGetForName( type.name() );
+            return statement.readOperations().relationshipTypeGetForName( type.name() );
         }
     }
 
     protected int propertyKeyId( String propertyKey )
     {
-        try ( Transaction ignored = db.beginTx() )
+        try ( Transaction ignored = db.beginTx();
+                Statement statement = statement() )
         {
-            return readOps().propertyKeyGetForName( propertyKey );
+            return statement.readOperations().propertyKeyGetForName( propertyKey );
         }
     }
 
-    protected ReadOperations readOps()
+    protected Statement statement()
     {
         DependencyResolver dependencyResolver = db.getDependencyResolver();
-        Statement statement = dependencyResolver.resolveDependency( ThreadToStatementContextBridge.class ).get();
-        return statement.readOperations();
+        return dependencyResolver.resolveDependency( ThreadToStatementContextBridge.class ).get();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TransactionEventsIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TransactionEventsIT.java
@@ -41,6 +41,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.event.TransactionData;
 import org.neo4j.graphdb.event.TransactionEventHandler;
 import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.security.AccessMode;
 import org.neo4j.kernel.api.security.AnonymousContext;
 import org.neo4j.kernel.api.security.AuthSubject;
@@ -205,10 +206,10 @@ public class TransactionEventsIT
 
     private void runTransaction( SecurityContext securityContext, Map<String,Object> metaData )
     {
-        try ( Transaction transaction = db.beginTransaction( KernelTransaction.Type.explicit, securityContext ) )
+        try ( Transaction transaction = db.beginTransaction( KernelTransaction.Type.explicit, securityContext );
+              Statement statement = db.getDependencyResolver().resolveDependency( ThreadToStatementContextBridge.class ).get() )
         {
-            db.getDependencyResolver().resolveDependency( ThreadToStatementContextBridge.class ).get()
-                    .queryRegistration().setMetaData( metaData );
+            statement.queryRegistration().setMetaData( metaData );
             db.createNode();
             transaction.success();
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/TestIndexImplOnNeo.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/TestIndexImplOnNeo.java
@@ -31,6 +31,7 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.index.Index;
+import org.neo4j.graphdb.index.IndexHits;
 import org.neo4j.graphdb.mockfs.UncloseableDelegatingFileSystemAbstraction;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.test.TestGraphDatabaseFactory;
@@ -87,7 +88,10 @@ public class TestIndexImplOnNeo
         {
             assertTrue( indexExists( indexName ) );
             assertEquals( config, db.index().getConfiguration( index ) );
-            assertEquals( 0, Iterables.count( index.get( "key", "something else" ) ) );
+            try ( IndexHits<Node> indexHits = index.get( "key", "something else" ) )
+            {
+                assertEquals( 0, Iterables.count( indexHits ) );
+            }
             tx.success();
         }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/SchemaStorageTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/SchemaStorageTest.java
@@ -38,7 +38,6 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.IndexCreator;
 import org.neo4j.helpers.collection.Iterators;
-import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.TokenWriteOperations;
@@ -86,9 +85,9 @@ public class SchemaStorageTest
     @BeforeClass
     public static void initStorage() throws Exception
     {
-        try ( Transaction transaction = db.beginTx() )
+        try ( Transaction transaction = db.beginTx();
+                Statement statement = getStatement() )
         {
-            Statement statement = getStatement();
             TokenWriteOperations tokenWriteOperations = statement.tokenWriteOperations();
             tokenWriteOperations.propertyKeyGetOrCreateForName( PROP1 );
             tokenWriteOperations.propertyKeyGetOrCreateForName( PROP2 );
@@ -392,32 +391,29 @@ public class SchemaStorageTest
 
     private static int labelId( String labelName )
     {
-        try ( Transaction ignore = db.beginTx() )
+        try ( Transaction ignore = db.beginTx();
+              Statement statement = getStatement() )
         {
-            return readOps().labelGetForName( labelName );
+            return statement.readOperations().labelGetForName( labelName );
         }
     }
 
     private int propId( String propName )
     {
-        try ( Transaction ignore = db.beginTx() )
+        try ( Transaction ignore = db.beginTx();
+              Statement statement = getStatement() )
         {
-            return readOps().propertyKeyGetForName( propName );
+            return statement.readOperations().propertyKeyGetForName( propName );
         }
     }
 
     private static int typeId( String typeName )
     {
-        try ( Transaction ignore = db.beginTx() )
+        try ( Transaction ignore = db.beginTx();
+                Statement statement = getStatement() )
         {
-            return readOps().relationshipTypeGetForName( typeName );
+            return statement.readOperations().relationshipTypeGetForName( typeName );
         }
-    }
-
-    private static ReadOperations readOps()
-    {
-        Statement statement = getStatement();
-        return statement.readOperations();
     }
 
     private static Statement getStatement()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestBidirectionalTraversal.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestBidirectionalTraversal.java
@@ -23,8 +23,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.function.Predicate;
-
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.PathExpander;
@@ -32,19 +30,20 @@ import org.neo4j.graphdb.PathExpanderBuilder;
 import org.neo4j.graphdb.PathExpanders;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.impl.traversal.StandardBranchCollisionDetector;
 import org.neo4j.graphdb.traversal.BidirectionalTraversalDescription;
-import org.neo4j.graphdb.traversal.BranchCollisionDetector;
 import org.neo4j.graphdb.traversal.BranchCollisionPolicy;
-import org.neo4j.graphdb.traversal.Evaluator;
 import org.neo4j.graphdb.traversal.Evaluators;
 import org.neo4j.graphdb.traversal.InitialBranchState;
 import org.neo4j.graphdb.traversal.SideSelectorPolicies;
 import org.neo4j.graphdb.traversal.TraversalBranch;
 import org.neo4j.graphdb.traversal.TraversalDescription;
+import org.neo4j.graphdb.traversal.Traverser;
 import org.neo4j.graphdb.traversal.Uniqueness;
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.helpers.collection.Iterators;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -76,10 +75,14 @@ public class TestBidirectionalTraversal extends TraversalTestBase
     {
         createGraph( "A TO B" );
 
-        Iterables.count( getGraphDb().bidirectionalTraversalDescription()
-            .startSide( getGraphDb().traversalDescription().uniqueness( Uniqueness.NODE_GLOBAL ) )
-            .endSide( getGraphDb().traversalDescription().uniqueness( Uniqueness.RELATIONSHIP_GLOBAL ) )
-            .traverse( getNodeWithName( "A" ), getNodeWithName( "B" ) ) );
+        Traverser traverse = getGraphDb().bidirectionalTraversalDescription()
+                .startSide( getGraphDb().traversalDescription().uniqueness( Uniqueness.NODE_GLOBAL ) )
+                .endSide( getGraphDb().traversalDescription().uniqueness( Uniqueness.RELATIONSHIP_GLOBAL ) )
+                .traverse( getNodeWithName( "A" ), getNodeWithName( "B" ) );
+        try ( ResourceIterator<Path> iterator = traverse.iterator() )
+        {
+            Iterators.count( iterator );
+        }
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestMultipleFilters.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestMultipleFilters.java
@@ -29,6 +29,8 @@ import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.ResourceIterable;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.traversal.Evaluation;
 import org.neo4j.graphdb.traversal.Evaluator;
@@ -76,14 +78,20 @@ public class TestMultipleFilters extends TraversalTestBase
         @Override
         public boolean test( Path item )
         {
-            for ( Relationship rel : item.endNode().getRelationships( Direction.OUTGOING ) )
+            ResourceIterable<Relationship> relationships = (ResourceIterable<Relationship>) item.endNode()
+                    .getRelationships( Direction.OUTGOING );
+            try ( ResourceIterator<Relationship> iterator = relationships.iterator() )
             {
-                if ( rel.getEndNode().equals( node ) )
+                while ( iterator.hasNext() )
                 {
-                    return true;
+                    Relationship rel = iterator.next();
+                    if ( rel.getEndNode().equals( node ) )
+                    {
+                        return true;
+                    }
                 }
+                return false;
             }
-            return false;
         }
 
         public Evaluation evaluate( Path path )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TraversalBranchImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TraversalBranchImplTest.java
@@ -21,14 +21,13 @@ package org.neo4j.kernel.impl.traversal;
 
 import org.junit.Test;
 
-import java.util.Collections;
-
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.PathExpander;
 import org.neo4j.graphdb.traversal.BranchState;
 import org.neo4j.graphdb.traversal.TraversalBranch;
 import org.neo4j.graphdb.traversal.TraversalContext;
+import org.neo4j.helpers.collection.Iterables;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -37,7 +36,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.neo4j.graphdb.traversal.Evaluation.INCLUDE_AND_CONTINUE;
-import static org.neo4j.helpers.collection.Iterables.asResourceIterable;
 
 public class TraversalBranchImplTest
 {
@@ -52,7 +50,7 @@ public class TraversalBranchImplTest
         @SuppressWarnings( "rawtypes" )
         PathExpander expander = mock( PathExpander.class );
         when( expander.expand( eq( branch ), any( BranchState.class ) ) )
-                .thenReturn( asResourceIterable( Collections.emptySet() ) );
+                .thenReturn( Iterables.emptyResourceIterable() );
         TraversalContext context = mock( TraversalContext.class );
         when( context.evaluate( eq( branch ), any( BranchState.class ) ) ).thenReturn( INCLUDE_AND_CONTINUE );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TraversalBranchImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TraversalBranchImplTest.java
@@ -36,8 +36,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.graphdb.traversal.Evaluation.INCLUDE_AND_CONTINUE;
+import static org.neo4j.helpers.collection.Iterables.asResourceIterable;
 
 public class TraversalBranchImplTest
 {
@@ -51,7 +51,8 @@ public class TraversalBranchImplTest
         TraversalBranchImpl branch = new TraversalBranchImpl( parent, source );
         @SuppressWarnings( "rawtypes" )
         PathExpander expander = mock( PathExpander.class );
-        when( expander.expand( eq( branch ), any( BranchState.class ) ) ).thenReturn( Collections.emptySet() );
+        when( expander.expand( eq( branch ), any( BranchState.class ) ) )
+                .thenReturn( asResourceIterable( Collections.emptySet() ) );
         TraversalContext context = mock( TraversalContext.class );
         when( context.evaluate( eq( branch ), any( BranchState.class ) ) ).thenReturn( INCLUDE_AND_CONTINUE );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TraversalTestBase.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TraversalTestBase.java
@@ -32,6 +32,8 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.ResourceIterable;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.traversal.Traverser;
 import org.neo4j.helpers.collection.Iterables;
@@ -86,12 +88,19 @@ public abstract class TraversalTestBase extends AbstractNeo4jTestCase
 
     protected Node getNodeWithName( String name )
     {
-        for ( Node node : getGraphDb().getAllNodes() )
+        ResourceIterable<Node> allNodes = getGraphDb().getAllNodes();
+        try ( ResourceIterator<Node> nodeIterator = allNodes.iterator() )
         {
-            String nodeName = (String) node.getProperty( "name", null );
-            if ( nodeName != null && nodeName.equals( name ) )
+            while ( nodeIterator.hasNext() )
             {
-                return node;
+                Node node = nodeIterator.next();
+                {
+                    String nodeName = (String) node.getProperty( "name", null );
+                    if ( nodeName != null && nodeName.equals( name ) )
+                    {
+                        return node;
+                    }
+                }
             }
         }
 

--- a/community/kernel/src/test/java/org/neo4j/test/DbRepresentation.java
+++ b/community/kernel/src/test/java/org/neo4j/test/DbRepresentation.java
@@ -183,15 +183,17 @@ public class DbRepresentation
                 Index<Node> tempIndex = db.index().forNodes( indexName );
                 for ( Map.Entry<String,Serializable> property : properties.props.entrySet() )
                 {
-                    IndexHits<Node> content = tempIndex.get( property.getKey(), property.getValue() );
-                    if ( content.hasNext() )
+                    try ( IndexHits<Node> content = tempIndex.get( property.getKey(), property.getValue() ) )
                     {
-                        for ( Node hit : content )
+                        if ( content.hasNext() )
                         {
-                            if ( hit.getId() == id )
+                            for ( Node hit : content )
                             {
-                                thisIndex.put( property.getKey(), property.getValue() );
-                                break;
+                                if ( hit.getId() == id )
+                                {
+                                    thisIndex.put( property.getKey(), property.getValue() );
+                                    break;
+                                }
                             }
                         }
                     }

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/EmptyIndexHits.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/EmptyIndexHits.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.index.impl.lucene.legacy;
 
+import org.neo4j.kernel.impl.api.legacyindex.AbstractIndexHits;
+
 /**
  * Empty implementation of {@link AbstractIndexHits} with no matches and {@link Float#NaN} as a score
  * @param <T> index hits type

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/TopDocsIterator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/TopDocsIterator.java
@@ -19,9 +19,6 @@
  */
 package org.neo4j.index.impl.lucene.legacy;
 
-import java.io.IOException;
-import java.util.Iterator;
-
 import org.apache.lucene.document.Document;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
@@ -30,8 +27,12 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopFieldCollector;
 
+import java.io.IOException;
+import java.util.Iterator;
+
 import org.neo4j.helpers.collection.ArrayIterator;
 import org.neo4j.index.lucene.QueryContext;
+import org.neo4j.kernel.impl.api.legacyindex.AbstractIndexHits;
 
 class TopDocsIterator extends AbstractIndexHits<Document>
 {

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/collector/DocValuesCollector.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/collector/DocValuesCollector.java
@@ -52,8 +52,8 @@ import java.util.Map;
 import org.neo4j.graphdb.index.IndexHits;
 import org.neo4j.helpers.collection.ArrayIterator;
 import org.neo4j.helpers.collection.PrefetchingIterator;
-import org.neo4j.index.impl.lucene.legacy.AbstractIndexHits;
 import org.neo4j.index.impl.lucene.legacy.EmptyIndexHits;
+import org.neo4j.kernel.impl.api.legacyindex.AbstractIndexHits;
 
 /**
  * Collector to record per-segment {@code DocIdSet}s and {@code LeafReaderContext}s for every

--- a/community/lucene-index/src/test/java/examples/RelatedNodesQuestionTest.java
+++ b/community/lucene-index/src/test/java/examples/RelatedNodesQuestionTest.java
@@ -53,8 +53,10 @@ public class RelatedNodesQuestionTest
             Relationship relationship = node1.createRelationshipTo( node2, RelationshipType.withName( "related" ) );
             index.add( relationship, "uuid", a_uuid );
             // query
-            IndexHits<Relationship> hits = index.get( "uuid", a_uuid, node1, node2 );
-            assertEquals( 1, hits.size() );
+            try ( IndexHits<Relationship> hits = index.get( "uuid", a_uuid, node1, node2 ) )
+            {
+                assertEquals( 1, hits.size() );
+            }
             tx.success();
         }
         service.shutdown();

--- a/community/lucene-index/src/test/java/org/neo4j/concurrencytest/ConstraintIndexConcurrencyTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/concurrencytest/ConstraintIndexConcurrencyTest.java
@@ -73,10 +73,9 @@ public class ConstraintIndexConcurrencyTest
         }
 
         // When
-        try ( Transaction tx = graphDb.beginTx() )
+        try ( Transaction tx = graphDb.beginTx();
+              Statement statement = statementSupplier.get() )
         {
-            // create a statement and perform a lookup
-            Statement statement = statementSupplier.get();
             int labelId = statement.readOperations().labelGetForName( label.name() );
             int propertyKeyId = statement.readOperations().propertyKeyGetForName( propertyKey );
             IndexDescriptor index = IndexDescriptorFactory.uniqueForLabel( labelId, propertyKeyId );

--- a/community/lucene-index/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForIndexHitsFacadeTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/graphdb/MandatoryTransactionsForIndexHitsFacadeTest.java
@@ -98,9 +98,11 @@ public class MandatoryTransactionsForIndexHitsFacadeTest
     private IndexHits<Node> queryIndex( Index<Node> index )
     {
         GraphDatabaseService graphDatabaseService = dbRule.getGraphDatabaseAPI();
-        try ( Transaction transaction = graphDatabaseService.beginTx() )
+        try ( Transaction ignored = graphDatabaseService.beginTx() )
         {
-            return index.get( "foo", 42 );
+            IndexHits<Node> hits = index.get( "foo", 42 );
+            hits.close();
+            return hits;
         }
     }
 }

--- a/community/lucene-index/src/test/java/org/neo4j/index/LegacyIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/LegacyIndexTest.java
@@ -29,6 +29,7 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.index.Index;
+import org.neo4j.graphdb.index.IndexHits;
 import org.neo4j.test.rule.DatabaseRule;
 import org.neo4j.test.rule.ImpermanentDatabaseRule;
 
@@ -124,6 +125,9 @@ public class LegacyIndexTest
 
     private static int sizeOf( Index<?> index )
     {
-        return index.query( "_id_:*" ).size();
+        try ( IndexHits<?> indexHits = index.query( "_id_:*" ) )
+        {
+            return indexHits.size();
+        }
     }
 }

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/TestAutoIndexing.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/TestAutoIndexing.java
@@ -19,12 +19,12 @@
  */
 package org.neo4j.index.impl.lucene.legacy;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -33,10 +33,11 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.index.AutoIndexer;
 import org.neo4j.graphdb.index.Index;
+import org.neo4j.graphdb.index.IndexHits;
 import org.neo4j.graphdb.index.ReadableIndex;
 import org.neo4j.graphdb.index.RelationshipIndex;
-import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.NeoStoreDataSource;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -45,7 +46,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import static org.neo4j.helpers.collection.Iterators.count;
 
 public class TestAutoIndexing
@@ -600,8 +600,11 @@ public class TestAutoIndexing
 
         newTransaction();
 
-        assertThat( graphDb.index().forRelationships( "relationship_auto_index" ).query( "_id_:*" ).size(),
-                equalTo( 1 ) );
+        try ( IndexHits<Relationship> relationshipIndexHits = graphDb.index()
+                .forRelationships( "relationship_auto_index" ).query( "_id_:*" ) )
+        {
+            assertThat( relationshipIndexHits.size(), equalTo( 1 ) );
+        }
 
         newTransaction();
 
@@ -609,8 +612,11 @@ public class TestAutoIndexing
 
         newTransaction();
 
-        assertThat( graphDb.index().forRelationships( "relationship_auto_index" ).query( "_id_:*" ).size(),
-                equalTo( 0 ) );
+        try ( IndexHits<Relationship> relationshipIndexHits = graphDb.index()
+                .forRelationships( "relationship_auto_index" ).query( "_id_:*" ) )
+        {
+            assertThat( relationshipIndexHits.size(), equalTo( 0 ) );
+        }
     }
 
     @Test
@@ -627,15 +633,19 @@ public class TestAutoIndexing
 
         newTransaction();
 
-        assertThat( graphDb.index().forNodes( "node_auto_index" ).query( "_id_:*" ).size(),
-                equalTo( 1 ) );
+        try ( IndexHits<Node> nodeIndexHits = graphDb.index().forNodes( "node_auto_index" ).query( "_id_:*" ) )
+        {
+            assertThat( nodeIndexHits.size(), equalTo( 1 ) );
+        }
 
         node1.delete();
 
         newTransaction();
 
-        assertThat( graphDb.index().forNodes( "node_auto_index" ).query( "_id_:*" ).size(),
-                equalTo( 0 ) );
+        try ( IndexHits<Node> nodeIndexHits = graphDb.index().forNodes( "node_auto_index" ).query( "_id_:*" ) )
+        {
+            assertThat( nodeIndexHits.size(), equalTo( 0 ) );
+        }
     }
 
     @Test

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/TestIndexDeletion.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/TestIndexDeletion.java
@@ -151,7 +151,10 @@ public class TestIndexDeletion
         index.delete();
         rollbackTx();
         beginTx();
-        index.get( key, value );
+        try ( IndexHits<Node> indexHits = index.get( key, value ) )
+        {
+            //empty
+        }
     }
 
     @Test

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/TestLuceneIndex.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/TestLuceneIndex.java
@@ -552,8 +552,10 @@ public class TestLuceneIndex extends AbstractLuceneIndexTest
         Index<Node> index = nodeIndex( LuceneIndexImplementation.EXACT_CONFIG );
         Node theNode = graphDb.createNode();
         index.remove( theNode );
-        IndexHits<Node> hits = index.query( "someRandomKey", theNode.getId() );
-        assertTrue( hits.size() >= 0 );
+        try ( IndexHits<Node> hits = index.query( "someRandomKey", theNode.getId() ) )
+        {
+            assertTrue( hits.size() >= 0 );
+        }
     }
 
     @Test
@@ -1290,14 +1292,18 @@ public class TestLuceneIndex extends AbstractLuceneIndexTest
         index.add( node2, key, "once upon a time there was" );
         restartTx();
 
-        IndexHits<Node> hits = index.query( key, new QueryContext( "once upon a time was" ).sort( Sort.RELEVANCE ) );
-        Node hit1 = hits.next();
-        float score1 = hits.currentScore();
-        Node hit2 = hits.next();
-        float score2 = hits.currentScore();
-        assertEquals( node2, hit1 );
-        assertEquals( node1, hit2 );
-        assertTrue( "Score 1 (" + score1 + ") should have been higher than score 2 (" + score2 + ")", score1 > score2 );
+        QueryContext queryContext = new QueryContext( "once upon a time was" ).sort( Sort.RELEVANCE );
+        try ( IndexHits<Node> hits = index.query( key, queryContext ) )
+        {
+            Node hit1 = hits.next();
+            float score1 = hits.currentScore();
+            Node hit2 = hits.next();
+            float score2 = hits.currentScore();
+            assertEquals( node2, hit1 );
+            assertEquals( node1, hit2 );
+            assertTrue( "Score 1 (" + score1 + ") should have been higher than score 2 (" + score2 + ")",
+                    score1 > score2 );
+        }
     }
 
     @Test
@@ -1354,8 +1360,10 @@ public class TestLuceneIndex extends AbstractLuceneIndexTest
         index.add( node2, key, value );
         restartTx();
         index.add( node3, key, value );
-        IndexHits<Node> hits = index.get( key, value );
-        assertEquals( 3, hits.size() );
+        try ( IndexHits<Node> hits = index.get( key, value ) )
+        {
+            assertEquals( 3, hits.size() );
+        }
     }
 
     @SuppressWarnings( "unchecked" )

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/MyCoreAPI.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/MyCoreAPI.java
@@ -45,9 +45,9 @@ public class MyCoreAPI
     public long makeNode( String label ) throws ProcedureException
     {
         long result;
-        try ( Transaction tx = graph.beginTransaction( KernelTransaction.Type.explicit, AnonymousContext.write() ) )
+        try ( Transaction tx = graph.beginTransaction( KernelTransaction.Type.explicit, AnonymousContext.write() );
+                Statement statement = this.txBridge.get() )
         {
-            Statement statement = this.txBridge.get();
             long nodeId = statement.dataWriteOperations().nodeCreate();
             int labelId = statement.tokenWriteOperations().labelGetOrCreateForName( label );
             statement.dataWriteOperations().nodeAddLabel( nodeId, labelId );
@@ -66,9 +66,9 @@ public class MyCoreAPI
     public long countNodes()
     {
         long result;
-        try ( Transaction tx = graph.beginTransaction( KernelTransaction.Type.explicit, AnonymousContext.read() ) )
+        try ( Transaction tx = graph.beginTransaction( KernelTransaction.Type.explicit, AnonymousContext.read() );
+                Statement statement = this.txBridge.get() )
         {
-            Statement statement = this.txBridge.get();
             result = statement.readOperations().countsForNode( -1 );
             tx.success();
         }

--- a/community/neo4j/src/test/java/counts/RebuildCountsTest.java
+++ b/community/neo4j/src/test/java/counts/RebuildCountsTest.java
@@ -34,6 +34,7 @@ import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.mockfs.UncloseableDelegatingFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.impl.api.index.inmemory.InMemoryIndexProvider;
 import org.neo4j.kernel.impl.api.index.inmemory.InMemoryIndexProviderFactory;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
@@ -138,11 +139,12 @@ public class RebuildCountsTest
 
     private int labelId( Label alien )
     {
-        try ( Transaction tx = db.beginTx() )
+        ThreadToStatementContextBridge contextBridge = ((GraphDatabaseAPI) db).getDependencyResolver()
+                .resolveDependency( ThreadToStatementContextBridge.class );
+        try ( Transaction tx = db.beginTx();
+              Statement statement = contextBridge.get() )
         {
-            return ((GraphDatabaseAPI) db).getDependencyResolver()
-                                          .resolveDependency( ThreadToStatementContextBridge.class )
-                                          .get().readOperations().labelGetForName( alien.name() );
+            return statement.readOperations().labelGetForName( alien.name() );
         }
     }
 

--- a/community/neo4j/src/test/java/org/neo4j/index/IndexSamplingIntegrationTest.java
+++ b/community/neo4j/src/test/java/org/neo4j/index/IndexSamplingIntegrationTest.java
@@ -27,10 +27,13 @@ import java.util.concurrent.TimeUnit;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.api.ReadOperations;
+import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
 import org.neo4j.kernel.impl.api.index.IndexingService;
@@ -96,7 +99,10 @@ public class IndexSamplingIntegrationTest
             {
                 for ( int i = 0; i < (nodes / 10) ; i++ )
                 {
-                    db.findNodes( label, property, names[i % names.length] ).next().delete();
+                    try ( ResourceIterator<Node> nodes = db.findNodes( label, property, names[i % names.length] ) )
+                    {
+                        nodes.next().delete();
+                    }
                     deletedNodes++;
                     tx.success();
                 }
@@ -186,13 +192,14 @@ public class IndexSamplingIntegrationTest
 
     private long indexId( GraphDatabaseAPI api ) throws IndexNotFoundKernelException
     {
-        try ( Transaction tx = api.beginTx() )
+        ThreadToStatementContextBridge contextBridge =
+                api.getDependencyResolver().resolveDependency( ThreadToStatementContextBridge.class );
+        try ( Transaction tx = api.beginTx();
+              Statement statement = contextBridge.get() )
         {
             IndexingService indexingService =
                     api.getDependencyResolver().resolveDependency( IndexingService.class );
-            ReadOperations readOperations =
-                    api.getDependencyResolver().resolveDependency( ThreadToStatementContextBridge.class ).get()
-                            .readOperations();
+            ReadOperations readOperations = statement.readOperations();
             int labelId = readOperations.labelGetForName( label.name() );
             int propertyKeyId = readOperations.propertyKeyGetForName( property );
             long indexId = indexingService.getIndexId( SchemaDescriptorFactory.forLabel( labelId, propertyKeyId ) );

--- a/community/neo4j/src/test/java/org/neo4j/tracers/PageCacheCountersIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/tracers/PageCacheCountersIT.java
@@ -186,9 +186,9 @@ public class PageCacheCountersIT
             while ( !canceled )
             {
                 PageCursorCounters pageCursorCounters;
-                try ( Transaction transaction = db.beginTx() )
+                try ( Transaction transaction = db.beginTx();
+                      KernelStatement kernelStatement = getKernelStatement( (GraphDatabaseAPI) db ) )
                 {
-                    KernelStatement kernelStatement = getKernelStatement( (GraphDatabaseAPI) db );
                     pageCursorCounters = kernelStatement.getPageCursorTracer();
                     Node node = db.createNode();
                     node.setProperty( "name", RandomStringUtils.random( localRandom.nextInt( 100 ) ) );

--- a/community/neo4j/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
+++ b/community/neo4j/src/test/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporterTest.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -51,6 +50,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.Iterables;
@@ -366,11 +366,11 @@ public class ParallelBatchImporterTest
         // Read all nodes, relationships and properties ad verify against the input data.
         try ( InputIterator<InputNode> nodes = nodes( nodeRandomSeed, nodeCount, inputIdGenerator, groups ).iterator();
               InputIterator<InputRelationship> relationships = relationships( relationshipRandomSeed, relationshipCount,
-                      inputIdGenerator, groups ).iterator() )
+                      inputIdGenerator, groups ).iterator();
+                ResourceIterator<Node> dbNodes = db.getAllNodes().iterator() )
         {
             // Nodes
             Map<String,Node> nodeByInputId = new HashMap<>( nodeCount );
-            Iterator<Node> dbNodes = db.getAllNodes().iterator();
             int verifiedNodes = 0;
             long allNodesScanLabelCount = 0;
             while ( nodes.hasNext() )

--- a/community/neo4j/src/test/java/recovery/TestRecoveryMultipleDataSources.java
+++ b/community/neo4j/src/test/java/recovery/TestRecoveryMultipleDataSources.java
@@ -26,6 +26,8 @@ import java.io.File;
 import java.io.IOException;
 
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.io.proc.ProcessUtil;
 import org.neo4j.kernel.impl.MyRelTypes;
@@ -66,9 +68,10 @@ public class TestRecoveryMultipleDataSources
         GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( storeDir );
 
         // Then
-        try ( Transaction ignored = db.beginTx() )
+        try ( Transaction ignored = db.beginTx();
+              ResourceIterator<RelationshipType> typeResourceIterator = db.getAllRelationshipTypes().iterator() )
         {
-            assertEquals( MyRelTypes.TEST.name(), db.getAllRelationshipTypes().iterator().next().name() );
+            assertEquals( MyRelTypes.TEST.name(), typeResourceIterator.next().name() );
         }
         finally
         {

--- a/community/neo4j/src/test/java/visibility/TestDatasourceCommitOrderDataVisibility.java
+++ b/community/neo4j/src/test/java/visibility/TestDatasourceCommitOrderDataVisibility.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.index.IndexHits;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.hamcrest.core.Is.is;
@@ -91,11 +92,11 @@ public class TestDatasourceCommitOrderDataVisibility
 
         Thread thread = new Thread( () ->
         {
-            try ( Transaction ignored = graphDatabaseService.beginTx() )
+            try ( Transaction ignored = graphDatabaseService.beginTx();
+                  IndexHits<Node> indexHits = graphDatabaseService.index()
+                          .forNodes( INDEX_NAME ).get( INDEX_KEY, INDEX_VALUE ); )
             {
-                assertThat(
-                        graphDatabaseService.index().forNodes( INDEX_NAME ).get( INDEX_KEY, INDEX_VALUE ).size(),
-                        is( 0 ) );
+                assertThat( indexHits.size(), is( 0 ) );
             }
             catch ( Throwable t )
             {

--- a/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/FunctionalTestPlugin.java
+++ b/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/FunctionalTestPlugin.java
@@ -33,6 +33,8 @@ import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.PathExpanders;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.ResourceIterable;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 
 @Description( "Here you can describe your plugin. It will show up in the description of the methods." )
@@ -244,10 +246,12 @@ public class FunctionalTestPlugin extends ServerPlugin
             Node other;
             if ( me.hasRelationship( RelationshipType.withName( "friend" ) ) )
             {
-                other = me.getRelationships( RelationshipType.withName( "friend" ) )
-                        .iterator()
-                        .next()
-                        .getOtherNode( me );
+                ResourceIterable<Relationship> relationships =
+                        (ResourceIterable<Relationship>) me.getRelationships( RelationshipType.withName( "friend" ) );
+                try ( ResourceIterator<Relationship> resourceIterator = relationships.iterator() )
+                {
+                    other = resourceIterator.next().getOtherNode( me );
+                }
             }
             else
             {

--- a/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/PluginFunctionalTestIT.java
+++ b/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/PluginFunctionalTestIT.java
@@ -44,7 +44,6 @@ import org.neo4j.server.rest.repr.RelationshipRepresentationTest;
 import org.neo4j.test.server.SharedServerTestBase;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.Assert.assertEquals;
@@ -406,9 +405,9 @@ public class PluginFunctionalTestIT extends SharedServerTestBase
         String methodUri = getPluginMethodUri( functionalTestHelper.nodeUri( n ), "pathToReference" );
 
         Map<String, Object> maps = PluginFunctionalTestHelper.makePostMap( methodUri );
-
-        assertThat( (String) maps.get( "start" ), endsWith( Long.toString( r ) ) );
-        assertThat( (String) maps.get( "end" ), endsWith( Long.toString( n ) ) );
+//
+//        assertThat( (String) maps.get( "start" ), endsWith( Long.toString( r ) ) );
+//        assertThat( (String) maps.get( "end" ), endsWith( Long.toString( n ) ) );
     }
 
     @Test

--- a/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/PluginFunctionalTestIT.java
+++ b/community/server-plugin-test/src/test/java/org/neo4j/server/plugins/PluginFunctionalTestIT.java
@@ -43,6 +43,7 @@ import org.neo4j.server.rest.repr.NodeRepresentationTest;
 import org.neo4j.server.rest.repr.RelationshipRepresentationTest;
 import org.neo4j.test.server.SharedServerTestBase;
 
+import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.IsNull.nullValue;
@@ -405,9 +406,9 @@ public class PluginFunctionalTestIT extends SharedServerTestBase
         String methodUri = getPluginMethodUri( functionalTestHelper.nodeUri( n ), "pathToReference" );
 
         Map<String, Object> maps = PluginFunctionalTestHelper.makePostMap( methodUri );
-//
-//        assertThat( (String) maps.get( "start" ), endsWith( Long.toString( r ) ) );
-//        assertThat( (String) maps.get( "end" ), endsWith( Long.toString( n ) ) );
+
+        assertThat( (String) maps.get( "start" ), endsWith( Long.toString( r ) ) );
+        assertThat( (String) maps.get( "end" ), endsWith( Long.toString( n ) ) );
     }
 
     @Test

--- a/community/server/pom.xml
+++ b/community/server/pom.xml
@@ -57,6 +57,9 @@
     <!-- Run integration tests against a server that is started elsewhere. -->
     <neo-server.external>false</neo-server.external>
     <neo-server.external.url>http://localhost:7474</neo-server.external.url>
+    <test.runner.jvm.settings.additional>
+      -Dorg.neo4j.kernel.impl.api.KernelStatement.trackStatements=false
+    </test.runner.jvm.settings.additional>
   </properties>
 
   <scm>

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/ExecutionResultSerializer.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/ExecutionResultSerializer.java
@@ -448,7 +448,10 @@ public class ExecutionResultSerializer
                 out.writeStartObject();
                 try
                 {
-                    writer.write( out, columns, row, TransactionStateChecker.create( container ) );
+                    try ( TransactionStateChecker txStateChecker = TransactionStateChecker.create( container ) )
+                    {
+                        writer.write( out, columns, row, txStateChecker );
+                    }
                 }
                 finally
                 {

--- a/community/server/src/test/java/org/neo4j/server/rest/RelationshipIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/RelationshipIT.java
@@ -30,6 +30,8 @@ import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.ResourceIterable;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.impl.annotations.Documented;
@@ -246,7 +248,11 @@ public class RelationshipIT extends AbstractRestFunctionalDocTestBase
 
         try ( Transaction transaction = romeo.getGraphDatabase().beginTx() )
         {
-            return romeo.getRelationships().iterator().next();
+            ResourceIterable<Relationship> relationships = (ResourceIterable<Relationship>) romeo.getRelationships();
+            try ( ResourceIterator<Relationship> iterator = relationships.iterator() )
+            {
+                return iterator.next();
+            }
         }
     }
 

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/GraphExtractionWriterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/GraphExtractionWriterTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.kernel.api.Statement;
 import org.neo4j.server.rest.domain.JsonHelper;
 import org.neo4j.server.rest.domain.JsonParseException;
 import org.neo4j.test.Property;
@@ -43,6 +44,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 import static org.neo4j.test.Property.property;
 import static org.neo4j.test.mockito.mock.GraphMock.node;
 import static org.neo4j.test.mockito.mock.GraphMock.path;
@@ -57,7 +59,8 @@ public class GraphExtractionWriterTest
     private final Node n3 = node( 42, properties( property( "name", "n3" ) ), "Foo", "Bar" );
     private final Relationship r1 = relationship( 7, n1, "ONE", n2, property( "name", "r1" ) );
     private final Relationship r2 = relationship( 8, n1, "TWO", n3, property( "name", "r2" ) );
-    private final TransactionStateChecker checker = new TransactionStateChecker( id -> false, id -> false );
+    private final TransactionStateChecker checker = new TransactionStateChecker( mock( Statement.class ),
+            id -> false, id -> false );
 
     @Test
     public void shouldExtractNodesFromRow() throws Exception

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/ReadOnlyGraphDatabaseProxy.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/ReadOnlyGraphDatabaseProxy.java
@@ -56,8 +56,9 @@ import org.neo4j.graphdb.schema.Schema;
 import org.neo4j.graphdb.security.URLAccessValidationError;
 import org.neo4j.graphdb.traversal.BidirectionalTraversalDescription;
 import org.neo4j.graphdb.traversal.TraversalDescription;
-import org.neo4j.helpers.collection.IterableWrapper;
+import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.PrefetchingResourceIterator;
+import org.neo4j.helpers.collection.ResourceIterableWrapper;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
@@ -643,12 +644,12 @@ public class ReadOnlyGraphDatabaseProxy implements GraphDatabaseService, GraphDa
         return () -> nodes.iterator().map( ReadOnlyNodeProxy::new );
     }
 
-    public Iterable<Relationship> relationships( Iterable<Relationship> relationships )
+    public ResourceIterable<Relationship> relationships( Iterable<Relationship> relationships )
     {
-        return new IterableWrapper<Relationship, Relationship>( relationships )
+        return new ResourceIterableWrapper<Relationship,Relationship>( Iterables.asResourceIterable( relationships ) )
         {
             @Override
-            protected Relationship underlyingObjectToObject( Relationship relationship )
+            protected Relationship map( Relationship relationship )
             {
                 return new ReadOnlyRelationshipProxy( relationship );
             }

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Cd.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Cd.java
@@ -28,7 +28,11 @@ import java.util.TreeSet;
 
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.ResourceIterable;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.Service;
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.helpers.collection.MappingResourceIterator;
 import org.neo4j.shell.App;
 import org.neo4j.shell.AppCommandParser;
 import org.neo4j.shell.Continuation;
@@ -92,20 +96,24 @@ public class Cd extends TransactionProvidingApp
         {
             // TODO Check if -r is supplied
             Node node = current.asNode();
-            for ( Node otherNode : RelationshipToNodeIterable.wrap(
-                    node.getRelationships(), node ) )
+            try ( MappingResourceIterator<Node,Relationship> mappingResourceIterator = RelationshipToNodeIterable
+                    .wrap( Iterables.asResourceIterable( node.getRelationships() ), node ) )
             {
-                long otherNodeId = otherNode.getId();
-                String title = findTitle( session, otherNode );
-                if ( title != null )
+                while ( mappingResourceIterator.hasNext() )
                 {
-                    if ( !result.contains( title ) )
+                    Node otherNode = mappingResourceIterator.next();
+                    long otherNodeId = otherNode.getId();
+                    String title = findTitle( session, otherNode );
+                    if ( title != null )
                     {
-                        maybeAddCompletionCandidate( result, title + "," + otherNodeId,
-                                lastWord );
+                        if ( !result.contains( title ) )
+                        {
+                            maybeAddCompletionCandidate( result, title + "," + otherNodeId,
+                                    lastWord );
+                        }
                     }
+                    maybeAddCompletionCandidate( result, "" + otherNodeId, lastWord );
                 }
-                maybeAddCompletionCandidate( result, "" + otherNodeId, lastWord );
             }
         }
         else
@@ -239,12 +247,17 @@ public class Cd extends TransactionProvidingApp
         }
 
         String titleMatch = (String) matchParts[0];
-        for ( Node otherNode : RelationshipToNodeIterable.wrap( node.getRelationships(), node ) )
+        try ( MappingResourceIterator<Node,Relationship> mappingResourceIterator = RelationshipToNodeIterable
+                .wrap( Iterables.asResourceIterable( node.getRelationships() ), node ) )
         {
-            String title = findTitle( session, otherNode );
-            if ( titleMatch.equals( title ) )
+            while ( mappingResourceIterator.hasNext() )
             {
-                return otherNode.getId();
+                Node otherNode = mappingResourceIterator.next();
+                String title = findTitle( session, otherNode );
+                if ( titleMatch.equals( title ) )
+                {
+                    return otherNode.getId();
+                }
             }
         }
         return -1;
@@ -296,12 +309,14 @@ public class Cd extends TransactionProvidingApp
         {
             Node currentNode = current.asNode();
             long startTime = System.currentTimeMillis();
-            for ( Relationship rel : currentNode.getRelationships() )
+            ResourceIterable<Relationship> relationships = Iterables.asResourceIterable( currentNode.getRelationships() );
+            try ( ResourceIterator<Relationship> resourceIterator = relationships.iterator() )
             {
+                Relationship rel = resourceIterator.next();
                 if ( newId.isNode() )
                 {
                     if ( rel.getOtherNode( currentNode ).getId() ==
-                        newId.getId() )
+                            newId.getId() )
                     {
                         return true;
                     }

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Schema.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/Schema.java
@@ -180,10 +180,13 @@ public class Schema extends TransactionProvidingApp
 
         validateLabelsAndProperty( labels, property );
 
-        Statement statement = getServer().getStatement();
-
-        int labelKey = statement.readOperations().labelGetForName( labels[0].name() );
-        int propertyKey = statement.readOperations().propertyKeyGetForName( property );
+        int labelKey;
+        int propertyKey;
+        try ( Statement statement = getServer().getStatement() )
+        {
+            labelKey = statement.readOperations().labelGetForName( labels[0].name() );
+            propertyKey = statement.readOperations().propertyKeyGetForName( property );
+        }
 
         if ( labelKey == -1 )
         {

--- a/community/shell/src/test/java/org/neo4j/shell/AppsIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/AppsIT.java
@@ -337,15 +337,15 @@ public class AppsIT extends AbstractShellIT
         executeCommand( "cd -a " + node.getId() );
         executeCommand( "MATCH (n) WHERE n = {self} RETURN n.name;", nodeOneName );
         executeCommand( "cd -r " + relationship.getId() );
-        executeCommand( "MATCH ()-[r]->() WHERE r = {self} RETURN r.name;", relationshipName );
-        executeCommand( "cd " + otherNode.getId() );
-        executeCommand( "MATCH (n) WHERE n = {self} RETURN n.name;", nodeTwoName );
-
-        executeCommand( "cd -a " + strayNode.getId() );
-        beginTx();
-        strayNode.delete();
-        finishTx();
-        executeCommand( "MATCH (n) WHERE id(n) = " + node.getId() + " RETURN n.name;", nodeOneName );
+//        executeCommand( "MATCH ()-[r]->() WHERE r = {self} RETURN r.name;", relationshipName );
+//        executeCommand( "cd " + otherNode.getId() );
+//        executeCommand( "MATCH (n) WHERE n = {self} RETURN n.name;", nodeTwoName );
+//
+//        executeCommand( "cd -a " + strayNode.getId() );
+//        beginTx();
+//        strayNode.delete();
+//        finishTx();
+//        executeCommand( "MATCH (n) WHERE id(n) = " + node.getId() + " RETURN n.name;", nodeOneName );
     }
 
     @Test

--- a/community/shell/src/test/java/org/neo4j/shell/AppsIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/AppsIT.java
@@ -337,15 +337,15 @@ public class AppsIT extends AbstractShellIT
         executeCommand( "cd -a " + node.getId() );
         executeCommand( "MATCH (n) WHERE n = {self} RETURN n.name;", nodeOneName );
         executeCommand( "cd -r " + relationship.getId() );
-//        executeCommand( "MATCH ()-[r]->() WHERE r = {self} RETURN r.name;", relationshipName );
-//        executeCommand( "cd " + otherNode.getId() );
-//        executeCommand( "MATCH (n) WHERE n = {self} RETURN n.name;", nodeTwoName );
-//
-//        executeCommand( "cd -a " + strayNode.getId() );
-//        beginTx();
-//        strayNode.delete();
-//        finishTx();
-//        executeCommand( "MATCH (n) WHERE id(n) = " + node.getId() + " RETURN n.name;", nodeOneName );
+        executeCommand( "MATCH ()-[r]->() WHERE r = {self} RETURN r.name;", relationshipName );
+        executeCommand( "cd " + otherNode.getId() );
+        executeCommand( "MATCH (n) WHERE n = {self} RETURN n.name;", nodeTwoName );
+
+        executeCommand( "cd -a " + strayNode.getId() );
+        beginTx();
+        strayNode.delete();
+        finishTx();
+        executeCommand( "MATCH (n) WHERE id(n) = " + node.getId() + " RETURN n.name;", nodeOneName );
     }
 
     @Test

--- a/community/shell/src/test/java/org/neo4j/shell/ReadOnlyServerIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/ReadOnlyServerIT.java
@@ -19,9 +19,9 @@
  */
 package org.neo4j.shell;
 
-import java.rmi.RemoteException;
-
 import org.junit.Test;
+
+import java.rmi.RemoteException;
 
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ProposerContextImplTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ProposerContextImplTest.java
@@ -19,16 +19,17 @@
  */
 package org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.context;
 
+import org.junit.Test;
+
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.junit.Test;
 
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.protocol.heartbeat.HeartbeatContext;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -90,6 +91,7 @@ public class ProposerContextImplTest
 
         HeartbeatContext heartbeatContext = mock( HeartbeatContext.class );
         when( heartbeatContext.getAlive() ).thenReturn( alive );
+        when( heartbeatContext.getUriForId( any( InstanceId.class ) ) ).thenReturn( URI.create( "http://localhost:8080" ) );
 
         // when
         ProposerContextImpl proposerContext = new ProposerContextImpl( new InstanceId( 1 ), commonContextState,

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_3/codegen/ir/CodeGenSugar.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_3/codegen/ir/CodeGenSugar.scala
@@ -75,6 +75,7 @@ trait CodeGenSugar extends MockitoSugar {
                       graphDb: GraphDatabaseQueryService,
                       mode: ExecutionMode = NormalMode): InternalExecutionResult = {
     val tx = graphDb.beginTransaction(KernelTransaction.Type.explicit, AnonymousContext.read())
+    var transactionalContext: TransactionalContextWrapper = null
     try {
       val locker: PropertyContainerLocker = new PropertyContainerLocker
       val contextFactory = Neo4jTransactionalContextFactory.create(graphDb, locker)
@@ -88,6 +89,7 @@ trait CodeGenSugar extends MockitoSugar {
       result.size
       result
     } finally {
+      transactionalContext.close(true)
       tx.close()
     }
   }

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_3/codegen/ir/CodeGenSugar.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_3/codegen/ir/CodeGenSugar.scala
@@ -79,7 +79,7 @@ trait CodeGenSugar extends MockitoSugar {
     try {
       val locker: PropertyContainerLocker = new PropertyContainerLocker
       val contextFactory = Neo4jTransactionalContextFactory.create(graphDb, locker)
-      val transactionalContext = TransactionalContextWrapper(
+      transactionalContext = TransactionalContextWrapper(
         contextFactory.newContext(ClientConnectionInfo.EMBEDDED_CONNECTION, tx,
                                   "no query text exists for this test", Collections.emptyMap()))
       val queryContext = new TransactionBoundQueryContext(transactionalContext)(mock[IndexSearchMonitor])

--- a/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLocksIT.java
+++ b/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLocksIT.java
@@ -266,11 +266,13 @@ public class DeferringLocksIT
 
     private void assertNodeWith( Label label, String key, Object value )
     {
-        ResourceIterator<Node> nodes = db.findNodes( label, key, value );
-        assertTrue( nodes.hasNext() );
-        Node foundNode = nodes.next();
-        assertTrue( foundNode.hasLabel( label ) );
-        assertEquals( value, foundNode.getProperty( key ) );
+        try ( ResourceIterator<Node> nodes = db.findNodes( label, key, value ) )
+        {
+            assertTrue( nodes.hasNext() );
+            Node foundNode = nodes.next();
+            assertTrue( foundNode.hasLabel( label ) );
+            assertEquals( value, foundNode.getProperty( key ) );
+        }
     }
 
     private Node createNodeWithProperty( Label label, String key, Object value )

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/LabelIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/LabelIT.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
@@ -33,7 +34,6 @@ import org.neo4j.kernel.impl.ha.ClusterManager;
 import org.neo4j.test.ha.ClusterRule;
 
 import static org.junit.Assert.assertEquals;
-
 import static org.neo4j.graphdb.Label.label;
 
 public class LabelIT
@@ -74,7 +74,10 @@ public class LabelIT
         try ( Transaction ignore = db.beginTx() )
         {
             ThreadToStatementContextBridge bridge = threadToStatementContextBridgeFrom( db );
-            return bridge.get().readOperations().labelGetForName( label.name() );
+            try ( Statement statement = bridge.get() )
+            {
+                return statement.readOperations().labelGetForName( label.name() );
+            }
         }
     }
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/HaCountsIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/HaCountsIT.java
@@ -177,9 +177,9 @@ public class HaCountsIT
     private IndexDescriptor createAnIndex( HighlyAvailableGraphDatabase db, Label label, String propertyName )
             throws KernelException
     {
-        try ( Transaction tx = db.beginTx() )
+        try ( Transaction tx = db.beginTx();
+              Statement statement = statement( db ) )
         {
-            Statement statement = statement( db );
             int labelId = statement.tokenWriteOperations().labelGetOrCreateForName( label.name() );
             int propertyKeyId = statement.tokenWriteOperations().propertyKeyGetOrCreateForName( propertyName );
             IndexDescriptor index = statement.schemaWriteOperations()
@@ -192,9 +192,9 @@ public class HaCountsIT
     private void assertOnNodeCounts( int expectedTotalNodes, int expectedLabelledNodes,
                                      Label label, HighlyAvailableGraphDatabase db )
     {
-        try ( Transaction ignored = db.beginTx() )
+        try ( Transaction ignored = db.beginTx();
+              Statement statement = statement( db ) )
         {
-            final Statement statement = statement( db );
             final int labelId = statement.readOperations().labelGetForName( label.name() );
             assertEquals( expectedTotalNodes, statement.readOperations().countsForNode( -1 ) );
             assertEquals( expectedLabelledNodes, statement.readOperations().countsForNode( labelId ) );
@@ -244,9 +244,10 @@ public class HaCountsIT
         long end = start + 60_000;
         while ( System.currentTimeMillis() < end )
         {
-            try ( Transaction tx = db.beginTx() )
+            try ( Transaction tx = db.beginTx();
+                  Statement statement = statement( db ) )
             {
-                switch ( statement( db ).readOperations().indexGetState( index ) )
+                switch ( statement.readOperations().indexGetState( index ) )
                 {
                 case ONLINE:
                     return indexingService( db ).getIndexId( index.schema() );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/PropertyConstraintsStressIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/PropertyConstraintsStressIT.java
@@ -41,6 +41,7 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.graphdb.TransientTransactionFailureException;
@@ -430,14 +431,17 @@ public class PropertyConstraintsStressIT
             try ( Transaction tx = db.beginTx() )
             {
                 Set<Object> values = new HashSet<>();
-                for ( Node node : loop( db.findNodes( label( type ) ) ) )
+                try ( ResourceIterator<Node> nodes = db.findNodes( label( type ) ) )
                 {
-                    Object value = node.getProperty( property );
-                    if ( values.contains( value ) )
+                    for ( Node node : loop( nodes ) )
                     {
-                        return false;
+                        Object value = node.getProperty( property );
+                        if ( values.contains( value ) )
+                        {
+                            return false;
+                        }
+                        values.add( value );
                     }
-                    values.add( value );
                 }
 
                 tx.success();

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/ClusterLocksIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/ClusterLocksIT.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionTerminatedException;
 import org.neo4j.helpers.collection.Iterables;
@@ -210,7 +211,9 @@ public class ClusterLocksIT
 
     private Node getNode( HighlyAvailableGraphDatabase db, Label testLabel ) throws EntityNotFoundException
     {
-        return db.findNodes( testLabel ).stream().findFirst()
-                .orElseThrow( () -> new EntityNotFoundException( EntityType.NODE, 0L ) );
+        try ( ResourceIterator<Node> nodes = db.findNodes( testLabel ) )
+        {
+            return nodes.stream().findFirst().orElseThrow( () -> new EntityNotFoundException( EntityType.NODE, 0L ) );
+        }
     }
 }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/AbstractConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/AbstractConstraintCreationIT.java
@@ -34,7 +34,6 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransientTransactionFailureException;
-import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.graphdb.schema.ConstraintDefinition;
 import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.graphdb.schema.Schema;
@@ -131,6 +130,7 @@ public abstract class AbstractConstraintCreationIT<Constraint extends Constraint
 
         // then
         assertEquals( constraint, single( constraints ) );
+        commit();
     }
 
     @Test
@@ -155,6 +155,8 @@ public abstract class AbstractConstraintCreationIT<Constraint extends Constraint
 
         // then
         assertEquals( constraint, single( constraints ) );
+
+        commit();
     }
 
     @Test
@@ -173,21 +175,24 @@ public abstract class AbstractConstraintCreationIT<Constraint extends Constraint
         // then
         Iterator<?> constraints = readOperations.constraintsGetAll();
         assertFalse( "should not have any constraints", constraints.hasNext() );
+        commit();
     }
 
     @Test
     public void shouldNotStoreConstraintThatIsRemovedInTheSameTransaction() throws Exception
     {
         // given
-        Statement statement = statementInNewTransaction( SecurityContext.AUTH_DISABLED );
+        try ( Statement statement = statementInNewTransaction( SecurityContext.AUTH_DISABLED ) )
+        {
 
-        Constraint constraint = createConstraint( statement.schemaWriteOperations(), descriptor );
+            Constraint constraint = createConstraint( statement.schemaWriteOperations(), descriptor );
 
-        // when
-        dropConstraint( statement.schemaWriteOperations(), constraint );
+            // when
+            dropConstraint( statement.schemaWriteOperations(), constraint );
 
-        // then
-        assertFalse( "should not have any constraints", statement.readOperations().constraintsGetAll().hasNext() );
+            // then
+            assertFalse( "should not have any constraints", statement.readOperations().constraintsGetAll().hasNext() );
+        }
 
         // when
         commit();
@@ -196,6 +201,7 @@ public abstract class AbstractConstraintCreationIT<Constraint extends Constraint
 
         // then
         assertFalse( "should not have any constraints", readOperations.constraintsGetAll().hasNext() );
+        commit();
     }
 
     @Test
@@ -222,6 +228,7 @@ public abstract class AbstractConstraintCreationIT<Constraint extends Constraint
 
             // then
             assertFalse( "should not have any constraints", statement.constraintsGetAll().hasNext() );
+            commit();
         }
     }
 
@@ -249,6 +256,7 @@ public abstract class AbstractConstraintCreationIT<Constraint extends Constraint
         {
             // good
         }
+        commit();
     }
 
     @Test
@@ -281,6 +289,7 @@ public abstract class AbstractConstraintCreationIT<Constraint extends Constraint
             // then
             assertEquals( singletonList( constraint ), asCollection( statement.constraintsGetAll() ) );
             schemaState.assertNotCleared( statement );
+            commit();
         }
     }
 

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodePropertyExistenceConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodePropertyExistenceConstraintCreationIT.java
@@ -143,6 +143,7 @@ public class NodePropertyExistenceConstraintCreationIT
             Iterator<ConstraintDescriptor> constraints = statement.constraintsGetForSchema( descriptor );
 
             assertEquals( constraint, single( constraints ) );
+            commit();
         }
     }
 }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintCreationIT.java
@@ -181,6 +181,7 @@ public class UniquenessConstraintCreationIT
         // then
         ReadOperations readOperations = readOperationsInNewTransaction();
         assertEquals( asSet( uniqueIndex ), asSet( readOperations.indexesGetAll() ) );
+        commit();
     }
 
     @Test
@@ -234,6 +235,7 @@ public class UniquenessConstraintCreationIT
             Iterator<ConstraintDescriptor> constraints = statement.constraintsGetForSchema( descriptor );
 
             assertEquals( ConstraintDescriptorFactory.existsForSchema( descriptor ), single( constraints ) );
+            commit();
         }
     }
 

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/MetricsKernelExtensionFactoryIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/MetricsKernelExtensionFactoryIT.java
@@ -151,7 +151,7 @@ public class MetricsKernelExtensionFactoryIT
         // GIVEN
         try ( Transaction tx = db.beginTx() )
         {
-            db.execute( "match (n:Label {name: 'Pontus'}) return n.name" );
+            db.execute( "match (n:Label {name: 'Pontus'}) return n.name" ).close();
             tx.success();
         }
 
@@ -163,7 +163,7 @@ public class MetricsKernelExtensionFactoryIT
         {
             try ( Transaction tx = db.beginTx() )
             {
-                db.execute( "match (n:Label {name: 'Pontus'}) return n.name" );
+                db.execute( "match (n:Label {name: 'Pontus'}) return n.name" ).close();
                 tx.success();
             }
             addNodes( 1 );

--- a/enterprise/runtime/neole/src/main/java/org/neo4j/impl/store/prototype/neole/CursorFactory.java
+++ b/enterprise/runtime/neole/src/main/java/org/neo4j/impl/store/prototype/neole/CursorFactory.java
@@ -78,12 +78,12 @@ class CursorFactory implements org.neo4j.impl.kernel.api.CursorFactory
     @Override
     public NodeManualIndexCursor allocateNodeManualIndexCursor()
     {
-        throw new UnsupportedOperationException( "not implemented" );
+        return null;
     }
 
     @Override
     public EdgeManualIndexCursor allocateEdgeManualIndexCursor()
     {
-        throw new UnsupportedOperationException( "not implemented" );
+        return null;
     }
 }

--- a/enterprise/runtime/neole/src/main/java/org/neo4j/impl/store/prototype/neole/CursorFactory.java
+++ b/enterprise/runtime/neole/src/main/java/org/neo4j/impl/store/prototype/neole/CursorFactory.java
@@ -78,12 +78,12 @@ class CursorFactory implements org.neo4j.impl.kernel.api.CursorFactory
     @Override
     public NodeManualIndexCursor allocateNodeManualIndexCursor()
     {
-        return null;
+        throw new UnsupportedOperationException( "not implemented" );
     }
 
     @Override
     public EdgeManualIndexCursor allocateEdgeManualIndexCursor()
     {
-        return null;
+        throw new UnsupportedOperationException( "not implemented" );
     }
 }

--- a/enterprise/runtime/neole/src/main/java/org/neo4j/impl/store/prototype/neole/PropertyCursor.java
+++ b/enterprise/runtime/neole/src/main/java/org/neo4j/impl/store/prototype/neole/PropertyCursor.java
@@ -22,7 +22,6 @@ package org.neo4j.impl.store.prototype.neole;
 import org.neo4j.string.UTF8;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.ValueGroup;
-import org.neo4j.values.storable.ValueWriter;
 import org.neo4j.values.storable.Values;
 
 import static org.neo4j.impl.store.prototype.neole.ReadStore.combineReference;
@@ -254,12 +253,6 @@ class PropertyCursor extends PartialPropertyCursor
         default:
             return null;
         }
-    }
-
-    @Override
-    public <E extends Exception> void writeTo( ValueWriter<E> target )
-    {
-
     }
 
     @Override

--- a/enterprise/runtime/neole/src/main/java/org/neo4j/impl/store/prototype/neole/PropertyCursor.java
+++ b/enterprise/runtime/neole/src/main/java/org/neo4j/impl/store/prototype/neole/PropertyCursor.java
@@ -22,6 +22,7 @@ package org.neo4j.impl.store.prototype.neole;
 import org.neo4j.string.UTF8;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.ValueGroup;
+import org.neo4j.values.storable.ValueWriter;
 import org.neo4j.values.storable.Values;
 
 import static org.neo4j.impl.store.prototype.neole.ReadStore.combineReference;
@@ -253,6 +254,12 @@ class PropertyCursor extends PartialPropertyCursor
         default:
             return null;
         }
+    }
+
+    @Override
+    public <E extends Exception> void writeTo( ValueWriter<E> target )
+    {
+
     }
 
     @Override

--- a/integrationtests/src/test/java/org/neo4j/bolt/SessionResetIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/SessionResetIT.java
@@ -62,6 +62,7 @@ import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import static java.util.Collections.newSetFromMap;
 import static java.util.concurrent.CompletableFuture.runAsync;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.IntStream.range;
@@ -132,7 +133,7 @@ public class SessionResetIT
         // periodic commit query can't be terminated so but reset must fail the transaction
         Future<Void> queryResult = runQueryInDifferentThreadAndResetSession( LONG_PERIODIC_COMMIT_QUERY, true );
 
-        assertNull( queryResult.get( 60, SECONDS ) );
+        assertNull( queryResult.get( 5,  MINUTES) );
         assertDatabaseIsIdle();
 
         // termination must cause transaction failure and no nodes should be committed

--- a/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/ProcedureIT.java
@@ -541,7 +541,7 @@ public class ProcedureIT
         // When
         try ( Transaction tx = db.beginTx() )
         {
-            db.execute( "CALL org.neo4j.procedure.writingProcedure()" );
+            db.execute( "CALL org.neo4j.procedure.writingProcedure()" ).close();
             tx.success();
         }
 
@@ -637,7 +637,7 @@ public class ProcedureIT
         // When
         try ( Transaction tx = db.beginTx() )
         {
-            db.execute( "CALL org.neo4j.procedure.writeProcedureCallingWriteProcedure()" );
+            db.execute( "CALL org.neo4j.procedure.writeProcedureCallingWriteProcedure()" ).close();
             tx.success();
         }
 
@@ -883,7 +883,7 @@ public class ProcedureIT
     {
         try ( Transaction ignore = db.beginTx() )
         {
-            db.execute( "CALL org.neo4j.procedure.simpleArgument(12)" );
+            db.execute( "CALL org.neo4j.procedure.simpleArgument(12)" ).close();
             db.createNode();
         }
     }
@@ -952,6 +952,7 @@ public class ProcedureIT
         {
             assertThat( result.next().get( "n.prop" ), equalTo( Integer.toString( i ) ) );
         }
+        result.close();
 
         //Make sure all the lines has been properly commited to the database.
         String[] dbContents = db.execute( "MATCH (n) return n.prop" ).stream().map( m -> (String) m.get( "n.prop" ) )

--- a/integrationtests/src/test/java/org/neo4j/procedure/UserFunctionIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/UserFunctionIT.java
@@ -88,6 +88,7 @@ public class UserFunctionIT
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
+    private static List<Exception> exceptionsInFunction = Collections.synchronizedList( new ArrayList<>() );
     private GraphDatabaseService db;
 
     @Test
@@ -466,12 +467,10 @@ public class UserFunctionIT
     {
         try ( Transaction ignore = db.beginTx() )
         {
-            db.execute( "RETURN org.neo4j.procedure.simpleArgument(12)" );
+            db.execute( "RETURN org.neo4j.procedure.simpleArgument(12)" ).close();
             db.createNode();
         }
     }
-
-    private static List<Exception> exceptionsInFunction = Collections.synchronizedList( new ArrayList<>() );
 
     @Test
     public void shouldPreserveSecurityContextWhenSpawningThreadsCreatingTransactionInFunctions() throws Throwable

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,13 @@
     <generate-config-docs-phase>prepare-package</generate-config-docs-phase>
     <hsqldb.version>2.3.2</hsqldb.version>
     <test.runner.jvm.settings.additional></test.runner.jvm.settings.additional>
-    <test.runner.jvm.settings>-Xmx2G -XX:+UseG1GC -XX:-OmitStackTraceInFastThrow -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=target/test-data -Dorg.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.DIRTY_MEMORY=true -Dorg.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.CHECK_NATIVE_ACCESS=true -Dorg.neo4j.io.pagecache.impl.muninn.usePreciseCursorErrorStackTraces=true -XX:+UnlockExperimentalVMOptions -XX:+TrustFinalNonStaticFields ${test.runner.jvm.settings.additional}</test.runner.jvm.settings>
+    <test.runner.jvm.settings>-Xmx2G -XX:+UseG1GC -XX:-OmitStackTraceInFastThrow -XX:+HeapDumpOnOutOfMemoryError
+      -XX:HeapDumpPath=target/test-data -Dorg.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.DIRTY_MEMORY=true
+      -Dorg.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.CHECK_NATIVE_ACCESS=true
+      -Dorg.neo4j.io.pagecache.impl.muninn.usePreciseCursorErrorStackTraces=true
+      -Dorg.neo4j.kernel.impl.api.KernelStatement.trackStatements=true
+      -XX:+UnlockExperimentalVMOptions -XX:+TrustFinalNonStaticFields ${test.runner.jvm.settings.additional}
+    </test.runner.jvm.settings>
     <doclint-groups>reference</doclint-groups>
     <jetty.version>9.2.9.v20150224</jetty.version>
     <findbugs.version>3.0.1</findbugs.version>

--- a/tools/src/test/java/org/neo4j/tools/rebuild/RebuildFromLogsTest.java
+++ b/tools/src/test/java/org/neo4j/tools/rebuild/RebuildFromLogsTest.java
@@ -38,6 +38,8 @@ import org.neo4j.consistency.checking.InconsistentStoreException;
 import org.neo4j.consistency.report.ConsistencySummaryStatistics;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.ResourceIterable;
+import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils;
@@ -189,12 +191,17 @@ public class RebuildFromLogsTest
                     @Override
                     void applyTx( GraphDatabaseService graphDb )
                     {
-                        for ( Node node : graphDb.getAllNodes() )
+                        ResourceIterable<Node> nodes = graphDb.getAllNodes();
+                        try ( ResourceIterator<Node> iterator = nodes.iterator() )
                         {
-                            if ( "value".equals( node.getProperty( CREATE_NODE_WITH_PROPERTY.name(), null ) ) )
+                            while ( iterator.hasNext() )
                             {
-                                node.setProperty( CREATE_NODE_WITH_PROPERTY.name(), "other" );
-                                break;
+                                Node node = iterator.next();
+                                if ( "value".equals( node.getProperty( CREATE_NODE_WITH_PROPERTY.name(), null ) ) )
+                                {
+                                    node.setProperty( CREATE_NODE_WITH_PROPERTY.name(), "other" );
+                                    break;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Add possibility to track not closed kernel statements and
where they were opened and closed during transaction lifecycle.
In case if statement tracking is enabled transaction that has unclosed
statement will not gonna be able to commit