### PR TITLE
Fixed so that the right type of exception is caught

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundQueryContext.scala
@@ -475,7 +475,7 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
         transactionalContext.statement.readOperations().relationshipVisit(id, NoopVisitor)
         true
       } catch {
-        case e: EntityNotFoundException =>
+        case e: org.neo4j.kernel.api.exceptions.EntityNotFoundException =>
           false
       }
     }


### PR DESCRIPTION
Previously it caught a Cypher exception when it should have been catching a kernel exception.
This fixes a flaky test by fixing the bug.