### PR TITLE
Respect dbms.allow_upgrade concerning LogEntryVersion

### DIFF
--- a/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckToolTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckToolTest.java
@@ -191,7 +191,7 @@ public class ConsistencyCheckToolTest
             tx.success();
         }
 
-        fs.snapshot( () -> db.shutdown() );
+        fs.snapshot( db::shutdown );
     }
 
     private void runConsistencyCheckToolWith( FileSystemAbstraction fileSystem, String... args )

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -102,6 +102,7 @@ import org.neo4j.kernel.impl.transaction.log.BatchingTransactionAppender;
 import org.neo4j.kernel.impl.transaction.log.LogFileInformation;
 import org.neo4j.kernel.impl.transaction.log.LogHeaderCache;
 import org.neo4j.kernel.impl.transaction.log.LogPosition;
+import org.neo4j.kernel.impl.transaction.log.LogTailScanner;
 import org.neo4j.kernel.impl.transaction.log.LogVersionRepository;
 import org.neo4j.kernel.impl.transaction.log.LoggingLogFileMonitor;
 import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
@@ -148,7 +149,6 @@ import org.neo4j.kernel.lifecycle.Lifecycles;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.kernel.monitoring.tracing.Tracers;
 import org.neo4j.kernel.recovery.DefaultRecoverySPI;
-import org.neo4j.kernel.recovery.LatestCheckPointFinder;
 import org.neo4j.kernel.recovery.PositionToRecoverFrom;
 import org.neo4j.kernel.recovery.Recovery;
 import org.neo4j.kernel.spi.legacyindex.IndexImplementation;
@@ -691,11 +691,11 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
             LogEntryReader<ReadableClosablePositionAwareChannel> logEntryReader,
             LogicalTransactionStore logicalTransactionStore )
     {
-        final LatestCheckPointFinder checkPointFinder =
-                new LatestCheckPointFinder( logFiles, fileSystemAbstraction, logEntryReader );
+        final LogTailScanner logTailScanner =
+                new LogTailScanner( logFiles, fileSystemAbstraction, logEntryReader );
         Recovery.SPI spi = new DefaultRecoverySPI(
                 storageEngine, logFiles, fileSystemAbstraction, logVersionRepository,
-                checkPointFinder, transactionIdStore, logicalTransactionStore, positionMonitor );
+                logTailScanner, transactionIdStore, logicalTransactionStore, positionMonitor );
         Recovery recovery = new Recovery( spi, recoveryMonitor );
         monitors.addMonitorListener( new Recovery.Monitor()
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreTransactionLogModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreTransactionLogModule.java
@@ -61,11 +61,6 @@ class NeoStoreTransactionLogModule
         return logicalTransactionStore;
     }
 
-    public PhysicalLogFiles logFiles()
-    {
-        return logFiles;
-    }
-
     CheckPointer checkPointing()
     {
         return checkPointer;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/recovery/RecoveryRequiredChecker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/recovery/RecoveryRequiredChecker.java
@@ -27,11 +27,11 @@ import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.transaction.log.LogPosition;
+import org.neo4j.kernel.impl.transaction.log.LogTailScanner;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
 import org.neo4j.kernel.impl.transaction.log.ReadableClosablePositionAwareChannel;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
 import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
-import org.neo4j.kernel.recovery.LatestCheckPointFinder;
 import org.neo4j.kernel.recovery.PositionToRecoverFrom;
 
 import static org.neo4j.kernel.recovery.PositionToRecoverFrom.NO_MONITOR;
@@ -67,7 +67,7 @@ public class RecoveryRequiredChecker
 
         LogEntryReader<ReadableClosablePositionAwareChannel> reader = new VersionAwareLogEntryReader<>();
 
-        LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fs, reader );
+        LogTailScanner finder = new LogTailScanner( logFiles, fs, reader );
         return new PositionToRecoverFrom( finder, NO_MONITOR ).apply( logVersion ) != LogPosition.UNSPECIFIED;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/recovery/RecoveryRequiredChecker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/recovery/RecoveryRequiredChecker.java
@@ -63,11 +63,12 @@ public class RecoveryRequiredChecker
         }
 
         long logVersion = MetaDataStore.getRecord( pageCache, neoStore, MetaDataStore.Position.LOG_VERSION );
+        MetaDataStore.setRecord( pageCache, neoStore, MetaDataStore.Position.LOG_VERSION, logVersion );
         PhysicalLogFiles logFiles = new PhysicalLogFiles( dataDir, fs );
 
         LogEntryReader<ReadableClosablePositionAwareChannel> reader = new VersionAwareLogEntryReader<>();
 
-        LogTailScanner finder = new LogTailScanner( logFiles, fs, reader );
-        return new PositionToRecoverFrom( finder, NO_MONITOR ).apply( logVersion ) != LogPosition.UNSPECIFIED;
+        LogTailScanner tailScanner = new LogTailScanner( logFiles, fs, reader );
+        return new PositionToRecoverFrom( tailScanner, NO_MONITOR ).get() != LogPosition.UNSPECIFIED;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/recovery/RecoveryRequiredChecker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/recovery/RecoveryRequiredChecker.java
@@ -62,8 +62,6 @@ public class RecoveryRequiredChecker
             return false;
         }
 
-        long logVersion = MetaDataStore.getRecord( pageCache, neoStore, MetaDataStore.Position.LOG_VERSION );
-        MetaDataStore.setRecord( pageCache, neoStore, MetaDataStore.Position.LOG_VERSION, logVersion );
         PhysicalLogFiles logFiles = new PhysicalLogFiles( dataDir, fs );
 
         LogEntryReader<ReadableClosablePositionAwareChannel> reader = new VersionAwareLogEntryReader<>();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
@@ -110,7 +110,6 @@ import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.kernel.spi.legacyindex.IndexImplementation;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.scheduler.JobScheduler;
-import org.neo4j.storageengine.api.CommandReaderFactory;
 import org.neo4j.storageengine.api.CommandsToApply;
 import org.neo4j.storageengine.api.StorageCommand;
 import org.neo4j.storageengine.api.StorageEngine;
@@ -153,7 +152,6 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
     private final IdOrderingQueue legacyIndexTransactionOrdering;
     private final LockService lockService;
     private final WorkSync<Supplier<LabelScanWriter>,LabelUpdateWork> labelScanStoreSync;
-    private final CommandReaderFactory commandReaderFactory;
     private final WorkSync<IndexingUpdateService,IndexUpdatesWork> indexUpdatesSync;
     private final IndexStoreView indexStoreView;
     private final LegacyIndexProviderLookup legacyIndexProviderLookup;
@@ -241,7 +239,6 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
 
             labelScanStoreSync = new WorkSync<>( labelScanStore::newWriter );
 
-            commandReaderFactory = new RecordStorageCommandReaderFactory();
             indexUpdatesSync = new WorkSync<>( indexingService );
 
             // Immutable state for creating/applying commands
@@ -274,12 +271,6 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
     public StoreReadLayer storeReadLayer()
     {
         return storeLayer;
-    }
-
-    @Override
-    public CommandReaderFactory commandReaderFactory()
-    {
-        return commandReaderFactory;
     }
 
     @SuppressWarnings( "resource" )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
@@ -110,6 +110,7 @@ import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.kernel.spi.legacyindex.IndexImplementation;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.scheduler.JobScheduler;
+import org.neo4j.storageengine.api.CommandReaderFactory;
 import org.neo4j.storageengine.api.CommandsToApply;
 import org.neo4j.storageengine.api.StorageCommand;
 import org.neo4j.storageengine.api.StorageEngine;
@@ -152,6 +153,7 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
     private final IdOrderingQueue legacyIndexTransactionOrdering;
     private final LockService lockService;
     private final WorkSync<Supplier<LabelScanWriter>,LabelUpdateWork> labelScanStoreSync;
+    private final CommandReaderFactory commandReaderFactory;
     private final WorkSync<IndexingUpdateService,IndexUpdatesWork> indexUpdatesSync;
     private final IndexStoreView indexStoreView;
     private final LegacyIndexProviderLookup legacyIndexProviderLookup;
@@ -239,6 +241,7 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
 
             labelScanStoreSync = new WorkSync<>( labelScanStore::newWriter );
 
+            commandReaderFactory = new RecordStorageCommandReaderFactory();
             indexUpdatesSync = new WorkSync<>( indexingService );
 
             // Immutable state for creating/applying commands
@@ -271,6 +274,12 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
     public StoreReadLayer storeReadLayer()
     {
         return storeLayer;
+    }
+
+    @Override
+    public CommandReaderFactory commandReaderFactory()
+    {
+        return commandReaderFactory;
     }
 
     @SuppressWarnings( "resource" )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/UpgradableDatabase.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/UpgradableDatabase.java
@@ -20,9 +20,7 @@
 package org.neo4j.kernel.impl.storemigration;
 
 import java.io.File;
-import java.io.IOException;
 
-import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.format.FormatFamily;
 import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
@@ -35,10 +33,6 @@ import org.neo4j.kernel.impl.storemigration.StoreUpgrader.UpgradingStoreVersionN
 import org.neo4j.kernel.impl.storemigration.StoreVersionCheck.Result;
 import org.neo4j.kernel.impl.storemigration.StoreVersionCheck.Result.Outcome;
 import org.neo4j.kernel.impl.transaction.log.LogTailScanner;
