### PR TITLE
Importer collects relationships with missing data

### DIFF
--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/CsvImporter.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/CsvImporter.java
@@ -115,7 +115,7 @@ class CsvImporter implements Importer
                 idType,
                 new WrappedCsvInputConfigurationForNeo4jAdmin( csvConfiguration( args, false ) ),
                 badCollector,
-                configuration.maxNumberOfProcessors() );
+                configuration.maxNumberOfProcessors(), !ignoreBadRelationships );
 
         ImportTool.doImport( outsideWorld.errorStream(), outsideWorld.errorStream(), storeDir, logsDir, reportFile, fs,
                 nodesFiles, relationshipsFiles, false, input, this.databaseConfig, badOutput, configuration );

--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -443,7 +443,7 @@ public class ImportTool
             input = new CsvInput( nodeData( inputEncoding, nodesFiles ), defaultFormatNodeFileHeader(),
                     relationshipData( inputEncoding, relationshipsFiles ), defaultFormatRelationshipFileHeader(),
                     idType, csvConfiguration( args, defaultSettingsSuitableForTests ), badCollector,
-                    configuration.maxNumberOfProcessors() );
+                    configuration.maxNumberOfProcessors(), !skipBadRelationships );
 
             doImport( out, err, storeDir, logsDir, badFile, fs, nodesFiles, relationshipsFiles,
                     enableStacktrace, input, dbConfig, badOutput, configuration );

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
@@ -1272,6 +1272,7 @@ public class ImportToolTest
             importTool(
                     "--into", dbRule.getStoreDirAbsolutePath(),
                     "--nodes", nodeData( true, config, nodeIds, TRUE ).getAbsolutePath(),
+                    "--skip-bad-relationships", "false",
                     "--relationships", relationshipData( true, config, relationshipDataLines,
                             TRUE, true ).getAbsolutePath() );
             fail( " Should fail during import." );
@@ -1859,6 +1860,47 @@ public class ImportToolTest
                 "--max-memory", "100M" );
     }
 
+    @Test
+    public void shouldTreatRelationshipWithMissingStartOrEndIdOrTypeAsBadRelationship() throws Exception
+    {
+        // GIVEN
+        List<String> nodeIds = asList( "a", "b", "c" );
+        Configuration config = Configuration.COMMAS;
+        File nodeData = nodeData( true, config, nodeIds, TRUE );
+
+        List<RelationshipDataLine> relationships = Arrays.asList(
+                relationship( "a", null, "TYPE" ),
+                relationship( null, "b", "TYPE" ),
+                relationship( "a", "b", null ) );
+
+        File relationshipData = relationshipData( true, config, relationships.iterator(), TRUE, true );
+        File bad = badFile();
+
+        // WHEN importing data where some relationships refer to missing nodes
+        importTool(
+                "--into", dbRule.getStoreDirAbsolutePath(),
+                "--nodes", nodeData.getAbsolutePath(),
+                "--bad", bad.getAbsolutePath(),
+                "--skip-bad-relationships", "true",
+                "--relationships", relationshipData.getAbsolutePath() );
+
+        String badContents = FileUtils.readTextFile( bad, Charset.defaultCharset() );
+        assertEquals( badContents, 3, occurencesOf( badContents, "is missing data" ) );
+    }
+
+    private static int occurencesOf( String text, String lookFor )
+    {
+        int index = -1;
+        int count = -1;
+        do
+        {
+            count++;
+            index = text.indexOf( lookFor, index + 1 );
+        }
+        while ( index != -1 );
+        return count;
+    }
+
     private File writeArrayCsv( String[] headers, String[] values ) throws FileNotFoundException
     {
         File data = file( fileName( "whitespace.csv" ) );
@@ -2281,14 +2323,19 @@ public class ImportToolTest
             RelationshipDataLine entry = data.next();
             if ( linePredicate.test( i ) )
             {
-                writer.println( entry.startNodeId +
-                                delimiter + entry.endNodeId +
-                                (specifyType ? (delimiter + entry.type) : "") +
+                writer.println( nullSafeString( entry.startNodeId ) +
+                                delimiter + nullSafeString( entry.endNodeId ) +
+                                (specifyType ? (delimiter + nullSafeString( entry.type )) : "") +
                                 delimiter + currentTimeMillis() +
                                 delimiter + (entry.name != null ? entry.name : "")
                 );
             }
         }
+    }
+
+    private static String nullSafeString( String endNodeId )
+    {
+        return endNodeId != null ? endNodeId : "";
     }
 
     private Iterator<RelationshipDataLine> randomRelationships( final List<String> nodeIds )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipTypeCheckerStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipTypeCheckerStep.java
