### PR TITLE
Align value module ordering with OpenCypher

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/SortPipe.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/SortPipe.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes
 
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.Id
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.{Comparer, ExecutionContext}
-import org.neo4j.values.AnyValue
+import org.neo4j.values.{AnyValue, AnyValues}
 
 case class SortPipe(source: Pipe, orderBy: Seq[SortDescription])
                    (val id: Id = new Id)
@@ -59,11 +59,10 @@ sealed trait SortDescription {
   def compareAny(a: AnyValue, b: AnyValue)(implicit qtx: QueryState): Int
 }
 
-//TODO these should use AnyValue comparator directly but it currently doesn't give the correct orderting
 case class Ascending(id: String) extends SortDescription with Comparer {
-  override def compareAny(a: AnyValue, b: AnyValue)(implicit qtx: QueryState): Int = compareForOrderability(Some("ORDER BY"), a, b)
+  override def compareAny(a: AnyValue, b: AnyValue)(implicit qtx: QueryState): Int = AnyValues.COMPARATOR.compare(a, b)
 }
 
 case class Descending(id: String) extends SortDescription with Comparer {
-  override def compareAny(a: AnyValue, b: AnyValue)(implicit qtx: QueryState): Int = compareForOrderability(Some("ORDER BY"), b, a)
+  override def compareAny(a: AnyValue, b: AnyValue)(implicit qtx: QueryState): Int = AnyValues.COMPARATOR.compare(b, a)
 }

--- a/community/values/src/main/java/org/neo4j/values/AnyValueComparator.java
+++ b/community/values/src/main/java/org/neo4j/values/AnyValueComparator.java
@@ -60,10 +60,28 @@ class AnyValueComparator implements Comparator<AnyValue>
             return -1;
         }
 
+        // We must handle sequences as a special case, as they can be both storable and virtual
+        boolean isSequence1 = v1.isSequenceValue();
+        boolean isSequence2 = v2.isSequenceValue();
+
+        if ( isSequence1 && isSequence2 )
+        {
+            return compareSequences( (SequenceValue)v1, (SequenceValue)v2 );
+        }
+        else if ( isSequence1 )
+        {
+            return compareSequenceAndNonSequence( (SequenceValue)v1, v2 );
+        }
+        else if ( isSequence2 )
+        {
+            return -compareSequenceAndNonSequence( (SequenceValue)v2, v1 );
+        }
+
+        // Handle remaining AnyValues
         boolean isValue1 = v1 instanceof Value;
         boolean isValue2 = v2 instanceof Value;
 
-        int x = -Boolean.compare( isValue1, isValue2 );
+        int x = Boolean.compare( isValue1, isValue2 );
 
         if ( x == 0 )
         {
@@ -98,5 +116,23 @@ class AnyValueComparator implements Comparator<AnyValue>
             return v1.compareTo( v2, this );
         }
         return x;
