### PR TITLE
Try to fix flaky GBPTreeLockTest

### DIFF
--- a/community/common/src/test/java/org/neo4j/test/Race.java
+++ b/community/common/src/test/java/org/neo4j/test/Race.java
@@ -52,6 +52,7 @@ public class Race
     private volatile boolean addSomeMinorRandomStartDelays;
     private volatile BooleanSupplier endCondition;
     private volatile boolean failure;
+    private boolean asyncExecution;
 
     public Race withRandomStartDelays()
     {
@@ -134,6 +135,16 @@ public class Race
     }
 
     /**
+     * Starts the race and returns without waiting for contestants to complete.
+     * Any exception thrown by contestant will be lost.
+     */
+    public void goAsync() throws Throwable
+    {
+        asyncExecution = true;
+        go( 0, TimeUnit.MILLISECONDS );
+    }
+
+    /**
      * Starts the race and waits indefinitely for all contestants to either fail or succeed.
      *
      * @throws Throwable on any exception thrown from any contestant.
@@ -165,6 +176,11 @@ public class Race
         }
         readySet.await();
         go.countDown();
+
+        if ( asyncExecution )
+        {
+            return;
+        }
 
         int errorCount = 0;
         long maxWaitTimeMillis = MILLISECONDS.convert( maxWaitTime, unit );

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeLockTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeLockTest.java
@@ -125,7 +125,7 @@ public class GBPTreeLockTest
         assertUU();
     }
 
-    @Test
+    @Test( timeout = 10_000 )
     public void test_race_ULvsUL() throws Throwable
     {
         assertOnlyOneSucceeds( lock::cleanerLock, lock::cleanerLock );
@@ -137,25 +137,25 @@ public class GBPTreeLockTest
         assertBothSucceeds( lock::cleanerLock, lock::writerLock );
     }
 
-    @Test
+    @Test( timeout = 10_000 )
     public void test_race_ULvsLL() throws Throwable
     {
         assertOnlyOneSucceeds( lock::cleanerLock, lock::writerAndCleanerLock );
     }
 
-    @Test
+    @Test( timeout = 10_000 )
     public void test_race_LUvsLU() throws Throwable
     {
         assertOnlyOneSucceeds( lock::writerLock, lock::writerLock );
     }
 
-    @Test
+    @Test( timeout = 10_000 )
     public void test_race_LUvsLL() throws Throwable
     {
         assertOnlyOneSucceeds( lock::writerLock, lock::writerAndCleanerLock );
     }
 
-    @Test
+    @Test( timeout = 10_000 )
     public void test_race_LLvsLL() throws Throwable
     {
         assertOnlyOneSucceeds( lock::writerAndCleanerLock, lock::writerAndCleanerLock );


### PR DESCRIPTION
Making verifying state variables volatile and printing a more
detailed error message in case of future failures.