### PR TITLE
Cluster overview procedure should not return array

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedure.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 import org.neo4j.causalclustering.core.consensus.LeaderLocator;
 import org.neo4j.causalclustering.core.consensus.NoLeaderFoundException;
@@ -120,7 +122,7 @@ public class ClusterOverviewProcedure extends CallableProcedure.BasicProcedure
         return map( ( endpoint ) -> new Object[]
                         {
                                 endpoint.memberId().toString(),
-                                endpoint.addresses().uriList().stream().map( URI::toString ).toArray(),
+                                endpoint.addresses().uriList().stream().map( URI::toString ).collect( Collectors.toList() ),
                                 endpoint.role().name(),
                                 endpoint.groups()
                         },

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedureTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/procedures/ClusterOverviewProcedureTest.java
@@ -24,6 +24,7 @@ import org.hamcrest.TypeSafeMatcher;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -80,17 +81,22 @@ public class ClusterOverviewProcedureTest
         LeaderLocator leaderLocator = mock( LeaderLocator.class );
         when( leaderLocator.getLeader() ).thenReturn( theLeader );
 
-        ClusterOverviewProcedure procedure = new ClusterOverviewProcedure( topologyService, leaderLocator, NullLogProvider.getInstance() );
+        ClusterOverviewProcedure procedure =
+                new ClusterOverviewProcedure( topologyService, leaderLocator, NullLogProvider.getInstance() );
 
         // when
         final RawIterator<Object[],ProcedureException> members = procedure.apply( null, new Object[0] );
 
         assertThat( members.next(), new IsRecord( theLeader.getUuid(), 5000, Role.LEADER, asSet( "core", "core0" ) ) );
-        assertThat( members.next(), new IsRecord( follower1.getUuid(), 5001, Role.FOLLOWER, asSet( "core", "core1" ) ) );
-        assertThat( members.next(), new IsRecord( follower2.getUuid(), 5002, Role.FOLLOWER, asSet( "core", "core2" ) ) );
+        assertThat( members.next(),
+                new IsRecord( follower1.getUuid(), 5001, Role.FOLLOWER, asSet( "core", "core1" ) ) );
+        assertThat( members.next(),
+                new IsRecord( follower2.getUuid(), 5002, Role.FOLLOWER, asSet( "core", "core2" ) ) );
 
-        assertThat( members.next(), new IsRecord( replica4.getUuid(), 6004, Role.READ_REPLICA, asSet( "replica", "replica4" ) ) );
-        assertThat( members.next(), new IsRecord( replica5.getUuid(), 6005, Role.READ_REPLICA, asSet( "replica", "replica5" ) ) );
+        assertThat( members.next(),
+                new IsRecord( replica4.getUuid(), 6004, Role.READ_REPLICA, asSet( "replica", "replica4" ) ) );
+        assertThat( members.next(),
+                new IsRecord( replica5.getUuid(), 6005, Role.READ_REPLICA, asSet( "replica", "replica5" ) ) );
 
         assertFalse( members.hasNext() );
     }
@@ -123,9 +129,9 @@ public class ClusterOverviewProcedureTest
                 return false;
             }
 
-            String[] boltAddresses = new String[]{"bolt://localhost:" + boltPort};
+            List<String> boltAddresses = Collections.singletonList( "bolt://localhost:" + boltPort );
 
-            if ( !Arrays.equals( boltAddresses, (Object[]) record[1] ) )
+            if ( !boltAddresses.equals( record[1] ) )
             {
                 return false;
             }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterOverviewIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterOverviewIT.java
@@ -326,6 +326,7 @@ public class ClusterOverviewIT
        return containsRole( unexpectedRole, 0 );
     }
 
+    @SuppressWarnings( "unchecked" )
     private List<MemberInfo> clusterOverview( GraphDatabaseFacade db )
             throws TransactionFailureException, ProcedureException
     {
@@ -340,8 +341,8 @@ public class ClusterOverviewIT
             while ( itr.hasNext() )
             {
                 Object[] row = itr.next();
-                Object[] addresses = (Object[]) row[1];
-                infos.add( new MemberInfo( Arrays.copyOf( addresses, addresses.length, String[].class ),
+                List<String> addresses = (List<String>) row[1];
+                infos.add( new MemberInfo( addresses.toArray( new String[addresses.size()] ),
                         Role.valueOf( (String) row[2] ) ) );
             }
         }


### PR DESCRIPTION
The procedure `dbms.cluster.overview` was creating arrays instead of lists and arrays
are not a supported return type of procedures.