### PR TITLE
Performs assertNoSuccessor as an assertion in GBPTree

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
@@ -43,6 +43,7 @@ import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
 
 import static java.lang.String.format;
+
 import static org.neo4j.index.internal.gbptree.Generation.generation;
 import static org.neo4j.index.internal.gbptree.Generation.stableGeneration;
 import static org.neo4j.index.internal.gbptree.Generation.unstableGeneration;
@@ -50,6 +51,7 @@ import static org.neo4j.index.internal.gbptree.GenerationSafePointer.MIN_GENERAT
 import static org.neo4j.index.internal.gbptree.Header.CARRY_OVER_PREVIOUS_HEADER;
 import static org.neo4j.index.internal.gbptree.Header.replace;
 import static org.neo4j.index.internal.gbptree.PageCursorUtil.checkOutOfBounds;
+import static org.neo4j.index.internal.gbptree.PointerChecking.assertNoSuccessor;
 
 /**
  * A generation-aware B+tree (GB+Tree) implementation directly atop a {@link PageCache} with no caching in between.
@@ -1118,7 +1120,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
                 cursor = openRootCursor( PagedFile.PF_SHARED_WRITE_LOCK );
                 stableGeneration = stableGeneration( generation );
                 unstableGeneration = unstableGeneration( generation );
-                PointerChecking.assertNoSuccessor( cursor, stableGeneration, unstableGeneration );
+                assert assertNoSuccessor( cursor, stableGeneration, unstableGeneration );
                 treeLogic.initialize( cursor );
                 success = true;
             }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/InternalTreeLogic.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/InternalTreeLogic.java
@@ -28,10 +28,10 @@ import org.neo4j.io.pagecache.PageCursor;
 import static org.neo4j.index.internal.gbptree.KeySearch.isHit;
 import static org.neo4j.index.internal.gbptree.KeySearch.positionOf;
 import static org.neo4j.index.internal.gbptree.PointerChecking.assertNoSuccessor;
-import static org.neo4j.index.internal.gbptree.StructurePropagation.KeyReplaceStrategy.BUBBLE;
-import static org.neo4j.index.internal.gbptree.StructurePropagation.KeyReplaceStrategy.REPLACE;
 import static org.neo4j.index.internal.gbptree.StructurePropagation.UPDATE_MID_CHILD;
 import static org.neo4j.index.internal.gbptree.StructurePropagation.UPDATE_RIGHT_CHILD;
+import static org.neo4j.index.internal.gbptree.StructurePropagation.KeyReplaceStrategy.BUBBLE;
+import static org.neo4j.index.internal.gbptree.StructurePropagation.KeyReplaceStrategy.REPLACE;
 
 /**
  * Implementation of GB+ tree insert/remove algorithms.
@@ -303,7 +303,7 @@ class InternalTreeLogic<KEY,VALUE>
             TreeNode.goTo( cursor, "child", childId );
             level.treeNodeId = cursor.getCurrentPageId();
 
-            assertNoSuccessor( cursor, stableGeneration, unstableGeneration );
+            assert assertNoSuccessor( cursor, stableGeneration, unstableGeneration );
         }
 
         assert TreeNode.isLeaf( cursor ) : "Ended up on a tree node which isn't a leaf after moving cursor towards " +

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/PointerChecking.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/PointerChecking.java
@@ -64,12 +64,13 @@ class PointerChecking
      * @param stableGeneration Current stable generation of tree.
      * @param unstableGeneration Current unstable generation of tree.
      */
-    static void assertNoSuccessor( PageCursor cursor, long stableGeneration, long unstableGeneration )
+    static boolean assertNoSuccessor( PageCursor cursor, long stableGeneration, long unstableGeneration )
     {
         long successor = TreeNode.successor( cursor, stableGeneration, unstableGeneration );
         if ( TreeNode.isNode( successor ) )
         {
             throw new TreeInconsistencyException( WRITER_TRAVERSE_OLD_STATE_MESSAGE );
         }
+        return true;
     }
 }


### PR DESCRIPTION
because it's somewhat costly when moving around a lot in the tree for
doing updates and have never been a real problem, it's just been added
there as additional confidence from the beginning.