### PR TITLE
Semantic checking of more multiple graphs clauses

### DIFF
--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/ast/rewriters/createGraphIntroducesHorizonTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/ast/rewriters/createGraphIntroducesHorizonTest.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_3.ast.rewriters
+
+import org.neo4j.cypher.internal.frontend.v3_3.ast.AstConstructionTestSupport
+import org.neo4j.cypher.internal.frontend.v3_3.ast.rewriters.createGraphIntroducesHorizon
+import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.CypherFunSuite
+
+class createGraphIntroducesHorizonTest extends CypherFunSuite with RewriteTest with AstConstructionTestSupport {
+
+  override val rewriterUnderTest = createGraphIntroducesHorizon
+
+  test("create x >> is rewritten") {
+    assertRewrite(
+      "CREATE GRAPH AT 'url' AS foo >>",
+      "CREATE GRAPH AT 'url' AS foo WITH * GRAPHS *, foo >>"
+    )
+  }
+
+  test("create << x is rewritten") {
+    assertRewrite(
+      "CREATE >> GRAPH AT 'url' AS foo",
+      "CREATE GRAPH AT 'url' AS foo WITH * GRAPHS *, >> foo"
+    )
+  }
+
+  test("create x is not rewritten without fish op") {
+    assertIsNotRewritten("CREATE GRAPH AT 'url' AS foo")
+  }
+
+}

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/Clause.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/Clause.scala
@@ -112,7 +112,7 @@ final case class DeleteGraphs(graphs: Seq[Variable])(val position: InputPosition
 
   override def semanticCheck: SemanticCheck =
     super.semanticCheck chain
-    graphs.foldSemanticCheck(_.ensureVariableDefined()) chain
+    graphs.foldSemanticCheck(_.ensureGraphDefined()) chain
     recordCurrentScope
 }
 
@@ -122,7 +122,9 @@ final case class Persist(graph: BoundGraphAs, to: GraphUrl)(val position: InputP
   override def name = "PERSIST"
 
   override def semanticCheck: SemanticCheck =
-    super.semanticCheck chain graph.semanticCheck
+    super.semanticCheck chain
+      graph.semanticCheck chain
+      recordCurrentScope
 }
 
 final case class Snapshot(graph: BoundGraphAs, to: GraphUrl)(val position: InputPosition)
