### PR TITLE
Renamed dbms.allow_format_migration to dbms.allow_upgrade for clarification

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -125,8 +125,12 @@ public class GraphDatabaseSettings implements LoadableConfig
             "older store version. " +
             "Setting this to `true` does not guarantee successful upgrade, it just " +
             "allows an upgrade to be performed." )
-    public static final Setting<Boolean> allow_store_upgrade = setting( "dbms.allow_format_migration", BOOLEAN,
-            FALSE );
+    @Deprecated
+    @ReplacedBy( "dbms.allow_upgrade" )
+    public static final Setting<Boolean> allow_store_upgrade = setting( "dbms.allow_format_migration", BOOLEAN, FALSE );
+
+    @Description( "Whether to allow an upgrade in case the current version of the database starts against an older version." )
+    public static final Setting<Boolean> allow_upgrade = setting( "dbms.allow_upgrade", BOOLEAN, FALSE );
 
     @Description( "Database record format. Enterprise edition only. Valid values: `standard`, `high_limit`. " +
                   "Default value:  `standard`." )

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/GraphDatabaseConfigurationMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/GraphDatabaseConfigurationMigrator.java
@@ -100,5 +100,14 @@ public class GraphDatabaseConfigurationMigrator extends BaseConfigurationMigrato
                 }
             }
         } );
+        add( new SpecificPropertyMigration( "dbms.allow_format_migration",
+                "dbms.allow_format_migration has been replaced with dbms.allow_upgrade." )
+        {
+            @Override
+            public void setValueWithOldSetting( String value, Map<String,String> rawConfiguration )
+            {
+                rawConfiguration.put( GraphDatabaseSettings.allow_upgrade.name(), value );
+            }
+        } );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexProviderStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexProviderStore.java
@@ -137,7 +137,7 @@ public class IndexProviderStore
         {
             throw new UpgradeNotAllowedByConfigurationException(
                     "Index version (managed by " + file + ") has changed " + "and cannot be upgraded unless " +
-                            GraphDatabaseSettings.allow_store_upgrade.name() +
+                            GraphDatabaseSettings.allow_upgrade.name() +
                             "=true is supplied in the configuration" );
         }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
@@ -148,7 +148,7 @@ public class StoreUpgrader
 
     private boolean isUpgradeAllowed()
     {
-        return config.get( GraphDatabaseSettings.allow_store_upgrade );
+        return config.get( GraphDatabaseSettings.allow_upgrade );
     }
 
     private void cleanupLegacyLeftOverDirsIn( File storeDir )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/UpgradeNotAllowedByConfigurationException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/UpgradeNotAllowedByConfigurationException.java
@@ -33,6 +33,6 @@ public class UpgradeNotAllowedByConfigurationException extends UpgradeNotAllowed
         super( String.format(
                 "Failed to start Neo4j with an older data store version. "
                         + "To enable automatic upgrade, please set configuration parameter \"%s=true\"",
-                GraphDatabaseSettings.allow_store_upgrade.name() ) );
+                GraphDatabaseSettings.allow_upgrade.name() ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
@@ -730,7 +730,7 @@ public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvide
 
     private void rejectAutoUpgrade( Map<String, String> params )
     {
-        if ( parseBoolean( params.get( GraphDatabaseSettings.allow_store_upgrade.name() ) ) )
+        if ( parseBoolean( params.get( GraphDatabaseSettings.allow_upgrade.name() ) ) )
         {
             throw new IllegalArgumentException( "Batch inserter is not allowed to do upgrade of a store" +
                                                 ", use " + EmbeddedGraphDatabase.class.getSimpleName() + " instead" );

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/TestGraphDatabaseConfigurationMigrator.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/TestGraphDatabaseConfigurationMigrator.java
@@ -155,6 +155,16 @@ public class TestGraphDatabaseConfigurationMigrator
         assertContainsWarningMessage();
     }
 
+    @Test
+    public void migrateAllowFormatMigration() throws Exception
+    {
+        Map<String,String> migratedProperties = migrator.apply( stringMap( "dbms.allow_format_migration", "true" ), getLog() );
+        assertEquals( "Old property should be migrated to new",
+                migratedProperties, stringMap( "dbms.allow_upgrade", "true" ));
+
+        assertContainsWarningMessage("dbms.allow_format_migration has been replaced with dbms.allow_upgrade.");
+    }
+
     private Log getLog()
     {
         return logProvider.getLog( GraphDatabaseConfigurationMigrator.class );

--- a/community/neo4j/src/test/java/db/DatabaseStartupTest.java
+++ b/community/neo4j/src/test/java/db/DatabaseStartupTest.java
@@ -41,6 +41,7 @@ import org.neo4j.test.rule.TestDirectory;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.allow_upgrade;
 
 public class DatabaseStartupTest
 {
@@ -81,7 +82,7 @@ public class DatabaseStartupTest
             assertTrue( ex.getCause() instanceof LifecycleException );
             assertTrue( ex.getCause().getCause() instanceof UpgradeNotAllowedByConfigurationException );
             assertEquals( "Failed to start Neo4j with an older data store version. To enable automatic upgrade, " +
-                          "please set configuration parameter \"dbms.allow_format_migration=true\"",
+                          "please set configuration parameter \"" + allow_upgrade.name() + "=true\"",
                     ex.getCause().getCause().getMessage());
         }
     }
@@ -113,7 +114,7 @@ public class DatabaseStartupTest
         try
         {
             new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir )
-                    .setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" ).newGraphDatabase();
+                    .setConfig( GraphDatabaseSettings.allow_upgrade, "true" ).newGraphDatabase();
             fail( "It should have failed." );
         }
         catch ( RuntimeException ex )