@@ -66,6 +66,7 @@ public class RelationshipTypeCheckerStep extends ProcessorStep<Batch<InputRelati
         Map<Object,MutableLong> typeMap = typeCheckers.computeIfAbsent( currentThread(), ( t ) -> new HashMap<>() );
         Stream.of( batch.input )
               .map( InputRelationship::typeAsObject )
+              .filter( type -> type != null )
               .forEach( type -> typeMap.computeIfAbsent( type, NEW_MUTABLE_LONG ).increment() );
         sender.send( batch );
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/BadCollector.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/BadCollector.java
@@ -173,9 +173,16 @@ public class BadCollector implements Collector
         {
             if ( message == null )
             {
-                message = format( "%s referring to missing node %s", relationship, specificValue );
+                message = !isMissingData( relationship )
+                        ? format( "%s referring to missing node %s", relationship, specificValue )
+                        : format( "%s is missing data", relationship );
             }
             return message;
+        }
+
+        private static boolean isMissingData( InputRelationship relationship )
+        {
+            return relationship.startNode() == null || relationship.endNode() == null || !relationship.hasType();
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputRelationship.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/InputRelationship.java
@@ -96,6 +96,15 @@ public class InputRelationship extends InputEntity
         return typeId.intValue();
     }
 
+    /**
+     * @return whether or not this relationship has a type assigned to it, whether via {@link #typeId()}
+     * (where {@link #hasTypeId()} is {@code true}), or via {@link #type()}.
+     */
+    public boolean hasType()
+    {
+        return hasTypeId() || type() != null;
+    }
+
     public void setType( String type )
     {
         this.type = type;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Inputs.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Inputs.java
@@ -19,24 +19,10 @@
  */
 package org.neo4j.unsafe.impl.batchimport.input;
 
-import java.io.File;
-
 import org.neo4j.unsafe.impl.batchimport.InputIterable;
 import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdGenerator;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
-import org.neo4j.unsafe.impl.batchimport.input.csv.Configuration;
-import org.neo4j.unsafe.impl.batchimport.input.csv.CsvInput;
-import org.neo4j.unsafe.impl.batchimport.input.csv.IdType;
-
-import static java.nio.charset.Charset.defaultCharset;
-import static org.neo4j.unsafe.impl.batchimport.input.InputEntityDecorators.NO_NODE_DECORATOR;
-import static org.neo4j.unsafe.impl.batchimport.input.InputEntityDecorators.NO_RELATIONSHIP_DECORATOR;
-import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.data;
-import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.defaultFormatNodeFileHeader;
-import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.defaultFormatRelationshipFileHeader;
-import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.nodeData;
-import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.relationshipData;
 
 public class Inputs
 {
@@ -76,15 +62,5 @@ public class Inputs
                 return badCollector;
             }
         };
