### PR TITLE
Show runtime in plan description

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/procs/ProcedureCallExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/procs/ProcedureCallExecutionPlan.scala
@@ -27,7 +27,7 @@ import org.neo4j.cypher.internal.compatibility.v3_3.runtime.commands.expressions
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.executionplan.{ExecutionPlan, ProcedureCallMode}
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.helpers.Counter
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes.{ExternalCSVResource, QueryState}
-import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.InternalPlanDescription.Arguments.{DbHits, Rows, Signature}
+import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.InternalPlanDescription.Arguments._
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.{Id, NoChildren, PlanDescriptionImpl}
 import org.neo4j.cypher.internal.compiler.v3_3.ProcedurePlannerName
 import org.neo4j.cypher.internal.compiler.v3_3.spi.{GraphStatistics, PlanContext, ProcedureSignature}
@@ -112,15 +112,19 @@ case class ProcedureCallExecutionPlan(signature: ProcedureSignature,
       argExprCommands.map(expr => ctx.asObject(expr.apply(ExecutionContext.empty)(state)))
     }
 
-    private def createNormalPlan =
-      PlanDescriptionImpl(new Id, "ProcedureCall", NoChildren,
-        Seq(createSignatureArgument),
-        resultSymbols.map(_._1).toSet
-      )
+  private def createNormalPlan =
+    PlanDescriptionImpl(new Id, "ProcedureCall", NoChildren,
+                        Seq(createSignatureArgument,
+                            Runtime(ProcedureRuntimeName.toTextOutput),
+                            RuntimeImpl(ProcedureRuntimeName.name)),
+                        resultSymbols.map(_._1).toSet
+    )
 
     private def createProfilePlanGenerator(rowCounter: Counter) = () =>
       PlanDescriptionImpl(new Id, "ProcedureCall", NoChildren,
-        Seq(createSignatureArgument, DbHits(1), Rows(rowCounter.counted)),
+        Seq(createSignatureArgument, DbHits(1), Rows(rowCounter.counted),
+            Runtime(ProcedureRuntimeName.toTextOutput),
+            RuntimeImpl(ProcedureRuntimeName.name)),
         resultSymbols.map(_._1).toSet
       )
 

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/compiled/codegen/CodeGenerator.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/compiled/codegen/CodeGenerator.scala
@@ -28,8 +28,9 @@ import org.neo4j.cypher.internal.compatibility.v3_3.runtime.compiled.codegen.ir.
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.compiled.codegen.spi.{CodeStructure, CodeStructureResult}
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.compiled.{CompiledExecutionResult, CompiledPlan, RunnablePlan}
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.executionplan.{PlanFingerprint, Provider}
+import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.InternalPlanDescription.Arguments.{Runtime, RuntimeImpl}
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.{Id, InternalPlanDescription, LogicalPlan2PlanDescription, LogicalPlanIdentificationBuilder}
-import org.neo4j.cypher.internal.compatibility.v3_3.runtime.{ExecutionMode, TaskCloser}
+import org.neo4j.cypher.internal.compatibility.v3_3.runtime.{CompiledRuntimeName, ExecutionMode, TaskCloser}
 import org.neo4j.cypher.internal.compiler.v3_3.planner.CantCompileQueryException
 import org.neo4j.cypher.internal.compiler.v3_3.planner.logical.plans.{LogicalPlan, ProduceResult}
 import org.neo4j.cypher.internal.compiler.v3_3.spi.{InstrumentedGraphStatistics, PlanContext}
@@ -69,7 +70,8 @@ class CodeGenerator(val structure: CodeStructure[GeneratedQuery], clock: Clock, 
         val descriptionTree = LogicalPlan2PlanDescription(plan, idMap, plannerName)
         val description: InternalPlanDescription = query.code.foldLeft(descriptionTree) {
           case (descriptionRoot, code) => descriptionRoot.addArgument(code)
-        }
+        }.addArgument(Runtime(CompiledRuntimeName.toTextOutput))
+          .addArgument(RuntimeImpl(CompiledRuntimeName.name))
 
         val builder = new RunnablePlan {
           def apply(queryContext: QueryContext, execMode: ExecutionMode,

--- a/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionResultTest.java
+++ b/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionResultTest.java
@@ -206,6 +206,20 @@ public class ExecutionResultTest
         assertThat( arguments.get( "runtime-impl" ), equalTo( "INTERPRETED" ) );
     }
 
+    @Test
+    public void shouldShowProcedureRuntimeInExecutionPlan()
+    {
+        // Given
+        Result result = db.execute( "EXPLAIN CALL db.labels" );
+
+        // When
+        Map<String,Object> arguments = result.getExecutionPlanDescription().getArguments();
+
+        // Then
+        assertThat( arguments.get( "runtime" ), equalTo( "PROCEDURE" ) );
+        assertThat( arguments.get( "runtime-impl" ), equalTo( "PROCEDURE" ) );
+    }
+
     private void createNode()
     {
         try ( Transaction tx = db.beginTx() )

--- a/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionResultTest.java
+++ b/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionResultTest.java
@@ -164,6 +164,48 @@ public class ExecutionResultTest
         Assert.assertThat( drop.getQueryStatistics().getConstraintsRemoved(), equalTo( 1 ) );
     }
 
+    @Test
+    public void shouldShowRuntimeInExecutionPlanDescription()
+    {
+        // Given
+        Result result = db.execute( "EXPLAIN MATCH (n) RETURN n.prop" );
+
+        // When
+        Map<String,Object> arguments = result.getExecutionPlanDescription().getArguments();
+
+        // Then
+        assertThat( arguments.get( "runtime" ), notNullValue() );
+        assertThat( arguments.get( "runtime-impl" ), notNullValue() );
+    }
+
+    @Test
+    public void shouldShowCompiledRuntimeInExecutionPlan()
+    {
+        // Given
+        Result result = db.execute( "EXPLAIN CYPHER runtime=compiled MATCH (n) RETURN n.prop" );
+
+        // When
+        Map<String,Object> arguments = result.getExecutionPlanDescription().getArguments();
+
+        // Then
+        assertThat( arguments.get( "runtime" ), equalTo( "COMPILED" ) );
+        assertThat( arguments.get( "runtime-impl" ), equalTo( "COMPILED" ) );
+    }
+
+    @Test
+    public void shouldShowInterpretedRuntimeInExecutionPlan()
+    {
+        // Given
+        Result result = db.execute( "EXPLAIN CYPHER runtime=interpreted MATCH (n) RETURN n.prop" );
+
+        // When
+        Map<String,Object> arguments = result.getExecutionPlanDescription().getArguments();
+
+        // Then
+        assertThat( arguments.get( "runtime" ), equalTo( "INTERPRETED" ) );
+        assertThat( arguments.get( "runtime-impl" ), equalTo( "INTERPRETED" ) );
+    }
+
     private void createNode()
     {
         try ( Transaction tx = db.beginTx() )


### PR DESCRIPTION
When using the compiled and the procedure runtime the information
of what runtime that was used was not passed along to the executionPlanDescription.