### PR TITLE
neo4j.service now waits until network is available before starting

### DIFF
--- a/new-packaging/src/common/neo4j.service
+++ b/new-packaging/src/common/neo4j.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Neo4j Graph Database
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 ExecStart=/usr/share/neo4j/bin/neo4j console


### PR DESCRIPTION
No point in starting before since startup will fail in that case.

For details see https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/