+    }
+
+    private int compareSequenceAndNonSequence( SequenceValue v1, AnyValue v2 )
+    {
+        boolean isValue2 = v2 instanceof Value;
+        if ( isValue2 )
+        {
+            return -1;
+        }
+        else
+        {
+            return virtualValueGroupComparator.compare( VirtualValueGroup.LIST, ((VirtualValue)v2).valueGroup() );
+        }
+    }
+
+    private int compareSequences( SequenceValue v1, SequenceValue v2 )
+    {
+        return v1.compareToSequence( v2, this );
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/AnyValues.java
+++ b/community/values/src/main/java/org/neo4j/values/AnyValues.java
@@ -57,6 +57,43 @@ public final class AnyValues
 {
     /**
      * Default AnyValue comparator. Will correctly compare all storable and virtual values.
+     *
+     * <h1>
+     * Orderability
+     *
+     * <a href="https://github.com/opencypher/openCypher/blob/master/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc">
+     *   The Cypher CIP defining orderability
+     * </a>
+     *
+     * <p>
+     * Ascending global sort order of disjoint types:
+     *
+     * <ul>
+     *   <li> MAP types
+     *   <ul>
+     *     <li> Regular map
+     *
+     *     <li> NODE
+     *
+     *     <li> RELATIONSHIP
+     *   </ul>
+     *
+     *  <li> LIST OF ANY?
+     *
+     *  <li> PATH
+     *
+     *  <li> POINT
+     *
+     *  <li> STRING
+     *
+     *  <li> BOOLEAN
+     *
+     *  <li> NUMBER
+     *    <ul>
+     *      <li> NaN values are treated as the largest numbers in orderability only (i.e. they are put after positive infinity)
+     *    </ul>
+     *  <li> VOID (i.e. the type of null)
+     * </ul>
      */
     public static final Comparator<AnyValue> COMPARATOR =
             new AnyValueComparator( Values.COMPARATOR, VirtualValueGroup::compareTo );

--- a/community/values/src/main/java/org/neo4j/values/SequenceValue.java
+++ b/community/values/src/main/java/org/neo4j/values/SequenceValue.java
@@ -18,6 +18,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 package org.neo4j.values;
+
+import java.util.Comparator;
+
 /**
  * Values that represent sequences of values (such as Lists or Arrays) need to implement this interface.
  * Thus we can get an equality check that is based on the values (e.g. List.equals(ArrayValue) )
@@ -52,4 +55,25 @@ public interface SequenceValue
     AnyValue value( int offset );
 
     int length();
+
+    default int compareToSequence( SequenceValue other, Comparator<AnyValue> comparator )
+    {
+        int i = 0;
+        int x = 0;
+        int length = Math.min( length(), other.length() );
+
+        while ( x == 0 && i < length )
+        {
+            x = comparator.compare( value( i ), other.value( i ) );
+            i++;
+        }
+
+        if ( x == 0 )
+        {
+            x = length() - other.length();
+        }
+
+        return x;
+    }
+
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/ArrayValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ArrayValue.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.values.storable;
 
+import java.util.Iterator;
+
+import org.neo4j.values.AnyValue;
 import org.neo4j.values.SequenceValue;
 
 /**
@@ -27,6 +30,31 @@ import org.neo4j.values.SequenceValue;
 public abstract class ArrayValue extends Value implements SequenceValue
 {
     public abstract int length();
+
+    public IterationPreference iterationPreference()
+    {
+        return IterationPreference.RANDOM_ACCESS;
+    }
+
+    public Iterator<AnyValue> iterator()
+    {
+        return new Iterator<AnyValue>()
+        {
+            private int offset;
+
+            @Override
+            public boolean hasNext()
+            {
+                return offset < length();
+            }
+
+            @Override
+            public AnyValue next()
+            {
+                return value( offset );
+            }
+        };
+    }
 
     @Override
     public boolean equals( boolean x )

--- a/community/values/src/main/java/org/neo4j/values/storable/NumberValues.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/NumberValues.java
@@ -242,56 +242,80 @@ public final class NumberValues
     public static int compareIntegerArrays( IntegralArray a, IntegralArray b )
     {
         int i = 0;
-        int length = a.length();
-        int x = length - b.length();
+        int x = 0;
+        int length = Math.min( a.length(), b.length() );
 
         while ( x == 0 && i < length )
         {
             x = Long.compare( a.longValue( i ), b.longValue( i ) );
             i++;
         }
+
+        if ( x == 0 )
+        {
+            x = a.length() - b.length();
+        }
+
         return x;
     }
 
     public static int compareIntegerVsFloatArrays( IntegralArray a, FloatingPointArray b )
     {
         int i = 0;
-        int length = a.length();
-        int x = length - b.length();
+        int x = 0;
+        int length = Math.min( a.length(), b.length() );
 
         while ( x == 0 && i < length )
         {
             x = compareLongAgainstDouble( a.longValue( i ), b.doubleValue( i ) );
             i++;
         }
+
+        if ( x == 0 )
+        {
+            x = a.length() - b.length();
+        }
+
         return x;
     }
 
     public static int compareFloatArrays( FloatingPointArray a, FloatingPointArray b )
     {
         int i = 0;
-        int length = a.length();
-        int x = length - b.length();
+        int x = 0;
+        int length = Math.min( a.length(), b.length() );
 
         while ( x == 0 && i < length )
         {
             x = Double.compare( a.doubleValue( i ), b.doubleValue( i ) );
             i++;
         }
+
+        if ( x == 0 )
+        {
+            x = a.length() - b.length();
+        }
+
         return x;
     }
 
     public static int compareBooleanArrays( BooleanArray a, BooleanArray b )
     {
         int i = 0;
-        int length = a.length();
-        int x = length - b.length();
+        int x = 0;
+        int length = Math.min( a.length(), b.length() );
 
         while ( x == 0 && i < length )
         {
             x = Boolean.compare( a.booleanValue( i ), b.booleanValue( i ) );
             i++;
         }
+
+        if ( x == 0 )
+        {
+            x = a.length() - b.length();
+        }
+
         return x;
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/TextValues.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TextValues.java
@@ -49,13 +49,17 @@ public final class TextValues
     public static int compareTextArrays( TextArray a, TextArray b )
     {
         int i = 0;
-        int length = a.length();
-        int x = length - b.length();
+        int x = 0;
+        int length = Math.min( a.length(), b.length() );
 
         while ( x == 0 && i < length )
         {
             x = a.stringValue( i ).compareTo( b.stringValue( i ) );
             i++;
+        }
+        if ( x == 0 )
+        {
+            x = a.length() - b.length();
         }
         return x;
     }

--- a/community/values/src/main/java/org/neo4j/values/storable/ValueGroup.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ValueGroup.java
@@ -22,15 +22,18 @@ package org.neo4j.values.storable;
 /**
  * The ValueGroup is the logical group or type of a Value. For example byte, short, int and long are all attempting
  * to represent mathematical integers, meaning that for comparison purposes they should be treated the same.
+ *
+ * The order here is defined in <a href="https://github.com/opencypher/openCypher/blob/master/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc">
+ *   The Cypher CIP defining orderability
+ * </a>
  */
 public enum ValueGroup
 {
+    TEXT_ARRAY,
+    BOOLEAN_ARRAY,
+    NUMBER_ARRAY,
     TEXT,
     BOOLEAN,
     NUMBER,
-    NUMBER_ARRAY,
-    TEXT_ARRAY,
-    BOOLEAN_ARRAY,
-    VIRTUAL,
     NO_VALUE,
 }

--- a/community/values/src/main/java/org/neo4j/values/virtual/ListValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/ListValue.java
@@ -152,6 +152,12 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
         }
 
         @Override
+        public IterationPreference iterationPreference()
+        {
+            return IterationPreference.RANDOM_ACCESS;
+        }
+
+        @Override
         public <E extends Exception> void writeTo( AnyValueWriter<E> writer ) throws E
         {
             int length = array.length();
@@ -220,6 +226,12 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
         }
 
         @Override
+        public IterationPreference iterationPreference()
+        {
+            return IterationPreference.RANDOM_ACCESS;
+        }
+
+        @Override
         public <E extends Exception> void writeTo( AnyValueWriter<E> writer ) throws E
         {
             writer.beginList( values.length );
@@ -265,6 +277,12 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
             assert !containsNull( values );
 
             this.values = values;
+        }
+
+        @Override
+        public IterationPreference iterationPreference()
+        {
+            return IterationPreference.ITERATION;
         }
 
         @Override
@@ -317,6 +335,12 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
             this.inner = inner;
             this.from = from;
             this.to = to;
+        }
+
+        @Override
+        public IterationPreference iterationPreference()
+        {
+            return inner.iterationPreference();
         }
 
         @Override
