### PR TITLE
IdMapper no longer keeps collision values in heap

### DIFF
--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -220,6 +220,7 @@ public class ImportTool
                         + "manual about available configuration options for a neo4j configuration file. "
                         + "Only configuration affecting store at time of creation will be read. "
                         + "Examples of supported config are:\n"
+                        + GraphDatabaseSettings.pagecache_memory.name() + "\n"
                         + GraphDatabaseSettings.dense_node_threshold.name() + "\n"
                         + GraphDatabaseSettings.string_block_size.name() + "\n"
                         + GraphDatabaseSettings.array_block_size.name(), true ),
@@ -606,6 +607,7 @@ public class ImportTool
         printIndented( "Max heap memory : " + bytes( Runtime.getRuntime().maxMemory() ), out );
         printIndented( "Processors: " + configuration.maxNumberOfProcessors(), out );
         printIndented( "Configured max memory: " + bytes( configuration.maxMemoryUsage() ), out );
+        printIndented( "Page cache memory: " + bytes( configuration.pageCacheMemory() ), out );
         out.println();
     }
 
@@ -667,6 +669,12 @@ public class ImportTool
             @Override
             public long pageCacheMemory()
             {
+                // If a specific page cache memory setting exists, then use it.
+                if ( dbConfig.getRaw( GraphDatabaseSettings.pagecache_memory.name() ).isPresent() )
+                {
+                    return dbConfig.get( GraphDatabaseSettings.pagecache_memory );
+                }
+
                 return defaultSettingsSuitableForTests ? mebiBytes( 8 ) : DEFAULT.pageCacheMemory();
             }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Batch.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/Batch.java
@@ -41,6 +41,8 @@ public class Batch<INPUT,RECORD extends PrimitiveRecord>
     public RECORD[] records;
 
     public PropertyRecord[][] propertyRecords;
+    // Property records which contain the node input ids
+    public PropertyRecord[] inputIdPropertyRecords;
     public int numberOfProperties;
 
     // Used by relationship stages to query idMapper and store ids here

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/IdMapperPreparationStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/IdMapperPreparationStage.java
@@ -19,26 +19,25 @@
  */
 package org.neo4j.unsafe.impl.batchimport;
 
+import java.util.function.LongFunction;
+
 import org.neo4j.helpers.progress.ProgressListener;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
 import org.neo4j.unsafe.impl.batchimport.input.Collector;
-import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.staging.Stage;
 import org.neo4j.unsafe.impl.batchimport.stats.StatsProvider;
 
