### PR TITLE
Replace Edge with Relationship in new Kernel API

### DIFF
--- a/community/kernel-api/README.adoc
+++ b/community/kernel-api/README.adoc
@@ -3,15 +3,15 @@ These are Tobias's API proposals for how the Cypher Runtime should interact with
 * link:src/main/java/org/neo4j/impl/kernel/api/Read.java[Read Operations] is where the focus of this proposal lies.
 * link:src/main/java/org/neo4j/impl/kernel/api/Write.java[Write Operations] are mentioned, but only as an incomplete thought experiment on how they fit in.
   In particular it is interesting to consider how and when writes become visible to reads (within the same transaction).
-* link:src/main/java/org/neo4j/impl/kernel/api/NodeCursor.java[NodeCursor], link:src/main/java/org/neo4j/impl/kernel/api/EdgeScanCursor.java[EdgeScanCursor] and link:src/main/java/org/neo4j/impl/kernel/api/EdgeTraversalCursor.java[EdgeTraversalCursor] are the main entry points for accessing nodes and relationships respectively.
+* link:src/main/java/org/neo4j/impl/kernel/api/NodeCursor.java[NodeCursor], link:src/main/java/org/neo4j/impl/kernel/api/RelationshipScanCursor.java[RelationshipScanCursor] and link:src/main/java/org/neo4j/impl/kernel/api/RelationshipTraversalCursor.java[RelationshipTraversalCursor] are the main entry points for accessing nodes and relationships respectively.
   These types are used directly with the store for scan operations. +
-  For accessing the relationships of a node, we first have to find the relationships of the types we are interested in via an link:src/main/java/org/neo4j/impl/kernel/api/EdgeGroupCursor.java[EdgeGroupCursor]. +
+  For accessing the relationships of a node, we first have to find the relationships of the types we are interested in via an link:src/main/java/org/neo4j/impl/kernel/api/RelationshipGroupCursor.java[RelationshipGroupCursor]. +
   For index lookup operations we get the link:src/main/java/org/neo4j/impl/kernel/api/NodeCursor.java[NodeCursor] via:
 * link:src/main/java/org/neo4j/impl/kernel/api/NodeIndexCursor.java[NodeValueIndexCursor] and link:src/main/java/org/neo4j/impl/kernel/api/NodeIndexCursor.java[NodeLabelIndexCursor] (and their shared base link:src/main/java/org/neo4j/impl/kernel/api/NodeIndexCursor.java[NodeIndexCursor]).
   This differentiation allows access to data available within the index which makes it possible to defer and sometimes avoid accessing the node store.
 * link:src/main/java/org/neo4j/impl/kernel/api/PropertyCursor.java[PropertyCursor] is used for accessing properties for both nodes and relationships.
 * Property values (and other types of values used in the runtime) are represented by the link:src/main/java/org/neo4j/impl/kernel/api/Value.java[Value class], but for common predicates link:src/main/java/org/neo4j/impl/kernel/api/PropertyCursor.java[PropertyCursor] provides direct methods for performing these without de-serialization.
-* "Manual Indexes" are accessed through link:src/main/java/org/neo4j/impl/kernel/api/NodeManualIndexCursor.java[NodeManualIndexCursor] and link:src/main/java/org/neo4j/impl/kernel/api/EdgeManualIndexCursor.java[EdgeManualIndexCursor].
+* "Manual Indexes" are accessed through link:src/main/java/org/neo4j/impl/kernel/api/NodeManualIndexCursor.java[NodeManualIndexCursor] and link:src/main/java/org/neo4j/impl/kernel/api/RelationshipManualIndexCursor.java[RelationshipManualIndexCursor].
   The shared base class link:src/main/java/org/neo4j/impl/kernel/api/ManualIndexCursor.java[ManualIndexCursor] defines access to the lucene information that leaks through from these search structures out via the "Core API".
 * Parallel scans are initialized through a (thread safe) link:src/main/java/org/neo4j/impl/kernel/api/Scan.java[Scan initializer].
   The usage of these is to initialize one cursor per thread.

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/CursorFactory.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/CursorFactory.java
@@ -25,9 +25,9 @@ public interface CursorFactory
 
     NodeCursor allocateNodeCursor();
 
-    EdgeScanCursor allocateEdgeScanCursor();
+    RelationshipScanCursor allocateRelationshipScanCursor();
 
-    EdgeTraversalCursor allocateEdgeTraversalCursor();
+    RelationshipTraversalCursor allocateRelationshipTraversalCursor();
 
     // properties
 
@@ -35,7 +35,7 @@ public interface CursorFactory
 
     // traversal
 
-    EdgeGroupCursor allocateEdgeGroupCursor();
+    RelationshipGroupCursor allocateRelationshipGroupCursor();
 
     // schema indexes
 
@@ -47,5 +47,5 @@ public interface CursorFactory
 
     NodeManualIndexCursor allocateNodeManualIndexCursor();
 
-    EdgeManualIndexCursor allocateEdgeManualIndexCursor();
+    RelationshipManualIndexCursor allocateRelationshipManualIndexCursor();
 }

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/NeighbourCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/NeighbourCursor.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- * This is an example of an abstraction on top of {@link EdgeScanCursor} and {@link EdgeGroupCursor}.
+ * This is an example of an abstraction on top of {@link RelationshipScanCursor} and {@link RelationshipGroupCursor}.
  */
 public abstract class NeighbourCursor implements NodeCursor
 {
@@ -34,9 +34,9 @@ public abstract class NeighbourCursor implements NodeCursor
         return new Builder( cursors ).outgoing( label );
     }
 
-    public static Builder outgoing( CursorFactory cursors, int label, PropertyPredicate edgeProperties )
+    public static Builder outgoing( CursorFactory cursors, int label, PropertyPredicate relationshipProperties )
     {
-        return new Builder( cursors ).outgoing( label, edgeProperties );
+        return new Builder( cursors ).outgoing( label, relationshipProperties );
     }
 
     public static Builder incoming( CursorFactory cursors, int label )
@@ -44,9 +44,9 @@ public abstract class NeighbourCursor implements NodeCursor
         return new Builder( cursors ).incoming( label );
     }
 
-    public static Builder incoming( CursorFactory cursors, int label, PropertyPredicate edgeProperties )
+    public static Builder incoming( CursorFactory cursors, int label, PropertyPredicate relationshipProperties )
     {
-        return new Builder( cursors ).incoming( label, edgeProperties );
+        return new Builder( cursors ).incoming( label, relationshipProperties );
     }
 
     public static Builder any( CursorFactory cursors, int label )
@@ -54,9 +54,9 @@ public abstract class NeighbourCursor implements NodeCursor
         return new Builder( cursors ).any( label );
     }
 
-    public static Builder any( CursorFactory cursors, int label, PropertyPredicate edgeProperties )
+    public static Builder any( CursorFactory cursors, int label, PropertyPredicate relationshipProperties )
     {
-        return new Builder( cursors ).any( label, edgeProperties );
+        return new Builder( cursors ).any( label, relationshipProperties );
     }
 
     public static NeighbourCursor outgoing( CursorFactory cursors )
@@ -64,10 +64,10 @@ public abstract class NeighbourCursor implements NodeCursor
         return new AnyLabel( cursors, true, false );
     }
 
-    public static NeighbourCursor outgoing( CursorFactory cursors, PropertyPredicate edgeProperties )
+    public static NeighbourCursor outgoing( CursorFactory cursors, PropertyPredicate relationshipProperties )
     {
-        Objects.requireNonNull( edgeProperties, "Edge PropertyPredicate" );
-        return new FilteringAnyLabel( cursors, true, false, edgeProperties );
+        Objects.requireNonNull( relationshipProperties, "Relationship PropertyPredicate" );
+        return new FilteringAnyLabel( cursors, true, false, relationshipProperties );
     }
 
     public static NeighbourCursor incoming( CursorFactory cursors )