-    }
-
-    public static Input csv( File nodes, File relationships, IdType idType,
-            Configuration configuration, Collector badCollector, int maxProcessors )
-    {
-        return new CsvInput(
-                nodeData( data( NO_NODE_DECORATOR, defaultCharset(), nodes ) ), defaultFormatNodeFileHeader(),
-                relationshipData( data( NO_RELATIONSHIP_DECORATOR, defaultCharset(), relationships ) ),
-                defaultFormatRelationshipFileHeader(), idType, configuration,
-                badCollector, maxProcessors );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ImportPanicIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/ImportPanicIT.java
@@ -90,7 +90,7 @@ public class ImportPanicIT
                 IdType.ACTUAL,
                 csvConfigurationWithLowBufferSize(),
                 new BadCollector( NullOutputStream.NULL_OUTPUT_STREAM, 0, 0 ),
-                Runtime.getRuntime().availableProcessors() );
+                Runtime.getRuntime().availableProcessors(), true );
 
         // WHEN
         try

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
@@ -55,6 +55,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -103,7 +104,7 @@ public class CsvInputTest
                         entry( "name", Type.PROPERTY, extractors.string() ),
                         entry( "labels", Type.LABEL, extractors.string() ) ),
                         null, null, idType, config( COMMAS ), silentBadCollector( 0 ),
-                        getRuntime().availableProcessors() );
+                        getRuntime().availableProcessors(), true );
 
         // WHEN/THEN
         try ( InputIterator<InputNode> nodes = input.nodes().iterator() )
@@ -128,7 +129,7 @@ public class CsvInputTest
                         entry( "type", Type.TYPE, extractors.string() ),
                         entry( "since", Type.PROPERTY, extractors.long_() ) ), idType, config( COMMAS ),
                         silentBadCollector( 0 ),
-                        getRuntime().availableProcessors() );
+                        getRuntime().availableProcessors(), true );
 
         // WHEN/THEN
         try ( InputIterator<InputRelationship> relationships = input.relationships().iterator() )
@@ -154,7 +155,7 @@ public class CsvInputTest
                 relationshipDataIterable, header(
                         entry( null, Type.START_ID, idType.extractor( extractors ) ),
                         entry( null, Type.END_ID, idType.extractor( extractors ) ) ),
-                idType, config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                idType, config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
 
         // WHEN
         try ( ResourceIterator<InputNode> iterator = input.nodes().iterator() )
@@ -199,7 +200,7 @@ public class CsvInputTest
                       entry( "type", Type.LABEL, extractors.string() ),
                       entry( "kills", Type.PROPERTY, extractors.int_() ) ),
                 null, null, IdType.ACTUAL, config( COMMAS ), silentBadCollector( 0 ),
-                getRuntime().availableProcessors() );
+                getRuntime().availableProcessors(), true );
 
         // WHEN
         try ( ResourceIterator<InputNode> nodes = input.nodes().iterator() )
@@ -224,7 +225,7 @@ public class CsvInputTest
                       entry( null, Type.ID, extractors.long_() ),
                       entry( "name", Type.PROPERTY, extractors.string() ) ),
                 null, null, IdType.ACTUAL, config( COMMAS ), silentBadCollector( 4 ),
-                getRuntime().availableProcessors() );
+                getRuntime().availableProcessors(), true );
 
         // WHEN
         try ( ResourceIterator<InputNode> nodes = input.nodes().iterator() )
@@ -250,7 +251,7 @@ public class CsvInputTest
         Input input = new CsvInput( data, defaultFormatNodeFileHeader(),
                                     null, null,
                                     IdType.STRING, config( COMMAS ), silentBadCollector( 0 ),
-                                    getRuntime().availableProcessors() );
+                                    getRuntime().availableProcessors(), true );
 
         // WHEN iterating over them, THEN the expected data should come out
         try ( InputIterator<InputNode> nodes = input.nodes().iterator() )
@@ -276,7 +277,7 @@ public class CsvInputTest
         Iterable<DataFactory<InputNode>> dataIterable = dataIterable( data );
         Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(),
                 null, null, IdType.ACTUAL, config( COMMAS ), silentBadCollector( 0 ),
-                getRuntime().availableProcessors() );
+                getRuntime().availableProcessors(), true );
 
         // WHEN/THEN
         try ( ResourceIterator<InputNode> nodes = input.nodes().iterator() )
