### PR TITLE
Fixed error with projections that are simple renames after unwind

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-interpreted-enterprise.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-interpreted-enterprise.txt
@@ -59,7 +59,6 @@ Using a pattern expression in a WITH
 Using a variable-length pattern expression in a WITH
 Using pattern expression in RETURN
 Aggregating on pattern expression
-Returning pattern expression in `exists()`
 Pattern expression inside list comprehension
 Filter relationships with properties using pattern predicate
 Filter using negated pattern predicate

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-interpreted-enterprise.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-interpreted-enterprise.txt
@@ -59,6 +59,7 @@ Using a pattern expression in a WITH
 Using a variable-length pattern expression in a WITH
 Using pattern expression in RETURN
 Aggregating on pattern expression
+Returning pattern expression in `exists()`
 Pattern expression inside list comprehension
 Filter relationships with properties using pattern predicate
 Filter using negated pattern predicate

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -733,7 +733,7 @@ return p""")
         |         RETURN candidate
       """.stripMargin
 
-    val res = succeedWith(Configs.AllExceptSleipnir - Configs.Compiled, query)
+    val res = succeedWith(Configs.All - Configs.Compiled, query)
 
     //Then
     res.toList should equal(List(Map("candidate" -> "John"), Map("candidate" -> "Jonathan")))

--- a/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-interpreted-enterprise.txt
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-interpreted-enterprise.txt
@@ -1,5 +1,4 @@
 Combining string operators' was blacklisted, but succeeded
-Cope with shadowed variables
 Count non-null values
 Counting directed self-relationships
 Counting distinct undirected self-relationships in self-relationship graph
@@ -12,7 +11,6 @@ DISTINCT on nullable values
 Directed match of a simple relationship, count
 Directed match on self-relationship graph, count
 Distinct on null
-Double unwinding a list of lists
 Get rows in the middle by param
 Get rows in the middle
 Run coalesce
@@ -21,7 +19,6 @@ Handling long chains of operators
 handling long chanins of operators
 Handle ORDER BY with LIMIT 1
 Handle projections with ORDER BY - GH#4937
-Honour the column name for RETURN items
 Keeping used expression 1
 LIMIT 0 should return an empty result
 Limit to two hits
@@ -29,7 +26,6 @@ Limiting amount of rows when there are fewer left than the LIMIT argument
 Matching a self-loop
 Matching and returning ordered results, with LIMIT
 Matching with aggregation
-Multiple unwinds after each other
 ORDER BY DESC should order booleans in the expected order
 ORDER BY DESC should order floats in the expected order
 ORDER BY DESC should order ints in the expected order
@@ -56,11 +52,8 @@ Simple counting of nodes
 Start the result from the second row by param
 Start the result from the second row
 Support column renaming for aggregates as well
-Support column renaming
 Support ordering by a property after being distinct-ified
 Support sort and distinct
-Unwind does not prune context
-Unwinding a concatenation of lists
 Use multiple MATCH clauses to do a Cartesian product
 Using aliased DISTINCT expression in ORDER BY
 `type()` on two relationships
@@ -110,12 +103,7 @@ Number-typed float comparison
 Any-typed string comparison
 Comparing nodes to nodes
 Comparing relationships to relationships
-IN should work with nested list subscripting
-IN should work with list slices
-Use dynamic property lookup based on parameters when there is no type information
 Use dynamic property lookup based on parameters when there is rhs type information
-Use collection lookup based on parameters when there is no type information
-Use collection lookup based on parameters when there is lhs type information
 Use collection lookup based on parameters when there is rhs type information
 Fail at runtime when attempting to index with an Int into a Map
 Fail at runtime when trying to index into a map with a non-string
@@ -304,7 +292,6 @@ Multiple aliasing and backreferencing
 Aggregating by a list property has a correct definition of equality
 Reusing variable names
 Handling DISTINCT with lists in maps