@@ -75,10 +75,10 @@ public abstract class NeighbourCursor implements NodeCursor
         return new AnyLabel( cursors, false, true );
     }
 
-    public static NeighbourCursor incoming( CursorFactory cursors, PropertyPredicate edgeProperties )
+    public static NeighbourCursor incoming( CursorFactory cursors, PropertyPredicate relationshipProperties )
     {
-        Objects.requireNonNull( edgeProperties, "Edge PropertyPredicate" );
-        return new FilteringAnyLabel( cursors, false, true, edgeProperties );
+        Objects.requireNonNull( relationshipProperties, "Relationship PropertyPredicate" );
+        return new FilteringAnyLabel( cursors, false, true, relationshipProperties );
     }
 
     public static NeighbourCursor any( CursorFactory cursors )
@@ -86,10 +86,10 @@ public abstract class NeighbourCursor implements NodeCursor
         return new AnyLabel( cursors, true, true );
     }
 
-    public static NeighbourCursor any( CursorFactory cursors, PropertyPredicate edgeProperties )
+    public static NeighbourCursor any( CursorFactory cursors, PropertyPredicate relationshipProperties )
     {
-        Objects.requireNonNull( edgeProperties, "Edge PropertyPredicate" );
-        return new FilteringAnyLabel( cursors, true, true, edgeProperties );
+        Objects.requireNonNull( relationshipProperties, "Relationship PropertyPredicate" );
+        return new FilteringAnyLabel( cursors, true, true, relationshipProperties );
     }
 
     public static final class Builder
@@ -113,9 +113,9 @@ public abstract class NeighbourCursor implements NodeCursor
             return outgoing( label, NO_FILTER );
         }
 
-        public Builder outgoing( int label, PropertyPredicate edgeProperties )
+        public Builder outgoing( int label, PropertyPredicate relationshipProperties )
         {
-            if ( Objects.requireNonNull( edgeProperties, "Edge PropertyPredicate" ) != NO_FILTER )
+            if ( Objects.requireNonNull( relationshipProperties, "Relationship PropertyPredicate" ) != NO_FILTER )
             {
                 filterProperties = true;
             }
@@ -125,7 +125,7 @@ public abstract class NeighbourCursor implements NodeCursor
                 {
                     entry = new Entry( key );
                 }
-                entry.outgoing( edgeProperties );
+                entry.outgoing( relationshipProperties );
                 return entry;
             } );
             return this;
@@ -136,9 +136,9 @@ public abstract class NeighbourCursor implements NodeCursor
             return incoming( label, NO_FILTER );
         }
 
-        public Builder incoming( int label, PropertyPredicate edgeProperties )
+        public Builder incoming( int label, PropertyPredicate relationshipProperties )
         {
-            if ( Objects.requireNonNull( edgeProperties, "Edge PropertyPredicate" ) != NO_FILTER )
+            if ( Objects.requireNonNull( relationshipProperties, "Relationship PropertyPredicate" ) != NO_FILTER )
             {
                 filterProperties = true;
             }
@@ -148,7 +148,7 @@ public abstract class NeighbourCursor implements NodeCursor
                 {
                     entry = new Entry( key );
                 }
-                entry.incoming( edgeProperties );
+                entry.incoming( relationshipProperties );
                 return entry;
             } );
             return this;
@@ -159,9 +159,9 @@ public abstract class NeighbourCursor implements NodeCursor
             return any( label, NO_FILTER );
         }
 
-        public Builder any( int label, PropertyPredicate edgeProperties )
+        public Builder any( int label, PropertyPredicate relationshipProperties )
         {
-            if ( Objects.requireNonNull( edgeProperties, "Edge PropertyPredicate" ) != NO_FILTER )
+            if ( Objects.requireNonNull( relationshipProperties, "Relationship PropertyPredicate" ) != NO_FILTER )
             {
                 filterProperties = true;
             }
@@ -171,7 +171,7 @@ public abstract class NeighbourCursor implements NodeCursor
                 {
                     entry = new Entry( key );
                 }
-                entry.any( edgeProperties );
+                entry.any( relationshipProperties );
                 return entry;
             } );
             return this;
@@ -252,14 +252,14 @@ public abstract class NeighbourCursor implements NodeCursor
     }
 
     private final NodeCursor neighbours;
-    private final EdgeGroupCursor group;
-    private final EdgeTraversalCursor edges;
+    private final RelationshipGroupCursor group;
+    private final RelationshipTraversalCursor relationships;
 
     public NeighbourCursor( CursorFactory cursors )
     {
         this.neighbours = cursors.allocateNodeCursor();
-        this.group = cursors.allocateEdgeGroupCursor();
-        this.edges = cursors.allocateEdgeTraversalCursor();
+        this.group = cursors.allocateRelationshipGroupCursor();
+        this.relationships = cursors.allocateRelationshipTraversalCursor();
     }
 
     /**
@@ -270,31 +270,31 @@ public abstract class NeighbourCursor implements NodeCursor
      */
     public final void of( NodeCursor node )
     {
-        node.edges( group );
+        node.relationships( group );
         // make sure these don't have state from previous use
         group.close();
-        edges.close();
+        relationships.close();
     }
 
     @Override
     public final boolean next()
     {
-        while ( !edges.next() )
+        while ( !relationships.next() )
         {
-            if ( !next( group, edges ) )
+            if ( !next( group, relationships ) )
             {
                 return false;
             }
         }
         do
         {
-            edges.neighbour( neighbours );
+            relationships.neighbour( neighbours );
         }
-        while ( edges.shouldRetry() );
+        while ( relationships.shouldRetry() );
         return neighbours.next();
     }
 
-    protected abstract boolean next( EdgeGroupCursor group, EdgeTraversalCursor edges );
+    protected abstract boolean next( RelationshipGroupCursor group, RelationshipTraversalCursor relationships );
 
     @Override
     public final boolean shouldRetry()
@@ -307,7 +307,7 @@ public abstract class NeighbourCursor implements NodeCursor
     {
         neighbours.close();
         group.close();
-        edges.close();
+        relationships.close();
     }
 
     @Override
@@ -329,27 +329,27 @@ public abstract class NeighbourCursor implements NodeCursor
     }
 
     @Override
-    public final void edges( EdgeGroupCursor cursor )
+    public final void relationships( RelationshipGroupCursor cursor )
     {
-        neighbours.edges( cursor );
+        neighbours.relationships( cursor );
     }
 
     @Override
-    public void outgoingEdges( EdgeGroupCursor groups, EdgeTraversalCursor edges )
+    public void outgoingRelationships( RelationshipGroupCursor groups, RelationshipTraversalCursor relationships )
     {
-        neighbours.outgoingEdges( groups, edges );
+        neighbours.outgoingRelationships( groups, relationships );
     }
 
     @Override
-    public void incomingEdges( EdgeGroupCursor groups, EdgeTraversalCursor edges )
+    public void incomingRelationships( RelationshipGroupCursor groups, RelationshipTraversalCursor relationships )
     {
-        neighbours.incomingEdges( groups, edges );
+        neighbours.incomingRelationships( groups, relationships );
     }
 
     @Override
-    public void allEdges( EdgeGroupCursor groups, EdgeTraversalCursor edges )
+    public void allRelationships( RelationshipGroupCursor groups, RelationshipTraversalCursor relationships )
     {
-        neighbours.allEdges( groups, edges );
+        neighbours.allRelationships( groups, relationships );
     }
 
     @Override
@@ -359,9 +359,9 @@ public abstract class NeighbourCursor implements NodeCursor
     }
 
     @Override
