### PR TITLE
Improved value handling in property store

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPack.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPack.java
@@ -359,6 +359,12 @@ public class Neo4jPack
         }
 
         @Override
+        public void writeUTF8( byte[] bytes, int offset, int length ) throws IOException
+        {
+            packUTF8(bytes, offset, length);
+        }
+
+        @Override
         public void writeString( String value ) throws IOException
         {
             pack( value );
@@ -374,24 +380,6 @@ public class Neo4jPack
         public void writeString( char[] value, int offset, int length ) throws IOException
         {
             pack( String.valueOf( value, offset, length ) );
-        }
-
-        @Override
-        public void beginUTF8( int size ) throws IOException
-        {
-            throw new UnsupportedOperationException( "pack stream cannot handle UTF8 values" );
-        }
-
-        @Override
-        public void copyUTF8( long fromAddress, int length ) throws IOException
-        {
-            throw new UnsupportedOperationException( "pack stream cannot handle UTF8 values" );
-        }
-
-        @Override
-        public void endUTF8() throws IOException
-        {
-            throw new UnsupportedOperationException( "pack stream cannot handle UTF8 values" );
         }
 
         @Override

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackStream.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackStream.java
@@ -334,6 +334,20 @@ public class PackStream
             }
         }
 
+        public void packUTF8( byte[] bytes, int offset, int length ) throws IOException
+        {
+            if ( bytes == null )
+            {
+                packNull();
+            }
+            else
+            {
+                packStringHeader( length );
+                out.writeBytes( bytes, offset, length );
+            }
+        }
+
+
         protected void packBytesHeader( int size ) throws IOException
         {
             if ( size <= Byte.MAX_VALUE )
@@ -786,7 +800,7 @@ public class PackStream
         public Unexpected( PackType expectedType, byte unexpectedMarkerByte )
         {
             super( "Wrong type received. Expected " + expectedType + ", received: " + type( unexpectedMarkerByte ) +
-                    " " + "(" + toHexString( unexpectedMarkerByte ) + ")." );
+                   " " + "(" + toHexString( unexpectedMarkerByte ) + ")." );
         }
 
         private static String toHexString( byte unexpectedMarkerByte )

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackStream.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackStream.java
@@ -347,7 +347,6 @@ public class PackStream
             }
         }
 
