### PR TITLE
Completely eliminates output from the backup store copy stress test

### DIFF
--- a/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckToolTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckToolTest.java
@@ -19,16 +19,16 @@
  */
 package org.neo4j.consistency;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-import org.mockito.ArgumentCaptor;
-
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Properties;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.mockito.ArgumentCaptor;
 
 import org.neo4j.consistency.ConsistencyCheckTool.ToolFailureException;
 import org.neo4j.consistency.checking.full.CheckConsistencyConfig;
@@ -72,10 +72,9 @@ public class ConsistencyCheckToolTest
         File storeDir = storeDirectory.directory();
         String[] args = {storeDir.getPath()};
         ConsistencyCheckService service = mock( ConsistencyCheckService.class );
-        PrintStream systemError = mock( PrintStream.class );
 
         // when
-        runConsistencyCheckToolWith( service, systemError, args );
+        runConsistencyCheckToolWith( service, args );
 
         // then
         verify( service ).runFullConsistencyCheck( eq( storeDir ), any( Config.class ),
@@ -90,10 +89,9 @@ public class ConsistencyCheckToolTest
         File storeDir = storeDirectory.directory();
         String[] args = {storeDir.getPath()};
         ConsistencyCheckService service = mock( ConsistencyCheckService.class );
-        PrintStream systemOut = mock( PrintStream.class );
 
         // when
-        runConsistencyCheckToolWith( service, systemOut, args );
+        runConsistencyCheckToolWith( service, args );
 
         // then
         ArgumentCaptor<Config> config = ArgumentCaptor.forClass( Config.class );
@@ -115,10 +113,9 @@ public class ConsistencyCheckToolTest
 
         String[] args = {storeDir.getPath(), "-config", configFile.getPath()};
         ConsistencyCheckService service = mock( ConsistencyCheckService.class );
-        PrintStream systemOut = mock( PrintStream.class );
 
         // when
-        runConsistencyCheckToolWith( service, systemOut, args );
+        runConsistencyCheckToolWith( service, args );
 
         // then
         ArgumentCaptor<Config> config = ArgumentCaptor.forClass( Config.class );
@@ -134,12 +131,11 @@ public class ConsistencyCheckToolTest
         // given
         ConsistencyCheckService service = mock( ConsistencyCheckService.class );
         String[] args = {};
-        PrintStream systemError = mock( PrintStream.class );
 
         try
         {
             // when
-            runConsistencyCheckToolWith( service, systemError, args );
+            runConsistencyCheckToolWith( service, args );
             fail( "should have thrown exception" );
         }
         catch ( ConsistencyCheckTool.ToolFailureException e )
@@ -156,12 +152,11 @@ public class ConsistencyCheckToolTest
         File configFile = storeDirectory.file( "nonexistent_file" );
         String[] args = {storeDirectory.directory().getPath(), "-config", configFile.getPath()};
         ConsistencyCheckService service = mock( ConsistencyCheckService.class );
-        PrintStream systemOut = mock( PrintStream.class );
 
         try
         {
             // when
-            runConsistencyCheckToolWith( service, systemOut, args );
+            runConsistencyCheckToolWith( service, args );
             fail( "should have thrown exception" );
         }
         catch ( ConsistencyCheckTool.ToolFailureException e )
@@ -202,15 +197,17 @@ public class ConsistencyCheckToolTest
     private void runConsistencyCheckToolWith( FileSystemAbstraction fileSystem, String... args )
             throws IOException, ToolFailureException
     {
-        new ConsistencyCheckTool( mock( ConsistencyCheckService.class ), fileSystem, mock( PrintStream.class ) ).run( args );
+        new ConsistencyCheckTool( mock( ConsistencyCheckService.class ), fileSystem, mock( PrintStream.class),
+                mock( PrintStream.class ) ).run( args );
     }
 
     private void runConsistencyCheckToolWith( ConsistencyCheckService
-            consistencyCheckService, PrintStream systemError, String... args ) throws ToolFailureException, IOException
+            consistencyCheckService, String... args ) throws ToolFailureException, IOException
     {
         try ( FileSystemAbstraction fileSystemAbstraction = new DefaultFileSystemAbstraction() )
         {
-            new ConsistencyCheckTool( consistencyCheckService, fileSystemAbstraction, systemError ).run( args );
+            new ConsistencyCheckTool( consistencyCheckService, fileSystemAbstraction, mock( PrintStream.class ),
+                    mock( PrintStream.class ) ).run( args );
         }
     }
 }

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupServiceIT.java
@@ -19,6 +19,16 @@
  */
 package org.neo4j.backup;
 
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.ConnectException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.com.ports.allocation.PortAuthority;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.junit.Before;
@@ -27,15 +37,6 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.mockito.Mockito;
 
-import java.io.File;
-import java.io.FileFilter;
-import java.io.IOException;
-import java.net.ConnectException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-
-import org.neo4j.com.ports.allocation.PortAuthority;
 import org.neo4j.com.storecopy.StoreCopyServer;
 import org.neo4j.com.storecopy.StoreUtil;
 import org.neo4j.consistency.checking.full.CheckConsistencyConfig;
