### PR TITLE
Correct documentation in neo4j.conf for causal_clustering.cluster_rou…

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
@@ -201,7 +201,7 @@ public class CausalClusteringSettings
 
     @Description( "How long drivers should cache the data from the `dbms.cluster.routing.getServers()` procedure." )
     public static final Setting<Long> cluster_routing_ttl =
-            setting( "causal_clustering.cluster_routing_ttl", DURATION, "5m", min(1_000L) );
+            setting( "causal_clustering.cluster_routing_ttl", DURATION, "300s", min(1_000L) );
 
     @Description( "Configure if the `dbms.cluster.routing.getServers()` procedure should include followers as read " +
             "endpoints or return only read replicas. If there are no read replicas in the cluster, followers are " +

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -232,8 +232,8 @@ dbms.connector.https.enabled=true
 #causal_clustering.pull_interval=1s
 
 # For how long should drivers cache the discovery data from
-# the dbms.cluster.routing.getServers() procedure. Defaults to 5s.
-#causal_clustering.cluster_routing_ttl=5m
+# the dbms.cluster.routing.getServers() procedure. Defaults to 300s.
+#causal_clustering.cluster_routing_ttl=300s
 
 #*****************************************************************
 # HA configuration


### PR DESCRIPTION
Correct value for `causal_clustering.cluster_routing_ttl` should be 5 minutes, not 5 seconds. For consistency specify as 300s everywhere.