-
         protected void packBytesHeader( int size ) throws IOException
         {
             if ( size <= Byte.MAX_VALUE )

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/Neo4jPackTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/Neo4jPackTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -236,6 +237,24 @@ public class Neo4jPackTest
         assertThat( unpacked, instanceOf( ListValue.class ) );
         assertThat( unpacked,
                 equalTo( VirtualValues.list( stringValue( "W" ), stringValue( "H" ), stringValue( "Y" ) ) ) );
+    }
+
+    @Test
+    public void shouldPackUtf8() throws IOException
+    {
+        // Given
+        String value = "\uD83D\uDE31";
+        byte[] bytes = value.getBytes( StandardCharsets.UTF_8 );
+        TextValue textValue = Values.utf8Value( bytes, 0, bytes.length );
+        PackedOutputArray output = new PackedOutputArray();
+        Neo4jPack.Packer packer = new Neo4jPack.Packer( output );
+        packer.pack( textValue );
+
+        // When
+        AnyValue unpacked = unpacked( output.bytes() );
+
+        // Then
+        assertThat( unpacked, equalTo( textValue ) );
     }
 
     private static class Unpackable

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/LabelChainWalker.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/LabelChainWalker.java
@@ -90,7 +90,7 @@ public class LabelChainWalker<RECORD extends AbstractBaseRecord, REPORT extends 
     public static long[] labelIds( List<DynamicRecord> recordList )
     {
         long[] idArray =
-                (long[]) getRightArray( readFullByteArrayFromHeavyRecords( recordList, PropertyType.ARRAY ) );
+                (long[]) getRightArray( readFullByteArrayFromHeavyRecords( recordList, PropertyType.ARRAY ) ).asObject();
         return LabelIdArray.stripNodeId( idArray );
     }
 

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
@@ -720,7 +720,7 @@ public class FullCheckIntegrationTest
             protected void transactionData( GraphStoreFixture.TransactionDataBuilder tx,
                                             GraphStoreFixture.IdGenerator next )
             {
-                long nodeId = ((long[]) getRightArray( readFullByteArrayFromHeavyRecords( chain, ARRAY ) ))[0];
+                long nodeId = ((long[]) getRightArray( readFullByteArrayFromHeavyRecords( chain, ARRAY ) ).asObject())[0];
                 NodeRecord before = inUse( new NodeRecord( nodeId, false, -1, -1 ) );
                 NodeRecord after = inUse( new NodeRecord( nodeId, false, -1, -1 ) );
                 DynamicRecord record1 = chain.get( 0 ).clone();

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/helpers/CastSupport.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/helpers/CastSupport.scala
@@ -20,6 +20,7 @@
 package org.neo4j.cypher.internal.compatibility.v3_3.runtime.helpers
 
 import org.neo4j.cypher.internal.frontend.v3_3.CypherTypeException
+import org.neo4j.string.UTF8
 import org.neo4j.values.storable.{ArrayValue, _}
 import org.neo4j.values.virtual._
 import org.neo4j.values.{AnyValue, AnyValueWriter}
@@ -105,15 +106,24 @@ object CastSupport {
 
   /*Returns a converter given a type value*/
   def getConverter(x: AnyValue): Converter = x match {
-    case _: CharValue => Converter(transform(new ArrayConverterWriter(classOf[Char], a => Values.charArray(a.asInstanceOf[Array[Char]]))))
-    case _: TextValue => Converter(transform(new ArrayConverterWriter(classOf[String], a => Values.stringArray(a.asInstanceOf[Array[String]]:_*))))
-    case _: BooleanValue => Converter(transform(new ArrayConverterWriter(classOf[Boolean], a => Values.booleanArray(a.asInstanceOf[Array[Boolean]]))))
-    case _: ByteValue => Converter(transform(new ArrayConverterWriter(classOf[Byte], a => Values.byteArray(a.asInstanceOf[Array[Byte]]))))
-    case _: ShortValue => Converter(transform(new ArrayConverterWriter(classOf[Short], a => Values.shortArray(a.asInstanceOf[Array[Short]]))))
-    case _: IntValue => Converter(transform(new ArrayConverterWriter(classOf[Int], a => Values.intArray(a.asInstanceOf[Array[Int]]))))
-    case _: LongValue => Converter(transform(new ArrayConverterWriter(classOf[Long], a => Values.longArray(a.asInstanceOf[Array[Long]]))))
-    case _: FloatValue => Converter(transform(new ArrayConverterWriter(classOf[Float], a => Values.floatArray(a.asInstanceOf[Array[Float]]))))
-    case _: DoubleValue => Converter(transform(new ArrayConverterWriter(classOf[Double], a => Values.doubleArray(a.asInstanceOf[Array[Double]]))))
+    case _: CharValue => Converter(
+      transform(new ArrayConverterWriter(classOf[Char], a => Values.charArray(a.asInstanceOf[Array[Char]]))))
+    case _: TextValue => Converter(
+      transform(new ArrayConverterWriter(classOf[String], a => Values.stringArray(a.asInstanceOf[Array[String]]: _*))))
+    case _: BooleanValue => Converter(
+      transform(new ArrayConverterWriter(classOf[Boolean], a => Values.booleanArray(a.asInstanceOf[Array[Boolean]]))))
+    case _: ByteValue => Converter(
+      transform(new ArrayConverterWriter(classOf[Byte], a => Values.byteArray(a.asInstanceOf[Array[Byte]]))))
+    case _: ShortValue => Converter(
+      transform(new ArrayConverterWriter(classOf[Short], a => Values.shortArray(a.asInstanceOf[Array[Short]]))))
+    case _: IntValue => Converter(
+      transform(new ArrayConverterWriter(classOf[Int], a => Values.intArray(a.asInstanceOf[Array[Int]]))))
+    case _: LongValue => Converter(
+      transform(new ArrayConverterWriter(classOf[Long], a => Values.longArray(a.asInstanceOf[Array[Long]]))))
+    case _: FloatValue => Converter(
+      transform(new ArrayConverterWriter(classOf[Float], a => Values.floatArray(a.asInstanceOf[Array[Float]]))))
+    case _: DoubleValue => Converter(
+      transform(new ArrayConverterWriter(classOf[Double], a => Values.doubleArray(a.asInstanceOf[Array[Double]]))))
     case _ => throw new CypherTypeException("Property values can only be of primitive types or arrays thereof")
   }
 
@@ -121,7 +131,9 @@ object CastSupport {
     value.writeTo(writer)
     writer.array
   }
-  private class ArrayConverterWriter(typ: Class[_], transformer: (AnyRef) => ArrayValue) extends AnyValueWriter[RuntimeException] {
+
+  private class ArrayConverterWriter(typ: Class[_], transformer: (AnyRef) => ArrayValue)
+    extends AnyValueWriter[RuntimeException] {
 
     private var _array: AnyRef = null
     private var index = 0
@@ -184,13 +196,8 @@ object CastSupport {
 
     override def writeString(value: Char): Unit = write(value)
 
-    override def writeString(value: Array[Char], offset: Int, length: Int): Unit = write(new String(value, offset, length))
-
-    override def beginUTF8(size: Int): Unit = fail()
-
-    override def copyUTF8(fromAddress: Long, length: Int): Unit = fail()
-
-    override def endUTF8(): Unit = fail()
+    override def writeString(value: Array[Char], offset: Int, length: Int): Unit = write(
+      new String(value, offset, length))
 
     override def beginArray(size: Int, arrayType: ValueWriter.ArrayType): Unit = fail()
 
@@ -199,6 +206,9 @@ object CastSupport {
     override def writeByteArray(value: Array[Byte]): Unit = {
       _array = value
     }
+
+    override def writeUTF8(bytes: Array[Byte], offset: Int, length: Int): Unit =
+      write(UTF8.decode(bytes, offset, length));
   }
 
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/ArrayEncoder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/ArrayEncoder.java
@@ -123,6 +123,12 @@ public final class ArrayEncoder
         }
 
         @Override
+        public void writeUTF8( byte[] bytes, int offset, int length ) throws RuntimeException
+        {
+            writeString( UTF8.decode( bytes, offset, length ) );
+        }
+
+        @Override
         public void writeString( char value )
         {
             builder.append( base64Encoder.encodeToString( UTF8.encode( Character.toString( value ) ) ) );
@@ -134,24 +140,6 @@ public final class ArrayEncoder
         {
             builder.append( value, offset, length );
             builder.append( '|' );
-        }
-
-        @Override
-        public void beginUTF8( int size )
-        {
-            throw new UnsupportedOperationException( "direct UTF8 encoding is not supported yet!" );
-        }
-
-        @Override
-        public void copyUTF8( long fromAddress, int length )
-        {
-            throw new UnsupportedOperationException( "direct UTF8 encoding is not supported yet!" );
-        }
-
-        @Override
-        public void endUTF8()
-        {
-            throw new UnsupportedOperationException( "direct UTF8 encoding is not supported yet!" );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/NodeUpdates.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/NodeUpdates.java
@@ -39,7 +39,6 @@ import static java.lang.String.format;
 import static java.util.Arrays.binarySearch;
 import static org.neo4j.kernel.impl.api.index.NodeUpdates.PropertyValueType.Changed;
 import static org.neo4j.kernel.impl.api.index.NodeUpdates.PropertyValueType.NoValue;
-import static org.neo4j.kernel.impl.store.ShortArray.EMPTY_LONG_ARRAY;
 
 /**
  * Subclasses of this represent events related to property changes due to node addition, deletion or update.
@@ -48,6 +47,7 @@ import static org.neo4j.kernel.impl.store.ShortArray.EMPTY_LONG_ARRAY;
 public class NodeUpdates implements PropertyLoader.PropertyLoadSink
 {
     private final long nodeId;
+    private static final long[] EMPTY_LONG_ARRAY = new long[0];
 
     // ASSUMPTION: these long arrays are actually sorted sets
     private final long[] labelsBefore;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursor.java
@@ -31,6 +31,7 @@ import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.util.Bits;
 import org.neo4j.string.UTF8;
+import org.neo4j.values.storable.ArrayValue;
 import org.neo4j.values.storable.BooleanValue;
 import org.neo4j.values.storable.ByteValue;
 import org.neo4j.values.storable.CharValue;
@@ -317,7 +318,7 @@ class StorePropertyPayloadCursor
         return ByteBuffer.allocate( newCapacity ).order( ByteOrder.LITTLE_ENDIAN );
     }
 
-    private static Value readArrayFromBuffer( ByteBuffer buffer )
+    private static ArrayValue readArrayFromBuffer( ByteBuffer buffer )
     {
         if ( buffer.limit() <= 0 )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursor.java
@@ -208,7 +208,7 @@ class StorePropertyPayloadCursor
         assertOfType( STRING );
         readFromStore( stringRecordCursor );
         buffer.flip();
-        return Values.stringValue( UTF8.decode( buffer.array(), 0, buffer.limit() ) );
+        return Values.utf8Value( buffer.array(), 0, buffer.limit() );
     }
 
     private Value shortArrayValue()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursor.java
@@ -31,6 +31,7 @@ import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.util.Bits;
 import org.neo4j.string.UTF8;
+import org.neo4j.values.storable.TextValue;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
 
@@ -188,18 +189,18 @@ class StorePropertyPayloadCursor
         return Double.longBitsToDouble( data[position + 1] );
     }
 
-    String shortStringValue()
+    TextValue shortStringValue()
     {
         assertOfType( SHORT_STRING );
         return LongerShortString.decode( data, position, currentBlocksUsed() );
     }
 
-    String stringValue()
+    TextValue stringValue()
     {
         assertOfType( STRING );
         readFromStore( stringRecordCursor );
         buffer.flip();
-        return UTF8.decode( buffer.array(), 0, buffer.limit() );
+        return Values.stringValue( UTF8.decode( buffer.array(), 0, buffer.limit() ) );
     }
 
     Value shortArrayValue()
@@ -238,9 +239,9 @@ class StorePropertyPayloadCursor
         case DOUBLE:
             return Values.doubleValue( doubleValue() );
         case SHORT_STRING:
-            return Values.stringValue( shortStringValue() );
+            return shortStringValue();
         case STRING:
-            return Values.stringValue( stringValue() );
+            return stringValue();
         case SHORT_ARRAY:
             return shortArrayValue();
         case ARRAY:

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursor.java
@@ -31,6 +31,14 @@ import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.util.Bits;
 import org.neo4j.string.UTF8;
+import org.neo4j.values.storable.BooleanValue;
+import org.neo4j.values.storable.ByteValue;
+import org.neo4j.values.storable.CharValue;
+import org.neo4j.values.storable.DoubleValue;
+import org.neo4j.values.storable.FloatValue;
+import org.neo4j.values.storable.IntValue;
+import org.neo4j.values.storable.LongValue;
+import org.neo4j.values.storable.ShortValue;
 import org.neo4j.values.storable.TextValue;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
@@ -136,60 +144,60 @@ class StorePropertyPayloadCursor
         return PropertyBlock.keyIndexId( currentHeader() );
     }
 
-    boolean booleanValue()
+    private BooleanValue booleanValue()
     {
         assertOfType( BOOL );
-        return PropertyBlock.fetchByte( currentHeader() ) == 1;
+        return Values.booleanValue( PropertyBlock.fetchByte( currentHeader() ) == 1 );
     }
 
-    byte byteValue()
+    private ByteValue byteValue()
     {
         assertOfType( BYTE );
-        return PropertyBlock.fetchByte( currentHeader() );
+        return Values.byteValue( PropertyBlock.fetchByte( currentHeader() ) );
     }
 
-    short shortValue()
+    private ShortValue shortValue()
     {
         assertOfType( SHORT );
-        return PropertyBlock.fetchShort( currentHeader() );
+        return Values.shortValue( PropertyBlock.fetchShort( currentHeader() ) );
     }
 
-    char charValue()
+    private CharValue charValue()
     {
         assertOfType( CHAR );
-        return (char) PropertyBlock.fetchShort( currentHeader() );
+        return Values.charValue( (char) PropertyBlock.fetchShort( currentHeader() ) );
     }
 
-    int intValue()
+    private IntValue intValue()
     {
         assertOfType( INT );
-        return PropertyBlock.fetchInt( currentHeader() );
+        return Values.intValue( PropertyBlock.fetchInt( currentHeader() ) );
     }
 
-    float floatValue()
+    private FloatValue floatValue()
     {
         assertOfType( FLOAT );
-        return Float.intBitsToFloat( PropertyBlock.fetchInt( currentHeader() ) );
+        return Values.floatValue( Float.intBitsToFloat( PropertyBlock.fetchInt( currentHeader() ) ) );
     }
 
-    long longValue()
+    private LongValue longValue()
     {
         assertOfType( LONG );
         if ( PropertyBlock.valueIsInlined( currentHeader() ) )
         {
-            return PropertyBlock.fetchLong( currentHeader() ) >>> 1;
+            return Values.longValue( PropertyBlock.fetchLong( currentHeader() ) >>> 1 );
         }
 
-        return data[position + 1];
+        return Values.longValue( data[position + 1] );
     }
 
-    double doubleValue()
+    private DoubleValue doubleValue()
     {
         assertOfType( DOUBLE );
-        return Double.longBitsToDouble( data[position + 1] );
+        return Values.doubleValue( Double.longBitsToDouble( data[position + 1] ) );
     }
 
-    TextValue shortStringValue()
+    private TextValue shortStringValue()
     {
         assertOfType( SHORT_STRING );
         return LongerShortString.decode( data, position, currentBlocksUsed() );
@@ -203,7 +211,7 @@ class StorePropertyPayloadCursor
         return Values.stringValue( UTF8.decode( buffer.array(), 0, buffer.limit() ) );
     }
 
-    Value shortArrayValue()
+    private Value shortArrayValue()
     {
         assertOfType( SHORT_ARRAY );
         Bits bits = valueAsBits();
@@ -223,21 +231,21 @@ class StorePropertyPayloadCursor
         switch ( type() )
         {
         case BOOL:
-            return Values.booleanValue( booleanValue() );
+            return booleanValue();
         case BYTE:
-            return Values.byteValue( byteValue() );
+            return byteValue();
         case SHORT:
-            return Values.shortValue( shortValue() );
+            return shortValue();
         case CHAR:
-            return Values.charValue( charValue() );
+            return charValue();
         case INT:
-            return Values.intValue( intValue() );
+            return intValue();
         case LONG:
-            return Values.longValue( longValue() );
+            return longValue();
         case FLOAT:
-            return Values.floatValue( floatValue() );
+            return floatValue();
         case DOUBLE:
-            return Values.doubleValue( doubleValue() );
+            return doubleValue();
         case SHORT_STRING:
             return shortStringValue();
         case STRING:

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicArrayStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicArrayStore.java
@@ -34,6 +34,8 @@ import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.util.Bits;
 import org.neo4j.logging.LogProvider;
+import org.neo4j.values.storable.Value;
+import org.neo4j.values.storable.Values;
 
 import static java.lang.System.arraycopy;
 
@@ -84,7 +86,7 @@ public class DynamicArrayStore extends AbstractDynamicStore
         }
 
         int arrayLength = Array.getLength( array );
-        int requiredBits = isByteArray ? Byte.SIZE : type.calculateRequiredBitsForArray( array, arrayLength);
+        int requiredBits = isByteArray ? Byte.SIZE : type.calculateRequiredBitsForArray( array, arrayLength );
         int totalBits = requiredBits * arrayLength;
         int numberOfBytes = (totalBits - 1) / 8 + 1;
         int bitsUsedInLastByte = totalBits % 8;
@@ -113,10 +115,10 @@ public class DynamicArrayStore extends AbstractDynamicStore
         else
         {
             Bits bits = Bits.bits( numberOfBytes );
-            bits.put( (byte)type.intValue() );
-            bits.put( (byte)bitsUsedInLastByte );
-            bits.put( (byte)requiredBits );
-            type.writeAll(array, arrayLength,requiredBits,bits);
+            bits.put( (byte) type.intValue() );
+            bits.put( (byte) bitsUsedInLastByte );
+            bits.put( (byte) requiredBits );
+            type.writeAll( array, arrayLength, requiredBits, bits );
             bytes = bits.asBytes();
         }
         allocateRecordsFromBytes( target, bytes, recordAllocator );
@@ -170,7 +172,7 @@ public class DynamicArrayStore extends AbstractDynamicStore
         }
     }
 
-    public static Object getRightArray( Pair<byte[],byte[]> data )
+    public static Value getRightArray( Pair<byte[],byte[]> data )
     {
         byte[] header = data.first();
         byte[] bArray = data.other();
@@ -189,7 +191,7 @@ public class DynamicArrayStore extends AbstractDynamicStore
                 dataBuffer.get( stringByteArray );
                 result[i] = PropertyStore.decodeString( stringByteArray );
             }
-            return result;
+            return Values.stringArray( result );
         }
         else
         {
@@ -200,23 +202,21 @@ public class DynamicArrayStore extends AbstractDynamicStore
             {
                 return type.createEmptyArray();
             }
-            Object result;
             if ( type == ShortArray.BYTE && requiredBits == Byte.SIZE )
             {   // Optimization for byte arrays (probably large ones)
-                result = bArray;
+                return Values.byteArray( bArray );
             }
             else
             {   // Fallback to the generic approach, which is a slower
                 Bits bits = Bits.bitsFromBytes( bArray );
                 int length = (bArray.length * 8 - (8 - bitsUsedInLastByte)) / requiredBits;
-                result = type.createArray( length, bits, requiredBits );
+                return type.createArray( length, bits, requiredBits );
             }
-            return result;
         }
     }
 
     public Object getArrayFor( Iterable<DynamicRecord> records )
     {
-        return getRightArray( readFullByteArray( records, PropertyType.ARRAY ) );
+        return getRightArray( readFullByteArray( records, PropertyType.ARRAY ) ).asObject();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicNodeLabels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicNodeLabels.java
@@ -81,7 +81,7 @@ public class DynamicNodeLabels implements NodeLabels
             return null;
         }
         return stripNodeId( (long[]) getRightArray( readFullByteArrayFromHeavyRecords(
-                node.getUsedDynamicLabelRecords(), ARRAY ) ) );
+                node.getUsedDynamicLabelRecords(), ARRAY ) ).asObject() );
     }
 
     @Override
@@ -226,14 +226,14 @@ public class DynamicNodeLabels implements NodeLabels
             AbstractDynamicStore dynamicLabelStore )
     {
         long[] storedLongs = (long[])
-            DynamicArrayStore.getRightArray( dynamicLabelStore.readFullByteArray( records, PropertyType.ARRAY ) );
+            DynamicArrayStore.getRightArray( dynamicLabelStore.readFullByteArray( records, PropertyType.ARRAY ) ).asObject();
         return LabelIdArray.stripNodeId( storedLongs );
     }
 
     public static long[] getDynamicLabelsArrayFromHeavyRecords( Iterable<DynamicRecord> records )
     {
         long[] storedLongs = (long[])
-            DynamicArrayStore.getRightArray( readFullByteArrayFromHeavyRecords( records, PropertyType.ARRAY ) );
+            DynamicArrayStore.getRightArray( readFullByteArrayFromHeavyRecords( records, PropertyType.ARRAY ) ).asObject();
         return LabelIdArray.stripNodeId( storedLongs );
     }
 
@@ -241,7 +241,7 @@ public class DynamicNodeLabels implements NodeLabels
             AbstractDynamicStore dynamicLabelStore )
     {
         long[] storedLongs = (long[])
-                DynamicArrayStore.getRightArray( dynamicLabelStore.readFullByteArray( records, PropertyType.ARRAY ) );
+                DynamicArrayStore.getRightArray( dynamicLabelStore.readFullByteArray( records, PropertyType.ARRAY ) ).asObject();
         return Pair.of(storedLongs[0], LabelIdArray.stripNodeId( storedLongs ));
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/LongerShortString.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/LongerShortString.java
@@ -26,6 +26,8 @@ import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.util.Bits;
 import org.neo4j.string.UTF8;
 import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
+import org.neo4j.values.storable.TextValue;
+import org.neo4j.values.storable.Values;
 
 /**
  * Supports encoding alphanumerical and <code>SP . - + , ' : / _</code>
@@ -897,17 +899,17 @@ public enum LongerShortString
      * @param block the value to decode to a short string.
      * @return the decoded short string
      */
-    public static String decode( PropertyBlock block )
+    public static TextValue decode( PropertyBlock block )
     {
         return decode( block.getValueBlocks(), 0, block.getValueBlocks().length );
     }
 
-    public static String decode( long[] blocks, int offset, int length )
+    public static TextValue decode( long[] blocks, int offset, int length )
     {
         long firstLong = blocks[offset];
         if ( (firstLong & 0xFFFFFF0FFFFFFFFFL) == 0 )
         {
-            return "";
+            return Values.EMPTY_STRING;
         }
         // key(24b) + type(4) = 28
         int encoding = (int) ((firstLong & 0x1F0000000L) >>> 28); // 5 bits of encoding
@@ -930,7 +932,7 @@ public enum LongerShortString
         decode( result, blocks, offset, table );
 
         // We know the char array is unshared, so use sharing constructor explicitly
-        return UnsafeUtil.newSharedArrayString( result );
+        return Values.stringValue( UnsafeUtil.newSharedArrayString( result ) );
     }
 
     private static void decode( char[] result, long[] blocks, int offset, LongerShortString table )
@@ -1055,7 +1057,7 @@ public enum LongerShortString
         }
     }
 
-    private static String decodeLatin1( long[] blocks, int offset, int stringLength )
+    private static TextValue decodeLatin1( long[] blocks, int offset, int stringLength )
     {
         char[] result = new char[stringLength];
         int block = offset;
@@ -1071,10 +1073,10 @@ public enum LongerShortString
             }
             result[i] = codePoint;
         }
-        return UnsafeUtil.newSharedArrayString( result );
+        return Values.stringValue( UnsafeUtil.newSharedArrayString( result ) );
     }
 
-    private static String decodeUTF8( long[] blocks, int offset, int stringLength )
+    private static TextValue decodeUTF8( long[] blocks, int offset, int stringLength )
     {
         byte[] result = new byte[stringLength];
         int block = offset;
@@ -1090,7 +1092,7 @@ public enum LongerShortString
             }
             result[i] = codePoint;
         }
-        return UTF8.decode( result );
+        return Values.stringValue( UTF8.decode( result ) );
     }
 
     public static int calculateNumberOfBlocksUsed( long firstBlock )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/LongerShortString.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/LongerShortString.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.util.Bits;