@@ -305,7 +306,7 @@ public class CsvInputTest
         Iterable<DataFactory<InputRelationship>> dataIterable = dataIterable( data );
         Input input = new CsvInput( null, null,
                 dataIterable, defaultFormatRelationshipFileHeader(), IdType.ACTUAL, config( COMMAS ),
-                silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
 
         // WHEN/THEN
         try ( ResourceIterator<InputRelationship> relationships = input.relationships().iterator() )
@@ -328,7 +329,7 @@ public class CsvInputTest
         Iterable<DataFactory<InputRelationship>> dataIterable = dataIterable( data );
         Input input = new CsvInput( null, null,
                 dataIterable, defaultFormatRelationshipFileHeader(), IdType.ACTUAL, config( COMMAS ),
-                silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
 
         // WHEN/THEN
         try ( ResourceIterator<InputRelationship> relationships = input.relationships().iterator() )
@@ -356,7 +357,7 @@ public class CsvInputTest
                 "Johan,2\n" );
         Iterable<DataFactory<InputNode>> dataIterable = dataIterable( data );
         Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), null, null, IdType.STRING,
-                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
 
         // WHEN
         try ( ResourceIterator<InputNode> nodes = input.nodes().iterator() )
@@ -378,7 +379,7 @@ public class CsvInputTest
                 ",Johan,2\n" ); // this node is anonymous
         Iterable<DataFactory<InputNode>> dataIterable = dataIterable( data );
         Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), null, null, IdType.STRING,
-                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
 
         // WHEN
         try ( ResourceIterator<InputNode> nodes = input.nodes().iterator() )
@@ -400,7 +401,7 @@ public class CsvInputTest
                 ",Johan,2\n" ); // this node is anonymous
         Iterable<DataFactory<InputNode>> dataIterable = dataIterable( data );
         Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), null, null, IdType.STRING,
-                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
 
         // WHEN
         try ( ResourceIterator<InputNode> nodes = input.nodes().iterator() )
@@ -422,7 +423,7 @@ public class CsvInputTest
                 "def,Johan,2\n" ); // this node is anonymous
         Iterable<DataFactory<InputNode>> dataIterable = dataIterable( data );
         Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), null, null, IdType.STRING,
-                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
 
         // WHEN
         try ( ResourceIterator<InputNode> nodes = input.nodes().iterator() )
@@ -444,7 +445,7 @@ public class CsvInputTest
                 "1,Johan,2\n" ); // this node is anonymous
         Iterable<DataFactory<InputNode>> dataIterable = dataIterable( data );
         Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), null, null, IdType.ACTUAL,
-                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
 
         // WHEN
         try ( ResourceIterator<InputNode> nodes = input.nodes().iterator() )
@@ -466,7 +467,7 @@ public class CsvInputTest
                 "1,Johan,Additional\n" );
         Iterable<DataFactory<InputNode>> dataIterable = dataIterable( data );
         Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), null, null, IdType.ACTUAL,
-                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
 
         // WHEN
         try ( ResourceIterator<InputNode> nodes = input.nodes().iterator() )
