### PR TITLE
Ignore NeoLE tests on BIG_ENDIAN platforms

### DIFF
--- a/enterprise/runtime/neole/src/test/java/org/neo4j/impl/store/prototype/neole/DeepEdgeTraversalCursorTest.java
+++ b/enterprise/runtime/neole/src/test/java/org/neo4j/impl/store/prototype/neole/DeepEdgeTraversalCursorTest.java
@@ -22,6 +22,8 @@ package org.neo4j.impl.store.prototype.neole;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import java.nio.ByteOrder;
+
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -103,6 +105,8 @@ public class DeepEdgeTraversalCursorTest
     @Test
     public void shouldTraverseTreeOfDepthThree() throws Exception
     {
+        org.junit.Assume.assumeTrue( ByteOrder.LITTLE_ENDIAN.equals( ByteOrder.nativeOrder() ) );
+
         try ( NodeCursor node = graph.allocateNodeCursor();
               EdgeGroupCursor group = graph.allocateEdgeGroupCursor();
               EdgeTraversalCursor edge1 = graph.allocateEdgeTraversalCursor();

--- a/enterprise/runtime/neole/src/test/java/org/neo4j/impl/store/prototype/neole/EdgeScanCursorTest.java
+++ b/enterprise/runtime/neole/src/test/java/org/neo4j/impl/store/prototype/neole/EdgeScanCursorTest.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.impl.store.prototype.neole;
 
+import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -188,6 +189,8 @@ public class EdgeScanCursorTest
     @Test
     public void shouldAccessNodes() throws Exception
     {
+        org.junit.Assume.assumeTrue( ByteOrder.LITTLE_ENDIAN.equals( ByteOrder.nativeOrder() ) );
+
         // given
         try ( EdgeScanCursor edges = graph.allocateEdgeScanCursor() )
         {

--- a/enterprise/runtime/neole/src/test/java/org/neo4j/impl/store/prototype/neole/EdgeTraversalCursorTest.java
+++ b/enterprise/runtime/neole/src/test/java/org/neo4j/impl/store/prototype/neole/EdgeTraversalCursorTest.java
@@ -22,6 +22,8 @@ package org.neo4j.impl.store.prototype.neole;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import java.nio.ByteOrder;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
@@ -116,6 +118,8 @@ public class EdgeTraversalCursorTest
     @Test
     public void shouldTraverseEdgesOfGivenType() throws Exception
     {
+        org.junit.Assume.assumeTrue( ByteOrder.LITTLE_ENDIAN.equals( ByteOrder.nativeOrder() ) );
+
         // given
         try ( NodeCursor node = graph.allocateNodeCursor();
               EdgeGroupCursor group = graph.allocateEdgeGroupCursor();
@@ -173,6 +177,8 @@ public class EdgeTraversalCursorTest
     @Test
     public void shouldFollowSpecificEdge() throws Exception
     {
+        org.junit.Assume.assumeTrue( ByteOrder.LITTLE_ENDIAN.equals( ByteOrder.nativeOrder() ) );
+
         // given
         try ( NodeCursor node = graph.allocateNodeCursor();
               EdgeGroupCursor group = graph.allocateEdgeGroupCursor();

--- a/enterprise/runtime/neole/src/test/java/org/neo4j/impl/store/prototype/neole/NodeCursorTest.java
+++ b/enterprise/runtime/neole/src/test/java/org/neo4j/impl/store/prototype/neole/NodeCursorTest.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.impl.store.prototype.neole;
 
+import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -148,6 +149,8 @@ public class NodeCursorTest
     @Test
     public void shouldReadLabels() throws Exception
     {
+        org.junit.Assume.assumeTrue( ByteOrder.LITTLE_ENDIAN.equals( ByteOrder.nativeOrder() ) );
+
         // given
         try ( NodeCursor nodes = graph.allocateNodeCursor() )
         {

--- a/enterprise/runtime/neole/src/test/java/org/neo4j/impl/store/prototype/neole/PropertyCursorTest.java
+++ b/enterprise/runtime/neole/src/test/java/org/neo4j/impl/store/prototype/neole/PropertyCursorTest.java
@@ -22,6 +22,7 @@ package org.neo4j.impl.store.prototype.neole;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import java.nio.ByteOrder;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -128,6 +129,8 @@ public class PropertyCursorTest
     @Test
     public void shouldAccessSingleProperty() throws Exception
     {
+        org.junit.Assume.assumeTrue( ByteOrder.LITTLE_ENDIAN.equals( ByteOrder.nativeOrder() ) );
+
         assertAccessSingleProperty( byteProp, Values.of( (byte)13 ) );
         assertAccessSingleProperty( shortProp, Values.of( (short)13 ) );
         assertAccessSingleProperty( intProp, Values.of( 13 ) );
@@ -145,6 +148,8 @@ public class PropertyCursorTest
     @Test
     public void shouldAccessAllNodeProperties() throws Exception
     {
+        org.junit.Assume.assumeTrue( ByteOrder.LITTLE_ENDIAN.equals( ByteOrder.nativeOrder() ) );
+
         // given
         try ( NodeCursor node = graph.allocateNodeCursor();
                 PropertyCursor props = graph.allocatePropertyCursor() )

--- a/enterprise/runtime/neole/src/test/java/org/neo4j/impl/store/prototype/neole/RandomEdgeTraversalCursorTest.java
+++ b/enterprise/runtime/neole/src/test/java/org/neo4j/impl/store/prototype/neole/RandomEdgeTraversalCursorTest.java
@@ -22,6 +22,7 @@ package org.neo4j.impl.store.prototype.neole;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -79,6 +80,8 @@ public class RandomEdgeTraversalCursorTest
     @Test
     public void shouldManageRandomTraversals() throws Exception
     {
+        org.junit.Assume.assumeTrue( ByteOrder.LITTLE_ENDIAN.equals( ByteOrder.nativeOrder() ) );
+
         // given
         try ( NodeCursor node = graph.allocateNodeCursor();
               EdgeGroupCursor group = graph.allocateEdgeGroupCursor();


### PR DESCRIPTION
NeoLE is a tool to support Cypher runtime development and to
use as inspiration when implementing the Kernel API in Neo4j.
We have no interest in supporting Big-Endian platforms and have
therefore decided to ignore NeoLE tests on Big-Endian platforms
if they would otherwise fail.