@@ -377,6 +401,12 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
         }
 
         @Override
+        public IterationPreference iterationPreference()
+        {
+            return inner.iterationPreference();
+        }
+
+        @Override
         public <E extends Exception> void writeTo( AnyValueWriter<E> writer ) throws E
         {
             writer.beginList( size() );
@@ -432,6 +462,12 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
         {
             this.inner = inner;
             this.transform = transform;
+        }
+
+        @Override
+        public IterationPreference iterationPreference()
+        {
+            return inner.iterationPreference();
         }
 
         @Override
@@ -619,6 +655,12 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
             return new FilteredIterator();
         }
 
+        @Override
+        public IterationPreference iterationPreference()
+        {
+            return IterationPreference.ITERATION;
+        }
+
         private class FilteredIterator implements Iterator<AnyValue>
         {
             private AnyValue next;
@@ -687,6 +729,12 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
             this.start = start;
             this.end = end;
             this.step = step;
+        }
+
+        @Override
+        public IterationPreference iterationPreference()
+        {
+            return IterationPreference.RANDOM_ACCESS;
         }
 
         @Override
@@ -788,6 +836,12 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
         ConcatList( ListValue[] lists )
         {
             this.lists = lists;
+        }
+
+        @Override
+        public IterationPreference iterationPreference()
+        {
+            return IterationPreference.ITERATION;
         }
 
         @Override

--- a/community/values/src/main/java/org/neo4j/values/virtual/PathValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/PathValue.java
@@ -104,18 +104,22 @@ public final class PathValue extends VirtualValue
 
         PathValue otherPath = (PathValue) other;
 