@@ -488,7 +489,7 @@ public class CsvInputTest
                 "1,Johan,10\n" );
         Iterable<DataFactory<InputNode>> dataIterable = dataIterable( data );
         Input input = new CsvInput( dataIterable, defaultFormatNodeFileHeader(), null, null, IdType.ACTUAL,
-                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
 
         // WHEN
         try ( ResourceIterator<InputNode> nodes = input.nodes().iterator() )
@@ -507,7 +508,7 @@ public class CsvInputTest
         try
         {
             new CsvInput( null, null, null, null, IdType.ACTUAL, customConfig( ',', ',', '"' ),
-                    silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                    silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
             fail( "Should not be possible" );
         }
         catch ( IllegalArgumentException e )
@@ -524,7 +525,7 @@ public class CsvInputTest
         try
         {
             new CsvInput( null, null, null, null, IdType.ACTUAL, customConfig( ',', ';', ',' ),
-                    silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                    silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
             fail( "Should not be possible" );
         }
         catch ( IllegalArgumentException e )
@@ -542,7 +543,7 @@ public class CsvInputTest
         try
         {
             new CsvInput( null, null, null, null, IdType.ACTUAL, customConfig( ',', ';', ';' ),
-                    silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                    silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
             fail( "Should not be possible" );
         }
         catch ( IllegalArgumentException e )
@@ -568,7 +569,7 @@ public class CsvInputTest
                 header( entry( null, Type.ID, group.name(), idType.extractor( extractors ) ),
                         entry( "name", Type.PROPERTY, extractors.string() ) ),
                         null, null, idType, config( COMMAS ),
-                        silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                        silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
 
         // WHEN/THEN
         try ( InputIterator<InputNode> nodes = input.nodes().iterator() )
@@ -596,7 +597,7 @@ public class CsvInputTest
                         entry( null, Type.TYPE, extractors.string() ),
                         entry( null, Type.END_ID, endNodeGroup.name(), idType.extractor( extractors ) ) ),
                         idType, config( COMMAS ),
-                        silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                        silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
 
         // WHEN/THEN
         try ( InputIterator<InputRelationship> relationships = input.relationships().iterator() )
@@ -619,7 +620,7 @@ public class CsvInputTest
         Iterable<DataFactory<InputRelationship>> dataIterable = dataIterable( data );
         Input input = new CsvInput( null, null, dataIterable, defaultFormatRelationshipFileHeader(),
                 IdType.ACTUAL, config( COMMAS ),
-                silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
 
         // WHEN
         try ( ResourceIterator<InputRelationship> relationships = input.relationships().iterator() )
@@ -641,7 +642,7 @@ public class CsvInputTest
                 "2,Johan,abc\n" +
                 "3,Emil,12" ) );
         Input input = new CsvInput( data, DataFactories.defaultFormatNodeFileHeader(), null, null,
-                IdType.INTEGER, config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                IdType.INTEGER, config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
 
         // WHEN
         try ( InputIterator<InputNode> nodes = input.nodes().iterator() )
@@ -671,7 +672,7 @@ public class CsvInputTest
                 "2,Johan,111,Person\n" +
                 "3,Emil,12,Person" ) );
         Input input = new CsvInput( data, defaultFormatNodeFileHeader(), null, null, IdType.INTEGER,
-                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
 
         // WHEN
         try ( InputIterator<InputNode> nodes = input.nodes().iterator() )
@@ -693,7 +694,7 @@ public class CsvInputTest
                 "2,KNOWS,3,Johan,111\n" +
                 "3,KNOWS,4,Emil,12" ) );
         Input input = new CsvInput( null, null, data, defaultFormatRelationshipFileHeader(), IdType.INTEGER,
-                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
 
         // WHEN
         try ( InputIterator<InputRelationship> relationships = input.relationships().iterator() )
@@ -714,7 +715,7 @@ public class CsvInputTest
                 DataFactories.nodeData( CsvInputTest.<InputNode>data( ":ID,name\n1,Mattias",
                         new FailingNodeDecorator( failure ) ) );
         Input input = new CsvInput( data, defaultFormatNodeFileHeader(), null, null, IdType.INTEGER,
-                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
 
         // WHEN
         try ( InputIterator<InputNode> nodes = input.nodes().iterator() )
@@ -738,7 +739,7 @@ public class CsvInputTest
                 "2,a;b,10;20"
                 ) );
         Input input = new CsvInput( data, defaultFormatNodeFileHeader(), null, null, IdType.INTEGER,
-                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
 
         // WHEN/THEN
         try ( InputIterator<InputNode> nodes = input.nodes().iterator() )
@@ -758,7 +759,7 @@ public class CsvInputTest
                 ":START_ID,:END_ID,:TYPE\n" +
                 ",1," ) );
         Input input = new CsvInput( null, null, data, defaultFormatRelationshipFileHeader(), IdType.INTEGER,
-                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
 
         // WHEN
         try ( InputIterator<InputRelationship> relationships = input.relationships().iterator() )
@@ -781,7 +782,7 @@ public class CsvInputTest
                 ":START_ID,:END_ID,:TYPE\n" +
                 "1,," ) );
         Input input = new CsvInput( null, null, data, defaultFormatRelationshipFileHeader(), IdType.INTEGER,
-                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
 
         // WHEN
         try ( InputIterator<InputRelationship> relationships = input.relationships().iterator() )
@@ -812,7 +813,7 @@ public class CsvInputTest
             }
         } );
         Input input = new CsvInput( data, defaultFormatNodeFileHeader(),
-                null, null, IdType.INTEGER, config, silentBadCollector( 0 ), getRuntime().availableProcessors() );
+                null, null, IdType.INTEGER, config, silentBadCollector( 0 ), getRuntime().availableProcessors(), true );
 
         // WHEN
         try ( InputIterator<InputNode> nodes = input.nodes().iterator() )