-import org.neo4j.string.UTF8;
 import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 import org.neo4j.values.storable.TextValue;
 import org.neo4j.values.storable.Values;
@@ -1092,7 +1091,7 @@ public enum LongerShortString
             }
             result[i] = codePoint;
         }
-        return Values.stringValue( UTF8.decode( result ) );
+        return Values.utf8Value( result );
     }
 
     public static int calculateNumberOfBlocksUsed( long firstBlock )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
@@ -348,13 +348,13 @@ public class PropertyStore extends CommonAbstractStore<PropertyRecord,NoStoreHea
         return decodeString( source.other() );
     }
 
-    public Object getArrayFor( PropertyBlock propertyBlock )
+    public Value getArrayFor( PropertyBlock propertyBlock )
     {
         ensureHeavy( propertyBlock );
         return getArrayFor( propertyBlock.getValueRecords() );
     }
 
-    public Object getArrayFor( Iterable<DynamicRecord> records )
+    public Value getArrayFor( Iterable<DynamicRecord> records )
     {
         return getRightArray( arrayStore.readFullByteArray( records, PropertyType.ARRAY ) );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyType.java
@@ -168,7 +168,7 @@ public enum PropertyType
         @Override
         public Value value( PropertyBlock block, PropertyStore store )
         {
-            return Values.stringValue( LongerShortString.decode( block ) );
+            return LongerShortString.decode( block );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyType.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyType.java
@@ -140,7 +140,7 @@ public enum PropertyType
         @Override
         public Value value( PropertyBlock block, PropertyStore store )
         {
-            return Values.of( store.getArrayFor( block ) );
+            return store.getArrayFor( block );
         }
 
         @Override
@@ -182,7 +182,7 @@ public enum PropertyType
         @Override
         public Value value( PropertyBlock block, PropertyStore store )
         {
-            return Values.of( ShortArray.decode( block ) );
+            return ShortArray.decode( block );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/ShortArray.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/ShortArray.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.util.Bits;
+import org.neo4j.values.storable.ArrayValue;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
 
@@ -60,8 +61,7 @@ public enum ShortArray
         }
 
         @Override
-        public
-        Value createArray( int length, Bits bits, int requiredBits )
+        public ArrayValue createArray( int length, Bits bits, int requiredBits )
         {
             if ( length == 0 )
             {
@@ -76,7 +76,7 @@ public enum ShortArray
         }
 
         @Override
-        public Value createEmptyArray()
+        public ArrayValue createEmptyArray()
         {
             return Values.EMPTY_BOOLEAN_ARRAY;
         }
@@ -138,8 +138,7 @@ public enum ShortArray
         }
 
         @Override
-        public
-        Value createArray( int length, Bits bits, int requiredBits )
+        public ArrayValue createArray( int length, Bits bits, int requiredBits )
         {
             if ( length == 0 )
             {
@@ -154,7 +153,7 @@ public enum ShortArray
         }
 
         @Override
-        public Value createEmptyArray()
+        public ArrayValue createEmptyArray()
         {
             return Values.EMPTY_BYTE_ARRAY;
         }
@@ -217,8 +216,7 @@ public enum ShortArray
         }
 
         @Override
-        public
-        Value createArray( int length, Bits bits, int requiredBits )
+        public ArrayValue createArray( int length, Bits bits, int requiredBits )
         {
             if ( length == 0 )
             {
@@ -233,7 +231,7 @@ public enum ShortArray
         }
 
         @Override
-        public Value createEmptyArray()
+        public ArrayValue createEmptyArray()
         {
             return Values.EMPTY_SHORT_ARRAY;
         }
@@ -295,8 +293,7 @@ public enum ShortArray
         }
 
         @Override
-        public
-        Value createArray( int length, Bits bits, int requiredBits )
+        public ArrayValue createArray( int length, Bits bits, int requiredBits )
         {
             if ( length == 0 )
             {
@@ -311,7 +308,7 @@ public enum ShortArray
         }
 
         @Override
-        public Value createEmptyArray()
+        public ArrayValue createEmptyArray()
         {
             return Values.EMPTY_CHAR_ARRAY;
         }
@@ -373,8 +370,7 @@ public enum ShortArray
         }
 
         @Override
-        public
-        Value createArray( int length, Bits bits, int requiredBits )
+        public ArrayValue createArray( int length, Bits bits, int requiredBits )
         {
             if ( length == 0 )
             {
@@ -389,7 +385,7 @@ public enum ShortArray
         }
 
         @Override
-        public Value createEmptyArray()
+        public ArrayValue createEmptyArray()
         {
             return Values.EMPTY_INT_ARRAY;
         }
@@ -452,8 +448,7 @@ public enum ShortArray
         }
 
         @Override
-        public
-        Value createArray( int length, Bits bits, int requiredBits )
+        public ArrayValue createArray( int length, Bits bits, int requiredBits )
         {
             if ( length == 0 )
             {
@@ -468,7 +463,7 @@ public enum ShortArray
         }
 
         @Override
-        public Value createEmptyArray()
+        public ArrayValue createEmptyArray()
         {
             return Values.EMPTY_LONG_ARRAY;
         }
@@ -531,8 +526,7 @@ public enum ShortArray
         }
 
         @Override
-        public
-        Value createArray( int length, Bits bits, int requiredBits )
+        public ArrayValue createArray( int length, Bits bits, int requiredBits )
         {
             if ( length == 0 )
             {
@@ -547,7 +541,7 @@ public enum ShortArray
         }
 
         @Override
-        public Value createEmptyArray()
+        public ArrayValue createEmptyArray()
         {
             return Values.EMPTY_FLOAT_ARRAY;
         }
@@ -610,8 +604,7 @@ public enum ShortArray
         }
 
         @Override
-        public
-        Value createArray( int length, Bits bits, int requiredBits )
+        public ArrayValue createArray( int length, Bits bits, int requiredBits )
         {
             if ( length == 0 )
             {
@@ -626,7 +619,7 @@ public enum ShortArray
         }
 
         @Override
-        public Value createEmptyArray()
+        public ArrayValue createEmptyArray()
         {
             return Values.EMPTY_DOUBLE_ARRAY;
         }
@@ -668,7 +661,7 @@ public enum ShortArray
         return type.intValue();
     }
 
-    public abstract Value createArray( int length, Bits bits, int requiredBits );
+    public abstract ArrayValue createArray( int length, Bits bits, int requiredBits );
 
     public static boolean encode( int keyId, Object array,
                                   PropertyBlock target, int payloadSizeInBytes )
@@ -818,5 +811,5 @@ public enum ShortArray
 
     public abstract void writeAll( Object array, int length, int requiredBits, Bits result );
 
-    public abstract Value createEmptyArray();
+    public abstract ArrayValue createEmptyArray();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/ShortArray.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/ShortArray.java
@@ -26,6 +26,8 @@ import java.util.Map;
 
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.util.Bits;
+import org.neo4j.values.storable.Value;
+import org.neo4j.values.storable.Values;
 
 public enum ShortArray
 {
@@ -59,24 +61,24 @@ public enum ShortArray
 
         @Override
         public
-        Object createArray( int length, Bits bits, int requiredBits )
+        Value createArray( int length, Bits bits, int requiredBits )
         {
             if ( length == 0 )
             {
-                return EMPTY_BOOLEAN_ARRAY;
+                return Values.EMPTY_BOOLEAN_ARRAY;
             }
             final boolean[] result = new boolean[length];
             for ( int i = 0; i < length; i++ )
             {
                 result[i] = bits.getByte( requiredBits ) != 0;
             }
-            return result;
+            return Values.booleanArray( result );
         }
 
         @Override
-        public Object createEmptyArray()
+        public Value createEmptyArray()
         {
-            return EMPTY_BOOLEAN_ARRAY;
+            return Values.EMPTY_BOOLEAN_ARRAY;
         }
     },
     BYTE( PropertyType.BYTE, 8, Byte.class, byte.class )
@@ -137,24 +139,24 @@ public enum ShortArray
 
         @Override
         public
-        Object createArray( int length, Bits bits, int requiredBits )
+        Value createArray( int length, Bits bits, int requiredBits )
         {
             if ( length == 0 )
             {
-                return EMPTY_BYTE_ARRAY;
+                return Values.EMPTY_BYTE_ARRAY;
             }
             final byte[] result = new byte[length];
             for ( int i = 0; i < length; i++ )
             {
                 result[i] = bits.getByte( requiredBits );
             }
-            return result;
+            return Values.byteArray( result );
         }
 
         @Override
-        public Object createEmptyArray()
+        public Value createEmptyArray()
         {
-            return EMPTY_BYTE_ARRAY;
+            return Values.EMPTY_BYTE_ARRAY;
         }
 
     },
@@ -216,24 +218,24 @@ public enum ShortArray
 
         @Override
         public
-        Object createArray( int length, Bits bits, int requiredBits )
+        Value createArray( int length, Bits bits, int requiredBits )
         {
             if ( length == 0 )
             {
-                return EMPTY_SHORT_ARRAY;
+                return Values.EMPTY_SHORT_ARRAY;
             }
             final short[] result = new short[length];
             for ( int i = 0; i < length; i++ )
             {
                 result[i] = bits.getShort( requiredBits );
             }
-            return result;
+            return Values.shortArray( result );
         }
 
         @Override
-        public Object createEmptyArray()
+        public Value createEmptyArray()
         {
-            return EMPTY_SHORT_ARRAY;
+            return Values.EMPTY_SHORT_ARRAY;
         }
     },
     CHAR( PropertyType.CHAR, 16, Character.class, char.class )