-Handling property access on the Any type
 Failing when performing property access on a non-map 1
 Failing when performing property access on a non-map 2
 Bad arguments for `range()`
@@ -382,7 +369,6 @@ Handling mixed relationship patterns 1
 Handling mixed relationship patterns 2
 Handling relationships that are already bound in variable length paths
 Fail when trying to compare strings and numbers
-Aliasing
 Handle dependencies across WITH
 Handle dependencies across WITH with SKIP
 WHERE after WITH should filter results

--- a/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-interpreted-enterprise.txt
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-interpreted-enterprise.txt
@@ -52,6 +52,7 @@ Simple counting of nodes
 Start the result from the second row by param
 Start the result from the second row
 Support column renaming for aggregates as well
+Support column renaming
 Support ordering by a property after being distinct-ified
 Support sort and distinct
 Use multiple MATCH clauses to do a Cartesian product
@@ -371,7 +372,6 @@ Handling relationships that are already bound in variable length paths
 Fail when trying to compare strings and numbers
 Handle dependencies across WITH
 Handle dependencies across WITH with SKIP
-WHERE after WITH should filter results
 WHERE after WITH can filter on top of an aggregation
 ORDER BY on an aggregating key
 WHERE on a DISTINCT column

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/RegisteredRewriter.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/RegisteredRewriter.scala
@@ -50,7 +50,7 @@ class RegisteredRewriter(tokenContext: TokenContext) {
         val rewriter = rewriteCreator(information, oldPlan)
 
         val newExpressions = expressions collect {
-          case (column, expression) if !expression.isInstanceOf[Variable] => column -> expression.endoRewrite(rewriter)
+          case (column, expression) => column -> expression.endoRewrite(rewriter)
         }
 
         val newPlan = oldPlan.copy(expressions = newExpressions)(oldPlan.solved)

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/interpreted/EnterprisePipeBuilder.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/interpreted/EnterprisePipeBuilder.scala
@@ -19,6 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_3.runtime.interpreted
 
+import org.neo4j.cypher.internal.compatibility.v3_3.runtime.ast.{NodeFromRegister, RelationshipFromRegister}
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.commands.convert.ExpressionConverters
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.commands.predicates.{Predicate, True}
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.commands.{expressions => commandExpressions}
@@ -156,6 +157,9 @@ class EnterprisePipeBuilder(fallback: PipeBuilder,
 
       case Projection(_, expressions) =>
         val expressionsWithOffsets = expressions map {
+          case (k, e:NodeFromRegister) =>
+            val offset = pipeline.getLongOffsetFor(k)
+            offset -> convertExpressions(e)
           case (k, e) =>
             val offset = pipeline.getReferenceOffsetFor(k)
             offset -> convertExpressions(e)

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/RegisteredRewriterTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/RegisteredRewriterTest.scala
@@ -221,6 +221,7 @@ class RegisteredRewriterTest extends CypherFunSuite with AstConstructionTestSupp
     // then
     resultPlan should equal(
       Projection(leaf, Map(
+        "x" -> NodeFromRegister(0, "x"),
         "x.propertyKey" -> NodeProperty(pipeline.getLongOffsetFor("x"), tokenId, "x.propertyKey")
       ))(solved)
     )
@@ -245,6 +246,7 @@ class RegisteredRewriterTest extends CypherFunSuite with AstConstructionTestSupp
     val nodeOffset = pipeline.getLongOffsetFor("x")
     resultPlan should equal(
       Projection(leaf, Map(
+        "x" -> NullCheck(0, NodeFromRegister(0, "x")),
         "x.propertyKey" -> NullCheck(nodeOffset, NodeProperty(nodeOffset, tokenId, "x.propertyKey"))
       ))(solved)
     )


### PR DESCRIPTION
This PR builds in #9881 and also replaces the TCK updates in #9885.

While local tests for #9881 passed, the merge into 3.3 caused the same test to fail, with a different error. Perhaps some side effect of another PR? In any case, this new PR should fix the failing test, again.