### PR TITLE
Fix IndexProviderCompatibilityTestSuite

### DIFF
--- a/community/io/src/test/java/org/neo4j/test/rule/PageCacheAndDependenciesRule.java
+++ b/community/io/src/test/java/org/neo4j/test/rule/PageCacheAndDependenciesRule.java
@@ -24,6 +24,7 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -45,17 +46,19 @@ public class PageCacheAndDependenciesRule implements TestRule
 
     public PageCacheAndDependenciesRule()
     {
-        this( () -> new EphemeralFileSystemRule() );
+        this( () -> new EphemeralFileSystemRule(), fs -> TestDirectory.testDirectory( fs ) );
     }
 
     /**
      * @param fsSupplier as {@link Supplier} to make it clear that it is this class that owns the created
      * {@link FileSystemRule} instance.
+     * @param directorySupplier {@link Supplier} of {@link TestDirectory}.
      */
-    public PageCacheAndDependenciesRule( Supplier<FileSystemRule<? extends FileSystemAbstraction>> fsSupplier )
+    public PageCacheAndDependenciesRule( Supplier<FileSystemRule<? extends FileSystemAbstraction>> fsSupplier,
+            Function<FileSystemAbstraction,TestDirectory> directorySupplier )
     {
         this.fs = fsSupplier.get();
-        this.directory = TestDirectory.testDirectory( fs );
+        this.directory = directorySupplier.apply( fs );
         this.chain = RuleChain.outerRule( fs ).around( directory ).around( pageCacheRule );
     }
 

--- a/community/io/src/test/java/org/neo4j/test/rule/TestDirectory.java
+++ b/community/io/src/test/java/org/neo4j/test/rule/TestDirectory.java
@@ -65,36 +65,38 @@ public class TestDirectory implements TestRule
     private Class<?> owningTest;
     private boolean keepDirectoryAfterSuccessfulTest;
     private File testDirectory;
+    private final String directoryDifferentiator;
 
-    private TestDirectory( FileSystemAbstraction fileSystem )
-    {
-        this.fileSystem = fileSystem;
-    }
-
-    private TestDirectory( FileSystemAbstraction fileSystem, Class<?> owningTest )
+    private TestDirectory( FileSystemAbstraction fileSystem, Class<?> owningTest, String directoryDifferentiator )
     {
         this.fileSystem = fileSystem;
         this.owningTest = owningTest;
+        this.directoryDifferentiator = directoryDifferentiator;
     }
 
     public static TestDirectory testDirectory()
     {
-        return new TestDirectory( new DefaultFileSystemAbstraction() );
+        return testDirectory( new DefaultFileSystemAbstraction() );
     }
 
     public static TestDirectory testDirectory( FileSystemAbstraction fs )
     {
-        return new TestDirectory( fs );
+        return testDirectory( null, fs );
     }
 
     public static TestDirectory testDirectory( Class<?> owningTest )
     {
-        return new TestDirectory( new DefaultFileSystemAbstraction(), owningTest );
+        return new TestDirectory( new DefaultFileSystemAbstraction(), owningTest, "" );
     }
 
     public static TestDirectory testDirectory( Class<?> owningTest, FileSystemAbstraction fs )
     {
-        return new TestDirectory( fs, owningTest );
+        return new TestDirectory( fs, owningTest, "" );
+    }
+
+    public static TestDirectory testDirectory( Class<?> owningTest, FileSystemAbstraction fs, String directoryDifferentiator )
+    {
+        return new TestDirectory( fs, owningTest, directoryDifferentiator );
     }
 
     @Override
@@ -248,7 +250,7 @@ public class TestDirectory implements TestRule
         return cleanDirectory( dir );
     }
 
-    private void evaluateClassBaseTestFolder( )
+    private void evaluateClassBaseTestFolder()
     {
         if ( owningTest == null )
         {
@@ -256,7 +258,7 @@ public class TestDirectory implements TestRule
         }
         try
         {
-            testClassBaseFolder = testDataDirectoryOf( fileSystem, owningTest, false );
+            testClassBaseFolder = testDataDirectoryOf( fileSystem, owningTest, directoryDifferentiator, false );
         }
         catch ( IOException e )
         {
@@ -264,11 +266,11 @@ public class TestDirectory implements TestRule
         }
     }
 
-    private static File testDataDirectoryOf( FileSystemAbstraction fs, Class<?> owningTest, boolean clean )
+    private static File testDataDirectoryOf( FileSystemAbstraction fs, Class<?> owningTest, String directoryDifferentiator, boolean clean )
             throws IOException
     {
         File testData = new File( locateTarget( owningTest ), "test-data" );
-        File result = new File( testData, shorten( owningTest.getName() ) ).getAbsoluteFile();
+        File result = new File( testData, shorten( owningTest.getName() + directoryDifferentiator ) ).getAbsoluteFile();
         if ( clean )
         {
             clean( fs, result );

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
@@ -31,6 +31,7 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.test.rule.PageCacheAndDependenciesRule;
+import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 import org.neo4j.test.runner.ParameterizedSuiteRunner;
 
@@ -53,7 +54,7 @@ public abstract class IndexProviderCompatibilityTestSuite
     public abstract static class Compatibility
     {
         @Rule
-        public PageCacheAndDependenciesRule pageCacheAndDependenciesRule = new PageCacheAndDependenciesRule( DefaultFileSystemRule::new );
+        public final PageCacheAndDependenciesRule pageCacheAndDependenciesRule;
 
         protected File graphDbDir;
         protected FileSystemAbstraction fs;
@@ -72,6 +73,9 @@ public abstract class IndexProviderCompatibilityTestSuite
 
         public Compatibility( IndexProviderCompatibilityTestSuite testSuite, IndexDescriptor descriptor )
         {
+            this.pageCacheAndDependenciesRule = new PageCacheAndDependenciesRule( DefaultFileSystemRule::new,
+                    fs -> TestDirectory.testDirectory( null, fs, "-" + testSuite.getClass().getSimpleName().substring( 0, 3 ) ) );
+
             this.testSuite = testSuite;
             this.descriptor = descriptor;
         }


### PR DESCRIPTION
... by introducing possibility to suffix test directory rule.

When running test suite in parallel, the same test directories
will be shared between different test suits because they are
generated from owning class (which is similar) and test name.

By adding a unique suffix per test suite we avoid this directory
sharing.