@@ -294,24 +296,24 @@ public enum ShortArray
 
         @Override
         public
-        Object createArray( int length, Bits bits, int requiredBits )
+        Value createArray( int length, Bits bits, int requiredBits )
         {
             if ( length == 0 )
             {
-                return EMPTY_CHAR_ARRAY;
+                return Values.EMPTY_CHAR_ARRAY;
             }
             final char[] result = new char[length];
             for ( int i = 0; i < length; i++ )
             {
                 result[i] = (char) bits.getShort( requiredBits );
             }
-            return result;
+            return Values.charArray( result );
         }
 
         @Override
-        public Object createEmptyArray()
+        public Value createEmptyArray()
         {
-            return EMPTY_CHAR_ARRAY;
+            return Values.EMPTY_CHAR_ARRAY;
         }
     },
     INT( PropertyType.INT, 32, Integer.class, int.class )
@@ -372,24 +374,24 @@ public enum ShortArray
 
         @Override
         public
-        Object createArray( int length, Bits bits, int requiredBits )
+        Value createArray( int length, Bits bits, int requiredBits )
         {
             if ( length == 0 )
             {
-                return EMPTY_INT_ARRAY;
+                return Values.EMPTY_INT_ARRAY;
             }
             final int[] result = new int[length];
             for ( int i = 0; i < length; i++ )
             {
                 result[i] = bits.getInt( requiredBits );
             }
-            return result;
+            return Values.intArray( result );
         }
 
         @Override