--- a/community/neo4j/src/test/java/upgrade/PlatformConstraintStoreUpgradeTest.java
+++ b/community/neo4j/src/test/java/upgrade/PlatformConstraintStoreUpgradeTest.java
@@ -93,7 +93,7 @@ public class PlatformConstraintStoreUpgradeTest
     private GraphDatabaseService createGraphDatabaseService()
     {
         return new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( workingDir )
-                .setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" )
+                .setConfig( GraphDatabaseSettings.allow_upgrade, "true" )
                 .setConfig( GraphDatabaseSettings.pagecache_swapper, TEST_PAGESWAPPER_NAME ).newGraphDatabase();
     }
 }

--- a/community/neo4j/src/test/java/upgrade/StoreUpgradeOnStartupTest.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgradeOnStartupTest.java
@@ -128,7 +128,7 @@ public class StoreUpgradeOnStartupTest
     {
         return new TestGraphDatabaseFactory()
                 .newEmbeddedDatabaseBuilder( workingDirectory )
-                .setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" )
+                .setConfig( GraphDatabaseSettings.allow_upgrade, "true" )
                 .newGraphDatabase();
     }
 }

--- a/community/neo4j/src/test/java/upgrade/StoreUpgraderInterruptionTestIT.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgraderInterruptionTestIT.java
@@ -206,7 +206,7 @@ public class StoreUpgraderInterruptionTestIT
     private StoreUpgrader newUpgrader( UpgradableDatabase upgradableDatabase, PageCache pageCache,
             MigrationProgressMonitor progressMonitor, SchemaIndexMigrator indexMigrator, StoreMigrator migrator )
     {
-        Config allowUpgrade = Config.defaults( GraphDatabaseSettings.allow_store_upgrade, "true" );
+        Config allowUpgrade = Config.defaults( GraphDatabaseSettings.allow_upgrade, "true" );
 
         StoreUpgrader upgrader = new StoreUpgrader( upgradableDatabase, progressMonitor, allowUpgrade, fs, pageCache,
                 NullLogProvider.getInstance() );

--- a/community/neo4j/src/test/java/upgrade/StoreUpgraderTest.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgraderTest.java
@@ -111,7 +111,7 @@ public class StoreUpgraderTest
     private final String version;
     private final SchemaIndexProvider schemaIndexProvider = new InMemoryIndexProvider();
 
-    private final Config allowMigrateConfig = Config.defaults( GraphDatabaseSettings.allow_store_upgrade, "true" );
+    private final Config allowMigrateConfig = Config.defaults( GraphDatabaseSettings.allow_upgrade, "true" );
 
     public StoreUpgraderTest( String version )
     {
@@ -188,7 +188,7 @@ public class StoreUpgraderTest
     public void shouldHaltUpgradeIfUpgradeConfigurationVetoesTheProcess() throws IOException
     {
         PageCache pageCache = pageCacheRule.getPageCache( fileSystem );
-        Config deniedMigrationConfig = Config.defaults( GraphDatabaseSettings.allow_store_upgrade, "false" );
+        Config deniedMigrationConfig = Config.defaults( GraphDatabaseSettings.allow_upgrade, "false" );
 
         UpgradableDatabase upgradableDatabase = new UpgradableDatabase( fileSystem,
                 new StoreVersionCheck( pageCache ),

--- a/community/server/src/main/java/org/neo4j/server/exception/UpgradeDisallowedStartupException.java
+++ b/community/server/src/main/java/org/neo4j/server/exception/UpgradeDisallowedStartupException.java
@@ -24,7 +24,7 @@ import org.neo4j.kernel.impl.storemigration.UpgradeNotAllowedException;
 import org.neo4j.logging.Log;
 import org.neo4j.server.ServerStartupException;
 
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.allow_store_upgrade;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.allow_upgrade;
 
 public class UpgradeDisallowedStartupException extends ServerStartupException
 {
@@ -40,7 +40,7 @@ public class UpgradeDisallowedStartupException extends ServerStartupException
         {
             log.error( "Neo4j cannot be started, because the database files require upgrading and upgrades are " +
                        "disabled in configuration. Please set '%s' to 'true' in your configuration file and try again.",
-                    allow_store_upgrade.name() );
+                    allow_upgrade.name() );
         }
         else
         {

--- a/community/server/src/test/java/org/neo4j/server/exception/ServerStartupErrorsTest.java
+++ b/community/server/src/test/java/org/neo4j/server/exception/ServerStartupErrorsTest.java
@@ -21,6 +21,7 @@ package org.neo4j.server.exception;
 
 import org.junit.Test;
 
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.impl.storemigration.UpgradeNotAllowedByConfigurationException;
 import org.neo4j.kernel.lifecycle.LifecycleException;
 import org.neo4j.logging.AssertableLogProvider;
@@ -50,7 +51,7 @@ public class ServerStartupErrorsTest
         logging.assertExactly( inLog( "console" )
                 .error( "Neo4j cannot be started, because the database files require upgrading and upgrades are " +
                         "disabled in configuration. Please set '%s' to 'true' in your configuration file and try " +
-                        "again.", "dbms.allow_format_migration" ) );
+                        "again.", GraphDatabaseSettings.allow_upgrade.name() ) );
 
     }
 }

--- a/community/server/src/test/java/org/neo4j/server/integration/StartupLoggingIT.java
+++ b/community/server/src/test/java/org/neo4j/server/integration/StartupLoggingIT.java
@@ -91,7 +91,7 @@ public class StartupLoggingIT extends ExclusiveServerTestBase
     {
         Map<String,String> relativeProperties = ServerTestUtils.getDefaultRelativeProperties();
 
-        relativeProperties.put( GraphDatabaseSettings.allow_store_upgrade.name(), Settings.TRUE);
+        relativeProperties.put( GraphDatabaseSettings.allow_upgrade.name(), Settings.TRUE);
 
         HttpConnector http = new HttpConnector( "http", Encryption.NONE );
         relativeProperties.put( http.type.name(), "HTTP" );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/CopiedStoreRecovery.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/CopiedStoreRecovery.java
@@ -101,8 +101,8 @@ public class CopiedStoreRecovery extends LifecycleAdapter
                 .setConfig( "dbms.backup.enabled", Settings.FALSE )
                 .setConfig( GraphDatabaseSettings.logs_directory, tempStore.getAbsolutePath() )
                 .setConfig( GraphDatabaseSettings.keep_logical_logs, Settings.TRUE )
-                .setConfig( GraphDatabaseSettings.allow_store_upgrade,
-                        config.get( GraphDatabaseSettings.allow_store_upgrade ).toString() )
+                .setConfig( GraphDatabaseSettings.allow_upgrade,
+                        config.get( GraphDatabaseSettings.allow_upgrade ).toString() )
                 .setConfig( GraphDatabaseSettings.record_format, config.get( GraphDatabaseSettings.record_format ) )
                 .newGraphDatabase();
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterCommunityToEnterpriseIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterCommunityToEnterpriseIT.java
@@ -19,12 +19,12 @@
  */
 package org.neo4j.causalclustering.scenarios;
 
-import java.io.File;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.io.File;
 
 import org.neo4j.backup.OnlineBackupSettings;
 import org.neo4j.causalclustering.discovery.Cluster;
@@ -42,8 +42,6 @@ import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 
 import static java.util.Collections.emptyMap;
-
-import static java.util.Collections.singletonMap;
 import static org.neo4j.causalclustering.discovery.Cluster.dataMatchesEventually;
 
 public class ClusterCommunityToEnterpriseIT
@@ -80,7 +78,7 @@ public class ClusterCommunityToEnterpriseIT
         // given
         File storeDir = testDir.makeGraphDbDir();
         GraphDatabaseService database = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir )
-                .setConfig( GraphDatabaseSettings.allow_store_upgrade, Settings.TRUE )
+                .setConfig( GraphDatabaseSettings.allow_upgrade, Settings.TRUE )
                 .setConfig( GraphDatabaseSettings.record_format, HighLimit.NAME )
                 .setConfig( OnlineBackupSettings.online_backup_enabled, Boolean.FALSE.toString() )
                 .newGraphDatabase();

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
@@ -345,8 +345,8 @@ public class StoreCopyClient
                 .setConfig( "dbms.backup.enabled", Settings.FALSE )
                 .setConfig( GraphDatabaseSettings.logs_directory, tempStore.getAbsolutePath() )
                 .setConfig( GraphDatabaseSettings.keep_logical_logs, Settings.TRUE )
-                .setConfig( GraphDatabaseSettings.allow_store_upgrade,
-                        config.get( GraphDatabaseSettings.allow_store_upgrade ).toString() )
+                .setConfig( GraphDatabaseSettings.allow_upgrade,
+                        config.get( GraphDatabaseSettings.allow_upgrade ).toString() )
                 .newGraphDatabase();
     }
 

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -527,7 +527,7 @@ public class HighlyAvailableEditionModule
             }
         };
 
