### PR TITLE
GetServers returns list not map

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/procedure/GetServersProcedureForMultiDC.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/procedure/GetServersProcedureForMultiDC.java
@@ -50,7 +50,7 @@ public class GetServersProcedureForMultiDC implements CallableProcedure
             procedureSignature( GET_SERVERS_V2.fullyQualifiedProcedureName() )
                     .in( CONTEXT.parameterName(), Neo4jTypes.NTMap )
                     .out( TTL.parameterName(), Neo4jTypes.NTInteger )
-                    .out( SERVERS.parameterName(), Neo4jTypes.NTMap )
+                    .out( SERVERS.parameterName(), Neo4jTypes.NTList( Neo4jTypes.NTMap ) )
                     .description( DESCRIPTION )
                     .build();
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/procedure/GetServersProcedureForSingleDC.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/procedure/GetServersProcedureForSingleDC.java
@@ -69,7 +69,7 @@ public class GetServersProcedureForSingleDC implements CallableProcedure
             ProcedureSignature.procedureSignature( GET_SERVERS_V2.fullyQualifiedProcedureName() )
                     .in( CONTEXT.parameterName(), Neo4jTypes.NTMap )
                     .out( TTL.parameterName(), Neo4jTypes.NTInteger )
-                    .out( SERVERS.parameterName(), Neo4jTypes.NTMap )
+                    .out( SERVERS.parameterName(), Neo4jTypes.NTList( Neo4jTypes.NTMap ) )
                     .description( DESCRIPTION )
                     .build();
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/procedure/LegacyGetServersProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/load_balancing/procedure/LegacyGetServersProcedure.java
@@ -64,7 +64,7 @@ public class LegacyGetServersProcedure implements CallableProcedure
     private final ProcedureSignature procedureSignature =
             ProcedureSignature.procedureSignature( GET_SERVERS_V1.fullyQualifiedProcedureName() )
                     .out( TTL.parameterName(), Neo4jTypes.NTInteger )
-                    .out( SERVERS.parameterName(), Neo4jTypes.NTMap )
+                    .out( SERVERS.parameterName(), Neo4jTypes.NTList( Neo4jTypes.NTMap ) )
                     .description( DESCRIPTION )
                     .build();
 
@@ -109,7 +109,8 @@ public class LegacyGetServersProcedure implements CallableProcedure
         }
         catch ( NoLeaderFoundException e )
         {
-            log.debug( "No leader server found. This can happen during a leader switch. No write end points available" );
+            log.debug(
+                    "No leader server found. This can happen during a leader switch. No write end points available" );
             return Optional.empty();
         }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/procedure/GetServersProcedureV1Test.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/procedure/GetServersProcedureV1Test.java
@@ -68,6 +68,7 @@ import static org.neo4j.causalclustering.identity.RaftTestMember.member;
 import static org.neo4j.helpers.collection.Iterators.asList;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTInteger;
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTList;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTMap;
 import static org.neo4j.logging.NullLogProvider.getInstance;
 
@@ -83,14 +84,14 @@ public class GetServersProcedureV1Test
     @Parameterized.Parameter( 2 )
     public boolean expectFollowersAsReadEndPoints;
 
-    @Parameterized.Parameters( name = "{0}")
+    @Parameterized.Parameters( name = "{0}" )
     public static Collection<Object[]> params()
     {
         return Arrays.asList(
                 new Object[]{"with followers as read end points", Config.defaults().augment(
-                        singletonMap( cluster_allow_reads_on_followers.name(), Settings.TRUE ) ), true },
+                        singletonMap( cluster_allow_reads_on_followers.name(), Settings.TRUE ) ), true},
                 new Object[]{"no followers as read end points", Config.defaults().augment(
-                        singletonMap( cluster_allow_reads_on_followers.name(), Settings.FALSE ) ), false }
+                        singletonMap( cluster_allow_reads_on_followers.name(), Settings.FALSE ) ), false}
         );
     }
 
@@ -133,7 +134,7 @@ public class GetServersProcedureV1Test
         // then
         assertThat( signature.outputSignature(), containsInAnyOrder(
                 FieldSignature.outputField( "ttl", NTInteger ),
-                FieldSignature.outputField( "servers", NTMap ) ) );
+                FieldSignature.outputField( "servers", NTList( NTMap ) ) ) );
     }
 
     @Test
@@ -225,7 +226,7 @@ public class GetServersProcedureV1Test
 
         // then
         ClusterView.Builder builder = new ClusterView.Builder();
-        builder.writeAddress( adressesForCore( 0 ).connectors().boltAddress()  );
+        builder.writeAddress( adressesForCore( 0 ).connectors().boltAddress() );
         builder.readAddress( adressesForCore( 0 ).connectors().boltAddress() );
         builder.routeAddress( adressesForCore( 0 ).connectors().boltAddress() );
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/procedure/GetServersProcedureV2Test.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/load_balancing/procedure/GetServersProcedureV2Test.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTInteger;
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTList;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTMap;
 
 public class GetServersProcedureV2Test
@@ -54,7 +55,7 @@ public class GetServersProcedureV2Test
 
         assertThat( signature.outputSignature(), containsInAnyOrder(
                 FieldSignature.outputField( "ttl", NTInteger ),
-                FieldSignature.outputField( "servers", NTMap ) ) );
+                FieldSignature.outputField( "servers", NTList( NTMap ) ) ) );
     }
 
     @Test
@@ -67,7 +68,7 @@ public class GetServersProcedureV2Test
         Map<String,String> clientContext = stringMap( "key", "value", "key2", "value2" );
 
         // when
-        getServers.apply( null, new Object[] { clientContext } );
+        getServers.apply( null, new Object[]{clientContext} );
 
         // then
         verify( plugin ).run( clientContext );


### PR DESCRIPTION
The signature of the `getServers` procedures are wrong, they return a list
of maps and not just a map.

NOTE: This has been fixed in 3.3 so please do a null merge.