-import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
-import org.neo4j.kernel.impl.transaction.log.ReadableClosablePositionAwareChannel;
-import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
-import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
 
 /**
  * Logic to check whether a database version is upgradable to the current version. It looks at the
@@ -46,16 +40,16 @@ import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
  */
 public class UpgradableDatabase
 {
-    private final FileSystemAbstraction fs;
     private final StoreVersionCheck storeVersionCheck;
     private final RecordFormats format;
+    private final LogTailScanner tailScanner;
 
-    public UpgradableDatabase( FileSystemAbstraction fs,
-            StoreVersionCheck storeVersionCheck, RecordFormats format )
+    public UpgradableDatabase( StoreVersionCheck storeVersionCheck, RecordFormats format,
+            LogTailScanner tailScanner )
     {
-        this.fs = fs;
         this.storeVersionCheck = storeVersionCheck;
         this.format = format;
+        this.tailScanner = tailScanner;
     }
 
     /**
@@ -103,7 +97,7 @@ public class UpgradableDatabase
             }
             else
             {
-                result = checkCleanShutDownByCheckPoint( storeDirectory );
+                result = checkCleanShutDownByCheckPoint();
                 if ( result.outcome.isSuccessful() )
                 {
                     return fromFormat;
@@ -133,22 +127,17 @@ public class UpgradableDatabase
         }
     }
 
-    private Result checkCleanShutDownByCheckPoint( File storeDirectory )
+    private Result checkCleanShutDownByCheckPoint()
     {
         // check version
-        PhysicalLogFiles logFiles = new PhysicalLogFiles( storeDirectory, fs );
-        LogEntryReader<ReadableClosablePositionAwareChannel> logEntryReader = new VersionAwareLogEntryReader<>();
-        LogTailScanner logTailScanner =
-                new LogTailScanner( logFiles, fs, logEntryReader );
         try
         {
-            LogTailScanner.LogTailInformation logTailInformation = logTailScanner.find( logFiles.getHighestLogVersion() );
-            if ( !logTailInformation.commitsAfterLastCheckPoint )
+            if ( !tailScanner.getTailInformation().commitsAfterLastCheckPoint )
             {
                 return new Result( Result.Outcome.ok, null, null );
             }
         }
-        catch ( IOException e )
+        catch ( Throwable throwable )
         {
             // ignore exception and return db not cleanly shutdown
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogTailScanner.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogTailScanner.java
@@ -17,35 +17,36 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.recovery;
+package org.neo4j.kernel.impl.transaction.log;
 
 import java.io.IOException;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
-import org.neo4j.kernel.impl.transaction.log.LogEntryCursor;
-import org.neo4j.kernel.impl.transaction.log.LogPosition;
-import org.neo4j.kernel.impl.transaction.log.LogVersionedStoreChannel;
-import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
-import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
-import org.neo4j.kernel.impl.transaction.log.ReadAheadLogChannel;
-import org.neo4j.kernel.impl.transaction.log.ReadableClosablePositionAwareChannel;
-import org.neo4j.kernel.impl.transaction.log.ReadableLogChannel;
 import org.neo4j.kernel.impl.transaction.log.entry.CheckPoint;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntry;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryCommit;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryVersion;
 
 import static org.neo4j.kernel.impl.transaction.log.LogVersionBridge.NO_MORE_CHANNELS;
 import static org.neo4j.kernel.impl.transaction.log.LogVersionRepository.INITIAL_LOG_VERSION;
 
-public class LatestCheckPointFinder
+/**
+ * This class collects information about the latest entries in the transaction log. Since the only way we have to collect
+ * said information is to scan the transaction log from beginning to end, which is costly, we do this once and save the
+ * result for others to consume.
+ * <p>
+ * Due to the nature of transaction logs and log rotation, a single transaction log file has to be scanned forward, and
+ * if the required data is not found we search backwards through log file versions.
+ */
+public class LogTailScanner
 {
     private final PhysicalLogFiles logFiles;
     private final FileSystemAbstraction fileSystem;
     private final LogEntryReader<ReadableClosablePositionAwareChannel> logEntryReader;
 
-    public LatestCheckPointFinder( PhysicalLogFiles logFiles, FileSystemAbstraction fileSystem,
+    public LogTailScanner( PhysicalLogFiles logFiles, FileSystemAbstraction fileSystem,
             LogEntryReader<ReadableClosablePositionAwareChannel> logEntryReader )
     {
         this.logFiles = logFiles;
@@ -53,13 +54,15 @@ public class LatestCheckPointFinder
         this.logEntryReader = logEntryReader;
     }
 
-    public LatestCheckPoint find( long fromVersionBackwards ) throws IOException
+    public LogTailInformation find( long fromVersionBackwards ) throws IOException
     {
         long version = fromVersionBackwards;
         long versionToSearchForCommits = fromVersionBackwards;
         LogEntryStart latestStartEntry = null;
         LogEntryStart oldestStartEntry = null;
         long oldestVersionFound = -1;
+        LogEntryVersion latestLogEntryVersion = null;
+
         while ( version >= INITIAL_LOG_VERSION )
         {
             LogVersionedStoreChannel channel =
@@ -82,10 +85,14 @@ public class LatestCheckPointFinder
                 while ( cursor.next() )
                 {
                     entry = cursor.get();
+
+                    // Collect data about latest checkpoint
                     if ( entry instanceof CheckPoint )
                     {
                         latestCheckPoint = entry.as();
                     }
+
+                    // Collect data about latest commits
                     if ( entry instanceof LogEntryStart )
                     {
                         LogEntryStart startEntry = entry.as();
@@ -102,13 +109,19 @@ public class LatestCheckPointFinder
                             firstStartEntry = false;
                         }
                     }
+
+                    // Collect data about latest entry version
+                    if ( latestLogEntryVersion == null || version == versionToSearchForCommits )
+                    {
+                        latestLogEntryVersion = entry.getVersion();
+                    }
                 }
             }
 
             if ( latestCheckPoint != null )
             {
                 return latestCheckPoint( fromVersionBackwards, version, latestStartEntry, oldestVersionFound,
-                        latestCheckPoint );
+                        latestCheckPoint, latestLogEntryVersion );
             }
 
             version--;
@@ -123,14 +136,15 @@ public class LatestCheckPointFinder
         boolean commitsAfterCheckPoint = oldestStartEntry != null;
         long firstTxAfterPosition = commitsAfterCheckPoint
                 ? extractFirstTxIdAfterPosition( oldestStartEntry.getStartPosition(), fromVersionBackwards )
-                : LatestCheckPoint.NO_TRANSACTION_ID;
+                : LogTailInformation.NO_TRANSACTION_ID;
 
-        return new LatestCheckPoint( null, commitsAfterCheckPoint, firstTxAfterPosition, oldestVersionFound );
+        return new LogTailInformation( null, commitsAfterCheckPoint, firstTxAfterPosition, oldestVersionFound,
+                latestLogEntryVersion );
     }
 
-    protected LatestCheckPoint latestCheckPoint( long fromVersionBackwards, long version, LogEntryStart
-            latestStartEntry,
-            long oldestVersionFound, CheckPoint latestCheckPoint ) throws IOException
+    protected LogTailInformation latestCheckPoint( long fromVersionBackwards, long version,
+            LogEntryStart latestStartEntry, long oldestVersionFound, CheckPoint latestCheckPoint,
+            LogEntryVersion latestLogEntryVersion ) throws IOException
     {
         // Is the latest start entry in this log file version later than what the latest check point targets?
         LogPosition target = latestCheckPoint.getLogPosition();
@@ -143,7 +157,7 @@ public class LatestCheckPointFinder
                 // This check point entry targets a previous log file.
                 // Go there and see if there's a transaction. Reader is capped to that log version.
                 startEntryAfterCheckPoint = extractFirstTxIdAfterPosition( target, version ) !=
-                        LatestCheckPoint.NO_TRANSACTION_ID;
+                        LogTailInformation.NO_TRANSACTION_ID;
             }
         }
 
@@ -151,9 +165,9 @@ public class LatestCheckPointFinder
         // Reader may continue into log files after the initial version.
         long firstTxIdAfterCheckPoint = startEntryAfterCheckPoint
                 ? extractFirstTxIdAfterPosition( target, fromVersionBackwards )
-                : LatestCheckPoint.NO_TRANSACTION_ID;
-        return new LatestCheckPoint( latestCheckPoint, startEntryAfterCheckPoint,
-                firstTxIdAfterCheckPoint, oldestVersionFound );
+                : LogTailInformation.NO_TRANSACTION_ID;
+        return new LogTailInformation( latestCheckPoint, startEntryAfterCheckPoint,
+                firstTxIdAfterCheckPoint, oldestVersionFound, latestLogEntryVersion );
     }
 
     /**
@@ -163,7 +177,7 @@ public class LatestCheckPointFinder
      *
      * @param initialPosition {@link LogPosition} to start scan from.
      * @param maxLogVersion max log version to scan.
-     * @return txId of closes commit entry to {@code initialPosition}, or {@link LatestCheckPoint#NO_TRANSACTION_ID}
+     * @return txId of closes commit entry to {@code initialPosition}, or {@link LogTailInformation#NO_TRANSACTION_ID}
      * if not found.
      * @throws IOException on I/O error.
      */
@@ -200,25 +214,27 @@ public class LatestCheckPointFinder
 
             currentPosition = LogPosition.start( currentPosition.getLogVersion() + 1 );
         }
-        return LatestCheckPoint.NO_TRANSACTION_ID;
+        return LogTailInformation.NO_TRANSACTION_ID;
     }
 
-    public static class LatestCheckPoint
+    public static class LogTailInformation
     {
         public static long NO_TRANSACTION_ID = -1;
 
-        public final CheckPoint checkPoint;
-        public final boolean commitsAfterCheckPoint;
+        public final CheckPoint lastCheckPoint;
+        public final boolean commitsAfterLastCheckPoint;
         public final long firstTxIdAfterLastCheckPoint;
         public final long oldestLogVersionFound;
+        public final LogEntryVersion latestLogEntryVersion;
 
-        public LatestCheckPoint( CheckPoint checkPoint, boolean commitsAfterCheckPoint,
-                long firstTxIdAfterLastCheckPoint, long oldestLogVersionFound )
+        public LogTailInformation( CheckPoint lastCheckPoint, boolean commitsAfterLastCheckPoint,
+                long firstTxIdAfterLastCheckPoint, long oldestLogVersionFound, LogEntryVersion latestLogEntryVersion )
         {
-            this.checkPoint = checkPoint;
-            this.commitsAfterCheckPoint = commitsAfterCheckPoint;
+            this.lastCheckPoint = lastCheckPoint;
+            this.commitsAfterLastCheckPoint = commitsAfterLastCheckPoint;
             this.firstTxIdAfterLastCheckPoint = firstTxIdAfterLastCheckPoint;
             this.oldestLogVersionFound = oldestLogVersionFound;
+            this.latestLogEntryVersion = latestLogEntryVersion;
         }
 
         @Override
@@ -233,34 +249,37 @@ public class LatestCheckPointFinder
                 return false;
             }
 