-    public final long edgeGroupReference()
+    public final long relationshipGroupReference()
     {
-        return neighbours.edgeGroupReference();
+        return neighbours.relationshipGroupReference();
     }
 
     @Override
@@ -383,7 +383,7 @@ public abstract class NeighbourCursor implements NodeCursor
         }
 
         @Override
-        protected boolean next( EdgeGroupCursor group, EdgeTraversalCursor edges )
+        protected boolean next( RelationshipGroupCursor group, RelationshipTraversalCursor relationships )
         {
             throw new UnsupportedOperationException( "not implemented" );
         }
@@ -406,7 +406,7 @@ public abstract class NeighbourCursor implements NodeCursor
         }
 
         @Override
-        protected boolean next( EdgeGroupCursor group, EdgeTraversalCursor edges )
+        protected boolean next( RelationshipGroupCursor group, RelationshipTraversalCursor relationships )
         {
             throw new UnsupportedOperationException( "not implemented" );
         }
@@ -420,7 +420,7 @@ public abstract class NeighbourCursor implements NodeCursor
         }
 
         @Override
-        protected boolean next( EdgeGroupCursor group, EdgeTraversalCursor edges )
+        protected boolean next( RelationshipGroupCursor group, RelationshipTraversalCursor relationships )
         {
             throw new UnsupportedOperationException( "not implemented" );
         }
@@ -437,7 +437,7 @@ public abstract class NeighbourCursor implements NodeCursor
         }
 
         @Override
-        protected boolean next( EdgeGroupCursor group, EdgeTraversalCursor edges )
+        protected boolean next( RelationshipGroupCursor group, RelationshipTraversalCursor relationships )
         {
             throw new UnsupportedOperationException( "not implemented" );
         }

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/NodeCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/NodeCursor.java
@@ -30,17 +30,17 @@ public interface NodeCursor extends Cursor
 
     boolean hasProperties();
 
-    void edges( EdgeGroupCursor cursor );
+    void relationships( RelationshipGroupCursor cursor );
 
-    void outgoingEdges( EdgeGroupCursor groups, EdgeTraversalCursor edges );
+    void outgoingRelationships( RelationshipGroupCursor groups, RelationshipTraversalCursor relationships );
 
-    void incomingEdges( EdgeGroupCursor groups, EdgeTraversalCursor edges );
+    void incomingRelationships( RelationshipGroupCursor groups, RelationshipTraversalCursor relationships );
 
-    void allEdges( EdgeGroupCursor groups, EdgeTraversalCursor edges );
+    void allRelationships( RelationshipGroupCursor groups, RelationshipTraversalCursor relationships );
 
     void properties( PropertyCursor cursor );
 
-    long edgeGroupReference();
+    long relationshipGroupReference();
 
     long propertiesReference();
 }

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/PropertyCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/PropertyCursor.java
@@ -26,7 +26,7 @@ import org.neo4j.values.storable.ValueGroup;
 import org.neo4j.values.storable.ValueWriter;
 
 /**
- * Cursor for scanning the properties of a node or edge.
+ * Cursor for scanning the properties of a node or relationship.
  */
 public interface PropertyCursor extends Cursor
 {

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Read.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Read.java
@@ -45,52 +45,51 @@ public interface Read
     Scan<NodeCursor> allNodesScan();
 
     /**
-     * @param reference
-     *         a reference from {@link NodeCursor#nodeReference()}, {@link EdgeDataAccessor#sourceNodeReference()},
-     *         {@link EdgeDataAccessor#targetNodeReference()}, {@link NodeIndexCursor#nodeReference()},
-     *         {@link EdgeIndexCursor#sourceNodeReference()}, or {@link EdgeIndexCursor#targetNodeReference()}.
-     * @param cursor
-     *         the cursor to use for consuming the results.
+     * @param reference a reference from {@link NodeCursor#nodeReference()}, {@link
+     * RelationshipDataAccessor#sourceNodeReference()},
+     * {@link RelationshipDataAccessor#targetNodeReference()}, {@link NodeIndexCursor#nodeReference()},
+     * {@link RelationshipIndexCursor#sourceNodeReference()}, or {@link RelationshipIndexCursor#targetNodeReference()}.
+     * @param cursor the cursor to use for consuming the results.
      */
     void singleNode( long reference, NodeCursor cursor );
 
     /**
      * @param reference
-     *         a reference from {@link EdgeDataAccessor#edgeReference()}.
+     *         a reference from {@link RelationshipDataAccessor#relationshipReference()}.
      * @param cursor
      *         the cursor to use for consuming the results.
      */
-    void singleEdge( long reference, EdgeScanCursor cursor );
+    void singleRelationship( long reference, RelationshipScanCursor cursor );
 
-    void allEdgesScan( EdgeScanCursor cursor );
+    void allRelationshipsScan( RelationshipScanCursor cursor );
 
-    Scan<EdgeScanCursor> allEdgesScan();
+    Scan<RelationshipScanCursor> allRelationshipsScan();
 
-    void edgeLabelScan( int label, EdgeScanCursor cursor );
+    void relationshipLabelScan( int label, RelationshipScanCursor cursor );
 
-    Scan<EdgeScanCursor> edgeLabelScan( int label );
+    Scan<RelationshipScanCursor> relationshipLabelScan( int label );
 
     /**
      * @param nodeReference
      *         a reference from {@link NodeCursor#nodeReference()}.
      * @param reference
-     *         a reference from {@link NodeCursor#edgeGroupReference()}.
+     *         a reference from {@link NodeCursor#relationshipGroupReference()}.
      * @param cursor
      *         the cursor to use for consuming the results.
      */
-    void edgeGroups( long nodeReference, long reference, EdgeGroupCursor cursor );
+    void relationshipGroups( long nodeReference, long reference, RelationshipGroupCursor cursor );
 
     /**
      * @param nodeReference
      *         a reference from {@link NodeCursor#nodeReference()}.
      * @param reference
-     *         a reference from {@link EdgeGroupCursor#outgoingReference()},
-     *         {@link EdgeGroupCursor#incomingReference()},
-     *         or {@link EdgeGroupCursor#loopsReference()}.
+     *         a reference from {@link RelationshipGroupCursor#outgoingReference()},
+     *         {@link RelationshipGroupCursor#incomingReference()},
+     *         or {@link RelationshipGroupCursor#loopsReference()}.
      * @param cursor
      *         the cursor to use for consuming the results.
      */
-    void edges( long nodeReference, long reference, EdgeTraversalCursor cursor );
+    void relationships( long nodeReference, long reference, RelationshipTraversalCursor cursor );
 
     /**
      * @param reference
@@ -102,19 +101,19 @@ public interface Read
 
     /**
      * @param reference
-     *         a reference from {@link EdgeDataAccessor#propertiesReference()}.
+     *         a reference from {@link RelationshipDataAccessor#propertiesReference()}.
      * @param cursor
      *         the cursor to use for consuming the results.
      */
-    void edgeProperties( long reference, PropertyCursor cursor );
+    void relationshipProperties( long reference, PropertyCursor cursor );
 
     // hints to the page cache about data we will be accessing in the future:
 
     void futureNodeReferenceRead( long reference );
 
-    void futureEdgeReferenceRead( long reference );
+    void futureRelationshipsReferenceRead( long reference );
 
     void futureNodePropertyReferenceRead( long reference );
 
-    void futureEdgePropertyReferenceRead( long reference );
+    void futureRelationshipPropertyReferenceRead( long reference );
 }

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipDataAccessor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipDataAccessor.java
@@ -20,8 +20,26 @@
 package org.neo4j.internal.kernel.api;
 
 /**
- * Cursor for accessing manual index edges.
+ * Surface for accessing relationship data.
  */
