### PR TITLE
Introduce `dbms.setConfigValue` to change dynamic configuration values

### DIFF
--- a/community/configuration/src/main/java/org/neo4j/configuration/ConfigOptions.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/ConfigOptions.java
@@ -60,7 +60,7 @@ public class ConfigOptions
                     return new ConfigValue( setting.name(), setting.description(),
                             setting.documentedDefaultValue(),
                         Optional.ofNullable( val.getValue() ),
-                            setting.valueDescription(), setting.internal(),
+                            setting.valueDescription(), setting.internal(), setting.dynamic(),
                             setting.deprecated(), setting.replacement() );
                 } )
                 .collect( Collectors.toList() );

--- a/community/configuration/src/main/java/org/neo4j/configuration/ConfigValue.java
+++ b/community/configuration/src/main/java/org/neo4j/configuration/ConfigValue.java
@@ -34,12 +34,13 @@ public class ConfigValue
     private final Optional<?> value;
     private final String valueDescription;
     private final boolean internal;
+    private final boolean dynamic;
     private final boolean deprecated;
     private final Optional<String> replacement;
 
     public ConfigValue( @Nonnull String name, @Nonnull Optional<String> description,
             @Nonnull Optional<String> documentedDefaultValue, @Nonnull Optional<?> value,
-            @Nonnull String valueDescription, boolean internal, boolean deprecated,
+            @Nonnull String valueDescription, boolean internal, boolean dynamic, boolean deprecated,
             @Nonnull Optional<String> replacement )
     {
         this.name = name;
@@ -48,6 +49,7 @@ public class ConfigValue
         this.value = value;
         this.valueDescription = valueDescription;
         this.internal = internal;
+        this.dynamic = dynamic;
         this.deprecated = deprecated;
         this.replacement = replacement;
     }
@@ -96,6 +98,11 @@ public class ConfigValue
     public boolean internal()
     {
         return internal;
+    }
+
+    public boolean dynamic()
+    {
+        return dynamic;
     }
 
     @Nonnull

--- a/community/configuration/src/test/java/org/neo4j/configuration/ConfigValueTest.java
+++ b/community/configuration/src/test/java/org/neo4j/configuration/ConfigValueTest.java
@@ -35,7 +35,7 @@ public class ConfigValueTest
     public void handlesEmptyValue() throws Exception
     {
         ConfigValue value = new ConfigValue( "name", Optional.empty(), Optional.empty(), Optional.empty(),
-                "description", false, false, Optional.empty() );
+                "description", false, false, false, Optional.empty() );
 
         assertEquals( Optional.empty(), value.value() );
         assertEquals( "null", value.toString() );