-            LatestCheckPoint that = (LatestCheckPoint) o;
+            LogTailInformation that = (LogTailInformation) o;
 
-            return commitsAfterCheckPoint == that.commitsAfterCheckPoint &&
+            return commitsAfterLastCheckPoint == that.commitsAfterLastCheckPoint &&
                    firstTxIdAfterLastCheckPoint == that.firstTxIdAfterLastCheckPoint &&
                    oldestLogVersionFound == that.oldestLogVersionFound &&
-                   (checkPoint == null ? that.checkPoint == null : checkPoint.equals( that.checkPoint ));
+                   (lastCheckPoint == null ? that.lastCheckPoint == null : lastCheckPoint
+                           .equals( that.lastCheckPoint )) &&
+                    latestLogEntryVersion.equals( that.latestLogEntryVersion );
         }
 
         @Override
         public int hashCode()
         {
-            int result = checkPoint != null ? checkPoint.hashCode() : 0;
-            result = 31 * result + (commitsAfterCheckPoint ? 1 : 0);
-            if ( commitsAfterCheckPoint )
+            int result = lastCheckPoint != null ? lastCheckPoint.hashCode() : 0;
+            result = 31 * result + (commitsAfterLastCheckPoint ? 1 : 0);
+            if ( commitsAfterLastCheckPoint )
             {
                 result = 31 * result + Long.hashCode( firstTxIdAfterLastCheckPoint );
             }
             result = 31 * result + Long.hashCode( oldestLogVersionFound );
+            result = 31 * result + latestLogEntryVersion.hashCode();
             return result;
         }
 
         @Override
         public String toString()
         {
-            return "LatestCheckPoint{" +
-                   "checkPoint=" + checkPoint +
-                   ", commitsAfterCheckPoint=" + commitsAfterCheckPoint +
-                   (commitsAfterCheckPoint ? ", firstTxIdAfterLastCheckPoint=" + firstTxIdAfterLastCheckPoint : "") +
+            return "LogTailInformation{" +
+                   "lastCheckPoint=" + lastCheckPoint +
+                   ", commitsAfterLastCheckPoint=" + commitsAfterLastCheckPoint +
+                   (commitsAfterLastCheckPoint ? ", firstTxIdAfterLastCheckPoint=" + firstTxIdAfterLastCheckPoint : "") +
                    ", oldestLogVersionFound=" + oldestLogVersionFound +
                    '}';
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogVersionUpgradeChecker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogVersionUpgradeChecker.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.log;
+
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.storemigration.UpgradeNotAllowedByConfigurationException;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryVersion;
+
+/**
+ * Here we check the latest entry in the transaction log and make sure it matches the current version, if this check
+ * fails, it means that we will write entries with a version not compatible with the previous version responsible for
+ * creating the transaction logs.
+ * <p>
+ * This can be considered an upgrade since the user is not able to revert back to the previous version of neo4j. This
+ * will effectively guard the users from accidental upgrades.
+ */
+public class LogVersionUpgradeChecker
+{
+    private LogVersionUpgradeChecker()
+    {
+        throw new AssertionError( "No instances allowed" );
+    }
+
+    public static void check( LogTailScanner tailScanner, Config config ) throws UpgradeNotAllowedByConfigurationException
+    {
+        if ( !config.get( GraphDatabaseSettings.allow_store_upgrade ) )
+        {
+            // The user doesn't want us to upgrade the store.
+            LogEntryVersion latestLogEntryVersion = tailScanner.getTailInformation().latestLogEntryVersion;
+            if ( latestLogEntryVersion != null && LogEntryVersion.moreRecentVersionExists( latestLogEntryVersion ) )
+            {
+                throw new UpgradeNotAllowedByConfigurationException();
+            }
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogVersionUpgradeChecker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogVersionUpgradeChecker.java
@@ -47,7 +47,13 @@ public class LogVersionUpgradeChecker
             LogEntryVersion latestLogEntryVersion = tailScanner.getTailInformation().latestLogEntryVersion;
             if ( latestLogEntryVersion != null && LogEntryVersion.moreRecentVersionExists( latestLogEntryVersion ) )
             {
-                throw new UpgradeNotAllowedByConfigurationException();
+                String message = String.format(
+                        "The version your upgrading to is using a new transaction log format. This is a non-reversible " +
+                                "upgrade and you wont be able to downgrade after starting. To allow upgrade, please set " +
+                                "configuration parameter \"%s=true\"",
+                        GraphDatabaseSettings.allow_upgrade.name() );
+
+                throw new UpgradeNotAllowedByConfigurationException( message );
             }
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogVersionUpgradeChecker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LogVersionUpgradeChecker.java
@@ -41,7 +41,7 @@ public class LogVersionUpgradeChecker
 
     public static void check( LogTailScanner tailScanner, Config config ) throws UpgradeNotAllowedByConfigurationException
     {
-        if ( !config.get( GraphDatabaseSettings.allow_store_upgrade ) )
+        if ( !config.get( GraphDatabaseSettings.allow_upgrade ) )
         {
             // The user doesn't want us to upgrade the store.
             LogEntryVersion latestLogEntryVersion = tailScanner.getTailInformation().latestLogEntryVersion;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryWriter.java
@@ -46,7 +46,7 @@ public class LogEntryWriter
      */
     public LogEntryWriter( FlushableChannel channel )
     {
-        this(channel, CURRENT );
+        this( channel, CURRENT );
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryWriter.java
@@ -37,17 +37,34 @@ import static org.neo4j.kernel.impl.transaction.log.entry.LogEntryVersion.CURREN
 public class LogEntryWriter
 {
     private final FlushableChannel channel;
+    private final LogEntryVersion version;
     private final Visitor<StorageCommand,IOException> serializer;
 
+    /**
+     * Create a writer that uses {@link LogEntryVersion#CURRENT} for versioning.
+     * @param channel underlying channel
+     */
     public LogEntryWriter( FlushableChannel channel )
     {
+        this(channel, CURRENT );
+    }
+
+    /**
+     * Create a writer that uses a different version than {@link LogEntryVersion#CURRENT}. Useful when writing test for
+     * migration/upgrade scenarios.
+     * @param channel underlying channel
+     * @param version version to put in the header
+     */
+    public LogEntryWriter( FlushableChannel channel, LogEntryVersion version )
+    {
         this.channel = channel;
+        this.version = version;
         this.serializer = new StorageCommandSerializer( channel );
     }
 
     private void writeLogEntryHeader( byte type ) throws IOException
     {
-        channel.put( CURRENT.byteCode() ).put( type );
+        channel.put( version.byteCode() ).put( type );
     }
 
     public void writeStartEntry( int masterId, int authorId, long timeWritten, long latestCommittedTxWhenStarted,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryWriter.java
@@ -37,7 +37,6 @@ import static org.neo4j.kernel.impl.transaction.log.entry.LogEntryVersion.CURREN
 public class LogEntryWriter
 {
     private final FlushableChannel channel;
-    private final LogEntryVersion version;
     private final Visitor<StorageCommand,IOException> serializer;
 
     /**
@@ -46,25 +45,13 @@ public class LogEntryWriter
      */
     public LogEntryWriter( FlushableChannel channel )
     {
-        this( channel, CURRENT );
-    }
-
-    /**
-     * Create a writer that uses a different version than {@link LogEntryVersion#CURRENT}. Useful when writing test for
-     * migration/upgrade scenarios.
-     * @param channel underlying channel
-     * @param version version to put in the header
-     */
-    public LogEntryWriter( FlushableChannel channel, LogEntryVersion version )
-    {
         this.channel = channel;
-        this.version = version;
         this.serializer = new StorageCommandSerializer( channel );
     }
 
     private void writeLogEntryHeader( byte type ) throws IOException
     {
-        channel.put( version.byteCode() ).put( type );
+        channel.put( CURRENT.byteCode() ).put( type );
     }
 
     public void writeStartEntry( int masterId, int authorId, long timeWritten, long latestCommittedTxWhenStarted,

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/DefaultRecoverySPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/DefaultRecoverySPI.java
@@ -27,6 +27,7 @@ import org.neo4j.kernel.impl.api.TransactionToApply;
 import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.LogPosition;
+import org.neo4j.kernel.impl.transaction.log.LogTailScanner;
 import org.neo4j.kernel.impl.transaction.log.LogVersionRepository;
 import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
@@ -52,7 +53,7 @@ public class DefaultRecoverySPI implements Recovery.SPI
     public DefaultRecoverySPI(
             StorageEngine storageEngine,
             PhysicalLogFiles logFiles, FileSystemAbstraction fs,
-            LogVersionRepository logVersionRepository, LatestCheckPointFinder checkPointFinder,
+            LogVersionRepository logVersionRepository, LogTailScanner logTailScanner,
             TransactionIdStore transactionIdStore, LogicalTransactionStore logicalTransactionStore,
             PositionToRecoverFrom.Monitor monitor )
     {
@@ -62,7 +63,7 @@ public class DefaultRecoverySPI implements Recovery.SPI
         this.logVersionRepository = logVersionRepository;
         this.transactionIdStore = transactionIdStore;
         this.logicalTransactionStore = logicalTransactionStore;
-        this.positionToRecoverFrom = new PositionToRecoverFrom( checkPointFinder, monitor );
+        this.positionToRecoverFrom = new PositionToRecoverFrom( logTailScanner, monitor );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/DefaultRecoverySPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/DefaultRecoverySPI.java
@@ -28,7 +28,6 @@ import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.LogPosition;
 import org.neo4j.kernel.impl.transaction.log.LogTailScanner;
-import org.neo4j.kernel.impl.transaction.log.LogVersionRepository;
 import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
 import org.neo4j.kernel.impl.transaction.log.TransactionCursor;
@@ -42,7 +41,6 @@ import static org.neo4j.kernel.impl.transaction.log.Commitment.NO_COMMITMENT;
 
 public class DefaultRecoverySPI implements Recovery.SPI
 {
-    private final LogVersionRepository logVersionRepository;
     private final PositionToRecoverFrom positionToRecoverFrom;
     private final PhysicalLogFiles logFiles;
     private final FileSystemAbstraction fs;
@@ -53,14 +51,13 @@ public class DefaultRecoverySPI implements Recovery.SPI
     public DefaultRecoverySPI(
             StorageEngine storageEngine,
             PhysicalLogFiles logFiles, FileSystemAbstraction fs,
-            LogVersionRepository logVersionRepository, LogTailScanner logTailScanner,
+            LogTailScanner logTailScanner,
             TransactionIdStore transactionIdStore, LogicalTransactionStore logicalTransactionStore,
             PositionToRecoverFrom.Monitor monitor )
     {
         this.storageEngine = storageEngine;
         this.logFiles = logFiles;
         this.fs = fs;
-        this.logVersionRepository = logVersionRepository;
         this.transactionIdStore = transactionIdStore;
         this.logicalTransactionStore = logicalTransactionStore;
         this.positionToRecoverFrom = new PositionToRecoverFrom( logTailScanner, monitor );
@@ -69,7 +66,7 @@ public class DefaultRecoverySPI implements Recovery.SPI
     @Override
     public LogPosition getPositionToRecoverFrom() throws IOException
     {
-        return positionToRecoverFrom.apply( logVersionRepository.getCurrentLogVersion() );
+        return positionToRecoverFrom.get();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageEngine.java
@@ -85,6 +85,12 @@ public interface StorageEngine
     void apply( CommandsToApply batch, TransactionApplicationMode mode ) throws Exception;
 
     /**
+     * @return a {@link CommandReaderFactory} capable of returning {@link CommandReader commands readers}
+     * for specific log entry versions.
+     */
+    CommandReaderFactory commandReaderFactory();
+
+    /**
      * Flushes and forces all changes down to underlying storage. This is a blocking call and when it returns
      * all changes applied to this storage engine will be durable.
      * @param limiter The {@link IOLimiter} used to moderate the rate of IO caused by the flush process.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageEngine.java
@@ -85,12 +85,6 @@ public interface StorageEngine
     void apply( CommandsToApply batch, TransactionApplicationMode mode ) throws Exception;
 
     /**
-     * @return a {@link CommandReaderFactory} capable of returning {@link CommandReader commands readers}
-     * for specific log entry versions.
-     */
-    CommandReaderFactory commandReaderFactory();
-
-    /**
      * Flushes and forces all changes down to underlying storage. This is a blocking call and when it returns
      * all changes applied to this storage engine will be durable.
      * @param limiter The {@link IOLimiter} used to moderate the rate of IO caused by the flush process.

--- a/community/kernel/src/test/java/org/neo4j/kernel/RecoveryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/RecoveryTest.java
@@ -37,6 +37,7 @@ import org.neo4j.kernel.impl.transaction.log.LogFile;
 import org.neo4j.kernel.impl.transaction.log.LogHeaderCache;
 import org.neo4j.kernel.impl.transaction.log.LogPosition;
 import org.neo4j.kernel.impl.transaction.log.LogPositionMarker;
+import org.neo4j.kernel.impl.transaction.log.LogTailScanner;
 import org.neo4j.kernel.impl.transaction.log.LogVersionRepository;
 import org.neo4j.kernel.impl.transaction.log.LogVersionedStoreChannel;
 import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
@@ -57,7 +58,6 @@ import org.neo4j.kernel.impl.transaction.log.entry.OnePhaseCommit;
 import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.recovery.DefaultRecoverySPI;
-import org.neo4j.kernel.recovery.LatestCheckPointFinder;
 import org.neo4j.kernel.recovery.Recovery;
 import org.neo4j.kernel.recovery.Recovery.RecoveryApplier;
 import org.neo4j.storageengine.api.StorageEngine;
@@ -138,7 +138,7 @@ public class RecoveryTest
         {
             StorageEngine storageEngine = mock( StorageEngine.class );
             final LogEntryReader<ReadableClosablePositionAwareChannel> reader = new VersionAwareLogEntryReader<>();
-            LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fileSystemRule.get(), reader );
+            LogTailScanner finder = new LogTailScanner( logFiles, fileSystemRule.get(), reader );
 
             LogHeaderCache logHeaderCache = new LogHeaderCache( 10 );
             TransactionMetadataCache metadataCache = new TransactionMetadataCache( 100 );
@@ -241,7 +241,7 @@ public class RecoveryTest
         {
             StorageEngine storageEngine = mock( StorageEngine.class );
             final LogEntryReader<ReadableClosablePositionAwareChannel> reader = new VersionAwareLogEntryReader<>();
-            LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fileSystemRule.get(), reader );
+            LogTailScanner finder = new LogTailScanner( logFiles, fileSystemRule.get(), reader );
 
             TransactionMetadataCache metadataCache = new TransactionMetadataCache( 100 );
             LogHeaderCache logHeaderCache = new LogHeaderCache( 10 );
@@ -379,7 +379,7 @@ public class RecoveryTest
         {
             StorageEngine storageEngine = mock( StorageEngine.class );
             final LogEntryReader<ReadableClosablePositionAwareChannel> reader = new VersionAwareLogEntryReader<>();
-            LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fileSystemRule.get(), reader );
+            LogTailScanner finder = new LogTailScanner( logFiles, fileSystemRule.get(), reader );
 
             TransactionMetadataCache metadataCache = new TransactionMetadataCache( 100 );
             LogHeaderCache logHeaderCache = new LogHeaderCache( 10 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/RecoveryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/RecoveryTest.java
@@ -138,17 +138,17 @@ public class RecoveryTest
         {
             StorageEngine storageEngine = mock( StorageEngine.class );
             final LogEntryReader<ReadableClosablePositionAwareChannel> reader = new VersionAwareLogEntryReader<>();
-            LogTailScanner finder = new LogTailScanner( logFiles, fileSystemRule.get(), reader );
+            LogTailScanner tailScanner = new LogTailScanner( logFiles, fileSystemRule.get(), reader );
 
             LogHeaderCache logHeaderCache = new LogHeaderCache( 10 );
             TransactionMetadataCache metadataCache = new TransactionMetadataCache( 100 );
             LogFile logFile = life.add( new PhysicalLogFile( fileSystemRule.get(), logFiles, 50,
-                    () -> transactionIdStore.getLastCommittedTransactionId(), logVersionRepository,
+                    transactionIdStore::getLastCommittedTransactionId, logVersionRepository,
                     mock( PhysicalLogFile.Monitor.class ), logHeaderCache ) );
             LogicalTransactionStore txStore = new PhysicalLogicalTransactionStore( logFile, metadataCache, reader );
 
             life.add( new Recovery( new DefaultRecoverySPI( storageEngine, logFiles, fileSystemRule.get(),
-                    logVersionRepository, finder, transactionIdStore, txStore, NO_MONITOR )
+                    tailScanner, transactionIdStore, txStore, NO_MONITOR )
             {
                 private int nr;
 
@@ -241,17 +241,17 @@ public class RecoveryTest
         {
             StorageEngine storageEngine = mock( StorageEngine.class );
             final LogEntryReader<ReadableClosablePositionAwareChannel> reader = new VersionAwareLogEntryReader<>();
-            LogTailScanner finder = new LogTailScanner( logFiles, fileSystemRule.get(), reader );
+            LogTailScanner tailScanner = new LogTailScanner( logFiles, fileSystemRule.get(), reader );
 
             TransactionMetadataCache metadataCache = new TransactionMetadataCache( 100 );
             LogHeaderCache logHeaderCache = new LogHeaderCache( 10 );
             LogFile logFile = life.add( new PhysicalLogFile( fileSystemRule.get(), logFiles, 50,
-                    () -> transactionIdStore.getLastCommittedTransactionId(), logVersionRepository,
+                    transactionIdStore::getLastCommittedTransactionId, logVersionRepository,
                     mock( PhysicalLogFile.Monitor.class ), logHeaderCache ) );
             LogicalTransactionStore txStore = new PhysicalLogicalTransactionStore( logFile, metadataCache, reader );
 
             life.add( new Recovery( new DefaultRecoverySPI( storageEngine, logFiles, fileSystemRule.get(),
-                    logVersionRepository, finder, transactionIdStore, txStore, NO_MONITOR )
+                    tailScanner, transactionIdStore, txStore, NO_MONITOR )
             {
                 @Override
                 public void startRecovery()
@@ -379,17 +379,17 @@ public class RecoveryTest
         {
             StorageEngine storageEngine = mock( StorageEngine.class );
             final LogEntryReader<ReadableClosablePositionAwareChannel> reader = new VersionAwareLogEntryReader<>();
-            LogTailScanner finder = new LogTailScanner( logFiles, fileSystemRule.get(), reader );
+            LogTailScanner tailScanner = new LogTailScanner( logFiles, fileSystemRule.get(), reader );
 
             TransactionMetadataCache metadataCache = new TransactionMetadataCache( 100 );
             LogHeaderCache logHeaderCache = new LogHeaderCache( 10 );
             LogFile logFile = life.add( new PhysicalLogFile( fileSystemRule.get(), logFiles, 50,
-                    () -> transactionIdStore.getLastCommittedTransactionId(), logVersionRepository,
+                    transactionIdStore::getLastCommittedTransactionId, logVersionRepository,
                     mock( PhysicalLogFile.Monitor.class ), logHeaderCache ) );
             LogicalTransactionStore txStore = new PhysicalLogicalTransactionStore( logFile, metadataCache, reader );
 
             life.add( new Recovery( new DefaultRecoverySPI( storageEngine, logFiles, fileSystemRule.get(),
-                    logVersionRepository, finder, transactionIdStore, txStore, NO_MONITOR )
+                    tailScanner, transactionIdStore, txStore, NO_MONITOR )
             {
                 @Override
                 public void startRecovery()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestStoreAccess.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestStoreAccess.java
@@ -47,7 +47,7 @@ public class TestStoreAccess
     private final File storeDir = new File( "dir" ).getAbsoluteFile();
 
     @Test
-    public void openingThroughStoreAccessShouldNotTriggerRecovery() throws Exception
+    public void openingThroughStoreAccessShouldNotTriggerRecovery() throws Throwable
     {
         try ( EphemeralFileSystemAbstraction snapshot = produceUncleanStore() )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/MigrationTestUtils.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/MigrationTestUtils.java
@@ -184,8 +184,8 @@ public class MigrationTestUtils
     {
         PhysicalLogFiles logFiles = new PhysicalLogFiles( workingDirectory, fileSystem );
         LogEntryReader<ReadableClosablePositionAwareChannel> logEntryReader = new VersionAwareLogEntryReader<>();
-        LogTailScanner finder = new LogTailScanner( logFiles, fileSystem, logEntryReader );
-        LogTailScanner.LogTailInformation logTailInformation = finder.find( logFiles.getHighestLogVersion() );
+        LogTailScanner tailScanner = new LogTailScanner( logFiles, fileSystem, logEntryReader );
+        LogTailScanner.LogTailInformation logTailInformation = tailScanner.getTailInformation();
 
         if ( logTailInformation.commitsAfterLastCheckPoint )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/LogTailScannerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/LogTailScannerTest.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.recovery;
+package org.neo4j.kernel.impl.transaction.log;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -37,41 +37,35 @@ import java.util.function.Supplier;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.transaction.DeadSimpleLogVersionRepository;
-import org.neo4j.kernel.impl.transaction.log.FlushablePositionAwareChannel;
-import org.neo4j.kernel.impl.transaction.log.LogHeaderCache;
-import org.neo4j.kernel.impl.transaction.log.LogPosition;
-import org.neo4j.kernel.impl.transaction.log.LogPositionMarker;
-import org.neo4j.kernel.impl.transaction.log.LogVersionRepository;
-import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
-import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
-import org.neo4j.kernel.impl.transaction.log.ReadableClosablePositionAwareChannel;
+import org.neo4j.kernel.impl.transaction.log.LogTailScanner.LogTailInformation;
 import org.neo4j.kernel.impl.transaction.log.entry.CheckPoint;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryVersion;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryWriter;
 import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
 import org.neo4j.kernel.lifecycle.LifeSupport;
-import org.neo4j.kernel.recovery.LatestCheckPointFinder.LatestCheckPoint;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.io.ByteUnit.mebiBytes;
+import static org.neo4j.kernel.impl.transaction.log.LogTailScanner.LogTailInformation.NO_TRANSACTION_ID;
 import static org.neo4j.kernel.impl.transaction.log.PhysicalLogFile.NO_MONITOR;
-import static org.neo4j.kernel.recovery.LatestCheckPointFinder.LatestCheckPoint.NO_TRANSACTION_ID;
 
 @RunWith( Parameterized.class )
-public class LatestCheckPointFinderTest
+public class LogTailScannerTest
 {
     @Rule
     public final EphemeralFileSystemRule fsRule = new EphemeralFileSystemRule();
     private final File directory = new File( "/somewhere" );
     private final LogEntryReader<ReadableClosablePositionAwareChannel> reader = new VersionAwareLogEntryReader<>();
-    private LatestCheckPointFinder finder;
+    private LogTailScanner finder;
     private PhysicalLogFiles logFiles;
     private final int startLogVersion;
     private final int endLogVersion;
+    private final LogEntryVersion latestLogEntryVersion = LogEntryVersion.CURRENT;
 
-    public LatestCheckPointFinderTest( Integer startLogVersion, Integer endLogVersion )
+    public LogTailScannerTest( Integer startLogVersion, Integer endLogVersion )
     {
         this.startLogVersion = startLogVersion;
         this.endLogVersion = endLogVersion;
@@ -88,7 +82,7 @@ public class LatestCheckPointFinderTest
     {
         fsRule.get().mkdirs( directory );
         logFiles = new PhysicalLogFiles( directory, fsRule.get() );
-        finder = new LatestCheckPointFinder( logFiles, fsRule.get(), reader );
+        finder = new LogTailScanner( logFiles, fsRule.get(), reader );
     }
 
     @Test
@@ -97,13 +91,13 @@ public class LatestCheckPointFinderTest
         // given no files
         setupLogFiles();
         int logVersion = startLogVersion;
-        LatestCheckPointFinder finder = new LatestCheckPointFinder( logFiles, fsRule.get(), reader );
+        LogTailScanner finder = new LogTailScanner( logFiles, fsRule.get(), reader );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( logVersion );
+        LogTailScanner.LogTailInformation logTailInformation = finder.find( logVersion );
 
         // then
-        assertLatestCheckPoint( false, false, NO_TRANSACTION_ID, -1, latestCheckPoint );
+        assertLatestCheckPoint( false, false, NO_TRANSACTION_ID, -1, logTailInformation );
     }
 
     @Test
@@ -114,10 +108,10 @@ public class LatestCheckPointFinderTest
         setupLogFiles( logFile() );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( logVersion );
+        LogTailScanner.LogTailInformation logTailInformation = finder.find( logVersion );
 
         // then
-        assertLatestCheckPoint( false, false, NO_TRANSACTION_ID, logVersion, latestCheckPoint );
+        assertLatestCheckPoint( false, false, NO_TRANSACTION_ID, logVersion, logTailInformation );
     }
 
     @Test
@@ -129,10 +123,10 @@ public class LatestCheckPointFinderTest
         setupLogFiles( logFile( start(), commit( txId ) ) );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( logVersion );
+        LogTailScanner.LogTailInformation logTailInformation = finder.find( logVersion );
 
         // then
-        assertLatestCheckPoint( false, true, txId, logVersion, latestCheckPoint );
+        assertLatestCheckPoint( false, true, txId, logVersion, logTailInformation );
     }
 
     @Test
@@ -142,10 +136,10 @@ public class LatestCheckPointFinderTest
         setupLogFiles( logFile(), logFile() );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
+        LogTailScanner.LogTailInformation logTailInformation = finder.find( endLogVersion );
 
         // then
-        assertLatestCheckPoint( false, false, NO_TRANSACTION_ID, startLogVersion, latestCheckPoint );
+        assertLatestCheckPoint( false, false, NO_TRANSACTION_ID, startLogVersion, logTailInformation );
     }
 
     @Test
@@ -156,10 +150,10 @@ public class LatestCheckPointFinderTest
         setupLogFiles( logFile(), logFile( start(), commit( txId ) ) );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
+        LogTailScanner.LogTailInformation logTailInformation = finder.find( endLogVersion );
 
         // then
-        assertLatestCheckPoint( false, true, txId, startLogVersion, latestCheckPoint );
+        assertLatestCheckPoint( false, true, txId, startLogVersion, logTailInformation );
     }
 
     @Test
@@ -169,10 +163,10 @@ public class LatestCheckPointFinderTest
         setupLogFiles( logFile(), logFile( start() ) );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
+        LogTailScanner.LogTailInformation logTailInformation = finder.find( endLogVersion );
 
         // then
-        assertLatestCheckPoint( false, true, NO_TRANSACTION_ID, startLogVersion, latestCheckPoint );
+        assertLatestCheckPoint( false, true, NO_TRANSACTION_ID, startLogVersion, logTailInformation );
     }
 
     @Test
@@ -183,10 +177,10 @@ public class LatestCheckPointFinderTest
         setupLogFiles( logFile(), logFile( start(), commit( txId ), start(), commit( txId + 1 ) ) );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
+        LogTailScanner.LogTailInformation logTailInformation = finder.find( endLogVersion );
 
         // then
-        assertLatestCheckPoint( false, true, txId, startLogVersion, latestCheckPoint );
+        assertLatestCheckPoint( false, true, txId, startLogVersion, logTailInformation );
     }
 
     @Test
@@ -201,10 +195,10 @@ public class LatestCheckPointFinderTest
                 logFile( checkPoint( position ) ) );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
+        LogTailInformation logTailInformation = finder.find( endLogVersion );
 
         // then
-        assertLatestCheckPoint( true, true, txId, endLogVersion, latestCheckPoint );
+        assertLatestCheckPoint( true, true, txId, endLogVersion, logTailInformation );
     }
 
     @Test
@@ -214,10 +208,10 @@ public class LatestCheckPointFinderTest
         setupLogFiles( logFile( checkPoint() ) );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
+        LogTailInformation logTailInformation = finder.find( endLogVersion );
 
         // then
-        assertLatestCheckPoint( true, false, NO_TRANSACTION_ID, endLogVersion, latestCheckPoint );
+        assertLatestCheckPoint( true, false, NO_TRANSACTION_ID, endLogVersion, logTailInformation );
     }
 
     @Test
@@ -227,10 +221,10 @@ public class LatestCheckPointFinderTest
         setupLogFiles( logFile( start(), checkPoint() ) );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
+        LogTailScanner.LogTailInformation logTailInformation = finder.find( endLogVersion );
 
         // then
-        assertLatestCheckPoint( true, false, NO_TRANSACTION_ID, endLogVersion, latestCheckPoint );
+        assertLatestCheckPoint( true, false, NO_TRANSACTION_ID, endLogVersion, logTailInformation );
     }
 
     @Test
@@ -238,16 +232,16 @@ public class LatestCheckPointFinderTest
     {
         long firstTxAfterCheckpoint = Integer.MAX_VALUE + 4L;
 
-        LatestCheckPointFinder checkPointFinder =
+        LogTailScanner checkPointFinder =
                 new FirstTxIdConfigurableCheckpointFinder( firstTxAfterCheckpoint, logFiles, fsRule.get(), reader );
         LogEntryStart startEntry = new LogEntryStart( 1, 2, 3L, 4L, new byte[]{5, 6},
                 new LogPosition( endLogVersion, Integer.MAX_VALUE + 17L ) );
         CheckPoint checkPoint = new CheckPoint( new LogPosition( endLogVersion, 16L ) );
-        LatestCheckPoint latestCheckPoint = checkPointFinder.latestCheckPoint( endLogVersion, endLogVersion, startEntry,
-                endLogVersion, checkPoint );
+        LogTailInformation
+                logTailInformation = checkPointFinder.latestCheckPoint( endLogVersion, endLogVersion, startEntry,
+                endLogVersion, checkPoint, latestLogEntryVersion );
 
-        assertLatestCheckPoint( true, true, firstTxAfterCheckpoint, endLogVersion,
-            latestCheckPoint );
+        assertLatestCheckPoint( true, true, firstTxAfterCheckpoint, endLogVersion, logTailInformation );
     }
 
     @Test
@@ -259,10 +253,10 @@ public class LatestCheckPointFinderTest
         setupLogFiles( logFile( start, commit( txId ), checkPoint( start ) ) );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
+        LogTailScanner.LogTailInformation logTailInformation = finder.find( endLogVersion );
 
         // then
-        assertLatestCheckPoint( true, true, txId, endLogVersion, latestCheckPoint );
+        assertLatestCheckPoint( true, true, txId, endLogVersion, logTailInformation );
     }
 
     @Test
@@ -273,10 +267,10 @@ public class LatestCheckPointFinderTest
         setupLogFiles( logFile( start, checkPoint( start ) ) );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
+        LogTailScanner.LogTailInformation logTailInformation = finder.find( endLogVersion );
 
         // then
-        assertLatestCheckPoint( true, true, NO_TRANSACTION_ID, endLogVersion, latestCheckPoint );
+        assertLatestCheckPoint( true, true, NO_TRANSACTION_ID, endLogVersion, logTailInformation );
     }
 
     @Test
@@ -286,10 +280,10 @@ public class LatestCheckPointFinderTest
         setupLogFiles( logFile( checkPoint(), start(), checkPoint() ) );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
+        LogTailScanner.LogTailInformation logTailInformation = finder.find( endLogVersion );
 
         // then
-        assertLatestCheckPoint( true, false, NO_TRANSACTION_ID, endLogVersion, latestCheckPoint );
+        assertLatestCheckPoint( true, false, NO_TRANSACTION_ID, endLogVersion, logTailInformation );
     }
 
     @Test
@@ -300,10 +294,10 @@ public class LatestCheckPointFinderTest
         setupLogFiles( logFile( checkPoint(), checkPoint(), start(), commit( txId ) ) );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
+        LogTailScanner.LogTailInformation logTailInformation = finder.find( endLogVersion );
 
         // then
-        assertLatestCheckPoint( true, true, txId, endLogVersion, latestCheckPoint );
+        assertLatestCheckPoint( true, true, txId, endLogVersion, logTailInformation );
     }
 
     @Test
@@ -315,10 +309,10 @@ public class LatestCheckPointFinderTest
         setupLogFiles( logFile( checkPoint() ), logFile( start, commit( txId ) ) );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
+        LogTailScanner.LogTailInformation logTailInformation = finder.find( endLogVersion );
 
         // then
-        assertLatestCheckPoint( true, true, txId, startLogVersion, latestCheckPoint );
+        assertLatestCheckPoint( true, true, txId, startLogVersion, logTailInformation );
     }
 
     @Test
@@ -329,10 +323,10 @@ public class LatestCheckPointFinderTest
         setupLogFiles( logFile( start, checkPoint() ), logFile() );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
+        LogTailInformation logTailInformation = finder.find( endLogVersion );
 
         // then
-        assertLatestCheckPoint( true, false, NO_TRANSACTION_ID, startLogVersion, latestCheckPoint );
+        assertLatestCheckPoint( true, false, NO_TRANSACTION_ID, startLogVersion, logTailInformation );
     }
 
     @Test
@@ -344,10 +338,10 @@ public class LatestCheckPointFinderTest
         setupLogFiles( logFile( start, commit( txId ) ), logFile( checkPoint( start ) ) );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
+        LogTailInformation logTailInformation = finder.find( endLogVersion );
 
         // then
-        assertLatestCheckPoint( true, true, txId, endLogVersion, latestCheckPoint );
+        assertLatestCheckPoint( true, true, txId, endLogVersion, logTailInformation );
     }
 
     @Test
@@ -359,10 +353,10 @@ public class LatestCheckPointFinderTest
         setupLogFiles( logFile( start ), logFile( checkPoint( start ) ) );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
+        LogTailInformation logTailInformation = finder.find( endLogVersion );
 
         // then
-        assertLatestCheckPoint( true, false, NO_TRANSACTION_ID, endLogVersion, latestCheckPoint );
+        assertLatestCheckPoint( true, false, NO_TRANSACTION_ID, endLogVersion, logTailInformation );
     }
 
     @Test
@@ -373,10 +367,10 @@ public class LatestCheckPointFinderTest
         setupLogFiles( logFile( start(), commit( 3 ), position ), logFile( checkPoint( position ) ) );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
+        LogTailScanner.LogTailInformation logTailInformation = finder.find( endLogVersion );
 
         // then
-        assertLatestCheckPoint( true, false, NO_TRANSACTION_ID, endLogVersion, latestCheckPoint );
+        assertLatestCheckPoint( true, false, NO_TRANSACTION_ID, endLogVersion, logTailInformation );
     }
 
     @Test
@@ -387,10 +381,10 @@ public class LatestCheckPointFinderTest
         setupLogFiles( logFile( start(), checkPoint(), start(), commit( txId ) ), logFile() );
 
         // when
-        LatestCheckPoint latestCheckPoint = finder.find( endLogVersion );
+        LogTailScanner.LogTailInformation logTailInformation = finder.find( endLogVersion );
 
         // then
-        assertLatestCheckPoint( true, true, txId, startLogVersion, latestCheckPoint );
+        assertLatestCheckPoint( true, true, txId, startLogVersion, logTailInformation );
     }
 
     // === Below is code for helping the tests above ===
@@ -534,18 +528,18 @@ public class LatestCheckPointFinderTest
     }
 
     private void assertLatestCheckPoint( boolean hasCheckPointEntry, boolean commitsAfterLastCheckPoint,
-            long firstTxIdAfterLastCheckPoint, long logVersion, LatestCheckPoint latestCheckPoint )
+            long firstTxIdAfterLastCheckPoint, long logVersion, LogTailScanner.LogTailInformation logTailInformation )
     {
-        assertEquals( hasCheckPointEntry, latestCheckPoint.checkPoint != null );
-        assertEquals( commitsAfterLastCheckPoint, latestCheckPoint.commitsAfterCheckPoint );
+        assertEquals( hasCheckPointEntry, logTailInformation.lastCheckPoint != null );
+        assertEquals( commitsAfterLastCheckPoint, logTailInformation.commitsAfterLastCheckPoint );
         if ( commitsAfterLastCheckPoint )
         {
-            assertEquals( firstTxIdAfterLastCheckPoint, latestCheckPoint.firstTxIdAfterLastCheckPoint );
+            assertEquals( firstTxIdAfterLastCheckPoint, logTailInformation.firstTxIdAfterLastCheckPoint );
         }
-        assertEquals( logVersion, latestCheckPoint.oldestLogVersionFound );
+        assertEquals( logVersion, logTailInformation.oldestLogVersionFound );
     }
 
-    private static class FirstTxIdConfigurableCheckpointFinder extends LatestCheckPointFinder
+    private static class FirstTxIdConfigurableCheckpointFinder extends LogTailScanner
     {
 
         private final long txId;
@@ -558,12 +552,13 @@ public class LatestCheckPointFinderTest
         }
 
         @Override
-        public LatestCheckPoint latestCheckPoint( long fromVersionBackwards, long version,
-                LogEntryStart latestStartEntry, long oldestVersionFound, CheckPoint latestCheckPoint )
+        public LogTailInformation latestCheckPoint( long fromVersionBackwards, long version,
+                LogEntryStart latestStartEntry, long oldestVersionFound, CheckPoint latestCheckPoint,
+                LogEntryVersion latestLogEntryVersion )
                 throws IOException
         {
             return super.latestCheckPoint( fromVersionBackwards, version, latestStartEntry, oldestVersionFound,
-                    latestCheckPoint );
+                    latestCheckPoint, latestLogEntryVersion );
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/LogVersionUpgradeCheckerIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/LogVersionUpgradeCheckerIT.java
@@ -66,7 +66,7 @@ public class LogVersionUpgradeCheckerIT
         final GraphDatabaseService db = new TestGraphDatabaseFactory()
                 .setFileSystem( fs.get() )
                 .newImpermanentDatabaseBuilder( storeDirectory.graphDbDir() )
-                .setConfig( GraphDatabaseSettings.allow_store_upgrade, "false" )
+                .setConfig( GraphDatabaseSettings.allow_upgrade, "false" )
                 .newGraphDatabase();
         db.shutdown();
     }
@@ -82,7 +82,7 @@ public class LogVersionUpgradeCheckerIT
         final GraphDatabaseService db = new TestGraphDatabaseFactory()
                 .setFileSystem( fs.get() )
                 .newImpermanentDatabaseBuilder( storeDirectory.graphDbDir() )
-                .setConfig( GraphDatabaseSettings.allow_store_upgrade, "false" )
+                .setConfig( GraphDatabaseSettings.allow_upgrade, "false" )
                 .newGraphDatabase();
         db.shutdown();
     }
@@ -96,7 +96,7 @@ public class LogVersionUpgradeCheckerIT
         final GraphDatabaseService db = new TestGraphDatabaseFactory()
                 .setFileSystem( fs.get() )
                 .newImpermanentDatabaseBuilder( storeDirectory.graphDbDir() )
-                .setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" )
+                .setConfig( GraphDatabaseSettings.allow_upgrade, "true" )
                 .newGraphDatabase();
         db.shutdown();
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/LogVersionUpgradeCheckerIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/LogVersionUpgradeCheckerIT.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.log;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.RuleChain;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.impl.storemigration.UpgradeNotAllowedByConfigurationException;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryVersion;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryWriter;
+import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
+import org.neo4j.kernel.lifecycle.Lifespan;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.test.matchers.NestedThrowableMatcher;
+import org.neo4j.test.rule.PageCacheRule;
+import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+
+import static org.neo4j.graphdb.Label.label;
+
+public class LogVersionUpgradeCheckerIT
+{
+    private final TestDirectory storeDirectory = TestDirectory.testDirectory();
+    private final DefaultFileSystemRule fs = new DefaultFileSystemRule();
+    private final PageCacheRule pageCacheRule = new PageCacheRule();
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule( storeDirectory ).around( fs ).around( pageCacheRule );
+
+    @Rule
+    public ExpectedException expect = ExpectedException.none();
+
+    @Test
+    public void startAsNormalWhenUpgradeIsNotAllowed() throws Exception
+    {
+        createGraphDbAndKillIt();
+
+        // Try to start with upgrading disabled
+        final GraphDatabaseService db = new TestGraphDatabaseFactory()
+                .setFileSystem( fs.get() )
+                .newImpermanentDatabaseBuilder( storeDirectory.graphDbDir() )
+                .setConfig( GraphDatabaseSettings.allow_store_upgrade, "false" )
+                .newGraphDatabase();
+        db.shutdown();
+    }
+
+    @Test
+    public void failToStartFromOlderTransactionLogsIfNotAllowed() throws Exception
+    {
+        createStoreWithLogEntryVersion( LogEntryVersion.V2_3 );
+
+        expect.expect( new NestedThrowableMatcher( UpgradeNotAllowedByConfigurationException.class ) );
+
+        // Try to start with upgrading disabled
+        final GraphDatabaseService db = new TestGraphDatabaseFactory()
+                .setFileSystem( fs.get() )
+                .newImpermanentDatabaseBuilder( storeDirectory.graphDbDir() )
+                .setConfig( GraphDatabaseSettings.allow_store_upgrade, "false" )
+                .newGraphDatabase();
+        db.shutdown();
+    }
+
+    @Test
+    public void startFromOlderTransactionLogsIfAllowed() throws Exception
+    {
+        createStoreWithLogEntryVersion( LogEntryVersion.V2_3 );
+
+        // Try to start with upgrading enabled
+        final GraphDatabaseService db = new TestGraphDatabaseFactory()
+                .setFileSystem( fs.get() )
+                .newImpermanentDatabaseBuilder( storeDirectory.graphDbDir() )
+                .setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" )
+                .newGraphDatabase();
+        db.shutdown();
+    }
+
+    private void createGraphDbAndKillIt() throws Exception
+    {
+        final GraphDatabaseService db = new TestGraphDatabaseFactory()
+                .setFileSystem( fs )
+                .newImpermanentDatabaseBuilder( storeDirectory.graphDbDir() )
+                .newGraphDatabase();
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.createNode( label( "FOO" ) );
+            db.createNode( label( "BAR" ) );
+            tx.success();
+        }
+
+        db.shutdown();
+    }
+
+    private void createStoreWithLogEntryVersion( LogEntryVersion logEntryVersion ) throws Exception
+    {
+        createGraphDbAndKillIt();
+        appendCheckpoint( logEntryVersion );
+    }
+
+    private void appendCheckpoint( LogEntryVersion logVersion ) throws IOException
+    {
+        AtomicLong lastId = new AtomicLong();
+        File storeDir = storeDirectory.graphDbDir();
+        PageCache pageCache = pageCacheRule.getPageCache( fs );
+        PhysicalLogFiles logFiles = new PhysicalLogFiles( storeDir, fs );
+        ReadOnlyLogVersionRepository logVersionRepository = new ReadOnlyLogVersionRepository( pageCache, storeDir );
+        PhysicalLogFile logFile = new PhysicalLogFile( fs, logFiles, Long.MAX_VALUE ,
+                lastId::get, logVersionRepository,
+                PhysicalLogFile.NO_MONITOR,
+                new LogHeaderCache( 10 ) );
+
+        LogTailScanner tailScanner = new LogTailScanner( logFiles, fs, new VersionAwareLogEntryReader<>() );
+        LogTailScanner.LogTailInformation tailInformation = tailScanner.getTailInformation();
+
+        try ( Lifespan lifespan = new Lifespan( logFile ) )
+        {
+            FlushablePositionAwareChannel channel = logFile.getWriter();
+            TransactionLogWriter transactionLogWriter = new TransactionLogWriter( new LogEntryWriter( channel,
+                    logVersion ) );
+
+            transactionLogWriter.checkPoint( tailInformation.lastCheckPoint.getLogPosition() );
+            channel.prepareForFlush().flush();
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/LogVersionUpgradeCheckerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/LogVersionUpgradeCheckerTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.log;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.storemigration.UpgradeNotAllowedByConfigurationException;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryVersion;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LogVersionUpgradeCheckerTest
+{
+    private LogTailScanner tailScanner = mock( LogTailScanner.class );
+
+    @Rule
+    public ExpectedException expect = ExpectedException.none();
+
+    @Test
+    public void noThrowWhenLatestVersionAndUpgradeIsNotAllowed() throws Throwable
+    {
+        when( tailScanner.getTailInformation() ).thenReturn( new OnlyVersionTailInformation( LogEntryVersion.CURRENT ) );
+
+        LogVersionUpgradeChecker.check( tailScanner, Config.defaults( GraphDatabaseSettings.allow_store_upgrade, "false") );
+    }
+
+    @Test
+    public void throwWhenVersionIsOlderAndUpgradeIsNotAllowed() throws Throwable
+    {
+        when( tailScanner.getTailInformation() ).thenReturn( new OnlyVersionTailInformation( LogEntryVersion.V2_3 ) );
+
+        expect.expect( UpgradeNotAllowedByConfigurationException.class );
+
+        LogVersionUpgradeChecker.check( tailScanner, Config.defaults( GraphDatabaseSettings.allow_store_upgrade, "false") );
+    }
+
+    @Test
+    public void stillAcceptLatestVersionWhenUpgradeIsAllowed() throws Throwable
+    {
+        when( tailScanner.getTailInformation() ).thenReturn( new OnlyVersionTailInformation( LogEntryVersion.CURRENT ) );
+
+        LogVersionUpgradeChecker.check( tailScanner, Config.defaults( GraphDatabaseSettings.allow_store_upgrade, "true") );
+    }
+
+    @Test
+    public void acceptOlderLogsWhenUpgradeIsAllowed() throws Throwable
+    {
+        when( tailScanner.getTailInformation() ).thenReturn( new OnlyVersionTailInformation( LogEntryVersion.V2_3 ) );
+
+        LogVersionUpgradeChecker.check( tailScanner, Config.defaults( GraphDatabaseSettings.allow_store_upgrade, "true") );
+    }
+
+    private static class OnlyVersionTailInformation extends LogTailScanner.LogTailInformation
+    {
+        OnlyVersionTailInformation( LogEntryVersion logEntryVersion )
+        {
+            super( null, false, 0, 0, 0, logEntryVersion );
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/LogVersionUpgradeCheckerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/LogVersionUpgradeCheckerTest.java
@@ -43,7 +43,7 @@ public class LogVersionUpgradeCheckerTest
     {
         when( tailScanner.getTailInformation() ).thenReturn( new OnlyVersionTailInformation( LogEntryVersion.CURRENT ) );
 
-        LogVersionUpgradeChecker.check( tailScanner, Config.defaults( GraphDatabaseSettings.allow_store_upgrade, "false") );
+        LogVersionUpgradeChecker.check( tailScanner, Config.defaults( GraphDatabaseSettings.allow_upgrade, "false") );
     }
 
     @Test
@@ -53,7 +53,7 @@ public class LogVersionUpgradeCheckerTest
 
         expect.expect( UpgradeNotAllowedByConfigurationException.class );
 
-        LogVersionUpgradeChecker.check( tailScanner, Config.defaults( GraphDatabaseSettings.allow_store_upgrade, "false") );
+        LogVersionUpgradeChecker.check( tailScanner, Config.defaults( GraphDatabaseSettings.allow_upgrade, "false") );
     }
 
     @Test
@@ -61,7 +61,7 @@ public class LogVersionUpgradeCheckerTest
     {
         when( tailScanner.getTailInformation() ).thenReturn( new OnlyVersionTailInformation( LogEntryVersion.CURRENT ) );
 
-        LogVersionUpgradeChecker.check( tailScanner, Config.defaults( GraphDatabaseSettings.allow_store_upgrade, "true") );
+        LogVersionUpgradeChecker.check( tailScanner, Config.defaults( GraphDatabaseSettings.allow_upgrade, "true") );
     }
 
     @Test
@@ -69,7 +69,7 @@ public class LogVersionUpgradeCheckerTest
     {
         when( tailScanner.getTailInformation() ).thenReturn( new OnlyVersionTailInformation( LogEntryVersion.V2_3 ) );
 
-        LogVersionUpgradeChecker.check( tailScanner, Config.defaults( GraphDatabaseSettings.allow_store_upgrade, "true") );
+        LogVersionUpgradeChecker.check( tailScanner, Config.defaults( GraphDatabaseSettings.allow_upgrade, "true") );
     }
 
     private static class OnlyVersionTailInformation extends LogTailScanner.LogTailInformation

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryVersionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/entry/LogEntryVersionTest.java
@@ -19,12 +19,19 @@
  */
 package org.neo4j.kernel.impl.transaction.log.entry;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class LogEntryVersionTest
 {
+    @Rule
+    public ExpectedException expect = ExpectedException.none();
+
     @Test
     public void shouldBeAbleToSelectAnyVersion() throws Exception
     {
@@ -39,5 +46,29 @@ public class LogEntryVersionTest
             // THEN
             assertEquals( version, selectedVersion );
         }
+    }
+
+    @Test
+    public void shouldWarnAboutOldLogVersion() throws Exception
+    {
+        expect.expect( IllegalArgumentException.class );
+        LogEntryVersion.byVersion( (byte)-4 );
+    }
+
+    @Test
+    public void shouldWarnAboutNewerLogVersion() throws Exception
+    {
+        expect.expect( IllegalArgumentException.class );
+        LogEntryVersion.byVersion( (byte)-42 ); // unused for now
+    }
+
+    @Test
+    public void moreRecent() throws Exception
+    {
+        assertTrue( LogEntryVersion.moreRecentVersionExists( LogEntryVersion.V2_3 ) );
+        assertTrue( LogEntryVersion.moreRecentVersionExists( LogEntryVersion.V3_0 ) );
+        assertTrue( LogEntryVersion.moreRecentVersionExists( LogEntryVersion.V2_3_5 ) );
+        assertTrue( LogEntryVersion.moreRecentVersionExists( LogEntryVersion.V3_0_2 ) );
+        assertFalse( LogEntryVersion.moreRecentVersionExists( LogEntryVersion.V3_0_10 ) );
     }
 }

--- a/community/neo4j/src/test/java/upgrade/StoreUpgraderInterruptionTestIT.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgraderInterruptionTestIT.java
@@ -227,7 +227,7 @@ public class StoreUpgraderInterruptionTestIT
     {
         GraphDatabaseService databaseService =
                 new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( workingDirectory )
-                        .setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" ).newGraphDatabase();
+                        .setConfig( GraphDatabaseSettings.allow_upgrade, "true" ).newGraphDatabase();
         databaseService.shutdown();
     }
 }

--- a/community/neo4j/src/test/java/upgrade/StoreUpgraderInterruptionTestIT.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgraderInterruptionTestIT.java
@@ -52,6 +52,9 @@ import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
 import org.neo4j.kernel.impl.storemigration.monitoring.SilentMigrationProgressMonitor;
 import org.neo4j.kernel.impl.storemigration.participant.SchemaIndexMigrator;
 import org.neo4j.kernel.impl.storemigration.participant.StoreMigrator;
+import org.neo4j.kernel.impl.transaction.log.LogTailScanner;
+import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
+import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.rule.PageCacheRule;
@@ -106,8 +109,7 @@ public class StoreUpgraderInterruptionTestIT
         MigrationTestUtils.prepareSampleLegacyDatabase( version, fs, workingDirectory, prepareDirectory );
         PageCache pageCache = pageCacheRule.getPageCache( fs );
         StoreVersionCheck check = new StoreVersionCheck( pageCache );
-        UpgradableDatabase upgradableDatabase =
-                new UpgradableDatabase( fs, check, Standard.LATEST_RECORD_FORMATS );
+        UpgradableDatabase upgradableDatabase = getUpgradableDatabase( check );
         SilentMigrationProgressMonitor progressMonitor = new SilentMigrationProgressMonitor();
         LogService logService = NullLogService.getInstance();
         StoreMigrator failingStoreMigrator = new StoreMigrator( fs, pageCache, CONFIG, logService )
@@ -147,6 +149,13 @@ public class StoreUpgraderInterruptionTestIT
         assertConsistentStore( workingDirectory );
     }
 
+    private UpgradableDatabase getUpgradableDatabase( StoreVersionCheck check )
+    {
+        PhysicalLogFiles logFiles = new PhysicalLogFiles( workingDirectory, fs );
+        LogTailScanner tailScanner = new LogTailScanner( logFiles, fs, new VersionAwareLogEntryReader<>() );
+        return new UpgradableDatabase( check, Standard.LATEST_RECORD_FORMATS, tailScanner );
+    }
+
     private SchemaIndexMigrator createIndexMigrator()
     {
         return new SchemaIndexMigrator( fs, schemaIndexProvider );
@@ -161,8 +170,7 @@ public class StoreUpgraderInterruptionTestIT
         MigrationTestUtils.prepareSampleLegacyDatabase( version, fs, workingDirectory, prepareDirectory );
         PageCache pageCache = pageCacheRule.getPageCache( fs );
         StoreVersionCheck check = new StoreVersionCheck( pageCache );
-        UpgradableDatabase upgradableDatabase =
-                new UpgradableDatabase( fs, check, Standard.LATEST_RECORD_FORMATS );
+        UpgradableDatabase upgradableDatabase = getUpgradableDatabase( check );
         SilentMigrationProgressMonitor progressMonitor = new SilentMigrationProgressMonitor();
         LogService logService = NullLogService.getInstance();
         StoreMigrator failingStoreMigrator = new StoreMigrator( fs, pageCache, CONFIG, logService )
@@ -217,7 +225,9 @@ public class StoreUpgraderInterruptionTestIT
 
     private void startStopDatabase( File workingDirectory )
     {
-        GraphDatabaseService databaseService = new TestGraphDatabaseFactory().newEmbeddedDatabase( workingDirectory );
+        GraphDatabaseService databaseService =
+                new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( workingDirectory )
+                        .setConfig( GraphDatabaseSettings.allow_store_upgrade, "true" ).newGraphDatabase();
         databaseService.shutdown();
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpWriterTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpWriterTest.java
@@ -34,6 +34,7 @@ import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageComma
 import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.command.Commands;
 import org.neo4j.kernel.impl.transaction.log.LogPosition;
+import org.neo4j.kernel.impl.transaction.log.LogTailScanner;
 import org.neo4j.kernel.impl.transaction.log.LogVersionBridge;
 import org.neo4j.kernel.impl.transaction.log.LogVersionedStoreChannel;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
@@ -48,7 +49,6 @@ import org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart;
 import org.neo4j.kernel.impl.transaction.log.entry.OnePhaseCommit;
 import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
 import org.neo4j.kernel.lifecycle.Lifespan;
-import org.neo4j.kernel.recovery.LatestCheckPointFinder;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.rule.NeoStoreDataSourceRule;
 import org.neo4j.test.rule.PageCacheRule;
@@ -119,12 +119,12 @@ public class TransactionLogCatchUpWriterTest
         LogEntryReader<ReadableClosablePositionAwareChannel> logEntryReader = new VersionAwareLogEntryReader<>(
                 new RecordStorageCommandReaderFactory(), InvalidLogEntryHandler.STRICT );
         PhysicalLogFiles logFiles = new PhysicalLogFiles( storeDir, fs );
-        final LatestCheckPointFinder checkPointFinder =
-                new LatestCheckPointFinder( logFiles, fs, logEntryReader );
+        final LogTailScanner logTailScanner =
+                new LogTailScanner( logFiles, fs, logEntryReader );
 
-        LatestCheckPointFinder.LatestCheckPoint checkPoint = checkPointFinder.find( 0 );
-        assertNotNull( checkPoint.checkPoint );
-        assertTrue( checkPoint.commitsAfterCheckPoint );
+        LogTailScanner.LogTailInformation checkPoint = logTailScanner.find( 0 );
+        assertNotNull( checkPoint.lastCheckPoint );
+        assertTrue( checkPoint.commitsAfterLastCheckPoint );
     }
 
     private void verifyTransactionsInLog( long fromTxId, long endTxId ) throws IOException

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpWriterTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpWriterTest.java
@@ -111,7 +111,6 @@ public class TransactionLogCatchUpWriterTest
         // then
         verifyTransactionsInLog( fromTxId, endTxId );
         verifyCheckpointInLog(); // necessary for recovery
-
     }
 
     private void verifyCheckpointInLog() throws IOException
@@ -122,9 +121,9 @@ public class TransactionLogCatchUpWriterTest
         final LogTailScanner logTailScanner =
                 new LogTailScanner( logFiles, fs, logEntryReader );
 
-        LogTailScanner.LogTailInformation checkPoint = logTailScanner.find( 0 );
-        assertNotNull( checkPoint.lastCheckPoint );
-        assertTrue( checkPoint.commitsAfterLastCheckPoint );
+        LogTailScanner.LogTailInformation tailInformation = logTailScanner.getTailInformation();
+        assertNotNull( tailInformation.lastCheckPoint );
+        assertTrue( tailInformation.commitsAfterLastCheckPoint );
     }
 
     private void verifyTransactionsInLog( long fromTxId, long endTxId ) throws IOException

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpWriterTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpWriterTest.java
@@ -35,6 +35,7 @@ import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.command.Commands;
 import org.neo4j.kernel.impl.transaction.log.LogPosition;
 import org.neo4j.kernel.impl.transaction.log.LogTailScanner;
+import org.neo4j.kernel.impl.transaction.log.LogTailScanner.LogTailInformation;
 import org.neo4j.kernel.impl.transaction.log.LogVersionBridge;
 import org.neo4j.kernel.impl.transaction.log.LogVersionedStoreChannel;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
@@ -118,10 +119,9 @@ public class TransactionLogCatchUpWriterTest
         LogEntryReader<ReadableClosablePositionAwareChannel> logEntryReader = new VersionAwareLogEntryReader<>(
                 new RecordStorageCommandReaderFactory(), InvalidLogEntryHandler.STRICT );
         PhysicalLogFiles logFiles = new PhysicalLogFiles( storeDir, fs );
-        final LogTailScanner logTailScanner =
-                new LogTailScanner( logFiles, fs, logEntryReader );
+        final LogTailScanner logTailScanner = new LogTailScanner( logFiles, fs, logEntryReader );
 
-        LogTailScanner.LogTailInformation tailInformation = logTailScanner.getTailInformation();
+        LogTailInformation tailInformation = logTailScanner.getTailInformation();
         assertNotNull( tailInformation.lastCheckPoint );
         assertTrue( tailInformation.commitsAfterLastCheckPoint );
     }

--- a/tools/src/main/java/org/neo4j/tools/migration/StoreMigration.java
+++ b/tools/src/main/java/org/neo4j/tools/migration/StoreMigration.java
@@ -46,9 +46,6 @@ import org.neo4j.kernel.impl.storemigration.DatabaseMigrator;
 import org.neo4j.kernel.impl.storemigration.StoreUpgrader;
 import org.neo4j.kernel.impl.storemigration.monitoring.VisibleMigrationProgressMonitor;
 import org.neo4j.kernel.impl.storemigration.participant.StoreMigrator;
-<<<<<<< HEAD
-import org.neo4j.kernel.impl.transaction.state.DefaultSchemaIndexProviderMap;
-=======
 import org.neo4j.kernel.impl.transaction.log.FlushablePositionAwareChannel;
 import org.neo4j.kernel.impl.transaction.log.LogHeaderCache;
 import org.neo4j.kernel.impl.transaction.log.LogTailScanner;
@@ -59,7 +56,7 @@ import org.neo4j.kernel.impl.transaction.log.ReadOnlyTransactionIdStore;
 import org.neo4j.kernel.impl.transaction.log.TransactionLogWriter;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryWriter;
 import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
->>>>>>> LogTailScanner updated
+import org.neo4j.kernel.impl.transaction.state.DefaultSchemaIndexProviderMap;
 import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.Lifespan;


### PR DESCRIPTION
During startup, we now check the version of the last appended transaction log entry and match it against the current version. This way we can detect when the `LogEntryVersion` is changed, and this is now considered an upgrade.

The error messages have also been improved when an unknown transaction log format is encountered, presenting the user with an educated guess of what actually is wrong the transaction logs.

This fixes issue #9775  by disallowing the server to fully start and append transaction log entries that the older version responsible for creating the transaction logs in the first place cannot read.