-public interface EdgeManualIndexCursor extends EdgeIndexCursor, ManualIndexCursor
+public interface RelationshipDataAccessor
 {
+    long relationshipReference(); // not sure relationships will have independent references,
+    // so exposing this might be leakage.
+
+    int label();
+
+    boolean hasProperties();
+
+    void source( NodeCursor cursor );
+
+    void target( NodeCursor cursor );
+
+    void properties( PropertyCursor cursor );
+
+    long sourceNodeReference();
+
+    long targetNodeReference();
+
+    long propertiesReference();
 }

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipGroupCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipGroupCursor.java
@@ -20,30 +20,33 @@
 package org.neo4j.internal.kernel.api;
 
 /**
- * Cursor for traversing the edge groups of a node.
+ * Cursor for traversing the relationship groups of a node.
  */
-public interface EdgeGroupCursor extends SuspendableCursor<EdgeGroupCursor.Position>
+public interface RelationshipGroupCursor extends SuspendableCursor<RelationshipGroupCursor.Position>
 {
     abstract class Position extends CursorPosition<Position>
     {
     }
 
     /**
-     * Find the first edge group with a label greater than or equal to the provided label.
+     * Find the first relationship group with a label greater than or equal to the provided label.
      * <p>
      * Note that the default implementation of this method (and most likely any sane use of this method - regardless of
-     * implementation) assumes that edge groups are ordered by label.
+     * implementation) assumes that relationship groups are ordered by label.
      *
-     * @param edgeLabel
-     *         the edge label to search for.
-     * @return {@code true} if a matching edge group was found, {@code false} if all edge groups within reach of this
-     * cursor were exhausted without finding a matching edge group.
+     * @param relationshipLabel the relationship label to search for.
+     * @return {@code true} if a matching relationship group was found, {@code false} if all relationship groups
+     * within
+     * reach
+     * of
+     * this
+     * cursor were exhausted without finding a matching relationship group.
      */
-    default boolean seek( int edgeLabel )
+    default boolean seek( int relationshipLabel )
     {
         while ( next() )
         {
-            if ( edgeLabel < edgeLabel() )
+            if ( relationshipLabel < relationshipLabel() )
             {
                 return true;
             }
@@ -51,7 +54,7 @@ public interface EdgeGroupCursor extends SuspendableCursor<EdgeGroupCursor.Posit
         return false;
     }
 
-    int edgeLabel();
+    int relationshipLabel();
 
     int outgoingCount();
 
@@ -65,11 +68,11 @@ public interface EdgeGroupCursor extends SuspendableCursor<EdgeGroupCursor.Posit
         return outgoingCount() + incomingCount() - loopCount();
     }
 
-    void outgoing( EdgeTraversalCursor cursor );
+    void outgoing( RelationshipTraversalCursor cursor );
 
-    void incoming( EdgeTraversalCursor cursor );
+    void incoming( RelationshipTraversalCursor cursor );
 
-    void loops( EdgeTraversalCursor cursor );
+    void loops( RelationshipTraversalCursor cursor );
 
     long outgoingReference();
 

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipIndexCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipIndexCursor.java
@@ -20,8 +20,22 @@
 package org.neo4j.internal.kernel.api;
 
 /**
- * Cursor for scanning edges, that is listing edges without grouping by source or target node.
+ * Cursor for scanning relationships of a schema index.
  */
-public interface EdgeScanCursor extends EdgeDataAccessor, Cursor
+public interface RelationshipIndexCursor extends Cursor
 {
+    void relationship( RelationshipScanCursor cursor );
+
+    void sourceNode( NodeCursor cursor );
+
+    void targetNode( NodeCursor cursor );
+
+    int relationshipLabel();
+
+    long sourceNodeReference();
+
+    long targetNodeReference();
+
+//  long relationshipReference(); // not sure relationships will have independent references, so exposing this might
+// be leakage.
 }

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipManualIndexCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipManualIndexCursor.java
@@ -20,21 +20,8 @@
 package org.neo4j.internal.kernel.api;
 
 /**
- * Cursor for scanning edges of a schema index.
+ * Cursor for accessing manual index relationships.
  */
-public interface EdgeIndexCursor extends Cursor
+public interface RelationshipManualIndexCursor extends RelationshipIndexCursor, ManualIndexCursor
 {
-    void edge( EdgeScanCursor cursor );
-
-    void sourceNode( NodeCursor cursor );
-
-    void targetNode( NodeCursor cursor );
-
-    int edgeLabel();
-
-    long sourceNodeReference();
-
-    long targetNodeReference();
-
-//  long edgeReference(); // not sure edges will have independent references, so exposing this might be leakage.
 }

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipScanCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipScanCursor.java
@@ -20,25 +20,8 @@
 package org.neo4j.internal.kernel.api;
 
 /**
- * Surface for accessing edge data.
+ * Cursor for scanning relationships, that is listing relationships without grouping by source or target node.
  */
-public interface EdgeDataAccessor
+public interface RelationshipScanCursor extends RelationshipDataAccessor, Cursor
 {
-    long edgeReference(); // not sure edges will have independent references, so exposing this might be leakage.
-
-    int label();
-
-    boolean hasProperties();
-
-    void source( NodeCursor cursor );
-
-    void target( NodeCursor cursor );
-
-    void properties( PropertyCursor cursor );
-
-    long sourceNodeReference();
-
-    long targetNodeReference();
-
-    long propertiesReference();
 }

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipTraversalCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/RelationshipTraversalCursor.java
@@ -20,9 +20,10 @@
 package org.neo4j.internal.kernel.api;
 
 /**
- * Cursor for traversing the edges of a single node.
+ * Cursor for traversing the relationships of a single node.
  */
-public interface EdgeTraversalCursor extends EdgeDataAccessor, SuspendableCursor<EdgeTraversalCursor.Position>
+public interface RelationshipTraversalCursor
+        extends RelationshipDataAccessor, SuspendableCursor<RelationshipTraversalCursor.Position>
 {
     abstract class Position extends CursorPosition<Position>
     {
@@ -31,11 +32,10 @@ public interface EdgeTraversalCursor extends EdgeDataAccessor, SuspendableCursor
     /**
      * Get the other node, the one that this cursor was not initialized from.
      * <p>
-     * Edge cursors have context, and know which node they are traversing edges for, making it possible and convenient
-     * to access the other node.
+     * Relationship cursors have context, and know which node they are traversing relationships for, making it
+     * possible and convenient to access the other node.
      *
-     * @param cursor
-     *         the cursor to use for accessing the other node.
+     * @param cursor the cursor to use for accessing the other node.
      */
     void neighbour( NodeCursor cursor );
 

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Write.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Write.java
@@ -30,9 +30,9 @@ interface Write
 
     void nodeDelete( long node );
 
-    long edgeCreate( long sourceNode, int edgeLabel, long targetNode );
+    long relationshipCreate( long sourceNode, int relationshipLabel, long targetNode );
 
-    void edgeDelete( long edge );
+    void relationshipDelete( long relationship );
 
     void nodeAddLabel( long node, int nodeLabel );
 
@@ -49,7 +49,7 @@ interface Write
 
     void nodeRemoveProperty( long node, int propertyKey );
 
-    void edgeSetProperty( long edge, int propertyKey, Value value );
+    void relationshipSetProperty( long relationship, int propertyKey, Value value );
 
-    void edgeRemoveProperty( long node, int propertyKey );
+    void relationshipRemoveProperty( long node, int propertyKey );
 }

--- a/enterprise/runtime/neole/src/main/java/org/neo4j/internal/store/prototype/neole/CursorFactory.java
+++ b/enterprise/runtime/neole/src/main/java/org/neo4j/internal/store/prototype/neole/CursorFactory.java
@@ -19,10 +19,10 @@
  */
 package org.neo4j.internal.store.prototype.neole;
 
-import org.neo4j.internal.kernel.api.EdgeManualIndexCursor;
 import org.neo4j.internal.kernel.api.NodeLabelIndexCursor;
 import org.neo4j.internal.kernel.api.NodeManualIndexCursor;
 import org.neo4j.internal.kernel.api.NodeValueIndexCursor;
+import org.neo4j.internal.kernel.api.RelationshipManualIndexCursor;
 
 class CursorFactory implements org.neo4j.internal.kernel.api.CursorFactory
 {
@@ -40,15 +40,15 @@ class CursorFactory implements org.neo4j.internal.kernel.api.CursorFactory
     }
 
     @Override
-    public EdgeScanCursor allocateEdgeScanCursor()
+    public RelationshipScanCursor allocateRelationshipScanCursor()
     {
-        return new org.neo4j.internal.store.prototype.neole.EdgeScanCursor( store );
+        return new RelationshipScanCursor( store );
     }
 
     @Override
-    public EdgeTraversalCursor allocateEdgeTraversalCursor()
+    public RelationshipTraversalCursor allocateRelationshipTraversalCursor()
     {
-        return new EdgeTraversalCursor( store );
+        return new RelationshipTraversalCursor( store );
     }
 
     @Override
@@ -58,9 +58,9 @@ class CursorFactory implements org.neo4j.internal.kernel.api.CursorFactory
     }
 
     @Override
-    public EdgeGroupCursor allocateEdgeGroupCursor()
+    public RelationshipGroupCursor allocateRelationshipGroupCursor()
     {
-        return new EdgeGroupCursor( store, new EdgeTraversalCursor( store ) );
+        return new RelationshipGroupCursor( store, new RelationshipTraversalCursor( store ) );
     }
 
     @Override
@@ -82,7 +82,7 @@ class CursorFactory implements org.neo4j.internal.kernel.api.CursorFactory
     }
 
     @Override