-        config.augment( GraphDatabaseSettings.allow_store_upgrade, Settings.FALSE );
+        config.augment( GraphDatabaseSettings.allow_upgrade, Settings.FALSE );
 
         constraintSemantics = new EnterpriseConstraintSemantics();
 

--- a/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/RollingUpgradeIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/RollingUpgradeIT.java
@@ -245,7 +245,7 @@ public class RollingUpgradeIT
                 server_id.name(), "" + serverId,
                 cluster_server.name(), localhost + ":" + (5000 + serverId),
                 ha_server.name(), localhost + ":" + (6000 + serverId),
-                GraphDatabaseSettings.allow_store_upgrade.name(), "true",
+                GraphDatabaseSettings.allow_upgrade.name(), "true",
                 GraphDatabaseSettings.pagecache_memory.name(), "8m",
                 OnlineBackupSettings.online_backup_server.name(), localhost + ":" + backupPort( serverId ),
                 initial_hosts.name(), localhost + ":" + 5000 + "," + localhost + ":" + 5001 + "," + localhost + ":" + 5002 );
@@ -363,7 +363,7 @@ public class RollingUpgradeIT
             debug( "Starting standalone db " + dbIndex + " to run upgrade" );
             tempDbForUpgrade = new TestGraphDatabaseFactory()
                     .newEmbeddedDatabaseBuilder( storeDir )
