### PR TITLE
Add feature toggle for stronger index entry hashing

### DIFF
--- a/community/common/src/main/java/org/neo4j/hashing/HashFunction.java
+++ b/community/common/src/main/java/org/neo4j/hashing/HashFunction.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.hashing;
+
+/**
+ * A hash function, as per this interface, will produce a deterministic value based on its input.
+ * <p>
+ * Hash functions are first initialised with a seed, which may be zero, and then updated with a succession of values
+ * that are mixed into the hash state in sequence.
+ * <p>
+ * Hash functions may have internal state, but can also be stateless, if their complete state can be represented by the
+ * 64-bit intermediate hash state.
+ *
+ * @see #incrementalXXH64()
+ * @see #javaUtilHashing()
+ * @see #xorShift32()
+ */
+public interface HashFunction
+{
+    /**
+     * Initialise the hash function with the given seed.
+     * <p>
+     * Different seeds should produce different final hash values.
+     *
+     * @param seed The initialisation seed for the hash function.
+     * @return An initialised intermediate hash state.
+     */
+    long initialise( long seed );
+
+    /**
+     * Update the hash state by mixing the given value into the given intermediate hash state.
+     *
+     * @param intermediateHash The intermediate hash state given either by {@link #initialise(long)}, or by a previous
+     * call to this function.
+     * @param value The value to add to the hash state.
+     * @return a new intermediate hash state with the value mixed in.
+     */
+    long update( long intermediateHash, long value );
+
+    /**
+     * Produce a final hash value from the given intermediate hash state.
+     *
+     * @param intermediateHash the intermediate hash state from which to produce a final hash value.
+     * @return the final hash value.
+     */
+    long finalise( long intermediateHash );
+
+    /**
+     * Reduce the given 64-bit hash value to a 32-bit value.
+     *
+     * @param hash The hash value to reduce.
+     * @return The 32-bit representation of the given hash value.
+     */
+    default int toInt( long hash )
+    {
+        return (int) ((hash >> 32) ^ hash);
+    }
+
+    /**
+     * Produce a 64-bit hash value from a single long value.
+     *
+     * @param value The single value to hash.
+     * @return The hash of the given value.
+     */
+    default long hashSingleValue( long value )
+    {
+        return finalise( update( initialise( 0 ), value ) );
+    }
+
+    /**
+     * Produce a 32-bit hash value from a single long value.
+     *
+     * @param value The single value to hash.
+     * @return The hash of the given value.
+     */
+    default int hashSingleValueToInt( long value )
+    {
+        return toInt( hashSingleValue( value ) );
+    }
+
+    /**
+     * Our incremental XXH64 based hash function.
+     * <p>
+     * This hash function is based on xxHash (XXH64 variant), but modified to work incrementally on 8-byte blocks
+     * instead of on 32-byte blocks. Basically, the 32-byte block hash loop has been removed, so we use the 8-byte
+     * block tail-loop for the entire input.
+     * <p>
+     * This hash function is roughly twice as fast as the hash function used for index entries since 2.2.0, about 30%
+     * faster than optimised murmurhash3 implementations though not as fast as optimised xxHash implementations due to
+     * the smaller block size. It is allocation free, unlike its predecessor. And it retains most of the excellent
+     * statistical properties of xxHash, failing only the "TwoBytes" and "Zeroes" keyset tests in SMHasher, passing 12
+     * out of 14 tests. According to <a href="https://twitter.com/Cyan4973/status/899995095549698049">Yann Collet on
+     * twitter</a>, this modification is expected to mostly cause degraded performance, and worsens some of the
+     * avalanche statistics.
+     * <p>
+     * This hash function is stateless, so the returned instance can be freely cached and accessed concurrently by
+     * multiple threads.
+     * <p>
+     * The <a href="http://cyan4973.github.io/xxHash/">xxHash</a> algorithm is originally by Yann Collet, and this
+     * implementation is with inspiration from Vsevolod Tolstopyatovs implementation in the
+     * <a href="https://github.com/OpenHFT/Zero-Allocation-Hashing">Zero Allocation Hashing</a> library.
+     * Credit for <a href="https://github.com/aappleby/smhasher">SMHasher</a> goes to Austin Appleby.
+     */
+    static HashFunction incrementalXXH64()
+    {
+        return IncrementalXXH64.INSTANCE;
+    }
+
+    /**
+     * Same hash function as that used by the standard library hash collections. It generates a hash by splitting the
+     * input value into segments, and then re-distributing those segments, so the end result is effectively a striped
+     * and then jumbled version of the input data. For randomly distributed keys, this has a good chance at generating
+     * an even hash distribution over the full hash space.
+     * <p>
+     * It performs exceptionally poorly for sequences of numbers, as the sequence increments all end up in the same
+     * stripe, generating hash values that will end up in the same buckets in collections.
+     * <p>
+     * This hash function is stateless, so the returned instance can be freely cached and accessed concurrently by
+     * multiple threads.
+     */
+    static HashFunction javaUtilHashing()
+    {
+        return JavaUtilHashFunction.INSTANCE;
+    }
+
+    /**
+     * The default hash function is based on a pseudo-random number generator, which uses the input value as a seed
+     * to the generator. This is very fast, and performs well for most input data. However, it is not guaranteed to
+     * generate a superb distribution, only a "decent" one.
+     * <p>
+     * This hash function is stateless, so the returned instance can be freely cached and accessed concurrently by
+     * multiple threads.
+     */
+    static HashFunction xorShift32()
+    {
+        return XorShift32HashFunction.INSTANCE;
+    }
+}