-    public EdgeManualIndexCursor allocateEdgeManualIndexCursor()
+    public RelationshipManualIndexCursor allocateRelationshipManualIndexCursor()
     {
         throw new UnsupportedOperationException( "not implemented" );
     }

--- a/enterprise/runtime/neole/src/main/java/org/neo4j/internal/store/prototype/neole/NodeCursor.java
+++ b/enterprise/runtime/neole/src/main/java/org/neo4j/internal/store/prototype/neole/NodeCursor.java
@@ -19,29 +19,31 @@
  */
 package org.neo4j.internal.store.prototype.neole;
 
-import org.neo4j.internal.kernel.api.EdgeTraversalCursor;
 import org.neo4j.internal.kernel.api.LabelSet;
 import org.neo4j.internal.kernel.api.PropertyCursor;
+import org.neo4j.internal.kernel.api.RelationshipGroupCursor;
+import org.neo4j.internal.kernel.api.RelationshipTraversalCursor;
 import org.neo4j.internal.store.cursors.ReadCursor;
 
-import static org.neo4j.internal.store.prototype.neole.EdgeCursor.NO_EDGE;
 import static org.neo4j.internal.store.prototype.neole.PartialPropertyCursor.NO_PROPERTIES;
 import static org.neo4j.internal.store.prototype.neole.ReadStore.combineReference;