-        public Object createEmptyArray()
+        public Value createEmptyArray()
         {
-            return EMPTY_INT_ARRAY;
+            return Values.EMPTY_INT_ARRAY;
         }
     },
     LONG( PropertyType.LONG, 64, Long.class, long.class )
@@ -451,24 +453,24 @@ public enum ShortArray
 
         @Override
         public
-        Object createArray( int length, Bits bits, int requiredBits )
+        Value createArray( int length, Bits bits, int requiredBits )
         {
             if ( length == 0 )
             {
-                return EMPTY_LONG_ARRAY;
+                return Values.EMPTY_LONG_ARRAY;
             }
             final long[] result = new long[length];
             for ( int i = 0; i < length; i++ )
             {
                 result[i] = bits.getLong( requiredBits );
             }
-            return result;
+            return Values.longArray( result );
         }
 
         @Override
-        public Object createEmptyArray()
+        public Value createEmptyArray()
         {
-            return EMPTY_LONG_ARRAY;
+            return Values.EMPTY_LONG_ARRAY;
         }
     },
     FLOAT( PropertyType.FLOAT, 32, Float.class, float.class )
@@ -530,24 +532,24 @@ public enum ShortArray
 
         @Override
         public
-        Object createArray( int length, Bits bits, int requiredBits )
+        Value createArray( int length, Bits bits, int requiredBits )
         {
             if ( length == 0 )
             {
-                return EMPTY_FLOAT_ARRAY;
+                return Values.EMPTY_FLOAT_ARRAY;
             }
             final float[] result = new float[length];
             for ( int i = 0; i < length; i++ )
             {
                 result[i] = Float.intBitsToFloat( bits.getInt( requiredBits ) );
             }
-            return result;
+            return Values.floatArray( result );
         }
 
         @Override
-        public Object createEmptyArray()
+        public Value createEmptyArray()
         {
-            return EMPTY_FLOAT_ARRAY;
+            return Values.EMPTY_FLOAT_ARRAY;
         }
     },
     DOUBLE( PropertyType.DOUBLE, 64, Double.class, double.class )
@@ -609,34 +611,26 @@ public enum ShortArray
 
         @Override
         public
-        Object createArray( int length, Bits bits, int requiredBits )
+        Value createArray( int length, Bits bits, int requiredBits )
         {
             if ( length == 0 )
             {
-                return EMPTY_DOUBLE_ARRAY;
+                return Values.EMPTY_DOUBLE_ARRAY;
             }
             final double[] result = new double[length];
             for ( int i = 0; i < length; i++ )
             {
                 result[i] = Double.longBitsToDouble( bits.getLong( requiredBits ) );
             }
-            return result;
+            return Values.doubleArray( result );
         }
 
         @Override
-        public Object createEmptyArray()
+        public Value createEmptyArray()
         {
-            return EMPTY_DOUBLE_ARRAY;
+            return Values.EMPTY_DOUBLE_ARRAY;
         }
     };
-    public static final boolean[] EMPTY_BOOLEAN_ARRAY = new boolean[0];
-    public static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
-    public static final short[] EMPTY_SHORT_ARRAY = new short[0];
-    public static final char[] EMPTY_CHAR_ARRAY = new char[0];
-    public static final int[] EMPTY_INT_ARRAY = new int[0];
-    public static final long[] EMPTY_LONG_ARRAY = new long[0];
-    public static final float[] EMPTY_FLOAT_ARRAY = new float[0];
-    public static final double[] EMPTY_DOUBLE_ARRAY = new double[0];
 
     private static boolean isPrimitive( Object array )
     {
@@ -674,7 +668,7 @@ public enum ShortArray
         return type.intValue();
     }
 
-    public abstract Object createArray( int length, Bits bits, int requiredBits );
+    public abstract Value createArray( int length, Bits bits, int requiredBits );
 
     public static boolean encode( int keyId, Object array,
                                   PropertyBlock target, int payloadSizeInBytes )
@@ -723,13 +717,13 @@ public enum ShortArray
         result.put( requiredBits, 6 );
     }
 
-    public static Object decode( PropertyBlock block )
+    public static Value decode( PropertyBlock block )
     {
         Bits bits = Bits.bitsFromLongs( Arrays.copyOf( block.getValueBlocks(), block.getValueBlocks().length) );
         return decode( bits );
     }
 