@@ -48,7 +48,7 @@ public class ConfigValueTest
     public void handlesInternal() throws Exception
     {
         ConfigValue value = new ConfigValue( "name", Optional.empty(), Optional.empty(), Optional.empty(),
-                "description", true, false,
+                "description", true, false, false,
                 Optional.empty() );
 
         assertTrue( value.internal() );
@@ -58,7 +58,7 @@ public class ConfigValueTest
     public void handlesNonEmptyValue() throws Exception
     {
         ConfigValue value = new ConfigValue( "name", Optional.empty(), Optional.empty(), Optional.of( 1 ),
-                "description", false, false, Optional.empty() );
+                "description", false, false, false, Optional.empty() );
 
         assertEquals( Optional.of( 1 ), value.value() );
         assertEquals( "1", value.toString() );
@@ -71,7 +71,7 @@ public class ConfigValueTest
     public void handlesDeprecationAndReplacement() throws Exception
     {
         ConfigValue value = new ConfigValue( "old_name", Optional.empty(), Optional.empty(), Optional.of( 1 ),
-                "description", false, true,
+                "description", false, false, true,
                 Optional.of( "new_name" ) );
 
         assertEquals( Optional.of( 1 ), value.value() );
@@ -85,7 +85,7 @@ public class ConfigValueTest
     public void handlesValueDescription() throws Exception
     {
         ConfigValue value = new ConfigValue( "old_name", Optional.empty(), Optional.empty(), Optional.of( 1 ),
-                "a simple integer", false, true,
+                "a simple integer", false, false, true,
                 Optional.of( "new_name" ) );
 
         assertEquals( Optional.of( 1 ), value.value() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
@@ -565,21 +565,20 @@ public class Config implements DiagnosticsProvider, Configuration
     }
 
     /**
+     * Updates a provided setting to a given value. This method is intended to be used for changing settings during
+     * runtime. If you want to change settings at startup, use {@link Config#augment}.
      *
-     * TODO: DRAGONS! This code works for the current dynamic variables(3), but is not generic.
-     * TODO: DRAGONS! No migration or config validation is done.
+     * @implNote No migration or config validation is done. If you need this you have to refactor this method.
      *
      * @param setting The setting to set to the specified value.
      * @param value The new value to set, passing {@code null} or empty should reset the value back to default value.
      * @throws IllegalArgumentException if the provided setting is unknown or not dynamic.
      * @throws InvalidSettingException if the value is not formatted correctly.
      */
-    public void setConfigValue( String setting, String value ) throws IllegalArgumentException, InvalidSettingException
+    public void updateDynamicSetting( String setting, String value ) throws IllegalArgumentException, InvalidSettingException
     {
         // Make sure the setting is valid and is marked as dynamic
-        Optional<ConfigValue> option =
-                configOptions.stream().map( it -> it.asConfigValues( params ) ).flatMap( List::stream )
-                        .filter( it -> it.name().equals( setting ) ).findFirst();
+        Optional<ConfigValue> option = findConfigValue( setting );
 
         if ( !option.isPresent() )
         {
@@ -615,6 +614,12 @@ public class Config implements DiagnosticsProvider, Configuration
 
             params.put( setting, value );
         }
+    }
+
+    private Optional<ConfigValue> findConfigValue( String setting )
+    {
+        return configOptions.stream().map( it -> it.asConfigValues( params ) ).flatMap( List::stream )
+                .filter( it -> it.name().equals( setting ) ).findFirst();
     }
 
     /**

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
@@ -280,7 +280,7 @@ public class EnterpriseBuiltInDbmsProcedures
         assertAdmin();
 
         Config config = resolver.resolveDependency( Config.class );
-        config.setConfigValue( setting, value ); // throws if something goes wrong
+        config.updateDynamicSetting( setting, value ); // throws if something goes wrong
     }
 
     /*

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
@@ -45,6 +45,7 @@ import org.neo4j.kernel.api.proc.ProcedureSignature;
 import org.neo4j.kernel.api.proc.UserFunctionSignature;
 import org.neo4j.kernel.api.query.ExecutingQuery;
 import org.neo4j.kernel.api.security.SecurityContext;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.KernelTransactions;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.proc.Procedures;
@@ -265,8 +266,21 @@ public class EnterpriseBuiltInDbmsProcedures
         private boolean isAdminProcedure( String procedureName )
         {
             return name.startsWith( "dbms.security." ) && ADMIN_PROCEDURES.contains( procedureName ) ||
-                   name.equals( "dbms.listConfig" );
+                   name.equals( "dbms.listConfig" ) ||
+                   name.equals( "dbms.setConfigValue" );
         }
+    }
+
+    @Description( "Updates a given setting value. Passing an empty value will result in removing the configured value " +
+            "and falling back to the default value. Changes will not persist and will be lost if the server is restarted." )
+    @Procedure( name = "dbms.setConfigValue", mode = DBMS )
+    public void setConfigValue( @Name( "setting" ) String setting, @Name( "value" ) String value )
+    {
+        securityContext.assertCredentialsNotExpired();
+        assertAdmin();
+
+        Config config = resolver.resolveDependency( Config.class );
+        config.setConfigValue( setting, value ); // throws if something goes wrong
     }
 
     /*

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/SetConfigValueProcedureTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/SetConfigValueProcedureTest.java
@@ -31,7 +31,6 @@ import org.neo4j.test.rule.ImpermanentEnterpriseDatabaseRule;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.log_queries;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.plugin_dir;
 
@@ -62,7 +61,6 @@ public class SetConfigValueProcedureTest
         expect.expectMessage( "Unknown setting: unknown.setting.indeed" );
 
         db.execute( "CALL dbms.setConfigValue('unknown.setting.indeed', 'foo')" );
-        fail( "Should throw IllegalArgumentException" );
     }
 
     @Test
@@ -73,7 +71,6 @@ public class SetConfigValueProcedureTest
 
         // Static setting, at least for now
         db.execute( "CALL dbms.setConfigValue('" + plugin_dir.name() + "', 'path/to/dir')" );
-        fail( "Should throw IllegalArgumentException" );
     }
 
     @Test
@@ -83,6 +80,5 @@ public class SetConfigValueProcedureTest
         expect.expectMessage( "Bad value 'invalid' for setting 'dbms.logs.query.enabled': must be 'true' or 'false'" );
 
         db.execute( "CALL dbms.setConfigValue('" + log_queries.name() + "', 'invalid')" );
-        fail( "Should throw InvalidSettingException" );
     }
 }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/SetConfigValueProcedureTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/SetConfigValueProcedureTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.enterprise.builtinprocs;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.graphdb.config.InvalidSettingException;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.helpers.Exceptions;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.test.rule.DatabaseRule;
+import org.neo4j.test.rule.ImpermanentEnterpriseDatabaseRule;
+import org.neo4j.test.rule.concurrent.ThreadingRule;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.cypher_hints_error;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.log_queries;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.plugin_dir;
+
+public class SetConfigValueProcedureTest
+{
+    @Rule
+    public final DatabaseRule db = new ImpermanentEnterpriseDatabaseRule()
+    {
+        @Override
+        protected void configure( GraphDatabaseBuilder builder )
+        {
+            builder.setConfig( cypher_hints_error, "true" );
+        }
+    };
+    @Rule
+    public final ThreadingRule threads = new ThreadingRule();
+
+    @Test
+    public void configShouldBeAffected() throws Exception
+    {
+        Config config = db.resolveDependency( Config.class );
+
+        db.execute( "CALL dbms.setConfigValue('" + log_queries.name() + "', 'false')" );
+        assertFalse( config.get( log_queries ) );
+
+        db.execute( "CALL dbms.setConfigValue('" + log_queries.name() + "', 'true')" );
+        assertTrue( config.get( log_queries ) );
+    }
+
+    @Test
+    public void failIfUnknownSetting() throws Exception
+    {
+        try
+        {
+            db.execute( "CALL dbms.setConfigValue('unknown.setting.indeed', 'foo')" );
+        }
+        catch ( Exception e )
+        {
+            Throwable cause = Exceptions.rootCause( e );
+            assertThat( cause, instanceOf( IllegalArgumentException.class ) );
+            assertThat( cause.getMessage(), equalTo( "Unknown setting: unknown.setting.indeed" ) );
+            return;
+        }
+        fail( "Should throw IllegalArgumentException" );
+    }
+
+    @Test
+    public void failIfStaticSetting() throws Exception
+    {
+        try
+        {
+            // Static setting, at least for now
+            db.execute( "CALL dbms.setConfigValue('" + plugin_dir.name() + "', 'path/to/dir')" );
+        }
+        catch ( Exception e )
+        {
+            Throwable cause = Exceptions.rootCause( e );
+            assertThat( cause, instanceOf( IllegalArgumentException.class ) );
+            assertThat( cause.getMessage(), equalTo( "Setting is not dynamic and can not be changed at runtime" ) );
+            return;
+        }
+        fail( "Should throw IllegalArgumentException" );
+    }
+
+    @Test
+    public void failIfInvalidValue() throws Exception
+    {
+        try
+        {
+            db.execute( "CALL dbms.setConfigValue('" + log_queries.name() + "', 'invalid')" );
+        }
+        catch ( Exception e )
+        {
+            Throwable cause = Exceptions.rootCause( e );
+            assertThat( cause, instanceOf( InvalidSettingException.class ) );
+            assertThat( cause.getMessage(),
+                    equalTo( "Bad value 'invalid' for setting 'dbms.logs.query.enabled': must be 'true' or 'false'" ) );
+            return;
+        }
+        fail( "Should throw InvalidSettingException" );
+    }
+}

--- a/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerTest.java
+++ b/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerTest.java
@@ -69,7 +69,7 @@ public class QueryLoggerTest
     public final FakeHeapAllocation heapAllocation = new FakeHeapAllocation();
     private long pageHits;
     private long pageFaults;
-    private long threshold = 10; //ms
+    private long thresholdInMillis = 10;
 
     @Test
     public void shouldLogQuerySlowerThanThreshold() throws Exception
@@ -109,7 +109,7 @@ public class QueryLoggerTest
 
         // and when
         ExecutingQuery query2 = query( SESSION_2, "TestUser2", QUERY_2 );
-        threshold = 5;
+        thresholdInMillis = 5;
         queryLogger.startQueryExecution( query2 );
         clock.forward( 9, TimeUnit.MILLISECONDS );
         queryLogger.endSuccess( query2 );
@@ -486,7 +486,7 @@ public class QueryLoggerTest
     {
         EnumSet<QueryLogEntryContent> flagSet = EnumSet.noneOf( QueryLogEntryContent.class );
         Collections.addAll( flagSet, flags );
-        return new QueryLogger( logProvider.getLog( getClass() ), () -> true, () -> threshold, flagSet );
+        return new QueryLogger( logProvider.getLog( getClass() ), () -> true, () -> thresholdInMillis, flagSet );
     }
 
     private ExecutingQuery query(

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
@@ -670,6 +670,19 @@ public abstract class BuiltInProceduresInteractionTestBase<S> extends ProcedureI
         } );
     }
 
+    //---------- config manipulation -----------
+
+    @Test
+    public void setConfigValueShouldBeAccessibleOnlyToAdmins() throws Exception
+    {
+        String call = "CALL dbms.setConfigValue('dbms.logs.query.enabled', 'false')";
+        assertFail( writeSubject, call, PERMISSION_DENIED );
+        assertFail( schemaSubject, call, PERMISSION_DENIED );
+        assertFail( readSubject, call, PERMISSION_DENIED );
+
+        assertEmpty( adminSubject, call );
+    }
+
     //---------- procedure guard -----------
 
     @Test

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseNeoServer.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseNeoServer.java
@@ -38,6 +38,7 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.enterprise.EnterpriseGraphDatabase;
 import org.neo4j.kernel.ha.HaSettings;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory.Dependencies;
 import org.neo4j.kernel.impl.util.UnsatisfiedDependencyException;
 import org.neo4j.logging.LogProvider;
@@ -89,6 +90,12 @@ public class EnterpriseNeoServer extends CommunityNeoServer
     public EnterpriseNeoServer( Config config, Dependencies dependencies, LogProvider logProvider )
     {
         super( config, createDbFactory( config ), dependencies, logProvider );
+    }
+
+    public EnterpriseNeoServer( Config config, Database.Factory dbFactory, GraphDatabaseFacadeFactory.Dependencies
+            dependencies, LogProvider logProvider )
+    {
+        super( config, dbFactory, dependencies, logProvider );
     }
 
     protected static Database.Factory createDbFactory( Config config )

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -234,6 +234,13 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>org.neo4j.app</groupId>
+          <artifactId>neo4j-server-enterprise</artifactId>
+          <version>${project.version}</version>
+          <type>test-jar</type>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 
   <licenses>


### PR DESCRIPTION
Enterprise version of neo4j now has a way to change configuration values at runtime through procedures. E.g.

    CALL dbms.setConfigValue('dbms.logs.query.enabled', 'true')

The procedure takes a setting followed by a value. If the value is empty, the setting will fallback to the default value. This only works for settings marked as dynamic, which is currently only:

- `dbms.transaction.timeout`
- `dbms.logs.query.threshold`
- `dbms.logs.query.enabled`

**Note:** Changes are never persisted and if the server is restarted all changes will be lost.