### PR TITLE
MemberID address resolution performed earlier

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchUpClient.java
@@ -31,8 +31,6 @@ import java.time.Clock;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import org.neo4j.causalclustering.discovery.TopologyService;
-import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.messaging.CatchUpRequest;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.helpers.NamedThreadFactory;
@@ -42,13 +40,13 @@ import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.ssl.SslPolicy;
 
+import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static org.neo4j.causalclustering.catchup.TimeoutLoop.waitForCompletion;
 
 public class CatchUpClient extends LifecycleAdapter
 {
     private final LogProvider logProvider;
-    private final TopologyService topologyService;
     private final Log log;
     private final Clock clock;
     private final Monitors monitors;
@@ -58,11 +56,9 @@ public class CatchUpClient extends LifecycleAdapter
 
     private NioEventLoopGroup eventLoopGroup;
 
-    public CatchUpClient( TopologyService topologyService, LogProvider logProvider, Clock clock,
-            long inactivityTimeoutMillis, Monitors monitors, SslPolicy sslPolicy )
+    public CatchUpClient( LogProvider logProvider, Clock clock, long inactivityTimeoutMillis, Monitors monitors, SslPolicy sslPolicy )
     {
         this.logProvider = logProvider;
-        this.topologyService = topologyService;
         this.log = logProvider.getLog( getClass() );
         this.clock = clock;
         this.inactivityTimeoutMillis = inactivityTimeoutMillis;
@@ -70,18 +66,12 @@ public class CatchUpClient extends LifecycleAdapter
         this.sslPolicy = sslPolicy;
     }
 
-    public <T> T makeBlockingRequest( MemberId upstream, CatchUpRequest request,
+    public <T> T makeBlockingRequest( AdvertisedSocketAddress upstream, CatchUpRequest request,
             CatchUpResponseCallback<T> responseHandler ) throws CatchUpClientException
     {
         CompletableFuture<T> future = new CompletableFuture<>();
-        Optional<AdvertisedSocketAddress> catchUpAddress = topologyService.findCatchupAddress( upstream );
 
-        if ( !catchUpAddress.isPresent() )
-        {
-            throw new CatchUpClientException( "Cannot find the target member socket address" );
-        }
-
-        CatchUpChannel channel = pool.acquire( catchUpAddress.get() );
+        CatchUpChannel channel = pool.acquire( upstream );
 
         future.whenComplete( ( result, e ) ->
         {
@@ -98,8 +88,7 @@ public class CatchUpClient extends LifecycleAdapter
         channel.setResponseHandler( responseHandler, future );
         channel.send( request );
 
-        String operation = String.format( "Timed out executing operation %s on %s (%s)",
-                request, upstream, catchUpAddress.get() );
+        String operation = format( "Timed out executing operation %s on %s", request, upstream );
 
         return waitForCompletion( future, operation, channel::millisSinceLastResponse, inactivityTimeoutMillis, log );
     }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStore.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStore.java
@@ -30,6 +30,7 @@ import org.neo4j.causalclustering.catchup.tx.TransactionLogCatchUpWriter;
 import org.neo4j.causalclustering.catchup.tx.TxPullClient;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.identity.StoreId;
+import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
@@ -132,13 +133,13 @@ public class RemoteStore
         }
     }
 
-    public CatchupResult tryCatchingUp( MemberId from, StoreId expectedStoreId, File storeDir ) throws StoreCopyFailedException, IOException
+    public CatchupResult tryCatchingUp( AdvertisedSocketAddress from, StoreId expectedStoreId, File storeDir ) throws StoreCopyFailedException, IOException
     {
         long pullIndex = getPullIndex( storeDir );
         return pullTransactions( from, expectedStoreId, storeDir, pullIndex, false );
     }
 
-    public void copy( MemberId from, StoreId expectedStoreId, File destDir )
+    public void copy( AdvertisedSocketAddress from, StoreId expectedStoreId, File destDir )
             throws StoreCopyFailedException, StreamingTransactionsFailedException
     {
         try
@@ -164,7 +165,7 @@ public class RemoteStore
         }
     }
 
-    private CatchupResult pullTransactions( MemberId from, StoreId expectedStoreId, File storeDir, long fromTxId, boolean asPartOfStoreCopy ) throws IOException, StoreCopyFailedException
+    private CatchupResult pullTransactions( AdvertisedSocketAddress from, StoreId expectedStoreId, File storeDir, long fromTxId, boolean asPartOfStoreCopy ) throws IOException, StoreCopyFailedException
     {
         try ( TransactionLogCatchUpWriter writer = transactionLogFactory.create( storeDir, fs, pageCache, logProvider, fromTxId, asPartOfStoreCopy ) )
         {
@@ -189,7 +190,7 @@ public class RemoteStore
         }
     }
 
-    public StoreId getStoreId( MemberId from ) throws StoreIdDownloadFailedException
+    public StoreId getStoreId( AdvertisedSocketAddress from ) throws StoreIdDownloadFailedException
     {
         return storeCopyClient.fetchStoreId( from );
     }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClient.java
@@ -27,6 +27,7 @@ import org.neo4j.causalclustering.catchup.CatchUpClientException;
 import org.neo4j.causalclustering.catchup.CatchUpResponseAdaptor;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.identity.StoreId;
+import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 
@@ -41,7 +42,7 @@ public class StoreCopyClient
         log = logProvider.getLog( getClass() );
     }
 
-    long copyStoreFiles( MemberId from, StoreId expectedStoreId, StoreFileStreams storeFileStreams )
+    long copyStoreFiles( AdvertisedSocketAddress from, StoreId expectedStoreId, StoreFileStreams storeFileStreams )
             throws StoreCopyFailedException
     {
         try
@@ -82,7 +83,7 @@ public class StoreCopyClient
         }
     }
 
-    StoreId fetchStoreId( MemberId from ) throws StoreIdDownloadFailedException
+    StoreId fetchStoreId( AdvertisedSocketAddress fromAddress ) throws StoreIdDownloadFailedException
     {
         try
         {
@@ -95,7 +96,7 @@ public class StoreCopyClient
                     signal.complete( response.storeId() );
                 }
             };
-            return catchUpClient.makeBlockingRequest( from, new GetStoreIdRequest(), responseHandler );
+            return catchUpClient.makeBlockingRequest( fromAddress, new GetStoreIdRequest(), responseHandler );
         }
         catch ( CatchUpClientException e )
         {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyProcess.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyProcess.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.identity.StoreId;
+import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.logging.Log;
@@ -48,7 +49,7 @@ public class StoreCopyProcess
         this.log = logProvider.getLog( getClass() );
     }
 