-    public static Object decode( Bits bits )
+    public static Value decode( Bits bits )
     {
         // [][][    ,bbbb][bbll,llll][yyyy,tttt][kkkk,kkkk][kkkk,kkkk][kkkk,kkkk]
         bits.getInt( 24 ); // Get rid of key
@@ -824,8 +818,8 @@ public enum ShortArray
 
     public abstract void writeAll( Object array, int length, int requiredBits, Bits result );
 
-    public Object createEmptyArray()
+    public Value createEmptyArray()
     {
-        return Array.newInstance( primitiveClass, 0 );
+        return Values.of(Array.newInstance( primitiveClass, 0 ));
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/ShortArray.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/ShortArray.java
@@ -818,8 +818,5 @@ public enum ShortArray
 
     public abstract void writeAll( Object array, int length, int requiredBits, Bits result );
 
-    public Value createEmptyArray()
-    {
-        return Values.of(Array.newInstance( primitiveClass, 0 ));
-    }
+    public abstract Value createEmptyArray();
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursorTest.java
@@ -47,6 +47,7 @@ import org.neo4j.values.storable.Values;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -57,7 +58,6 @@ import static org.mockito.Mockito.when;
 import static org.neo4j.kernel.impl.api.store.StorePropertyPayloadCursorTest.Param.param;
 import static org.neo4j.kernel.impl.api.store.StorePropertyPayloadCursorTest.Param.paramArg;
 import static org.neo4j.kernel.impl.api.store.StorePropertyPayloadCursorTest.Params.params;
-import static org.neo4j.test.assertion.Assert.assertObjectOrArrayEquals;
 
 @RunWith( Enclosed.class )
 public class StorePropertyPayloadCursorTest
@@ -176,6 +176,7 @@ public class StorePropertyPayloadCursorTest
             // When
             assertTrue( cursor.next() );
             assertNotNull( cursor.stringValue() );
+            assertNotEquals( Values.NO_VALUE, cursor.stringValue() );
 
             assertTrue( cursor.next() );
             assertNotNull( cursor.arrayValue() );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestLongerShortString.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestLongerShortString.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
+import org.neo4j.values.storable.Values;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -78,7 +79,7 @@ public class TestLongerShortString
                     PropertyBlock record = new PropertyBlock();
                     if ( LongerShortString.encode( 10, string, record, DEFAULT_PAYLOAD_SIZE ) )
                     {
-                        assertEquals( string, LongerShortString.decode( record ) );
+                        assertEquals( Values.stringValue( string ), LongerShortString.decode( record ) );
                     }
                 }
             }
@@ -104,20 +105,22 @@ public class TestLongerShortString
     public void canEncodeLowerHex() throws Exception
     {
         assertCanEncodeAndDecodeToSame( "da39a3ee5e6b4b0d3255bfef95601890afd80709" ); // sha1hex('') len=40
-        assertCanEncodeAndDecodeToSame( "0123456789" + "abcdefabcd" + "0a0b0c0d0e" + "1a1b1c1d1e" + "f9e8d7c6b5" + "a4f3" ); // len=54
+        assertCanEncodeAndDecodeToSame(
+                "0123456789" + "abcdefabcd" + "0a0b0c0d0e" + "1a1b1c1d1e" + "f9e8d7c6b5" + "a4f3" ); // len=54
         assertCannotEncode( "da39a3ee5e6b4b0d3255bfef95601890afd80709" + "0123456789" + "abcde" ); // len=55
         // test not failing on long illegal hex
-        assertCannotEncode( "aaaaaaaaaa" + "bbbbbbbbbb" + "cccccccccc" + "dddddddddd" + "eeeeeeeeee" + "x");
+        assertCannotEncode( "aaaaaaaaaa" + "bbbbbbbbbb" + "cccccccccc" + "dddddddddd" + "eeeeeeeeee" + "x" );
     }
 
     @Test
     public void canEncodeUpperHex() throws Exception
     {
         assertCanEncodeAndDecodeToSame( "DA39A3EE5E6B4B0D3255BFEF95601890AFD80709" ); // sha1HEX('') len=40
-        assertCanEncodeAndDecodeToSame( "0123456789" + "ABCDEFABCD" + "0A0B0C0D0E" + "1A1B1C1D1E" + "F9E8D7C6B5" + "A4F3" ); // len=54
+        assertCanEncodeAndDecodeToSame(
+                "0123456789" + "ABCDEFABCD" + "0A0B0C0D0E" + "1A1B1C1D1E" + "F9E8D7C6B5" + "A4F3" ); // len=54
         assertCannotEncode( "DA39A3EE5E6B4B0D3255BFEF95601890AFD80709" + "0123456789" + "ABCDE" ); // len=55
         // test not failing on long illegal HEX
-        assertCannotEncode( "AAAAAAAAAA" + "BBBBBBBBBB" + "CCCCCCCCCC" + "DDDDDDDDDD" + "EEEEEEEEEE" + "X");
+        assertCannotEncode( "AAAAAAAAAA" + "BBBBBBBBBB" + "CCCCCCCCCC" + "DDDDDDDDDD" + "EEEEEEEEEE" + "X" );
     }
 
     @Test
@@ -152,7 +155,7 @@ public class TestLongerShortString
     {
         PropertyBlock target = new PropertyBlock();
         assertTrue( LongerShortString.encode( 0, string, target, payloadSize ) );
-        assertEquals( string, LongerShortString.decode( target ) );
+        assertEquals( Values.stringValue( string ), LongerShortString.decode( target ) );
     }
 
     private void assertCannotEncode( String string )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestShortArray.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestShortArray.java
@@ -21,9 +21,8 @@ package org.neo4j.kernel.impl.store;
 
 import org.junit.Test;
 
-import java.lang.reflect.Array;
-
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
+import org.neo4j.values.AnyValues;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -36,28 +35,28 @@ public class TestShortArray
     @Test
     public void canEncodeSomeSampleArraysWithDefaultPayloadSize() throws Exception
     {
-        assertCanEncodeAndDecodeToSameValue( new boolean[] { true, false, true,
-                true, true, true, true, true, true, true, false, true } );
-        assertCanEncodeAndDecodeToSameValue( new byte[] { -1, -10, 43, 127, 0, 4, 2, 3, 56, 47, 67, 43 } );
-        assertCanEncodeAndDecodeToSameValue( new short[] { 1,2,3,45,5,6,7 } );
-        assertCanEncodeAndDecodeToSameValue( new int[] { 1,2,3,4,5,6,7 } );
-        assertCanEncodeAndDecodeToSameValue( new long[] { 1,2,3,4,5,6,7 } );
-        assertCanEncodeAndDecodeToSameValue( new float[] { 0.34f, 0.21f } );
-        assertCanEncodeAndDecodeToSameValue( new long[] { 1 << 63, 1 << 63 } );
-        assertCanEncodeAndDecodeToSameValue( new long[] { 1 << 63, 1 << 63,
-                1 << 63 } );
-        assertCanEncodeAndDecodeToSameValue( new byte[] { 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0 } );
-        assertCanEncodeAndDecodeToSameValue( new long[] { 0, 0, 0, 0, 0, 0, 0,
+        assertCanEncodeAndDecodeToSameValue( new boolean[]{true, false, true,
+                true, true, true, true, true, true, true, false, true} );
+        assertCanEncodeAndDecodeToSameValue( new byte[]{-1, -10, 43, 127, 0, 4, 2, 3, 56, 47, 67, 43} );
+        assertCanEncodeAndDecodeToSameValue( new short[]{1, 2, 3, 45, 5, 6, 7} );
+        assertCanEncodeAndDecodeToSameValue( new int[]{1, 2, 3, 4, 5, 6, 7} );
+        assertCanEncodeAndDecodeToSameValue( new long[]{1, 2, 3, 4, 5, 6, 7} );
+        assertCanEncodeAndDecodeToSameValue( new float[]{0.34f, 0.21f} );
+        assertCanEncodeAndDecodeToSameValue( new long[]{1 << 63, 1 << 63} );
+        assertCanEncodeAndDecodeToSameValue( new long[]{1 << 63, 1 << 63,
+                1 << 63} );
+        assertCanEncodeAndDecodeToSameValue( new byte[]{0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0} );
+        assertCanEncodeAndDecodeToSameValue( new long[]{0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0 } );
+                0, 0, 0} );
     }
 
     @Test
     public void testCannotEncodeMarginal() throws Exception
     {
-        assertCanNotEncode( new long[] { 1L << 15, 1, 1, 1, 1, 1, 1, 1, 1,
-                1, 1, 1, 1, 1 } );
+        assertCanNotEncode( new long[]{1L << 15, 1, 1, 1, 1, 1, 1, 1, 1,
+                1, 1, 1, 1, 1} );
     }
 
     @Test
