### PR TITLE
Increase timeout even further in TestCommunication

### DIFF
--- a/enterprise/com/src/test/java/org/neo4j/com/TestCommunication.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/TestCommunication.java
@@ -289,10 +289,10 @@ public class TestCommunication
         }
         assertTrue( writer.getSizeRead() >= failAtSize );
 
-        long maxWaitUntil = System.currentTimeMillis() + 10_000L;
+        long maxWaitUntil = System.currentTimeMillis() + 60_000L;
         while ( !server.responseFailureEncountered() && System.currentTimeMillis() < maxWaitUntil )
         {
-            sleep( 10 );
+            sleep( 100 );
         }
         assertTrue( "Failure writing the response should have been encountered", server.responseFailureEncountered() );
         assertFalse( "Response shouldn't have been successful", server.responseHasBeenWritten() );


### PR DESCRIPTION
Apparently 10s is not enough to reach desired state in serverStopsStreamingToDeadClient(). Give it a whole minute!

The last attempt fixing this, if it still fails it should be removed. The test basically checks that we stop writing data to a closed channel, which throws `IOException` anyway. 