### PR TITLE
Attempt to address flakiness on some CC tests

### DIFF
--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/CatchUpTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/CatchUpTest.java
@@ -111,8 +111,23 @@ public class CatchUpTest
 
         // when
         net.reconnect( sleepyId );
-        Thread.sleep( 500 ); // TODO: This needs an injectable/controllable timeout service for the log shipper.
-        net.processMessages();
+        RaftMachine raftMachine = fixture.members().withId( sleepyId ).raftInstance();
+        /*
+         * This needs an injectable/controllable timeout service for the log shipper. Since we do not have that, we
+         * must wait until all messages have propagated or on a timeout. We know that the commit index must reach 5
+         * to make sure that everything has propagated.
+         * There is an obvious trade off here, given the absence of an injectable timeout service in log shipper. If
+         * this is dependent on an artificial timeout (say, wait 500ms and see if everything made it) then there is a
+         * chance that while everything would have made it if we waited a bit longer, we just don't know that. If, on
+         * the other hand we wait until everything makes it, then if a bug is introduced the test won't fail but it will
+         * just hang forever. We opt for the second case here, since it's detectable, traceable and doesn't suffer from
+         * false negatives (if this loop hangs, it does show a bug).
+         */
+        while ( raftMachine.state().commitIndex() < 5 )
+        {
+            Thread.sleep( 100 ); // Some messages pending, wait a bit
+            net.processMessages();
+        }
 
         // then
         assertThat( integerValues( fixture.members().withId( sleepyId ).raftLog() ), hasItems( 10, 20, 30, 40 ) );


### PR DESCRIPTION
Tries to address flakiness in ElectionTest and CatchupTest. Both, at their root, are caused by RaftLogShipper having its own scheduler which cannot be controlled by the tests, so inaccurate conditions have to be made up. This patch makes these conditions more reliable but does not address the root cause, just the flakiness.