--- a/community/common/src/main/java/org/neo4j/hashing/IncrementalXXH64.java
+++ b/community/common/src/main/java/org/neo4j/hashing/IncrementalXXH64.java
@@ -20,29 +20,12 @@
 package org.neo4j.hashing;
 
 /**
- * The (our) incremental XXH64 hash function.
- * <p>
- * This hash function is based on xxHash (XXH64 variant), but modified to work incrementally on 8-byte blocks
- * instead of on 32-byte blocks. Basically, the 32-byte block hash loop has been removed, so we use the 8-byte
- * block tail-loop for the entire input.
- * <p>
- * This hash function is roughly twice as fast as its predecessor, about 30% faster than optimised murmurhash3
- * implementations though not as fast as optimised xxHash implementations due to the smaller block size.
- * It is allocation free, unlike its predecessor. And it retains most of the excellent statistical properties of
- * xxHash, failing only the "TwoBytes" and "Zeroes" keyset tests in SMHasher, passing 12 out of 14 tests.
- * <p>
- * The hasher is used by first {@link IncrementalXXH64#init(long) initialising} the state with a seed, which can be any
- * arbitrary 64-bit integer, including zero. The produced state is then recursively cycled through the
- * {@link IncrementalXXH64#update(long, long) update} function and merged with an input word as many times as desired.
- * When the input has been consumed, the final hash value is then produced from the last intermediate hash value with
- * the {@link IncrementalXXH64#finalise(long) finalise} function.
- * <p>
- * The xxHash algorithm is originally by Yann Collet, http://cyan4973.github.io/xxHash/, and this implementation is
- * with inspiration from Vsevolod Tolstopyatovs implementation in https://github.com/OpenHFT/Zero-Allocation-Hashing.
- * Credit for SMHasher goes to Austin Appleby, https://github.com/aappleby/smhasher.
+ * @see HashFunction#incrementalXXH64()
  */
