### PR TITLE
Validate type of fields added to legacy index.

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSource.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSource.java
@@ -27,8 +27,11 @@ import org.apache.lucene.analysis.core.LowerCaseFilter;
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
 import org.apache.lucene.analysis.core.WhitespaceTokenizer;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SnapshotDeletionPolicy;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Sort;
@@ -42,6 +45,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -111,6 +115,45 @@ public class LuceneDataSource extends LifecycleAdapter
     private boolean closed;
     private LuceneFilesystemFacade filesystemFacade;
     private IndexReferenceFactory indexReferenceFactory;
+    private Map<IndexIdentifier,Map<String,DocValuesType>> indexTypeMap;
+
+    public void assertValidType( String key, Object value, IndexIdentifier identifier )
+    {
+        DocValuesType expectedType;
+        String expectedTypeName;
+        if ( value instanceof Number )
+        {
+            expectedType = DocValuesType.SORTED_NUMERIC;
+            expectedTypeName = "numbers";
+        }
+        else
+        {
+            expectedType = DocValuesType.SORTED_SET;
+            expectedTypeName = "strings";
+        }
+        Map<String,DocValuesType> stringDocValuesTypeMap = indexTypeMap.get( identifier );
+        // If the index searcher has never been loaded, we need to load it now to populate the map.
+        if ( stringDocValuesTypeMap == null )
+        {
+            getIndexSearcher( identifier );
+            stringDocValuesTypeMap = indexTypeMap.get( identifier );
+        }
+        DocValuesType actualType;
+        synchronized ( stringDocValuesTypeMap )
+        {
+            actualType = stringDocValuesTypeMap.get( key );
+            if ( actualType == null )
+            {
+                actualType = expectedType;
+                stringDocValuesTypeMap.put( key, expectedType );
+            }
+        }
+        if ( !actualType.equals( expectedType ) )
+        {
+            throw new IllegalArgumentException(
+                    String.format( "Cannot index '%s' for key '%s', since this key has been used to index another %s.", value, key, expectedTypeName ) );
+        }
+    }
 
     /**
      * Constructs this data source.
@@ -140,6 +183,7 @@ public class LuceneDataSource extends LifecycleAdapter
         this.indexReferenceFactory = readOnly ?
                                      new ReadOnlyIndexReferenceFactory( filesystemFacade, baseStorePath, typeCache ) :
                                      new WritableIndexReferenceFactory( filesystemFacade, baseStorePath, typeCache );
+        this.indexTypeMap = new HashMap<IndexIdentifier,Map<String,DocValuesType>>();
         closed = false;
     }
 
@@ -281,6 +325,15 @@ public class LuceneDataSource extends LifecycleAdapter
             {
                 indexReference = indexReferenceFactory.createIndexReference( identifier );
                 indexSearchers.put( identifier, indexReference );
+                HashMap<String,DocValuesType> fieldTypes = new HashMap<>();
+                for ( LeafReaderContext leafReaderContext : indexReference.getSearcher().getTopReaderContext().leaves() )
+                {
+                    for ( FieldInfo fieldInfo : leafReaderContext.reader().getFieldInfos() )
+                    {
+                        fieldTypes.put( fieldInfo.name, fieldInfo.getDocValuesType() );
+                    }
+                }
+                indexTypeMap.put( identifier, fieldTypes );
             }
             else
             {

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneLegacyIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneLegacyIndex.java
@@ -20,6 +20,9 @@
 package org.neo4j.index.impl.lucene.legacy;
 
 import org.apache.lucene.document.Document;
+import org.apache.lucene.index.DocValuesType;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.MultiReader;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.BooleanClause.Occur;
@@ -109,6 +112,7 @@ public abstract class LuceneLegacyIndex implements LegacyIndex
         for ( Object oneValue : IoPrimitiveUtils.asArray( value ) )
         {
             oneValue = getCorrectValue( oneValue );
+            dataSource.assertValidType( key, oneValue, identifier );
             transaction.add( this, entity, key, oneValue );
             commandFactory.addNode( identifier.indexName, entityId, key, oneValue );
         }

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/TestIndexDelectionFs.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/TestIndexDelectionFs.java
@@ -30,8 +30,8 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.io.fs.FileUtils;
-import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.impl.index.IndexEntityType;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.assertFalse;
@@ -75,8 +75,6 @@ public class TestIndexDelectionFs
             Node node = db.createNode();
             index.add( node, "someKey", "someValue" );
             otherIndex.add( node, "someKey", "someValue" );
-            assertFalse( pathToLuceneIndex.exists() );
-            assertFalse( pathToOtherLuceneIndex.exists() );
             tx.success();
         }
 


### PR DESCRIPTION
Without this validation, a transaction could commit, but fail to write to
disk if the type of the field was invalid.