-import static org.neo4j.unsafe.impl.batchimport.Utils.idsOf;
-
 /**
- * Performs {@link IdMapper#prepare(InputIterable, Collector, ProgressListener)}
+ * Performs {@link IdMapper#prepare(LongFunction, Collector, ProgressListener)}
  * embedded in a {@link Stage} as to take advantage of statistics and monitoring provided by that framework.
  */
 public class IdMapperPreparationStage extends Stage
 {
-    public IdMapperPreparationStage( Configuration config, IdMapper idMapper, InputIterable<InputNode> nodes,
+    public IdMapperPreparationStage( Configuration config, IdMapper idMapper, LongFunction<Object> inputIdLookup,
             Collector collector, StatsProvider memoryUsageStats )
     {
         super( "Prepare node index", config );
         add( new IdMapperPreparationStep( control(), config,
-                idMapper, idsOf( nodes ), collector, memoryUsageStats ) );
+                idMapper, inputIdLookup, collector, memoryUsageStats ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/IdMapperPreparationStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/IdMapperPreparationStep.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.unsafe.impl.batchimport;
 
+import java.util.function.LongFunction;
+
 import org.neo4j.helpers.progress.ProgressListener;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
 import org.neo4j.unsafe.impl.batchimport.input.Collector;
@@ -35,23 +37,23 @@ import org.neo4j.unsafe.impl.batchimport.stats.StatsProvider;
 public class IdMapperPreparationStep extends LonelyProcessingStep
 {
     private final IdMapper idMapper;
-    private final InputIterable<Object> allIds;
+    private final LongFunction<Object> inputIdLookup;
     private final Collector collector;
 
     public IdMapperPreparationStep( StageControl control, Configuration config,
-            IdMapper idMapper, InputIterable<Object> allIds, Collector collector,
+            IdMapper idMapper, LongFunction<Object> inputIdLookup, Collector collector,
             StatsProvider... additionalStatsProviders )
     {
         super( control, "" /*named later in the progress listener*/, config, additionalStatsProviders );
         this.idMapper = idMapper;
-        this.allIds = allIds;
+        this.inputIdLookup = inputIdLookup;
         this.collector = collector;
     }
 
     @Override
     protected void process()
     {
-        idMapper.prepare( allIds, collector, new ProgressListener.Adapter()
+        idMapper.prepare( inputIdLookup, collector, new ProgressListener.Adapter()
         {
             @Override
             public void started( String task )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/InputIdValueEncoderStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/InputIdValueEncoderStep.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import org.neo4j.kernel.impl.store.PropertyStore;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.kernel.impl.store.record.PropertyBlock;
+import org.neo4j.kernel.impl.store.record.PropertyRecord;
+import org.neo4j.unsafe.impl.batchimport.input.InputNode;
+import org.neo4j.unsafe.impl.batchimport.staging.BatchSender;
+import org.neo4j.unsafe.impl.batchimport.staging.ProcessorStep;
+import org.neo4j.unsafe.impl.batchimport.staging.StageControl;
+
+public class InputIdValueEncoderStep extends ProcessorStep<Batch<InputNode,NodeRecord>>
+{
+    static final int INPUT_ID_KEY_ID = 0;
+    private final PropertyStore inputIdValueStore;
+
+    public InputIdValueEncoderStep( StageControl control, Configuration config, PropertyStore inputIdValueStore )
+    {
+        super( control, ":ID", config, 0 );
+        this.inputIdValueStore = inputIdValueStore;
+    }
+
+    @Override
+    protected void process( Batch<InputNode,NodeRecord> batch, BatchSender sender ) throws Throwable
+    {
+        batch.inputIdPropertyRecords = new PropertyRecord[batch.input.length];
+        for ( int i = 0; i < batch.input.length; i++ )
+        {
+            Object id = batch.input[i].id();
+            if ( id != null )
+            {
+                PropertyBlock block = new PropertyBlock();
+                PropertyStore.encodeValue( block, INPUT_ID_KEY_ID, id, inputIdValueStore.getStringStore(),
+                        inputIdValueStore.getArrayStore() );
+
+                // An optimization where each property record will represent one input :ID and the id of
+                // the property record will be the node record id, for efficient assignment and latter,
+                // efficient lookup.
+                PropertyRecord record = new PropertyRecord( batch.records[i].getId() );
+                record.setInUse( true );
+                record.addPropertyBlock( block );
+                batch.inputIdPropertyRecords[i] = record;
+            }
+        }
+        sender.send( batch );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeStage.java
@@ -83,9 +83,11 @@ public class NodeStage extends Stage
         add( new NodeEncoderStep( control(), config, idMapper, idGenerator,
                 neoStore.getLabelRepository(), nodeStore, memoryUsage ) );
         add( new PropertyEncoderStep<>( control(), config, neoStore.getPropertyKeyRepository(), propertyStore ) );
+        add( new InputIdValueEncoderStep( control(), config, neoStore.getInputIdValueStore() ) );
         add( new LabelScanStorePopulationStep( control(), config, labelScanStore ) );
-        add( new EntityStoreUpdaterStep<>( control(), config, nodeStore, propertyStore, writeMonitor,
-                storeUpdateMonitor ) );
+        add( new EntityStoreUpdaterStep<>( control(), config, nodeStore,
+                propertyStore, neoStore.getInputIdValueStore(),
+                writeMonitor, storeUpdateMonitor ) );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.function.LongFunction;
 import java.util.function.Predicate;
 
 import org.neo4j.collection.primitive.Primitive;
@@ -69,8 +70,6 @@ import static java.lang.String.format;
 import static java.lang.System.currentTimeMillis;
 import static org.neo4j.helpers.Format.bytes;
 import static org.neo4j.unsafe.impl.batchimport.AdditionalInitialIds.EMPTY;
-import static org.neo4j.unsafe.impl.batchimport.SourceOrCachedInputIterable.cachedForSure;
-import static org.neo4j.unsafe.impl.batchimport.input.InputCache.MAIN;
 import static org.neo4j.unsafe.impl.batchimport.staging.ExecutionSupervisors.superviseExecution;
 import static org.neo4j.unsafe.impl.batchimport.staging.ExecutionSupervisors.withDynamicProcessorAssignment;
 
@@ -179,7 +178,6 @@ public class ParallelBatchImporter implements BatchImporter
             StatsProvider memoryUsageStats = new MemoryUsageStatsProvider( nodeRelationshipCache, idMapper );
             InputIterable<InputNode> nodes = input.nodes();
             InputIterable<InputRelationship> relationships = input.relationships();
-            InputIterable<InputNode> cachedNodes = cachedForSure( nodes, inputCache.nodes( MAIN, true ) );
 
             RelationshipStore relationshipStore = neoStore.getRelationshipStore();
 
@@ -193,7 +191,8 @@ public class ParallelBatchImporter implements BatchImporter
             neoStore.stopFlushingPageCache();
             if ( idMapper.needsPreparation() )
             {
-                executeStage( new IdMapperPreparationStage( config, idMapper, cachedNodes,
+                LongFunction<Object> inputIdLookup = new StoredInputIdLookup( neoStore.getInputIdValueStore() );
+                executeStage( new IdMapperPreparationStage( config, idMapper, inputIdLookup,
                         badCollector, memoryUsageStats ) );
                 PrimitiveLongIterator duplicateNodeIds = badCollector.leftOverDuplicateNodesIds();
                 if ( duplicateNodeIds.hasNext() )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipStage.java
@@ -81,7 +81,7 @@ public class RelationshipStage extends Stage
         add( new RelationshipRecordPreparationStep( control(), config, neoStore.getRelationshipTypeRepository() ) );
         add( new CalculateDenseNodesStep( control(), config, cache, badCollector ) );
         add( new PropertyEncoderStep<>( control(), config, neoStore.getPropertyKeyRepository(), propertyStore ) );
-        add( new EntityStoreUpdaterStep<>( control(), config, relationshipStore, propertyStore,
+        add( new EntityStoreUpdaterStep<>( control(), config, relationshipStore, propertyStore, null,
                 writeMonitor, storeUpdateMonitor ) );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/StoredInputIdLookup.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/StoredInputIdLookup.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport;
+
+import java.util.function.LongFunction;
+
+import org.neo4j.kernel.impl.store.PropertyStore;
+import org.neo4j.kernel.impl.store.record.PropertyBlock;
+import org.neo4j.kernel.impl.store.record.PropertyRecord;
+import org.neo4j.kernel.impl.store.record.RecordLoad;
+
+import static org.neo4j.unsafe.impl.batchimport.InputIdValueEncoderStep.INPUT_ID_KEY_ID;
+
+class StoredInputIdLookup implements LongFunction<Object>
+{
+    private final PropertyStore inputIdValueStore;
+
+    StoredInputIdLookup( PropertyStore inputIdValueStore )
+    {
+        this.inputIdValueStore = inputIdValueStore;
+    }
+
+    @Override
+    public Object apply( long id )
+    {
+        PropertyRecord record = inputIdValueStore.newRecord();
+        inputIdValueStore.getRecord( id, record, RecordLoad.NORMAL );
+        PropertyBlock block = record.getPropertyBlock( INPUT_ID_KEY_ID );
+        assert block != null;
+        return inputIdValueStore.getValue( block );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMapper.java
@@ -19,8 +19,9 @@
  */
 package org.neo4j.unsafe.impl.batchimport.cache.idmapping;
 
+import java.util.function.LongFunction;
+
 import org.neo4j.helpers.progress.ProgressListener;
-import org.neo4j.unsafe.impl.batchimport.InputIterable;
 import org.neo4j.unsafe.impl.batchimport.cache.MemoryStatsVisitor;
 import org.neo4j.unsafe.impl.batchimport.input.Collector;
 import org.neo4j.unsafe.impl.batchimport.input.Group;
@@ -48,9 +49,9 @@ public interface IdMapper extends MemoryStatsVisitor.Visitable
     void put( Object inputId, long actualId, Group group );
 
     /**
-     * @return whether or not a call to {@link #prepare(InputIterable, Collector, ProgressListener)} needs to commence after all calls to
-     * {@link #put(Object, long, Group)} and before any call to {@link #get(Object, Group)}. I.e. whether or not all ids
-     * needs to be put before making any call to {@link #get(Object, Group)}.
+     * @return whether or not a call to {@link #prepare(LongFunction, Collector, ProgressListener)} needs to commence
+     * after all calls to {@link #put(Object, long, Group)} and before any call to {@link #get(Object, Group)}.
+     * I.e. whether or not all ids needs to be put before making any call to {@link #get(Object, Group)}.
      */
     boolean needsPreparation();
 
@@ -58,18 +59,19 @@ public interface IdMapper extends MemoryStatsVisitor.Visitable
      * After all mappings have been {@link #put(Object, long, Group)} call this method to prepare for
      * {@link #get(Object, Group)}.
      *
-     * @param allIds put earlier, in the event of difficult collisions so that more information have to be read
+     * @param inputIdLookup to access input ids passed into {@link #put(Object, long, Group)} prior to this call.
      * from the input data again, data that normally isn't necessary and hence discarded.
      * @param collector {@link Collector} for bad entries, such as duplicate node ids.
      * @param progress reports preparation progress.
      */
-    void prepare( InputIterable<Object> allIds, Collector collector, ProgressListener progress );
+    void prepare( LongFunction<Object> inputIdLookup, Collector collector, ProgressListener progress );
 
     /**
-     * Returns an actual node id representing {@code inputId}. For this call to work {@link #prepare(InputIterable, Collector, ProgressListener)} must have
+     * Returns an actual node id representing {@code inputId}. For this call to work
+     * {@link #prepare(LongFunction, Collector, ProgressListener)} must have
      * been called after all calls to {@link #put(Object, long, Group)} have been made,
      * iff {@link #needsPreparation()} returns {@code true}. Otherwise ids can be retrieved right after
-     * @link #put(Object, long) being put}
+     * {@link #put(Object, long, Group) being put}
      *
      * @param inputId the input id to get the actual node id for.
      * @param group {@link Group} the given {@code inputId} must exist in, i.e. have been put with.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMappers.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMappers.java
@@ -19,8 +19,9 @@
  */
 package org.neo4j.unsafe.impl.batchimport.cache.idmapping;
 
+import java.util.function.LongFunction;
+
 import org.neo4j.helpers.progress.ProgressListener;
-import org.neo4j.unsafe.impl.batchimport.InputIterable;
 import org.neo4j.unsafe.impl.batchimport.cache.MemoryStatsVisitor;
 import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.EncodingIdMapper;
@@ -54,7 +55,7 @@ public class IdMappers
         }
 
         @Override
-        public void prepare( InputIterable<Object> nodeData, Collector collector, ProgressListener progress )
+        public void prepare( LongFunction<Object> nodeData, Collector collector, ProgressListener progress )
         {   // No need to prepare anything
         }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/DuplicateInputIdException.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/DuplicateInputIdException.java
@@ -25,14 +25,13 @@ import static java.lang.String.format;
 
 public class DuplicateInputIdException extends DataException
 {
-    public DuplicateInputIdException( Object id, String groupName, String sourceLocation1, String sourceLocation2 )
+    public DuplicateInputIdException( Object id, String groupName )
     {
-        super( message( id, groupName, sourceLocation1, sourceLocation2 ) );
+        super( message( id, groupName ) );
     }
 
-    public static String message( Object id, String groupName, String sourceLocation1, String sourceLocation2 )
+    public static String message( Object id, String groupName )
     {
-        return format( "Id '%s' is defined more than once in %s, at least at %s and %s",
-                id, groupName, sourceLocation1, sourceLocation2 );
+        return format( "Id '%s' is defined more than once in %s", id, groupName );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/BadCollector.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/BadCollector.java
@@ -82,10 +82,9 @@ public class BadCollector implements Collector
     }
 
     @Override
-    public void collectDuplicateNode( final Object id, long actualId, final String group,
-            final String firstSource, final String otherSource )
+    public void collectDuplicateNode( final Object id, long actualId, final String group )
     {
-        checkTolerance( DUPLICATE_NODES, new NodesProblemReporter( id, group, firstSource, otherSource ) );
+        checkTolerance( DUPLICATE_NODES, new NodesProblemReporter( id, group ) );
 
         if ( leftOverDuplicateNodeIdsCursor == leftOverDuplicateNodeIds.length )
         {
@@ -183,27 +182,23 @@ public class BadCollector implements Collector
     {
         private final Object id;
         private final String group;
-        private final String firstSource;
-        private final String otherSource;
 
-        NodesProblemReporter( Object id, String group, String firstSource, String otherSource )
+        NodesProblemReporter( Object id, String group )
         {
             this.id = id;
             this.group = group;
-            this.firstSource = firstSource;
-            this.otherSource = otherSource;
         }
 
         @Override
         public String message()
         {
-            return DuplicateInputIdException.message( id, group, firstSource, otherSource );
+            return DuplicateInputIdException.message( id, group );
         }
 
         @Override
         public InputException exception()
         {
-            return new DuplicateInputIdException( id, group, firstSource, otherSource );
+            return new DuplicateInputIdException( id, group );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Collector.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Collector.java
@@ -29,7 +29,7 @@ public interface Collector extends AutoCloseable
 {
     void collectBadRelationship( InputRelationship relationship, Object specificValue );
 
-    void collectDuplicateNode( Object id, long actualId, String group, String firstSource, String otherSource );
+    void collectDuplicateNode( Object id, long actualId, String group );
 
     void collectExtraColumns( String source, long row, String value );
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Collectors.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Collectors.java
@@ -29,7 +29,7 @@ import org.neo4j.io.NullOutputStream;
  */
 public class Collectors
 {
-    public static Collector silentBadCollector( int tolerance )
+    public static Collector silentBadCollector( long tolerance )
     {
         return silentBadCollector( tolerance, BadCollector.COLLECT_ALL );
     }
@@ -39,7 +39,7 @@ public class Collectors
         return badCollector( NullOutputStream.NULL_OUTPUT_STREAM, tolerance, collect );
     }
 
-    public static Collector badCollector( OutputStream out, int tolerance )
+    public static Collector badCollector( OutputStream out, long tolerance )
     {
         return badCollector( out, tolerance, BadCollector.COLLECT_ALL, false );
     }
@@ -49,17 +49,17 @@ public class Collectors
         return new BadCollector( out, tolerance, collect, false );
     }
 
-    public static Collector badCollector( OutputStream out, int tolerance, int collect, boolean skipBadEntriesLogging )
+    public static Collector badCollector( OutputStream out, long tolerance, int collect, boolean skipBadEntriesLogging )
     {
         return new BadCollector( out, tolerance, collect, skipBadEntriesLogging );
     }
 
-    public static Function<OutputStream,Collector> badCollector( final int tolerance )
+    public static Function<OutputStream,Collector> badCollector( final long tolerance )
     {
         return badCollector( tolerance, BadCollector.COLLECT_ALL );
     }
 
-    public static Function<OutputStream,Collector> badCollector( final int tolerance, final int collect )
+    public static Function<OutputStream,Collector> badCollector( final long tolerance, final int collect )
     {
         return out -> badCollector( out, tolerance, collect, false );
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
@@ -72,6 +72,9 @@ import static org.neo4j.graphdb.factory.GraphDatabaseSettings.dense_node_thresho
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.store.MetaDataStore.DEFAULT_NAME;
+import static org.neo4j.kernel.impl.store.StoreType.PROPERTY;
+import static org.neo4j.kernel.impl.store.StoreType.PROPERTY_ARRAY;
+import static org.neo4j.kernel.impl.store.StoreType.PROPERTY_STRING;
 import static org.neo4j.kernel.impl.store.StoreType.RELATIONSHIP_GROUP;
 import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_COMMIT_TIMESTAMP;
 
@@ -155,8 +158,8 @@ public class BatchingNeoStores implements AutoCloseable, MemoryStatsVisitor.Visi
                 neoStores.getRelationshipTypeTokenStore() );
 
         // Instantiate the temporary stores
-        temporaryNeoStores = newStoreFactory(
-                "temp." + DEFAULT_NAME, DELETE_ON_CLOSE ).openNeoStores( true, RELATIONSHIP_GROUP );
+        temporaryNeoStores = newStoreFactory( temp( DEFAULT_NAME ), DELETE_ON_CLOSE ).openNeoStores( true,
+                RELATIONSHIP_GROUP, PROPERTY_STRING, PROPERTY_ARRAY, PROPERTY );
 
         // Initialize kernel extensions
         Dependencies dependencies = new Dependencies();
@@ -175,6 +178,11 @@ public class BatchingNeoStores implements AutoCloseable, MemoryStatsVisitor.Visi
         life.start();
         labelScanStore = life.add( extensions.resolveDependency( LabelScanStoreProvider.class,
                 new NamedLabelScanStoreSelectionStrategy( neo4jConfig ) ).getLabelScanStore() );
+    }
+
+    private static String temp( String name )
+    {
+        return "temp." + name;
     }
 
     public static BatchingNeoStores batchingNeoStores( FileSystemAbstraction fileSystem, File storeDir,
@@ -281,6 +289,11 @@ public class BatchingNeoStores implements AutoCloseable, MemoryStatsVisitor.Visi
     public CountsTracker getCountsStore()
     {
         return neoStores.getCounts();
+    }
+
+    public PropertyStore getInputIdValueStore()
+    {
+        return temporaryNeoStores.getPropertyStore();
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/BadCollectorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/BadCollectorTest.java
@@ -93,7 +93,7 @@ public class BadCollectorTest
         badCollector.collectBadRelationship( inputRelationship().build(), 2 );
         try
         {
-            badCollector.collectDuplicateNode( 1, 1, "group", "source", "otherSource" );
+            badCollector.collectDuplicateNode( 1, 1, "group" );
             fail( "Should have thrown an InputException" );
         }
         catch ( InputException ignored )
@@ -111,7 +111,7 @@ public class BadCollectorTest
         BadCollector badCollector = new BadCollector( badOutputFile(), tolerance, BadCollector.COLLECT_ALL );
 
         // when
-        badCollector.collectDuplicateNode( 1, 1, "group", "source", "otherSource" );
+        badCollector.collectDuplicateNode( 1, 1, "group" );
         try
         {
             badCollector.collectBadRelationship( inputRelationship().build(), 2 );
@@ -132,7 +132,7 @@ public class BadCollectorTest
         BadCollector badCollector = new BadCollector( badOutputFile(), tolerance, BadCollector.DUPLICATE_NODES );
 
         // when
-        badCollector.collectDuplicateNode( 1, 1, "group", "source", "otherSource" );
+        badCollector.collectDuplicateNode( 1, 1, "group" );
         try
         {
             badCollector.collectBadRelationship( inputRelationship().build(), 2 );
@@ -156,7 +156,7 @@ public class BadCollectorTest
         badCollector.collectBadRelationship( inputRelationship().build(), 2 );
         try
         {
-            badCollector.collectDuplicateNode( 1, 1, "group", "source", "otherSource" );
+            badCollector.collectDuplicateNode( 1, 1, "group" );
         }
         catch ( InputException ignored )
         {
@@ -176,7 +176,7 @@ public class BadCollectorTest
         // when
         for ( int i = 0; i < 15; i++ )
         {
-            badCollector.collectDuplicateNode( i, i, "group", "source" + i, "otherSource" + i );
+            badCollector.collectDuplicateNode( i, i, "group" );
         }
 
         // then
@@ -194,9 +194,9 @@ public class BadCollectorTest
     {
         // GIVEN
         BadCollector badCollector = new BadCollector( badOutputFile(), 10, BadCollector.DUPLICATE_NODES );
-        badCollector.collectDuplicateNode( "a", 10, "group", "source1", "source2" );
-        badCollector.collectDuplicateNode( "b", 8, "group", "source1", "source2" );
-        badCollector.collectDuplicateNode( "c", 12, "group", "source1", "source2" );
+        badCollector.collectDuplicateNode( "a", 10, "group" );
+        badCollector.collectDuplicateNode( "b", 8, "group" );
+        badCollector.collectDuplicateNode( "c", 12, "group" );
 
         // WHEN
         long[] nodeIds = PrimitiveLongCollections.asArray( badCollector.leftOverDuplicateNodesIds() );
@@ -215,7 +215,7 @@ public class BadCollectorTest
         int count = 10_000;
         for ( int i = 0; i < count; i++ )
         {
-            collector.collectDuplicateNode( i, i, "group", "first", "other" );
+            collector.collectDuplicateNode( i, i, "group" );
         }
 
         // THEN
@@ -229,7 +229,7 @@ public class BadCollectorTest
         BadCollector badCollector = new BadCollector( outputStream, 100, COLLECT_ALL, true );
         for ( int i = 0; i < 2; i++ )
         {
-            badCollector.collectDuplicateNode( i, i, "group", "source" + i, "otherSource" + i );
+            badCollector.collectDuplicateNode( i, i, "group" );
         }
         badCollector.collectBadRelationship( inputRelationship().build(), 2 );
         badCollector.collectExtraColumns( "a,b,c", 1, "a" );


### PR DESCRIPTION
The input ids from the node import (:ID) are encoded into a more
memory-efficient representation for mapping :ID --> node record id.
Some input ids happens to be duplicates and even some encoded ids will
accidentally be the same. For collisions within the same input group
the actual input ids needs to be compared to see whether or not they
are actual or accidental collisions.

Previously this was done by going through the input one more time,
from start to end and collecting the collision-marked ids into memory
for duplicate detection as well as during the input id --> node id
lookups later. In the event of lots of collisions, which btw increases
with number of imported nodes (the accidental collisions), this may
require a lot of memory. The second pass of the input is also suboptimal
performance-wise.

This is changed such that input ids are stored into a temporary
property store next to the imported db where there's a simple 1-to-1
mapping between node and input id property record.
This has a slight cost to the node import and relationship import stages,
but on the flip side speeds up IdMapper preparation stage and cuts down
on heap memory usage in scenarios where there are lots of input id collisions.

NOTE: One thing that gets sacrificed is precise information about input id collisions,
source file and line. If we really want that we'll have to work on getting that back somehow.

To sum things up:
PROS:
- The `RESOLVE` part of `Prepare` stage is way faster because it doesn't have to go through the entire node input one more time
- No collision values are loaded into heap

CONS:
- Temporarily increased space on disk during import to store the node input IDs
- Node stage may be slower due to also storing these input IDs
- Lost ability to precisely locate duplicate input IDs in source files
- Relationship stage may be slower if there are a lot of collisions. Unaffected on low or no collisions

So sweet spot of improvement is where there are more than zero and a low amount of collisions (accidental and actual) compared to total count, which seems to be the far most common case. In this scenario:
- Node import takes a slight hit
- RESOLVE phase in Prepare stage is way faster and won't hog (heap) memory

For the worst-case scenario where a big part of the data are collisions:
- Node import takes a slight hit
- RESOLVE phase in Prepare stage is still faster than going through the entire input again and still won't hog (heap) memory, only temporarily allocates a fraction of what it used to do during the phase, which gets released afterwards.
- Relationship import takes a slight hit