-public class IncrementalXXH64
+class IncrementalXXH64 implements HashFunction
 {
+    static final HashFunction INSTANCE = new IncrementalXXH64();
+
     private static final long Prime1 = -7046029288634856825L;
     private static final long Prime2 = -4417276706812531889L;
     private static final long Prime3 = 1609587929392839161L;
@@ -53,12 +36,14 @@ public class IncrementalXXH64
     {
     }
 
-    public static long init( long seed )
+    @Override
+    public long initialise( long seed )
     {
         return seed + Prime5;
     }
 
-    public static long update( long hash, long block )
+    @Override
+    public long update( long hash, long block )
     {
         hash += 8;
         block *= Prime2;
@@ -69,7 +54,8 @@ public class IncrementalXXH64
         return hash;
     }
 
-    public static long finalise( long hash )
+    @Override
+    public long finalise( long hash )
     {
         hash ^= hash >>> 33;
         hash *= Prime2;

--- a/community/common/src/main/java/org/neo4j/hashing/IncrementalXXH64.java
+++ b/community/common/src/main/java/org/neo4j/hashing/IncrementalXXH64.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.hashing;
+
+/**
+ * The (our) incremental XXH64 hash function.
+ * <p>
+ * This hash function is based on xxHash (XXH64 variant), but modified to work incrementally on 8-byte blocks
+ * instead of on 32-byte blocks. Basically, the 32-byte block hash loop has been removed, so we use the 8-byte
+ * block tail-loop for the entire input.
+ * <p>
+ * This hash function is roughly twice as fast as its predecessor, about 30% faster than optimised murmurhash3
+ * implementations though not as fast as optimised xxHash implementations due to the smaller block size.
+ * It is allocation free, unlike its predecessor. And it retains most of the excellent statistical properties of
+ * xxHash, failing only the "TwoBytes" and "Zeroes" keyset tests in SMHasher, passing 12 out of 14 tests.
+ * <p>
+ * The hasher is used by first {@link IncrementalXXH64#init(long) initialising} the state with a seed, which can be any
+ * arbitrary 64-bit integer, including zero. The produced state is then recursively cycled through the
+ * {@link IncrementalXXH64#update(long, long) update} function and merged with an input word as many times as desired.
+ * When the input has been consumed, the final hash value is then produced from the last intermediate hash value with
+ * the {@link IncrementalXXH64#finalise(long) finalise} function.
+ */
+public class IncrementalXXH64
+{
+    private static final long Prime1 = -7046029288634856825L;
+    private static final long Prime2 = -4417276706812531889L;
+    private static final long Prime3 = 1609587929392839161L;
+    private static final long Prime4 = -8796714831421723037L;
+    private static final long Prime5 = 2870177450012600261L;
+
+    private IncrementalXXH64()
+    {
+    }
+
+    public static long init( long seed )
+    {
+        return seed + Prime5;
+    }
+
+    public static long update( long hash, long block )
+    {
+        hash += 8;
+        block *= Prime2;
+        block = Long.rotateLeft( block, 31 );
+        block *= Prime1;
+        hash ^= block;
+        hash = Long.rotateLeft( hash, 27 ) * Prime1 + Prime4;
+        return hash;
+    }
+
+    public static long finalise( long hash )
+    {
+        hash ^= hash >>> 33;
+        hash *= Prime2;
+        hash ^= hash >>> 29;
+        hash *= Prime3;
+        hash ^= hash >>> 32;
+        return hash;
+    }
+}

--- a/community/common/src/main/java/org/neo4j/hashing/IncrementalXXH64.java
+++ b/community/common/src/main/java/org/neo4j/hashing/IncrementalXXH64.java
@@ -36,6 +36,10 @@ package org.neo4j.hashing;
  * {@link IncrementalXXH64#update(long, long) update} function and merged with an input word as many times as desired.
  * When the input has been consumed, the final hash value is then produced from the last intermediate hash value with
  * the {@link IncrementalXXH64#finalise(long) finalise} function.
+ * <p>
+ * The xxHash algorithm is originally by Yann Collet, http://cyan4973.github.io/xxHash/, and this implementation is
+ * with inspiration from Vsevolod Tolstopyatovs implementation in https://github.com/OpenHFT/Zero-Allocation-Hashing.
+ * Credit for SMHasher goes to Austin Appleby, https://github.com/aappleby/smhasher.
  */
 public class IncrementalXXH64
 {

--- a/community/common/src/main/java/org/neo4j/hashing/JavaUtilHashFunction.java
+++ b/community/common/src/main/java/org/neo4j/hashing/JavaUtilHashFunction.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.hashing;
+
+/**
+ * @see HashFunction#javaUtilHashing()
+ */
+class JavaUtilHashFunction implements HashFunction
+{
+    static final HashFunction INSTANCE = new JavaUtilHashFunction();
+
+    private JavaUtilHashFunction()
+    {
+    }
+
+    @Override
+    public long initialise( long seed )
+    {
+        return seed;
+    }
+
+    @Override
+    public long update( long intermediateHash, long value )
+    {
+        return hashSingleValueToInt( intermediateHash + value );
+    }
+
+    @Override
+    public long finalise( long intermediateHash )
+    {
+        return intermediateHash;
+    }
+
+    @Override
+    public int hashSingleValueToInt( long value )
+    {
+        int h = (int) ((value >>> 32) ^ value);
+        h ^= (h >>> 20) ^ (h >>> 12);
+        return h ^ (h >>> 7) ^ (h >>> 4);
+    }
+}

--- a/community/common/src/main/java/org/neo4j/hashing/XorShift32HashFunction.java
+++ b/community/common/src/main/java/org/neo4j/hashing/XorShift32HashFunction.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.hashing;
+
+/**
+ * @see HashFunction#xorShift32()
+ */
+class XorShift32HashFunction implements HashFunction
+{
+    static final XorShift32HashFunction INSTANCE = new XorShift32HashFunction();
+
+    private XorShift32HashFunction()
+    {
+    }
+
+    @Override
+    public long initialise( long seed )
+    {
+        return 0;
+    }
+
+    @Override
+    public long update( long intermediateHash, long value )
+    {
+        return hashSingleValueToInt( intermediateHash + value );
+    }
+
+    @Override
+    public long finalise( long intermediateHash )
+    {
+        return intermediateHash;
+    }
+
+    @Override
+    public int hashSingleValueToInt( long value )
+    {
+        value ^= value << 21;
+        value ^= value >>> 35;
+        value ^= value << 4;
+        return (int) ((value >>> 32) ^ value);
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/ResourceTypes.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/ResourceTypes.java
@@ -19,15 +19,18 @@
  */
 package org.neo4j.kernel.impl.locking;
 
+import java.lang.reflect.Array;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.neo4j.hashing.IncrementalXXH64;
 import org.neo4j.kernel.api.properties.DefinedProperty;
 import org.neo4j.kernel.api.properties.Property;
 import org.neo4j.kernel.api.schema.IndexQuery;
 import org.neo4j.kernel.impl.util.concurrent.LockWaitStrategies;
 import org.neo4j.storageengine.api.lock.ResourceType;
 import org.neo4j.storageengine.api.lock.WaitStrategy;
+import org.neo4j.unsafe.impl.internal.dragons.FeatureToggles;
 
 import static org.neo4j.collection.primitive.hopscotch.HopScotchHashingAlgorithm.DEFAULT_HASHING;
 
@@ -40,7 +43,11 @@ public enum ResourceTypes implements ResourceType
     INDEX_ENTRY( 4, LockWaitStrategies.INCREMENTAL_BACKOFF ),
     LEGACY_INDEX( 5, LockWaitStrategies.INCREMENTAL_BACKOFF );
 
-    private static final Map<Integer, ResourceType> idToType = new HashMap<>();
+    private static final boolean useStrongHashing =
+            FeatureToggles.flag( ResourceTypes.class, "useStrongHashing", false );
+
+    private static final Map<Integer,ResourceType> idToType = new HashMap<>();
+
     static
     {
         for ( ResourceTypes resourceTypes : ResourceTypes.values() )
@@ -71,35 +78,52 @@ public enum ResourceTypes implements ResourceType
         return waitStrategy;
     }
 
+    /**
+     * The schema index entry hashing method used up until 2.2.0.
+     */
     public static long legacyIndexResourceId( String name, String key )
     {
-        return (long)name.hashCode() << 32 | key.hashCode();
+        return (long) name.hashCode() << 32 | key.hashCode();
     }
 
     /**
      * This is the schema index entry hashing method used since 2.2.0 and onwards.
+     * <p>
+     * Use the {@link ResourceTypes#useStrongHashing} feature toggle to use a stronger hash function, which will become
+     * the default in a future release. <strong>Note</strong> that changing this hash function is effectively a
+     * clustering protocol change in HA setups. Causal cluster setups are unaffected because followers do not take any
+     * locks on the cluster leader.
      */
     public static long indexEntryResourceId( long labelId, IndexQuery.ExactPredicate... predicates )
     {
-        return indexEntryResourceId( labelId, predicates, 0 );
+        if ( !useStrongHashing )
+        {
+            // Default
+            return indexEntryResourceId_2_2_0( labelId, predicates, 0 );
+        }
+        else
+        {
+            // Opt-in
+            return indexEntryResourceId_4_x( labelId, predicates );
+        }
     }
 
-    private static long indexEntryResourceId( long labelId, IndexQuery.ExactPredicate[] predicates, int i )
+    private static long indexEntryResourceId_2_2_0( long labelId, IndexQuery.ExactPredicate[] predicates, int i )
     {
         int propertyKeyId = predicates[i].propertyKeyId();
         Object value = predicates[i].value();
         // Note:
         // It is important that single-property indexes only hash with this particular call; no additional hashing!
-        long hash = indexEntryResourceId( labelId, propertyKeyId, stringOf( propertyKeyId, value ) );
+        long hash = indexEntryResourceId_2_2_0( labelId, propertyKeyId, stringOf( propertyKeyId, value ) );
         i++;
         if ( i < predicates.length )
         {
-            hash = hash( hash + indexEntryResourceId( labelId, predicates, i ) );
+            hash = hash( hash + indexEntryResourceId_2_2_0( labelId, predicates, i ) );
         }
         return hash;
     }
 
-    private static long indexEntryResourceId( long labelId, long propertyKeyId, String propertyValue )
+    private static long indexEntryResourceId_2_2_0( long labelId, long propertyKeyId, String propertyValue )
     {
         long hob = hash( labelId + hash( propertyKeyId ) );
         hob <<= 32;
@@ -134,5 +158,89 @@ public enum ResourceTypes implements ResourceType
     public static ResourceType fromId( int typeId )
     {
         return idToType.get( typeId );
+    }
+
+    /**
+     * This is a stronger, full 64-bit hashing method for schema index entries that we should use by default in a
+     * future release, where we will also upgrade the HA protocol version. Currently this is indicated by the "4_x"
+     * name suffix, but any version where the HA protocol version changes anyway would be just as good an opportunity.
+     *
+     * @see IncrementalXXH64
+     */
+    public static long indexEntryResourceId_4_x( long labelId, IndexQuery.ExactPredicate... predicates )
+    {
+        long hash = IncrementalXXH64.init( 0x0123456789abcdefL );
+
+        hash = IncrementalXXH64.update( hash, labelId );
+
+        for ( IndexQuery.ExactPredicate predicate : predicates )
+        {
+            int propertyKeyId = predicate.propertyKeyId();
+            Object value = predicate.value();
+            Class<?> type = value.getClass();
+
+            hash = IncrementalXXH64.update( hash, propertyKeyId );
+
+            if ( type == String.class )
+            {
+                String str = (String) value;
+                int length = str.length();
+
+                hash = IncrementalXXH64.update( hash, length );
+
+                for ( int i = 0; i < length; i++ )
+                {
+                    hash = IncrementalXXH64.update( hash, str.charAt( i ) );
+                }
+            }
+            else if ( type.isArray() )
+            {
+                int length = Array.getLength( value );
+                Class<?> componentType = type.getComponentType();
+
+                hash = IncrementalXXH64.update( hash, length );
+
+                if ( componentType == String.class )
+                {
+                    for ( int i = 0; i < length; i++ )
+                    {
+                        String str = (String) Array.get( value, i );
+                        int len = str.length();
+
+                        hash = IncrementalXXH64.update( hash, len );
+
+                        for ( int j = 0; i < len; j++ )
+                        {
+                            hash = IncrementalXXH64.update( hash, str.charAt( j ) );
+                        }
+                    }
+                }
+                else if ( componentType == Double.class )
+                {
+                    for ( int i = 0; i < length; i++ )
+                    {
+                        hash = IncrementalXXH64.update(
+                                hash, Double.doubleToLongBits( (Double) Array.get( value, i ) ) );
+                    }
+                }
+                else
+                {
+                    for ( int i = 0; i < length; i++ )
+                    {
+                        hash = IncrementalXXH64.update( hash, ((Number) Array.get( value, i )).longValue() );
+                    }
+                }
+            }
+            else if ( type == Double.class )
+            {
+                hash = IncrementalXXH64.update( hash, Double.doubleToLongBits( (Double) value ) );
+            }
+            else
+            {
+                hash = IncrementalXXH64.update( hash, ((Number) value).longValue() );
+            }
+        }
+
+        return IncrementalXXH64.finalise( hash );
     }
 }

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/HopScotchHashingAlgorithm.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/HopScotchHashingAlgorithm.java
@@ -381,42 +381,12 @@ public class HopScotchHashingAlgorithm
     }
 
     /**
-     * Same hash function as that used by the standard library hash collections. It generates a hash by splitting the
-     * input value into segments, and then re-distributing those segments, so the end result is effectively a striped
-     * and then jumbled version of the input data. For randomly distributed keys, this has a good chance at generating
-     * an even hash distribution over the full hash space.
-     *
-     * It performs exceptionally poorly for sequences of numbers, as the sequence increments all end up in the same
-     * stripe, generating hash values that will end up in the same buckets in collections.
+     * The default hash function for primitive collections. This hash function is quite fast but has mediocre
+     * statistics.
+     * @see org.neo4j.hashing.HashFunction#xorShift32()
      */
-    public static final HashFunction JUL_HASHING = new HashFunction()
-    {
-        @Override
-        public int hash( long value )
-        {
-            int h = (int) ((value >>> 32) ^ value);
-            h ^= (h >>> 20) ^ (h >>> 12);
-            return h ^ (h >>> 7) ^ (h >>> 4);
-        }
-    };
-
-    /**
-     * The default hash function is based on a pseudo-random number generator, which uses the input value as a seed
-     * to the generator. This is very fast, and performs well for most input data. However, it is not guaranteed to
-     * generate a superb distribution, only a "decent" one.
-     */
-    public static final HashFunction DEFAULT_HASHING = new HashFunction()
-    {
-        @Override
-        public int hash( long value )
-        {
-            value ^= value << 21;
-            value ^= value >>> 35;
-            value ^= value << 4;
-
-            return (int) ((value >>> 32) ^ value);
-        }
-    };
+    static final HashFunction DEFAULT_HASHING =
+            org.neo4j.hashing.HashFunction.xorShift32()::hashSingleValueToInt;
 
     public interface ResizeMonitor<VALUE>
     {

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/HopScotchHashingAlgorithm.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/HopScotchHashingAlgorithm.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.collection.primitive.hopscotch;
 
+import org.neo4j.hashing.HashFunction;
+
 import static java.lang.Long.numberOfLeadingZeros;
 import static java.lang.Long.numberOfTrailingZeros;
 
@@ -274,7 +276,7 @@ public class HopScotchHashingAlgorithm
 
     private static int indexOf( HashFunction hashFunction, long key, int tableMask )
     {
-        return hashFunction.hash( key ) & tableMask;
+        return hashFunction.hashSingleValueToInt( key ) & tableMask;
     }
 
     private static <VALUE> void growTable( Table<VALUE> oldTable, Monitor monitor,
@@ -375,18 +377,12 @@ public class HopScotchHashingAlgorithm
         /*No additional logic*/
     };
 
-    public interface HashFunction
-    {
-        int hash( long value );
-    }
-
     /**
      * The default hash function for primitive collections. This hash function is quite fast but has mediocre
      * statistics.
      * @see org.neo4j.hashing.HashFunction#xorShift32()
      */
-    static final HashFunction DEFAULT_HASHING =
-            org.neo4j.hashing.HashFunction.xorShift32()::hashSingleValueToInt;
+    static final HashFunction DEFAULT_HASHING = HashFunction.xorShift32();
 
     public interface ResizeMonitor<VALUE>
     {

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveIntHashSet.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveIntHashSet.java
@@ -134,7 +134,7 @@ public class PrimitiveIntHashSet extends AbstractIntHopScotchCollection<Object> 
         @Override
         public boolean visited( int value ) throws RuntimeException
         {
-            hash += DEFAULT_HASHING.hash( value );
+            hash += DEFAULT_HASHING.hashSingleValueToInt( value );
             return false;
         }
 

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveIntLongHashMap.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveIntLongHashMap.java
@@ -155,7 +155,7 @@ public class PrimitiveIntLongHashMap extends AbstractIntHopScotchCollection<long
         @Override
         public boolean visited( int key, long value ) throws RuntimeException
         {
-            hash += DEFAULT_HASHING.hash( key + DEFAULT_HASHING.hash( value ) );
+            hash += DEFAULT_HASHING.hashSingleValueToInt( key + DEFAULT_HASHING.hashSingleValueToInt( value ) );
             return false;
         }
 

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveIntObjectHashMap.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveIntObjectHashMap.java
@@ -140,7 +140,7 @@ public class PrimitiveIntObjectHashMap<VALUE> extends AbstractIntHopScotchCollec
         @Override
         public boolean visited( int key, T value ) throws RuntimeException
         {
-            hash += DEFAULT_HASHING.hash( key + value.hashCode() );
+            hash += DEFAULT_HASHING.hashSingleValueToInt( key + value.hashCode() );
             return false;
         }
 

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongHashSet.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongHashSet.java
@@ -134,7 +134,7 @@ public class PrimitiveLongHashSet extends AbstractLongHopScotchCollection<Object
         @Override
         public boolean visited( long value ) throws RuntimeException
         {
-            hash += DEFAULT_HASHING.hash( value );
+            hash += DEFAULT_HASHING.hashSingleValueToInt( value );
             return false;
         }
 

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongIntHashMap.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongIntHashMap.java
@@ -154,7 +154,7 @@ public class PrimitiveLongIntHashMap extends AbstractLongHopScotchCollection<int
         @Override
         public boolean visited( long key, int value ) throws RuntimeException
         {
-            hash += DEFAULT_HASHING.hash( key + DEFAULT_HASHING.hash( value ) );
+            hash += DEFAULT_HASHING.hashSingleValueToInt( key + DEFAULT_HASHING.hashSingleValueToInt( value ) );
             return false;
         }
 

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongLongHashMap.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongLongHashMap.java
@@ -154,7 +154,7 @@ public class PrimitiveLongLongHashMap extends AbstractLongHopScotchCollection<lo
         @Override
         public boolean visited( long key, long value ) throws RuntimeException
         {
-            hash += DEFAULT_HASHING.hash( key + DEFAULT_HASHING.hash( value ) );
+            hash += DEFAULT_HASHING.hashSingleValueToInt( key + DEFAULT_HASHING.hashSingleValueToInt( value ) );
             return false;
         }
 

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongObjectHashMap.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongObjectHashMap.java
@@ -140,7 +140,7 @@ public class PrimitiveLongObjectHashMap<VALUE> extends AbstractLongHopScotchColl
         @Override
         public boolean visited( long key, T value ) throws RuntimeException
         {
-            hash += DEFAULT_HASHING.hash( key + value.hashCode() );
+            hash += DEFAULT_HASHING.hashSingleValueToInt( key + value.hashCode() );
             return false;
         }
 


### PR DESCRIPTION
We can alternatively make it an `unsupported.` setting, and pass its value to the `ConstraintEnforcingEntityOperations`, which could then make the decision about what hash function to use. That approach would have the advantage that we could change the default value depending on the edition, such that only HA setups would keep using the old hash function.