### PR TITLE
ParallelLifecycle now propagates internal exceptions

### DIFF
--- a/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ParallelLifecycle.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ParallelLifecycle.java
@@ -87,7 +87,7 @@ class ParallelLifecycle extends LifecycleAdapter
         List<Future<?>> futures = new ArrayList<>();
         for ( Lifecycle lifecycle : lifecycles )
         {
-            service.submit( () ->
+            futures.add( service.submit( () ->
             {
                 try
                 {
@@ -97,7 +97,7 @@ class ParallelLifecycle extends LifecycleAdapter
                 {
                     throw launderedException( e );
                 }
-            } );
+            } ) );
         }
 
         service.shutdown();


### PR DESCRIPTION
`ParallelLifecycle` used to run cluster eats exceptions. `Future` has to be saved and be dereferenced for exceptions to be rethrown.

This will allow easier debugging when we have failing tests.