### PR TITLE
Applies label and index updates in parallel

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/IndexBatchTransactionApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/IndexBatchTransactionApplierTest.java
@@ -77,7 +77,7 @@ public class IndexBatchTransactionApplierTest
             }
         }
         // THEN all assertions happen inside the LabelScanWriter#write and #close
-        verify( labelScanSync ).apply( any() );
+        verify( labelScanSync ).applyAsync( any() );
     }
 
     private Supplier<LabelScanWriter> singletonProvider( final LabelScanWriter writer )


### PR DESCRIPTION
When applying a transaction both label updates and index updates are enqueued and applied
as a batch at the end of the transaction(s). On top of this sits one WorkSync for label updates
and another for index updates, batching together work from concurrent transactions so that
only one out of all concurrently applying transactions applies all label and index updates.

Previously label updates and index updates were applied in sequence, from one transaction's
perspective in that it would submit its label update to the WorkSync and either apply them,
together with other concurrent transaction's label updates, or just sit and wait for them to
be applied by another concurrent transaction. Only after that would it do the same for its
index updates.

This commit further increases batching and parallelism by calling WorkSync#applyAsync
for label updates and moving on to index updates immediately and in the end awaiting label
updates to complete.