### PR TITLE
Check only first property for uniqueness during uniqueness constraint verification

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneDocumentStructure.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneDocumentStructure.java
@@ -259,6 +259,12 @@ public class LuceneDocumentStructure
         return encoding.encodeField( encoding.key(), value );
     }
 
+    public static boolean useFieldForUniquenessVerification( String fieldName )
+    {
+        return !LuceneDocumentStructure.NODE_ID_KEY.equals( fieldName ) &&
+                ValueEncoding.fieldPropertyNumber( fieldName ) == 0;
+    }
+
     private static class DocWithId
     {
         private final Document document;

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/ValueEncoding.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/ValueEncoding.java
@@ -186,6 +186,16 @@ enum ValueEncoding
         return propertyNumber + key();
     }
 
+    static int fieldPropertyNumber( String fieldName )
+    {
+        int index = 0;
+        for ( int i = 0; i < fieldName.length() && Character.isDigit( fieldName.charAt( i ) ); i++ )
+        {
+            index++;
+        }
+        return index == 0 ? 0 : Integer.parseInt( fieldName.substring( 0, index ) );
+    }
+
     abstract boolean canEncode( Object value );
 
     abstract Field encodeField( String name, Object value );

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/PartitionedUniquenessVerifier.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/PartitionedUniquenessVerifier.java
@@ -72,19 +72,17 @@ public class PartitionedUniquenessVerifier implements UniquenessVerifier
     {
         for ( String field : allFields() )
         {
-            if ( LuceneDocumentStructure.NODE_ID_KEY.equals( field ) )
+            if ( LuceneDocumentStructure.useFieldForUniquenessVerification( field ) )
             {
-                continue;
-            }
-
-            TermsEnum terms = LuceneDocumentStructure.originalTerms( termsForField( field ), field );
-            BytesRef termsRef;
-            while ( (termsRef = terms.next()) != null )
-            {
-                if ( terms.docFreq() > 1 )
+                TermsEnum terms = LuceneDocumentStructure.originalTerms( termsForField( field ), field );
+                BytesRef termsRef;
+                while ( (termsRef = terms.next()) != null )
                 {
-                    TermQuery query = new TermQuery( new Term( field, termsRef ) );
-                    searchForDuplicates( query, accessor, propKeyIds, terms.docFreq() );
+                    if ( terms.docFreq() > 1 )
+                    {
+                        TermQuery query = new TermQuery( new Term( field, termsRef ) );
+                        searchForDuplicates( query, accessor, propKeyIds, terms.docFreq() );
+                    }
                 }
             }
         }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/SimpleUniquenessVerifier.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/verification/SimpleUniquenessVerifier.java
@@ -67,19 +67,17 @@ public class SimpleUniquenessVerifier implements UniquenessVerifier
                 Fields fields = leafReaderContext.reader().fields();
                 for ( String field : fields )
                 {
-                    if ( LuceneDocumentStructure.NODE_ID_KEY.equals( field ) )
+                    if ( LuceneDocumentStructure.useFieldForUniquenessVerification( field ) )
                     {
-                        continue;
-                    }
-
-                    TermsEnum terms = LuceneDocumentStructure.originalTerms( fields.terms( field ), field );
-                    BytesRef termsRef;
-                    while ( (termsRef = terms.next()) != null )
-                    {
-                        if ( terms.docFreq() > 1 )
+                        TermsEnum terms = LuceneDocumentStructure.originalTerms( fields.terms( field ), field );
+                        BytesRef termsRef;
+                        while ( (termsRef = terms.next()) != null )
                         {
-                            collector.init( terms.docFreq() );
-                            searcher.search( new TermQuery( new Term( field, termsRef ) ), collector );
+                            if ( terms.docFreq() > 1 )
+                            {
+                                collector.init( terms.docFreq() );
+                                searcher.search( new TermQuery( new Term( field, termsRef ) ), collector );
+                            }
                         }
                     }
                 }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneDocumentStructureTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneDocumentStructureTest.java
@@ -36,9 +36,12 @@ import org.junit.rules.ExpectedException;
 import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.neo4j.kernel.api.impl.schema.LuceneDocumentStructure.NODE_ID_KEY;
 import static org.neo4j.kernel.api.impl.schema.LuceneDocumentStructure.newSeekQuery;
+import static org.neo4j.kernel.api.impl.schema.LuceneDocumentStructure.useFieldForUniquenessVerification;
 import static org.neo4j.kernel.api.impl.schema.ValueEncoding.Array;
 import static org.neo4j.kernel.api.impl.schema.ValueEncoding.Bool;
 import static org.neo4j.kernel.api.impl.schema.ValueEncoding.Number;
@@ -251,5 +254,16 @@ public class LuceneDocumentStructureTest
 
         // then
         assertThat( "Should contain term value", prefixQuery.toString(), containsString( "Prefix" ) );
+    }
+
+    @Test
+    public void checkFieldUsageForUniquenessVerification() throws Exception
+    {
+        assertFalse( useFieldForUniquenessVerification( "id" ) );
+        assertFalse( useFieldForUniquenessVerification( "1number" ) );
+        assertTrue( useFieldForUniquenessVerification( "number" ) );
+        assertFalse( useFieldForUniquenessVerification( "1string" ) );
+        assertFalse( useFieldForUniquenessVerification( "10string" ) );
+        assertTrue( useFieldForUniquenessVerification( "string" ) );
     }
 }


### PR DESCRIPTION
Before we were checking all the fields of index for uniqueness
when we were about to create uniqueness constraint. That was fine for
one property index but n case of the composite index of N properties
we would actually do verification N times while checking combinations
for first property only is more than enough.