@@ -98,21 +97,6 @@ public class TestShortArray
         PropertyBlock target = new PropertyBlock();
         boolean encoded = ShortArray.encode( 0, value, target, payloadSize );
         assertTrue( encoded );
-        assertArraysEquals( value, ShortArray.decode( target ) );
-    }
-
-    private void assertArraysEquals( Object value1, Object value2 )
-    {
-        assertEquals( value1.getClass().getComponentType(), value2.getClass().getComponentType() );
-        int length1 = Array.getLength( value1 );
-        int length2 = Array.getLength( value2 );
-        assertEquals( length1, length2 );
-
-        for ( int i = 0; i < length1; i++ )
-        {
-            Object item1 = Array.get( value1, i );
-            Object item2 = Array.get( value2, i );
-            assertEquals( item1, item2 );
-        }
+        assertEquals( AnyValues.of( value ), ShortArray.decode( target ) );
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/BaseToObjectValueWriter.java
+++ b/community/values/src/main/java/org/neo4j/values/BaseToObjectValueWriter.java
@@ -34,6 +34,7 @@ import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.spatial.Point;
 import org.neo4j.helpers.collection.ReverseArrayIterator;
+import org.neo4j.string.UTF8;
 import org.neo4j.values.storable.TextArray;
 import org.neo4j.values.storable.TextValue;
 import org.neo4j.values.virtual.CoordinateReferenceSystem;
@@ -45,10 +46,11 @@ import static org.neo4j.helpers.collection.Iterators.iteratorsEqual;
 
 /**
  * Base class for converting AnyValue to normal java objects.
- *
+ * <p>
  * This base class takes care of converting all "normal" java types such as
  * number types, booleans, strings, arrays and lists. It leaves to the extending
  * class to handle neo4j specific types such as nodes, edges and points.
+ *
  * @param <E>
  */
 public abstract class BaseToObjectValueWriter<E extends Exception> implements AnyValueWriter<E>
@@ -64,7 +66,8 @@ public abstract class BaseToObjectValueWriter<E extends Exception> implements An
 
     protected abstract Relationship newRelationshipProxyById( long id );
 
-    protected abstract Point newGeographicPoint( double longitude, double latitude, String name, int code, String href );
+    protected abstract Point newGeographicPoint( double longitude, double latitude, String name, int code,
+            String href );
 
     protected abstract Point newCartesianPoint( double x, double y, String name, int code, String href );
 
@@ -349,21 +352,9 @@ public abstract class BaseToObjectValueWriter<E extends Exception> implements An
     }
 
     @Override
-    public void beginUTF8( int size ) throws RuntimeException
+    public void writeUTF8( byte[] bytes, int offset, int length ) throws E
     {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void copyUTF8( long fromAddress, int length ) throws RuntimeException
-    {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void endUTF8() throws RuntimeException
-    {
-        throw new UnsupportedOperationException();
+        writeValue( UTF8.decode( bytes, offset, length ) );
     }
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
@@ -171,3 +171,4 @@ public abstract class StringValue extends TextValue
         }
     }
 }
+

--- a/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.values.storable;
 
+import java.nio.charset.StandardCharsets;
+
 import static java.lang.String.format;
 
 public abstract class StringValue extends TextValue