+import static org.neo4j.internal.store.prototype.neole.RelationshipCursor.NO_RELATIONSHIP;
+import static org.neo4j.internal.store.prototype.neole.RelationshipGroupCursor.encodeDirectRelationshipReference;
 
 class NodeCursor extends ReadCursor implements org.neo4j.internal.kernel.api.NodeCursor
 {
     /**
      * <pre>
-     *  0: in use     (1 byte)
-     *  1: edges      (4 bytes)
-     *  5: properties (4 bytes)
-     *  9: labels     (5 bytes)
-     * 14: extra      (1 byte)
+     *  0: in use        (1 byte)
+     *  1: relationships (4 bytes)
+     *  5: properties    (4 bytes)
+     *  9: labels        (5 bytes)
+     * 14: extra         (1 byte)
      * </pre>
      * <h2>in use</h2>
      * <pre>
      * [    ,   x] in use
-     * [    ,xxx ] high(edges)
+     * [    ,xxx ] high(relationships)
      * [xxxx,    ] high(properties)
      * </pre>
      * <h2>labels</h2>
@@ -125,20 +127,20 @@ class NodeCursor extends ReadCursor implements org.neo4j.internal.kernel.api.Nod
     }
 
     @Override
-    public long edgeGroupReference()
+    public long relationshipGroupReference()
     {
-        long edges = combineReference( unsignedInt( 1 ), (unsignedByte( 0 ) & 0x0EL) << 31 );
+        long relationships = combineReference( unsignedInt( 1 ), (unsignedByte( 0 ) & 0x0EL) << 31 );
         if ( (readByte( 14 ) & 0x01) != 0 )
         {
-            return edges;
+            return relationships;
         }
-        else if ( edges == NO_EDGE )
+        else if ( relationships == NO_RELATIONSHIP )
         {
-            return NO_EDGE;
+            return NO_RELATIONSHIP;
         }
         else
         {
-            return EdgeGroupCursor.encodeDirectEdgeReference( edges );
+            return encodeDirectRelationshipReference( relationships );
         }
     }
 
@@ -163,25 +165,25 @@ class NodeCursor extends ReadCursor implements org.neo4j.internal.kernel.api.Nod
     }
 
     @Override
-    public void edges( org.neo4j.internal.kernel.api.EdgeGroupCursor cursor )
+    public void relationships( RelationshipGroupCursor cursor )
     {
-        store.edgeGroups( nodeReference(), edgeGroupReference(), cursor );
+        store.relationshipGroups( nodeReference(), relationshipGroupReference(), cursor );
     }
 
     @Override
-    public void outgoingEdges( org.neo4j.internal.kernel.api.EdgeGroupCursor groups, org.neo4j.internal.kernel.api.EdgeTraversalCursor edges )
-    {
-        throw new UnsupportedOperationException( "not implemented" );
-    }
-
-    @Override
-    public void incomingEdges( org.neo4j.internal.kernel.api.EdgeGroupCursor groups, EdgeTraversalCursor edges )
+    public void outgoingRelationships( RelationshipGroupCursor groups, RelationshipTraversalCursor relationships )
     {
         throw new UnsupportedOperationException( "not implemented" );
     }
 
     @Override
-    public void allEdges( org.neo4j.internal.kernel.api.EdgeGroupCursor groups, EdgeTraversalCursor edges )
+    public void incomingRelationships( RelationshipGroupCursor groups, RelationshipTraversalCursor relationships )
+    {
+        throw new UnsupportedOperationException( "not implemented" );
+    }
+
+    @Override
+    public void allRelationships( RelationshipGroupCursor groups, RelationshipTraversalCursor relationships )
     {
         throw new UnsupportedOperationException( "not implemented" );
     }

--- a/enterprise/runtime/neole/src/main/java/org/neo4j/internal/store/prototype/neole/ReadStore.java
+++ b/enterprise/runtime/neole/src/main/java/org/neo4j/internal/store/prototype/neole/ReadStore.java
@@ -25,26 +25,33 @@ import java.io.IOException;
 import org.neo4j.internal.kernel.api.IndexPredicate;
 import org.neo4j.internal.kernel.api.IndexReference;
 import org.neo4j.internal.kernel.api.Read;
+import org.neo4j.internal.kernel.api.RelationshipGroupCursor;
+import org.neo4j.internal.kernel.api.RelationshipScanCursor;
+import org.neo4j.internal.kernel.api.RelationshipTraversalCursor;
 import org.neo4j.internal.kernel.api.Scan;
 import org.neo4j.internal.store.cursors.MemoryManager;
-import org.neo4j.internal.store.cursors.ReadCursor;
 
-import static org.neo4j.internal.store.prototype.neole.EdgeCursor.NO_EDGE;
 import static org.neo4j.internal.store.prototype.neole.PartialPropertyCursor.NO_PROPERTIES;
+import static org.neo4j.internal.store.prototype.neole.RelationshipCursor.NO_RELATIONSHIP;
 import static org.neo4j.internal.store.prototype.neole.StoreFile.fixedSizeRecordFile;
 
 public class ReadStore extends MemoryManager implements Read
 {
-    private static final String NODE_STORE = "neostore.nodestore.db", EDGE_STORE = "neostore.relationshipstore.db",
-            EDGE_GROUP_STORE = "neostore.relationshipgroupstore.db", PROPERTY_STORE = "neostore.propertystore.db";
+    private static final String NODE_STORE = "neostore.nodestore.db", RELATIONSHIP_STORE =
+            "neostore.relationshipstore.db",
+            RELATIONSHIP_GROUP_STORE = "neostore.relationshipgroupstore.db", PROPERTY_STORE =
+            "neostore.propertystore.db";
     private static final long INTEGER_MINUS_ONE = 0xFFFF_FFFFL;
-    private final StoreFile nodes, edges, edgeGroups, properties;
+    private final StoreFile nodes, relationships, relationshipGroups, properties;
 
     public ReadStore( File storeDir ) throws IOException
     {
         this.nodes = fixedSizeRecordFile( new File( storeDir, NODE_STORE ), NodeCursor.RECORD_SIZE );
-        this.edges = fixedSizeRecordFile( new File( storeDir, EDGE_STORE ), EdgeCursor.RECORD_SIZE );
-        this.edgeGroups = fixedSizeRecordFile( new File( storeDir, EDGE_GROUP_STORE ), EdgeGroupCursor.RECORD_SIZE );
+        this.relationships =
+                fixedSizeRecordFile( new File( storeDir, RELATIONSHIP_STORE ), RelationshipCursor.RECORD_SIZE );
+        this.relationshipGroups =
+                fixedSizeRecordFile( new File( storeDir, RELATIONSHIP_GROUP_STORE ), org.neo4j.internal.store
+                        .prototype.neole.RelationshipGroupCursor.RECORD_SIZE );
         this.properties = fixedSizeRecordFile( new File( storeDir, PROPERTY_STORE ), PropertyCursor.RECORD_SIZE );
     }
 
@@ -94,51 +101,55 @@ public class ReadStore extends MemoryManager implements Read
     }
 
     @Override
-    public void singleEdge( long reference, org.neo4j.internal.kernel.api.EdgeScanCursor cursor )
+    public void singleRelationship( long reference, RelationshipScanCursor cursor )
     {
-        ((EdgeScanCursor) cursor).init( edges, reference, reference );
+        ((org.neo4j.internal.store.prototype.neole.RelationshipScanCursor) cursor)
+                .init( relationships, reference, reference );
     }
 
     @Override
-    public void allEdgesScan( org.neo4j.internal.kernel.api.EdgeScanCursor cursor )
+    public void allRelationshipsScan( RelationshipScanCursor cursor )
     {
-        ((EdgeScanCursor) cursor).init( edges, 0, edges.maxReference );
+        ((org.neo4j.internal.store.prototype.neole.RelationshipScanCursor) cursor).
+                init( relationships, 0, relationships.maxReference );
     }
 
     @Override
-    public Scan<org.neo4j.internal.kernel.api.EdgeScanCursor> allEdgesScan()
+    public Scan<RelationshipScanCursor> allRelationshipsScan()
     {
         throw new UnsupportedOperationException( "not implemented" );
     }
 
     @Override
-    public void edgeLabelScan( int label, org.neo4j.internal.kernel.api.EdgeScanCursor cursor )
+    public void relationshipLabelScan( int label, RelationshipScanCursor cursor )
     {
         throw new UnsupportedOperationException( "not implemented" );
     }
 
     @Override
-    public Scan<org.neo4j.internal.kernel.api.EdgeScanCursor> edgeLabelScan( int label )
+    public Scan<RelationshipScanCursor> relationshipLabelScan( int label )
     {
         throw new UnsupportedOperationException( "not implemented" );
     }
 
     @Override
-    public void edgeGroups( long nodeReference, long reference, org.neo4j.internal.kernel.api.EdgeGroupCursor cursor )
+    public void relationshipGroups( long nodeReference, long reference, RelationshipGroupCursor cursor )
     {
-        ((EdgeGroupCursor) cursor).init( edgeGroups, edges, nodeReference, reference );
+        ((org.neo4j.internal.store.prototype.neole.RelationshipGroupCursor) cursor).
+                init( relationshipGroups, relationships, nodeReference, reference );
     }
 
     @Override
-    public void edges( long nodeReference, long reference, org.neo4j.internal.kernel.api.EdgeTraversalCursor cursor )
+    public void relationships( long nodeReference, long reference, RelationshipTraversalCursor cursor )
     {
-        if ( reference == NO_EDGE )
+        if ( reference == NO_RELATIONSHIP )
         {
             cursor.close();
         }
         else
         {
-            ((EdgeTraversalCursor) cursor).init( edges, nodeReference, reference );
+            ((org.neo4j.internal.store.prototype.neole.RelationshipTraversalCursor) cursor)
+                    .init( relationships, nodeReference, reference );
         }
     }
 
@@ -156,7 +167,7 @@ public class ReadStore extends MemoryManager implements Read
     }
 
     @Override
-    public void edgeProperties( long reference, org.neo4j.internal.kernel.api.PropertyCursor cursor )
+    public void relationshipProperties( long reference, org.neo4j.internal.kernel.api.PropertyCursor cursor )
     {
         throw new UnsupportedOperationException( "not implemented" );
     }
@@ -168,7 +179,7 @@ public class ReadStore extends MemoryManager implements Read
     }
 
     @Override
-    public void futureEdgeReferenceRead( long reference )
+    public void futureRelationshipsReferenceRead( long reference )
     {
         throw new UnsupportedOperationException( "not implemented" );
     }
@@ -180,7 +191,7 @@ public class ReadStore extends MemoryManager implements Read
     }
 
     @Override
-    public void futureEdgePropertyReferenceRead( long reference )
+    public void futureRelationshipPropertyReferenceRead( long reference )
     {
         throw new UnsupportedOperationException( "not implemented" );
     }

--- a/enterprise/runtime/neole/src/main/java/org/neo4j/internal/store/prototype/neole/RelationshipCursor.java
+++ b/enterprise/runtime/neole/src/main/java/org/neo4j/internal/store/prototype/neole/RelationshipCursor.java
@@ -21,12 +21,13 @@ package org.neo4j.internal.store.prototype.neole;
 
 import org.neo4j.internal.kernel.api.NodeCursor;
 import org.neo4j.internal.kernel.api.PropertyCursor;
+import org.neo4j.internal.kernel.api.RelationshipDataAccessor;
 import org.neo4j.internal.store.cursors.ReadCursor;
 
 import static org.neo4j.internal.store.prototype.neole.PartialPropertyCursor.NO_PROPERTIES;
 import static org.neo4j.internal.store.prototype.neole.ReadStore.combineReference;
 
-abstract class EdgeCursor extends ReadCursor implements org.neo4j.internal.kernel.api.EdgeDataAccessor
+abstract class RelationshipCursor extends ReadCursor implements RelationshipDataAccessor
 {
     /**
      * <pre>
@@ -58,10 +59,10 @@ abstract class EdgeCursor extends ReadCursor implements org.neo4j.internal.kerne
      * </pre>
      */
     static final int RECORD_SIZE = 34;
-    static final long NO_EDGE = -1;
+    static final long NO_RELATIONSHIP = -1;
     protected final ReadStore store;
 
-    EdgeCursor( ReadStore store )
+    RelationshipCursor( ReadStore store )
     {
         this.store = store;
     }
@@ -78,7 +79,7 @@ abstract class EdgeCursor extends ReadCursor implements org.neo4j.internal.kerne
     }
 
     @Override
