### PR TITLE
Fixed error in unwind with projection in slotted runtime

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-interpreted-enterprise.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-interpreted-enterprise.txt
@@ -1,5 +1,3 @@
-Case should handle mixed number types
-Case should handle mixed types
 Returning a CASE expression into pattern expression
 Returning a CASE expression into integer
 Returning a CASE expression with label predicates

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -705,6 +705,40 @@ return p""")
     res.toList should equal(List(Map("n1.prop" -> 1, "n2.prop" -> 2)))
   }
 
+  test("should handle unwind with filtering projections") {
+    // Given
+    val query =
+      """
+        |WITH ['John', 'Mark', 'Jonathan', 'Bill'] AS somenames
+        |         UNWIND somenames AS candidate
+        |         WITH candidate
+        |         WHERE candidate STARTS WITH 'Jo'
+        |         RETURN candidate
+      """.stripMargin
+
+    val res = succeedWith(Configs.All - Configs.Compiled, query)
+
+    //Then
+    res.toList should equal(List(Map("candidate" -> "John"), Map("candidate" -> "Jonathan")))
+  }
+
+  test("should handle unwind with filtering projections with renames") {
+    // Given
+    val query =
+      """
+        |WITH ['John', 'Mark', 'Jonathan', 'Bill'] AS somenames
+        |         UNWIND somenames AS names
+        |         WITH names AS candidate
+        |         WHERE candidate STARTS WITH 'Jo'
+        |         RETURN candidate
+      """.stripMargin
+
+    val res = succeedWith(Configs.AllExceptSleipnir - Configs.Compiled, query)
+
+    //Then
+    res.toList should equal(List(Map("candidate" -> "John"), Map("candidate" -> "Jonathan")))
+  }
+
   test("should handle distinct, variable length and relationship predicate") {
     // Given
     val node1 = createNode()

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/RegisteredRewriter.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/RegisteredRewriter.scala
@@ -157,12 +157,16 @@ class RegisteredRewriter(tokenContext: TokenContext) {
         }
 
       case Variable(k) =>
-        pipelineInformation(k) match {
-          case LongSlot(offset, false, CTNode, name) => NodeFromRegister(offset, name)
-          case LongSlot(offset, true, CTNode, name) => NullCheck(offset, NodeFromRegister(offset, name))
-          case LongSlot(offset, false, CTRelationship, name) => RelationshipFromRegister(offset, name)
-          case LongSlot(offset, true, CTRelationship, name) => NullCheck(offset, RelationshipFromRegister(offset, name))
-          case RefSlot(offset, _, _, _) => ReferenceFromRegister(offset)
+        pipelineInformation.get(k) match {
+          case Some(slot) => slot match {
+            case LongSlot(offset, false, CTNode, name) => NodeFromRegister(offset, name)
+            case LongSlot(offset, true, CTNode, name) => NullCheck(offset, NodeFromRegister(offset, name))
+            case LongSlot(offset, false, CTRelationship, name) => RelationshipFromRegister(offset, name)
+            case LongSlot(offset, true, CTRelationship, name) => NullCheck(offset, RelationshipFromRegister(offset, name))
+            case RefSlot(offset, _, _, _) => ReferenceFromRegister(offset)
+            case _ =>
+              throw new CantCompileQueryException("Unknown type for `" + k + "` in the pipeline information")
+          }
           case _ =>
             throw new CantCompileQueryException("Did not find `" + k + "` in the pipeline information")
         }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/interpreted/expressions/EnterpriseExpressionConverters.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/interpreted/expressions/EnterpriseExpressionConverters.scala
@@ -30,6 +30,8 @@ object EnterpriseExpressionConverters extends ExpressionConverter {
     expression match {
       case runtimeAst.NodeFromRegister(offset, _) =>
         Some(runtimeExpression.NodeFromRegister(offset))
+      case runtimeAst.ReferenceFromRegister(offset) =>
+        Some(runtimeExpression.ReferenceFromRegister(offset))
       case runtimeAst.NodeProperty(offset, token, _) =>
         Some(runtimeExpression.NodeProperty(offset, token))
       case runtimeAst.RelationshipProperty(offset, token, _) =>


### PR DESCRIPTION
The UNWIND support is incomplete and does not work for actual queries. There are several missing pieces and this PR fixes two:
- The existance of a renaming projection will cause an uncaught exception in planning, breaking fallback to interpreted (and therefor also breaking downstream builds like docs)
- No support for ReferenceFromRegister in expression converters, fixing this gets very simple unwind queries to work with slotted runtime

More work is required to get unwind to work with more complex cases, but this PR is important to get downstream builds to pass.