-    public void replaceWithStoreFrom( MemberId source, StoreId expectedStoreId )
+    public void replaceWithStoreFrom( AdvertisedSocketAddress source, StoreId expectedStoreId )
             throws IOException, StoreCopyFailedException, StreamingTransactionsFailedException
     {
         try ( TemporaryStoreDirectory tempStore = new TemporaryStoreDirectory( fs, pageCache,

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/CatchupPollingProcess.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/CatchupPollingProcess.java
@@ -34,10 +34,13 @@ import org.neo4j.causalclustering.catchup.storecopy.StreamingTransactionsFailedE
 import org.neo4j.causalclustering.core.consensus.schedule.RenewableTimeoutService;
 import org.neo4j.causalclustering.core.consensus.schedule.RenewableTimeoutService.RenewableTimeout;
 import org.neo4j.causalclustering.core.consensus.schedule.RenewableTimeoutService.TimeoutName;
+import org.neo4j.causalclustering.core.state.snapshot.TopologyLookupException;
+import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.identity.StoreId;
 import org.neo4j.causalclustering.readreplica.UpstreamDatabaseSelectionException;
 import org.neo4j.causalclustering.readreplica.UpstreamDatabaseStrategySelector;
+import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 import org.neo4j.kernel.internal.DatabaseHealth;
 import org.neo4j.kernel.lifecycle.Lifecycle;
@@ -88,6 +91,7 @@ public class CatchupPollingProcess extends LifecycleAdapter
     private final long txPullIntervalMillis;
     private final BatchingTxApplier applier;
     private final PullRequestMonitor pullRequestMonitor;
+    private final TopologyService topologyService;
 
     private RenewableTimeout timeout;
     private volatile State state = TX_PULLING;
@@ -99,7 +103,8 @@ public class CatchupPollingProcess extends LifecycleAdapter
             Lifecycle startStopOnStoreCopy, CatchUpClient catchUpClient,
             UpstreamDatabaseStrategySelector selectionStrategy, RenewableTimeoutService timeoutService,
             long txPullIntervalMillis, BatchingTxApplier applier, Monitors monitors,
-            StoreCopyProcess storeCopyProcess, Supplier<DatabaseHealth> databaseHealthSupplier )
+            StoreCopyProcess storeCopyProcess, Supplier<DatabaseHealth> databaseHealthSupplier,
+            TopologyService topologyService )
 
     {
         this.localDatabase = localDatabase;
@@ -113,6 +118,7 @@ public class CatchupPollingProcess extends LifecycleAdapter
         this.pullRequestMonitor = monitors.newMonitor( PullRequestMonitor.class );
         this.storeCopyProcess = storeCopyProcess;
         this.databaseHealthSupplier = databaseHealthSupplier;
+        this.topologyService = topologyService;
     }
 
     @Override
@@ -246,10 +252,11 @@ public class CatchupPollingProcess extends LifecycleAdapter
         TxPullRequest txPullRequest = new TxPullRequest( lastQueuedTxId, localStoreId );
         log.debug( "Pull transactions from %s where tx id > %d [batch #%d]", upstream, lastQueuedTxId, batchCount );
 
+        AdvertisedSocketAddress fromAddress = topologyService.findCatchupAddress( upstream ).orElseThrow( () -> new TopologyLookupException(upstream) );
         TxStreamFinishedResponse response;
         try
         {
-            response = catchUpClient.makeBlockingRequest( upstream, txPullRequest, new CatchUpResponseAdaptor<TxStreamFinishedResponse>()
+            response = catchUpClient.makeBlockingRequest( fromAddress, txPullRequest, new CatchUpResponseAdaptor<TxStreamFinishedResponse>()
             {
                 @Override
                 public void onTxPullResponse( CompletableFuture<TxStreamFinishedResponse> signal, TxPullResponse response )
@@ -323,9 +330,10 @@ public class CatchupPollingProcess extends LifecycleAdapter
             throw new RuntimeException( throwable );
         }
 
+        AdvertisedSocketAddress fromAddress = topologyService.findCatchupAddress( upstream ).orElseThrow( () -> new TopologyLookupException(upstream) );
         try
         {
-            storeCopyProcess.replaceWithStoreFrom( upstream, localStoreId );
+            storeCopyProcess.replaceWithStoreFrom( fromAddress, localStoreId );
         }
         catch ( IOException | StoreCopyFailedException | StreamingTransactionsFailedException e )
         {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TxPullClient.java
@@ -27,6 +27,7 @@ import org.neo4j.causalclustering.catchup.CatchUpResponseAdaptor;
 import org.neo4j.causalclustering.catchup.TxPullRequestResult;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.identity.StoreId;
+import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.kernel.monitoring.Monitors;
 
 public class TxPullClient
@@ -40,12 +41,12 @@ public class TxPullClient
         this.pullRequestMonitor = monitors.newMonitor( PullRequestMonitor.class );
     }
 
-    public TxPullRequestResult pullTransactions( MemberId from, StoreId storeId, long previousTxId,
+    public TxPullRequestResult pullTransactions( AdvertisedSocketAddress fromAddress, StoreId storeId, long previousTxId,
                                                  TxPullResponseListener txPullResponseListener )
             throws CatchUpClientException
     {
         pullRequestMonitor.txPullRequest( previousTxId );
-        return catchUpClient.makeBlockingRequest( from, new TxPullRequest( previousTxId, storeId ),
+        return catchUpClient.makeBlockingRequest( fromAddress, new TxPullRequest( previousTxId, storeId ),
                 new CatchUpResponseAdaptor<TxPullRequestResult>()
                 {
                     private long lastTxIdReceived = previousTxId;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/RaftReplicator.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/RaftReplicator.java
@@ -27,7 +27,7 @@ import org.neo4j.causalclustering.core.consensus.NoLeaderFoundException;
 import org.neo4j.causalclustering.core.consensus.RaftMessages;
 import org.neo4j.causalclustering.core.replication.session.LocalSessionPool;
 import org.neo4j.causalclustering.core.replication.session.OperationContext;
-import org.neo4j.causalclustering.helper.RetryStrategy;
+import org.neo4j.causalclustering.helper.TimeoutStrategy;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.messaging.Outbound;
 import org.neo4j.graphdb.DatabaseShutdownException;
@@ -46,21 +46,21 @@ public class RaftReplicator extends LifecycleAdapter implements Replicator, List
     private final Outbound<MemberId,RaftMessages.RaftMessage> outbound;
     private final ProgressTracker progressTracker;
     private final LocalSessionPool sessionPool;
-    private final RetryStrategy retryStrategy;
+    private final TimeoutStrategy timeoutStrategy;
     private final AvailabilityGuard availabilityGuard;
     private final LeaderLocator leaderLocator;
     private final Log log;
 
     public RaftReplicator( LeaderLocator leaderLocator, MemberId me,
             Outbound<MemberId,RaftMessages.RaftMessage> outbound, LocalSessionPool sessionPool,
-            ProgressTracker progressTracker, RetryStrategy retryStrategy, AvailabilityGuard availabilityGuard,
+            ProgressTracker progressTracker, TimeoutStrategy timeoutStrategy, AvailabilityGuard availabilityGuard,
             LogProvider logProvider )
     {
         this.me = me;
         this.outbound = outbound;
         this.progressTracker = progressTracker;
         this.sessionPool = sessionPool;
-        this.retryStrategy = retryStrategy;
+        this.timeoutStrategy = timeoutStrategy;
         this.availabilityGuard = availabilityGuard;
 
         this.leaderLocator = leaderLocator;
@@ -76,7 +76,7 @@ public class RaftReplicator extends LifecycleAdapter implements Replicator, List
         DistributedOperation operation = new DistributedOperation( command, session.globalSession(), session.localOperationId() );
         Progress progress = progressTracker.start( operation );
 
-        RetryStrategy.Timeout timeout = retryStrategy.newTimeout();
+        TimeoutStrategy.Timeout timeout = timeoutStrategy.newTimeout();
         do
         {
             assertDatabaseNotShutdown();

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
@@ -56,6 +56,7 @@ import org.neo4j.causalclustering.core.state.machines.CoreStateMachinesModule;
 import org.neo4j.causalclustering.core.state.snapshot.CoreStateDownloader;
 import org.neo4j.causalclustering.core.state.storage.DurableStateStorage;
 import org.neo4j.causalclustering.core.state.storage.StateStorage;
+import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.logging.MessageLogger;
 import org.neo4j.causalclustering.messaging.CoreReplicatedContentMarshal;
@@ -99,6 +100,7 @@ public class CoreServerModule
         final LifeSupport life = platformModule.life;
         final Monitors monitors = platformModule.monitors;
         final JobScheduler jobScheduler = platformModule.jobScheduler;
+        final TopologyService topologyService = clusteringModule.topologyService();
 
         LogProvider logProvider = logging.getInternalLogProvider();
         LogProvider userLogProvider = logging.getUserLogProvider();
@@ -120,8 +122,7 @@ public class CoreServerModule
 
         long inactivityTimeoutMillis = config.get( CausalClusteringSettings.catch_up_client_inactivity_timeout ).toMillis();
         CatchUpClient catchUpClient = life
-                .add( new CatchUpClient( clusteringModule.topologyService(), logProvider, Clocks.systemClock(),
-                        inactivityTimeoutMillis, monitors, sslPolicy ) );
+                .add( new CatchUpClient( logProvider, Clocks.systemClock(), inactivityTimeoutMillis, monitors, sslPolicy ) );
 
         RemoteStore remoteStore = new RemoteStore( logProvider, fileSystem, platformModule.pageCache,
                 new StoreCopyClient( catchUpClient, logProvider ),
@@ -177,7 +178,7 @@ public class CoreServerModule
 
         CoreStateDownloader downloader = new CoreStateDownloader( localDatabase, servicesToStopOnStoreCopy,
                 remoteStore, catchUpClient, logProvider, storeCopyProcess, coreStateMachinesModule.coreStateMachines,
-                snapshotService, commandApplicationProcess );
+                snapshotService, commandApplicationProcess, topologyService );
 
         RaftMessageHandler messageHandler = new RaftMessageHandler( localDatabase, logProvider,
                 consensusModule.raftMachine(), downloader, commandApplicationProcess );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloader.java
@@ -31,12 +31,15 @@ import org.neo4j.causalclustering.catchup.storecopy.StoreCopyProcess;
 import org.neo4j.causalclustering.core.state.CommandApplicationProcess;
 import org.neo4j.causalclustering.core.state.CoreSnapshotService;
 import org.neo4j.causalclustering.core.state.machines.CoreStateMachines;
+import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.identity.StoreId;
+import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 
+import static java.lang.String.format;
 import static org.neo4j.causalclustering.catchup.CatchupResult.E_TRANSACTION_PRUNED;
 import static org.neo4j.causalclustering.catchup.CatchupResult.SUCCESS_END_OF_STREAM;
 
@@ -53,11 +56,12 @@ public class CoreStateDownloader
     private final CoreStateMachines coreStateMachines;
     private final CoreSnapshotService snapshotService;
     private final CommandApplicationProcess applicationProcess;
+    private final TopologyService topologyService;
 
     public CoreStateDownloader( LocalDatabase localDatabase, Lifecycle startStopOnStoreCopy,
             RemoteStore remoteStore, CatchUpClient catchUpClient, LogProvider logProvider,
-            StoreCopyProcess storeCopyProcess, CoreStateMachines coreStateMachines,
-            CoreSnapshotService snapshotService, CommandApplicationProcess applicationProcess )
+            StoreCopyProcess storeCopyProcess, CoreStateMachines coreStateMachines, CoreSnapshotService snapshotService,
+            CommandApplicationProcess applicationProcess, TopologyService topologyService )
     {
         this.localDatabase = localDatabase;
         this.startStopOnStoreCopy = startStopOnStoreCopy;
@@ -68,6 +72,7 @@ public class CoreStateDownloader
         this.coreStateMachines = coreStateMachines;
         this.snapshotService = snapshotService;
         this.applicationProcess = applicationProcess;
+        this.topologyService = topologyService;
     }
 
     public void downloadSnapshot( MemberId source ) throws StoreCopyFailedException
@@ -85,7 +90,8 @@ public class CoreStateDownloader
                 localDatabase.stop();
             }
 
-            StoreId remoteStoreId = remoteStore.getStoreId( source );
+            AdvertisedSocketAddress fromAddress = topologyService.findCatchupAddress( source ).orElseThrow( () -> new TopologyLookupException( source ) );
+            StoreId remoteStoreId = remoteStore.getStoreId( fromAddress );
             if ( !isEmptyStore && !remoteStoreId.equals( localDatabase.storeId() ) )
             {
                 throw new StoreCopyFailedException( "StoreId mismatch and not empty" );
@@ -103,7 +109,7 @@ public class CoreStateDownloader
              * are ahead, and the correct decisions for their applicability have already been taken as encapsulated
              * in the copied store. */
 
-            CoreSnapshot coreSnapshot = catchUpClient.makeBlockingRequest( source, new CoreSnapshotRequest(),
+            CoreSnapshot coreSnapshot = catchUpClient.makeBlockingRequest( fromAddress, new CoreSnapshotRequest(),
                     new CatchUpResponseAdaptor<CoreSnapshot>()
                     {
                         @Override
@@ -115,19 +121,19 @@ public class CoreStateDownloader
 
             if ( isEmptyStore )
             {
-                storeCopyProcess.replaceWithStoreFrom( source, remoteStoreId );
+                storeCopyProcess.replaceWithStoreFrom( fromAddress, remoteStoreId );
             }
             else
             {
                 StoreId localStoreId = localDatabase.storeId();
-                CatchupResult catchupResult = remoteStore.tryCatchingUp( source, localStoreId, localDatabase.storeDir() );
+                CatchupResult catchupResult = remoteStore.tryCatchingUp( fromAddress, localStoreId, localDatabase.storeDir() );
 
                 if ( catchupResult == E_TRANSACTION_PRUNED )
                 {
-                    log.info( "Failed to pull transactions from " + source + ". They may have been pruned away." );
+                    log.info( format( "Failed to pull transactions from %s (%s). They may have been pruned away.", source, fromAddress ) );
                     localDatabase.delete();
 
-                    storeCopyProcess.replaceWithStoreFrom( source, localStoreId );
+                    storeCopyProcess.replaceWithStoreFrom( fromAddress, localStoreId );
                 }
                 else if ( catchupResult != SUCCESS_END_OF_STREAM )
                 {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/TopologyLookupException.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/TopologyLookupException.java
@@ -17,20 +17,26 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.causalclustering.discovery;
+package org.neo4j.causalclustering.core.state.snapshot;
 
 import org.neo4j.causalclustering.identity.MemberId;
-import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.util.JobScheduler;
-import org.neo4j.logging.LogProvider;
-import org.neo4j.ssl.SslPolicy;
 
-public interface DiscoveryServiceFactory
+import static java.lang.String.format;
+
+public class TopologyLookupException extends RuntimeException
 {
-    CoreTopologyService coreTopologyService( Config config, SslPolicy sslPolicy, MemberId myself,
-            JobScheduler jobScheduler, LogProvider logProvider, LogProvider userLogProvider,
-            HostnameResolver hostnameResolver, TopologyServiceRetryStrategy topologyServiceRetryStrategy );
+    public TopologyLookupException( Throwable cause )
+    {
+        super( cause );
+    }
 
-    TopologyService topologyService( Config config, SslPolicy sslPolicy, LogProvider logProvider,
-            JobScheduler jobScheduler, MemberId myself, HostnameResolver hostnameResolver, TopologyServiceRetryStrategy topologyServiceRetryStrategy );
+    public TopologyLookupException( MemberId memberId )
+    {
+        super( format( "Cannot find the target member %s socket address", memberId ) );
+    }
+
+    public TopologyLookupException( String message )
+    {
+        super( message );
+    }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/MultiRetryStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/MultiRetryStrategy.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.discovery;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.logging.NullLogProvider;
+
+/**
+ * Implementation of the RetryStrategy that repeats the retriable function until the correct result has been retrieved or the limit of retries has been
+ * encountered.
+ * There is a fixed delay between each retry.
+ *
+ * @param <I> the type of input of the retriable function
+ * @param <E> the type of output of the retriable function
+ */
+public class MultiRetryStrategy<I, E> implements RetryStrategy<I,E>
+{
+    private final long delayInMillis;
+    private final long retries;
+    private final LogProvider logProvider;
+
+    /**
+     * @param delayInMillis number of milliseconds between each attempt at getting the desired result
+     * @param retries the number of attempts to perform before giving up
+     */
+    public MultiRetryStrategy( long delayInMillis, long retries )
+    {
+        this( delayInMillis, retries, NullLogProvider.getInstance() );
+    }
+
+    /**
+     * @param delayInMillis number of milliseconds between each attempt at getting the desired result
+     * @param retries the number of attempts to perform before giving up
+     * @param logProvider {@see LogProvider}
+     */
+    public MultiRetryStrategy( long delayInMillis, long retries, LogProvider logProvider )
+    {
+        this.delayInMillis = delayInMillis;
+        this.retries = retries;
+        this.logProvider = logProvider;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public E apply( I input, Function<I,E> retriable, Predicate<E> wasRetrySuccessful )
+    {
+        Log log = logProvider.getLog( MultiRetryStrategy.class );
+        E result = retriable.apply( input );
+        int currentIteration = 0;
+        while ( !wasRetrySuccessful.test( result ) && currentIteration++ < retries )
+        {
+            log.debug( "Try attempt was unsuccessful for input: %s\n", input );
+            try
+            {
+                Thread.sleep( delayInMillis );
+            }
+            catch ( InterruptedException e )
+            {
+                throw new RuntimeException( e );
+            }
+            result = retriable.apply( input );
+        }
+        return result;
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/NoRetriesStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/NoRetriesStrategy.java
@@ -17,36 +17,16 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.causalclustering.helper;
+package org.neo4j.causalclustering.discovery;
 
-import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
-public class ConstantTimeRetryStrategy implements RetryStrategy
+public class NoRetriesStrategy<I, E> implements RetryStrategy<I,E>
 {
-    private final Timeout constantTimeout;
-
-    public ConstantTimeRetryStrategy( long backoffTime, TimeUnit timeUnit )
-    {
-        long backoffTimeMillis = timeUnit.toMillis( backoffTime );
-
-        constantTimeout = new Timeout()
-        {
-            @Override
-            public long getMillis()
-            {
-                return backoffTimeMillis;
-            }
-
-            @Override
-            public void increment()
-            {
-            }
-        };
-    }
-
     @Override
-    public Timeout newTimeout()
+    public E apply( I input, Function<I,E> retriable, Predicate<E> shouldRetry )
     {
-        return constantTimeout;
+        return retriable.apply( input );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RetryStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/RetryStrategy.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.discovery;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * A strategy pattern for deciding how retries will be handled.
+ * <p>
+ * Depending on the implementation, it is assumed the retriable function will be executed until conditions satisyfing desired output are met and then the latest
+ * (or most valid)
+ * result will be returned
+ * </p>
+ *
+ * @param <I> Type of input used for the input function (assumes 1-parameter input functions)
+ * @param <E> Type of output returned from retriable function
+ */
+public interface RetryStrategy<I, E>
+{
+    /**
+     * Run a given function until a satisfying result is achieved
+     *
+     * @param input the input parameter that is given to the retriable function
+     * @param retriable a function that will be executed multiple times until it returns a valid output
+     * @param shouldRetry a predicate deciding if the output of the retriable function is valid. Assume that the function will retry if this returns false and
+     * exit if it returns true
+     * @return the latest (or most valid) output of the retriable function, depending on implementation
+     */
+    E apply( I input, Function<I,E> retriable, Predicate<E> shouldRetry );
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyServiceMultiRetryStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyServiceMultiRetryStrategy.java
@@ -17,15 +17,17 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.causalclustering.helper;
+package org.neo4j.causalclustering.discovery;
 
-public interface RetryStrategy
+import java.util.Optional;
+
+import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.helpers.AdvertisedSocketAddress;
+
+public class TopologyServiceMultiRetryStrategy extends MultiRetryStrategy<MemberId,Optional<AdvertisedSocketAddress>> implements TopologyServiceRetryStrategy
 {
-    Timeout newTimeout();
-
-    interface Timeout
+    public TopologyServiceMultiRetryStrategy( long delayInMillis, long retries )
     {
-        long getMillis();
-        void increment();
+        super( delayInMillis, retries );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyServiceNoRetriesStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyServiceNoRetriesStrategy.java
@@ -19,18 +19,11 @@
  */
 package org.neo4j.causalclustering.discovery;
 
+import java.util.Optional;
+
 import org.neo4j.causalclustering.identity.MemberId;
-import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.util.JobScheduler;
-import org.neo4j.logging.LogProvider;
-import org.neo4j.ssl.SslPolicy;
+import org.neo4j.helpers.AdvertisedSocketAddress;
 
-public interface DiscoveryServiceFactory
+public class TopologyServiceNoRetriesStrategy extends NoRetriesStrategy<MemberId,Optional<AdvertisedSocketAddress>> implements TopologyServiceRetryStrategy
 {
-    CoreTopologyService coreTopologyService( Config config, SslPolicy sslPolicy, MemberId myself,
-            JobScheduler jobScheduler, LogProvider logProvider, LogProvider userLogProvider,
-            HostnameResolver hostnameResolver, TopologyServiceRetryStrategy topologyServiceRetryStrategy );
-
-    TopologyService topologyService( Config config, SslPolicy sslPolicy, LogProvider logProvider,
-            JobScheduler jobScheduler, MemberId myself, HostnameResolver hostnameResolver, TopologyServiceRetryStrategy topologyServiceRetryStrategy );
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyServiceRetryStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/TopologyServiceRetryStrategy.java
@@ -19,18 +19,11 @@
  */
 package org.neo4j.causalclustering.discovery;
 
+import java.util.Optional;
+
 import org.neo4j.causalclustering.identity.MemberId;
-import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.util.JobScheduler;
-import org.neo4j.logging.LogProvider;
-import org.neo4j.ssl.SslPolicy;
+import org.neo4j.helpers.AdvertisedSocketAddress;
 
-public interface DiscoveryServiceFactory
+public interface TopologyServiceRetryStrategy extends RetryStrategy<MemberId, Optional<AdvertisedSocketAddress>>
 {
-    CoreTopologyService coreTopologyService( Config config, SslPolicy sslPolicy, MemberId myself,
-            JobScheduler jobScheduler, LogProvider logProvider, LogProvider userLogProvider,
-            HostnameResolver hostnameResolver, TopologyServiceRetryStrategy topologyServiceRetryStrategy );
-
-    TopologyService topologyService( Config config, SslPolicy sslPolicy, LogProvider logProvider,
-            JobScheduler jobScheduler, MemberId myself, HostnameResolver hostnameResolver, TopologyServiceRetryStrategy topologyServiceRetryStrategy );
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/ConstantTimeTimeoutStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/ConstantTimeTimeoutStrategy.java
@@ -21,29 +21,16 @@ package org.neo4j.causalclustering.helper;
 
 import java.util.concurrent.TimeUnit;
 
-/**
- * Exponential backoff strategy helper class. Exponent is always 2.
- */
-public class ExponentialBackoffStrategy implements TimeoutStrategy
+public class ConstantTimeTimeoutStrategy implements TimeoutStrategy
 {
-    private final long initialBackoffTimeMillis;
-    private final long upperBoundBackoffTimeMillis;
+    private final Timeout constantTimeout;
 
-    public ExponentialBackoffStrategy( long initialBackoffTime, long upperBoundBackoffTime, TimeUnit timeUnit )
+    public ConstantTimeTimeoutStrategy( long backoffTime, TimeUnit timeUnit )
     {
-        assert initialBackoffTime <= upperBoundBackoffTime;
+        long backoffTimeMillis = timeUnit.toMillis( backoffTime );
 
-        this.initialBackoffTimeMillis = timeUnit.toMillis( initialBackoffTime );
-        this.upperBoundBackoffTimeMillis = timeUnit.toMillis( upperBoundBackoffTime );
-    }
-
-    @Override
-    public Timeout newTimeout()
-    {
-        return new Timeout()
+        constantTimeout = new Timeout()
         {
-            private long backoffTimeMillis = initialBackoffTimeMillis;
-
             @Override
             public long getMillis()
             {
@@ -53,8 +40,13 @@ public class ExponentialBackoffStrategy implements TimeoutStrategy
             @Override
             public void increment()
             {
-                backoffTimeMillis = Math.min( backoffTimeMillis * 2, upperBoundBackoffTimeMillis );
             }
         };
+    }
+
+    @Override
+    public Timeout newTimeout()
+    {
+        return constantTimeout;
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/TimeoutStrategy.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/TimeoutStrategy.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.helper;
+
+public interface TimeoutStrategy
+{
+    Timeout newTimeout();
+
+    interface Timeout
+    {
+        long getMillis();
+        void increment();
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStoreTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStoreTest.java
@@ -32,6 +32,7 @@ import org.neo4j.causalclustering.catchup.tx.TxPullClient;
 import org.neo4j.causalclustering.catchup.tx.TxPullResponseListener;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.identity.StoreId;
+import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.monitoring.Monitors;
@@ -64,7 +65,7 @@ public class RemoteStoreTest
                 null, storeCopyClient, txPullClient, factory( writer ), new Monitors() );
 
         // when
-        MemberId localhost = new MemberId( UUID.randomUUID() );
+        AdvertisedSocketAddress localhost = new AdvertisedSocketAddress( "127.0.0.1", 1234 );
         remoteStore.copy( localhost, storeId, new File( "destination" ) );
 
         // then
@@ -78,7 +79,7 @@ public class RemoteStoreTest
         // given
         long lastFlushedTxId = 12;
         StoreId wantedStoreId = new StoreId( 1, 2, 3, 4 );
-        MemberId localhost = new MemberId( UUID.randomUUID() );
+        AdvertisedSocketAddress localhost = new AdvertisedSocketAddress( "127.0.0.1", 1234 );
 
         StoreCopyClient storeCopyClient = mock( StoreCopyClient.class );
         when( storeCopyClient.copyStoreFiles( eq( localhost ), eq( wantedStoreId ), any( StoreFileStreams.class ) ) )
@@ -115,7 +116,7 @@ public class RemoteStoreTest
                 storeCopyClient, txPullClient, factory( writer ), new Monitors() );
 
         doThrow( StoreCopyFailedException.class ).when( txPullClient )
-                .pullTransactions( any( MemberId.class ), eq( storeId ), anyLong(), any( TransactionLogCatchUpWriter.class ) );
+                .pullTransactions( any( AdvertisedSocketAddress.class ), eq( storeId ), anyLong(), any( TransactionLogCatchUpWriter.class ) );
 
         // when
         try

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/replication/RaftReplicatorTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/replication/RaftReplicatorTest.java
@@ -35,8 +35,8 @@ import org.neo4j.causalclustering.core.consensus.ReplicatedInteger;
 import org.neo4j.causalclustering.core.replication.session.GlobalSession;
 import org.neo4j.causalclustering.core.replication.session.LocalSessionPool;
 import org.neo4j.causalclustering.core.state.Result;
-import org.neo4j.causalclustering.helper.ConstantTimeRetryStrategy;
-import org.neo4j.causalclustering.helper.RetryStrategy;
+import org.neo4j.causalclustering.helper.ConstantTimeTimeoutStrategy;
+import org.neo4j.causalclustering.helper.TimeoutStrategy;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.messaging.Message;
 import org.neo4j.causalclustering.messaging.Outbound;
@@ -68,7 +68,7 @@ public class RaftReplicatorTest
     private MemberId leader = new MemberId( UUID.randomUUID() );
     private GlobalSession session = new GlobalSession( UUID.randomUUID(), myself );
     private LocalSessionPool sessionPool = new LocalSessionPool( session );
-    private RetryStrategy retryStrategy = new ConstantTimeRetryStrategy( 0, MILLISECONDS );
+    private TimeoutStrategy timeoutStrategy = new ConstantTimeTimeoutStrategy( 0, MILLISECONDS );
     private AvailabilityGuard availabilityGuard = new AvailabilityGuard( Clocks.systemClock(), NullLog.getInstance() );
 
     @Test
@@ -81,7 +81,7 @@ public class RaftReplicatorTest
 
         RaftReplicator replicator =
                 new RaftReplicator( leaderLocator, myself, outbound, sessionPool,
-                        capturedProgress, retryStrategy, availabilityGuard, NullLogProvider.getInstance() );
+                        capturedProgress, timeoutStrategy, availabilityGuard, NullLogProvider.getInstance() );
 
         ReplicatedInteger content = ReplicatedInteger.valueOf( 5 );
         Thread replicatingThread = replicatingThread( replicator, content, false );
@@ -108,7 +108,7 @@ public class RaftReplicatorTest
         CapturingOutbound outbound = new CapturingOutbound();
 
         RaftReplicator replicator = new RaftReplicator( leaderLocator, myself, outbound,
-                sessionPool, capturedProgress, retryStrategy, availabilityGuard, NullLogProvider.getInstance() );
+                sessionPool, capturedProgress, timeoutStrategy, availabilityGuard, NullLogProvider.getInstance() );
 
         ReplicatedInteger content = ReplicatedInteger.valueOf( 5 );
         Thread replicatingThread = replicatingThread( replicator, content, false );
@@ -132,7 +132,7 @@ public class RaftReplicatorTest
         CapturingOutbound outbound = new CapturingOutbound();
 
         RaftReplicator replicator = new RaftReplicator( leaderLocator, myself, outbound,
-                sessionPool, capturedProgress, retryStrategy, availabilityGuard, NullLogProvider.getInstance() );
+                sessionPool, capturedProgress, timeoutStrategy, availabilityGuard, NullLogProvider.getInstance() );
 
         ReplicatedInteger content = ReplicatedInteger.valueOf( 5 );
         Thread replicatingThread = replicatingThread( replicator, content, true );
@@ -162,7 +162,7 @@ public class RaftReplicatorTest
         CapturingOutbound outbound = new CapturingOutbound();
 
         RaftReplicator replicator =
-                new RaftReplicator( leaderLocator, myself, outbound, sessionPool, capturedProgress, retryStrategy,
+                new RaftReplicator( leaderLocator, myself, outbound, sessionPool, capturedProgress, timeoutStrategy,
                         availabilityGuard, NullLogProvider.getInstance() );
 
         ReplicatedInteger content = ReplicatedInteger.valueOf( 5 );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.neo4j.causalclustering.catchup.CatchUpClient;
@@ -34,8 +35,10 @@ import org.neo4j.causalclustering.catchup.storecopy.StoreCopyProcess;
 import org.neo4j.causalclustering.core.state.CommandApplicationProcess;
 import org.neo4j.causalclustering.core.state.CoreSnapshotService;
 import org.neo4j.causalclustering.core.state.machines.CoreStateMachines;
+import org.neo4j.causalclustering.discovery.TopologyService;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.identity.StoreId;
+import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.logging.NullLogProvider;
 
@@ -57,24 +60,27 @@ public class CoreStateDownloaderTest
     private final StoreCopyProcess storeCopyProcess = mock( StoreCopyProcess.class );
     private CoreSnapshotService snaptshotService = mock( CoreSnapshotService.class );
     private CommandApplicationProcess applicationProcess = mock( CommandApplicationProcess.class );
+    private TopologyService topologyService = mock( TopologyService.class );
 
     private final CoreStateMachines coreStateMachines = mock( CoreStateMachines.class );
 
     private final NullLogProvider logProvider = NullLogProvider.getInstance();
 
     private final MemberId remoteMember = new MemberId( UUID.randomUUID() );
+    private final AdvertisedSocketAddress remoteAddress = new AdvertisedSocketAddress( "remoteAddress", 1234 );
     private final StoreId storeId = new StoreId( 1, 2, 3, 4 );
     private final File storeDir = new File( "graph.db" );
 
     private final CoreStateDownloader downloader =
             new CoreStateDownloader( localDatabase, startStopLife, remoteStore, catchUpClient, logProvider,
-                    storeCopyProcess, coreStateMachines, snaptshotService, applicationProcess );
+                    storeCopyProcess, coreStateMachines, snaptshotService, applicationProcess, topologyService );
 
     @Before
     public void commonMocking() throws IOException
     {
         when( localDatabase.storeId() ).thenReturn( storeId );
         when( localDatabase.storeDir() ).thenReturn( storeDir );
+        when( topologyService.findCatchupAddress( remoteMember ) ).thenReturn( Optional.of( remoteAddress ) );
     }
 
     @Test
@@ -82,7 +88,7 @@ public class CoreStateDownloaderTest
     {
         // given
         StoreId remoteStoreId = new StoreId( 5, 6, 7, 8 );
-        when( remoteStore.getStoreId( remoteMember ) ).thenReturn( remoteStoreId );
+        when( remoteStore.getStoreId( remoteAddress ) ).thenReturn( remoteStoreId );
         when( localDatabase.isEmpty() ).thenReturn( true );
 
         // when
@@ -90,7 +96,7 @@ public class CoreStateDownloaderTest
 
         // then
         verify( remoteStore, never() ).tryCatchingUp( any(), any(), any() );
-        verify( storeCopyProcess ).replaceWithStoreFrom( remoteMember, remoteStoreId );
+        verify( storeCopyProcess ).replaceWithStoreFrom( remoteAddress, remoteStoreId );
     }
 
     @Test
@@ -115,7 +121,7 @@ public class CoreStateDownloaderTest
         // given
         when( localDatabase.isEmpty() ).thenReturn( false );
         StoreId remoteStoreId = new StoreId( 5, 6, 7, 8 );
-        when( remoteStore.getStoreId( remoteMember ) ).thenReturn( remoteStoreId );
+        when( remoteStore.getStoreId( remoteAddress ) ).thenReturn( remoteStoreId );
 
         // when
         try
@@ -138,14 +144,14 @@ public class CoreStateDownloaderTest
     {
         // given
         when( localDatabase.isEmpty() ).thenReturn( false );
-        when( remoteStore.getStoreId( remoteMember ) ).thenReturn( storeId );
-        when( remoteStore.tryCatchingUp( remoteMember, storeId, storeDir ) ).thenReturn( SUCCESS_END_OF_STREAM );
+        when( remoteStore.getStoreId( remoteAddress ) ).thenReturn( storeId );
+        when( remoteStore.tryCatchingUp( remoteAddress, storeId, storeDir ) ).thenReturn( SUCCESS_END_OF_STREAM );
 
         // when
         downloader.downloadSnapshot( remoteMember );
 
         // then
-        verify( remoteStore ).tryCatchingUp( remoteMember, storeId, storeDir );
+        verify( remoteStore ).tryCatchingUp( remoteAddress, storeId, storeDir );
         verify( remoteStore, never() ).copy( any(), any(), any() );
     }
 
@@ -154,14 +160,14 @@ public class CoreStateDownloaderTest
     {
         // given
         when( localDatabase.isEmpty() ).thenReturn( false );
-        when( remoteStore.getStoreId( remoteMember ) ).thenReturn( storeId );
-        when( remoteStore.tryCatchingUp( remoteMember, storeId, storeDir ) ).thenReturn( E_TRANSACTION_PRUNED );
+        when( remoteStore.getStoreId( remoteAddress ) ).thenReturn( storeId );
+        when( remoteStore.tryCatchingUp( remoteAddress, storeId, storeDir ) ).thenReturn( E_TRANSACTION_PRUNED );
 
         // when
         downloader.downloadSnapshot( remoteMember );
 
         // then
-        verify( remoteStore ).tryCatchingUp( remoteMember, storeId, storeDir );
-        verify( storeCopyProcess ).replaceWithStoreFrom( remoteMember, storeId );
+        verify( remoteStore ).tryCatchingUp( remoteAddress, storeId, storeDir );
+        verify( storeCopyProcess ).replaceWithStoreFrom( remoteAddress, storeId );
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/HazelcastClientTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/HazelcastClientTest.java
@@ -99,6 +99,7 @@ import static org.neo4j.helpers.collection.Iterators.asSet;
 public class HazelcastClientTest
 {
     private MemberId myself = new MemberId( UUID.randomUUID() );
+    private final TopologyServiceRetryStrategy topologyServiceRetryStrategy = new TopologyServiceNoRetriesStrategy();
 
     private Config config()
     {
@@ -123,7 +124,7 @@ public class HazelcastClientTest
         HazelcastConnector connector = mock( HazelcastConnector.class );
         OnDemandJobScheduler jobScheduler = new OnDemandJobScheduler();
 
-        HazelcastClient client = new HazelcastClient( connector, jobScheduler, NullLogProvider.getInstance(), config(), myself );
+        HazelcastClient client = new HazelcastClient( connector, jobScheduler, NullLogProvider.getInstance(), config(), myself, topologyServiceRetryStrategy );
 
         HazelcastInstance hazelcastInstance = mock( HazelcastInstance.class );
         when( connector.connectToHazelcast() ).thenReturn( hazelcastInstance );
@@ -155,7 +156,7 @@ public class HazelcastClientTest
         HazelcastConnector connector = mock( HazelcastConnector.class );
         OnDemandJobScheduler jobScheduler = new OnDemandJobScheduler();
 
-        HazelcastClient client = new HazelcastClient( connector, jobScheduler, NullLogProvider.getInstance(), config(), myself );
+        HazelcastClient client = new HazelcastClient( connector, jobScheduler, NullLogProvider.getInstance(), config(), myself, topologyServiceRetryStrategy );
 
         HazelcastInstance hazelcastInstance = mock( HazelcastInstance.class );
         when( connector.connectToHazelcast() ).thenReturn( hazelcastInstance );
@@ -203,7 +204,7 @@ public class HazelcastClientTest
 
         OnDemandJobScheduler jobScheduler = new OnDemandJobScheduler();
 
-        HazelcastClient client = new HazelcastClient( connector, jobScheduler, logProvider, config(), myself );
+        HazelcastClient client = new HazelcastClient( connector, jobScheduler, logProvider, config(), myself, topologyServiceRetryStrategy );
 
         com.hazelcast.core.Cluster cluster = mock( Cluster.class );
         when( hazelcastInstance.getCluster() ).thenReturn( cluster );
@@ -253,7 +254,7 @@ public class HazelcastClientTest
         when( connector.connectToHazelcast() ).thenReturn( hazelcastInstance );
 
         OnDemandJobScheduler jobScheduler = new OnDemandJobScheduler();
-        HazelcastClient hazelcastClient = new HazelcastClient( connector, jobScheduler, NullLogProvider.getInstance(), config(), myself );
+        HazelcastClient hazelcastClient = new HazelcastClient( connector, jobScheduler, NullLogProvider.getInstance(), config(), myself, topologyServiceRetryStrategy );
 
         // when
         hazelcastClient.start();
@@ -296,7 +297,7 @@ public class HazelcastClientTest
         when( connector.connectToHazelcast() ).thenReturn( hazelcastInstance );
 
         OnDemandJobScheduler jobScheduler = new OnDemandJobScheduler();
-        HazelcastClient hazelcastClient = new HazelcastClient( connector, jobScheduler, NullLogProvider.getInstance(), config(), myself );
+        HazelcastClient hazelcastClient = new HazelcastClient( connector, jobScheduler, NullLogProvider.getInstance(), config(), myself, topologyServiceRetryStrategy );
 
         hazelcastClient.start();
 
@@ -327,7 +328,7 @@ public class HazelcastClientTest
 
         OnDemandJobScheduler jobScheduler = new OnDemandJobScheduler();
 
-        HazelcastClient hazelcastClient = new HazelcastClient( connector, jobScheduler, NullLogProvider.getInstance(), config(), myself );
+        HazelcastClient hazelcastClient = new HazelcastClient( connector, jobScheduler, NullLogProvider.getInstance(), config(), myself, topologyServiceRetryStrategy );
 
         hazelcastClient.start();
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/MultiRetryStrategyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/MultiRetryStrategyTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.discovery;
+
+import org.junit.Test;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MultiRetryStrategyTest
+{
+    private static final Predicate<Integer> ALWAYS_VALID = i -> true;
+    private static final Predicate<Integer> NEVER_VALID = i -> false;
+    private static final Predicate<Integer> VALID_ON_SECOND_TIME = new Predicate<Integer>()
+    {
+        private boolean nextSuccessful;
+        @Override
+        public boolean test( Integer integer )
+        {
+            if ( !nextSuccessful )
+            {
+                nextSuccessful = true;
+                return false;
+            }
+            return true;
+        }
+    };
+
+    @Test
+    public void successOnRetryCausesNoDelay()
+    {
+        // given
+        int delay = 1000;
+        int retries = 10;
+        MultiRetryStrategy<Integer,Integer> subject = new MultiRetryStrategy<>( delay, retries );
+
+        // when
+        long startTime = System.currentTimeMillis();
+        Integer result = subject.apply( 3, Function.identity(), ALWAYS_VALID );
+        long endTime = System.currentTimeMillis();
+
+        // then
+        long duration = endTime - startTime;
+        assertTrue( duration < delay );
+        assertEquals( 3, result.intValue() );
+    }
+
+    @Test
+    public void numberOfIterationsDoesNotExceedMaximum()
+    {
+        // given
+        int delay = 20;
+        int retries = 10;
+        MultiRetryStrategy<Integer,Integer> subject = new MultiRetryStrategy<>( delay, retries );
+
+        // when
+        long startTime = System.currentTimeMillis();
+        Integer result = subject.apply( 3, Function.identity(), NEVER_VALID );
+        long endTime = System.currentTimeMillis();
+
+        // then
+        long duration = endTime - startTime;
+        double durationInSeconds = duration / 1000.0;
+        double expectedDurationInSeconds = (delay * retries) / 1000.0;
+        double marginOfErrorInSeconds = (delay / 1000.0) / 2;
+        assertEquals( expectedDurationInSeconds, durationInSeconds, marginOfErrorInSeconds );
+    }
+
+    @Test
+    public void successfulRetriesBreakTheRetryLoop()
+    {
+        // given
+        int delay = 200;
+        int retries = 10;
+        MultiRetryStrategy<Integer,Integer> subject = new MultiRetryStrategy<>( delay, retries );
+
+        // when
+        long startTime = System.currentTimeMillis();
+        Integer result = subject.apply( 3, Function.identity(), VALID_ON_SECOND_TIME );
+        long endTime = System.currentTimeMillis();
+
+        // then
+        long duration = endTime - startTime;
+        double durationInSeconds = duration / 1000.0;
+        double expectedDurationInSeconds = delay / 1000.0;
+        double marginOfErrorInSeconds = (delay / 1000.0) / 4;
+        assertEquals( expectedDurationInSeconds, durationInSeconds, marginOfErrorInSeconds );
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryReadReplicaClient.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryReadReplicaClient.java
@@ -80,7 +80,11 @@ class SharedDiscoveryReadReplicaClient extends LifecycleAdapter implements Topol
     @Override
     public Optional<AdvertisedSocketAddress> findCatchupAddress( MemberId upstream )
     {
-        return sharedDiscoveryService.coreTopology( null ).find( upstream ).map( info -> Optional.of( info.getCatchupServer() ) )
-                .orElseGet( () -> sharedDiscoveryService.readReplicaTopology().find( upstream ).map( ReadReplicaInfo::getCatchupServer ) );
+        return sharedDiscoveryService.coreTopology( null )
+                .find( upstream )
+                .map( info -> Optional.of( info.getCatchupServer() ) )
+                .orElseGet( () -> sharedDiscoveryService.readReplicaTopology()
+                        .find( upstream )
+                        .map( ReadReplicaInfo::getCatchupServer ) );
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryService.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryService.java
@@ -49,7 +49,7 @@ public class SharedDiscoveryService implements DiscoveryServiceFactory
 
     @Override
     public CoreTopologyService coreTopologyService( Config config, SslPolicy sslPolicy, MemberId myself, JobScheduler jobScheduler,
-            LogProvider logProvider, LogProvider userLogProvider, HostnameResolver hostnameResolver )
+            LogProvider logProvider, LogProvider userLogProvider, HostnameResolver hostnameResolver, TopologyServiceRetryStrategy topologyServiceRetryStrategy )
     {
         SharedDiscoveryCoreClient sharedDiscoveryCoreClient =
                 new SharedDiscoveryCoreClient( this, myself, logProvider, config );
@@ -60,7 +60,7 @@ public class SharedDiscoveryService implements DiscoveryServiceFactory
 
     @Override
     public TopologyService topologyService( Config config, SslPolicy sslPolicy, LogProvider logProvider,
-            JobScheduler jobScheduler, MemberId myself, HostnameResolver hostnameResolver )
+            JobScheduler jobScheduler, MemberId myself, HostnameResolver hostnameResolver, TopologyServiceRetryStrategy topologyServiceRetryStrategy )
     {
         return new SharedDiscoveryReadReplicaClient( this, config, myself, logProvider );
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryServiceIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/SharedDiscoveryServiceIT.java
@@ -97,7 +97,7 @@ public class SharedDiscoveryServiceIT
         HostnameResolver hostnameResolver = new NoOpHostnameResolver();
 
         CoreTopologyService topologyService = disoveryServiceFactory
-                .coreTopologyService( config(), null, member, jobScheduler, logProvider, userLogProvider, hostnameResolver );
+                .coreTopologyService( config(), null, member, jobScheduler, logProvider, userLogProvider, hostnameResolver, new TopologyServiceNoRetriesStrategy() );
         return sharedClientStarter( topologyService, expectedTargetSet );
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helper/ExponentialBackoffStrategyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helper/ExponentialBackoffStrategyTest.java
@@ -33,7 +33,7 @@ public class ExponentialBackoffStrategyTest
     {
         // given
         ExponentialBackoffStrategy strategy = new ExponentialBackoffStrategy( 1, 1 << NUMBER_OF_ACCESSES, MILLISECONDS );
-        RetryStrategy.Timeout timeout = strategy.newTimeout();
+        TimeoutStrategy.Timeout timeout = strategy.newTimeout();
 
         // when
         for ( int i = 0; i < NUMBER_OF_ACCESSES; i++ )
@@ -50,7 +50,7 @@ public class ExponentialBackoffStrategyTest
     {
         // given
         ExponentialBackoffStrategy strategy = new ExponentialBackoffStrategy( 1, 1 << NUMBER_OF_ACCESSES, MILLISECONDS );
-        RetryStrategy.Timeout timeout = strategy.newTimeout();
+        TimeoutStrategy.Timeout timeout = strategy.newTimeout();
 
         // when
         for ( int i = 0; i < NUMBER_OF_ACCESSES; i++ )
@@ -68,7 +68,7 @@ public class ExponentialBackoffStrategyTest
         // given
         long upperBound = (1 << NUMBER_OF_ACCESSES) - 5;
         ExponentialBackoffStrategy strategy = new ExponentialBackoffStrategy( 1, upperBound, MILLISECONDS );
-        RetryStrategy.Timeout timeout = strategy.newTimeout();
+        TimeoutStrategy.Timeout timeout = strategy.newTimeout();
 
         // when
         for ( int i = 0; i < NUMBER_OF_ACCESSES; i++ )


### PR DESCRIPTION
Address resolution of cluster members is now performed earlier.
TopologyService has been removed from many classes that will be used in the future in the backup client.
A retry mechanism has been introduced to handle he fact that it is now possible to request an address for a member
before the table of member addresses has been refreshed