### PR TITLE
Fix IndexProviderCompatibilityTestSuite

### DIFF
--- a/community/io/src/test/java/org/neo4j/test/rule/PageCacheAndDependenciesRule.java
+++ b/community/io/src/test/java/org/neo4j/test/rule/PageCacheAndDependenciesRule.java
@@ -45,17 +45,18 @@ public class PageCacheAndDependenciesRule implements TestRule
 
     public PageCacheAndDependenciesRule()
     {
-        this( () -> new EphemeralFileSystemRule() );
+        this( EphemeralFileSystemRule::new, null );
     }
 
     /**
      * @param fsSupplier as {@link Supplier} to make it clear that it is this class that owns the created
      * {@link FileSystemRule} instance.
+     * @param clazz class to make distinctions for test directories
      */
-    public PageCacheAndDependenciesRule( Supplier<FileSystemRule<? extends FileSystemAbstraction>> fsSupplier )
+    public PageCacheAndDependenciesRule( Supplier<FileSystemRule<? extends FileSystemAbstraction>> fsSupplier, Class<?> clazz )
     {
         this.fs = fsSupplier.get();
-        this.directory = TestDirectory.testDirectory( fs );
+        this.directory = TestDirectory.testDirectory( clazz, fs );
         this.chain = RuleChain.outerRule( fs ).around( directory ).around( pageCacheRule );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexProviderCompatibilityTestSuite.java
@@ -53,7 +53,7 @@ public abstract class IndexProviderCompatibilityTestSuite
     public abstract static class Compatibility
     {
         @Rule
-        public PageCacheAndDependenciesRule pageCacheAndDependenciesRule = new PageCacheAndDependenciesRule( DefaultFileSystemRule::new );
+        public final PageCacheAndDependenciesRule pageCacheAndDependenciesRule;
 
         protected File graphDbDir;
         protected FileSystemAbstraction fs;
@@ -74,6 +74,7 @@ public abstract class IndexProviderCompatibilityTestSuite
         {
             this.testSuite = testSuite;
             this.descriptor = descriptor;
+            pageCacheAndDependenciesRule = new PageCacheAndDependenciesRule( DefaultFileSystemRule::new, testSuite.getClass() );
         }
 
         protected void withPopulator( IndexPopulator populator, ThrowingConsumer<IndexPopulator,Exception> runWithPopulator ) throws Exception

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueConstraintCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/UniqueConstraintCompatibility.java
@@ -24,10 +24,9 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
-import org.junit.Rule;
 import org.junit.Test;
 
-import java.io.File;
+import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -53,15 +52,11 @@ import org.neo4j.kernel.impl.spi.KernelContext;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.test.TestGraphDatabaseFactory;
-import org.neo4j.test.rule.TestDirectory;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
-
-import static java.util.Arrays.asList;
-
 import static org.neo4j.kernel.impl.locking.LockService.LockType;
 
 @Ignore( "Not a test. This is a compatibility suite that provides test cases for verifying" +
@@ -132,6 +127,20 @@ public class UniqueConstraintCompatibility extends IndexProviderCompatibilityTes
      *
      * There's a lot of work to be done here.
      */
+
+    @Before
+    public void setUp()
+    {
+        TestGraphDatabaseFactory dbFactory = new TestGraphDatabaseFactory();
+        dbFactory.setKernelExtensions( Collections.singletonList( new PredefinedSchemaIndexProviderFactory( indexProvider ) ) );
+        db = dbFactory.newImpermanentDatabase( graphDbDir );
+    }
+
+    @After
+    public void tearDown()
+    {
+        db.shutdown();
+    }
 
     // -- Tests:
 
@@ -980,26 +989,6 @@ public class UniqueConstraintCompatibility extends IndexProviderCompatibilityTes
         {
             throw new AssertionError( "Interrupted", e );
         }
-    }
-
-    // -- Set Up: Environment parts
-
-    @Rule
-    public TestDirectory testDirectory = TestDirectory.testDirectory( getClass() );
-
-    @Before
-    public void setUp()
-    {
-        File storeDir = testDirectory.graphDbDir();
-        TestGraphDatabaseFactory dbfactory = new TestGraphDatabaseFactory();
-        dbfactory.setKernelExtensions( asList( new PredefinedSchemaIndexProviderFactory( indexProvider ) ) );
-        db = dbfactory.newImpermanentDatabase( storeDir );
-    }
-
-    @After
-    public void tearDown()
-    {
-        db.shutdown();
     }
 
     private static class PredefinedSchemaIndexProviderFactory extends KernelExtensionFactory<PredefinedSchemaIndexProviderFactory.NoDeps>


### PR DESCRIPTION
When running test suite in parallel, the same test directories will be shared between different test suits because they are generated from owning class (which is similar) and test name.

This makes the test directories use the test suite class instead as a distinguisher.