### PR TITLE
Fix statement acquisition in token accessing built-in procedures

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/procs/ProcedureExecutionResult.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/procs/ProcedureExecutionResult.scala
@@ -140,7 +140,9 @@ class ProcedureExecutionResult[E <: Exception](context: QueryContext,
   }
 
   override def executionPlanDescription(): InternalPlanDescription = executionMode match {
-    case ProfileMode if executionResults.hasNext => throw new ProfilerStatisticsNotReadyException()
+    case ProfileMode if executionResults.hasNext =>
+      completed(success = false)
+      throw new ProfilerStatisticsNotReadyException()
     case _ => executionPlanDescriptionGenerator()
       .addArgument(Runtime(ProcedureRuntimeName.toTextOutput))
       .addArgument(RuntimeImpl(ProcedureRuntimeName.toTextOutput))

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/PipeDecorator.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/PipeDecorator.scala
@@ -30,7 +30,7 @@ trait PipeDecorator {
 
   def decorate(pipe: Pipe, iter: Iterator[ExecutionContext]): Iterator[ExecutionContext]
 
-  def decorate(plan: InternalPlanDescription, isProfileReady: => Boolean): InternalPlanDescription
+  def decorate(plan: InternalPlanDescription, verifyProfileReady: () => Unit): InternalPlanDescription
 
   /*
    * Returns the inner decorator of this decorator. The inner decorator is used for nested expressions
@@ -42,7 +42,7 @@ trait PipeDecorator {
 object NullPipeDecorator extends PipeDecorator {
   def decorate(pipe: Pipe, iter: Iterator[ExecutionContext]): Iterator[ExecutionContext] = iter
 
-  def decorate(plan: InternalPlanDescription, isProfileReady: => Boolean): InternalPlanDescription = plan
+  def decorate(plan: InternalPlanDescription, verifyProfileReady: () => Unit): InternalPlanDescription = plan
 
   def decorate(pipe: Pipe, state: QueryState): QueryState = state
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/profiler/Profiler.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/profiler/Profiler.scala
@@ -23,9 +23,8 @@ import org.neo4j.collection.primitive.PrimitiveLongIterator
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.ExecutionContext
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.helpers.PrimitiveLongHelper
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes.{Pipe, PipeDecorator, QueryState}
-import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.{Id, InternalPlanDescription}
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.InternalPlanDescription.Arguments
-import org.neo4j.cypher.internal.frontend.v3_3.ProfilerStatisticsNotReadyException
+import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.{Id, InternalPlanDescription}
 import org.neo4j.cypher.internal.spi.v3_3.{DelegatingOperations, DelegatingQueryContext, Operations, QueryContext}
 import org.neo4j.graphdb.{Node, PropertyContainer, Relationship}
 import org.neo4j.helpers.MathUtil
@@ -78,9 +77,8 @@ class Profiler(databaseInfo: DatabaseInfo = DatabaseInfo.COMMUNITY) extends Pipe
     databaseInfo.edition != Edition.community
   }
 
-  def decorate(plan: InternalPlanDescription, isProfileReady: => Boolean): InternalPlanDescription = {
-    if (!isProfileReady)
-      throw new ProfilerStatisticsNotReadyException()
+  def decorate(plan: InternalPlanDescription, verifyProfileReady: () => Unit): InternalPlanDescription = {
+    verifyProfileReady()
 
     plan map {
       input: InternalPlanDescription =>
@@ -108,8 +106,8 @@ class Profiler(databaseInfo: DatabaseInfo = DatabaseInfo.COMMUNITY) extends Pipe
 
     def decorate(pipe: Pipe, iter: Iterator[ExecutionContext]): Iterator[ExecutionContext] = iter
 
-    def decorate(plan: InternalPlanDescription, isProfileReady: => Boolean): InternalPlanDescription =
-      outerProfiler.decorate(plan, isProfileReady)
+    def decorate(plan: InternalPlanDescription, verifyProfileReady: () => Unit): InternalPlanDescription =
+      outerProfiler.decorate(plan, verifyProfileReady)
   }
 
   def registerParentPipe(pipe: Pipe): Unit =

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/profiler/ProfilerTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/profiler/ProfilerTest.scala
@@ -45,7 +45,7 @@ class ProfilerTest extends CypherFunSuite {
 
     //WHEN
     materialize(pipe.createResults(queryState))
-    val decoratedResult = profiler.decorate(planDescription, isProfileReady = true)
+    val decoratedResult = profiler.decorate(planDescription, verifyProfileReady = () => {})
 
     //THEN
     assertRecorded(decoratedResult, "foo", expectedRows = 10, expectedDbHits = 20)
@@ -63,7 +63,7 @@ class ProfilerTest extends CypherFunSuite {
 
     //WHEN
     materialize(pipe.createResults(queryState))
-    val decoratedResult = profiler.decorate(planDescription, isProfileReady = true)
+    val decoratedResult = profiler.decorate(planDescription, verifyProfileReady = () => {})
 
     //THEN
     assertRecorded(decoratedResult, "foo", expectedRows = 10, expectedDbHits = 20,
@@ -90,7 +90,7 @@ class ProfilerTest extends CypherFunSuite {
 
     //WHEN
     materialize(pipe3.createResults(queryState))
-    val decoratedResult = profiler.decorate(planDescription, isProfileReady = true)
+    val decoratedResult = profiler.decorate(planDescription, verifyProfileReady = () => {})
 
     //THEN
     assertRecorded(decoratedResult, "foo", expectedRows = 10, expectedDbHits = 25)
@@ -112,7 +112,7 @@ class ProfilerTest extends CypherFunSuite {
 
     //WHEN
     materialize(pipe3.createResults(queryState))
-    val decoratedResult = profiler.decorate(planDescription, isProfileReady = true)
+    val decoratedResult = profiler.decorate(planDescription, verifyProfileReady = () => {})
 
     //THEN
     assertRecorded(decoratedResult, "foo", expectedRows = 10, expectedDbHits = 25, expectedPageCacheHits = 2, expectedPageCacheMisses = 7)
@@ -139,7 +139,7 @@ class ProfilerTest extends CypherFunSuite {
 
     // WHEN we create the results,
     materialize(apply.createResults(queryState))
-    val decoratedResult = profiler.decorate(planDescription, isProfileReady = true)
+    val decoratedResult = profiler.decorate(planDescription, verifyProfileReady = () => {})
 
     // THEN
     assertRecorded(decoratedResult, "rhs", expectedRows = 10 * 20, expectedDbHits = 10 * 30)
@@ -167,7 +167,7 @@ class ProfilerTest extends CypherFunSuite {
 
     // WHEN we create the results,
     materialize(pipeUnderInspection.createResults(queryState))
-    val decoratedResult = profiler.decorate(planDescription, isProfileReady = true)
+    val decoratedResult = profiler.decorate(planDescription, verifyProfileReady = () => {})
 
     // THEN the ProjectionNewPipe has correctly recorded the dbhits
     assertRecorded(decoratedResult, "Projection", expectedRows = 1, expectedDbHits = DB_HITS)
@@ -195,7 +195,7 @@ class ProfilerTest extends CypherFunSuite {
 
     // WHEN we create the results,
     materialize(pipeUnderInspection.createResults(queryState))
-    val decoratedResult = profiler.decorate(planDescription, isProfileReady = true)
+    val decoratedResult = profiler.decorate(planDescription, verifyProfileReady = () => {})
 
     // THEN the ProjectionNewPipe has correctly recorded the page cache hits
     assertRecorded(decoratedResult, "Projection", expectedRows = 1, expectedDbHits = 2, expectedPageCacheHits = 3, expectedPageCacheMisses = 4)
@@ -231,7 +231,7 @@ class ProfilerTest extends CypherFunSuite {
       "innerInner" -> innerInnerPipe,
       "Projection" -> pipeUnderInspection
     )
-    val decoratedResult = profiler.decorate(description, isProfileReady = true)
+    val decoratedResult = profiler.decorate(description, verifyProfileReady = () => {})
 
     // THEN the ProjectionNewPipe has correctly recorded the dbhits
     assertRecorded(decoratedResult, "Projection", expectedRows = 1, expectedDbHits = DB_HITS * 2)

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
@@ -75,9 +75,16 @@ public class BuiltInProcedures
     @Procedure( name = "db.labels", mode = READ )
     public Stream<LabelResult> listLabels()
     {
-        try ( Statement statement = tx.acquireStatement() )
+        Statement statement = tx.acquireStatement();
+        try
         {
+            // Ownership of the reference to the acquired statement is transfered to the returned iterator stream
             return TokenAccess.LABELS.inUse( statement ).map( LabelResult::new ).stream();
+        }
+        catch ( Throwable t )
+        {
+            statement.close();
+            throw t;
         }
     }
 
@@ -85,9 +92,16 @@ public class BuiltInProcedures
     @Procedure( name = "db.propertyKeys", mode = READ )
     public Stream<PropertyKeyResult> listPropertyKeys()
     {
-        try ( Statement statement = tx.acquireStatement() )
+        Statement statement = tx.acquireStatement();
+        try
         {
+            // Ownership of the reference to the acquired statement is transfered to the returned iterator stream
             return TokenAccess.PROPERTY_KEYS.inUse( statement ).map( PropertyKeyResult::new ).stream();
+        }
+        catch ( Throwable t )
+        {
+            statement.close();
+            throw t;
         }
     }
 
@@ -95,9 +109,16 @@ public class BuiltInProcedures
     @Procedure( name = "db.relationshipTypes", mode = READ )
     public Stream<RelationshipTypeResult> listRelationshipTypes()
     {
-        try ( Statement statement = tx.acquireStatement() )
+        Statement statement = tx.acquireStatement();
+        try
         {
+            // Ownership of the reference to the acquired statement is transfered to the returned iterator stream
             return TokenAccess.RELATIONSHIP_TYPES.inUse( statement ).map( RelationshipTypeResult::new ).stream();
+        }
+        catch ( Throwable t )
+        {
+            statement.close();
+            throw t;
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TokenAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TokenAccess.java
@@ -129,7 +129,7 @@ public abstract class TokenAccess<R>
 
     private abstract static class TokenIterator<T> extends PrefetchingResourceIterator<T>
     {
-        final Statement statement;
+        Statement statement;
         final TokenAccess<T> access;
         final Iterator<Token> tokens;
 
@@ -143,7 +143,11 @@ public abstract class TokenAccess<R>
         @Override
         public void close()
         {
-            statement.close();
+            if ( statement != null )
+            {
+                statement.close();
+                statement = null;
+            }
         }
 
         static <T> ResourceIterator<T> inUse( Statement statement, TokenAccess<T> access )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
@@ -670,7 +670,11 @@ class ReflectiveProcedureCompiler
             @Override
             public void close() throws Exception
             {
-                closeable.close();
+                if ( closeable != null )
+                {
+                    closeable.close();
+                    closeable = null;
+                }
             }
         }
     }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProcedureCallSupportAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProcedureCallSupportAcceptanceTest.scala
@@ -87,4 +87,26 @@ class ProcedureCallSupportAcceptanceTest extends ProcedureCallAcceptanceTest {
       map("one", "alpha", "newTwo", "beta")
     ))
   }
+
+  test("should be able to execute union of multiple token accessing procedures") {
+    val a = createLabeledNode("Foo")
+    val b = createLabeledNode("Bar")
+    relate(a, b, "REL", Map("prop" -> 1))
+
+    val query =
+      "CALL db.labels() YIELD label RETURN label as result " +
+      "UNION " +
+      "CALL db.relationshipTypes() YIELD relationshipType RETURN relationshipType as result " +
+      "UNION " +
+      "CALL db.propertyKeys() YIELD propertyKey RETURN propertyKey as result"
+
+    val result = graph.execute(query)
+
+    result.columnAs[String]("result").stream().toArray.toList shouldEqual List(
+      "Foo",
+      "Bar",
+      "REL",
+      "prop"
+    )
+  }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProfilerAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProfilerAcceptanceTest.scala
@@ -177,6 +177,17 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
     result.close() // ensure that the transaction is closed
   }
 
+  test("unfinished profiler complains [using CALL within larger query]") {
+    //GIVEN
+    createLabeledNode("Person")
+    val result = graph.execute("PROFILE CALL db.labels() YIELD label WITH label as r RETURN r")
+
+    //WHEN THEN
+    val ex = intercept[QueryExecutionException](result.getExecutionPlanDescription)
+    ex.getCause.getCause shouldBe a [ProfilerStatisticsNotReadyException]
+    result.close() // ensure that the transaction is closed
+  }
+
   test("tracks number of rows") {
     //GIVEN
     // due to the cost model, we need a bunch of nodes for the planner to pick a plan that does lookup by id

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/compiled/CompiledExecutionResult.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/compiled/CompiledExecutionResult.scala
@@ -53,7 +53,10 @@ class CompiledExecutionResult(taskCloser: TaskCloser,
     compiledCode.accept(visitor)
 
   override def executionPlanDescription(): InternalPlanDescription = {
-    if (!taskCloser.isClosed) throw new ProfilerStatisticsNotReadyException
+    if (!taskCloser.isClosed) {
+      completed(success = false)
+      throw new ProfilerStatisticsNotReadyException
+    }
 
     compiledCode.executionPlanDescription()
       .addArgument(Runtime(CompiledRuntimeName.toTextOutput))


### PR DESCRIPTION
The built-in procedures using `TokenAccess` (`db.labels()`,
`db.relationshipTypes()`, `db.propertyKeys()`) would close their
acquired `KernelStatement` prematurely before returning an iterator
stream was using the statement and that would close it when exhausted.
This caused a problem when a multiple of these procedure calls were
made in the same query. Changed this so that ownership of the acquired
statement reference is transferred to the iterator (which is consistent
with the core API call usage of `TokenAccess`).

Also changed the `TokenIterator.close()` to be idempotent, since
exhausting the procedure stream also causes close to be invoked.