-    public long edgeReference()
+    public long relationshipReference()
     {
         return virtualAddress();
     }
@@ -107,22 +108,22 @@ abstract class EdgeCursor extends ReadCursor implements org.neo4j.internal.kerne
         return combineReference( unsignedInt( 29 ), ((long) unsignedByte( 0 ) & 0xF0L) << 28 );
     }
 
-    long sourcePrevEdgeReference()
+    long sourcePrevRelationshipReference()
     {
         return combineReference( unsignedInt( 13 ), ((long) unsignedShort( 9 ) & 0x0E00L) << 23 );
     }
 
-    long sourceNextEdgeReference()
+    long sourceNextRelationshipReference()
     {
         return combineReference( unsignedInt( 17 ), ((long) unsignedShort( 9 ) & 0x01C0L) << 26 );
     }
 
-    long targetPrevEdgeReference()
+    long targetPrevRelationshipReference()
     {
         return combineReference( unsignedInt( 21 ), ((long) unsignedShort( 9 ) & 0x0038L) << 29 );
     }
 
-    long targetNextEdgeReference()
+    long targetNextRelationshipReference()
     {
         return combineReference( unsignedInt( 25 ), ((long) unsignedShort( 9 ) & 0x0007L) << 32 );
     }
@@ -148,6 +149,6 @@ abstract class EdgeCursor extends ReadCursor implements org.neo4j.internal.kerne
     @Override
     public void properties( PropertyCursor cursor )
     {
-        store.edgeProperties( propertiesReference(), cursor );
+        store.relationshipProperties( propertiesReference(), cursor );
     }
 }

--- a/enterprise/runtime/neole/src/main/java/org/neo4j/internal/store/prototype/neole/RelationshipScanCursor.java
+++ b/enterprise/runtime/neole/src/main/java/org/neo4j/internal/store/prototype/neole/RelationshipScanCursor.java
@@ -19,18 +19,18 @@
  */
 package org.neo4j.internal.store.prototype.neole;
 