-                    .setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" )
+                    .setConfig( GraphDatabaseSettings.allow_upgrade, "true" )
                     .newGraphDatabase();
         }
         finally

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreMigrationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/StoreMigrationIT.java
@@ -195,7 +195,7 @@ public class StoreMigrationIT
     private static void createDb( RecordFormats recordFormat, File storeDir ) throws IOException
     {
         GraphDatabaseService database = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir )
-                .setConfig( GraphDatabaseSettings.allow_store_upgrade, Settings.TRUE )
+                .setConfig( GraphDatabaseSettings.allow_upgrade, Settings.TRUE )
                 .setConfig( GraphDatabaseSettings.record_format, recordFormat.storeVersion() ).newGraphDatabase();
         database.shutdown();
     }
@@ -292,7 +292,7 @@ public class StoreMigrationIT
     protected GraphDatabaseService getGraphDatabaseService( File db, String storeVersion )
     {
         return new EnterpriseGraphDatabaseFactory().newEmbeddedDatabaseBuilder( db )
-                .setConfig( GraphDatabaseSettings.allow_store_upgrade, Settings.TRUE )
+                .setConfig( GraphDatabaseSettings.allow_upgrade, Settings.TRUE )
                 .setConfig( GraphDatabaseSettings.record_format, storeVersion ).newGraphDatabase();
     }
 }

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/upgrade/RecordFormatsMigrationIT.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/upgrade/RecordFormatsMigrationIT.java
@@ -135,7 +135,7 @@ public class RecordFormatsMigrationIT
     private GraphDatabaseService startDb( String recordFormatName )
     {
         return new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( testDirectory.graphDbDir() )
-                .setConfig( GraphDatabaseSettings.allow_store_upgrade, Settings.TRUE )
+                .setConfig( GraphDatabaseSettings.allow_upgrade, Settings.TRUE )
                 .setConfig( GraphDatabaseSettings.record_format, recordFormatName )
                 .newGraphDatabase();
     }