@@ -140,7 +142,9 @@ final case class Relocate(graph: BoundGraphAs, to: GraphUrl)(val position: Input
   override def name = "RELOCATE"
 
   override def semanticCheck: SemanticCheck =
-    super.semanticCheck chain graph.semanticCheck
+    super.semanticCheck chain
+      graph.semanticCheck chain
+      recordCurrentScope
 }
 
 case class Start(items: Seq[StartItem], where: Option[Where])(val position: InputPosition) extends Clause {

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/Clause.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/Clause.scala
@@ -133,7 +133,9 @@ final case class Snapshot(graph: BoundGraphAs, to: GraphUrl)(val position: Input
   override def name = "SNAPSHOT"
 
   override def semanticCheck: SemanticCheck =
-    super.semanticCheck chain graph.semanticCheck
+    super.semanticCheck chain
+      graph.semanticCheck chain
+      recordCurrentScope
 }
 
 final case class Relocate(graph: BoundGraphAs, to: GraphUrl)(val position: InputPosition)

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/Clause.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/Clause.scala
@@ -94,42 +94,15 @@ final case class CreateNewSourceGraph(snapshot: Boolean, graph: Variable, of: Op
   extends CreateGraphClause {
 
   override def semanticCheck: SemanticCheck =
-    super.semanticCheck chain
-    updateSetContextGraphs() chain
-    recordCurrentScope
+    (s: SemanticState) => error(s, SemanticError("Clause not rewritten as expected (see PreparatoryRewriting)", position))
 
-  private def updateSetContextGraphs(): SemanticCheck = {
-    val check: (SemanticState) => Either[SemanticError, SemanticState] = (s: SemanticState) => {
-      s.currentScope.contextGraphs match {
-        case Some(context) =>
-          s.updateContextGraphs(context.updated(Some(graph.name)))
-        case None =>
-          Left(SemanticError("No context graph in scope", position))
-      }
-    }
-    graph.declareGraph chain check
-  }
 }
 
 final case class CreateNewTargetGraph(snapshot: Boolean, graph: Variable, of: Option[Pattern], at: GraphUrl)(val position: InputPosition)
   extends CreateGraphClause {
 
   override def semanticCheck: SemanticCheck =
-    super.semanticCheck chain
-    updateSetContextGraphs() chain
-    recordCurrentScope
-
-  private def updateSetContextGraphs(): SemanticCheck = {
-    val check: (SemanticState) => Either[SemanticError, SemanticState] = (s: SemanticState) => {
-      s.currentScope.contextGraphs match {
-        case Some(context) =>
-          s.updateContextGraphs(context.updated(Some(context.source), Some(graph.name)))
-        case None =>
-          Left(SemanticError("No context graph in scope", position))
-      }
-    }
-    graph.declareGraph chain check
-  }
+    (s: SemanticState) => error(s, SemanticError("Clause not rewritten as expected (see PreparatoryRewriting)", position))
 }
 
 final case class DeleteGraphs(graphs: Seq[Variable])(val position: InputPosition)

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/GraphReturnItems.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/GraphReturnItems.scala
@@ -74,7 +74,7 @@ final case class GraphReturnItems(includeExisting: Boolean, items: Seq[GraphRetu
 
   val graphs: Seq[SingleGraphAs] = items.flatMap(_.graphs)
 
-  val singleGraph: Option[SingleGraphAs] = if (graphs.nonEmpty && graphs.tail.isEmpty) graphs.headOption else None
+  val singleGraph: Option[SingleGraphAs] = if (!includeExisting && graphs.nonEmpty && graphs.tail.isEmpty) graphs.headOption else None
   val newSource: Option[SingleGraphAs] = singleGraph orElse items.flatMap(_.newSource).headOption
   val newTarget: Option[SingleGraphAs] = items.flatMap(_.newTarget).headOption orElse newSource
 

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/Variable.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/Variable.scala
@@ -30,7 +30,11 @@ case class Variable(name: String)(val position: InputPosition) extends Expressio
   //
   def semanticCheck(ctx: SemanticContext): (SemanticState) => SemanticCheckResult = s => this.ensureVariableDefined()(s) match {
     case Right(ss) => SemanticCheckResult.success(ss)
-    case Left(error) => SemanticCheckResult.error(declareVariable(CTAny.covariant)(s).right.get, error)
+    case Left(error) => declareVariable(CTAny.covariant)(s) match {
+        // if the variable is a graph, declaring it will fail
+      case Right(ss) => SemanticCheckResult.error(ss, error)
+      case Left(_error) => SemanticCheckResult.error(s, _error)
+    }
   }
 
   // double-dispatch helpers

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/rewriters/createGraphIntroducesHorizon.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/rewriters/createGraphIntroducesHorizon.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypher.internal.frontend.v3_3.ast.rewriters
+
+import org.neo4j.cypher.internal.frontend.v3_3.ast._
+import org.neo4j.cypher.internal.frontend.v3_3.{Rewriter, bottomUp}
+
+case object createGraphIntroducesHorizon extends Rewriter {
+
+  def apply(that: AnyRef): AnyRef = instance(that)
+
+  private val instance = bottomUp(Rewriter.lift {
+    case query@SingleQuery(clauses) =>
+      val newClauses = clauses.flatMap {
+        case clause@CreateNewSourceGraph(snapshot, graph, of, at) =>
+          val createGraph = CreateRegularGraph(snapshot, graph, of, at)(clause.position)
+          val p = clause.position
+          val newWith = With(
+            ReturnItems(includeExisting = true, Seq.empty)(p),
+            GraphReturnItems(includeExisting = true, Seq(NewContextGraphs(GraphAs(graph, None)(p))(p)))(p)
+          )(p)
+          Seq(createGraph, newWith)
+
+        case clause@CreateNewTargetGraph(snapshot, graph, of, at) =>
+          val createGraph = CreateRegularGraph(snapshot, graph, of, at)(clause.position)
+          val p = clause.position
+          val newWith = With(
+            ReturnItems(includeExisting = true, Seq.empty)(p),
+            GraphReturnItems(includeExisting = true, Seq(NewTargetGraph(GraphAs(graph, None)(p))(p)))(p)
+          )(p)
+          Seq(createGraph, newWith)
+
+        case clause =>
+          Some(clause)
+      }
+      query.copy(clauses = newClauses)(query.position)
+  })
+}

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/phases/PreparatoryRewriting.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/phases/PreparatoryRewriting.scala
@@ -25,6 +25,7 @@ case object PreparatoryRewriting extends Phase[BaseContext, BaseState, BaseState
   override def process(from: BaseState, context: BaseContext): BaseState = {
 
     val rewrittenStatement = from.statement().endoRewrite(inSequence(
+      createGraphIntroducesHorizon,
       normalizeGraphReturnItems,
       normalizeReturnClauses(context.exceptionCreator),
       normalizeWithClauses(context.exceptionCreator),

--- a/community/cypher/frontend-3.3/src/test/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/MultipleGraphClauseSemanticCheckingTest.scala
+++ b/community/cypher/frontend-3.3/src/test/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/MultipleGraphClauseSemanticCheckingTest.scala
@@ -37,7 +37,7 @@ class MultipleGraphClauseSemanticCheckingTest
       """WITH 1 AS a GRAPH source AT 'src' >> GRAPH target AT 'tgt'
         |RETURN * GRAPHS *""".stripMargin) shouldVerify { result: SemanticCheckResult =>
       result.errors shouldBe empty
-      verify(result.formattedContexts) shouldEqualFixNewlines
+      result.formattedContexts shouldEqualFixNewlines
         """// Start
           |--
           |// (With(false,ReturnItems(false,Vector(AliasedReturnItem(SignedDecimalIntegerLiteral(1),Variable(a)))),GraphReturnItems(false,List(NewContextGraphs(GraphAtAs(GraphUrl(Right(StringLiteral(src))),Some(Variable(source)),false),Some(GraphAtAs(GraphUrl(Right(StringLiteral(tgt))),Some(Variable(target)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
@@ -46,52 +46,53 @@ class MultipleGraphClauseSemanticCheckingTest
           |--
           |// End
         """
-      verify(result.formattedScopes) shouldEqualFixNewlines
-        """{
-          |  {
-          |  }
-          |  { /* source >> target */
-          |    a: 10
-          |    GRAPH source: 18
-          |    GRAPH target: 43
-          |  }
-          |  {
-          |    a: 10
-          |    GRAPH source: 18
-          |    GRAPH target: 43
-          |  }
-          |}"""
+        result.formattedScopes shouldEqualFixNewlines
+          """{
+            |  {
+            |  }
+            |  { /* source >> target */
+            |    a: 10
+            |    GRAPH source: 18
+            |    GRAPH target: 43
+            |  }
+            |  {
+            |    a: 10
+            |    GRAPH source: 18
+            |    GRAPH target: 43
+            |  }
+            |}"""
     }
   }
 
   test("GRAPHS * keeps existing graphs in scope (2)") {
     parsing(
       """WITH 1 AS a GRAPH source AT 'src' >> GRAPH target AT 'tgt'
-        |RETURN GRAPHS *""".stripMargin) shouldVerify { result: SemanticCheckResult =>
-      result.errors shouldBe empty
-      verify(result.formattedContexts) shouldEqualFixNewlines
-        """// Start
-          |--
-          |// (With(false,ReturnItems(false,Vector(AliasedReturnItem(SignedDecimalIntegerLiteral(1),Variable(a)))),GraphReturnItems(false,List(NewContextGraphs(GraphAtAs(GraphUrl(Right(StringLiteral(src))),Some(Variable(source)),false),Some(GraphAtAs(GraphUrl(Right(StringLiteral(tgt))),Some(Variable(target)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
-          |source >> target
-          |// (Return(false,DiscardCardinality(),Some(GraphReturnItems(true,List())),None,None,None,Set()),line 2, column 1 (offset: 59))
-          |--
-          |// End
-        """
-      verify(result.formattedScopes) shouldEqualFixNewlines
-        """{
-          |  {
-          |  }
-          |  { /* source >> target */
-          |    a: 10
-          |    GRAPH source: 18
-          |    GRAPH target: 43
-          |  }
-          |  {
-          |    GRAPH source: 18
-          |    GRAPH target: 43
-          |  }
-          |}"""
+        |RETURN GRAPHS *
+      """.stripMargin) shouldVerify { result: SemanticCheckResult =>
+        result.errors shouldBe empty
+        result.formattedContexts shouldEqualFixNewlines
+          """// Start
+            |--
+            |// (With(false,ReturnItems(false,Vector(AliasedReturnItem(SignedDecimalIntegerLiteral(1),Variable(a)))),GraphReturnItems(false,List(NewContextGraphs(GraphAtAs(GraphUrl(Right(StringLiteral(src))),Some(Variable(source)),false),Some(GraphAtAs(GraphUrl(Right(StringLiteral(tgt))),Some(Variable(target)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
+            |source >> target
+            |// (Return(false,DiscardCardinality(),Some(GraphReturnItems(true,List())),None,None,None,Set()),line 2, column 1 (offset: 59))
+            |--
+            |// End
+          """
+        result.formattedScopes shouldEqualFixNewlines
+          """{
+            |  {
+            |  }
+            |  { /* source >> target */
+            |    a: 10
+            |    GRAPH source: 18
+            |    GRAPH target: 43
+            |  }
+            |  {
+            |    GRAPH source: 18
+            |    GRAPH target: 43
+            |  }
+            |}"""
     }
   }
 
@@ -99,38 +100,39 @@ class MultipleGraphClauseSemanticCheckingTest
     parsing(
       """WITH GRAPH source AT 'src' >> GRAPH target AT 'tgt'
         |WITH 1 AS a
-        |RETURN * GRAPHS *""".stripMargin) shouldVerify { result: SemanticCheckResult =>
-      result.errors shouldBe empty
-      verify(result.formattedContexts) shouldEqualFixNewlines
-        """// Start
-          |--
-          |// (With(false,DiscardCardinality(),GraphReturnItems(false,List(NewContextGraphs(GraphAtAs(GraphUrl(Right(StringLiteral(src))),Some(Variable(source)),false),Some(GraphAtAs(GraphUrl(Right(StringLiteral(tgt))),Some(Variable(target)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
-          |source >> target
-          |// (With(false,ReturnItems(false,Vector(AliasedReturnItem(SignedDecimalIntegerLiteral(1),Variable(a)))),GraphReturnItems(true,List()),None,None,None,None),line 2, column 1 (offset: 52))
-          |source >> target
-          |// (Return(false,ReturnItems(true,List()),Some(GraphReturnItems(true,List())),None,None,None,Set()),line 3, column 1 (offset: 64))
-          |--
-          |// End
-        """
-      verify(result.formattedScopes) shouldEqualFixNewlines
-        """{
-          |  {
-          |  }
-          |  { /* source >> target */
-          |    GRAPH source: 11
-          |    GRAPH target: 36
-          |  }
-          |  { /* source >> target */
-          |    a: 62
-          |    GRAPH source: 11
-          |    GRAPH target: 36
-          |  }
-          |  {
-          |    a: 62
-          |    GRAPH source: 11
-          |    GRAPH target: 36
-          |  }
-          |}"""
+        |RETURN * GRAPHS *
+      """.stripMargin) shouldVerify { result: SemanticCheckResult =>
+        result.errors shouldBe empty
+        result.formattedContexts shouldEqualFixNewlines
+          """// Start
+            |--
+            |// (With(false,DiscardCardinality(),GraphReturnItems(false,List(NewContextGraphs(GraphAtAs(GraphUrl(Right(StringLiteral(src))),Some(Variable(source)),false),Some(GraphAtAs(GraphUrl(Right(StringLiteral(tgt))),Some(Variable(target)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
+            |source >> target
+            |// (With(false,ReturnItems(false,Vector(AliasedReturnItem(SignedDecimalIntegerLiteral(1),Variable(a)))),GraphReturnItems(true,List()),None,None,None,None),line 2, column 1 (offset: 52))
+            |source >> target
+            |// (Return(false,ReturnItems(true,List()),Some(GraphReturnItems(true,List())),None,None,None,Set()),line 3, column 1 (offset: 64))
+            |--
+            |// End
+          """
+        result.formattedScopes shouldEqualFixNewlines
+          """{
+            |  {
+            |  }
+            |  { /* source >> target */
+            |    GRAPH source: 11
+            |    GRAPH target: 36
+            |  }
+            |  { /* source >> target */
+            |    a: 62
+            |    GRAPH source: 11
+            |    GRAPH target: 36
+            |  }
+            |  {
+            |    a: 62
+            |    GRAPH source: 11
+            |    GRAPH target: 36
+            |  }
+            |}"""
     }
   }
 
@@ -138,29 +140,29 @@ class MultipleGraphClauseSemanticCheckingTest
     parsing(
       """WITH GRAPH source AT 'src' >> GRAPH target AT 'tgt'
         |RETURN GRAPH foo AT 'url', GRAPH bar AT 'url'""".stripMargin) shouldVerify { result: SemanticCheckResult =>
-      result.errors shouldBe empty
-      verify(result.formattedContexts) shouldEqualFixNewlines
-        """// Start
-          |--
-          |// (With(false,DiscardCardinality(),GraphReturnItems(false,List(NewContextGraphs(GraphAtAs(GraphUrl(Right(StringLiteral(src))),Some(Variable(source)),false),Some(GraphAtAs(GraphUrl(Right(StringLiteral(tgt))),Some(Variable(target)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
-          |source >> target
-          |// (Return(false,DiscardCardinality(),Some(GraphReturnItems(false,List(ReturnedGraph(GraphAtAs(GraphUrl(Right(StringLiteral(url))),Some(Variable(foo)),false)), ReturnedGraph(GraphAtAs(GraphUrl(Right(StringLiteral(url))),Some(Variable(bar)),false))))),None,None,None,Set()),line 2, column 1 (offset: 52))
-          |--
-          |// End
-        """
-      verify(result.formattedScopes) shouldEqualFixNewlines
-        """{
-          |  {
-          |  }
-          |  { /* source >> target */
-          |    GRAPH source: 11
-          |    GRAPH target: 36
-          |  }
-          |  {
-          |    GRAPH bar: 85
-          |    GRAPH foo: 65
-          |  }
-          |}"""
+        result.errors shouldBe empty
+        result.formattedContexts shouldEqualFixNewlines
+          """// Start
+            |--
+            |// (With(false,DiscardCardinality(),GraphReturnItems(false,List(NewContextGraphs(GraphAtAs(GraphUrl(Right(StringLiteral(src))),Some(Variable(source)),false),Some(GraphAtAs(GraphUrl(Right(StringLiteral(tgt))),Some(Variable(target)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
+            |source >> target
+            |// (Return(false,DiscardCardinality(),Some(GraphReturnItems(false,List(ReturnedGraph(GraphAtAs(GraphUrl(Right(StringLiteral(url))),Some(Variable(foo)),false)), ReturnedGraph(GraphAtAs(GraphUrl(Right(StringLiteral(url))),Some(Variable(bar)),false))))),None,None,None,Set()),line 2, column 1 (offset: 52))
+            |--
+            |// End
+          """
+        result.formattedScopes shouldEqualFixNewlines
+          """{
+            |  {
+            |  }
+            |  { /* source >> target */
+            |    GRAPH source: 11
+            |    GRAPH target: 36
+            |  }
+            |  {
+            |    GRAPH bar: 85
+            |    GRAPH foo: 65
+            |  }
+            |}"""
     }
   }
 
@@ -168,29 +170,30 @@ class MultipleGraphClauseSemanticCheckingTest
     parsing(
       """WITH 1 AS a GRAPH source AT 'src' >> GRAPH target AT 'tgt'
         |RETURN a""".stripMargin) shouldVerify { result: SemanticCheckResult =>
-      result.errors shouldBe empty
-      verify(result.formattedContexts) shouldEqualFixNewlines
-        """// Start
-          |--
-          |// (With(false,ReturnItems(false,Vector(AliasedReturnItem(SignedDecimalIntegerLiteral(1),Variable(a)))),GraphReturnItems(false,List(NewContextGraphs(GraphAtAs(GraphUrl(Right(StringLiteral(src))),Some(Variable(source)),false),Some(GraphAtAs(GraphUrl(Right(StringLiteral(tgt))),Some(Variable(target)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
-          |source >> target
-          |// (Return(false,ReturnItems(false,List(AliasedReturnItem(Variable(a),Variable(a)))),None,None,None,None,Set()),line 2, column 1 (offset: 59))
-          |--
-          |// End
-        """
-      verify(result.formattedScopes) shouldEqualFixNewlines
-        """{
-          |  {
-          |  }
-          |  { /* source >> target */
-          |    a: 10 66
-          |    GRAPH source: 18
-          |    GRAPH target: 43
-          |  }
-          |  {
-          |    a: 10 66 67
-          |  }
-          |}"""
+        result.errors shouldBe empty
+        result.formattedContexts shouldEqualFixNewlines
+          """
+            |// Start
+            |--
+            |// (With(false,ReturnItems(false,Vector(AliasedReturnItem(SignedDecimalIntegerLiteral(1),Variable(a)))),GraphReturnItems(false,List(NewContextGraphs(GraphAtAs(GraphUrl(Right(StringLiteral(src))),Some(Variable(source)),false),Some(GraphAtAs(GraphUrl(Right(StringLiteral(tgt))),Some(Variable(target)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
+            |source >> target
+            |// (Return(false,ReturnItems(false,List(AliasedReturnItem(Variable(a),Variable(a)))),None,None,None,None,Set()),line 2, column 1 (offset: 59))
+            |--
+            |// End
+            """
+        result.formattedScopes shouldEqualFixNewlines
+          """{
+            |  {
+            |  }
+            |  { /* source >> target */
+            |    a: 10 66
+            |    GRAPH source: 18
+            |    GRAPH target: 43
+            |  }
+            |  {
+            |    a: 10 66 67
+            |  }
+            |}"""
     }
   }
 
@@ -199,35 +202,35 @@ class MultipleGraphClauseSemanticCheckingTest
       """WITH 1 AS a GRAPH source AT 'src' >> GRAPH target AT 'tgt'
         |WITH a GRAPH source
         |RETURN a""".stripMargin) shouldVerify { result: SemanticCheckResult =>
-      result.errors shouldBe empty
-      verify(result.formattedContexts) shouldEqualFixNewlines
-        """// Start
-          |--
-          |// (With(false,ReturnItems(false,Vector(AliasedReturnItem(SignedDecimalIntegerLiteral(1),Variable(a)))),GraphReturnItems(false,List(NewContextGraphs(GraphAtAs(GraphUrl(Right(StringLiteral(src))),Some(Variable(source)),false),Some(GraphAtAs(GraphUrl(Right(StringLiteral(tgt))),Some(Variable(target)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
-          |source >> target
-          |// (With(false,ReturnItems(false,Vector(AliasedReturnItem(Variable(a),Variable(a)))),GraphReturnItems(false,List(ReturnedGraph(GraphAs(Variable(source),Some(Variable(source)),false)))),None,None,None,None),line 2, column 1 (offset: 59))
-          |source >> source
-          |// (Return(false,ReturnItems(false,List(AliasedReturnItem(Variable(a),Variable(a)))),None,None,None,None,Set()),line 3, column 1 (offset: 79))
-          |--
-          |// End
-        """
-      verify(result.formattedScopes) shouldEqualFixNewlines
-        """{
-          |  {
-          |  }
-          |  { /* source >> target */
-          |    a: 10 64
-          |    GRAPH source: 18 72
-          |    GRAPH target: 43
-          |  }
-          |  { /* source >> source */
-          |    a: 10 64 65 86
-          |    GRAPH source: 72
-          |  }
-          |  {
-          |    a: 10 64 65 86 87
-          |  }
-          |}"""
+        result.errors shouldBe empty
+        result.formattedContexts shouldEqualFixNewlines
+          """// Start
+            |--
+            |// (With(false,ReturnItems(false,Vector(AliasedReturnItem(SignedDecimalIntegerLiteral(1),Variable(a)))),GraphReturnItems(false,List(NewContextGraphs(GraphAtAs(GraphUrl(Right(StringLiteral(src))),Some(Variable(source)),false),Some(GraphAtAs(GraphUrl(Right(StringLiteral(tgt))),Some(Variable(target)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
+            |source >> target
+            |// (With(false,ReturnItems(false,Vector(AliasedReturnItem(Variable(a),Variable(a)))),GraphReturnItems(false,List(ReturnedGraph(GraphAs(Variable(source),Some(Variable(source)),false)))),None,None,None,None),line 2, column 1 (offset: 59))
+            |source >> source
+            |// (Return(false,ReturnItems(false,List(AliasedReturnItem(Variable(a),Variable(a)))),None,None,None,None,Set()),line 3, column 1 (offset: 79))
+            |--
+            |// End
+          """
+        result.formattedScopes shouldEqualFixNewlines
+          """{
+            |  {
+            |  }
+            |  { /* source >> target */
+            |    a: 10 64
+            |    GRAPH source: 18 72
+            |    GRAPH target: 43
+            |  }
+            |  { /* source >> source */
+            |    a: 10 64 65 86
+            |    GRAPH source: 72
+            |  }
+            |  {
+            |    a: 10 64 65 86 87
+            |  }
+            |}"""
     }
   }
 
@@ -248,43 +251,44 @@ class MultipleGraphClauseSemanticCheckingTest
         |WITH a
         |MATCH (c)
         |RETURN a, c""".stripMargin) shouldVerify { result: SemanticCheckResult =>
-      result.errors shouldBe empty
-      verify(result.formattedContexts) shouldEqualFixNewlines
-        """// Start
-          |--
-          |// (With(false,ReturnItems(false,Vector(AliasedReturnItem(SignedDecimalIntegerLiteral(1),Variable(a)))),GraphReturnItems(false,List(NewContextGraphs(GraphAtAs(GraphUrl(Right(StringLiteral(src))),Some(Variable(source)),false),Some(GraphAtAs(GraphUrl(Right(StringLiteral(tgt))),Some(Variable(target)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
-          |source >> target
-          |// (Match(false,Pattern(List(EveryPath(NodePattern(Some(Variable(b)),List(),None)))),List(),None),line 2, column 1 (offset: 59))
-          |source >> target
-          |// (With(false,ReturnItems(false,Vector(AliasedReturnItem(Variable(a),Variable(a)))),GraphReturnItems(true,List()),None,None,None,None),line 3, column 1 (offset: 69))
-          |source >> target
-          |// (Match(false,Pattern(List(EveryPath(NodePattern(Some(Variable(c)),List(),None)))),List(),None),line 4, column 1 (offset: 76))
-          |source >> target
-          |// (Return(false,ReturnItems(false,List(AliasedReturnItem(Variable(a),Variable(a)), AliasedReturnItem(Variable(c),Variable(c)))),None,None,None,None,Set()),line 5, column 1 (offset: 86))
-          |--
-          |// End
-        """
-      verify(result.formattedScopes) shouldEqualFixNewlines
-        """{
-          |  {
-          |  }
-          |  { /* source >> target */
-          |    a: 10 74
-          |    b: 66
-          |    GRAPH source: 18
-          |    GRAPH target: 43
-          |  }
-          |  { /* source >> target */
-          |    a: 10 74 75 93
-          |    c: 83 96
-          |    GRAPH source: 18
-          |    GRAPH target: 43
-          |  }
-          |  {
-          |    a: 10 74 75 93 94
-          |    c: 83 96 97
-          |  }
-          |}"""
+        result.errors shouldBe empty
+        result.formattedContexts shouldEqualFixNewlines
+          """
+            |// Start
+            |--
+            |// (With(false,ReturnItems(false,Vector(AliasedReturnItem(SignedDecimalIntegerLiteral(1),Variable(a)))),GraphReturnItems(false,List(NewContextGraphs(GraphAtAs(GraphUrl(Right(StringLiteral(src))),Some(Variable(source)),false),Some(GraphAtAs(GraphUrl(Right(StringLiteral(tgt))),Some(Variable(target)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
+            |source >> target
+            |// (Match(false,Pattern(List(EveryPath(NodePattern(Some(Variable(b)),List(),None)))),List(),None),line 2, column 1 (offset: 59))
+            |source >> target
+            |// (With(false,ReturnItems(false,Vector(AliasedReturnItem(Variable(a),Variable(a)))),GraphReturnItems(true,List()),None,None,None,None),line 3, column 1 (offset: 69))
+            |source >> target
+            |// (Match(false,Pattern(List(EveryPath(NodePattern(Some(Variable(c)),List(),None)))),List(),None),line 4, column 1 (offset: 76))
+            |source >> target
+            |// (Return(false,ReturnItems(false,List(AliasedReturnItem(Variable(a),Variable(a)), AliasedReturnItem(Variable(c),Variable(c)))),None,None,None,None,Set()),line 5, column 1 (offset: 86))
+            |--
+            |// End
+          """
+        result.formattedScopes shouldEqualFixNewlines
+          """{
+            |  {
+            |  }
+            |  { /* source >> target */
+            |    a: 10 74
+            |    b: 66
+            |    GRAPH source: 18
+            |    GRAPH target: 43
+            |  }
+            |  { /* source >> target */
+            |    a: 10 74 75 93
+            |    c: 83 96
+            |    GRAPH source: 18
+            |    GRAPH target: 43
+            |  }
+            |  {
+            |    a: 10 74 75 93 94
+            |    c: 83 96 97
+            |  }
+            |}"""
     }
   }
 
@@ -294,43 +298,42 @@ class MultipleGraphClauseSemanticCheckingTest
         |FROM GRAPH new AT 'new'
         |MATCH (b)
         |RETURN a GRAPHS *""".stripMargin) shouldVerify { result: SemanticCheckResult =>
-      result.errors shouldBe empty
-      verify(result.formattedContexts) shouldEqualFixNewlines
-        """// Start
-          |--
-          |// (With(false,ReturnItems(false,Vector(AliasedReturnItem(SignedDecimalIntegerLiteral(1),Variable(a)))),GraphReturnItems(false,List(NewContextGraphs(GraphAtAs(GraphUrl(Right(StringLiteral(src))),Some(Variable(source)),false),Some(GraphAtAs(GraphUrl(Right(StringLiteral(tgt))),Some(Variable(target)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
-          |source >> target
-          |// (With(false,ReturnItems(true,Vector()),GraphReturnItems(true,List(NewContextGraphs(GraphAtAs(GraphUrl(Right(StringLiteral(new))),Some(Variable(new)),false),None))),None,None,None,None),line 2, column 6 (offset: 64))
-          |new >> new
-          |// (Match(false,Pattern(List(EveryPath(NodePattern(Some(Variable(b)),List(),None)))),List(),None),line 3, column 1 (offset: 83))
-          |new >> new
-          |// (Return(false,ReturnItems(false,List(AliasedReturnItem(Variable(a),Variable(a)))),Some(GraphReturnItems(true,List())),None,None,None,Set()),line 4, column 1 (offset: 93))
-          |--
-          |// End
-        """
-      verify(result.formattedScopes) shouldEqualFixNewlines
-        """{
-          |  {
-          |  }
-          |  { /* source >> target */
-          |    a: 10
-          |    GRAPH source: 18
-          |    GRAPH target: 43
-          |  }
-          |  { /* new >> new */
-          |    a: 10 100
-          |    b: 90
-          |    GRAPH new: 70
-          |    GRAPH source: 18
-          |    GRAPH target: 43
-          |  }
-          |  {
-          |    a: 10 100 101
-          |    GRAPH new: 70
-          |    GRAPH source: 18
-          |    GRAPH target: 43
-          |  }
-          |}"""
+      result.formattedContexts shouldEqualFixNewlines
+          """// Start
+            |--
+            |// (With(false,ReturnItems(false,Vector(AliasedReturnItem(SignedDecimalIntegerLiteral(1),Variable(a)))),GraphReturnItems(false,List(NewContextGraphs(GraphAtAs(GraphUrl(Right(StringLiteral(src))),Some(Variable(source)),false),Some(GraphAtAs(GraphUrl(Right(StringLiteral(tgt))),Some(Variable(target)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
+            |source >> target
+            |// (With(false,ReturnItems(true,Vector()),GraphReturnItems(true,List(NewContextGraphs(GraphAtAs(GraphUrl(Right(StringLiteral(new))),Some(Variable(new)),false),None))),None,None,None,None),line 2, column 6 (offset: 64))
+            |new >> new
+            |// (Match(false,Pattern(List(EveryPath(NodePattern(Some(Variable(b)),List(),None)))),List(),None),line 3, column 1 (offset: 83))
+            |new >> new
+            |// (Return(false,ReturnItems(false,List(AliasedReturnItem(Variable(a),Variable(a)))),Some(GraphReturnItems(true,List())),None,None,None,Set()),line 4, column 1 (offset: 93))
+            |--
+            |// End
+          """
+        result.formattedScopes shouldEqualFixNewlines
+          """{
+            |  {
+            |  }
+            |  { /* source >> target */
+            |    a: 10
+            |    GRAPH source: 18
+            |    GRAPH target: 43
+            |  }
+            |  { /* new >> new */
+            |    a: 10 100
+            |    b: 90
+            |    GRAPH new: 70
+            |    GRAPH source: 18
+            |    GRAPH target: 43
+            |  }
+            |  {
+            |    a: 10 100 101
+            |    GRAPH new: 70
+            |    GRAPH source: 18
+            |    GRAPH target: 43
+            |  }
+            |}"""
     }
   }
 
