### PR TITLE
Uniqueness check with different duplicate check strategies.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexEntryConflictException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/exceptions/index/IndexEntryConflictException.java
@@ -28,7 +28,6 @@ import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.ValueTuple;
 
 import static java.lang.String.format;
-import static java.lang.String.valueOf;
 import static org.neo4j.kernel.api.StatementConstants.NO_SUCH_NODE;
 
 /**
@@ -40,7 +39,7 @@ public class IndexEntryConflictException extends Exception
     private final long addedNodeId;
     private final long existingNodeId;
 
-    public IndexEntryConflictException( long existingNodeId, long addedNodeId, Value propertyValue )
+    public IndexEntryConflictException( long existingNodeId, long addedNodeId, Value... propertyValue )
     {
         this( existingNodeId, addedNodeId, ValueTuple.of( propertyValue ) );
     }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/DuplicateCheckStrategy.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/DuplicateCheckStrategy.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.schema.verification;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.kernel.api.StatementConstants;
+import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
+import org.neo4j.values.storable.Value;
+import org.neo4j.values.storable.ValueTuple;
+
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+
+/**
+ * Base class for strategy used for duplicate check during verification of value uniqueness during
+ * constraint creation.
+ *
+ * Each particular strategy determines how uniqueness check is done and how to accumulate and store those values for
+ * to make check time and resource consumption optimal.
+ */
+abstract class DuplicateCheckStrategy
+{
+    /**
+     * Check uniqueness of multiple properties that belong to a node with provided node id
+     * @param values property values
+     * @param nodeId checked node id
+     * @throws IndexEntryConflictException
+     */
+    abstract void checkForDuplicate( Value[] values, long nodeId )
+            throws IndexEntryConflictException;
+
+    /**
+     * Check uniqueness of single property that belong to a node with provided node id.
+     * @param value property value
+     * @param nodeId checked node id
+     * @throws IndexEntryConflictException
+     */
+    abstract void checkForDuplicate( Value value, long nodeId ) throws IndexEntryConflictException;
+
+    private static boolean propertyValuesEqual( Value[] properties, Value[] values )
+    {
+        if ( properties.length != values.length )
+        {
+            return false;
+        }
+        for ( int i = 0; i < properties.length; i++ )
+        {
+            if ( !properties[i].equals( values[i] ) )
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Duplicate check strategy that uses plain hash map. Should be optimal for small amount of entries.
+     */
+    static class MapDuplicateCheckStrategy extends DuplicateCheckStrategy
+    {
+        private Map<Object,Long> valueNodeIdMap;
+
+        MapDuplicateCheckStrategy( int expectedNumberOfEntries )
+        {
+            this.valueNodeIdMap = new HashMap<>( expectedNumberOfEntries );
+        }
+
+        @Override
+        public void checkForDuplicate( Value[] values, long nodeId )
+                throws IndexEntryConflictException
+        {
+            Long previousNodeId = valueNodeIdMap.put( ValueTuple.of( values ), nodeId );
+            if ( previousNodeId != null )
+            {
+                throw new IndexEntryConflictException( previousNodeId, nodeId, ValueTuple.of( values ) );
+            }
+        }
+
+        @Override
+        void checkForDuplicate( Value value, long nodeId ) throws IndexEntryConflictException
+        {
+            Long previousNodeId = valueNodeIdMap.put( value, nodeId );
+            if ( previousNodeId != null )
+            {
+                throw new IndexEntryConflictException( previousNodeId, nodeId, value );
+            }
+        }
+
+    }
+
+    /**
+     * Strategy that uses arrays to store entries and uses hash codes to split those entries over different buckets.
+     * Number of buckets and size of entries block are dynamic and evaluated based on expected number of duplicates.
+     */
+    static class BucketsDuplicateCheckStrategy extends DuplicateCheckStrategy
+    {
+        private static final int BASE_ENTRY_SIZE = 1000;
+        private static final int DEFAULT_BUCKETS = 10;
+        static final int BUCKET_STRATEGY_ENTRIES_THRESHOLD = BASE_ENTRY_SIZE * DEFAULT_BUCKETS;
+
+        private static final int MAX_NUMBER_OF_BUCKETS = 100;
+        private final int numberOfBuckets;
+        private BucketEntry[] buckets;
+        private final int bucketSetSize;
+
+        BucketsDuplicateCheckStrategy()
+        {
+            this( BUCKET_STRATEGY_ENTRIES_THRESHOLD );
+        }
+
+        BucketsDuplicateCheckStrategy( int expectedNumberOfEntries )
+        {
+            numberOfBuckets = min( MAX_NUMBER_OF_BUCKETS, (expectedNumberOfEntries / BASE_ENTRY_SIZE) + 1 );
+            buckets = new BucketEntry[numberOfBuckets];
+            bucketSetSize = max( 100, BUCKET_STRATEGY_ENTRIES_THRESHOLD / numberOfBuckets );
+        }
+
+        @Override
+        public void checkForDuplicate( Value[] values, long nodeId )
+                throws IndexEntryConflictException
+        {
+            BucketEntry current = bucketEntrySet( Arrays.hashCode( values ), bucketSetSize );
+
+            // We either have to find the first conflicting entry set element,
+            // or append one for the property we just fetched:
+            scan:
+            do
+            {
+                for ( int i = 0; i < bucketSetSize; i++ )
+                {
+                    Value[] currentValues = (Value[]) current.value[i];
+
+                    if ( current.nodeId[i] == StatementConstants.NO_SUCH_NODE )
+                    {
+                        current.value[i] = values;
+                        current.nodeId[i] = nodeId;
+                        if ( i == bucketSetSize - 1 )
+                        {
+                            current.next = new BucketEntry( bucketSetSize );
+                        }
+                        break scan;
+                    }
+                    else if ( propertyValuesEqual( values, currentValues ) )
+                    {
+                        throw new IndexEntryConflictException( current.nodeId[i], nodeId, currentValues );
+                    }
+                }
+                current = current.next;
+            }
+            while ( current != null );
+        }
+
+        @Override
+        void checkForDuplicate( Value propertyValue, long nodeId ) throws IndexEntryConflictException
+        {
+            BucketEntry current = bucketEntrySet( propertyValue.hashCode(), bucketSetSize );
+
+            // We either have to find the first conflicting entry set element,
+            // or append one for the property we just fetched:
+            scan:
+            do
+            {
+                for ( int i = 0; i < bucketSetSize; i++ )
+                {
+                    Value value = (Value) current.value[i];
+
+                    if ( current.nodeId[i] == StatementConstants.NO_SUCH_NODE )
+                    {
+                        current.value[i] = propertyValue;
+                        current.nodeId[i] = nodeId;
+                        if ( i == bucketSetSize - 1 )
+                        {
+                            current.next = new BucketEntry( bucketSetSize );
+                        }
+                        break scan;
+                    }
+                    else if ( propertyValue.equals( value ) )
+                    {
+                        throw new IndexEntryConflictException( current.nodeId[i], nodeId, value );
+                    }
+                }
+                current = current.next;
+            }
+            while ( current != null );
+        }
+
+        private BucketEntry bucketEntrySet( int hashCode, int entrySetSize )
+        {
+            int bucket = Math.abs( hashCode ) % numberOfBuckets;
+            BucketEntry current = buckets[bucket];
+            if ( current == null )
+            {
+                current = new BucketEntry( entrySetSize );
+                buckets[bucket] = current;
+            }
+            return current;
+        }
+
+        /**
+         * Each bucket entry contains arrays of nodes and corresponding values and link to next BucketEntry in the
+         * chain for cases when we have more data then the size of one bucket. So bucket entries will form a
+         * chain of entries to represent values in particular bucket
+         */
+        private static class BucketEntry
+        {
+            final Object[] value;
+            final long[] nodeId;
+            BucketEntry next;
+
+            BucketEntry( int entrySize )
+            {
+                value = new Object[entrySize];
+                nodeId = new long[entrySize];
+                Arrays.fill( nodeId, StatementConstants.NO_SUCH_NODE );
+            }
+        }
+    }
+}

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/SimpleUniquenessVerifier.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/SimpleUniquenessVerifier.java
@@ -79,7 +79,7 @@ public class SimpleUniquenessVerifier implements UniquenessVerifier
                     {
                         if ( terms.docFreq() > 1 )
                         {
-                            collector.reset();
+                            collector.init( terms.docFreq() );
                             searcher.search( new TermQuery( new Term( field, termsRef ) ), collector );
                         }
                     }
@@ -106,7 +106,7 @@ public class SimpleUniquenessVerifier implements UniquenessVerifier
             DuplicateCheckingCollector collector = DuplicateCheckingCollector.forProperties( accessor, propKeyIds );
             for ( Value[] valueTuple : updatedValueTuples )
             {
-                collector.reset();
+                collector.init();
                 Query query = LuceneDocumentStructure.newSeekQuery( valueTuple );
                 indexSearcher().search( query, collector );
             }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/verification/DuplicateCheckStrategyTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/verification/DuplicateCheckStrategyTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.schema.verification;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.neo4j.function.Factory;
+import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
+import org.neo4j.kernel.api.impl.schema.verification.DuplicateCheckStrategy.BucketsDuplicateCheckStrategy;
+import org.neo4j.kernel.api.impl.schema.verification.DuplicateCheckStrategy.MapDuplicateCheckStrategy;
+import org.neo4j.values.storable.TextValue;
+import org.neo4j.values.storable.Value;
+import org.neo4j.values.storable.ValueTuple;
+import org.neo4j.values.storable.Values;
+
+import static java.lang.String.format;
+import static org.neo4j.kernel.api.impl.schema.verification.DuplicateCheckStrategy.BucketsDuplicateCheckStrategy.BUCKET_STRATEGY_ENTRIES_THRESHOLD;
+
+@RunWith( Parameterized.class )
+public class DuplicateCheckStrategyTest
+{
+
+    @Parameterized.Parameters
+    public static List<Factory<? extends DuplicateCheckStrategy>> duplicateCheckStrategies()
+    {
+        return Arrays.asList( () -> new MapDuplicateCheckStrategy( 1000 ),
+                () -> new BucketsDuplicateCheckStrategy( randomNumberOfEntries() ) );
+    }
+
+    @Parameterized.Parameter
+    public Factory<DuplicateCheckStrategy> duplicateCheckStrategyFactory;
+    private DuplicateCheckStrategy checkStrategy;
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Before
+    public void setUp() throws IllegalAccessException, InstantiationException
+    {
+        checkStrategy = duplicateCheckStrategyFactory.newInstance();
+    }
+
+    @Test
+    public void checkStringSinglePropertyDuplicates() throws Exception
+    {
+        String duplicatedString = "duplicate";
+
+        Value propertyValue = Values.stringValue( duplicatedString );
+
+        expectedException.expect( IndexEntryConflictException.class );
+        expectedException.expectMessage(
+                format( "Both node 1 and node 2 share the property value %s", ValueTuple.of( propertyValue ) ) );
+
+        checkStrategy.checkForDuplicate( propertyValue, 1 );
+        checkStrategy.checkForDuplicate( propertyValue, 2 );
+    }
+
+    @Test
+    public void checkNumericSinglePropertyDuplicates() throws Exception
+    {
+        double duplicatedNumber = 0.33d;
+        Value property = Values.doubleValue( duplicatedNumber );
+
+        expectedException.expect( IndexEntryConflictException.class );
+        expectedException.expectMessage(
+                format( "Both node 3 and node 4 share the property value %s", ValueTuple.of( property ) ) );
+
+        checkStrategy.checkForDuplicate( property, 3 );
+        checkStrategy.checkForDuplicate( property, 4 );
+    }
+
+    @Test
+    public void duplicateFoundAmongUniqueStringSingleProperty() throws IndexEntryConflictException
+    {
+        for ( int i = 0; i < randomNumberOfEntries(); i++ )
+        {
+            String propertyValue = String.valueOf( i );
+            TextValue stringValue = Values.stringValue( propertyValue );
+            checkStrategy.checkForDuplicate( stringValue, i );
+        }
+
+        int duplicateTarget = BUCKET_STRATEGY_ENTRIES_THRESHOLD - 2;
+        String duplicate = String.valueOf( duplicateTarget );
+        TextValue duplicatedValue = Values.stringValue( duplicate );
+        expectedException.expect( IndexEntryConflictException.class );
+        expectedException.expectMessage(
+                format( "Both node %d and node 3 share the property value %s", duplicateTarget, ValueTuple.of( duplicatedValue ) ) );
+        checkStrategy.checkForDuplicate( duplicatedValue, 3 );
+    }
+
+    @Test
+    public void duplicateFoundAmongUniqueNumberSingleProperty() throws IndexEntryConflictException
+    {
+        double propertyValue = 0;
+        for ( int i = 0; i < randomNumberOfEntries(); i++ )
+        {
+            Value doubleValue = Values.doubleValue( propertyValue );
+            checkStrategy.checkForDuplicate( doubleValue, i );
+            propertyValue += 1;
+        }
+
+        int duplicateTarget = BUCKET_STRATEGY_ENTRIES_THRESHOLD - 8;
+        double duplicateValue = duplicateTarget;
+        Value duplicate = Values.doubleValue( duplicateValue );
+        expectedException.expect( IndexEntryConflictException.class );
+        expectedException.expectMessage(
+                format( "Both node %d and node 3 share the property value %s", duplicateTarget, ValueTuple.of( duplicate ) ) );
+        checkStrategy.checkForDuplicate( duplicate, 3 );
+    }
+
+    @Test
+    public void noDuplicatesDetectedForUniqueStringSingleProperty() throws IndexEntryConflictException
+    {
+        for ( int i = 0; i < randomNumberOfEntries(); i++ )
+        {
+            String propertyValue = String.valueOf( i );
+            Value value = Values.stringValue( propertyValue );
+            checkStrategy.checkForDuplicate( value, i );
+        }
+    }
+
+    @Test
+    public void noDuplicatesDetectedForUniqueNumberSingleProperty() throws IndexEntryConflictException
+    {
+        double propertyValue = 0;
+        int numberOfIterations = randomNumberOfEntries();
+        for ( int i = 0; i < numberOfIterations; i++ )
+        {
+            propertyValue += 1d / numberOfIterations;
+            Value value = Values.doubleValue( propertyValue );
+            checkStrategy.checkForDuplicate( value, i );
+        }
+    }
+
+    // multiple
+
+    @Test
+    public void checkStringMultiplePropertiesDuplicates() throws Exception
+    {
+        String duplicateA = "duplicateA";
+        String duplicateB = "duplicateB";
+        Value propertyA = Values.stringValue( duplicateA );
+        Value propertyB = Values.stringValue( duplicateB );
+
+        expectedException.expect( IndexEntryConflictException.class );
+        expectedException.expectMessage( format( "Both node 1 and node 2 share the property value %s",
+                ValueTuple.of( duplicateA, duplicateB ) ) );
+
+        checkStrategy.checkForDuplicate( new Value[]{propertyA, propertyB}, 1 );
+        checkStrategy.checkForDuplicate( new Value[]{propertyA, propertyB}, 2 );
+    }
+
+    @Test
+    public void checkNumericMultiplePropertiesDuplicates() throws Exception
+    {
+        Number duplicatedNumberA = 0.33d;
+        Number duplicatedNumberB = 2;
+        Value propertyA = Values.doubleValue( duplicatedNumberA.doubleValue() );
+        Value propertyB = Values.intValue( duplicatedNumberB.intValue() );
+
+        expectedException.expect( IndexEntryConflictException.class );
+        expectedException.expectMessage( format( "Both node 3 and node 4 share the property value %s",
+                ValueTuple.of( propertyA, propertyB ) ) );
+
+        checkStrategy.checkForDuplicate( new Value[]{propertyA, propertyB}, 3 );
+        checkStrategy.checkForDuplicate( new Value[]{propertyA, propertyB}, 4 );
+    }
+
+    @Test
+    public void duplicateFoundAmongUniqueStringMultipleProperties() throws IndexEntryConflictException
+    {
+        for ( int i = 0; i < randomNumberOfEntries(); i++ )
+        {
+            String propertyValueA = String.valueOf( i );
+            String propertyValueB = String.valueOf( -i );
+            Value propertyA = Values.stringValue( propertyValueA );
+            Value propertyB = Values.stringValue( propertyValueB );
+            checkStrategy.checkForDuplicate( new Value[]{propertyA, propertyB}, i );
+        }
+
+        int duplicateTarget = BUCKET_STRATEGY_ENTRIES_THRESHOLD - 2;
+        String duplicatedValueA = String.valueOf( duplicateTarget );
+        String duplicatedValueB = String.valueOf( -duplicateTarget );
+        Value propertyA = Values.stringValue( duplicatedValueA );
+        Value propertyB = Values.stringValue( duplicatedValueB );
+        expectedException.expect( IndexEntryConflictException.class );
+        expectedException.expectMessage( format( "Both node %d and node 3 share the property value %s",
+                duplicateTarget, ValueTuple.of( propertyA, propertyB ) ) );
+        checkStrategy.checkForDuplicate( new Value[]{propertyA, propertyB}, 3 );
+    }
+
+    @Test
+    public void duplicateFoundAmongUniqueNumberMultipleProperties() throws IndexEntryConflictException
+    {
+        double propertyValue = 0;
+        for ( int i = 0; i < randomNumberOfEntries(); i++ )
+        {
+            double propertyValueA = propertyValue;
+            double propertyValueB = -propertyValue;
+            Value propertyA = Values.doubleValue( propertyValueA );
+            Value propertyB = Values.doubleValue( propertyValueB );
+            checkStrategy.checkForDuplicate( new Value[]{propertyA, propertyB}, i );
+            propertyValue += 1;
+        }
+
+        int duplicateTarget = BUCKET_STRATEGY_ENTRIES_THRESHOLD - 8;
+        double duplicateValueA = duplicateTarget;
+        double duplicateValueB = -duplicateTarget;
+        Value propertyA = Values.doubleValue( duplicateValueA );
+        Value propertyB = Values.doubleValue( duplicateValueB );
+        expectedException.expect( IndexEntryConflictException.class );
+        expectedException.expectMessage( format( "Both node %d and node 3 share the property value %s",
+                duplicateTarget, ValueTuple.of( duplicateValueA, duplicateValueB ) ) );
+        checkStrategy.checkForDuplicate( new Value[]{propertyA, propertyB}, 3 );
+    }
+
+    @Test
+    public void noDuplicatesDetectedForUniqueStringMultipleProperties() throws IndexEntryConflictException
+    {
+        for ( int i = 0; i < randomNumberOfEntries(); i++ )
+        {
+            String propertyValueA = String.valueOf( i );
+            String propertyValueB = String.valueOf( -i );
+            Value propertyA = Values.stringValue( propertyValueA );
+            Value propertyB = Values.stringValue( propertyValueB );
+            checkStrategy.checkForDuplicate( new Value[]{propertyA, propertyB}, i );
+        }
+    }
+
+    @Test
+    public void noDuplicatesDetectedForUniqueNumberMultipleProperties() throws IndexEntryConflictException
+    {
+        double propertyValueA = 0;
+        double propertyValueB = 0;
+        int numberOfIterations = randomNumberOfEntries();
+        for ( int i = 0; i < numberOfIterations; i++ )
+        {
+            propertyValueA += 1d / numberOfIterations;
+            propertyValueB -= 1d / numberOfIterations;
+            Value propertyA = Values.doubleValue( propertyValueA );
+            Value propertyB = Values.doubleValue( propertyValueB );
+            checkStrategy.checkForDuplicate( new Value[]{propertyA, propertyB}, i );
+        }
+    }
+
+    private static int randomNumberOfEntries()
+    {
+        return ThreadLocalRandom.current().nextInt( BUCKET_STRATEGY_ENTRIES_THRESHOLD, BUCKET_STRATEGY_ENTRIES_THRESHOLD << 1 );
+    }
+
+}


### PR DESCRIPTION
Introduce duplicate checking strategies:
use simple map strategy for cases when expected number of elements is
small enough, use dynamic bucket based array strategy in case if expected
number of elements is quite high.
Proposed changes speedups things significantly and for quite big numbers of
duplicates allow create unique indexes in seconds instead of minutes.