-class EdgeScanCursor extends EdgeCursor implements org.neo4j.internal.kernel.api.EdgeScanCursor
+class RelationshipScanCursor extends RelationshipCursor implements org.neo4j.internal.kernel.api.RelationshipScanCursor
 {
     private long maxReference;
 
-    EdgeScanCursor( ReadStore store )
+    RelationshipScanCursor( ReadStore store )
     {
         super( store );
     }
 
-    void init( StoreFile edges, long reference, long maxReference )
+    void init( StoreFile relationships, long reference, long maxReference )
     {
-        edges.initializeCursor( reference, this );
+        relationships.initializeCursor( reference, this );
         initializeScanCursor();
         this.maxReference = maxReference;
     }

--- a/enterprise/runtime/neole/src/main/java/org/neo4j/internal/store/prototype/neole/RelationshipTraversalCursor.java
+++ b/enterprise/runtime/neole/src/main/java/org/neo4j/internal/store/prototype/neole/RelationshipTraversalCursor.java
@@ -21,19 +21,20 @@ package org.neo4j.internal.store.prototype.neole;
 
 import static java.lang.String.format;
 
-class EdgeTraversalCursor extends EdgeCursor implements org.neo4j.internal.kernel.api.EdgeTraversalCursor
+class RelationshipTraversalCursor extends RelationshipCursor
+        implements org.neo4j.internal.kernel.api.RelationshipTraversalCursor
 {
     private long originNodeReference;
 
-    EdgeTraversalCursor( ReadStore store )
+    RelationshipTraversalCursor( ReadStore store )
     {
         super( store );
         this.originNodeReference = Long.MIN_VALUE;
     }
 
-    void init( StoreFile edges, long originNodeReference, long reference )
+    void init( StoreFile relationships, long originNodeReference, long reference )
     {
-        edges.initializeCursor( reference, this );
+        relationships.initializeCursor( reference, this );
         this.originNodeReference = ~originNodeReference;
     }
 
@@ -104,9 +105,9 @@ class EdgeTraversalCursor extends EdgeCursor implements org.neo4j.internal.kerne
         }
         else
         {
-            next = nextEdgeReference();
+            next = nextRelationshipReference();
         }
-        if ( next == NO_EDGE )
+        if ( next == NO_RELATIONSHIP )
         {
             close();
             return false;
@@ -114,20 +115,20 @@ class EdgeTraversalCursor extends EdgeCursor implements org.neo4j.internal.kerne
         return moveToVirtualAddress( next );
     }
 
-    private long nextEdgeReference()
+    private long nextRelationshipReference()
     {
         final long source = sourceNodeReference(), target = targetNodeReference();
         if ( source == originNodeReference )
         {
-            return sourceNextEdgeReference();
+            return sourceNextRelationshipReference();
         }
         if ( target == originNodeReference )
         {
-            return targetNextEdgeReference();
+            return targetNextRelationshipReference();
         }
         throw new IllegalStateException( format(
                 "%d is not part of this chain! source=0x%x, target=0x%x, origin=0x%x",
-                edgeReference(),
+                relationshipReference(),
                 source,
                 target,
                 originNodeReference ) );

--- a/enterprise/runtime/neole/src/test/java/org/neo4j/internal/store/prototype/neole/DeepRelationshipTraversalCursorTest.java
+++ b/enterprise/runtime/neole/src/test/java/org/neo4j/internal/store/prototype/neole/DeepRelationshipTraversalCursorTest.java
@@ -28,9 +28,9 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.internal.kernel.api.EdgeGroupCursor;
-import org.neo4j.internal.kernel.api.EdgeTraversalCursor;
 import org.neo4j.internal.kernel.api.NodeCursor;
+import org.neo4j.internal.kernel.api.RelationshipGroupCursor;
+import org.neo4j.internal.kernel.api.RelationshipTraversalCursor;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
@@ -40,7 +40,7 @@ import static org.junit.Assume.assumeThat;
 import static org.neo4j.graphdb.RelationshipType.withName;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.dense_node_threshold;
 
-public class DeepEdgeTraversalCursorTest
+public class DeepRelationshipTraversalCursorTest
 {
     private static long three_root;
     private static int expected_total, expected_unique;
@@ -107,9 +107,9 @@ public class DeepEdgeTraversalCursorTest
     {
         assumeThat( "x86_64", equalTo( System.getProperty( "os.arch" ) ) );
         try ( NodeCursor node = graph.allocateNodeCursor();
-              EdgeGroupCursor group = graph.allocateEdgeGroupCursor();
-              EdgeTraversalCursor edge1 = graph.allocateEdgeTraversalCursor();
-              EdgeTraversalCursor edge2 = graph.allocateEdgeTraversalCursor();
+              RelationshipGroupCursor group = graph.allocateRelationshipGroupCursor();
+              RelationshipTraversalCursor relationship1 = graph.allocateRelationshipTraversalCursor();
+              RelationshipTraversalCursor relationship2 = graph.allocateRelationshipTraversalCursor();
               PrimitiveLongSet leafs = Primitive.longSet() )
         {
             long total = 0;
@@ -117,28 +117,28 @@ public class DeepEdgeTraversalCursorTest
             // when
             graph.singleNode( three_root, node );
             assertTrue( "access root node", node.next() );
-            node.edges( group );
+            node.relationships( group );
             assertFalse( "single root", node.next() );
 
             assertTrue( "access group of root", group.next() );
-            group.incoming( edge1 );
+            group.incoming( relationship1 );
             assertFalse( "single group of root", group.next() );
 
-            while ( edge1.next() )
+            while ( relationship1.next() )
             {
-                edge1.neighbour( node );
+                relationship1.neighbour( node );
 
                 assertTrue( "child level 1", node.next() );
-                node.edges( group );
+                node.relationships( group );
                 assertFalse( "single node", node.next() );
 
                 assertTrue( "group of level 1 child", group.next() );
-                group.incoming( edge2 );
+                group.incoming( relationship2 );
                 assertFalse( "single group of level 1 child", group.next() );
 
-                while ( edge2.next() )
+                while ( relationship2.next() )
                 {
-                    leafs.add( edge2.neighbourNodeReference() );
+                    leafs.add( relationship2.neighbourNodeReference() );
                     total++;
                 }
             }

--- a/enterprise/runtime/neole/src/test/java/org/neo4j/internal/store/prototype/neole/GraphSetup.java
+++ b/enterprise/runtime/neole/src/test/java/org/neo4j/internal/store/prototype/neole/GraphSetup.java
@@ -30,10 +30,6 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
-import org.neo4j.internal.kernel.api.EdgeGroupCursor;
-import org.neo4j.internal.kernel.api.EdgeManualIndexCursor;
-import org.neo4j.internal.kernel.api.EdgeScanCursor;
-import org.neo4j.internal.kernel.api.EdgeTraversalCursor;
 import org.neo4j.internal.kernel.api.IndexPredicate;
 import org.neo4j.internal.kernel.api.IndexReference;
 import org.neo4j.internal.kernel.api.NodeCursor;
@@ -42,6 +38,10 @@ import org.neo4j.internal.kernel.api.NodeManualIndexCursor;
 import org.neo4j.internal.kernel.api.NodeValueIndexCursor;
 import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.Read;
+import org.neo4j.internal.kernel.api.RelationshipGroupCursor;
+import org.neo4j.internal.kernel.api.RelationshipManualIndexCursor;
+import org.neo4j.internal.kernel.api.RelationshipScanCursor;
+import org.neo4j.internal.kernel.api.RelationshipTraversalCursor;
 import org.neo4j.internal.kernel.api.Scan;
 
 public abstract class GraphSetup extends TestResource implements Read, org.neo4j.internal.kernel.api.CursorFactory
@@ -155,45 +155,45 @@ public abstract class GraphSetup extends TestResource implements Read, org.neo4j
     }
 
     @Override
-    public void singleEdge( long reference, EdgeScanCursor cursor )
+    public void singleRelationship( long reference, RelationshipScanCursor cursor )
     {
-        store.singleEdge( reference, cursor );
+        store.singleRelationship( reference, cursor );
     }
 
     @Override
-    public void allEdgesScan( EdgeScanCursor cursor )
+    public void allRelationshipsScan( RelationshipScanCursor cursor )
     {
-        store.allEdgesScan( cursor );
+        store.allRelationshipsScan( cursor );
     }
 
     @Override
-    public Scan<EdgeScanCursor> allEdgesScan()
+    public Scan<RelationshipScanCursor> allRelationshipsScan()
     {
-        return store.allEdgesScan();
+        return store.allRelationshipsScan();
     }
 
     @Override
-    public void edgeLabelScan( int label, EdgeScanCursor cursor )
+    public void relationshipLabelScan( int label, RelationshipScanCursor cursor )
     {
-        store.edgeLabelScan( label, cursor );
+        store.relationshipLabelScan( label, cursor );
     }
 
     @Override
-    public Scan<EdgeScanCursor> edgeLabelScan( int label )
+    public Scan<RelationshipScanCursor> relationshipLabelScan( int label )
     {
-        return store.edgeLabelScan( label );
+        return store.relationshipLabelScan( label );
     }
 
     @Override
-    public void edgeGroups( long nodeReference, long reference, EdgeGroupCursor cursor )
+    public void relationshipGroups( long nodeReference, long reference, RelationshipGroupCursor cursor )
     {
-        store.edgeGroups( nodeReference, reference, cursor );
+        store.relationshipGroups( nodeReference, reference, cursor );
     }
 
     @Override
-    public void edges( long nodeReference, long reference, EdgeTraversalCursor cursor )
+    public void relationships( long nodeReference, long reference, RelationshipTraversalCursor cursor )
     {
-        store.edges( nodeReference, reference, cursor );
+        store.relationships( nodeReference, reference, cursor );
     }
 
     @Override
@@ -203,9 +203,9 @@ public abstract class GraphSetup extends TestResource implements Read, org.neo4j
     }
 
     @Override
-    public void edgeProperties( long reference, PropertyCursor cursor )
+    public void relationshipProperties( long reference, PropertyCursor cursor )
     {
-        store.edgeProperties( reference, cursor );
+        store.relationshipProperties( reference, cursor );
     }
 
     @Override
@@ -215,9 +215,9 @@ public abstract class GraphSetup extends TestResource implements Read, org.neo4j
     }
 
     @Override
-    public void futureEdgeReferenceRead( long reference )
+    public void futureRelationshipsReferenceRead( long reference )
     {
-        store.futureEdgeReferenceRead( reference );
+        store.futureRelationshipsReferenceRead( reference );
     }
 
     @Override
@@ -227,9 +227,9 @@ public abstract class GraphSetup extends TestResource implements Read, org.neo4j
     }
 
     @Override
-    public void futureEdgePropertyReferenceRead( long reference )
+    public void futureRelationshipPropertyReferenceRead( long reference )
     {
-        store.futureEdgePropertyReferenceRead( reference );
+        store.futureRelationshipPropertyReferenceRead( reference );
     }
 
     @Override
@@ -239,15 +239,15 @@ public abstract class GraphSetup extends TestResource implements Read, org.neo4j
     }
 
     @Override
-    public EdgeScanCursor allocateEdgeScanCursor()
+    public RelationshipScanCursor allocateRelationshipScanCursor()
     {
-        return cursors.allocateEdgeScanCursor();
+        return cursors.allocateRelationshipScanCursor();
     }
 
     @Override
-    public EdgeTraversalCursor allocateEdgeTraversalCursor()
+    public RelationshipTraversalCursor allocateRelationshipTraversalCursor()
     {
-        return cursors.allocateEdgeTraversalCursor();
+        return cursors.allocateRelationshipTraversalCursor();
     }
 
     @Override
@@ -257,9 +257,9 @@ public abstract class GraphSetup extends TestResource implements Read, org.neo4j
     }
 
     @Override
-    public EdgeGroupCursor allocateEdgeGroupCursor()
+    public RelationshipGroupCursor allocateRelationshipGroupCursor()
     {
-        return cursors.allocateEdgeGroupCursor();
+        return cursors.allocateRelationshipGroupCursor();
     }
 
     @Override
@@ -281,8 +281,8 @@ public abstract class GraphSetup extends TestResource implements Read, org.neo4j
     }
 
     @Override
-    public EdgeManualIndexCursor allocateEdgeManualIndexCursor()
+    public RelationshipManualIndexCursor allocateRelationshipManualIndexCursor()
     {
-        return cursors.allocateEdgeManualIndexCursor();
+        return cursors.allocateRelationshipManualIndexCursor();
     }
 }


### PR DESCRIPTION
Rename Edge to Relationship in the Kernel API and NeoLE. 

I think this replacement seriously degrades the readability of the code in many cases. I acknowledge the value of consistent naming, but making this PR was just painful...