### PR TITLE
More efficient parameter handling in compiled runtime

### DIFF
--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/ParameterConverter.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/ParameterConverter.java
@@ -1,0 +1,552 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.codegen;
+
+import java.lang.reflect.Array;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+
+import org.neo4j.cypher.internal.compatibility.v3_3.runtime.CartesianPoint;
+import org.neo4j.cypher.internal.compatibility.v3_3.runtime.GeographicPoint;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.helpers.collection.ReverseArrayIterator;
+import org.neo4j.kernel.impl.core.NodeManager;
+import org.neo4j.values.AnyValueWriter;
+import org.neo4j.values.storable.TextArray;
+import org.neo4j.values.storable.TextValue;
+import org.neo4j.values.virtual.CoordinateReferenceSystem;
+import org.neo4j.values.virtual.EdgeValue;
+import org.neo4j.values.virtual.MapValue;
+import org.neo4j.values.virtual.NodeValue;
+
+import static org.neo4j.helpers.collection.Iterators.iteratorsEqual;
+
+/**
+ * Used for turning parameters into appropriate types in the compiled runtime
+ */
+class ParameterConverter implements AnyValueWriter<RuntimeException>
+{
+    private final Deque<Writer> stack = new ArrayDeque<>();
+    private final NodeManager nodeManager;
+
+    ParameterConverter( NodeManager manager )
+    {
+        this.nodeManager = manager;
+        stack.push( new ObjectWriter() );
+    }
+
+    public Object value()
+    {
+        assert stack.size() == 1;
+        return stack.getLast().value();
+    }
+
+    private void writeValue( Object value )
+    {
+        assert !stack.isEmpty();
+        Writer head = stack.peek();
+        head.write( value );
+    }
+
+    @Override
+    public void writeNodeReference( long nodeId ) throws RuntimeException
+    {
+        writeValue( new NodeIdWrapperImpl( nodeId ) );
+    }
+
+    @Override
+    public void writeNode( long nodeId, TextArray ignore, MapValue properties ) throws RuntimeException
+    {
+        writeValue( new NodeIdWrapperImpl( nodeId ) );
+    }
+
+    @Override
+    public void writeEdgeReference( long edgeId ) throws RuntimeException
+    {
+        writeValue( new RelationshipIdWrapperImpl( edgeId ) );
+    }
+
+    @Override
+    public void writeEdge( long edgeId, long startNodeId, long endNodeId, TextValue type, MapValue properties )
+            throws RuntimeException
+    {
+        writeValue( new RelationshipIdWrapperImpl( edgeId ) );
+    }
+
+    @Override
+    public void beginMap( int size ) throws RuntimeException
+    {
+        stack.push( new MapWriter( size ) );
+    }
+
+    @Override
+    public void endMap() throws RuntimeException
+    {
+        assert !stack.isEmpty();
+        writeValue( stack.pop().value() );
+    }
+
+    @Override
+    public void beginList( int size ) throws RuntimeException
+    {
+        stack.push( new ListWriter( size ) );
+    }
+
+    @Override
+    public void endList() throws RuntimeException
+    {
+        assert !stack.isEmpty();
+        writeValue( stack.pop().value() );
+    }
+
+    @Override
+    public void writePath( NodeValue[] nodes, EdgeValue[] edges ) throws RuntimeException
+    {
+        assert nodes != null;
+        assert nodes.length > 0;
+        assert edges != null;
+        assert nodes.length == edges.length + 1;
+
+        Node[] nodeProxies = new Node[nodes.length];
+        for ( int i = 0; i < nodes.length; i++ )
+        {
+            nodeProxies[i] = nodeManager.newNodeProxyById( nodes[i].id() );
+        }
+        Relationship[] relationship = new Relationship[edges.length];
+        for ( int i = 0; i < edges.length; i++ )
+        {
+            relationship[i] = nodeManager.newRelationshipProxyById( edges[i].id() );
+        }
+        writeValue( new Path()
+        {
+            @Override
+            public Node startNode()
+            {
+                return nodeProxies[0];
+            }
+
+            @Override
+            public Node endNode()
+            {
+                return nodeProxies[nodeProxies.length - 1];
+            }
+
+            @Override
+            public Relationship lastRelationship()
+            {
+                return relationship[relationship.length - 1];
+            }
+
+            @Override
+            public Iterable<Relationship> relationships()
+            {
+                return Arrays.asList( relationship );
+            }
+
+            @Override
+            public Iterable<Relationship> reverseRelationships()
+            {
+                return () -> new ReverseArrayIterator<>( relationship );
+            }
+
+            @Override
+            public Iterable<Node> nodes()
+            {
+                return Arrays.asList( nodeProxies );
+            }
+
+            @Override
+            public Iterable<Node> reverseNodes()
+            {
+                return () -> new ReverseArrayIterator<>( nodeProxies );
+            }
+
+            @Override
+            public int length()
+            {
+                return relationship.length;
+            }
+
+            @Override
+            public int hashCode()
+            {
+                if ( relationship.length == 0 )
+                {
+                    return startNode().hashCode();
+                }
+                else
+                {
+                    return Arrays.hashCode( relationship );
+                }
+            }
+
+            @Override
+            public boolean equals( Object obj )
+            {
+                if ( this == obj )
+                {
+                    return true;
+                }
+                else if ( obj instanceof Path )
+                {
+                    Path other = (Path) obj;
+                    return startNode().equals( other.startNode() ) &&
+                           iteratorsEqual( this.relationships().iterator(), other.relationships().iterator() );
+
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            @Override
+            public Iterator<PropertyContainer> iterator()
+            {
+                return new Iterator<PropertyContainer>()
+                {
+                    Iterator<? extends PropertyContainer> current = nodes().iterator();
+                    Iterator<? extends PropertyContainer> next = relationships().iterator();
+
+                    public boolean hasNext()
+                    {
+                        return current.hasNext();
+                    }
+
+                    public PropertyContainer next()
+                    {
+                        try
+                        {
+                            return current.next();
+                        }
+                        finally
+                        {
+                            Iterator<? extends PropertyContainer> temp = current;
+                            current = next;
+                            next = temp;
+                        }
+                    }
+
+                    public void remove()
+                    {
+                        next.remove();
+                    }
+                };
+            }
+        } );
+    }
+
+    @Override
+    public void beginPoint( CoordinateReferenceSystem coordinateReferenceSystem ) throws RuntimeException
+    {
+        stack.push( new PointWriter( coordinateReferenceSystem ) );
+    }
+
+    @Override
+    public void endPoint() throws RuntimeException
+    {
+        assert !stack.isEmpty();
+        writeValue( stack.pop().value() );
+    }
+
+    @Override
+    public void writeNull() throws RuntimeException
+    {
+        writeValue( null );
+    }
+
+    @Override
+    public void writeBoolean( boolean value ) throws RuntimeException
+    {
+        writeValue( value );
+    }
+
+    @Override
+    public void writeInteger( byte value ) throws RuntimeException
+    {
+        writeValue( value );
+    }
+
+    @Override
+    public void writeInteger( short value ) throws RuntimeException
+    {
+        writeValue( value );
+    }
+
+    @Override
+    public void writeInteger( int value ) throws RuntimeException
+    {
+        writeValue( value );
+    }
+
+    @Override
+    public void writeInteger( long value ) throws RuntimeException
+    {
+        writeValue( value );
+    }
+
+    @Override
+    public void writeFloatingPoint( float value ) throws RuntimeException
+    {
+        writeValue( value );
+    }
+
+    @Override
+    public void writeFloatingPoint( double value ) throws RuntimeException
+    {
+        writeValue( value );
+    }
+
+    @Override
+    public void writeString( String value ) throws RuntimeException
+    {
+        writeValue( value );
+    }
+
+    @Override
+    public void writeString( char value ) throws RuntimeException
+    {
+        writeValue( value );
+    }
+
+    @Override
+    public void writeString( char[] value, int offset, int length ) throws RuntimeException
+    {
+        writeValue( new String( value, offset, length ) );
+    }
+
+    @Override
+    public void beginUTF8( int size ) throws RuntimeException
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void copyUTF8( long fromAddress, int length ) throws RuntimeException
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void endUTF8() throws RuntimeException
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void beginArray( int size, ArrayType arrayType ) throws RuntimeException
+    {
+        stack.push( new ArrayWriter( size, arrayType ) );
+    }
+
+    @Override
+    public void endArray() throws RuntimeException
+    {
+        assert !stack.isEmpty();
+        writeValue( stack.pop().value() );
+    }
+
+    @Override
+    public void writeByteArray( byte[] value ) throws RuntimeException
+    {
+        writeValue( value );
+    }
+
+    private interface Writer
+    {
+        void write( Object value );
+
+        Object value();
+    }
+
+    private static class ObjectWriter implements Writer
+    {
+        private Object value;
+
+        @Override
+        public void write( Object value )
+        {
+            this.value = value;
+        }
+
+        @Override
+        public Object value()
+        {
+            return value;
+        }
+    }
+
+    private static class MapWriter implements Writer
+    {
+        private String key;
+        private boolean isKey = true;
+        private final HashMap<String,Object> map;
+
+        MapWriter( int size )
+        {
+            this.map = new HashMap<>( size );
+        }
+
+        @Override
+        public void write( Object value )
+        {
+            if ( isKey )
+            {
+                key = (String) value;
+                isKey = false;
+            }
+            else
+            {
+                map.put( key, value );
+                isKey = true;
+            }
+        }
+
+        @Override
+        public Object value()
+        {
+            return map;
+        }
+    }
+
+    private static class ArrayWriter implements Writer
+    {
+        protected final Object array;
+        private int index;
+
+        ArrayWriter( int size, ArrayType arrayType )
+        {
+            switch ( arrayType )
+            {
+            case SHORT:
+                this.array = Array.newInstance( short.class, size );
+                break;
+            case INT:
+                this.array = Array.newInstance( int.class, size );
+                break;
+            case BYTE:
+                this.array = Array.newInstance( byte.class, size );
+                break;
+            case LONG:
+                this.array = Array.newInstance( long.class, size );
+                break;
+            case FLOAT:
+                this.array = Array.newInstance( float.class, size );
+                break;
+            case DOUBLE:
+                this.array = Array.newInstance( double.class, size );
+                break;
+            case BOOLEAN:
+                this.array = Array.newInstance( boolean.class, size );
+                break;
+            case STRING:
+                this.array = Array.newInstance( String.class, size );
+                break;
+            case CHAR:
+                this.array = Array.newInstance( char.class, size );
+                break;
+            default:
+                this.array = new Object[size];
+            }
+        }
+
+        @Override
+        public void write( Object value )
+        {
+            Array.set( array, index++, value );
+        }
+
+        @Override
+        public Object value()
+        {
+            return array;
+        }
+    }
+
+    private static class ListWriter implements Writer
+    {
+        private final List<Object> list;
+
+        ListWriter( int size )
+        {
+            this.list = new ArrayList<>( size );
+        }
+
+        @Override
+        public void write( Object value )
+        {
+            list.add( value );
+        }
+
+        @Override
+        public Object value()
+        {
+            return list;
+        }
+    }
+
+    private class PointWriter implements Writer
+    {
+        //TODO it is quite silly that the point writer doesn't give me the whole thing at once
+        private final double[] coordinates = new double[2];
+        private int index;
+        private final CoordinateReferenceSystem crs;
+
+        PointWriter( CoordinateReferenceSystem crs )
+        {
+            this.crs = crs;
+        }
+
+        @Override
+        public void write( Object value )
+        {
+            coordinates[index++] = (double) value;
+        }
+
+        @Override
+        public Object value()
+        {
+            if ( crs.code() == CoordinateReferenceSystem.WGS84.code() )
+            {
+                return new GeographicPoint( coordinates[0], coordinates[1],
+                        new org.neo4j.cypher.internal.compatibility.v3_3.runtime.CRS( crs.name, crs.code,
+                                crs.href ) );
+            }
+            else if ( crs.code() == CoordinateReferenceSystem.Cartesian.code() )
+            {
+                return new CartesianPoint( coordinates[0], coordinates[1],
+                        new org.neo4j.cypher.internal.compatibility.v3_3.runtime.CRS( crs.name, crs.code,
+                                crs.href ) );
+            }
+            else
+            {
+                throw new IllegalArgumentException( crs + " is not a supported coordinate reference system" );
+            }
+        }
+    }
+}

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/ParameterConverter.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/ParameterConverter.java
@@ -289,19 +289,19 @@ class ParameterConverter implements AnyValueWriter<RuntimeException>
     @Override
     public void writeInteger( byte value ) throws RuntimeException
     {
-        writeValue( value );
+        writeValue( (long) value );
     }
 
     @Override
     public void writeInteger( short value ) throws RuntimeException
     {
-        writeValue( value );
+        writeValue( (long) value );
     }
 
     @Override
     public void writeInteger( int value ) throws RuntimeException
     {
-        writeValue( value );
+        writeValue( (long) value );
     }
 
     @Override
@@ -313,7 +313,7 @@ class ParameterConverter implements AnyValueWriter<RuntimeException>
     @Override
     public void writeFloatingPoint( float value ) throws RuntimeException
     {
-        writeValue( value );
+        writeValue( (double) value );
     }
 
     @Override

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/ParameterConverter.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/ParameterConverter.java
@@ -36,6 +36,7 @@ import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.helpers.collection.ReverseArrayIterator;
 import org.neo4j.kernel.impl.core.NodeManager;
+import org.neo4j.string.UTF8;
 import org.neo4j.values.AnyValueWriter;
 import org.neo4j.values.storable.TextArray;
 import org.neo4j.values.storable.TextValue;
@@ -341,21 +342,9 @@ class ParameterConverter implements AnyValueWriter<RuntimeException>
     }
 
     @Override
-    public void beginUTF8( int size ) throws RuntimeException
+    public void writeUTF8( byte[] bytes, int offset, int length ) throws RuntimeException
     {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void copyUTF8( long fromAddress, int length ) throws RuntimeException
-    {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void endUTF8() throws RuntimeException
-    {
-        throw new UnsupportedOperationException();
+        writeValue( UTF8.decode( bytes, offset, length ) );
     }
 
     @Override

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/BuildInterpretedExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/BuildInterpretedExecutionPlan.scala
@@ -19,8 +19,8 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_3.runtime
 
-import org.neo4j.cypher.internal.compatibility.v3_3.runtime.commands.convert.{CommunityExpressionConverter, ExpressionConverters}
 import org.neo4j.cypher.internal.InternalExecutionResult
+import org.neo4j.cypher.internal.compatibility.v3_3.runtime.commands.convert.{CommunityExpressionConverter, ExpressionConverters}
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.executionplan._
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.phases.CompilationState
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes.Pipe
@@ -35,7 +35,7 @@ import org.neo4j.cypher.internal.frontend.v3_3.phases.CompilationPhaseTracer.Com
 import org.neo4j.cypher.internal.frontend.v3_3.phases.{InternalNotificationLogger, Phase}
 import org.neo4j.cypher.internal.frontend.v3_3.{PeriodicCommitInOpenTransactionException, PlannerName}
 import org.neo4j.cypher.internal.spi.v3_3.{QueryContext, UpdateCountingQueryContext}
-import org.neo4j.values.AnyValue
+import org.neo4j.values.virtual.MapValue
 
 object
 
@@ -62,7 +62,7 @@ BuildInterpretedExecutionPlan extends Phase[CommunityRuntimeContext, LogicalPlan
     val execPlan = new ExecutionPlan {
       private val fingerprint = context.createFingerprintReference(fp)
 
-      override def run(queryContext: QueryContext, planType: ExecutionMode, params: Map[String, AnyValue]): InternalExecutionResult =
+      override def run(queryContext: QueryContext, planType: ExecutionMode, params: MapValue): InternalExecutionResult =
         func(queryContext, planType, params)
 
       override def isPeriodicCommit: Boolean = periodicCommitInfo.isDefined
@@ -94,8 +94,8 @@ BuildInterpretedExecutionPlan extends Phase[CommunityRuntimeContext, LogicalPlan
                                        resultBuilderFactory: ExecutionResultBuilderFactory,
                                        notificationLogger: InternalNotificationLogger,
                                         runtimeName: RuntimeName):
-  (QueryContext, ExecutionMode, Map[String, AnyValue]) => InternalExecutionResult =
-    (queryContext: QueryContext, planType: ExecutionMode, params: Map[String, AnyValue]) => {
+  (QueryContext, ExecutionMode, MapValue) => InternalExecutionResult =
+    (queryContext: QueryContext, planType: ExecutionMode, params: MapValue) => {
       val builder = resultBuilderFactory.create()
 
       val profiling = planType == ProfileMode

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/DefaultExecutionResultBuilderFactory.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/DefaultExecutionResultBuilderFactory.scala
@@ -29,7 +29,7 @@ import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.plans.LogicalPlan
 import org.neo4j.cypher.internal.frontend.v3_3.CypherException
 import org.neo4j.cypher.internal.frontend.v3_3.phases.InternalNotificationLogger
 import org.neo4j.cypher.internal.spi.v3_3.{CSVResources, QueryContext}
-import org.neo4j.values.AnyValue
+import org.neo4j.values.virtual.MapValue
 
 import scala.collection.mutable
 
@@ -65,7 +65,7 @@ case class DefaultExecutionResultBuilderFactory(pipeInfo: PipeInfo,
       exceptionDecorator = newDecorator
     }
 
-    def build(queryId: AnyRef, planType: ExecutionMode, params: Map[String, AnyValue],
+    def build(queryId: AnyRef, planType: ExecutionMode, params: MapValue,
               notificationLogger: InternalNotificationLogger, runtimeName: RuntimeName): InternalExecutionResult = {
       taskCloser.addTask(queryContext.transactionalContext.close)
       val state = new QueryState(queryContext, externalResource, params, pipeDecorator, queryId = queryId,

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/ExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/ExecutionPlan.scala
@@ -26,10 +26,10 @@ import org.neo4j.cypher.internal.compiler.v3_3.spi.{GraphStatistics, PlanContext
 import org.neo4j.cypher.internal.frontend.v3_3.PlannerName
 import org.neo4j.cypher.internal.frontend.v3_3.notification.InternalNotification
 import org.neo4j.cypher.internal.spi.v3_3.QueryContext
-import org.neo4j.values.AnyValue
+import org.neo4j.values.virtual.MapValue
 
 abstract class ExecutionPlan {
-  def run(queryContext: QueryContext, planType: ExecutionMode, params: Map[String, AnyValue]): InternalExecutionResult
+  def run(queryContext: QueryContext, planType: ExecutionMode, params: MapValue): InternalExecutionResult
   def isPeriodicCommit: Boolean
   def plannerUsed: PlannerName
   def isStale(lastTxId: () => Long, statistics: GraphStatistics): Boolean

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/ExecutionResultBuilder.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/ExecutionResultBuilder.scala
@@ -20,19 +20,19 @@
 package org.neo4j.cypher.internal.compatibility.v3_3.runtime.executionplan
 
 import org.neo4j.cypher.internal.InternalExecutionResult
-import org.neo4j.cypher.internal.compatibility.v3_3.runtime.{ExecutionMode, RuntimeName}
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes.PipeDecorator
+import org.neo4j.cypher.internal.compatibility.v3_3.runtime.{ExecutionMode, RuntimeName}
 import org.neo4j.cypher.internal.frontend.v3_3.CypherException
 import org.neo4j.cypher.internal.frontend.v3_3.phases.InternalNotificationLogger
 import org.neo4j.cypher.internal.spi.v3_3.QueryContext
-import org.neo4j.values.AnyValue
+import org.neo4j.values.virtual.MapValue
 
 trait ExecutionResultBuilder {
   def setQueryContext(context: QueryContext)
   def setLoadCsvPeriodicCommitObserver(batchRowCount: Long)
   def setPipeDecorator(newDecorator: PipeDecorator)
   def setExceptionDecorator(newDecorator: CypherException => CypherException)
-  def build(queryId: AnyRef, planType: ExecutionMode, params: Map[String, AnyValue],
+  def build(queryId: AnyRef, planType: ExecutionMode, params: MapValue,
             notificationLogger: InternalNotificationLogger, runtimeName: RuntimeName): InternalExecutionResult
 }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/procs/ProcedureCallExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/procs/ProcedureCallExecutionPlan.scala
@@ -36,7 +36,7 @@ import org.neo4j.cypher.internal.frontend.v3_3.notification.InternalNotification
 import org.neo4j.cypher.internal.frontend.v3_3.symbols.CypherType
 import org.neo4j.cypher.internal.spi.v3_3.QueryContext
 import org.neo4j.graphdb.Notification
-import org.neo4j.values.AnyValue
+import org.neo4j.values.virtual.MapValue
 
 /**
   * Execution plan for calling procedures
@@ -66,7 +66,7 @@ case class ProcedureCallExecutionPlan(signature: ProcedureSignature,
     private val argExprCommands: Seq[expressions.Expression] =  argExprs.map(converter.toCommandExpression) ++
       signature.inputSignature.drop(argExprs.size).flatMap(_.default).map(o => Literal(o.value))
 
-    override def run(ctx: QueryContext, planType: ExecutionMode, params: Map[String, AnyValue]): InternalExecutionResult = {
+    override def run(ctx: QueryContext, planType: ExecutionMode, params: MapValue): InternalExecutionResult = {
       val input = evaluateArguments(ctx, params)
 
       val taskCloser = new TaskCloser
@@ -107,7 +107,7 @@ case class ProcedureCallExecutionPlan(signature: ProcedureSignature,
       }
     }
 
-    private def evaluateArguments(ctx: QueryContext, params: Map[String, AnyValue]): Seq[Any] = {
+    private def evaluateArguments(ctx: QueryContext, params: MapValue): Seq[Any] = {
       val state = new QueryState(ctx, ExternalCSVResource.empty, params)
       argExprCommands.map(expr => ctx.asObject(expr.apply(ExecutionContext.empty)(state)))
     }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/procs/PureSideEffectExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/procs/PureSideEffectExecutionPlan.scala
@@ -29,7 +29,7 @@ import org.neo4j.cypher.internal.compiler.v3_3.spi.{GraphStatistics, PlanContext
 import org.neo4j.cypher.internal.frontend.v3_3.PlannerName
 import org.neo4j.cypher.internal.frontend.v3_3.notification.InternalNotification
 import org.neo4j.cypher.internal.spi.v3_3.{QueryContext, UpdateCountingQueryContext}
-import org.neo4j.values.AnyValue
+import org.neo4j.values.virtual.MapValue
 
 /**
   * Execution plan for performing pure side-effects, i.e. returning no data to the user.
@@ -42,7 +42,7 @@ case class PureSideEffectExecutionPlan(name: String, queryType: InternalQueryTyp
   extends ExecutionPlan {
 
     override def run(ctx: QueryContext, planType: ExecutionMode,
-                     params: Map[String, AnyValue]): InternalExecutionResult = {
+                     params: MapValue): InternalExecutionResult = {
       if (planType == ExplainMode) {
         //close all statements
         ctx.transactionalContext.close(success = true)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/helpers/ValueConversion.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/helpers/ValueConversion.scala
@@ -26,8 +26,8 @@ import org.neo4j.graphdb.spatial.{Geometry, Point}
 import org.neo4j.graphdb.{Node, Path, Relationship}
 import org.neo4j.values.storable.Values
 import org.neo4j.values.storable.Values.byteArray
-import org.neo4j.values.virtual.VirtualValues
 import org.neo4j.values.virtual.VirtualValues.fromArray
+import org.neo4j.values.virtual.{MapValue, VirtualValues}
 import org.neo4j.values.{AnyValue, AnyValues}
 
 import scala.collection.JavaConverters._
@@ -49,7 +49,7 @@ object ValueConversion {
     case symbols.CTGeometry => o => AnyValues.asPointValue(o.asInstanceOf[Geometry])
   }
 
-  def asValues(params: Map[String, Any]): Map[String, AnyValue] = Eagerly.immutableMapValues(params, asValue)
+  def asValues(params: Map[String, Any]): MapValue = VirtualValues.map(Eagerly.immutableMapValues(params, asValue).asJava)
   def asValue(value: Any): AnyValue = value match {
     case null => Values.NO_VALUE
     case s: String => Values.stringValue(s)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/helpers/simpleExpressionEvaluator.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/helpers/simpleExpressionEvaluator.scala
@@ -25,6 +25,7 @@ import org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes.{NullPipeDecor
 import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.ExpressionEvaluator
 import org.neo4j.cypher.internal.frontend.v3_3.ast.Expression
 import org.neo4j.cypher.internal.frontend.v3_3.{CypherException => InternalCypherException}
+import org.neo4j.values.virtual.VirtualValues
 
 import scala.collection.mutable
 
@@ -35,13 +36,12 @@ object simpleExpressionEvaluator extends ExpressionEvaluator {
     val converters = new ExpressionConverters(CommunityExpressionConverter)
     val commandExpr = converters.toCommandExpression(expr)
 
-    implicit val emptyQueryState = new QueryState(query = null, resources = null, params = Map.empty,
+    implicit val emptyQueryState = new QueryState(query = null, resources = null, params = VirtualValues.EMPTY_MAP,
                                                   decorator = NullPipeDecorator, triadicState = mutable.Map.empty,
                                                   repeatableReads = mutable.Map.empty)
 
     try {
-      val foo = Some(commandExpr(ExecutionContext.empty))
-      foo
+      Some(commandExpr(ExecutionContext.empty))
     }
     catch {
       case e: InternalCypherException => None // Silently disregard expressions that cannot be evaluated in an empty context

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/EagerAggregationPipe.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/EagerAggregationPipe.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.compatibility.v3_3.runtime.commands.expressions
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes.aggregation.AggregationFunction
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.Id
 import org.neo4j.values.AnyValue
-import org.neo4j.values.virtual.{ListValue, VirtualValues}
+import org.neo4j.values.virtual.{ListValue, MapValue, VirtualValues}
 
 import scala.collection.mutable.{Map => MutableMap}
 
@@ -46,7 +46,7 @@ case class EagerAggregationPipe(source: Pipe, keyExpressions: Set[String], aggre
     val keyNamesSize = keyNames.size
     val mapSize = keyNamesSize + aggregationNames.size
 
-    def createEmptyResult(params: Map[String, Any]): Iterator[ExecutionContext] = {
+    def createEmptyResult(params: MapValue): Iterator[ExecutionContext] = {
       val newMap = MutableMaps.empty
       val aggregationNamesAndFunctions = aggregationNames zip aggregations.map(_._2.createAggregationFunction.result)
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/QueryState.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/QueryState.scala
@@ -29,12 +29,13 @@ import org.neo4j.cypher.internal.compatibility.v3_3.runtime.commands.predicates.
 import org.neo4j.cypher.internal.frontend.v3_3.ParameterNotFoundException
 import org.neo4j.cypher.internal.spi.v3_3.QueryContext
 import org.neo4j.values.AnyValue
+import org.neo4j.values.virtual.MapValue
 
 import scala.collection.mutable
 
 class QueryState(val query: QueryContext,
                  val resources: ExternalCSVResource,
-                 val params: Map[String, AnyValue],
+                 val params: MapValue,
                  val decorator: PipeDecorator = NullPipeDecorator,
                  val timeReader: TimeReader = new TimeReader,
                  var initialContext: Option[ExecutionContext] = None,
@@ -56,8 +57,10 @@ class QueryState(val query: QueryContext,
 
   def readTimeStamp(): Long = timeReader.getTime
 
-  def  getParam(key: String): AnyValue =
-    params.getOrElse(key, throw new ParameterNotFoundException("Expected a parameter named " + key))
+  def  getParam(key: String): AnyValue = {
+    if (!params.containsKey(key)) throw new ParameterNotFoundException("Expected a parameter named " + key)
+    params.get(key)
+  }
 
   def getStatistics: QueryStatistics = query.getOptStatistics.getOrElse(QueryState.defaultStatistics)
 

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/ParameterConverterTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/ParameterConverterTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.codegen;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.spatial.Point;
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.kernel.impl.core.NodeManager;
+import org.neo4j.kernel.impl.core.NodeProxy;
+import org.neo4j.kernel.impl.core.RelationshipProxy;
+import org.neo4j.values.AnyValue;
+import org.neo4j.values.storable.LongArray;
+import org.neo4j.values.storable.Values;
+import org.neo4j.values.virtual.EdgeValue;
+import org.neo4j.values.virtual.ListValue;
+import org.neo4j.values.virtual.MapValue;
+import org.neo4j.values.virtual.NodeValue;
+import org.neo4j.values.virtual.PathValue;
+import org.neo4j.values.virtual.PointValue;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.neo4j.values.storable.Values.FALSE;
+import static org.neo4j.values.storable.Values.TRUE;
+import static org.neo4j.values.storable.Values.byteValue;
+import static org.neo4j.values.storable.Values.doubleValue;
+import static org.neo4j.values.storable.Values.floatValue;
+import static org.neo4j.values.storable.Values.intValue;
+import static org.neo4j.values.storable.Values.longValue;
+import static org.neo4j.values.storable.Values.shortValue;
+import static org.neo4j.values.storable.Values.stringArray;
+import static org.neo4j.values.storable.Values.stringValue;
+import static org.neo4j.values.virtual.VirtualValues.EMPTY_MAP;
+import static org.neo4j.values.virtual.VirtualValues.edgeValue;
+import static org.neo4j.values.virtual.VirtualValues.list;
+import static org.neo4j.values.virtual.VirtualValues.map;
+import static org.neo4j.values.virtual.VirtualValues.nodeValue;
+import static org.neo4j.values.virtual.VirtualValues.path;
+import static org.neo4j.values.virtual.VirtualValues.pointGeographic;
+
+public class ParameterConverterTest
+{
+    private ParameterConverter converter = new ParameterConverter( mock( NodeManager.class ) );
+
+    @Before
+    public void setup()
+    {
+        NodeManager manager = mock( NodeManager.class );
+        when( manager.newNodeProxyById( anyLong() ) ).thenAnswer( invocationOnMock ->
+        {
+            long id = invocationOnMock.getArgumentAt( 0, long.class );
+            NodeProxy mock = mock( NodeProxy.class );
+            when( mock.getId() ).thenReturn( id );
+            return mock;
+        } );
+        when( manager.newRelationshipProxyById( anyLong() ) ).thenAnswer( invocationOnMock ->
+        {
+            long id = invocationOnMock.getArgumentAt( 0, long.class );
+            RelationshipProxy mock = mock( RelationshipProxy.class );
+            when( mock.getId() ).thenReturn( id );
+            return mock;
+        } );
+        converter = new ParameterConverter( manager );
+    }
+
+    @Test
+    public void shouldTurnAllIntegerTypesToLongs()
+    {
+        AnyValue[] values =
+                new AnyValue[]{byteValue( (byte) 13 ), shortValue( (short) 13 ), intValue( 13 ), longValue( 13L )};
+
+        for ( AnyValue val : values )
+        {
+            val.writeTo( converter );
+            Object value = converter.value();
+            assertThat( value, instanceOf( Long.class ) );
+            assertThat( value, equalTo( 13L ) );
+        }
+    }
+
+    @Test
+    public void shouldTurnAllFloatingTypesToDoubles()
+    {
+        AnyValue[] values = new AnyValue[]{floatValue( 13f ), doubleValue( 13d )};
+
+        for ( AnyValue val : values )
+        {
+            val.writeTo( converter );
+            Object value = converter.value();
+            assertThat( value, instanceOf( Double.class ) );
+            assertThat( value, equalTo( 13d ) );
+        }
+    }
+
+    @Test
+    public void shouldHandleNodes()
+    {
+        // Given
+        NodeValue nodeValue = nodeValue( 42L, stringArray( "L" ), EMPTY_MAP );
+
+        // When
+        nodeValue.writeTo( converter );
+
+        // Then
+        assertThat( converter.value(), equalTo( new NodeIdWrapperImpl( 42L ) ) );
+    }
+
+    @Test
+    public void shouldHandleEdges()
+    {
+        // Given
+        EdgeValue edgeValue = edgeValue( 1L, nodeValue( 42L, stringArray( "L" ), EMPTY_MAP ),
+                nodeValue( 42L, stringArray( "L" ), EMPTY_MAP ), stringValue( "R" ), EMPTY_MAP );
+
+        // When
+        edgeValue.writeTo( converter );
+
+        // Then
+        assertThat( converter.value(), equalTo( new RelationshipIdWrapperImpl( 1L ) ) );
+    }
+
+    @Test
+    public void shouldHandleBooleans()
+    {
+        TRUE.writeTo( converter );
+        assertThat( converter.value(), equalTo( true ) );
+        FALSE.writeTo( converter );
+        assertThat( converter.value(), equalTo( false ) );
+    }
+
+    @Test
+    public void shouldHandlePaths()
+    {
+        // Given
+        NodeValue n1 = nodeValue( 42L, stringArray( "L" ), EMPTY_MAP );
+        NodeValue n2 = nodeValue( 43L, stringArray( "L" ), EMPTY_MAP );
+        PathValue p = path(
+                new NodeValue[]{n1, n2},
+                new EdgeValue[]{edgeValue( 1L, n1, n2, stringValue( "T" ), EMPTY_MAP )} );
+
+        // When
+        p.writeTo( converter );
+
+        // Then
+        Object value = converter.value();
+        assertThat( value, instanceOf( Path.class ) );
+        Path path = (Path) value;
+        assertThat( path.length(), equalTo( 1 ) );
+        assertThat( path.startNode().getId(), equalTo( 42L ) );
+        assertThat( path.endNode().getId(), equalTo( 43L ) );
+        assertThat( path.relationships().iterator().next().getId(), equalTo( 1L ) );
+    }
+
+    @Test
+    public void shouldHandlePoints()
+    {
+        // Given
+        PointValue pointValue = pointGeographic( 1.0, 2.0 );
+
+        // When
+        pointValue.writeTo( converter );
+
+        // Then
+        Object value = converter.value();
+        assertThat( value, instanceOf( Point.class ) );
+        Point point = (Point) value;
+        assertThat( point.getCoordinate().getCoordinate().get( 0 ), equalTo( 1.0 ) );
+        assertThat( point.getCoordinate().getCoordinate().get( 1 ), equalTo( 2.0 ) );
+        assertThat( point.getCRS().getCode(), equalTo( 4326 ) );
+    }
+
+    @Test
+    public void shouldHandleLists()
+    {
+        // Given
+        ListValue list = list( stringValue( "foo" ), longValue( 42L ), TRUE );
+
+        // When
+        list.writeTo( converter );
+
+        // Then
+        assertThat( converter.value(), equalTo( Arrays.asList( "foo", 42L, true ) ) );
+    }
+
+    @Test
+    public void shouldHandleArrays()
+    {
+        // Given
+        LongArray longArray = Values.longArray( new long[]{1L, 2L, 3L} );
+
+        // When
+        longArray.writeTo( converter );
+
+        // Then
+        assertThat( converter.value(), equalTo( new long[]{1L, 2L, 3L} ) );
+    }
+
+    @Test
+    public void shouldHandleMaps()
+    {
+        // Given
+        MapValue map = map( new String[]{"foo", "bar"}, new AnyValue[]{longValue( 42L ), stringValue( "baz" )} );
+
+        // When
+        map.writeTo( converter );
+
+        // Then
+        assertThat( converter.value(), equalTo( MapUtil.map( "foo", 42L, "bar", "baz" ) ) );
+    }
+
+    @Test
+    public void shouldHandleListWithMaps()
+    {
+        // Given
+        ListValue list =
+                list( longValue( 42L ),
+                        map( new String[]{"foo", "bar"}, new AnyValue[]{longValue( 42L ), stringValue( "baz" )} ) );
+
+        // When
+        list.writeTo( converter );
+
+        // Then
+        List<?> converted = (List<?>) converter.value();
+        assertThat( converted.get( 0 ), equalTo( 42L ) );
+        assertThat( converted.get( 1 ), equalTo( MapUtil.map( "foo", 42L, "bar", "baz" ) ) );
+    }
+
+    @Test
+    public void shouldHandleMapsWithLists()
+    {
+        // Given
+        MapValue map =
+                map( new String[]{"foo", "bar"}, new AnyValue[]{longValue( 42L ), list( stringValue( "baz" ) )} );
+
+        // When
+        map.writeTo( converter );
+
+        // Then
+        Map<?,?> value = (Map<?,?>) converter.value();
+        assertThat( value.get( "foo" ), equalTo( 42L ) );
+        assertThat( value.get( "bar" ), equalTo( singletonList( "baz" ) ) );
+        assertThat( value.size(), equalTo( 2 ) );
+    }
+}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/codegen/CompiledConversionUtilsTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/codegen/CompiledConversionUtilsTest.scala
@@ -23,9 +23,9 @@ import java.util
 import java.util.stream.{DoubleStream, IntStream, LongStream}
 
 import org.mockito.Mockito.when
+import org.neo4j.cypher.internal.codegen.CompiledConversionUtils.makeValueNeoSafe
 import org.neo4j.cypher.internal.frontend.v3_3.CypherTypeException
 import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.CypherFunSuite
-import org.neo4j.cypher.internal.codegen.CompiledConversionUtils.makeValueNeoSafe
 import org.neo4j.graphdb.{Node, Relationship}
 
 import scala.collection.JavaConverters._
@@ -75,11 +75,6 @@ class CompiledConversionUtilsTest extends CypherFunSuite {
 
   test("should be able to turn a primitive array into a collection") {
     CompiledConversionUtils.toCollection(Array(1337L, 42L)).asScala.toList should equal(List(1337L, 42))
-  }
-
-  test("should preserve primitiveness when loading parameter") {
-    CompiledConversionUtils.loadParameter(Array(1L, 2L, 13L)).getClass.getComponentType.isPrimitive shouldBe true
-    CompiledConversionUtils.loadParameter(Array(1L, 2L, "Hello")).getClass.getComponentType.isPrimitive shouldBe false
   }
 
   test("should be able to use a composite key in a hash map") {
@@ -196,18 +191,4 @@ class CompiledConversionUtilsTest extends CypherFunSuite {
   when(node.getId).thenReturn(11L)
   private val rel = mock[Relationship]
   when(rel.getId).thenReturn(13L)
-
-  val testLoadParameter = Seq(
-    (null, null),
-    (node, new NodeIdWrapperImpl(11L)),
-    (rel, new RelationshipIdWrapperImpl(13L)),
-    (Array(node, rel), Array(new NodeIdWrapperImpl(11L), new RelationshipIdWrapperImpl(13L)))
-  )
-
-  testLoadParameter.foreach {
-    case (v, expected) =>
-      test(s"loadParameter($v) == $expected)") {
-        CompiledConversionUtils.loadParameter(v) should equal(expected)
-      }
-  }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/ExecutionWorkflowBuilderTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/ExecutionWorkflowBuilderTest.scala
@@ -30,6 +30,7 @@ import org.neo4j.cypher.internal.frontend.v3_3.phases.devNullLogger
 import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.ir.v3_3.{Cardinality, CardinalityEstimation, PlannerQuery}
 import org.neo4j.cypher.internal.spi.v3_3.{QueryContext, QueryTransactionalContext}
+import org.neo4j.values.virtual.VirtualValues.EMPTY_MAP
 
 class ExecutionWorkflowBuilderTest extends CypherFunSuite {
   val PlannerName = IDPPlannerName
@@ -51,7 +52,7 @@ class ExecutionWorkflowBuilderTest extends CypherFunSuite {
     builder.setQueryContext(context)
 
     // THEN
-    val result = builder.build("42", NormalMode, Map.empty, devNullLogger, InterpretedRuntimeName)
+    val result = builder.build("42", NormalMode, EMPTY_MAP, devNullLogger, InterpretedRuntimeName)
     result shouldBe a [PipeExecutionResult]
     result.asInstanceOf[PipeExecutionResult].result shouldBe a[EagerResultIterator]
   }
@@ -69,7 +70,7 @@ class ExecutionWorkflowBuilderTest extends CypherFunSuite {
     builder.setQueryContext(context)
 
     // THEN
-    val result = builder.build("42", NormalMode, Map.empty, devNullLogger, InterpretedRuntimeName)
+    val result = builder.build("42", NormalMode,EMPTY_MAP, devNullLogger, InterpretedRuntimeName)
     result shouldBe a [PipeExecutionResult]
     result.asInstanceOf[PipeExecutionResult].result should not be an[EagerResultIterator]
   }
@@ -88,7 +89,7 @@ class ExecutionWorkflowBuilderTest extends CypherFunSuite {
     builder.setQueryContext(context)
 
     // THEN
-    val result = builder.build("42", ExplainMode, Map.empty, devNullLogger, InterpretedRuntimeName)
+    val result = builder.build("42", ExplainMode, EMPTY_MAP, devNullLogger, InterpretedRuntimeName)
     result shouldBe a [ExplainExecutionResult]
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/ExecutionWorkflowBuilderTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/ExecutionWorkflowBuilderTest.scala
@@ -70,7 +70,7 @@ class ExecutionWorkflowBuilderTest extends CypherFunSuite {
     builder.setQueryContext(context)
 
     // THEN
-    val result = builder.build("42", NormalMode,EMPTY_MAP, devNullLogger, InterpretedRuntimeName)
+    val result = builder.build("42", NormalMode, EMPTY_MAP, devNullLogger, InterpretedRuntimeName)
     result shouldBe a [PipeExecutionResult]
     result.asInstanceOf[PipeExecutionResult].result should not be an[EagerResultIterator]
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/procs/ProcedureCallExecutionPlanTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/procs/ProcedureCallExecutionPlanTest.scala
@@ -32,6 +32,7 @@ import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.frontend.v3_3.{DummyPosition, symbols}
 import org.neo4j.cypher.internal.spi.v3_3.{QueryContext, QueryTransactionalContext}
 import org.neo4j.values.storable.LongValue
+import org.neo4j.values.virtual.VirtualValues.EMPTY_MAP
 
 class ProcedureCallExecutionPlanTest extends CypherFunSuite {
 
@@ -43,7 +44,7 @@ class ProcedureCallExecutionPlanTest extends CypherFunSuite {
                                           notifications = Set.empty, converters)
 
     // When
-    val res = proc.run(ctx, NormalMode, Map.empty)
+    val res = proc.run(ctx, NormalMode, EMPTY_MAP)
 
     // Then
     res.toList should equal(List(Map("b" -> 84)))
@@ -56,7 +57,7 @@ class ProcedureCallExecutionPlanTest extends CypherFunSuite {
                                           notifications = Set.empty, converters)
 
     // When
-    proc.run(ctx, NormalMode, Map.empty)
+    proc.run(ctx, NormalMode,EMPTY_MAP)
 
     // Then without touching the result, it should have been spooled out
     iteratorExhausted should equal(true)
@@ -69,7 +70,7 @@ class ProcedureCallExecutionPlanTest extends CypherFunSuite {
                                           notifications = Set.empty, converters)
 
     // When
-    proc.run(ctx, NormalMode, Map.empty)
+    proc.run(ctx, NormalMode,EMPTY_MAP)
 
     // Then without touching the result, the Kernel iterator should not be touched
     iteratorExhausted should equal(false)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/procs/ProcedureCallExecutionPlanTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/procs/ProcedureCallExecutionPlanTest.scala
@@ -57,7 +57,7 @@ class ProcedureCallExecutionPlanTest extends CypherFunSuite {
                                           notifications = Set.empty, converters)
 
     // When
-    proc.run(ctx, NormalMode,EMPTY_MAP)
+    proc.run(ctx, NormalMode, EMPTY_MAP)
 
     // Then without touching the result, it should have been spooled out
     iteratorExhausted should equal(true)
@@ -70,7 +70,7 @@ class ProcedureCallExecutionPlanTest extends CypherFunSuite {
                                           notifications = Set.empty, converters)
 
     // When
-    proc.run(ctx, NormalMode,EMPTY_MAP)
+    proc.run(ctx, NormalMode, EMPTY_MAP)
 
     // Then without touching the result, the Kernel iterator should not be touched
     iteratorExhausted should equal(false)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/QueryStateHelper.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/QueryStateHelper.scala
@@ -24,8 +24,10 @@ import org.mockito.stubbing.Answer
 import org.mockito.{Matchers, Mockito}
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.ExecutionContext
 import org.neo4j.cypher.internal.spi.v3_3.QueryContext
-import org.neo4j.graphdb.{Node, Relationship}
 import org.neo4j.graphdb.spatial.Point
+import org.neo4j.graphdb.{Node, Relationship}
+import org.neo4j.values.virtual.MapValue
+import org.neo4j.values.virtual.VirtualValues.EMPTY_MAP
 import org.neo4j.values.{AnyValue, BaseToObjectValueWriter}
 
 import scala.collection.mutable
@@ -34,7 +36,7 @@ object QueryStateHelper {
   def empty: QueryState = emptyWith()
 
   def emptyWith(query: QueryContext = null, resources: ExternalCSVResource = null,
-                params: Map[String, AnyValue] = Map.empty, decorator: PipeDecorator = NullPipeDecorator,
+                params: MapValue = EMPTY_MAP, decorator: PipeDecorator = NullPipeDecorator,
                 initialContext: Option[ExecutionContext] = None) =
     new QueryState(query = query, resources = resources, params = params, decorator = decorator,
       initialContext = initialContext, triadicState = mutable.Map.empty, repeatableReads = mutable.Map.empty)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/AllShortestPathsPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/AllShortestPathsPipeTest.scala
@@ -27,7 +27,7 @@ import org.neo4j.cypher.internal.frontend.v3_3.SemanticDirection
 import org.neo4j.cypher.internal.frontend.v3_3.symbols._
 import org.neo4j.graphdb.Node
 import org.neo4j.values.virtual.PathValue
-import org.neo4j.values.virtual.VirtualValues.fromNodeProxy
+import org.neo4j.values.virtual.VirtualValues.{EMPTY_MAP, fromNodeProxy}
 
 import scala.collection.mutable
 
@@ -40,7 +40,7 @@ class AllShortestPathsPipeTest extends GraphDatabaseFunSuite {
                                                      SemanticDirection.BOTH, allowZeroLength = false, Some(15),
                                                      single = false, relIterator = None))()
     graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, {queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipe.createResults(queryState).toList.map(m => m("p").asInstanceOf[PathValue])
       })
     }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/QueryStateTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/QueryStateTestSupport.scala
@@ -23,6 +23,7 @@ import org.neo4j.cypher.GraphDatabaseTestSupport
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes.QueryState
 import org.neo4j.kernel.api.KernelTransaction
 import org.neo4j.kernel.api.security.SecurityContext.AUTH_DISABLED
+import org.neo4j.values.virtual.VirtualValues.EMPTY_MAP
 
 trait QueryStateTestSupport {
   self: GraphDatabaseTestSupport =>
@@ -30,7 +31,7 @@ trait QueryStateTestSupport {
   def withQueryState[T](f: QueryState => T) = {
     val tx = graph.beginTransaction(KernelTransaction.Type.explicit, AUTH_DISABLED)
     try {
-      QueryStateHelper.withQueryState(graph, tx, Map.empty, queryState => {
+      QueryStateHelper.withQueryState(graph, tx, EMPTY_MAP, queryState => {
         f(queryState)
       })
     } finally {
@@ -41,7 +42,7 @@ trait QueryStateTestSupport {
   def withCountsQueryState[T](f: QueryState => T) = {
     val tx = graph.beginTransaction(KernelTransaction.Type.explicit, AUTH_DISABLED)
     try {
-      QueryStateHelper.withQueryState(graph, tx, Map.empty, queryState =>
+      QueryStateHelper.withQueryState(graph, tx, EMPTY_MAP, queryState =>
         {
           val state = QueryStateHelper.countStats(queryState)
           f(state)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/SingleShortestPathPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/SingleShortestPathPipeTest.scala
@@ -27,7 +27,7 @@ import org.neo4j.cypher.internal.frontend.v3_3.SemanticDirection
 import org.neo4j.cypher.internal.frontend.v3_3.symbols._
 import org.neo4j.graphdb.Node
 import org.neo4j.values.virtual.PathValue
-import org.neo4j.values.virtual.VirtualValues.{fromNodeProxy, fromRelationshipProxy}
+import org.neo4j.values.virtual.VirtualValues.{EMPTY_MAP, fromNodeProxy, fromRelationshipProxy}
 
 class SingleShortestPathPipeTest extends GraphDatabaseFunSuite {
   private val path = ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq(), SemanticDirection.BOTH,
@@ -54,7 +54,7 @@ class SingleShortestPathPipeTest extends GraphDatabaseFunSuite {
 
     val pipe = ShortestPathPipe(source, path)()
     graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipe.createResults(queryState).next()("p").asInstanceOf[PathValue]
       })
     }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/pipes/FullPruningVarLengthExpandPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/pipes/FullPruningVarLengthExpandPipeTest.scala
@@ -31,8 +31,8 @@ import org.neo4j.cypher.internal.frontend.v3_3.SemanticDirection
 import org.neo4j.graphdb.Node
 import org.neo4j.kernel.api.KernelTransaction.Type
 import org.neo4j.kernel.api.security.SecurityContext
-import org.neo4j.values.virtual.VirtualValues.fromNodeProxy
-import org.neo4j.values.virtual.{EdgeValue, NodeValue}
+import org.neo4j.values.virtual.VirtualValues.{EMPTY_MAP, fromNodeProxy}
+import org.neo4j.values.virtual.{EdgeValue, NodeValue, VirtualValues}
 
 import scala.collection.immutable.IndexedSeq
 import scala.util.Random
@@ -46,7 +46,7 @@ class FullPruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
     val pipeUnderTest = createPipe(src, 1, 2, SemanticDirection.OUTGOING)
 
     graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipeUnderTest.createResults(queryState) shouldBe empty
       })
     }
@@ -60,7 +60,7 @@ class FullPruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
     val pipeUnderTest = createPipe(src, 1, 2, SemanticDirection.OUTGOING)
 
     graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         val toList: Seq[ExecutionContext] = pipeUnderTest.createResults(queryState).toList
         toList should beEquivalentTo(List(Map("from" -> n1, "to" -> n2)))
       })
@@ -75,7 +75,7 @@ class FullPruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
     val pipeUnderTest = createPipe(src, 0, 2, SemanticDirection.OUTGOING)
 
     graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipeUnderTest.createResults(queryState).toList should beEquivalentTo(List(
           Map("from" -> n1, "to" -> n2),
           Map("from" -> n1, "to" -> n1)
@@ -100,7 +100,7 @@ class FullPruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
     val pipeUnderTest = createPipe(src, min, max, SemanticDirection.OUTGOING)
 
     graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipeUnderTest.createResults(queryState).map(_.apply("to")).toSet should equal(
           nodes.slice(min, max + 1).map(fromNodeProxy).toSet // Slice is excluding the end, whereas ()-[*3..5]->() is including
         )
@@ -122,7 +122,7 @@ class FullPruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
     val pipeUnderTest = createPipe(src, 2, 2, SemanticDirection.BOTH)
 
     graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipeUnderTest.createResults(queryState).toList should beEquivalentTo(
           List(
             Map("from" -> n1, "to" -> n2)
@@ -156,7 +156,7 @@ class FullPruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
     val pipeUnderTest = createPipe(src, 4, 4, SemanticDirection.BOTH)
 
     graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipeUnderTest.createResults(queryState).toSet should equal(
           Set(
             Map("from" -> fromNodeProxy(n1), "to" -> fromNodeProxy(n4))
@@ -192,7 +192,7 @@ class FullPruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
     val pipeUnderTest = createPipe(src, 5, 5, SemanticDirection.BOTH)
 
     graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipeUnderTest.createResults(queryState).toSet should equal(
           Set(
             Map("from" -> fromNodeProxy(n1), "to" -> fromNodeProxy(n4))
@@ -218,7 +218,7 @@ class FullPruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
     val pipeUnderTest = createPipe(src, 1, 2, SemanticDirection.BOTH, predicate, True())
 
     graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipeUnderTest.createResults(queryState).toList should beEquivalentTo(
           List(
             Map("from" -> n1, "to" -> n2)
@@ -244,7 +244,7 @@ class FullPruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
     val pipeUnderTest = createPipe(src, 1, 2, SemanticDirection.BOTH, True(), predicate)
 
     graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipeUnderTest.createResults(queryState).toList should beEquivalentTo(
           List(
             Map("from" -> n1, "to" -> n2)
@@ -278,7 +278,7 @@ class FullPruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
     val pipeUnderTest = createPipe(src, 1, 4, SemanticDirection.OUTGOING)
 
     graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipeUnderTest.createResults(queryState).toSet should equal(nodes.tail.map(n => Map("from" -> fromNodeProxy(n1), "to" -> fromNodeProxy(n))).toSet)
       })
     }
@@ -297,7 +297,7 @@ class FullPruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
     val pipeUnderTest = createPipe(src, 1, 4, SemanticDirection.OUTGOING)
 
     graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipeUnderTest.createResults(queryState).toSet should equal(Set(
           Map("from" -> nodeValues(1), "to" -> nodeValues(2)),
           Map("from" -> nodeValues(1), "to" -> nodeValues(3)),
@@ -359,13 +359,13 @@ class FullPruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
     val comparison = DistinctPipe(pipe, Map("from" -> Variable("from"), "to" -> Variable("to")))()
 
     val distinctExpand = graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipeUnderTest.createResults(queryState).toList
       })
     }
 
     val distinctAfterVarLengthExpand = graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         comparison.createResults(queryState).toList
       })
     }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/pipes/PruningVarLengthExpandPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/pipes/PruningVarLengthExpandPipeTest.scala
@@ -31,7 +31,8 @@ import org.neo4j.graphdb.Node
 import org.neo4j.kernel.api.KernelTransaction.Type
 import org.neo4j.kernel.api.security.SecurityContext
 import org.neo4j.values.AnyValues.asNodeValue
-import org.neo4j.values.virtual.{EdgeValue, NodeValue}
+import org.neo4j.values.virtual.VirtualValues.EMPTY_MAP
+import org.neo4j.values.virtual.{EdgeValue, NodeValue, VirtualValues}
 
 import scala.collection.immutable.IndexedSeq
 import scala.util.Random
@@ -45,7 +46,7 @@ class PruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
     val pipeUnderTest = createPipe(src, 1, 2, SemanticDirection.OUTGOING)
 
     graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipeUnderTest.createResults(queryState) shouldBe empty
       })
     }
@@ -59,7 +60,7 @@ class PruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
     val pipeUnderTest = createPipe(src, 1, 2, SemanticDirection.OUTGOING)
 
     graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipeUnderTest.createResults(queryState).toList shouldBe List(Map("from" -> asNodeValue(n1), "to" -> asNodeValue(n2)))
       })
     }
@@ -73,7 +74,7 @@ class PruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
     val pipeUnderTest = createPipe(src, 0, 2, SemanticDirection.OUTGOING)
 
     graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipeUnderTest.createResults(queryState).toList shouldBe List(
           Map("from" -> asNodeValue(n1), "to" -> asNodeValue(n2)),
           Map("from" -> asNodeValue(n1), "to" -> asNodeValue(n1))
@@ -98,7 +99,7 @@ class PruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
     val pipeUnderTest = createPipe(src, min, max, SemanticDirection.OUTGOING)
 
     graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipeUnderTest.createResults(queryState).map(_.apply("to")).toSet should equal(
           nodes.slice(min, max + 1).map(asNodeValue).toSet // Slice is excluding the end, whereas ()-[*3..5]->() is including
         )
@@ -120,7 +121,7 @@ class PruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
     val pipeUnderTest = createPipe(src, 2, 2, SemanticDirection.BOTH)
 
     graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipeUnderTest.createResults(queryState).toList should equal(
           List(
             Map("from" -> asNodeValue(n1), "to" -> asNodeValue(n2))
@@ -147,7 +148,7 @@ class PruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
     val pipeUnderTest = createPipe(src, 1, 2, SemanticDirection.BOTH, predicate, True())
 
     graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipeUnderTest.createResults(queryState).toList should equal(
           List(
             Map("from" -> asNodeValue(n1), "to" -> asNodeValue(n2))
@@ -174,7 +175,7 @@ class PruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
     val pipeUnderTest = createPipe(src, 1, 2, SemanticDirection.BOTH, True(), predicate)
 
     graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipeUnderTest.createResults(queryState).toList should equal(
           List(
             Map("from" -> asNodeValue(n1), "to" -> asNodeValue(n2))
@@ -207,7 +208,7 @@ class PruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
     val pipeUnderTest = createPipe(src, 1, 4, SemanticDirection.OUTGOING)
 
     graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipeUnderTest.createResults(queryState).toSet should equal(nodes.tail.map(n => Map("from" -> asNodeValue(n1), "to" -> asNodeValue(n))).toSet)
       })
     }
@@ -226,7 +227,7 @@ class PruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
     val pipeUnderTest = createPipe(src, 1, 4, SemanticDirection.OUTGOING)
 
     graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipeUnderTest.createResults(queryState).toSet should equal(Set(
           Map("from" -> asNodeValue(nodes(1)), "to" -> asNodeValue(nodes(2))),
           Map("from" -> asNodeValue(nodes(1)), "to" -> asNodeValue(nodes(3))),
@@ -288,13 +289,13 @@ class PruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
     val comparison = DistinctPipe(pipe, Map("from" -> Variable("from"), "to" -> Variable("to")))()
 
     val distinctExpand = graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipeUnderTest.createResults(queryState).toList
       })
     }
 
     val distinctAfterVarLengthExpand = graph.withTx { tx =>
-      withQueryState(graph, tx, Map.empty, { queryState =>
+      withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         comparison.createResults(queryState).toList
       })
     }

--- a/community/values/src/main/java/org/neo4j/values/storable/LongArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/LongArray.java
@@ -26,7 +26,7 @@ import org.neo4j.values.SequenceValue;
 
 import static java.lang.String.format;
 
-abstract class LongArray extends IntegralArray
+public abstract class LongArray extends IntegralArray
 {
     abstract long[] value();
 

--- a/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/v3_3/executionplan/GeneratedQuery.java
+++ b/enterprise/cypher/cypher/src/main/java/org/neo4j/cypher/internal/v3_3/executionplan/GeneratedQuery.java
@@ -19,15 +19,13 @@
  */
 package org.neo4j.cypher.internal.v3_3.executionplan;
 
-import java.util.Map;
-
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.ExecutionMode;
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.TaskCloser;
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.executionplan.Provider;
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.InternalPlanDescription;
 import org.neo4j.cypher.internal.spi.v3_3.QueryContext;
 import org.neo4j.cypher.internal.v3_3.codegen.QueryExecutionTracer;
-import org.neo4j.graphdb.ExecutionPlanDescription;
+import org.neo4j.values.virtual.MapValue;
 
 public interface GeneratedQuery
 {
@@ -37,5 +35,5 @@ public interface GeneratedQuery
             ExecutionMode executionMode,
             Provider<InternalPlanDescription> description,
             QueryExecutionTracer tracer,
-            Map<String,Object> params );
+            MapValue params );
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildEnterpriseInterpretedExecutionPlan.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildEnterpriseInterpretedExecutionPlan.scala
@@ -38,7 +38,7 @@ import org.neo4j.cypher.internal.frontend.v3_3.phases.CompilationPhaseTracer.Com
 import org.neo4j.cypher.internal.frontend.v3_3.phases.{CompilationPhaseTracer, Monitors, Phase}
 import org.neo4j.cypher.internal.frontend.v3_3.{CypherException, PlannerName}
 import org.neo4j.cypher.internal.spi.v3_3.QueryContext
-import org.neo4j.values.AnyValue
+import org.neo4j.values.virtual.MapValue
 
 object BuildEnterpriseInterpretedExecutionPlan extends Phase[EnterpriseRuntimeContext, LogicalPlanState, CompilationState] {
   override def phase: CompilationPhaseTracer.CompilationPhase = PIPE_BUILDING
@@ -95,12 +95,12 @@ object BuildEnterpriseInterpretedExecutionPlan extends Phase[EnterpriseRuntimeCo
                                      isPeriodicCommit: Boolean,
                                      plannerUsed: PlannerName,
                                      override val plannedIndexUsage: Seq[IndexUsage],
-                                     runFunction: (QueryContext, ExecutionMode, Map[String, AnyValue]) => InternalExecutionResult,
+                                     runFunction: (QueryContext, ExecutionMode, MapValue) => InternalExecutionResult,
                                      pipe: Pipe,
                                      config: CypherCompilerConfiguration) extends executionplan.ExecutionPlan {
 
     override def run(queryContext: QueryContext, planType: ExecutionMode,
-                     params: Map[String, AnyValue]): InternalExecutionResult =
+                     params: MapValue): InternalExecutionResult =
       runFunction(queryContext, planType, params)
 
     override def isStale(lastTxId: () => Long, statistics: GraphStatistics): Boolean = fingerprint

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/compiled/ExecutionPlanBuilder.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/compiled/ExecutionPlanBuilder.scala
@@ -30,6 +30,7 @@ import org.neo4j.cypher.internal.frontend.v3_3.PlannerName
 import org.neo4j.cypher.internal.spi.v3_3.QueryContext
 import org.neo4j.cypher.internal.v3_3.codegen.QueryExecutionTracer
 import org.neo4j.cypher.internal.v3_3.codegen.profiling.ProfilingTracer
+import org.neo4j.values.virtual.MapValue
 
 object ExecutionPlanBuilder {
   type DescriptionProvider =
@@ -74,6 +75,6 @@ trait RunnablePlan {
   def apply(queryContext: QueryContext,
             execMode: ExecutionMode,
             descriptionProvider: DescriptionProvider,
-            params: Map[String, Any],
+            params: MapValue,
             closer: TaskCloser): InternalExecutionResult
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/compiled/codegen/CodeGenerator.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/compiled/codegen/CodeGenerator.scala
@@ -38,6 +38,7 @@ import org.neo4j.cypher.internal.frontend.v3_3.{PlannerName, SemanticTable}
 import org.neo4j.cypher.internal.spi.v3_3.QueryContext
 import org.neo4j.cypher.internal.v3_3.codegen.QueryExecutionTracer
 import org.neo4j.cypher.internal.v3_3.executionplan.{GeneratedQuery, GeneratedQueryExecution}
+import org.neo4j.values.virtual.MapValue
 
 class CodeGenerator(val structure: CodeStructure[GeneratedQuery], clock: Clock, conf: CodeGenConfiguration = CodeGenConfiguration() ) {
 
@@ -72,11 +73,11 @@ class CodeGenerator(val structure: CodeStructure[GeneratedQuery], clock: Clock, 
 
         val builder = new RunnablePlan {
           def apply(queryContext: QueryContext, execMode: ExecutionMode,
-                    descriptionProvider: DescriptionProvider, params: Map[String, Any],
+                    descriptionProvider: DescriptionProvider, params: MapValue,
                     closer: TaskCloser): InternalExecutionResult = {
             val (provider, tracer) = descriptionProvider(description)
             val execution: GeneratedQueryExecution = query.query.execute(closer, queryContext, execMode,
-              provider, tracer.getOrElse(QueryExecutionTracer.NONE), asJavaHashMap(params))
+              provider, tracer.getOrElse(QueryExecutionTracer.NONE),params)
             new CompiledExecutionResult(closer, queryContext, execution, provider)
           }
         }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/codegen/GeneratedMethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/codegen/GeneratedMethodStructure.scala
@@ -49,7 +49,7 @@ import org.neo4j.kernel.api.schema.{IndexQuery, LabelSchemaDescriptor}
 import org.neo4j.kernel.impl.api.RelationshipDataExtractor
 import org.neo4j.kernel.impl.api.store.RelationshipIterator
 import org.neo4j.values.storable._
-import org.neo4j.values.virtual.{EdgeValue, NodeValue, VirtualValues}
+import org.neo4j.values.virtual.{EdgeValue, MapValue, NodeValue, VirtualValues}
 import org.neo4j.values.{AnyValue, AnyValues}
 
 import scala.collection.mutable
@@ -375,10 +375,12 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
 
   override def expectParameter(key: String, variableName: String, codeGenType: CodeGenType) = {
     using(
-      generator.ifStatement(not(invoke(params, mapContains, constant(key))))) { block =>
+      generator.ifStatement(not(invoke(params,  method[MapValue, Boolean]("containsKey", typeRef[String]), constant(key))))) { block =>
       block.throwException(parameterNotFoundException(key))
     }
-    val invokeLoadParameter = invoke(loadParameter, invoke(params, mapGet, constantExpression(key)))
+    val invokeLoadParameter = invoke(loadParameter,
+                                     invoke(params, method[MapValue, AnyValue]("get", typeRef[String]), constantExpression(key)),
+                                     get(generator.self(), fields.entityAccessor))
     generator.assign(lowerType(codeGenType), variableName,
       // We assume the value in the parameter map will always be boxed, so if we are declaring
       // a primitive variable we need to force it to be unboxed

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/codegen/GeneratedQueryStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/codegen/GeneratedQueryStructure.scala
@@ -20,7 +20,6 @@
 package org.neo4j.cypher.internal.spi.v3_3.codegen
 
 import java.lang.reflect.Modifier
-import java.util
 import java.util.stream.{DoubleStream, IntStream, LongStream}
 
 import org.neo4j.codegen.Expression.{constant, invoke, newArray, newInstance}
@@ -46,6 +45,7 @@ import org.neo4j.cypher.internal.v3_3.executionplan.{GeneratedQuery, GeneratedQu
 import org.neo4j.kernel.api.ReadOperations
 import org.neo4j.kernel.impl.core.NodeManager
 import org.neo4j.values.result.QueryResult.QueryResultVisitor
+import org.neo4j.values.virtual.MapValue
 
 import scala.collection.mutable
 
@@ -118,7 +118,7 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
         param[ExecutionMode]("executionMode"),
         param[Provider[InternalPlanDescription]]("description"),
         param[QueryExecutionTracer]("tracer"),
-        param[util.Map[String, Object]]("params"))) { execute =>
+        param[MapValue]("params"))) { execute =>
         execute.returns(
           invoke(
             newInstance(execution),
@@ -128,7 +128,7 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
               typeRef[ExecutionMode],
               typeRef[Provider[InternalPlanDescription]],
               typeRef[QueryExecutionTracer],
-              typeRef[util.Map[String, Object]]),
+              typeRef[MapValue]),
             execute.load("closer"),
             execute.load("queryContext"),
             execute.load("executionMode"),
@@ -200,7 +200,7 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
       executionMode = clazz.field(typeRef[ExecutionMode], "executionMode"),
       description = clazz.field(typeRef[Provider[InternalPlanDescription]], "description"),
       tracer = clazz.field(typeRef[QueryExecutionTracer], "tracer"),
-      params = clazz.field(typeRef[util.Map[String, Object]], "params"),
+      params = clazz.field(typeRef[MapValue], "params"),
       closeable = clazz.field(typeRef[Completable], "closeable"),
       queryContext = clazz.field(typeRef[QueryContext], "queryContext"))
   }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/codegen/Methods.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/codegen/Methods.scala
@@ -82,7 +82,7 @@ object Methods {
   val equals = method[Object, Boolean]("equals", typeRef[Object])
   val or = method[CompiledConversionUtils, java.lang.Boolean]("or", typeRef[Object], typeRef[Object])
   val not = method[CompiledConversionUtils, java.lang.Boolean]("not", typeRef[Object])
-  val loadParameter = method[CompiledConversionUtils, java.lang.Object]("loadParameter", typeRef[Object])
+  val loadParameter = method[CompiledConversionUtils, Object]("loadParameter", typeRef[AnyValue], typeRef[NodeManager])
   val relationshipTypeGetForName = method[ReadOperations, Int]("relationshipTypeGetForName", typeRef[String])
   val relationshipTypeGetName = method[ReadOperations, String]("relationshipTypeGetName", typeRef[Int])
   val nodeExists = method[ReadOperations, Boolean]("nodeExists", typeRef[Long])

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/codegen/Templates.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/codegen/Templates.scala
@@ -43,6 +43,7 @@ import org.neo4j.kernel.api.{ReadOperations, StatementTokenNameLookup, TokenName
 import org.neo4j.kernel.impl.api.RelationshipDataExtractor
 import org.neo4j.kernel.impl.core.NodeManager
 import org.neo4j.values.storable.{Value, Values}
+import org.neo4j.values.virtual.MapValue
 
 /**
   * Contains common code generation constructs.
@@ -139,14 +140,14 @@ object Templates {
     param[Provider[InternalPlanDescription]]("description"),
     param[QueryExecutionTracer]("tracer"),
 
-    param[util.Map[String, Object]]("params")).
+    param[MapValue]("params")).
     invokeSuper().
     put(self(classHandle), typeRef[TaskCloser], "closer", load("closer", typeRef[TaskCloser])).
     put(self(classHandle), typeRef[QueryContext], "queryContext", load("queryContext", typeRef[QueryContext])).
     put(self(classHandle), typeRef[ExecutionMode], "executionMode", load("executionMode", typeRef[ExecutionMode])).
     put(self(classHandle), typeRef[Provider[InternalPlanDescription]], "description", load("description", typeRef[InternalPlanDescription])).
     put(self(classHandle), typeRef[QueryExecutionTracer], "tracer", load("tracer", typeRef[QueryExecutionTracer])).
-    put(self(classHandle), typeRef[util.Map[String, Object]], "params", load("params", typeRef[util.Map[String, Object]])).
+    put(self(classHandle), typeRef[MapValue], "params", load("params", typeRef[MapValue])).
     put(self(classHandle), typeRef[NodeManager], "nodeManager",
         cast(typeRef[NodeManager],
              invoke(load("queryContext", typeRef[QueryContext]), method[QueryContext, Object]("entityAccessor")))).

--- a/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/CompiledRuntimeEchoIT.java
+++ b/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/CompiledRuntimeEchoIT.java
@@ -39,31 +39,31 @@ public class CompiledRuntimeEchoIT
     public void shouldBeAbleToEchoMaps()
     {
         echo( map( "foo", "bar" ) );
-        echo( map( "foo", 42 ) );
-        echo( map( "foo", map( "bar", map( "baz", 1337 ) ) ) );
+        echo( map( "foo", 42L ) );
+        echo( map( "foo", map( "bar", map( "baz", 1337L ) ) ) );
     }
 
     @Test
     public void shouldBeAbleToEchoLists()
     {
-        echo( asList( 1, 2, 3 ) );
-        echo( asList( "a", 1, 17 ) );
-        echo( map( "foo", asList( asList( 1, 2, 3 ), "foo" ) ) );
+        echo( asList( 1L, 2L, 3L ) );
+        echo( asList( "a", 1L, 17L ) );
+        echo( map( "foo", asList( asList( 1L, 2L, 3L ), "foo" ) ) );
     }
 
     @Test
     public void shouldBeAbleToEchoListsOfMaps()
     {
         echo( singletonList( map( "foo", "bar" ) ) );
-        echo( asList( "a", 1, 17, map( "foo", asList( 1, 2, 3 ) ) ) );
-        echo( asList( "foo", asList( map( "bar", 42 ), "foo" ) ) );
+        echo( asList( "a", 1L, 17L, map( "foo", asList( 1L, 2L, 3L ) ) ) );
+        echo( asList( "foo", asList( map( "bar", 42L ), "foo" ) ) );
     }
 
     @Test
     public void shouldBeAbleToEchoMapsOfLists()
     {
         echo( map( "foo", singletonList( "bar" ) ) );
-        echo( map( "foo", singletonList( map( "bar", map( "baz", 1337 ) ) ) ) );
+        echo( map( "foo", singletonList( map( "bar", map( "baz", 1337L ) ) ) ) );
     }
 
     private void echo( Object value )

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_3/codegen/ir/BuildProbeTableInstructionsTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_3/codegen/ir/BuildProbeTableInstructionsTest.scala
@@ -39,6 +39,7 @@ import org.neo4j.kernel.api.ReadOperations
 import org.neo4j.kernel.impl.core.{NodeManager, NodeProxy}
 import org.neo4j.values.AnyValue
 import org.neo4j.values.storable._
+import org.neo4j.values.virtual.VirtualValues.EMPTY_MAP
 import org.neo4j.values.virtual.{ListValue, MapValue, NodeValue}
 
 import scala.collection.{JavaConverters, mutable}
@@ -204,7 +205,7 @@ class BuildProbeTableInstructionsTest extends CypherFunSuite with CodeGenSugar {
   private def runTest(buildInstruction: BuildProbeTable, nodes: Set[Variable]): List[Map[String, Object]] = {
     val instructions = buildProbeTableWithTwoAllNodeScans(buildInstruction, nodes)
     val ids = instructions.flatMap(_.allOperatorIds.map(id => id -> null)).toMap
-    evaluate(instructions, queryContext, Seq(resultRowKey), Map.empty[String, Object], ids)
+    evaluate(instructions, queryContext, Seq(resultRowKey), EMPTY_MAP, ids)
   }
 
   private def buildProbeTableWithTwoAllNodeScans(buildInstruction: BuildProbeTable, nodes: Set[Variable]): Seq[Instruction] = {

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_3/codegen/ir/CodeGenSugar.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_3/codegen/ir/CodeGenSugar.scala
@@ -49,9 +49,9 @@ import org.neo4j.kernel.impl.coreapi.PropertyContainerLocker
 import org.neo4j.kernel.impl.query.Neo4jTransactionalContextFactory
 import org.neo4j.kernel.impl.query.clientconnection.ClientConnectionInfo
 import org.neo4j.time.Clocks
+import org.neo4j.values.virtual.MapValue
+import org.neo4j.values.virtual.VirtualValues.EMPTY_MAP
 import org.scalatest.mock.MockitoSugar
-
-import scala.collection.JavaConversions
 
 trait CodeGenSugar extends MockitoSugar {
 
@@ -84,7 +84,7 @@ trait CodeGenSugar extends MockitoSugar {
                                   "no query text exists for this test", Collections.emptyMap()))
       val queryContext = new TransactionBoundQueryContext(transactionalContext)(mock[IndexSearchMonitor])
       val result = plan
-        .executionResultBuilder(queryContext, mode, tracer(mode, queryContext), Map.empty, new TaskCloser)
+        .executionResultBuilder(queryContext, mode, tracer(mode, queryContext), EMPTY_MAP, new TaskCloser)
       tx.success()
       result.size
       result
@@ -97,7 +97,7 @@ trait CodeGenSugar extends MockitoSugar {
   def evaluate(instructions: Seq[Instruction],
                qtx: QueryContext = mockQueryContext(),
                columns: Seq[String] = Seq.empty,
-               params: Map[String, AnyRef] = Map.empty,
+               params: MapValue = EMPTY_MAP,
                operatorIds: Map[String, Id] = Map.empty): List[Map[String, Object]] = {
     val clazz = compile(instructions, columns, operatorIds)
     val result = newInstance(clazz, queryContext = qtx, params = params)
@@ -134,9 +134,9 @@ trait CodeGenSugar extends MockitoSugar {
                   executionMode: ExecutionMode = null,
                   provider: Provider[InternalPlanDescription] = null,
                   queryExecutionTracer: QueryExecutionTracer = QueryExecutionTracer.NONE,
-                  params: Map[String, AnyRef] = Map.empty): InternalExecutionResult = {
+                  params: MapValue = EMPTY_MAP): InternalExecutionResult = {
     val generated = clazz.execute(taskCloser, queryContext,
-                                  executionMode, provider, queryExecutionTracer, JavaConversions.mapAsJavaMap(params))
+                                  executionMode, provider, queryExecutionTracer, params)
     new CompiledExecutionResult(taskCloser, queryContext, generated, provider)
   }
 


### PR DESCRIPTION
After the big value refactoring the compiled runtime had to do a lot
of unnecessary work on parameters, going from objects to values, back to
objects and then also introspect all those objects. This changes so that
it no longer needs to do that work.