### PR TITLE
Test another hypothesis for serverStopsStreamingToDeadClient flakiness

### DIFF
--- a/enterprise/com/src/test/java/org/neo4j/com/MadeUpServer.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/MadeUpServer.java
@@ -38,7 +38,7 @@ public class MadeUpServer extends Server<MadeUpCommunicationInterface, Void>
     private volatile boolean responseWritten;
     private volatile boolean responseFailureEncountered;
     private final byte internalProtocolVersion;
-    public static final int FRAME_LENGTH = 1024 * 1024 * 1;
+    public static final int FRAME_LENGTH = 1024 * 1024;
 
     public MadeUpServer( MadeUpCommunicationInterface requestTarget, final int port, byte internalProtocolVersion,
                          byte applicationProtocolVersion, TxChecksumVerifier txVerifier, final int chunkSize )

--- a/enterprise/com/src/test/java/org/neo4j/com/TestCommunication.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/TestCommunication.java
@@ -276,11 +276,11 @@ public class TestCommunication
         MadeUpClient client = builder.client();
         addToLifeAndStart( server, client );
 
-        int failAtSize = FRAME_LENGTH / 2;
+        int failAtSize = FRAME_LENGTH / 1024;
         ClientCrashingWriter writer = new ClientCrashingWriter( client, failAtSize );
         try
         {
-            client.fetchDataStream( writer, FRAME_LENGTH * 10 );
+            client.fetchDataStream( writer, FRAME_LENGTH * 100 );
             assertTrue( writer.getSizeRead() >= failAtSize );
             fail( "Should fail in the middle" );
         }


### PR DESCRIPTION
Another source of flakiness could be that the server never gets a failure due to it actually being able to fill up the buffers before the client closes the channel, thus not receiving an error while writing.

Let us make streaming data bigger and client fail earlier.