@@ -111,6 +113,61 @@ public abstract class StringValue extends TextValue
         public int length()
         {
             return value.length();
+        }
+    }
+
+    /*
+     * Just as a normal StringValue but is backed by a byte array and does string
+     * serialization lazily.
+      *
+      * TODO in this implementation most operation will actually load the string
+      * such as hashCode, length, equals etc. These could be implemented using
+      * the byte array directly
+     */
+    static final class UTF8StringValue extends StringValue
+    {
+        private volatile String value;
+        private final byte[] bytes;
+        private final int offset;
+        private final int length;
+
+        UTF8StringValue( byte[] bytes, int offset, int length )
+        {
+            assert bytes != null;
+            this.bytes = bytes;
+            this.offset = offset;
+            this.length = length;
+        }
+
+        @Override
+        public <E extends Exception> void writeTo( ValueWriter<E> writer ) throws E
+        {
+            writer.writeUTF8( bytes, offset, length );
+        }
+
+        @Override
+        String value()
+        {
+            String s = value;
+            if ( s == null )
+            {
+                synchronized ( this )
+                {
+                    s = value;
+                    if ( s == null )
+                    {
+                        s = value = new String( bytes, offset, length, StandardCharsets.UTF_8 );
+
+                    }
+                }
+            }
+            return s;
+        }
+
+        @Override
+        public int length()
+        {
+            return value().length();
         }
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/ValueWriter.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ValueWriter.java
@@ -28,6 +28,7 @@ package org.neo4j.values.storable;
  */
 public interface ValueWriter<E extends Exception>
 {
+
     enum ArrayType
     {
         BYTE,
@@ -61,18 +62,14 @@ public interface ValueWriter<E extends Exception>
 
     void writeString( char value ) throws E;
 
+    void writeUTF8( byte[] bytes, int offset, int length ) throws E;
+
     default void writeString( char[] value ) throws E
     {
         writeString( value, 0, value.length );
     }
 
     void writeString( char[] value, int offset, int length ) throws E;
-
-    void beginUTF8( int size ) throws E;
-
-    void copyUTF8( long fromAddress, int length ) throws E;
-
-    void endUTF8() throws E;
 
     void beginArray( int size, ArrayType arrayType ) throws E;
 
@@ -133,22 +130,12 @@ public interface ValueWriter<E extends Exception>
         }
 
         @Override
+        public void writeUTF8( byte[] bytes, int offset, int length ) throws E
+        { //no-op
+        }
+
+        @Override
         public void writeString( char[] value, int offset, int length ) throws E
-        {   // no-op
-        }
-
-        @Override
-        public void beginUTF8( int size ) throws E
-        {   // no-op
-        }
-
-        @Override
-        public void copyUTF8( long fromAddress, int length ) throws E
-        {   // no-op
-        }
-
-        @Override
-        public void endUTF8() throws E
         {   // no-op
         }
 

--- a/community/values/src/main/java/org/neo4j/values/storable/Values.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Values.java
@@ -107,7 +107,12 @@ public final class Values
 
     public static final Value NO_VALUE = NoValue.NO_VALUE;
 
-    public static final TextValue utf8Value(byte[] bytes, int offset, int length)
+    public static TextValue utf8Value( byte[] bytes )
+    {
+        return utf8Value( bytes, 0, bytes.length );
+    }
+
+    public static TextValue utf8Value( byte[] bytes, int offset, int length )
     {
         return new StringValue.UTF8StringValue( bytes, offset, length );
     }
@@ -203,7 +208,7 @@ public final class Values
         return new FloatValue( value );
     }
 
-    public static TextArray stringArray( String...value )
+    public static TextArray stringArray( String... value )
     {
         return new StringArray.Direct( value );
     }

--- a/community/values/src/main/java/org/neo4j/values/storable/Values.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Values.java
@@ -51,6 +51,14 @@ public final class Values
     public static final TextValue EMPTY_STRING = Values.stringValue( "" );
     public static final DoubleValue E = Values.doubleValue( Math.E );
     public static final DoubleValue PI = Values.doubleValue( Math.PI );
+    public static final Value EMPTY_SHORT_ARRAY = Values.shortArray( new short[0] );
+    public static final Value EMPTY_BOOLEAN_ARRAY = Values.booleanArray( new boolean[0] );
+    public static final Value EMPTY_BYTE_ARRAY = Values.byteArray( new byte[0] );
+    public static final Value EMPTY_CHAR_ARRAY = Values.charArray( new char[0] );
+    public static final Value EMPTY_INT_ARRAY = Values.intArray( new int[0] );
+    public static final Value EMPTY_LONG_ARRAY = Values.longArray( new long[0] );
+    public static final Value EMPTY_FLOAT_ARRAY = Values.floatArray( new float[0] );
+    public static final Value EMPTY_DOUBLE_ARRAY = Values.doubleArray( new double[0] );
 
     private Values()
     {

--- a/community/values/src/main/java/org/neo4j/values/storable/Values.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Values.java
@@ -107,6 +107,11 @@ public final class Values
 
     public static final Value NO_VALUE = NoValue.NO_VALUE;
 
+    public static final TextValue utf8Value(byte[] bytes, int offset, int length)
+    {
+        return new StringValue.UTF8StringValue( bytes, offset, length );
+    }
+
     public static TextValue stringValue( String value )
     {
         return new StringValue.Direct( value );

--- a/community/values/src/main/java/org/neo4j/values/storable/Values.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Values.java
@@ -51,14 +51,14 @@ public final class Values
     public static final TextValue EMPTY_STRING = Values.stringValue( "" );
     public static final DoubleValue E = Values.doubleValue( Math.E );
     public static final DoubleValue PI = Values.doubleValue( Math.PI );
-    public static final Value EMPTY_SHORT_ARRAY = Values.shortArray( new short[0] );
-    public static final Value EMPTY_BOOLEAN_ARRAY = Values.booleanArray( new boolean[0] );
-    public static final Value EMPTY_BYTE_ARRAY = Values.byteArray( new byte[0] );
-    public static final Value EMPTY_CHAR_ARRAY = Values.charArray( new char[0] );
-    public static final Value EMPTY_INT_ARRAY = Values.intArray( new int[0] );
-    public static final Value EMPTY_LONG_ARRAY = Values.longArray( new long[0] );
-    public static final Value EMPTY_FLOAT_ARRAY = Values.floatArray( new float[0] );
-    public static final Value EMPTY_DOUBLE_ARRAY = Values.doubleArray( new double[0] );
+    public static final ArrayValue EMPTY_SHORT_ARRAY = Values.shortArray( new short[0] );
+    public static final ArrayValue EMPTY_BOOLEAN_ARRAY = Values.booleanArray( new boolean[0] );
+    public static final ArrayValue EMPTY_BYTE_ARRAY = Values.byteArray( new byte[0] );
+    public static final ArrayValue EMPTY_CHAR_ARRAY = Values.charArray( new char[0] );
+    public static final ArrayValue EMPTY_INT_ARRAY = Values.intArray( new int[0] );
+    public static final ArrayValue EMPTY_LONG_ARRAY = Values.longArray( new long[0] );
+    public static final ArrayValue EMPTY_FLOAT_ARRAY = Values.floatArray( new float[0] );
+    public static final ArrayValue EMPTY_DOUBLE_ARRAY = Values.doubleArray( new double[0] );
 
     private Values()
     {

--- a/community/values/src/test/java/org/neo4j/values/storable/BufferValueWriter.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/BufferValueWriter.java
@@ -25,13 +25,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.neo4j.string.UTF8;
+
 import static java.lang.String.format;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.neo4j.values.storable.BufferValueWriter.SpecialKind.BeginArray;
-import static org.neo4j.values.storable.BufferValueWriter.SpecialKind.BeginUTF8;
-import static org.neo4j.values.storable.BufferValueWriter.SpecialKind.CopyUTF8;
 import static org.neo4j.values.storable.BufferValueWriter.SpecialKind.EndArray;
-import static org.neo4j.values.storable.BufferValueWriter.SpecialKind.EndUTF8;
 import static org.neo4j.values.storable.BufferValueWriter.SpecialKind.WriteByteArray;
 import static org.neo4j.values.storable.BufferValueWriter.SpecialKind.WriteCharArray;
 
@@ -41,9 +40,6 @@ public class BufferValueWriter implements ValueWriter<RuntimeException>
     {
         WriteCharArray,
         WriteByteArray,
-        BeginUTF8,
-        CopyUTF8,
-        EndUTF8,
         BeginArray,
         EndArray,
     }
@@ -159,27 +155,15 @@ public class BufferValueWriter implements ValueWriter<RuntimeException>
     }
 
     @Override
+    public void writeUTF8( byte[] bytes, int offset, int length ) throws RuntimeException
+    {
+        buffer.add( UTF8.decode( bytes, offset, length ) );
+    }
+
+    @Override
     public void writeString( char[] value, int offset, int length )
     {
         buffer.add( Specials.charArray( value, offset, length ) );
-    }
-
-    @Override
-    public void beginUTF8( int size )
-    {
-        buffer.add( Specials.beginUTF8( size ) );
-    }
-
-    @Override
-    public void copyUTF8( long fromAddress, int length )
-    {
-        buffer.add( Specials.copyUTF8( fromAddress, length ) );
-    }
-
-    @Override
-    public void endUTF8()
-    {
-        buffer.add( Specials.endUTF8() );
     }
 
     @Override
@@ -210,22 +194,7 @@ public class BufferValueWriter implements ValueWriter<RuntimeException>
 
         public static Special byteArray( byte[] value )
         {
-            return new Special( WriteByteArray,  Arrays.hashCode( value ) );
-        }
-
-        public static Special beginUTF8( int size )
-        {
-            return new Special( BeginUTF8, size );
-        }
-
-        public static Special copyUTF8( long fromAddress, int length )
-        {
-            return new Special( CopyUTF8, format( "%d %d", fromAddress, length ) );
-        }
-
-        public static Special endUTF8()
-        {
-            return new Special( EndUTF8, 0 );
+            return new Special( WriteByteArray, Arrays.hashCode( value ) );
         }
 
         public static Special beginArray( int size, ArrayType arrayType )

--- a/community/values/src/test/java/org/neo4j/values/storable/ThrowingValueWriterTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/ThrowingValueWriterTest.java
@@ -110,25 +110,13 @@ public class ThrowingValueWriterTest
         }
 
         @Override
+        public void writeUTF8( byte[] bytes, int offset, int length ) throws TestException
+        {
+            throw new TestException();
+        }
+
+        @Override
         public void writeString( char[] value, int offset, int length ) throws TestException
-        {
-            throw new TestException();
-        }
-
-        @Override
-        public void beginUTF8( int size ) throws TestException
-        {
-            throw new TestException();
-        }
-
-        @Override
-        public void copyUTF8( long fromAddress, int length ) throws TestException
-        {
-            throw new TestException();
-        }
-
-        @Override
-        public void endUTF8() throws TestException
         {
             throw new TestException();
         }

--- a/community/values/src/test/java/org/neo4j/values/storable/UTF8StringValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/UTF8StringValueTest.java
@@ -1,0 +1,48 @@
+package org.neo4j.values.storable;
+
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.neo4j.values.storable.Values.stringValue;
+import static org.neo4j.values.storable.Values.utf8Value;
+
+public class UTF8StringValueTest
+{
+    private String[] strings = {"", "1337", " ", "普通话/普通話", "\uD83D\uDE21"};
+
+    @Test
+    public void shouldHandleDifferentTypesOfStrings()
+    {
+        for ( String string : strings )
+        {
+            TextValue stringValue = stringValue( string );
+            byte[] bytes = string.getBytes( StandardCharsets.UTF_8 );
+            TextValue utf8 = utf8Value( bytes, 0, bytes.length );
+            assertSame( stringValue, utf8 );
+        }
+    }
+
+    @Test
+    public void shouldHandleOffset()
+    {
+        // Given
+        byte[] bytes = "abcdefg".getBytes( StandardCharsets.UTF_8 );
+
+        // When
+        TextValue textValue = utf8Value( bytes, 3, 2 );
+
+        // Then
+        assertSame( textValue, stringValue( "de" ) );
+    }
+
+    private void assertSame( TextValue lhs, TextValue rhs )
+    {
+        assertThat( lhs.length(), equalTo( rhs.length() ) );
+        assertThat( lhs, equalTo( rhs ) );
+        assertThat( rhs, equalTo( lhs ) );
+        assertThat( lhs.hashCode(), equalTo( rhs.hashCode() ) );
+    }
+}

--- a/community/values/src/test/java/org/neo4j/values/storable/UTF8StringValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/UTF8StringValueTest.java
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.neo4j.values.storable;
 
 import org.junit.Test;
@@ -20,7 +39,7 @@ public class UTF8StringValueTest
         {
             TextValue stringValue = stringValue( string );
             byte[] bytes = string.getBytes( StandardCharsets.UTF_8 );
-            TextValue utf8 = utf8Value( bytes, 0, bytes.length );
+            TextValue utf8 = utf8Value( bytes );
             assertSame( stringValue, utf8 );
         }
     }


### PR DESCRIPTION
- Remove `Values.of` instead create with the correct type
- Create `UTF8StringValue` that doesn't need to create a string instance when serializing
- Use `UTF8StringValue` whenever possible