### PR TITLE
Fix migration failures for native label scan store

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
@@ -180,12 +180,23 @@ public class NativeLabelScanStore implements LabelScanStore
         this.pageCache = pageCache;
         this.pageSize = pageSize;
         this.fullStoreChangeStream = fullStoreChangeStream;
-        this.storeFile = new File( storeDir, FILE_NAME );
+        this.storeFile = getLabelScanStoreFile( storeDir );
         this.singleWriter = new NativeLabelScanWriter( 1_000 );
         this.readOnly = readOnly;
         this.monitors = monitors;
         this.monitor = monitors.newMonitor( Monitor.class );
         this.recoveryCleanupWorkCollector = recoveryCleanupWorkCollector;
+    }
+
+    /**
+     * Returns the file backing the label scan store.
+     *
+     * @param storeDir The store directory to use.
+     * @return the file backing the label scan store
+     */
+    public static File getLabelScanStoreFile( File storeDir )
+    {
+        return new File( storeDir, FILE_NAME );
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/SchemaIndexMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/SchemaIndexMigrator.java
@@ -76,5 +76,4 @@ public class SchemaIndexMigrator extends AbstractStoreMigrationParticipant
     {
         fileSystem.deleteRecursively( indexRootDirectory );
     }
-
 }


### PR DESCRIPTION
Migration in the high limit format is performed with the batch importer that end up creating an empty label scan store file, which made `NativeLabelScanStoreMigrator` think the migration had already happened.

This PR forces the `NativeLabelScanStoreMigrator` to always recreate the file even when it is present.