@@ -836,7 +837,7 @@ public class CsvInputTest
         // WHEN
         Collector collector = mock( Collector.class );
         Input input = new CsvInput( data, defaultFormatNodeFileHeader(),
-                null, null, IdType.INTEGER, config( COMMAS ), collector, getRuntime().availableProcessors() );
+                null, null, IdType.INTEGER, config( COMMAS ), collector, getRuntime().availableProcessors(), true );
 
         // THEN
         try ( InputIterator<InputNode> nodes = input.nodes().iterator() )
@@ -849,6 +850,26 @@ public class CsvInputTest
         verify( collector, times( 1 ) ).collectExtraColumns( anyString(), eq( 1L ), eq( (String)null ) );
         verify( collector, times( 1 ) ).collectExtraColumns( anyString(), eq( 2L ), eq( (String)null ) );
         verify( collector, times( 1 ) ).collectExtraColumns( anyString(), eq( 2L ), eq( "additional" ) );
+    }
+
+    @Test
+    public void shouldSkipRelationshipValidationIfToldTo() throws Exception
+    {
+     // GIVEN
+        Iterable<DataFactory<InputRelationship>> data = relationshipData( CsvInputTest.<InputRelationship>data(
+                ":START_ID,:END_ID,:TYPE\n" +
+                ",," ) );
+        Input input = new CsvInput( null, null, data, defaultFormatRelationshipFileHeader(), IdType.INTEGER,
+                config( COMMAS ), silentBadCollector( 0 ), getRuntime().availableProcessors(), false );
+
+        // WHEN
+        try ( InputIterator<InputRelationship> relationships = input.relationships().iterator() )
+        {
+            InputRelationship relationship = relationships.next();
+            assertNull( relationship.startNode() );
+            assertNull( relationship.endNode() );
+            assertNull( relationship.type() );
+        }
     }
 
     private Configuration customConfig( final char delimiter, final char arrayDelimiter, final char quote )

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecoratorIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecoratorIT.java
@@ -74,7 +74,7 @@ public class ExternalPropertiesDecoratorIT
                 nodeData( data( decorator, () -> mainData( count ) ) ), defaultFormatNodeFileHeader(),
                 null, null,
                 idType, config,
-                collector, processors );
+                collector, processors, true );
 
         // WHEN/THEN
         try ( InputIterator<InputNode> nodes = input.nodes().iterator() )


### PR DESCRIPTION
Previously a relationship with missing START_ID, END_ID or TYPE would immediately
fail an import, due to them being considered mandatory fields. Now they are considered
bad relationships and can be collected instead, if collecting bad relationships is
enabled and it's withing the bad tolerance.

This will allow for a more flexible input reader for imports.