@@ -339,37 +342,37 @@ class MultipleGraphClauseSemanticCheckingTest
       """WITH 1 AS a GRAPH source AT 'src' >> GRAPH target AT 'tgt'
         |INTO GRAPH new AT 'new'
         |RETURN a""".stripMargin) shouldVerify { result: SemanticCheckResult =>
-      result.errors shouldBe empty
-      verify(result.formattedContexts) shouldEqualFixNewlines
-        """// Start
-          |--
-          |// (With(false,ReturnItems(false,Vector(AliasedReturnItem(SignedDecimalIntegerLiteral(1),Variable(a)))),GraphReturnItems(false,List(NewContextGraphs(GraphAtAs(GraphUrl(Right(StringLiteral(src))),Some(Variable(source)),false),Some(GraphAtAs(GraphUrl(Right(StringLiteral(tgt))),Some(Variable(target)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
-          |source >> target
-          |// (With(false,ReturnItems(true,Vector()),GraphReturnItems(true,List(NewTargetGraph(GraphAtAs(GraphUrl(Right(StringLiteral(new))),Some(Variable(new)),false)))),None,None,None,None),line 2, column 6 (offset: 64))
-          |source >> new
-          |// (Return(false,ReturnItems(false,List(AliasedReturnItem(Variable(a),Variable(a)))),None,None,None,None,Set()),line 3, column 1 (offset: 83))
-          |--
-          |// End
-        """
-      verify(result.formattedScopes) shouldEqualFixNewlines
-        """{
-          |  {
-          |  }
-          |  { /* source >> target */
-          |    a: 10
-          |    GRAPH source: 18
-          |    GRAPH target: 43
-          |  }
-          |  { /* source >> new */
-          |    a: 10 90
-          |    GRAPH new: 70
-          |    GRAPH source: 18
-          |    GRAPH target: 43
-          |  }
-          |  {
-          |    a: 10 90 91
-          |  }
-          |}"""
+
+        result.formattedContexts shouldEqualFixNewlines
+          """// Start
+            |--
+            |// (With(false,ReturnItems(false,Vector(AliasedReturnItem(SignedDecimalIntegerLiteral(1),Variable(a)))),GraphReturnItems(false,List(NewContextGraphs(GraphAtAs(GraphUrl(Right(StringLiteral(src))),Some(Variable(source)),false),Some(GraphAtAs(GraphUrl(Right(StringLiteral(tgt))),Some(Variable(target)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
+            |source >> target
+            |// (With(false,ReturnItems(true,Vector()),GraphReturnItems(true,List(NewTargetGraph(GraphAtAs(GraphUrl(Right(StringLiteral(new))),Some(Variable(new)),false)))),None,None,None,None),line 2, column 6 (offset: 64))
+            |source >> new
+            |// (Return(false,ReturnItems(false,List(AliasedReturnItem(Variable(a),Variable(a)))),None,None,None,None,Set()),line 3, column 1 (offset: 83))
+            |--
+            |// End
+          """
+        result.formattedScopes shouldEqualFixNewlines
+          """{
+            |  {
+            |  }
+            |  { /* source >> target */
+            |    a: 10
+            |    GRAPH source: 18
+            |    GRAPH target: 43
+            |  }
+            |  { /* source >> new */
+            |    a: 10 90
+            |    GRAPH new: 70
+            |    GRAPH source: 18
+            |    GRAPH target: 43
+            |  }
+            |  {
+            |    a: 10 90 91
+            |  }
+            |}"""
     }
   }
 
