### PR TITLE
Server tests using CommunityBootStrapper sets its own home directory

### DIFF
--- a/community/server/src/test/java/org/neo4j/server/ServerBootstrapperTest.java
+++ b/community/server/src/test/java/org/neo4j/server/ServerBootstrapperTest.java
@@ -27,23 +27,31 @@ import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
+
 import javax.annotation.Nonnull;
 
+import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.GraphDatabaseDependencies;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.ConfigurationValidator;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.test.rule.SuppressOutput;
+import org.neo4j.test.rule.TestDirectory;
 
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 
+import static org.neo4j.dbms.DatabaseManagementSystemSettings.database_path;
+
 public class ServerBootstrapperTest
 {
     @Rule
     public final SuppressOutput suppress = SuppressOutput.suppress( SuppressOutput.System.out );
+
+    @Rule
+    public TestDirectory homeDir = TestDirectory.testDirectory();
 
     @Test
     public void shouldNotThrowNullPointerExceptionIfConfigurationValidationFails() throws Exception
@@ -70,7 +78,8 @@ public class ServerBootstrapperTest
         dir.deleteOnExit();
 
         // when
-        serverBootstrapper.start( dir, Optional.empty(), Collections.emptyMap() );
+        serverBootstrapper.start( dir, Optional.empty(), MapUtil.stringMap(
+                database_path.name(), homeDir.absolutePath().getAbsolutePath() ) );
 
         // then no exceptions are thrown and
         assertThat( suppress.getOutputVoice().lines(), not( empty() ) );

--- a/community/server/src/test/java/org/neo4j/server/integration/StartupLoggingIT.java
+++ b/community/server/src/test/java/org/neo4j/server/integration/StartupLoggingIT.java
@@ -46,8 +46,10 @@ import org.neo4j.test.rule.SuppressOutput;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.server.ExclusiveServerTestBase;
 
-import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
+
+import static java.util.Arrays.asList;
+
 import static org.neo4j.bolt.v1.transport.integration.Neo4jWithSocket.DEFAULT_CONNECTOR_KEY;
 import static org.neo4j.server.AbstractNeoServer.NEO4J_IS_STARTING_MESSAGE;
 
@@ -108,6 +110,8 @@ public class StartupLoggingIT extends ExclusiveServerTestBase
         relativeProperties.put( bolt.enabled.name(), "true" );
         relativeProperties.put( bolt.advertised_address.name(), "localhost:0" );
 
+        relativeProperties.put( DatabaseManagementSystemSettings.database_path.name(),
+                homeDir.absolutePath().getAbsolutePath() );
         return relativeProperties;
     }
 


### PR DESCRIPTION
Otherwise they would fail if they happened to be run in parallel