--- a/integrationtests/src/test/java/org/neo4j/storeupgrade/LegacyIndexesUpgradeTest.java
+++ b/integrationtests/src/test/java/org/neo4j/storeupgrade/LegacyIndexesUpgradeTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.function.IntFunction;
 
@@ -124,7 +123,7 @@ public class LegacyIndexesUpgradeTest
     {
         GraphDatabaseFactory factory = new TestGraphDatabaseFactory();
         GraphDatabaseBuilder builder = factory.newEmbeddedDatabaseBuilder( testDir.graphDbDir() );
-        builder.setConfig( GraphDatabaseSettings.allow_store_upgrade, Boolean.toString( allowUpgread ) );
+        builder.setConfig( GraphDatabaseSettings.allow_upgrade, Boolean.toString( allowUpgread ) );
         builder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
         return builder.newGraphDatabase();
     }

--- a/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
+++ b/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIntegrationTest.java
@@ -145,7 +145,7 @@ public class StoreUpgradeIntegrationTest
 
             GraphDatabaseFactory factory = new TestGraphDatabaseFactory();
             GraphDatabaseBuilder builder = factory.newEmbeddedDatabaseBuilder( dir );
-            builder.setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" );
+            builder.setConfig( GraphDatabaseSettings.allow_upgrade, "true" );
             builder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
             builder.setConfig( GraphDatabaseSettings.logs_directory, testDir.directory( "logs" ).getAbsolutePath() );
             GraphDatabaseService db = builder.newGraphDatabase();
@@ -176,7 +176,7 @@ public class StoreUpgradeIntegrationTest
             props.putAll( ServerTestUtils.getDefaultRelativeProperties() );
             props.setProperty( DatabaseManagementSystemSettings.data_directory.name(), rootDir.getAbsolutePath() );
             props.setProperty( GraphDatabaseSettings.logs_directory.name(), rootDir.getAbsolutePath() );
-            props.setProperty( GraphDatabaseSettings.allow_store_upgrade.name(), "true" );
+            props.setProperty( GraphDatabaseSettings.allow_upgrade.name(), "true" );
             props.setProperty( GraphDatabaseSettings.pagecache_memory.name(), "8m" );
             props.setProperty( new HttpConnector( "http" ).type.name(), "HTTP" );
             props.setProperty( new HttpConnector( "http" ).enabled.name(), "true" );
@@ -207,7 +207,7 @@ public class StoreUpgradeIntegrationTest
             File dir = store.prepareDirectory( testDir.graphDbDir() );
             GraphDatabaseFactory factory = new TestGraphDatabaseFactory();
             GraphDatabaseBuilder builder = factory.newEmbeddedDatabaseBuilder( dir );
