### PR TITLE
Create and check for existence for relationship simultaneous

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/ExceptionTranslatingQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/ExceptionTranslatingQueryContext.scala
@@ -298,6 +298,9 @@ class ExceptionTranslatingQueryContext(val inner: QueryContext) extends QueryCon
 
     override def isDeletedInThisTx(id: Long): Boolean =
       translateException(inner.isDeletedInThisTx(id))
+
+    override def getByIdIfExists(id: Long): Option[T] =
+      translateException(inner.getByIdIfExists(id))
   }
 
   class ExceptionTranslatingTransactionalContext(inner: QueryTransactionalContext) extends DelegatingQueryTransactionalContext(inner) {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/IdSeekIterator.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/IdSeekIterator.scala
@@ -49,7 +49,8 @@ abstract class IdSeekIterator[T <: PropertyContainer]
   private def computeNextEntity(): T = {
     while (entityIds.hasNext) {
       val id = asLongEntityId(entityIds.next())
-      return operations.getByIdIfExists(id.longValue()).getOrElse(null.asInstanceOf[T])
+      val maybeEntity = operations.getByIdIfExists(id.longValue())
+      if(maybeEntity.isDefined) return maybeEntity.get
     }
     null.asInstanceOf[T]
   }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/IdSeekIterator.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/IdSeekIterator.scala
@@ -49,9 +49,7 @@ abstract class IdSeekIterator[T <: PropertyContainer]
   private def computeNextEntity(): T = {
     while (entityIds.hasNext) {
       val id = asLongEntityId(entityIds.next())
-      if (operations.exists(id.longValue()))
-        return operations.getById(id.longValue())
-
+      return operations.getByIdIfExists(id.longValue()).getOrElse(null.asInstanceOf[T])
     }
     null.asInstanceOf[T]
   }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/DelegatingQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/DelegatingQueryContext.scala
@@ -274,6 +274,8 @@ class DelegatingOperations[T <: PropertyContainer](protected val inner: Operatio
   override def releaseExclusiveLock(obj: Long): Unit = inner.releaseExclusiveLock(obj)
 
   override def exists(id: Long): Boolean = singleDbHit(inner.exists(id))
+
+  override def getByIdIfExists(id: Long): Option[T] = singleDbHit(inner.getByIdIfExists(id))
 }
 
 class DelegatingQueryTransactionalContext(val inner: QueryTransactionalContext) extends QueryTransactionalContext {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/QueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/QueryContext.scala
@@ -235,6 +235,8 @@ trait Operations[T <: PropertyContainer] {
   def releaseExclusiveLock(obj: Long): Unit
 
   def exists(id: Long): Boolean
+
+  def getByIdIfExists(id: Long): Option[T]
 }
 
 trait QueryTransactionalContext {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundQueryContext.scala
@@ -416,10 +416,12 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
 
     override def getByIdIfExists(id: Long): Option[Node] = {
       try {
-        Some(entityAccessor.newNodeProxyById(id))
+        if(transactionalContext.statement.readOperations().nodeExists(id))
+          Some(entityAccessor.newNodeProxyById(id))
       } catch {
-        case e: NotFoundException => None
+        case e: NotFoundException =>
       }
+      None
     }
   }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundQueryContext.scala
@@ -414,15 +414,11 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
     override def exists(id: Long): Boolean =
       transactionalContext.statement.readOperations().nodeExists(id)
 
-    override def getByIdIfExists(id: Long): Option[Node] = {
-      try {
-        if(transactionalContext.statement.readOperations().nodeExists(id))
-          Some(entityAccessor.newNodeProxyById(id))
-      } catch {
-        case e: NotFoundException =>
-      }
-      None
-    }
+    override def getByIdIfExists(id: Long): Option[Node] =
+      if (transactionalContext.statement.readOperations().nodeExists(id))
+        Some(entityAccessor.newNodeProxyById(id))
+      else
+        None
   }
 
   class RelationshipOperations extends BaseOperations[Relationship] {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/DirectedDirectedRelationshipByIdSeekPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/DirectedDirectedRelationshipByIdSeekPipeTest.scala
@@ -35,8 +35,7 @@ class DirectedDirectedRelationshipByIdSeekPipeTest extends CypherFunSuite {
     // given
     val (startNode, rel, endNode) = getRelWithNodes
     val relOps= mock[Operations[Relationship]]
-    when(relOps.exists(17)).thenReturn(true)
-    when(relOps.getById(17)).thenReturn(rel)
+    when(relOps.getByIdIfExists(17)).thenReturn(Some(rel))
 
     val to = "to"
     val from = "from"
@@ -60,10 +59,8 @@ class DirectedDirectedRelationshipByIdSeekPipeTest extends CypherFunSuite {
     val to = "to"
     val from = "from"
 
-    when(relationshipOps.getById(42)).thenReturn(r1)
-    when(relationshipOps.exists(42)).thenReturn(true)
-    when(relationshipOps.getById(21)).thenReturn(r2)
-    when(relationshipOps.exists(21)).thenReturn(true)
+    when(relationshipOps.getByIdIfExists(42)).thenReturn(Some(r1))
+    when(relationshipOps.getByIdIfExists(21)).thenReturn(Some(r2))
     val queryState = QueryStateHelper.emptyWith(
       query = when(mock[QueryContext].relationshipOps).thenReturn(relationshipOps).getMock[QueryContext]
     )

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/NodeByIdSeekPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/NodeByIdSeekPipeTest.scala
@@ -35,8 +35,7 @@ class NodeByIdSeekPipeTest extends CypherFunSuite {
     val id = 17
     val node = nodeProxy(17)
     val nodeOps = when(mock[Operations[Node]].getById(id)).thenReturn(node).getMock[Operations[Node]]
-    when(nodeOps.getById(17)).thenReturn(node)
-    when(nodeOps.exists(17)).thenReturn(true)
+    when(nodeOps.getByIdIfExists(17)).thenReturn(Some(node))
     val queryState = QueryStateHelper.emptyWith(
       query = when(mock[QueryContext].nodeOps).thenReturn(nodeOps).getMock[QueryContext]
     )
@@ -55,12 +54,9 @@ class NodeByIdSeekPipeTest extends CypherFunSuite {
     val node3 = nodeProxy(11)
     val nodeOps = mock[Operations[Node]]
 
-    when(nodeOps.getById(42)).thenReturn(node1)
-    when(nodeOps.exists(42)).thenReturn(true)
-    when(nodeOps.getById(21)).thenReturn(node2)
-    when(nodeOps.exists(21)).thenReturn(true)
-    when(nodeOps.getById(11)).thenReturn(node3)
-    when(nodeOps.exists(11)).thenReturn(true)
+    when(nodeOps.getByIdIfExists(42)).thenReturn(Some(node1))
+    when(nodeOps.getByIdIfExists(21)).thenReturn(Some(node2))
+    when(nodeOps.getByIdIfExists(11)).thenReturn(Some(node3))
 
     val queryState = QueryStateHelper.emptyWith(
       query = when(mock[QueryContext].nodeOps).thenReturn(nodeOps).getMock[QueryContext]

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/UndirectedDirectedRelationshipByIdSeekPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/UndirectedDirectedRelationshipByIdSeekPipeTest.scala
@@ -36,8 +36,7 @@ class UndirectedDirectedRelationshipByIdSeekPipeTest extends CypherFunSuite {
     // given
     val (startNode, rel, endNode) = getRelWithNodes
     val relOps= mock[Operations[Relationship]]
-    when(relOps.exists(17)).thenReturn(true)
-    when(relOps.getById(17)).thenReturn(rel)
+    when(relOps.getByIdIfExists(17)).thenReturn(Some(rel))
 
     val to = "to"
     val from = "from"
@@ -64,10 +63,8 @@ class UndirectedDirectedRelationshipByIdSeekPipeTest extends CypherFunSuite {
     val to = "to"
     val from = "from"
 
-    when(relationshipOps.getById(42)).thenReturn(r1)
-    when(relationshipOps.exists(42)).thenReturn(true)
-    when(relationshipOps.getById(21)).thenReturn(r2)
-    when(relationshipOps.exists(21)).thenReturn(true)
+    when(relationshipOps.getByIdIfExists(42)).thenReturn(Some(r1))
+    when(relationshipOps.getByIdIfExists(21)).thenReturn(Some(r2))
     val queryState = QueryStateHelper.emptyWith(
       query = when(mock[QueryContext].relationshipOps).thenReturn(relationshipOps).getMock[QueryContext]
     )


### PR DESCRIPTION
Deletion might cause a race condition when deletion the same relationship concurrent. 
We now check for existence and creation at the same time, removing the race.