-        int x = Integer.compare( edges.length, otherPath.edges.length );
+        int x = nodes[0].compareTo( otherPath.nodes[0], comparator );
         if ( x == 0 )
         {
-            for ( int i = 0; i < edges.length; i++ )
+            int i = 0;
+            int length = Math.min( edges.length, otherPath.edges.length );
+
+            while ( x == 0 && i < length )
             {
                 x = edges[i].compareTo( otherPath.edges[i], comparator );
-                if ( x != 0 )
-                {
-                    return x;
-                }
+                ++i;
             }
-            x = nodes[0].compareTo( otherPath.nodes[0], comparator );
+
+            if ( x == 0 )
+            {
+                x = Integer.compare( edges.length, otherPath.edges.length );
+            }
         }
 
         return x;

--- a/community/values/src/main/java/org/neo4j/values/virtual/VirtualValueGroup.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/VirtualValueGroup.java
@@ -25,13 +25,11 @@ package org.neo4j.values.virtual;
  */
 public enum VirtualValueGroup
 {
+    MAP,
     NODE,
     EDGE,
-    PATH,
-    LABEL,
-    LABEL_SET,
-    POINT,
     LIST,
-    MAP,
+    PATH,
+    POINT,
     NO_VALUE,
 }

--- a/community/values/src/test/java/org/neo4j/values/AnyValueComparatorTest.java
+++ b/community/values/src/test/java/org/neo4j/values/AnyValueComparatorTest.java
@@ -104,16 +104,18 @@ public class AnyValueComparatorTest
 
             // Path
             path( nodes( 1L ), edges() ),
-            path( nodes( 2L ), edges() ),
-            path( nodes( 3L ), edges() ),
             path( nodes( 1L, 2L ), edges( 1L ) ),
-            path( nodes( 4L, 5L ), edges( 2L ) ),
-            path( nodes( 1L, 2L ), edges( 3L ) ), // non-zero length paths are ordered by edges,
             path( nodes( 1L, 2L, 3L ), edges( 1L, 2L ) ),
             path( nodes( 1L, 2L, 3L ), edges( 1L, 3L ) ),
-            path( nodes( 1L, 2L, 3L ), edges( 2L, 3L ) ),
             path( nodes( 1L, 2L, 3L, 4L ), edges( 1L, 3L, 4L ) ),
             path( nodes( 1L, 2L, 3L, 4L ), edges( 1L, 4L, 2L ) ),
+            path( nodes( 1L, 2L, 3L ), edges( 2L, 3L ) ),
+            path( nodes( 1L, 2L ), edges( 3L ) ),
+            path( nodes( 2L ), edges() ),
+            path( nodes( 2L, 1L ), edges( 1L ) ),
+            path( nodes( 3L ), edges() ),
+            path( nodes( 4L, 5L ), edges( 2L ) ),
+            path( nodes( 5L, 4L ), edges( 2L ) ),
 
             // SCALARS AND POINTS
 

