### PR TITLE
LogEntryParser no longer accepts zeros as valid entries

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryByteCodes.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryByteCodes.java
@@ -26,9 +26,6 @@ public class LogEntryByteCodes
         throw new AssertionError(); // no instances are allowed
     }
 
-    // empty record due to memory mapped file
-    public static final byte EMPTY = (byte) 0;
-
     // Real entries
     public static final byte TX_START = (byte) 1;
     public static final byte COMMAND = (byte) 3;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryParsersV2_3.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryParsersV2_3.java
@@ -29,28 +29,6 @@ import org.neo4j.storageengine.api.StorageCommand;
 
 public enum LogEntryParsersV2_3 implements LogEntryParser<LogEntry>
 {
-    EMPTY
-            {
-                @Override
-                public LogEntry parse( LogEntryVersion version, ReadableClosableChannel channel, LogPositionMarker marker,
-                                       CommandReaderFactory commandReader ) throws IOException
-                {
-                    return null;
-                }
-
-                @Override
-                public byte byteCode()
-                {
-                    return LogEntryByteCodes.EMPTY;
-                }
-
-                @Override
-                public boolean skip()
-                {
-                    return false;
-                }
-            },
-
     TX_START
             {
                 @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/VersionAwareLogEntryReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/VersionAwareLogEntryReader.java
@@ -70,10 +70,6 @@ public class VersionAwareLogEntryReader<SOURCE extends ReadableClosablePositionA
                 channel.getCurrentPosition( positionMarker );
 
                 byte versionCode = channel.get();
-                if ( versionCode == 0 )
-                {
-                    return null;
-                }
                 byte typeCode = channel.get();
 
                 LogEntryVersion version = null;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryParserDispatcherV6Test.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryParserDispatcherV6Test.java
@@ -34,7 +34,6 @@ import org.neo4j.storageengine.api.CommandReaderFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 
 public class LogEntryParserDispatcherV6Test
 {
@@ -118,18 +117,6 @@ public class LogEntryParserDispatcherV6Test
 
         // then
         assertEquals( command, logEntry );
-        assertFalse( parser.skip() );
-    }
-
-    @Test
-    public void shouldParseEmptyEntry() throws IOException
-    {
-        // when
-        final LogEntryParser parser = version.entryParser( LogEntryByteCodes.EMPTY );
-        final LogEntry logEntry = parser.parse( version, new InMemoryClosableChannel(), marker, commandReader );
-
-        // then
-        assertNull( logEntry );
         assertFalse( parser.skip() );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/VersionAwareLogEntryReaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/VersionAwareLogEntryReaderTest.java
@@ -144,22 +144,6 @@ public class VersionAwareLogEntryReaderTest
     }
 
     @Test
-    public void shouldReturnNullWhenLogEntryIsEmpty() throws IOException
-    {
-        // given
-        LogEntryVersion version = LogEntryVersion.CURRENT;
-        final InMemoryClosableChannel channel = new InMemoryClosableChannel();
-        channel.put( version.byteCode() );
-        channel.put( LogEntryByteCodes.EMPTY );
-
-        // when
-        final LogEntry logEntry = logEntryReader.readLogEntry( channel );
-
-        // then
-        assertNull( logEntry );
-    }
-
-    @Test
     public void shouldReturnNullWhenNotEnoughDataInTheChannel() throws IOException
     {
         // given
@@ -170,24 +154,6 @@ public class VersionAwareLogEntryReaderTest
 
         // then
         assertNull( logEntry );
-    }
-
-    @Test
-    public void shouldParseStreamOfZerosAsEmptyLogEntries() throws Exception
-    {
-        // GIVEN
-        LogEntryReader<ReadableClosablePositionAwareChannel> reader = new VersionAwareLogEntryReader<>();
-        InMemoryClosableChannel channel = new InMemoryClosableChannel();
-        int count = 100;
-        channel.put( new byte[count], count );
-
-        // WHEN/THEN
-        for ( int i = 0; i < count; i++ )
-        {
-            LogEntry entry = reader.readLogEntry( channel );
-            assertNull( entry );
-            assertEquals( i + 1, channel.readerPosition() );
-        }
     }
 
     @Test

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedTokenRequestSerializer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedTokenRequestSerializer.java
@@ -23,6 +23,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
@@ -45,6 +46,7 @@ public class ReplicatedTokenRequestSerializer
 {
     private ReplicatedTokenRequestSerializer()
     {
+        throw new AssertionError();
     }
 
     public static void marshal( ReplicatedTokenRequest content, WritableChannel channel ) throws IOException
@@ -103,7 +105,7 @@ public class ReplicatedTokenRequestSerializer
             e.printStackTrace(); // TODO: Handle or throw.
         }
 
-        byte[] commandsBytes = commandBuffer.array().clone();
+        byte[] commandsBytes = Arrays.copyOf( commandBuffer.array(), commandBuffer.writerIndex() );
         commandBuffer.release();
 
         return commandsBytes;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedTokenRequestSerializer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedTokenRequestSerializer.java
@@ -46,7 +46,7 @@ public class ReplicatedTokenRequestSerializer
 {
     private ReplicatedTokenRequestSerializer()
     {
-        throw new AssertionError();
+        throw new AssertionError( "Should not be instantiated" );
     }
 
     public static void marshal( ReplicatedTokenRequest content, WritableChannel channel ) throws IOException
@@ -105,6 +105,10 @@ public class ReplicatedTokenRequestSerializer
             e.printStackTrace(); // TODO: Handle or throw.
         }
 
+        /*
+         * This trims down the array to send up to the actual index it was written. Not doing this would send additional
+         * zeroes which not only wasteful, but also not handled by the LogEntryReader receiving this.
+         */
         byte[] commandsBytes = Arrays.copyOf( commandBuffer.array(), commandBuffer.writerIndex() );
         commandBuffer.release();
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransactionFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransactionFactory.java
@@ -49,6 +49,7 @@ public class ReplicatedTransactionFactory
 
     private ReplicatedTransactionFactory()
     {
+        throw new AssertionError( "Should not be instantiated" );
     }
 
     public static ReplicatedTransaction createImmutableReplicatedTransaction( TransactionRepresentation tx  )
@@ -71,6 +72,10 @@ public class ReplicatedTransactionFactory
             throw new RuntimeException( e );
         }
 
+        /*
+         * This trims down the array to send up to the actual index it was written. Not doing this would send additional
+         * zeroes which not only wasteful, but also not handled by the LogEntryReader receiving this.
+         */
         byte[] txBytes = Arrays.copyOf( transactionBuffer.array(), transactionBuffer.writerIndex() );
         transactionBuffer.release();
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransactionFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransactionFactory.java
@@ -71,10 +71,6 @@ public class ReplicatedTransactionFactory
             throw new RuntimeException( e );
         }
 
-        /*
-         * This trims down the array to send up to the actual index it was written. While sending additional zeroes
-         * is safe, since LogEntryReader stops reading once it sees a zero entry, it is wasteful.
-         */
         byte[] txBytes = Arrays.copyOf( transactionBuffer.array(), transactionBuffer.writerIndex() );
         transactionBuffer.release();
 


### PR DESCRIPTION
The reason the parser originally supported zeroes was due to memory mapped files having zeroes. Since those old log formats are no longer supported this behavior is no longer desired.