-            builder.setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" );
+            builder.setConfig( GraphDatabaseSettings.allow_upgrade, "true" );
             builder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
             builder.setConfig( GraphDatabaseSettings.logs_directory, testDir.directory( "logs" ).getAbsolutePath() );
             GraphDatabaseService db = builder.newGraphDatabase();
@@ -283,7 +283,7 @@ public class StoreUpgradeIntegrationTest
             new File( dir, "debug.log" ).delete(); // clear the log
             GraphDatabaseFactory factory = new TestGraphDatabaseFactory();
             GraphDatabaseBuilder builder = factory.newEmbeddedDatabaseBuilder( dir );
-            builder.setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" );
+            builder.setConfig( GraphDatabaseSettings.allow_upgrade, "true" );
             builder.setConfig( GraphDatabaseSettings.pagecache_memory, "8m" );
             try
             {
@@ -330,7 +330,7 @@ public class StoreUpgradeIntegrationTest
 
             GraphDatabaseFactory factory = new TestGraphDatabaseFactory();
             GraphDatabaseBuilder builder = factory.newEmbeddedDatabaseBuilder( dir );
-            builder.setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" );
+            builder.setConfig( GraphDatabaseSettings.allow_upgrade, "true" );
             builder.setConfig( GraphDatabaseSettings.record_format, store.getFormatFamily() );
             GraphDatabaseService db = builder.newGraphDatabase();
             try

--- a/new-packaging/src/debian/package.postinst
+++ b/new-packaging/src/debian/package.postinst
@@ -92,7 +92,7 @@ case "$1" in
             echo "You must tell the database to migrate your active database when the service starts."
             echo "To do this, use the following command:"
             echo
-            echo "    sudo -u neo4j -g adm sed -i 's/#dbms.allow_format_migration=true/dbms.allow_format_migration=true/' /etc/neo4j/neo4j.conf"
+            echo "    sudo -u neo4j -g adm sed -i 's/#dbms.allow_upgrade=true/dbms.allow_upgrade=true/' /etc/neo4j/neo4j.conf"
             echo
             echo "Finally, start the database service:"
             echo

--- a/packaging/neo4j-desktop/src/main/resources/org/neo4j/desktop/config/neo4j-default.conf
+++ b/packaging/neo4j-desktop/src/main/resources/org/neo4j/desktop/config/neo4j-default.conf
@@ -67,7 +67,7 @@ dbms.connector.https.enabled=true
 dbms.logs.http.enabled=false
 
 # Enable this to be able to upgrade a store from an older version.
-#dbms.allow_format_migration=true
+#dbms.allow_upgrade=true
 
 # The amount of memory to use for mapping the store files, in bytes (or
 # kilobytes with the 'k' suffix, megabytes with 'm' and gigabytes with 'g').

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
@@ -26,7 +26,7 @@ dbms.directories.import=import
 #dbms.security.auth_enabled=false
 
 # Enable this to be able to upgrade a store from an older version.
-#dbms.allow_format_migration=true
+#dbms.allow_upgrade=true
 
 # Java Heap Size: by default the Java heap size is dynamically
 # calculated based on available system resources.

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -27,7 +27,7 @@ dbms.directories.import=import
 #dbms.security.auth_enabled=false
 
 # Enable this to be able to upgrade a store from an older version.
-#dbms.allow_format_migration=true
+#dbms.allow_upgrade=true
 
 # Java Heap Size: by default the Java heap size is dynamically
 # calculated based on available system resources.

--- a/tools/src/main/java/org/neo4j/tools/migration/StoreMigration.java
+++ b/tools/src/main/java/org/neo4j/tools/migration/StoreMigration.java
@@ -87,7 +87,7 @@ public class StoreMigration
 
     private static Config getMigrationConfig()
     {
-        return Config.defaults( GraphDatabaseSettings.allow_store_upgrade, Settings.TRUE);
+        return Config.defaults( GraphDatabaseSettings.allow_upgrade, Settings.TRUE);
     }
 
     public void run( final FileSystemAbstraction fs, final File storeDirectory, Config config,


### PR DESCRIPTION
Configuration option `dbms.allow_format_migration` has been renamed to `dbms.allow_upgrade` since it applies to more than format migration. 

The expected behaviour is that the database should refuse to start if any changes will be made to the store that will prevent the database from starting on a previous version of neo4j.