--- a/community/values/src/test/java/org/neo4j/values/AnyValueComparatorTest.java
+++ b/community/values/src/test/java/org/neo4j/values/AnyValueComparatorTest.java
@@ -54,13 +54,21 @@ public class AnyValueComparatorTest
     private Comparator<AnyValue> comparator = AnyValues.COMPARATOR;
 
     private Object[] objs = new Object[]{
-            // Storable values
-            "hello",
-            true,
-            1L,
-            Math.PI,
-            Short.MAX_VALUE,
-            Double.NaN,
+            // MAP LIKE TYPES
+
+            // Map
+            map(),
+            map( "1", 'a' ),
+            map( "1", 'b' ),
+            map( "2", 'a' ),
+            map( "1", map( "1", map( "1", 'a' ) ), "2", 'x' ),
+            map( "1", map( "1", map( "1", 'b' ) ), "2", 'x' ),
+            map( "1", 'a', "2", 'b' ),
+            map( "1", 'b', "2", map() ),
+            map( "1", 'b', "2", map( "10", 'a' ) ),
+            map( "1", 'b', "2", map( "10", 'b' ) ),
+            map( "1", 'b', "2", map( "20", 'a' ) ),
+            map( "1", 'b', "2", 'a' ),
 
             // Node
             node( 1L ),
@@ -72,6 +80,27 @@ public class AnyValueComparatorTest
             edgeValue( 2L, nodeValue( 1L, stringArray( "L" ), emptyMap() ),
                     nodeValue( 2L, stringArray( "L" ), emptyMap() ), stringValue( "type" ), emptyMap() ),
             edge( 3L ),
+
+            // LIST AND STORABLE ARRAYS
+
+            // List
+            list(),
+            new String[]{"a"},
+            new boolean[]{false},
+            list( 1 ),
+            list( 1, 2 ),
+            list( 1, 3 ),
+            list( 2, 1 ),
+            new short[]{2, 3},
+            list( 3 ),
+            list( 3, list( 1 ) ),
+            list( 3, list( 1, 2 ) ),
+            list( 3, list( 2 ) ),
+            list( 3, 1 ),
+            new double[]{3.0, 2.0},
+            list( 4, list( 1, list( 1 ) ) ),
+            list( 4, list( 1, list( 2 ) ) ),
+            new int[]{4, 1},
 
             // Path
             path( nodes( 1L ), edges() ),
@@ -86,6 +115,8 @@ public class AnyValueComparatorTest
             path( nodes( 1L, 2L, 3L, 4L ), edges( 1L, 3L, 4L ) ),
             path( nodes( 1L, 2L, 3L, 4L ), edges( 1L, 4L, 2L ) ),
 
+            // SCALARS AND POINTS
+
             // Point
             pointCartesian( -1.0, -1.0 ),
             pointCartesian( 1.0, 1.0 ),
@@ -96,32 +127,14 @@ public class AnyValueComparatorTest
             pointGeographic( 1.0, 2.0 ),
             pointGeographic( 2.0, 1.0 ),
 
-            // List
-            list(),
-            list( 1 ),
-            list( 3 ),
-            list( 1, 2 ),
-            list( 1, 3 ),
-            list( 2, 1 ),
-            list( 3, list( 1 ) ),
-            list( 3, list( 2 ) ),
-            list( 3, list( 1, 2 ) ),
-            list( 4, list( 1, list( 1 ) ) ),
-            list( 4, list( 1, list( 2 ) ) ),
+            // Scalars
+            "hello",
+            true,
+            1L,
+            Math.PI,
+            Short.MAX_VALUE,
+            Double.NaN,
 
-            // Map
-            map(),
-            map( "1", 'a' ),
-            map( "1", 'b' ),
-            map( "2", 'a' ),
-            map( "1", 'a', "2", 'b' ),
-            map( "1", 'b', "2", 'a' ),
-            map( "1", 'b', "2", map() ),
-            map( "1", 'b', "2", map( "10", 'a' ) ),
-            map( "1", 'b', "2", map( "10", 'b' ) ),
-            map( "1", 'b', "2", map( "20", 'a' ) ),
-            map( "1", map( "1", map( "1", 'a' ) ), "2", 'x' ),
-            map( "1", map( "1", map( "1", 'b' ) ), "2", 'x' ),
             // OTHER
             null,
     };

--- a/community/values/src/test/java/org/neo4j/values/storable/ValueComparisonTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/ValueComparisonTest.java
@@ -38,6 +38,23 @@ public class ValueComparisonTest
     private Comparator<Value> comparator = Values.COMPARATOR;
 
     private Object[] objs = new Object[]{
+            // ARRAYS
+            new String[]{},
+            new String[]{"a"},
+            new String[]{"a", "aa"},
+            new char[]{'a', 'b'},
+            new String[]{"aa"},
+            new boolean[]{},
+            new boolean[]{false},
+            new boolean[]{false, true},
+            new boolean[]{true},
+            new int[]{},
+            new double[]{-1.0},
+            new long[]{-1, 44},
+            new float[]{2},
+            new short[]{2, 3},
+            new byte[]{3, -99, -99},
+
             // STRING
             "",
             Character.MIN_VALUE,


### PR DESCRIPTION
This PR changes the ordering of storable and virtual `Value`s. This is done to align with the accepted [OpenCypher CIP defining orderability](https://github.com/opencypher/openCypher/blob/master/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc).

Changes to value ordering when comparing **storable** values:
  * Arrays are ordered before scalars

Changes to value ordering when comparing **all** values:
  * supertypes are ordered as `map`, `node`, `relationship`, `list/array`, `path`, `point`, `text`, `boolean`, `number`, `NO_VALUE`
  * lists have dictionary order, eg. `[], [1], [1,2], [2], ...` 
  * paths are ordered as lists of alternating nodes and relationships

Finally this allows us to use `AnyValues.COMPARATOR` for `SortPipe` ordering.