@@ -386,8 +389,9 @@ class MultipleGraphClauseSemanticCheckingTest
     parsing(
       """WITH GRAPHS foo >> bar
         |RETURN 1""".stripMargin) shouldVerify { result: SemanticCheckResult =>
+
       result.errors shouldBe empty
-      verify(result.formattedContexts) shouldEqualFixNewlines
+      result.formattedContexts shouldEqualFixNewlines
         """// Start
           |--
           |// (With(false,DiscardCardinality(),GraphReturnItems(false,List(NewContextGraphs(GraphAs(Variable(foo),Some(Variable(foo)),false),Some(GraphAs(Variable(bar),Some(Variable(bar)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
@@ -395,7 +399,7 @@ class MultipleGraphClauseSemanticCheckingTest
           |// (Return(false,ReturnItems(false,List(AliasedReturnItem(SignedDecimalIntegerLiteral(1),Variable(1)))),None,None,None,None,Set()),line 2, column 1 (offset: 23))
           |--
           |// End"""
-      verify(result.formattedScopes) shouldEqualFixNewlines
+      result.formattedScopes shouldEqualFixNewlines
         """{
           |  {
           |    GRAPH bar: 19
@@ -435,7 +439,7 @@ class MultipleGraphClauseSemanticCheckingTest
         |DELETE (a)
         |RETURN GRAPHS *""".stripMargin) shouldVerify { result: SemanticCheckResult =>
       result.errors shouldBe empty
-      verify(result.formattedContexts) shouldEqualFixNewlines
+      result.formattedContexts shouldEqualFixNewlines
         """// Start
           |--
           |// (With(false,DiscardCardinality(),GraphReturnItems(false,List(NewContextGraphs(GraphAs(Variable(foo),Some(Variable(foo)),false),Some(GraphAs(Variable(bar),Some(Variable(bar)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
@@ -445,7 +449,7 @@ class MultipleGraphClauseSemanticCheckingTest
           |// (Return(false,DiscardCardinality(),Some(GraphReturnItems(true,List())),None,None,None,Set()),line 7, column 1 (offset: 98))
           |--
           |// End"""
-      verify(result.formattedScopes) shouldEqualFixNewlines
+      result.formattedScopes shouldEqualFixNewlines
         """{
           |  {
           |    GRAPH bar: 19
@@ -513,7 +517,7 @@ class MultipleGraphClauseSemanticCheckingTest
         |MATCH (b)
         |RETURN * GRAPHS *""".stripMargin) shouldVerify { result: SemanticCheckResult =>
       result.errors shouldBe empty
-      verify(result.formattedContexts) shouldEqualFixNewlines
+      result.formattedContexts shouldEqualFixNewlines
         """// Start
           |--
           |// (With(false,DiscardCardinality(),GraphReturnItems(false,List(NewContextGraphs(GraphAs(Variable(foo),Some(Variable(foo)),false),Some(GraphAs(Variable(bar),Some(Variable(bar)),false))), ReturnedGraph(GraphAs(Variable(baz),Some(Variable(baz)),false)))),None,None,None,None),line 1, column 1 (offset: 0))
@@ -527,7 +531,7 @@ class MultipleGraphClauseSemanticCheckingTest
           |// (Return(false,ReturnItems(true,List()),Some(GraphReturnItems(true,List())),None,None,None,Set()),line 5, column 1 (offset: 82))
           |--
           |// End"""
-      verify(result.formattedScopes) shouldEqualFixNewlines
+      result.formattedScopes shouldEqualFixNewlines
         """{
           |  {
           |    GRAPH bar: 19
@@ -605,7 +609,7 @@ class MultipleGraphClauseSemanticCheckingTest
         |MATCH (b)
         |RETURN * GRAPHS *""".stripMargin) shouldVerify { result: SemanticCheckResult =>
       result.errors shouldBe empty
-      verify(result.formattedContexts) shouldEqualFixNewlines
+      result.formattedContexts shouldEqualFixNewlines
         """// Start
           |--
           |// (With(false,DiscardCardinality(),GraphReturnItems(false,List(NewContextGraphs(GraphAs(Variable(foo),Some(Variable(foo)),false),Some(GraphAs(Variable(bar),Some(Variable(bar)),false))), ReturnedGraph(GraphAs(Variable(baz),Some(Variable(baz)),false)))),None,None,None,None),line 1, column 1 (offset: 0))
@@ -619,7 +623,7 @@ class MultipleGraphClauseSemanticCheckingTest
           |// (Return(false,ReturnItems(true,List()),Some(GraphReturnItems(true,List())),None,None,None,Set()),line 5, column 1 (offset: 93))
           |--
           |// End"""
-      verify(result.formattedScopes) shouldEqualFixNewlines
+      result.formattedScopes shouldEqualFixNewlines
         """{
           |  {
           |    GRAPH bar: 19
@@ -656,7 +660,7 @@ class MultipleGraphClauseSemanticCheckingTest
         |MATCH (b)
         |RETURN * GRAPHS *""".stripMargin) shouldVerify { result: SemanticCheckResult =>
       result.errors shouldBe empty
-      verify(result.formattedContexts) shouldEqualFixNewlines
+      result.formattedContexts shouldEqualFixNewlines
         """// Start
           |--
           |// (With(false,DiscardCardinality(),GraphReturnItems(false,List(NewContextGraphs(GraphAs(Variable(foo),Some(Variable(foo)),false),Some(GraphAs(Variable(bar),Some(Variable(bar)),false))), ReturnedGraph(GraphAs(Variable(baz),Some(Variable(baz)),false)))),None,None,None,None),line 1, column 1 (offset: 0))
@@ -670,7 +674,7 @@ class MultipleGraphClauseSemanticCheckingTest
           |// (Return(false,ReturnItems(true,List()),Some(GraphReturnItems(true,List())),None,None,None,Set()),line 5, column 1 (offset: 92))
           |--
           |// End"""
-      verify(result.formattedScopes) shouldEqualFixNewlines
+      result.formattedScopes shouldEqualFixNewlines
         """{
           |  {
           |    GRAPH bar: 19
@@ -706,7 +710,7 @@ class MultipleGraphClauseSemanticCheckingTest
         |MATCH (b)
         |RETURN * GRAPHS *""".stripMargin) shouldVerify { result: SemanticCheckResult =>
       result.errors shouldBe empty
-      verify(result.formattedContexts) shouldEqualFixNewlines
+      result.formattedContexts shouldEqualFixNewlines
         """// Start
           |--
           |// (With(false,DiscardCardinality(),GraphReturnItems(false,List(NewContextGraphs(GraphAtAs(GraphUrl(Right(StringLiteral(url))),Some(Variable(  FRESHID21)),true),Some(GraphAs(Variable(bar),Some(Variable(bar)),false))), ReturnedGraph(GraphAs(Variable(baz),Some(Variable(baz)),false)))),None,None,None,None),line 1, column 1 (offset: 0))
@@ -718,7 +722,7 @@ class MultipleGraphClauseSemanticCheckingTest
           |// (Return(false,ReturnItems(true,List()),Some(GraphReturnItems(true,List())),None,None,None,Set()),line 4, column 1 (offset: 58))
           |--
           |// End"""
-      verify(result.formattedScopes) shouldEqualFixNewlines
+      result.formattedScopes shouldEqualFixNewlines
         """{
           |  {
           |    GRAPH bar: 23
@@ -753,7 +757,7 @@ class MultipleGraphClauseSemanticCheckingTest
         |RETURN a.name GRAPHS *
         |""".stripMargin) shouldVerify { result: SemanticCheckResult =>
       result.errors shouldBe empty
-      verify(result.formattedContexts) shouldEqualFixNewlines
+      result.formattedContexts shouldEqualFixNewlines
         """// Start
           |--
           |// (With(false,DiscardCardinality(),GraphReturnItems(false,List(NewContextGraphs(GraphAtAs(GraphUrl(Right(StringLiteral(url))),Some(Variable(bar)),false),Some(GraphAtAs(GraphUrl(Right(StringLiteral(url2))),Some(Variable(foo)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
@@ -769,7 +773,7 @@ class MultipleGraphClauseSemanticCheckingTest
           |// (Return(false,ReturnItems(false,List(AliasedReturnItem(Property(Variable(a),PropertyKeyName(name)),Variable(a.name)))),Some(GraphReturnItems(true,List())),None,None,None,Set()),line 7, column 1 (offset: 159))
           |--
           |// End"""
-      verify(result.formattedScopes) shouldEqualFixNewlines
+      result.formattedScopes shouldEqualFixNewlines
         """{
           |  {
           |    {
@@ -815,7 +819,7 @@ class MultipleGraphClauseSemanticCheckingTest
         |""".stripMargin) shouldVerify { result: SemanticCheckResult =>
 
       result.errors shouldBe empty
-      verify(result.formattedContexts) shouldEqualFixNewlines
+      result.formattedContexts shouldEqualFixNewlines
         """// Start
           |--
           |// (With(false,DiscardCardinality(),GraphReturnItems(false,List(NewContextGraphs(GraphAtAs(GraphUrl(Right(StringLiteral(url))),Some(Variable(bar)),false),Some(GraphAtAs(GraphUrl(Right(StringLiteral(url2))),Some(Variable(foo)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
@@ -831,7 +835,7 @@ class MultipleGraphClauseSemanticCheckingTest
           |// (Return(false,ReturnItems(false,List(AliasedReturnItem(Property(Variable(a),PropertyKeyName(name)),Variable(a.name)))),Some(GraphReturnItems(true,List())),None,None,None,Set()),line 7, column 1 (offset: 155))
           |--
           |// End"""
-      verify(result.formattedScopes) shouldEqualFixNewlines
+      result.formattedScopes shouldEqualFixNewlines
         """{
           |  {
           |    {

--- a/community/cypher/frontend-3.3/src/test/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/MultipleGraphClauseSemanticCheckingTest.scala
+++ b/community/cypher/frontend-3.3/src/test/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/MultipleGraphClauseSemanticCheckingTest.scala
@@ -958,11 +958,11 @@ class MultipleGraphClauseSemanticCheckingTest
       result.formattedContexts shouldEqualFixNewlines
         """// Start
           |--
-          |// With(false,DiscardCardinality(),GraphReturnItems(false,List(NewContextGraphs(GraphAs(Variable(foo),Some(Variable(foo))),Some(GraphAs(Variable(bar),Some(Variable(bar))))))),None,None,None,None)
+          |// (With(false,DiscardCardinality(),GraphReturnItems(false,List(NewContextGraphs(GraphAs(Variable(foo),Some(Variable(foo)),false),Some(GraphAs(Variable(bar),Some(Variable(bar)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
           |foo >> bar
-          |// Persist(false,GraphAs(Variable(foo),Some(Variable(foo))),GraphUrl(Right(StringLiteral(url))))
+          |// (Persist(GraphAs(Variable(foo),Some(Variable(foo)),false),GraphUrl(Right(StringLiteral(url)))),line 2, column 22 (offset: 44))
           |foo >> bar
-          |// Return(false,DiscardCardinality(),Some(GraphReturnItems(false,List(ReturnedGraph(GraphAs(Variable(bar),Some(Variable(bar))))))),None,None,None,Set())
+          |// (Return(false,DiscardCardinality(),Some(GraphReturnItems(false,List(ReturnedGraph(GraphAs(Variable(bar),Some(Variable(bar)),false))))),None,None,None,Set()),line 3, column 1 (offset: 50))
           |--
           |// End"""
       result.formattedScopes shouldEqualFixNewlines
@@ -985,18 +985,18 @@ class MultipleGraphClauseSemanticCheckingTest
   test("relocate graph") {
     parsing(
       """WITH GRAPHS foo >> bar
-        |RELOCATE SNAPSHOT GRAPH foo TO 'url'
+        |RELOCATE GRAPH foo TO 'url'
         |RETURN GRAPHS bar
       """.stripMargin) shouldVerify { result: SemanticCheckResult =>
 
       result.formattedContexts shouldEqualFixNewlines
         """// Start
           |--
-          |// With(false,DiscardCardinality(),GraphReturnItems(false,List(NewContextGraphs(GraphAs(Variable(foo),Some(Variable(foo))),Some(GraphAs(Variable(bar),Some(Variable(bar))))))),None,None,None,None)
+          |// (With(false,DiscardCardinality(),GraphReturnItems(false,List(NewContextGraphs(GraphAs(Variable(foo),Some(Variable(foo)),false),Some(GraphAs(Variable(bar),Some(Variable(bar)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
           |foo >> bar
-          |// Relocate(true,GraphAs(Variable(foo),Some(Variable(foo))),GraphUrl(Right(StringLiteral(url))))
+          |// (Relocate(GraphAs(Variable(foo),Some(Variable(foo)),false),GraphUrl(Right(StringLiteral(url)))),line 2, column 23 (offset: 45))
           |foo >> bar
-          |// Return(false,DiscardCardinality(),Some(GraphReturnItems(false,List(ReturnedGraph(GraphAs(Variable(bar),Some(Variable(bar))))))),None,None,None,Set())
+          |// (Return(false,DiscardCardinality(),Some(GraphReturnItems(false,List(ReturnedGraph(GraphAs(Variable(bar),Some(Variable(bar)),false))))),None,None,None,Set()),line 3, column 1 (offset: 51))
           |--
           |// End"""
       result.formattedScopes shouldEqualFixNewlines
@@ -1006,11 +1006,11 @@ class MultipleGraphClauseSemanticCheckingTest
           |    GRAPH foo: 12
           |  }
           |  { /* foo >> bar */
-          |    GRAPH bar: 19 74
-          |    GRAPH foo: 12 47
+          |    GRAPH bar: 19 65
+          |    GRAPH foo: 12 38
           |  }
           |  {
-          |    GRAPH bar: 74
+          |    GRAPH bar: 65
           |  }
           |}"""
     }
@@ -1026,11 +1026,11 @@ class MultipleGraphClauseSemanticCheckingTest
       result.formattedContexts shouldEqualFixNewlines
         """// Start
           |--
-          |// With(false,DiscardCardinality(),GraphReturnItems(false,List(NewContextGraphs(GraphAs(Variable(foo),Some(Variable(foo))),Some(GraphAs(Variable(bar),Some(Variable(bar))))))),None,None,None,None)
+          |// (With(false,DiscardCardinality(),GraphReturnItems(false,List(NewContextGraphs(GraphAs(Variable(foo),Some(Variable(foo)),false),Some(GraphAs(Variable(bar),Some(Variable(bar)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
           |foo >> bar
-          |// DeleteGraphs(List(Variable(foo), Variable(bar)))
+          |// (DeleteGraphs(List(Variable(foo), Variable(bar))),line 2, column 15 (offset: 37))
           |foo >> bar
-          |// Return(false,ReturnItems(false,List(AliasedReturnItem(SignedDecimalIntegerLiteral(1),Variable(1)))),None,None,None,None,Set())
+          |// (Return(false,ReturnItems(false,List(AliasedReturnItem(SignedDecimalIntegerLiteral(1),Variable(1)))),None,None,None,None,Set()),line 3, column 1 (offset: 46))
           |--
           |// End"""
       result.formattedScopes shouldEqualFixNewlines
@@ -1045,6 +1045,40 @@ class MultipleGraphClauseSemanticCheckingTest
           |  }
           |  {
           |    1: 54
+          |  }
+          |}"""
+    }
+  }
+
+  test("snapshot graph") {
+    parsing(
+      """WITH GRAPHS foo >> bar
+        |SNAPSHOT GRAPH foo TO 'url'
+        |RETURN 1
+      """.stripMargin) shouldVerify { result: SemanticCheckResult =>
+
+      result.formattedContexts shouldEqualFixNewlines
+        """// Start
+          |--
+          |// (With(false,DiscardCardinality(),GraphReturnItems(false,List(NewContextGraphs(GraphAs(Variable(foo),Some(Variable(foo)),false),Some(GraphAs(Variable(bar),Some(Variable(bar)),false))))),None,None,None,None),line 1, column 1 (offset: 0))
+          |foo >> bar
+          |// (Snapshot(GraphAs(Variable(foo),Some(Variable(foo)),false),GraphUrl(Right(StringLiteral(url)))),line 2, column 23 (offset: 45))
+          |foo >> bar
+          |// (Return(false,ReturnItems(false,List(AliasedReturnItem(SignedDecimalIntegerLiteral(1),Variable(1)))),None,None,None,None,Set()),line 3, column 1 (offset: 51))
+          |--
+          |// End"""
+      result.formattedScopes shouldEqualFixNewlines
+        """{
+          |  {
+          |    GRAPH bar: 19
+          |    GRAPH foo: 12
+          |  }
+          |  { /* foo >> bar */
+          |    GRAPH bar: 19
+          |    GRAPH foo: 12 38
+          |  }
+          |  {
+          |    1: 59
           |  }
           |}"""
     }

--- a/community/cypher/frontend-3.3/src/test/scala/org/neo4j/cypher/internal/frontend/v3_3/parser/ParserTest.scala
+++ b/community/cypher/frontend-3.3/src/test/scala/org/neo4j/cypher/internal/frontend/v3_3/parser/ParserTest.scala
@@ -60,7 +60,7 @@ trait ParserTest[T, J] extends CypherFunSuite {
   def assertFails(s: String)(implicit p: Rule1[T]) {
     parseRule(p ~ EOI, s).result match {
       case None    =>
-      case Some(a) => fail(s"'$s' should not have been parsed correctly, parsed as $a")
+      case Some(thing) => fail(s"'$s' should not have been parsed correctly, parsed as $thing")
     }
   }
 


### PR DESCRIPTION
- `CREATE` and `>>` operator
- `PERSIST`, `RELOCATE`, `DELETE GRAPHS`, `SNAPSHOT`

`DELETE GRAPHS` keeps the deleted graph variables in scope -- we might want to change this.