@@ -119,6 +120,13 @@ public class BackupServiceIT
     private static final String NODE_STORE = StoreFactory.NODE_STORE_NAME;
     private static final String RELATIONSHIP_STORE = StoreFactory.RELATIONSHIP_STORE_NAME;
     private static final String BACKUP_HOST = "localhost";
+    private static final OutputStream NULL_OUTPUT = new OutputStream()
+    {
+        @Override
+        public void write( int b ) throws IOException
+        {
+        }
+    };
 
     private final Monitors monitors = new Monitors();
     private final IOLimiter limiter = IOLimiter.unlimited();
@@ -152,13 +160,13 @@ public class BackupServiceIT
     private BackupService backupService()
     {
         return new BackupService( () -> new UncloseableDelegatingFileSystemAbstraction( fileSystemRule.get() ),
-                FormattedLogProvider.toOutputStream( System.out ), new Monitors() );
+                FormattedLogProvider.toOutputStream( NULL_OUTPUT ), NULL_OUTPUT, new Monitors() );
     }
 
     private BackupService backupService( LogProvider logProvider )
     {
         return new BackupService( () -> new UncloseableDelegatingFileSystemAbstraction( fileSystemRule.get() ),
-                logProvider, new Monitors() );
+                logProvider, NULL_OUTPUT, new Monitors() );
     }
 
     @Test

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/CompositeConstraintIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/CompositeConstraintIT.java
@@ -19,12 +19,12 @@
  */
 package org.neo4j;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.consistency.ConsistencyCheckService;
 import org.neo4j.consistency.ConsistencyCheckTool;
@@ -89,7 +89,8 @@ public class CompositeConstraintIT
     private static ConsistencyCheckService.Result checkDbConsistency( File storeDir )
             throws ConsistencyCheckTool.ToolFailureException, IOException
     {
-        return ConsistencyCheckTool.runConsistencyCheckTool( new String[]{storeDir.getAbsolutePath()} );
+        return ConsistencyCheckTool.runConsistencyCheckTool( new String[]{storeDir.getAbsolutePath()},
+                System.out, System.err );
     }
 
     private static void awaitIndex( GraphDatabaseService database )

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/BackupStoreCopyInteractionStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/BackupStoreCopyInteractionStressTesting.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.causalclustering.stresstests;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
-
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
@@ -35,10 +30,15 @@ import java.util.function.BiFunction;
 import java.util.function.BooleanSupplier;
 import java.util.function.IntFunction;
 
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
 import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.HazelcastDiscoveryServiceFactory;
-import org.neo4j.concurrent.Futures;
 import org.neo4j.causalclustering.discovery.IpFamily;
+import org.neo4j.concurrent.Futures;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.helpers.SocketAddress;
 import org.neo4j.io.fs.FileSystemAbstraction;

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/IdReusabilityStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/IdReusabilityStressTesting.java
@@ -19,10 +19,6 @@
  */
 package org.neo4j.causalclustering.stresstests;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.security.SecureRandom;
 import java.util.List;
@@ -36,6 +32,10 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BooleanSupplier;
 import java.util.stream.Collectors;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.CoreClusterMember;
@@ -146,7 +146,8 @@ public class IdReusabilityStressTesting
         // Check consistency
         for ( String storeDirectory : storeDirectories )
         {
-            ConsistencyCheckService.Result result = runConsistencyCheckTool( new String[]{storeDirectory} );
+            ConsistencyCheckService.Result result = runConsistencyCheckTool( new String[]{storeDirectory},
+                    System.out, System.err );
             if ( !result.isSuccessful() )
             {
                 throw new RuntimeException( "Not consistent database in " + storeDirectory );

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/StartStopLoad.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/StartStopLoad.java
@@ -20,6 +20,7 @@
 package org.neo4j.causalclustering.stresstests;
 
 import java.io.File;
+import java.io.PrintStream;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.BooleanSupplier;
 
@@ -35,6 +36,7 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensions;
 
 import static org.neo4j.consistency.ConsistencyCheckTool.runConsistencyCheckTool;
+import static org.neo4j.io.NullOutputStream.NULL_OUTPUT_STREAM;
 
 class StartStopLoad extends RepeatUntilOnSelectedMemberCallable
 {
@@ -71,7 +73,8 @@ class StartStopLoad extends RepeatUntilOnSelectedMemberCallable
             fs.copyRecursively( storeDir, storeDirectory.storeDir() );
             new CopiedStoreRecovery( Config.defaults(), kernelExtensions.listFactories(),  pageCache )
                     .recoverCopiedStore( storeDirectory.storeDir() );
-            ConsistencyCheckService.Result result = runConsistencyCheckTool( new String[]{storeDir.getAbsolutePath()} );
+            ConsistencyCheckService.Result result = runConsistencyCheckTool( new String[]{storeDir.getAbsolutePath()},
+                    new PrintStream( NULL_OUTPUT_STREAM ), new PrintStream( System.err ) );
             if ( !result.isSuccessful() )
             {
                 throw new RuntimeException( "Not consistent database in " + storeDir );


### PR DESCRIPTION
The latest surefire plugin is more strict in its management of
 forked JVM exit errors and this test seems to crash the JVM
 because of excessive console output. This change completes
 what PR #9709 started, by eliminating all output from CC
 and backup operations.