### PR TITLE
Re-introduce Eager in slotted runtime

### DIFF
--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/plans/LogicalPlan.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/plans/LogicalPlan.scala
@@ -49,7 +49,6 @@ abstract class LogicalPlan
   def assignIds(): Unit = recurseAssignIds(new LogicalPlanId(0))
 
   private var _id: Option[LogicalPlanId] = None
-  protected def assignId(id: Option[LogicalPlanId]): Unit = _id = id
 
   protected def recurseAssignIds(sofar: LogicalPlanId): LogicalPlanId = {
     if(_id.nonEmpty)

--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/plans/SingleRow.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/plans/SingleRow.scala
@@ -27,9 +27,4 @@ case class SingleRow()(val solved: PlannerQuery with CardinalityEstimation)
   val argumentIds: Set[IdName] = Set.empty
 
   def availableSymbols = argumentIds
-
-  override def dup(children: Seq[AnyRef]) = {
-    assert(children.isEmpty)
-    SingleRow()(solved).asInstanceOf[this.type]
-  }
 }

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/plans/LogicalPlanAssignedIdTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/plans/LogicalPlanAssignedIdTest.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_3.planner.logical.plans
+
+import org.neo4j.cypher.internal.compiler.v3_3.planner.LogicalPlanningTestSupport2
+import org.neo4j.cypher.internal.frontend.v3_3.{Rewriter, topDown}
+import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.CypherFunSuite
+
+class LogicalPlanAssignedIdTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
+  test("assignedId survives rewriting") {
+    val sr1 = SingleRow()(solved)
+    val pr = Projection(sr1, Map.empty)(solved)
+    pr.assignIds()
+
+    val prPrim = pr.endoRewrite(topDown(Rewriter.lift {
+      case sr: SingleRow => SingleRow()(solved)
+    }))
+
+    pr.assignedId should equal(prPrim.assignedId)
+    pr.lhs.get.assignedId should equal(prPrim.lhs.get.assignedId)
+  }
+
+  test("assignedIds are different between plans") {
+    val sr1 = SingleRow()(solved)
+    val sr2 = SingleRow()(solved)
+    val apply = Apply(sr1, sr2)(solved)
+    apply.assignIds()
+
+    sr1.assignedId shouldNot equal(sr2.assignedId)
+  }
+
+  test("tree structure is assigned ids in a predictable way") {
+    /*
+         6
+      2     5
+    0  1   3 4
+     */
+    val sr1A = SingleRow()(solved)
+    val sr2A = SingleRow()(solved)
+    val applyA = Apply(sr1A, sr2A)(solved)
+    val sr1B = SingleRow()(solved)
+    val sr2B = SingleRow()(solved)
+    val applyB = Apply(sr1B, sr2B)(solved)
+    val applyAll = Apply(applyA, applyB)(solved) // I heard you guys like Apply, so we applied an Apply in your Apply
+
+    applyAll.assignIds()
+
+    sr1A.assignedId should equal(0)
+    sr2A.assignedId should equal(1)
+    applyA.assignedId should equal(2)
+    sr1B.assignedId should equal(3)
+    sr2B.assignedId should equal(4)
+    applyB.assignedId should equal(5)
+    applyAll.assignedId should equal(6)
+  }
+
+}

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/plans/LogicalPlanAssignedIdTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/plans/LogicalPlanAssignedIdTest.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v3_3.planner.logical.plans
 
 import org.neo4j.cypher.internal.compiler.v3_3.planner.LogicalPlanningTestSupport2
-import org.neo4j.cypher.internal.frontend.v3_3.{Rewriter, topDown}
+import org.neo4j.cypher.internal.frontend.v3_3.{CypherException, Rewriter, topDown}
 import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.CypherFunSuite
 
 class LogicalPlanAssignedIdTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
@@ -62,13 +62,20 @@ class LogicalPlanAssignedIdTest extends CypherFunSuite with LogicalPlanningTestS
 
     applyAll.assignIds()
 
-    sr1A.assignedId should equal(0)
-    sr2A.assignedId should equal(1)
-    applyA.assignedId should equal(2)
-    sr1B.assignedId should equal(3)
-    sr2B.assignedId should equal(4)
-    applyB.assignedId should equal(5)
-    applyAll.assignedId should equal(6)
+    sr1A.assignedId.underlying should equal(0)
+    sr2A.assignedId.underlying should equal(1)
+    applyA.assignedId.underlying should equal(2)
+    sr1B.assignedId.underlying should equal(3)
+    sr2B.assignedId.underlying should equal(4)
+    applyB.assignedId.underlying should equal(5)
+    applyAll.assignedId.underlying should equal(6)
+  }
+
+  test("cant assign ids twice") {
+    val sr1 = SingleRow()(solved)
+    val pr = Projection(sr1, Map.empty)(solved)
+    pr.assignIds()
+    intercept[CypherException](pr.assignIds())
   }
 
 }

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/plans/LogicalPlanAssignedIdTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/plans/LogicalPlanAssignedIdTest.scala
@@ -20,8 +20,8 @@
 package org.neo4j.cypher.internal.compiler.v3_3.planner.logical.plans
 
 import org.neo4j.cypher.internal.compiler.v3_3.planner.LogicalPlanningTestSupport2
-import org.neo4j.cypher.internal.frontend.v3_3.{CypherException, Rewriter, topDown}
 import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.frontend.v3_3.{CypherException, Rewriter, topDown}
 
 class LogicalPlanAssignedIdTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
   test("assignedId survives rewriting") {
@@ -48,9 +48,9 @@ class LogicalPlanAssignedIdTest extends CypherFunSuite with LogicalPlanningTestS
 
   test("tree structure is assigned ids in a predictable way") {
     /*
-         6
-      2     5
-    0  1   3 4
+                ApplyAll(6)
+        ApplyA(5)         ApplyB(2)
+    SR1A(4)  SR2A(3)   SR1B(1) SR2B(0)
      */
     val sr1A = SingleRow()(solved)
     val sr2A = SingleRow()(solved)
@@ -62,13 +62,13 @@ class LogicalPlanAssignedIdTest extends CypherFunSuite with LogicalPlanningTestS
 
     applyAll.assignIds()
 
-    sr1A.assignedId.underlying should equal(0)
-    sr2A.assignedId.underlying should equal(1)
-    applyA.assignedId.underlying should equal(2)
-    sr1B.assignedId.underlying should equal(3)
-    sr2B.assignedId.underlying should equal(4)
-    applyB.assignedId.underlying should equal(5)
     applyAll.assignedId.underlying should equal(6)
+    applyA.assignedId.underlying should equal(5)
+    sr1A.assignedId.underlying should equal(4)
+    sr2A.assignedId.underlying should equal(3)
+    applyB.assignedId.underlying should equal(2)
+    sr1B.assignedId.underlying should equal(1)
+    sr2B.assignedId.underlying should equal(0)
   }
 
   test("cant assign ids twice") {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
@@ -103,16 +103,52 @@ trait CypherComparisonSupport extends CypherTestSupport {
       config.scenarios.head
   }
 
+  protected def updateWith(expectedSuccessFrom: TestConfiguration, query: String, params: (String, Any)*): InternalExecutionResult =
+    updateWithAndExpectPlansToBeSimilar(expectedSuccessFrom, query, false, params: _*)
+
+  protected def updateWith(expectedSuccessFrom: TestConfiguration, ignoreScenarios: TestConfiguration, query: String, params: (String, Any)*): InternalExecutionResult =
+    updateWithAndExpectPlansToBeSimilar(expectedSuccessFrom, ignoreScenarios, query, false, params: _*)
+
+  protected def updateWithAndExpectPlansToBeSimilar(expectedSuccessFrom: TestConfiguration,
+                                                    query: String,
+                                                    params: (String, Any)*): InternalExecutionResult =
+    updateWithAndExpectPlansToBeSimilar(expectedSuccessFrom, query, true, params: _*)
+
   protected def updateWithAndExpectPlansToBeSimilar(expectedSuccessFrom: TestConfiguration,
                                                     query: String,
                                                     checkPlans: Boolean,
                                                     params: (String, Any)*): InternalExecutionResult = {
+    updateWithAndExpectPlansToBeSimilar(expectedSuccessFrom, Configs.Empty, query, checkPlans, params: _*)
+  }
+
+  protected def updateWithAndExpectPlansToBeSimilar(expectedSuccessFrom: TestConfiguration,
+                                                    ignoreScenarios: TestConfiguration,
+                                                    query: String,
+                                                    checkPlans: Boolean,
+                                                    params: (String, Any)*): InternalExecutionResult = {
+    updateWithAndExpectPlansToBeSimilar(expectedSuccessFrom, ignoreScenarios, query, checkPlans, () => {}, params: _*)
+  }
+
+  protected def updateWithAndExpectPlansToBeSimilar(expectedSuccessFrom: TestConfiguration,
+                                                    ignoreScenarios: TestConfiguration,
+                                                    query: String,
+                                                    checkPlans: Boolean,
+                                                    executeBefore: () => Unit,
+                                                    params: (String, Any)*): InternalExecutionResult = {
+    assertHasNoOverlap(expectedSuccessFrom, ignoreScenarios)
+    val runAgainstScenarios = Configs.AbsolutelyAll - ignoreScenarios
+
     val firstScenario = extractFirstScenario(expectedSuccessFrom)
 
-    val positiveResults = (Configs.AbsolutelyAll.scenarios - firstScenario).flatMap {
+    val positiveResults = (runAgainstScenarios.scenarios - firstScenario).flatMap {
       thisScenario =>
         thisScenario.prepare()
-        val tryResult = graph.rollback(Try(innerExecute(s"CYPHER ${thisScenario.preparserOptions} $query", params.toMap)))
+        val tryResult: Try[InternalExecutionResult] = graph.rollback(
+          {
+            executeBefore()
+            Try(innerExecute(s"CYPHER ${thisScenario.preparserOptions} $query", params.toMap))
+          }
+        )
 
         val expectedToSucceed = expectedSuccessFrom.scenarios.contains(thisScenario)
 
@@ -134,6 +170,7 @@ trait CypherComparisonSupport extends CypherTestSupport {
     }
 
     firstScenario.prepare()
+    executeBefore()
     val lastResult = innerExecute(s"CYPHER ${firstScenario.preparserOptions} $query", params.toMap)
     firstScenario.checkStateForSuccess(query)
     firstScenario.checkResultForSuccess(query, lastResult)
@@ -149,21 +186,30 @@ trait CypherComparisonSupport extends CypherTestSupport {
     lastResult
   }
 
-  protected def updateWithAndExpectPlansToBeSimilar(expectedSuccessFrom: TestConfiguration, query: String, params: (String, Any)*): InternalExecutionResult = updateWithAndExpectPlansToBeSimilar(expectedSuccessFrom, query, true, params: _*)
+  private def assertHasNoOverlap(expectedSuccessFrom: TestConfiguration, ignoreScenarios: TestConfiguration) = {
+    val hasOverlap = expectedSuccessFrom.scenarios.exists(ignoreScenarios.scenarios.contains(_))
+    if (hasOverlap)
+      fail("Set of configurations that were expected to succeed and the set of configs that should be ignored are overlapping")
+  }
 
-  protected def updateWith(expectedSuccessFrom: TestConfiguration, query: String, params: (String, Any)*): InternalExecutionResult = updateWithAndExpectPlansToBeSimilar(expectedSuccessFrom, query, false, params: _*)
+  protected def succeedWith(expectedSuccessFrom: TestConfiguration, query: String, params: (String, Any)*): InternalExecutionResult =
+    succeedWithAndMaybeCheckPlans(expectedSuccessFrom, query, false, params: _*)
 
-  protected def succeedWithAndExpectPlansToBeSimilar(expectedSuccessFrom: TestConfiguration, query: String, params: (String, Any)*): InternalExecutionResult = succeedWithAndMaybeCheckPlans(expectedSuccessFrom, query, true, params: _*)
+  protected def succeedWithAndExpectPlansToBeSimilar(expectedSuccessFrom: TestConfiguration,
+                                                     query: String,
+                                                     params: (String, Any)*): InternalExecutionResult =
+    succeedWithAndMaybeCheckPlans(expectedSuccessFrom, query, true, params: _*)
 
-  protected def succeedWith(expectedSuccessFrom: TestConfiguration, query: String, params: (String, Any)*): InternalExecutionResult = succeedWithAndMaybeCheckPlans(expectedSuccessFrom, query, false, params: _*)
+  protected def succeedWithAndMaybeCheckPlans(expectedSuccessFrom: TestConfiguration, query: String, checkPlans: Boolean, params: (String, Any)*):
+  InternalExecutionResult =
+    succeedWithAndMaybeCheckPlans(expectedSuccessFrom, Configs.Empty, query, checkPlans, params: _*)
 
-  protected def succeedWithAndMaybeCheckPlans(expectedSuccessFrom: TestConfiguration,
-                                              query: String,
-                                              checkPlans: Boolean,
-                                              params: (String, Any)*):
+  protected def succeedWithAndMaybeCheckPlans(expectedSuccessFrom: TestConfiguration, ignoreScenarios: TestConfiguration, query: String, checkPlans: Boolean, params: (String, Any)*):
   InternalExecutionResult = {
+    assertHasNoOverlap(expectedSuccessFrom, ignoreScenarios)
+    val runAgainstScenarios = Configs.AbsolutelyAll - ignoreScenarios
     if (expectedSuccessFrom.scenarios.isEmpty) {
-      for (thisScenario <- Configs.AbsolutelyAll.scenarios) {
+      for (thisScenario <- runAgainstScenarios.scenarios) {
         thisScenario.prepare()
         val tryResult = Try(innerExecute(s"CYPHER ${thisScenario.preparserOptions} $query", params.toMap))
         thisScenario.checkStateForFailure(query)
@@ -176,7 +222,7 @@ trait CypherComparisonSupport extends CypherTestSupport {
       val firstResult: InternalExecutionResult = innerExecute(s"CYPHER ${firstScenario.preparserOptions} $query", params.toMap)
       firstScenario.checkStateForSuccess(query)
 
-      for (thisScenario <- Configs.AbsolutelyAll.scenarios if thisScenario != firstScenario) {
+      for (thisScenario <- runAgainstScenarios.scenarios if thisScenario != firstScenario) {
         thisScenario.prepare()
         val tryResult = Try(innerExecute(s"CYPHER ${thisScenario.preparserOptions} $query", params.toMap))
 
@@ -280,6 +326,14 @@ trait CypherComparisonSupport extends CypherTestSupport {
     def SlottedInterpreted: TestConfiguration = TestScenario(Versions.Default, Planners.Default, Runtimes.Slotted)
 
     def Cost2_3: TestConfiguration = TestScenario(Versions.V2_3, Planners.Cost, Runtimes.Default)
+
+    def Cost3_1: TestConfiguration = TestScenario(Versions.V3_1, Planners.Cost, Runtimes.Default)
+
+    def Rule2_3: TestConfiguration = TestScenario(Versions.V2_3, Planners.Rule, Runtimes.Default)
+
+    def Rule3_1: TestConfiguration = TestScenario(Versions.V3_1, Planners.Rule, Runtimes.Default)
+
+    def CurrentRulePlanner: TestConfiguration = TestScenario(Versions.latest, Planners.Rule, Runtimes.Default)
 
     def Version2_3: TestConfiguration = TestConfiguration(Versions.V2_3, Planners.all, Runtimes.Default)
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
@@ -135,7 +135,7 @@ trait CypherComparisonSupport extends CypherTestSupport {
                                                     checkPlans: Boolean,
                                                     executeBefore: () => Unit,
                                                     params: (String, Any)*): InternalExecutionResult = {
-    assertHasNoOverlap(expectedSuccessFrom, ignoreScenarios)
+    assertNoOverlap(expectedSuccessFrom, ignoreScenarios)
     val runAgainstScenarios = Configs.AbsolutelyAll - ignoreScenarios
 
     val firstScenario = extractFirstScenario(expectedSuccessFrom)
@@ -186,7 +186,7 @@ trait CypherComparisonSupport extends CypherTestSupport {
     lastResult
   }
 
-  private def assertHasNoOverlap(expectedSuccessFrom: TestConfiguration, ignoreScenarios: TestConfiguration) = {
+  private def assertNoOverlap(expectedSuccessFrom: TestConfiguration, ignoreScenarios: TestConfiguration) = {
     val hasOverlap = expectedSuccessFrom.scenarios.exists(ignoreScenarios.scenarios.contains(_))
     if (hasOverlap)
       fail("Set of configurations that were expected to succeed and the set of configs that should be ignored are overlapping")
@@ -206,7 +206,7 @@ trait CypherComparisonSupport extends CypherTestSupport {
 
   protected def succeedWithAndMaybeCheckPlans(expectedSuccessFrom: TestConfiguration, ignoreScenarios: TestConfiguration, query: String, checkPlans: Boolean, params: (String, Any)*):
   InternalExecutionResult = {
-    assertHasNoOverlap(expectedSuccessFrom, ignoreScenarios)
+    assertNoOverlap(expectedSuccessFrom, ignoreScenarios)
     val runAgainstScenarios = Configs.AbsolutelyAll - ignoreScenarios
     if (expectedSuccessFrom.scenarios.isEmpty) {
       for (thisScenario <- runAgainstScenarios.scenarios) {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
@@ -23,7 +23,7 @@ import org.neo4j.collection.RawIterator
 import org.neo4j.cypher.internal.InternalExecutionResult
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.helpers.Counter
 import org.neo4j.cypher.internal.compiler.v3_3.test_helpers.CreateTempFileTestSupport
-import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport, QueryStatisticsTestSupport}
+import org.neo4j.cypher.{ExecutionEngineFunSuite, QueryStatisticsTestSupport}
 import org.neo4j.graphdb.{Direction, Node}
 import org.neo4j.kernel.api.exceptions.ProcedureException
 import org.neo4j.kernel.api.proc
@@ -39,7 +39,7 @@ class EagerizationAcceptanceTest
   extends ExecutionEngineFunSuite
   with TableDrivenPropertyChecks
   with QueryStatisticsTestSupport
-  with NewPlannerTestSupport
+  with CypherComparisonSupport
   with CreateTempFileTestSupport {
 
   val VERBOSE = false
@@ -59,7 +59,7 @@ class EagerizationAcceptanceTest
                   |RETURN n.val AS nv, m.val AS mv
                 """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
 
     result.toList should equal(List(Map("nv" -> 2, "mv" -> 2),
                                     Map("nv" -> 2, "mv" -> 2)))
@@ -78,7 +78,7 @@ class EagerizationAcceptanceTest
                   |RETURN n.val AS nv, m.val AS mv
                 """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3 - Configs.Rule2_3, Configs.Rule2_3, query)
 
     result.toList should equal(List(Map("nv" -> 2, "mv" -> 2),
                                     Map("nv" -> 2, "mv" -> 2)))
@@ -99,7 +99,11 @@ class EagerizationAcceptanceTest
                   |RETURN n.val AS nv, m.val AS mv
                 """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWithAndExpectPlansToBeSimilar(
+      Configs.CommunityInterpreted - Configs.Cost2_3 - Configs.Cost3_1 - Configs.AllRulePlanners,
+      Configs.AllRulePlanners + Configs.Cost3_1,
+      query,
+      checkPlans = false)
 
     result.toList should equal(List(Map("nv" -> 2, "mv" -> 2),
                                     Map("nv" -> 2, "mv" -> 2)))
@@ -117,7 +121,11 @@ class EagerizationAcceptanceTest
                   |RETURN r.val AS rv
                 """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWithAndExpectPlansToBeSimilar(
+      Configs.CommunityInterpreted - Configs.Cost2_3 - Configs.AllRulePlanners - Configs.Cost3_1,
+      Configs.Cost3_1 + Configs.AllRulePlanners,
+      query,
+      checkPlans = false)
 
     result.toList should equal(List(Map("rv" -> 3), Map("rv" -> 3)))
     assertStats(result, propertiesWritten = 2)
@@ -135,7 +143,11 @@ class EagerizationAcceptanceTest
                   |RETURN r.val AS rv
                 """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWithAndExpectPlansToBeSimilar(
+      Configs.CommunityInterpreted - Configs.Cost2_3 - Configs.AllRulePlanners - Configs.Cost3_1,
+      Configs.Cost3_1 + Configs.AllRulePlanners,
+      query,
+      checkPlans = false)
 
     result.toList should equal(List(Map("rv" -> 3), Map("rv" -> 3)))
     assertStats(result, propertiesWritten = 2)
@@ -153,7 +165,11 @@ class EagerizationAcceptanceTest
                   |RETURN count(*)
                 """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWithAndExpectPlansToBeSimilar(
+      Configs.CommunityInterpreted - Configs.Cost2_3 - Configs.AllRulePlanners - Configs.Cost3_1,
+      Configs.AllRulePlanners + Configs.Cost3_1,
+      query,
+      checkPlans = false)
 
     result.columnAs[Long]("count(*)").next should equal(2)
     assertStats(result, nodesDeleted = 1, relationshipsDeleted = 1)
@@ -166,7 +182,11 @@ class EagerizationAcceptanceTest
     relate(a, b, "T")
     val query = "MATCH (a)-[t:T]-(b) DELETE t RETURN count(*) as count"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWithAndExpectPlansToBeSimilar(
+      Configs.CommunityInterpreted - Configs.Cost2_3 - Configs.AllRulePlanners - Configs.Cost3_1,
+      Configs.AllRulePlanners + Configs.Cost3_1,
+      query,
+      checkPlans = false)
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsDeleted = 1)
     assertNumberOfEagerness(query, 1)
@@ -200,7 +220,11 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (a), (b) CALL user.mkRel(a, b) YIELD relId WITH * MATCH ()-[rel]->() WHERE id(rel) = relId RETURN rel"
 
-    val result = executeWithCostPlannerAndInterpretedRuntimeOnly(query)
+    val result = updateWithAndExpectPlansToBeSimilar(
+      Configs.CommunityInterpreted - Configs.AllRulePlanners - Configs.Version2_3 - Configs.Cost3_1 - Configs.Version3_2,
+      Configs.Cost3_1 + Configs.Version3_2,
+      query,
+      checkPlans = false)
     result.size should equal(4)
 
     // Correct! Eagerization happens as part of query context operation
@@ -238,7 +262,15 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (a), (b) CALL user.mkRel(a, b) MATCH (a)-[rel]->(b) RETURN rel"
 
-    val result = executeWithCostPlannerAndInterpretedRuntimeOnly(query)
+    // only run against one scenario, otherwise count increments unpredictably due to fallback
+    val succeedScenarios = Configs.Version3_3 - Configs.Procs - Configs.Compiled - Configs.AllRulePlanners - Configs.SlottedInterpreted
+    succeedScenarios.scenarios.size should equal(1)
+    val result = succeedWithAndMaybeCheckPlans(
+      succeedScenarios,
+      Configs.AbsolutelyAll - succeedScenarios,
+      query,
+      checkPlans = false)
+
     result.size should equal(4)
     counter.counted should equal(4)
 
@@ -285,7 +317,11 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (x), (y) CALL user.expand(x, y) YIELD relId RETURN x, y, relId"
 
-    val result = executeWithCostPlannerAndInterpretedRuntimeOnly(query)
+    val result = succeedWithAndMaybeCheckPlans(
+      Configs.CommunityInterpreted - Configs.Compiled  - Configs.AllRulePlanners - Configs.Cost3_1 - Configs.Version2_3,
+      Configs.Cost3_1,
+      query,
+      checkPlans = false)
     result.size should equal(2)
 
     // Correct! No eagerization necessary
@@ -333,7 +369,15 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (x), (y) CALL user.expand(x, y) WITH * MATCH (x)-[rel]->(y) RETURN *"
 
-    val result = executeWithCostPlannerAndInterpretedRuntimeOnly(query)
+    // only run against one scenario, otherwise count increments unpredictably due to fallback
+    val succeedScenarios = Configs.Version3_3 - Configs.Procs - Configs.Compiled - Configs.AllRulePlanners - Configs.SlottedInterpreted
+    succeedScenarios.scenarios.size should equal(1)
+    val result = succeedWithAndMaybeCheckPlans(
+      succeedScenarios,
+      Configs.AbsolutelyAll - succeedScenarios,
+      query,
+      checkPlans = false)
+
     result.size should equal(2)
     counter.counted should equal(2)
 
@@ -347,7 +391,7 @@ class EagerizationAcceptanceTest
     relate(a, b, "T")
     val query = "MATCH (a)-[t:T]-(b) CREATE (a)-[:T]->(b) RETURN count(*) as count"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsCreated = 2)
     assertNumberOfEagerness(query, 1)
@@ -359,7 +403,7 @@ class EagerizationAcceptanceTest
     relate(a, b, "T", Map("prop1" -> "foo"))
     val query = "MATCH (a)-[t:T {prop1: 'foo'}]-(b) CREATE (a)-[:T {prop2: 'bar'}]->(b) RETURN count(*) as count"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsCreated = 2, propertiesWritten = 2)
     assertNumberOfEagerness(query, 0)
@@ -371,7 +415,7 @@ class EagerizationAcceptanceTest
     relate(a, b, "T", Map("prop1" -> "foo"))
     val query = "MATCH (a)-[t:T {prop1: 'foo'}]-(b) CREATE (a)-[:T {prop1: 'foo'}]->(b) RETURN count(*) as count"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsCreated = 2, propertiesWritten = 2)
     assertNumberOfEagerness(query, 1)
@@ -384,7 +428,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH p=(:L)-[*]-() DELETE p RETURN count(*) as count"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsDeleted = 1, nodesDeleted = 2)
     assertNumberOfEagerness(query, 1)
@@ -397,7 +441,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH p=(:L)-[*]-() DETACH DELETE p RETURN count(*) as count"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsDeleted = 1, nodesDeleted = 2)
     assertNumberOfEagerness(query, 1)
@@ -407,7 +451,7 @@ class EagerizationAcceptanceTest
     graph.execute("CREATE (a:Person {id: 42})-[:FRIEND_OF]->(b:Person {id:42}), (b)-[:FRIEND_OF]->(a), (:Person)-[:FRIEND_OF]->(b)")
 
     val query = "MATCH (p1:Person {id: 42})-[r:FRIEND_OF]->(p2:Person {id:42}) DETACH DELETE r, p1, p2 RETURN count(*) AS count"
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsDeleted = 3, nodesDeleted = 2)
     assertNumberOfEagerness(query, 1)
@@ -417,7 +461,7 @@ class EagerizationAcceptanceTest
     graph.execute("CREATE (a:Person {id: 42})-[:FRIEND_OF]->(b:Person {id:42}), (b)-[:FRIEND_OF]->(a), (:Person)-[:FRIEND_OF]->(b)")
 
     val query = "MATCH p = (p1:Person {id: 42})-[r:FRIEND_OF]->(p2:Person {id:42}) DETACH DELETE p RETURN count(*) AS count"
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsDeleted = 3, nodesDeleted = 2)
     assertNumberOfEagerness(query, 1)
@@ -429,7 +473,7 @@ class EagerizationAcceptanceTest
     relate(a, b, "T")
     val query = "MATCH (a)-[t:T]->(b) CREATE (a)-[:T]->(b) RETURN count(*) as count"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Int]("count").next should equal(1)
     assertStats(result, relationshipsCreated = 1)
     assertNumberOfEagerness(query, 1, optimalEagerCount = 0)
@@ -441,7 +485,7 @@ class EagerizationAcceptanceTest
     relate(a, b, "T")
     val query = "MATCH (a)-[t:T]-(b) CREATE (a)-[:T2]->(b) RETURN count(*) as count"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsCreated = 2)
     assertNumberOfEagerness(query, 0)
@@ -455,7 +499,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (n) DELETE n MERGE (m {p: 0}) ON CREATE SET m.p = 1 RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
 
     assertStats(result, nodesCreated = 2, propertiesWritten = 4, nodesDeleted = 2)
     result.columnAs[Long]("count(*)").next shouldBe 2
@@ -476,7 +520,7 @@ class EagerizationAcceptanceTest
         |RETURN count(*)
       """.stripMargin
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, nodesCreated = 1, nodesDeleted = 2, propertiesWritten = 1, labelsAdded = 1)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertNumberOfEagerness(query, 1)
@@ -495,7 +539,7 @@ class EagerizationAcceptanceTest
         |RETURN b2.deleted
       """.stripMargin
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, nodesCreated = 1, nodesDeleted = 3, propertiesWritten = 1, labelsAdded = 1)
     result.columnAs[Node]("b2.deleted").toList should equal(List(null, null, null))
     assertNumberOfEagerness(query, 1)
@@ -515,7 +559,7 @@ class EagerizationAcceptanceTest
         |RETURN b2.deleted
       """.stripMargin
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, nodesCreated = 2, nodesDeleted = 2, propertiesWritten = 2, labelsAdded = 2)
     result.columnAs[Node]("b2.deleted").toList should equal(List(null, null))
     assertNumberOfEagerness(query, 2, optimalEagerCount = 1)
@@ -533,7 +577,7 @@ class EagerizationAcceptanceTest
         |RETURN count(*)
       """.stripMargin
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.toList should equal(List(Map("count(*)" -> 2)))
     assertStats(result, nodesCreated = 1, nodesDeleted = 2)
     assertNumberOfEagerness(query, 1)
@@ -555,7 +599,7 @@ class EagerizationAcceptanceTest
         |RETURN count(*)
       """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, nodesCreated = 0, nodesDeleted = 2)
     result.columnAs[Long]("count(*)").next shouldBe 8
     assertNumberOfEagerness(query, 0)
@@ -574,7 +618,7 @@ class EagerizationAcceptanceTest
         |RETURN exists(t2.id)
       """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, relationshipsDeleted = 2, relationshipsCreated = 1)
 
     // Merge should not be able to match on deleted relationship
@@ -594,7 +638,7 @@ class EagerizationAcceptanceTest
         |RETURN count(*)
       """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, relationshipsDeleted = 1, relationshipsCreated = 1)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertNumberOfEagerness(query, 2)
@@ -613,7 +657,7 @@ class EagerizationAcceptanceTest
         |RETURN exists(t2.id)
       """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, relationshipsDeleted = 2, relationshipsCreated = 1)
     result.toList should equal(List(Map("exists(t2.id)" -> false), Map("exists(t2.id)" -> false)))
     assertNumberOfEagerness(query, 2, optimalEagerCount = 1)
@@ -632,7 +676,7 @@ class EagerizationAcceptanceTest
         |RETURN exists(t2.id)
       """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, relationshipsDeleted = 2, relationshipsCreated = 1)
     result.toList should equal(List(Map("exists(t2.id)" -> false), Map("exists(t2.id)" -> false)))
     assertNumberOfEagerness(query, 2, optimalEagerCount = 1)
@@ -651,7 +695,7 @@ class EagerizationAcceptanceTest
         |RETURN count(*)
       """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, relationshipsDeleted = 2, relationshipsCreated = 1)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertNumberOfEagerness(query, 2)
@@ -664,7 +708,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (a), (b) CREATE (a)-[:KNOWS]->(b) RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, relationshipsCreated = 4)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertNumberOfEagerness(query, 0)
@@ -676,7 +720,11 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH () CREATE () WITH * MATCH (n) RETURN count(*) AS count"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(
+      Configs.CommunityInterpreted - Configs.Cost2_3 - Configs.Rule2_3,
+      Configs.Rule2_3,
+      query)
+
     assertStats(result, nodesCreated = 2)
     result.columnAs[Int]("count").next should equal(8)
     assertNumberOfEagerness(query, 1)
@@ -688,7 +736,10 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (k) CREATE (l {prop: 44}) WITH * MATCH (m) CREATE (n {prop:45}) RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(
+      Configs.CommunityInterpreted - Configs.Cost2_3 - Configs.Rule2_3,
+      Configs.Rule2_3,
+      query)
 
     result.columnAs[Long]("count(*)").next shouldBe 8
     assertStats(result, nodesCreated = 10, propertiesWritten = 10)
@@ -700,23 +751,28 @@ class EagerizationAcceptanceTest
     createNode()
     createNode()
 
-    graph.inTx {
+    val executeBefore: () => Unit = () => {
       createNode()
       createNode()
       createNode()
-
-      val query = "MATCH () CREATE () RETURN count(*)"
-
-      val result = executeWithCostPlannerAndInterpretedRuntimeOnly(query)
-      result.columnAs[Long]("count(*)").next shouldBe 6
-      assertStats(result, nodesCreated = 6)
-      assertNumberOfEagerness(query, 0)
     }
+
+    val query = "MATCH () CREATE () RETURN count(*)"
+
+    val result = updateWithAndExpectPlansToBeSimilar(
+      Configs.CommunityInterpreted - Configs.Cost2_3,
+      Configs.Empty,
+      query,
+      checkPlans = false,
+      executeBefore)
+    result.columnAs[Long]("count(*)").next shouldBe 6
+    assertStats(result, nodesCreated = 6)
+    assertNumberOfEagerness(query, 0)
   }
 
   test("should not introduce eagerness for leaf create match") {
     val query = "CREATE () WITH * MATCH () RETURN count(*)"
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, nodesCreated = 1)
     result should not(use("ReadOnly"))
     result.columnAs[Long]("count(*)").next shouldBe 1
@@ -727,7 +783,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("L")
     val query = "MATCH (:L) CREATE (:L) RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 1, labelsAdded = 1)
     assertNumberOfEagerness(query, 0)
@@ -739,7 +795,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (n:L {id: 0}) USING INDEX n:L(id) CREATE (:L {id:0}) RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 1, labelsAdded = 1,  propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
@@ -750,7 +806,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (), () CREATE () RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, nodesCreated = 4)
     assertNumberOfEagerness(query, 1)
@@ -761,7 +817,7 @@ class EagerizationAcceptanceTest
     createNode("prop1" -> 42, "prop2" -> 42)
     val query = "MATCH (a {prop1: 42}), (n {prop2: 42}) CREATE ({prop3: 42}) RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, nodesCreated = 4, propertiesWritten = 4)
     assertNumberOfEagerness(query, 0)
@@ -772,7 +828,7 @@ class EagerizationAcceptanceTest
     createNode("prop1" -> 42, "prop2" -> 42)
     val query = "MATCH (a {prop1: 42}), (n {prop2: 42}) CREATE ({prop1: 42, prop2: 42}) RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, nodesCreated = 4, propertiesWritten = 8)
     assertNumberOfEagerness(query, 1)
@@ -783,7 +839,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (a), (b) CREATE (a)-[r:KNOWS]->(b) SET r = { key: 42 } RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 4, propertiesWritten = 4)
     assertNumberOfEagerness(query, 0)
@@ -793,7 +849,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode())
     val query = "MATCH (n) WHERE (n)-->() CREATE (n)-[:T]->() RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 1, relationshipsCreated = 1)
     assertNumberOfEagerness(query, 0)
@@ -804,7 +860,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode())
     val query = "MATCH ()--() CREATE () RETURN count(*) AS count"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count").next shouldBe 4
     assertStats(result, nodesCreated = 4)
     assertNumberOfEagerness(query,  0)
@@ -821,7 +877,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH () CREATE () RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 1)
     assertNumberOfEagerness(query,  0)
@@ -832,7 +888,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (a), (b) CREATE (a)-[:TYPE]->(b) RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 4)
     assertNumberOfEagerness(query, 0)
@@ -843,7 +899,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (a), (b) WITH a, b ORDER BY id(a) CREATE (a)-[:TYPE]->(b) RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 4)
     assertNumberOfEagerness(query, 0)
@@ -854,7 +910,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (a) CREATE (a)-[:TYPE]->() RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, nodesCreated = 2, relationshipsCreated = 2)
     assertNumberOfEagerness(query, 0)
@@ -865,7 +921,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (), (a) CREATE (a)-[:TYPE]->() RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, nodesCreated = 4, relationshipsCreated = 4)
     assertNumberOfEagerness(query, 1)
@@ -876,7 +932,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode(), "TYPE")
     val query = "MATCH (a)-[:TYPE]->(b) CREATE (a)-[:TYPE]->(b) RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, relationshipsCreated = 2)
     result.columnAs[Int]("count(*)").next should equal(2)
     assertNumberOfEagerness(query, 1, optimalEagerCount = 0)
@@ -888,7 +944,7 @@ class EagerizationAcceptanceTest
     relate(a, b, "TYPE") // NOTE: The order the nodes are related should not affect the result (opposite from the test below)
     val query = "MATCH (a)-[:TYPE]->(b) CREATE (a)<-[:TYPE]-(b) RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, relationshipsCreated = 1)
     result.columnAs[Int]("count(*)").next should equal(1)
     assertNumberOfEagerness(query, 1)
@@ -900,7 +956,7 @@ class EagerizationAcceptanceTest
     relate(b, a, "TYPE") // NOTE: The order the nodes are related should not affect the result (opposite from the test above)
     val query = "MATCH (a)-[:TYPE]->(b) CREATE (a)<-[:TYPE]-(b) RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, relationshipsCreated = 1)
     result.columnAs[Int]("count(*)").next should equal(1)
     assertNumberOfEagerness(query, 1)
@@ -911,7 +967,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode(), "TYPE")
     val query = "MATCH (a)-[:TYPE]-(b) CREATE (a)-[:TYPE]->(b) RETURN count(*) as count"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, relationshipsCreated = 4)
     result.columnAs[Int]("count").next should equal(4)
     assertNumberOfEagerness(query, 1)
@@ -922,7 +978,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode(), "TYPE")
     val query = "MATCH (a)-[:TYPE]-(b) MERGE (a)-[:TYPE]->(b) RETURN count(*) as count"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, relationshipsCreated = 2)
     assertNumberOfEagerness(query, 1)
     result.columnAs[Int]("count").next should equal(4)
@@ -934,7 +990,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode(), "TYPE")
     val query = "MATCH ()-[:TYPE]->(), (a)-[:TYPE]->(b) CREATE (a)-[:TYPE]->(b) RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, relationshipsCreated = 2)
     assertNumberOfEagerness(query, 1)
@@ -945,7 +1001,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode(), "TYPE")
     val query = "MATCH ()-[:TYPE]->() MATCH (a)-[:TYPE]->(b) CREATE (a)-[:TYPE]->(b) RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 4)
     assertNumberOfEagerness(query, 1)
@@ -956,7 +1012,10 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode(), "TYPE")
     val query = "MATCH ()-[:TYPE]->() CREATE (a)-[:TYPE]->(b) WITH * MATCH ()-[:TYPE]->() CREATE (c)-[:TYPE]->(d) RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(
+      Configs.CommunityInterpreted - Configs.Cost2_3 - Configs.Rule2_3,
+      Configs.Rule2_3,
+      query)
     result.columnAs[Long]("count(*)").next shouldBe 8
     assertStats(result, nodesCreated = 20, relationshipsCreated = 10)
     assertNumberOfEagerness(query, 3, optimalEagerCount = 2)
@@ -967,7 +1026,7 @@ class EagerizationAcceptanceTest
     relate(createLabeledNode("LabelOne"), createLabeledNode("LabelTwo"), "TYPE")
     val query = "MATCH ()-[:TYPE]->() MATCH (a:LabelOne)-[:TYPE]->(b:LabelTwo) CREATE (a)-[:TYPE]->(b) RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 4)
     assertNumberOfEagerness(query, 1)
@@ -978,7 +1037,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode(), "T1")
     val query = "MATCH ()-[:T1]->() CREATE ()-[:T2]->() RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, nodesCreated = 4, relationshipsCreated = 2)
     assertNumberOfEagerness(query, 0)
@@ -995,7 +1054,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Person), (m:Movie) DELETE a, m RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, nodesDeleted = 4)
     assertNumberOfEagerness(query, 1)
@@ -1008,7 +1067,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Person) DELETE a RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, nodesDeleted = 2)
     assertNumberOfEagerness(query, 0)
@@ -1019,7 +1078,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r]-(b) DELETE r,a,b RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, nodesDeleted = 2, relationshipsDeleted = 1)
     assertNumberOfEagerness(query, 1)
@@ -1032,7 +1091,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r]-(b) DELETE r, a, b RETURN count(*) as count"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.toList should equal(List(Map("count" -> 2)))
     assertStats(result, nodesDeleted = 2, relationshipsDeleted = 1)
     assertNumberOfEagerness(query, 1)
@@ -1045,7 +1104,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r {prop : 3}]-(b) DELETE r, a, b RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, nodesDeleted = 2, relationshipsDeleted = 1)
     assertNumberOfEagerness(query, 1)
@@ -1059,7 +1118,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r]->(b) DETACH DELETE a, b RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
 
     result.toList should equal (List(Map("count(*)" -> 2)))
     assertStats(result, nodesDeleted = 2, relationshipsDeleted = 2)
@@ -1074,7 +1133,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r]->(b) DELETE r RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
 
     result.toList should equal (List(Map("count(*)" -> 2)))
     assertStats(result, relationshipsDeleted = 2)
@@ -1087,7 +1146,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:A)-[r]->(b:B) DELETE r, a, b RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.toList should equal (List(Map("count(*)" -> 2)))
     assertStats(result, nodesDeleted = 4, relationshipsDeleted = 2)
     assertNumberOfEagerness(query, 1, optimalEagerCount = 0)
@@ -1099,7 +1158,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (b:B)<-[r]-(a:A) DELETE r, a, b RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.toList should equal (List(Map("count(*)" -> 2)))
     assertStats(result, nodesDeleted = 4, relationshipsDeleted = 2)
     assertNumberOfEagerness(query, 1, optimalEagerCount = 0)
@@ -1113,7 +1172,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r {prop : 3}]->(b) DELETE r, a, b RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.toList should equal (List(Map("count(*)" -> 4)))
     assertStats(result, nodesDeleted = 8, relationshipsDeleted = 4)
     assertNumberOfEagerness(query, 1, optimalEagerCount = 0)
@@ -1129,7 +1188,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r]-(b) DELETE r, a, b RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.toList should equal (List(Map("count(*)" -> 12)))
     assertStats(result, nodesDeleted = 12, relationshipsDeleted = 6)
     assertNumberOfEagerness(query, 1)
@@ -1142,7 +1201,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:A)-[r]-(b) DELETE r, a, b RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.toList should equal (List(Map("count(*)" -> 4)))
     assertStats(result, nodesDeleted = 6, relationshipsDeleted = 3)
     assertNumberOfEagerness(query, 1)
@@ -1156,7 +1215,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r {prop : 3}]-(b) DELETE r, a, b RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.toList should equal (List(Map("count(*)" -> 8)))
     assertStats(result, nodesDeleted = 8, relationshipsDeleted = 4)
     assertNumberOfEagerness(query, 1)
@@ -1171,7 +1230,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r1]->(b)-[r2]->(c) DELETE r1, r2, a, b, c RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.toList should equal (List(Map("count(*)" -> 4)))
     assertStats(result, nodesDeleted = 5, relationshipsDeleted = 4)
     assertNumberOfEagerness(query, 1)
@@ -1186,7 +1245,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r*]->(b) DETACH DELETE a, b RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.toList should equal (List(Map("count(*)" -> 8)))
     assertStats(result, nodesDeleted = 5, relationshipsDeleted = 4)
     assertNumberOfEagerness(query, 1)
@@ -1196,7 +1255,7 @@ class EagerizationAcceptanceTest
   test("create directional relationship with property, match and delete relationship and nodes within same query should be eager and work") {
     val query = "CREATE ()-[:T {prop: 3}]->() WITH * MATCH (a)-[r {prop : 3}]->(b) DELETE r, a, b RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 2, relationshipsCreated = 1, propertiesWritten = 1, nodesDeleted = 2, relationshipsDeleted = 1)
     assertNumberOfEagerness(query, 1)
@@ -1210,7 +1269,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("A")
     val query = "MATCH (a:A) OPTIONAL MATCH (b:B) CREATE (:B) RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 6
     assertStats(result, nodesCreated = 6, labelsAdded = 6)
     assertNumberOfEagerness(query, 1)
@@ -1222,7 +1281,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("A")
     val query = "MATCH (a:A) OPTIONAL MATCH (b:B) CREATE (:A) RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 6
     assertStats(result, nodesCreated = 6, labelsAdded = 6)
     assertNumberOfEagerness(query, 0)
@@ -1243,7 +1302,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Person) OPTIONAL MATCH (a)-[r1]-() DELETE a, r1 RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 7
     assertStats(result, nodesDeleted = 2, relationshipsDeleted = 7)
     assertNumberOfEagerness(query, 1)
@@ -1257,7 +1316,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Person) MERGE (b) WITH * OPTIONAL MATCH (a)-[r1]-(b) DELETE r1 RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 3
     assertStats(result, relationshipsDeleted = 2)
     assertNumberOfEagerness(query, 2, optimalEagerCount = 1)
@@ -1276,7 +1335,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Person) OPTIONAL MATCH (a)-[r1]-(), (m:Movie)-[r2]-() DELETE a, r1, m, r2 RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 6
     assertStats(result, nodesDeleted = 3, relationshipsDeleted = 4)
     assertNumberOfEagerness(query, 1)
@@ -1287,7 +1346,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Movie")
     val query = "MATCH (a:Person), (m:Movie) CREATE (a)-[:T]->(m) WITH a OPTIONAL MATCH (a) RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, relationshipsCreated = 1)
     assertNumberOfEagerness(query, 0)
@@ -1301,7 +1360,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (m1:Two), (m2:Two), (n) MERGE (q) ON MATCH SET q:Two RETURN count(*) AS c"
 
-    val result: InternalExecutionResult = updateWithBothPlannersAndCompatibilityMode(query)
+    val result: InternalExecutionResult = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, labelsAdded = 1)
     assertNumberOfEagerness(query, 1)
     result.toList should equal(List(Map("c" -> 36)))
@@ -1313,7 +1372,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (m1:Two), (m2:Two), (n) MERGE (q:Three) ON MATCH SET q:Two RETURN count(*) AS c"
 
-    val result: InternalExecutionResult = updateWithBothPlannersAndCompatibilityMode(query)
+    val result: InternalExecutionResult = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, labelsAdded = 2, nodesCreated = 1)
     result.toList should equal(List(Map("c" -> 12)))
     assertNumberOfEagerness(query, 1)
@@ -1325,7 +1384,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (a:Two), (b) MERGE (q {p: 1}) RETURN count(*) AS c"
 
-    val result: InternalExecutionResult = updateWithBothPlannersAndCompatibilityMode(query)
+    val result: InternalExecutionResult = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, nodesCreated = 1, propertiesWritten = 1)
     result.toList should equal(List(Map("c" -> 6)))
     assertNumberOfEagerness(query, 1)
@@ -1337,7 +1396,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (m1:Two), (m2:Two) MERGE (q) ON MATCH SET q:One RETURN count(*) AS c"
 
-    val result: InternalExecutionResult = updateWithBothPlannersAndCompatibilityMode(query)
+    val result: InternalExecutionResult = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, labelsAdded = 3)
     result.toList should equal(List(Map("c" -> 12)))
     assertNumberOfEagerness(query, 0)
@@ -1349,7 +1408,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (m1:Two), (m2:Two), (n) MERGE (q) ON CREATE SET q:Two RETURN count(*) AS c"
 
-    val result: InternalExecutionResult = updateWithBothPlannersAndCompatibilityMode(query)
+    val result: InternalExecutionResult = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, labelsAdded = 0)
     result.toList should equal(List(Map("c" -> 36)))
 
@@ -1362,7 +1421,7 @@ class EagerizationAcceptanceTest
     createNode(Map("id" -> 0))
     val query = "MATCH (b {id: 0}), (c {id: 0}), (a) MERGE () ON MATCH SET a.id = 0 RETURN count(*) AS c"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.toList should equal(List(Map("c" -> 36)))
     assertStats(result, propertiesWritten = 36)
 
@@ -1375,7 +1434,7 @@ class EagerizationAcceptanceTest
     createNode(Map("id" -> 0))
     val query = "MATCH (b {id: 0}), (c {id: 0}) MERGE (a) ON MATCH SET a.id2 = 0 RETURN count(*) AS c"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.toList should equal(List(Map("c" -> 12)))
     assertStats(result, propertiesWritten = 12)
 
@@ -1388,7 +1447,7 @@ class EagerizationAcceptanceTest
     createNode(Map("id" -> 0))
     val query = "MATCH (b {id: 0}), (c {id: 0}), (a) MERGE () ON CREATE SET a = {id: 0} RETURN count(*) AS c"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.toList should equal(List(Map("c" -> 36)))
     assertStats(result, propertiesWritten = 0)
 
@@ -1401,7 +1460,7 @@ class EagerizationAcceptanceTest
     createNode(Map("id" -> 0))
     val query = "MATCH (b {id: 0}), (c {id: 0}), (a) MERGE () ON CREATE SET a += {id: 0} RETURN count(*) AS c"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.toList should equal(List(Map("c" -> 36)))
     assertStats(result, propertiesWritten = 0)
 
@@ -1414,7 +1473,7 @@ class EagerizationAcceptanceTest
     createNode(Map("id" -> 0))
     val query = "MATCH (b {id: 0}), (c {id: 0}), (a) MERGE () ON MATCH SET a = {map} RETURN count(*) AS c"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query, "map" -> Map("id" -> 0))
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, "map" -> Map("id" -> 0))
     result.toList should equal(List(Map("c" -> 36)))
     assertStats(result, propertiesWritten = 36)
 
@@ -1433,7 +1492,7 @@ class EagerizationAcceptanceTest
                   |RETURN count(*)
                 """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, nodesDeleted = 2, relationshipsDeleted = 2)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertNumberOfEagerness(query, 1)
@@ -1452,7 +1511,7 @@ class EagerizationAcceptanceTest
                   |RETURN count(*)
                 """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, nodesDeleted = 2, relationshipsDeleted = 2)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertNumberOfEagerness(query, 1)
@@ -1463,7 +1522,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (a), (b) MERGE (a)-[r:KNOWS]->(b) RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 4)
     assertNumberOfEagerness(query, 0)
@@ -1476,7 +1535,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON MATCH SET a.prop = 42 RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
@@ -1491,7 +1550,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON MATCH SET b:Foo RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 3, labelsAdded = 1)
 
@@ -1508,7 +1567,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON MATCH SET a:Bar RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 3, labelsAdded = 1)
     assertNumberOfEagerness(query, 1)
@@ -1523,7 +1582,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON CREATE SET b:Foo RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 3, labelsAdded = 2)
     //TODO this we need to consider not only overlap but also what known labels the node we set has
@@ -1539,7 +1598,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON CREATE SET a:Bar RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 3, labelsAdded = 2)
     assertNumberOfEagerness(query, 1)
@@ -1549,7 +1608,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("A")
     val query = "MATCH (a:A) MERGE (a)-[:BAR]->(b:B) WITH a MATCH (a) WHERE (a)-[:FOO]->() RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 0
     assertStats(result, relationshipsCreated = 1, nodesCreated = 1, labelsAdded = 1)
     assertNumberOfEagerness(query, 0)
@@ -1563,7 +1622,10 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:A) MERGE (a)-[:BAR]->(b:A) WITH a MATCH (a2) RETURN count (a2) AS nodes"
 
-    val result: InternalExecutionResult = updateWithBothPlanners(query)
+    val result: InternalExecutionResult = updateWith(
+      Configs.CommunityInterpreted - Configs.Cost2_3 - Configs.Rule2_3,
+      Configs.Rule2_3,
+      query)
     assertStats(result, nodesCreated = 2, relationshipsCreated = 2, labelsAdded = 2)
     result.toList should equal(List(Map("nodes" -> 15)))
     assertNumberOfEagerness(query, 1)
@@ -1574,7 +1636,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("B")
     val query = "MATCH (a:A), (b:B) MERGE (a)-[:BAR]->(b) WITH a MATCH (a) WHERE (a)-[:FOO]->() RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 0
     assertStats(result, relationshipsCreated = 1)
     assertNumberOfEagerness(query, 0)
@@ -1583,7 +1645,7 @@ class EagerizationAcceptanceTest
   test("never ending query should end - this is the query that prompted Eagerness in the first place") {
     createNode()
     val query = "MATCH (a) CREATE ()"
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.Interpreted - Configs.Cost2_3, query)
     assertStats(result, nodesCreated = 1)
     assertNumberOfEagerness(query, 0)
   }
@@ -1594,7 +1656,7 @@ class EagerizationAcceptanceTest
 
     val query = "UNWIND range(0, 9) AS i MATCH (x) MERGE (m {v: i % 2}) ON CREATE SET m:Merged CREATE ({v: (i + 1) % 2}) RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 20
     assertStats(result, nodesCreated = 22, propertiesWritten = 22, labelsAdded = 2)
     assertNumberOfEagerness(query, 2)
@@ -1606,7 +1668,7 @@ class EagerizationAcceptanceTest
 
     val query = "UNWIND range(0, 9) AS i MATCH (x) MATCH (m {v: i % 2}) CREATE ({v: (i + 1) % 2}) RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 10
     assertStats(result, nodesCreated = 10, propertiesWritten = 10)
     assertNumberOfEagerness(query, 1)
@@ -1618,7 +1680,7 @@ class EagerizationAcceptanceTest
 
     val query = "UNWIND range(0, 9) AS i MATCH (x) WITH * CREATE ({v: i % 2}) MERGE (m {v: (i + 1) % 2}) ON CREATE SET m:Merged RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 200
     assertStats(result, nodesCreated = 20, propertiesWritten = 20, labelsAdded = 0)
     assertNumberOfEagerness(query, 2)
@@ -1629,7 +1691,7 @@ class EagerizationAcceptanceTest
   test("should not be eager when merging on two different labels") {
     val query = "MERGE(:L1) MERGE(p:L2) ON CREATE SET p.name = 'Blaine' RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 2, propertiesWritten = 1, labelsAdded = 2)
     assertNumberOfEagerness(query, 0)
@@ -1640,7 +1702,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("L1")
     val query = "MERGE(:L1) MERGE(p:L1) ON CREATE SET p.name = 'Blaine' RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result)
     assertNumberOfEagerness(query, 0)
@@ -1650,7 +1712,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MERGE(:L1) MERGE(p:L1) ON CREATE SET p.name = 'Blaine' RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 1, labelsAdded = 1)
     assertNumberOfEagerness(query, 0)
@@ -1661,7 +1723,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Person")
     val query = "MERGE() MERGE(p: Person) ON CREATE SET p.name = 'Blaine' RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result)
     assertNumberOfEagerness(query, 0)
@@ -1672,7 +1734,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MERGE() MERGE(p: Person) ON CREATE SET p.name = 'Blaine' RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
@@ -1682,7 +1744,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MERGE() MERGE(p) ON CREATE SET p.name = 'Blaine' RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result)
     assertNumberOfEagerness(query, 0)
@@ -1691,7 +1753,7 @@ class EagerizationAcceptanceTest
   ignore("does not need to be eager when no merge has labels, merges create") {
     val query = "MERGE() MERGE(p) ON CREATE SET p.name = 'Blaine' RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 1)
     assertNumberOfEagerness(query, 0)
@@ -1700,7 +1762,7 @@ class EagerizationAcceptanceTest
   test("Multiple single node merges building on each other through property values should be eager") {
     val query = "MERGE(a {p: 1}) MERGE(b {p: a.p}) MERGE(c {p: b.p}) RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 1, propertiesWritten = 1)
     assertNumberOfEagerness(query, 2)
@@ -1709,7 +1771,7 @@ class EagerizationAcceptanceTest
   test("Multiple single node merges should be eager") {
     val query = "UNWIND [0, 1] AS i MERGE (a {p: i % 2}) MERGE (b {p: (i + 1) % 2}) ON CREATE SET b:ShouldNotBeSet RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, nodesCreated = 2, propertiesWritten = 2, labelsAdded = 0)
     assertNumberOfEagerness(query, 1)
@@ -1718,7 +1780,7 @@ class EagerizationAcceptanceTest
   test("should not be eager when merging on already bound variables") {
     val query = "MERGE (city:City) MERGE (country:Country) MERGE (city)-[:IN]->(country) RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 2, labelsAdded = 2, relationshipsCreated = 1)
   }
@@ -1729,7 +1791,7 @@ class EagerizationAcceptanceTest
     val query = """MATCH (src:LeftLabel), (dst:RightLabel)
               |MERGE (src)-[r:IS_RELATED_TO ]->(dst)
               |ON CREATE SET r.p3 = 42""".stripMargin
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
 
     assertStats(result, relationshipsCreated = 1, propertiesWritten = 1)
     assertNumberOfEagerness(query,  0)
@@ -1741,7 +1803,7 @@ class EagerizationAcceptanceTest
     createLabeledNode(Map("prop" -> 5), "Node")
     val query = "MATCH (n:Node {prop:5}) SET n.value = 10 RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
@@ -1751,7 +1813,7 @@ class EagerizationAcceptanceTest
     createLabeledNode(Map("prop" -> 5), "Node")
     val query = "MATCH (n:Node) SET n:Lol RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, labelsAdded = 1)
     assertNumberOfEagerness(query, 0)
@@ -1761,7 +1823,7 @@ class EagerizationAcceptanceTest
     createLabeledNode(Map("prop" -> 5), "Lol")
     val query = "MATCH (n:Lol) SET n:Lol RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, labelsAdded = 0)
     assertNumberOfEagerness(query, 0)
@@ -1773,7 +1835,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (m1:Two), (m2:Two), (n) SET n:Two RETURN count(*) AS c"
 
-    val result: InternalExecutionResult = updateWithBothPlannersAndCompatibilityMode(query)
+    val result: InternalExecutionResult = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, labelsAdded = 1)
     assertNumberOfEagerness(query, 1)
     result.toList should equal(List(Map("c" -> 12)))
@@ -1784,7 +1846,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (n), (m1:Lol), (m2:Lol) SET n:Rofl RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, labelsAdded = 2)
     assertNumberOfEagerness(query, 0)
@@ -1797,7 +1859,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Foo")
     val query = "MATCH (n) CREATE (m) WITH * MATCH (o:Foo) SET n:Foo RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 8
     assertStats(result, labelsAdded = 2, nodesCreated = 4)
     assertNumberOfEagerness(query, 1)
@@ -1810,7 +1872,10 @@ class EagerizationAcceptanceTest
     createLabeledNode("B")
     val query = "MATCH (n:A) CREATE (m:C) WITH * MATCH (o:B), (p:C) SET p:B RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(
+      Configs.CommunityInterpreted - Configs.Cost2_3 - Configs.Rule2_3,
+      Configs.Rule2_3,
+      query)
     result.columnAs[Long]("count(*)").next shouldBe 8
     assertStats(result, labelsAdded = 4, nodesCreated = 2)
     assertNumberOfEagerness(query, 2)
@@ -1823,7 +1888,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Bar")
     val query = "MATCH (n) CREATE (m) WITH * MATCH (o:Bar) SET n:Foo RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 8
     assertStats(result, labelsAdded = 2, nodesCreated = 4)
     assertNumberOfEagerness(query, 0)
@@ -1833,7 +1898,7 @@ class EagerizationAcceptanceTest
     createNode(Map("name" -> "thing"))
     val query = "MATCH (n {name : 'thing'}) SET n:Lol RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, labelsAdded = 1)
     assertNumberOfEagerness(query, 0)
@@ -1843,7 +1908,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (n) SET n.prop = 5 RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
@@ -1853,7 +1918,7 @@ class EagerizationAcceptanceTest
     createNode(Map("prop" -> 20))
     val query = "MATCH (n { prop: 20 }) SET n.prop = 10 RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
@@ -1863,7 +1928,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Node")
     val query = "MATCH (n:Node) SET n.prop = 10 RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
@@ -1872,7 +1937,7 @@ class EagerizationAcceptanceTest
   test("single label+property match followed by set property should not be eager") {
     val query = "MATCH (n:Node {prop:5}) SET n.prop = 10 RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 0
     assertNumberOfEagerness(query, 0)
   }
@@ -1883,7 +1948,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (b :Book {isbn : '123'}) SET b.isbn = '456' RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertNumberOfEagerness(query, 0)
   }
@@ -1894,7 +1959,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a), (b :Book {isbn : '123'}) SET a.isbn = '456' RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
     assertNumberOfEagerness(query, 1)
@@ -1905,7 +1970,7 @@ class EagerizationAcceptanceTest
     createNode(Map("id" -> 0))
     val query = "MATCH (a),(b {id: 0}),(c {id: 0}) SET a.id = 0 RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, propertiesWritten = 2)
     assertNumberOfEagerness(query, 1)
@@ -1916,7 +1981,7 @@ class EagerizationAcceptanceTest
     createNode(Map("id" -> 0))
     val query = "MATCH (a),(b {id: 0}),(c {id: 0}) SET c.id = 1 RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, propertiesWritten = 2)
     assertNumberOfEagerness(query, 1)
@@ -1928,7 +1993,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (b {id: 0}) SET b.id = 1 RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
@@ -1939,7 +2004,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (n {prop : 5})-[r]-() SET r.prop = 6 RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
@@ -1950,7 +2015,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (n {prop : 5})-[r]-(m) SET m.prop = 5 RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, propertiesWritten = 1)
     result.toList should equal(List(Map("count(*)" -> 1)))
     assertNumberOfEagerness(query, 1)
@@ -1960,7 +2025,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode(), "prop" -> 3)
     val query = "MATCH ()-[r {prop : 3}]-() SET r.prop = 6 RETURN count(*) AS c"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, propertiesWritten = 2)
     result.toList should equal(List(Map("c" -> 2)))
 
@@ -1972,7 +2037,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH ()-[r {prop1 : 3}]-() SET r.prop2 = 6 RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, propertiesWritten = 2)
     assertNumberOfEagerness(query, 0)
@@ -1982,7 +2047,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode(), "prop" -> 3)
     val query = "MATCH (n)-[r {prop : 3}]-() SET n.prop = 6 RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, propertiesWritten = 2)
     assertNumberOfEagerness(query, 0)
@@ -1994,7 +2059,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH ()-[r]-() WHERE exists(r.prop) SET r.prop = 'foo' RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, propertiesWritten = 2)
     assertNumberOfEagerness(query, 0)
@@ -2006,7 +2071,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH ()-[r]-() WHERE exists(r.prop1) SET r.prop2 = 'foo'"
 
-    assertStats(updateWithBothPlannersAndCompatibilityMode(query), propertiesWritten = 2)
+    assertStats(updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query), propertiesWritten = 2)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -2019,7 +2084,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH ()-[r {prop: 42}]-(), (:L)-[r2]-() SET r2.prop = 42"
 
     assertNumberOfEagerness(query, 1)
-    assertStats(updateWithBothPlannersAndCompatibilityMode(query), propertiesWritten = 2)
+    assertStats(updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query), propertiesWritten = 2)
   }
 
   test("setting property in tail should be eager if overlap") {
@@ -2029,7 +2094,7 @@ class EagerizationAcceptanceTest
     createNode("prop" -> 42)
     val query = "MATCH (n) CREATE (m) WITH * MATCH (o {prop:42}) SET n.prop = 42 RETURN count(*) as count"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Int]("count").next should equal(8)
     assertStats(result, propertiesWritten = 8, nodesCreated = 4)
     assertNumberOfEagerness(query, 1)
@@ -2042,7 +2107,10 @@ class EagerizationAcceptanceTest
     createNode("prop" -> 42)
     val query = "MATCH (n {prop: 42}) CREATE (m) WITH * MATCH (o) SET n.prop = 42 RETURN count(*) as count"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(
+      Configs.CommunityInterpreted - Configs.Cost2_3 - Configs.Rule2_3,
+      Configs.Rule2_3,
+      query)
     result.columnAs[Int]("count").next should equal(12)
     assertStats(result, propertiesWritten = 12, nodesCreated = 2)
     assertNumberOfEagerness(query, 1)
@@ -2063,7 +2131,10 @@ class EagerizationAcceptanceTest
         |SET m.prop = 42
         |RETURN count(*) as count""".stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(
+      Configs.CommunityInterpreted - Configs.Cost2_3 - Configs.Rule2_3,
+      Configs.Rule2_3,
+      query)
     result.columnAs[Int]("count").next should equal(14)
     assertStats(result, propertiesWritten = 14, nodesCreated = 3)
     assertNumberOfEagerness(query, 1)
@@ -2076,7 +2147,7 @@ class EagerizationAcceptanceTest
     createNode("prop" -> 42)
     val query = "MATCH (n) CREATE (m) WITH * MATCH (o {prop:42}) SET n.prop2 = 42 RETURN count(*) as count"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Int]("count").next should equal(8)
     assertStats(result, propertiesWritten = 8, nodesCreated = 4)
     assertNumberOfEagerness(query, 0)
@@ -2085,7 +2156,7 @@ class EagerizationAcceptanceTest
   test("matching node property, writing with += should be eager") {
     relate(createNode(Map("prop" -> 5)),createNode())
     val query = "MATCH (n {prop : 5})-[r]-(m) SET m += {prop: 5} RETURN count(*)"
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, propertiesWritten = 1)
     result.toList should equal(List(Map("count(*)" -> 1)))
 
@@ -2095,7 +2166,7 @@ class EagerizationAcceptanceTest
   test("matching node property, writing with += should not be eager when we can avoid it") {
     relate(createNode(Map("prop" -> 5)),createNode())
     val query = "MATCH (n {prop : 5})-[r]-(m) SET m += {prop2: 5} RETURN count(*)"
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, propertiesWritten = 1)
     result.toList should equal(List(Map("count(*)" -> 1)))
 
@@ -2110,7 +2181,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (n {prop : 5})-[r]->(m) SET m += {props} RETURN count(*)"
 
-    val result = updateWithBothPlanners(query, "props" -> Map("prop" -> 5))
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, "props" -> Map("prop" -> 5))
     assertStats(result, propertiesWritten = 1)
     result.toList should equal(List(Map("count(*)" -> 1)))
     assertNumberOfEagerness(query, 1)
@@ -2119,7 +2190,7 @@ class EagerizationAcceptanceTest
   test("matching rel property, writing with += should not be eager when we can avoid it") {
     relate(createNode(Map("prop" -> 5)),createNode())
     val query = "MATCH (n {prop : 5})-[r]-(m) SET m += {prop2: 5} RETURN count(*)"
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, propertiesWritten = 1)
     result.toList should equal(List(Map("count(*)" -> 1)))
 
@@ -2131,7 +2202,7 @@ class EagerizationAcceptanceTest
     createLabeledNode(Map("prop" -> 5), "Node", "Lol")
     val query = "MATCH (n:Node) REMOVE n:Lol"
 
-    assertStats(updateWithBothPlannersAndCompatibilityMode(query), labelsRemoved = 1)
+    assertStats(updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query), labelsRemoved = 1)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -2139,7 +2210,7 @@ class EagerizationAcceptanceTest
     createLabeledNode(Map("prop" -> 5), "Node")
     val query = "MATCH (n:Node) REMOVE n:Node"
 
-    assertStats(updateWithBothPlannersAndCompatibilityMode(query), labelsRemoved = 1)
+    assertStats(updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query), labelsRemoved = 1)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -2148,7 +2219,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (m:Lol), (n) REMOVE n:Lol RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
 
     assertStats(result, labelsRemoved = 1)
     result.columnAs[Long]("count(*)").next shouldBe 2
@@ -2160,7 +2231,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Lol")
     val query = "MATCH (m:Lol), (n:Lol) REMOVE m:Lol RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
 
     assertStats(result, labelsRemoved = 2)
     result.columnAs[Long]("count(*)").next shouldBe 4
@@ -2173,7 +2244,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("C")
     val query = "MATCH  (m1:A), (m2:B), (n:C) REMOVE n:C RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, labelsRemoved = 1)
     assertNumberOfEagerness(query, 0)
@@ -2185,7 +2256,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (m1:Two), (m2:Two), (n) REMOVE n:Two RETURN count(*) AS c"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, labelsRemoved = 2)
     assertNumberOfEagerness(query, 1)
     result.toList should equal(List(Map("c" -> 12)))
@@ -2197,7 +2268,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("B")
     val query = "MATCH (n), (m1:A), (m2:A) REMOVE n:B RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 12
     assertStats(result, labelsRemoved = 3)
     assertNumberOfEagerness(query, 0)
@@ -2208,7 +2279,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Foo")
     val query = "MATCH (n) CREATE (m) WITH * MATCH (o:Foo) REMOVE n:Foo RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, labelsRemoved = 2, nodesCreated = 2)
     assertNumberOfEagerness(query, 1)
@@ -2219,7 +2290,10 @@ class EagerizationAcceptanceTest
     createLabeledNode("Foo")
     val query = "MATCH (n) CREATE (m:Foo) WITH * MATCH (o:Foo) REMOVE n:Foo RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(
+      Configs.CommunityInterpreted - Configs.Cost2_3 - Configs.Rule2_3,
+      Configs.Rule2_3,
+      query)
     result.columnAs[Long]("count(*)").next shouldBe 8
     assertNumberOfEagerness(query, 2)
     assertStats(result, labelsAdded = 2, labelsRemoved = 2, nodesCreated = 2)
@@ -2232,7 +2306,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Bar")
     val query = "MATCH (n) CREATE (m) WITH * MATCH (o:Bar) REMOVE n:Foo RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 8
     assertStats(result, labelsRemoved = 2, nodesCreated = 4)
     assertNumberOfEagerness(query, 0)
@@ -2244,7 +2318,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (n:Foo)--(m) REMOVE m:Foo RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, labelsRemoved = 4)
     assertNumberOfEagerness(query, 0)
@@ -2260,7 +2334,7 @@ class EagerizationAcceptanceTest
     // Relationship match is non-directional, so should give 2 rows
     val query = "MATCH (a)-[t:T]-(b) UNWIND [1] as i DELETE t RETURN count(*) as count"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsDeleted = 1)
     // this assertion depends on unnestApply and cleanUpEager
@@ -2275,7 +2349,7 @@ class EagerizationAcceptanceTest
     // Relationship match is non-directional, so should give 2 rows
     val query = "CREATE () WITH * MATCH (a)-[t:T]-(b) UNWIND [1] as i DELETE t RETURN count(*) as count"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, nodesCreated = 1, relationshipsDeleted = 1)
     // this assertion depends on unnestApply and cleanUpEager
@@ -2290,7 +2364,7 @@ class EagerizationAcceptanceTest
     // Relationship match is non-directional, so should give 2 rows
     val query = "CREATE () WITH * CREATE () WITH * MATCH (a)-[t:T]-(b) UNWIND [1] as i DELETE t RETURN count(*) as count"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, nodesCreated = 2, relationshipsDeleted = 1)
     // this assertion depends on unnestApply and cleanUpEager
@@ -2303,7 +2377,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (), () UNWIND [] AS i CREATE () RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next() should equal(0)
     assertStats(result, nodesCreated = 0)
     assertNumberOfEagerness(query, 1)
@@ -2315,7 +2389,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (), () UNWIND [0] AS i CREATE () RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next() should equal(4)
     assertStats(result, nodesCreated = 4)
     assertNumberOfEagerness(query, 1)
@@ -2327,7 +2401,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (), () UNWIND [0, 0] AS i CREATE () RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next() should equal(8)
     assertStats(result, nodesCreated = 8)
     assertNumberOfEagerness(query, 1)
@@ -2339,7 +2413,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH () UNWIND [0] as i MATCH () CREATE () RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next() should equal(4)
     assertStats(result, nodesCreated = 4)
     assertNumberOfEagerness(query, 1)
@@ -2351,7 +2425,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH () UNWIND [0] as i MATCH () UNWIND [0] as j CREATE () RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next() should equal(4)
     assertStats(result, nodesCreated = 4)
     assertNumberOfEagerness(query, 1)
@@ -2363,7 +2437,7 @@ class EagerizationAcceptanceTest
 
     val query = "MERGE () WITH * UNWIND [0] as i MATCH () UNWIND [0] as j CREATE () RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next() should equal(4)
     assertStats(result, nodesCreated = 4)
     assertNumberOfEagerness(query, 2, optimalEagerCount = 1)
@@ -2377,7 +2451,7 @@ class EagerizationAcceptanceTest
     //val query = "UNWIND [0] as u MATCH (a), (b) FOREACH(i in range(0, 1) | DELETE a) RETURN count(*)"
     val query = "MATCH (a), (b) FOREACH(i in range(0, 1) | DELETE a) RETURN count(*)"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next() should equal(4)
     assertStats(result, nodesDeleted = 2)
     assertNumberOfEagerness(query, 1)
@@ -2396,7 +2470,7 @@ class EagerizationAcceptanceTest
         |)
         |RETURN count(*)""".stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next() should equal(2)
     assertStats(result, nodesCreated = 2, labelsAdded = 2, propertiesWritten = 8)
     assertNumberOfEagerness(query, 1)
@@ -2420,7 +2494,7 @@ class EagerizationAcceptanceTest
         |RETURN count(*)
       """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     assertStats(result, nodesCreated = 2, nodesDeleted = 2, propertiesWritten = 6, labelsAdded = 2)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertNumberOfEagerness(query, 1)
@@ -2441,7 +2515,7 @@ class EagerizationAcceptanceTest
         |)
         |RETURN count(*)""".stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next() should equal(2)
     assertStats(result, nodesCreated = 2, labelsAdded = 2, propertiesWritten = 6)
     assertNumberOfEagerness(query, 0)
@@ -2463,7 +2537,7 @@ class EagerizationAcceptanceTest
         |)
         |RETURN count(*)""".stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next() should equal(2)
     assertStats(result, nodesCreated = 4, labelsAdded = 4, propertiesWritten = 24)
     assertNumberOfEagerness(query, 2)
@@ -2483,7 +2557,7 @@ class EagerizationAcceptanceTest
         |)
         |RETURN count(*)""".stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next() should equal(1)
     assertStats(result, nodesCreated = 4, labelsAdded = 4)
     assertNumberOfEagerness(query, 0)
@@ -2509,7 +2583,7 @@ class EagerizationAcceptanceTest
 
     val query = s"MATCH (a)-[t:T]-(b) LOAD CSV FROM '$url' AS line DELETE t RETURN count(*) as count"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsDeleted = 1)
     // this assertion depends on unnestApply and cleanUpEager
@@ -2528,7 +2602,7 @@ class EagerizationAcceptanceTest
 
     val query = s"CREATE () WITH * MATCH (a)-[t:T]-(b) LOAD CSV FROM '$url' AS line DELETE t RETURN count(*) as count"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, nodesCreated = 1, relationshipsDeleted = 1)
     // this assertion depends on unnestApply and cleanUpEager
@@ -2546,7 +2620,7 @@ class EagerizationAcceptanceTest
 
     val query = s"MATCH () LOAD CSV FROM '$url' AS i MATCH () UNWIND [0] as j CREATE () RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next() should equal(4)
     assertStats(result, nodesCreated = 4)
     assertNumberOfEagerness(query, 1)
@@ -2563,7 +2637,7 @@ class EagerizationAcceptanceTest
 
     val query = s"MERGE () WITH * LOAD CSV FROM '$url' AS line MATCH () LOAD CSV FROM '$url' AS line2 CREATE () RETURN count(*)"
 
-    val result = updateWithBothPlannersAndCompatibilityMode(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.columnAs[Long]("count(*)").next() should equal(4)
     assertStats(result, nodesCreated = 4)
     assertNumberOfEagerness(query, 2, optimalEagerCount = 1)
@@ -2590,7 +2664,7 @@ class EagerizationAcceptanceTest
         |RETURN d, c2""".stripMargin
 
     cookies.foreach { case (name, node)  =>
-      val result = updateWithBothPlanners(query, ("cookie" -> name))
+      val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, ("cookie" -> name))
       assertStats(result, nodesDeleted = 1, relationshipsDeleted = 2)
     }
     assertNumberOfEagerness(query, 2)
@@ -2605,7 +2679,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (c:Cookie) DELETE c WITH 1 as t MATCH (x:Cookie) RETURN count(*) as count"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
 
     result.columnAs[Int]("count").next should equal(0)
     assertStats(result, nodesDeleted = 2)
@@ -2621,7 +2695,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH p=(:Cookie) DELETE p WITH 1 as t MATCH (x:Cookie) RETURN count(*) as count"
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
 
     result.columnAs[Int]("count").next should equal(0)
     assertStats(result, nodesDeleted = 2)
@@ -2639,7 +2713,10 @@ class EagerizationAcceptanceTest
                   |RETURN labels
                 """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(
+      Configs.CommunityInterpreted - Configs.Cost2_3 - Configs.Rule2_3,
+      Configs.Rule2_3,
+      query)
     result.toList should equal(List(Map("labels" -> List()), Map("labels" -> List())))
     assertStats(result, labelsAdded = 2)
     assertNumberOfEagerness(query, 1)
@@ -2656,7 +2733,10 @@ class EagerizationAcceptanceTest
                   |RETURN labels
                 """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(
+      Configs.CommunityInterpreted - Configs.Cost2_3 - Configs.Rule2_3,
+      Configs.Rule2_3,
+      query)
     result.toList should equal(List(Map("labels" -> List("Foo")), Map("labels" -> List("Foo"))))
     assertStats(result, labelsRemoved = 2)
     assertNumberOfEagerness(query, 1)
@@ -2672,7 +2752,10 @@ class EagerizationAcceptanceTest
                   |RETURN labels(n), labels(m)
                 """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(
+      Configs.CommunityInterpreted - Configs.Cost2_3 - Configs.Rule2_3,
+      Configs.Rule2_3,
+      query)
     result.toList should equal(List(Map("labels(n)" -> List("Foo"), "labels(m)" -> List("Foo")),
                                     Map("labels(n)" -> List("Foo"), "labels(m)" -> List("Foo"))))
     assertStats(result, labelsAdded = 2)
@@ -2690,7 +2773,7 @@ class EagerizationAcceptanceTest
                   |RETURN labels(n), labels(m)
                 """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
     result.toList should equal(List(Map("labels(n)" -> List("Foo"), "labels(m)" -> List("Foo")),
                                     Map("labels(n)" -> List("Foo"), "labels(m)" -> List("Foo"))))
     assertStats(result, labelsAdded = 2)
@@ -2707,7 +2790,10 @@ class EagerizationAcceptanceTest
                   |RETURN labels(n), labels(m)
                 """.stripMargin
 
-    val result = updateWithBothPlanners(query)
+    val result = updateWith(
+      Configs.CommunityInterpreted - Configs.Cost2_3 - Configs.Rule2_3,
+      Configs.Rule2_3,
+      query)
     result.toList should equal(List(Map("labels(n)" -> List(), "labels(m)" -> List()),
                                     Map("labels(n)" -> List(), "labels(m)" -> List())))
     assertStats(result, labelsRemoved = 2)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UpdateReportingAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UpdateReportingAcceptanceTest.scala
@@ -19,13 +19,13 @@
  */
 package org.neo4j.internal.cypher.acceptance
 
-import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport}
+import org.neo4j.cypher.ExecutionEngineFunSuite
 
-class UpdateReportingAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
+class UpdateReportingAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
   test("creating a node gets reported as such") {
-    val output = updateWithBothPlannersAndCompatibilityMode("create (:A)").dumpToString()
+    val output = updateWith(Configs.Interpreted - Configs.Cost2_3, "create (:A)").dumpToString()
 
-    output should include ("Nodes created: 1")
-    output should include ("Labels added: 1")
+    output should include("Nodes created: 1")
+    output should include("Labels added: 1")
   }
 }

--- a/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -231,6 +231,9 @@ Failing when using a variable that is already bound in CREATE
 
 // Updating queries
 Fail when imposing new predicates on a variable that is already bound
+Create a relationship with the correct direction
+Nodes are not created when aliases are applied to variable names multiple times
+Only a single node is created when an alias is applied to a variable name multiple times
 Combine MATCH, WITH and CREATE
 A bound node should be recognized after projection with WITH + MERGE node
 A bound node should be recognized after projection with WITH + MERGE pattern

--- a/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -232,10 +232,6 @@ Failing when using a variable that is already bound in CREATE
 // Updating queries
 Fail when imposing new predicates on a variable that is already bound
 Create a relationship with the correct direction
-Nodes are not created when aliases are applied to variable names multiple times
-Only a single node is created when an alias is applied to a variable name multiple times
-Combine MATCH, WITH and CREATE
-A bound node should be recognized after projection with WITH + MERGE node
 A bound node should be recognized after projection with WITH + MERGE pattern
 Delete nodes
 Detach delete node
@@ -275,7 +271,6 @@ Should be able to use properties from match in ON MATCH
 Should be able to use properties from match in ON MATCH and ON CREATE
 Should be able to set labels on match
 Should be able to set labels on match and on create
-Should support updates while merging
 Merges should not be able to match on deleted nodes
 ON CREATE on created nodes
 Creating a relationship

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/SlottedPipeBuilderTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/SlottedPipeBuilderTest.scala
@@ -99,6 +99,33 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
     )
   }
 
+  test("eagerize before create node") {
+    // given
+    val label = LabelName("label")(pos)
+    val allNodeScan: AllNodesScan = AllNodesScan(x, Set.empty)(solved)
+    val eager = Eager(allNodeScan)(solved)
+    val createNode = CreateNode(eager, z, Seq(label), None)(solved)
+
+    // when
+    val pipe = build(createNode)
+
+    // then
+    val beforeEagerPipelineInformation = PipelineInformation.empty
+      .newLong("x", false, CTNode)
+
+    val afterEagerPipelineInformation = PipelineInformation.empty
+      .newLong("x", false, CTNode)
+      .newLong("z", false, CTNode)
+
+    pipe should equal(
+      CreateNodeSlottedPipe(
+        EagerSlottedPipe(
+          AllNodesScanSlottedPipe("x", beforeEagerPipelineInformation)(),
+          afterEagerPipelineInformation)(),
+        "z", afterEagerPipelineInformation, Seq(LazyLabel(label)), None)()
+    )
+  }
+
   test("create node") {
     // given
     val label = LabelName("label")(pos)

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/SlotAllocation.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/SlotAllocation.scala
@@ -236,6 +236,10 @@ object SlotAllocation {
         newPipeline.newReference(variable, nullable = true, CTAny)
         newPipeline
 
+      case Eager(_) =>
+        val newPipeline = incomingPipeline.seedClone()
+        newPipeline
+
       case p => throw new SlotAllocationFailed(s"Don't know how to handle $p")
     }
 

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/SlotAllocation.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/SlotAllocation.scala
@@ -40,9 +40,9 @@ import scala.collection.mutable
   **/
 object SlotAllocation {
 
-  def allocateSlots(lp: LogicalPlan): Map[LogicalPlan, PipelineInformation] = {
+  def allocateSlots(lp: LogicalPlan): Map[LogicalPlanId, PipelineInformation] = {
 
-    val result = new mutable.OpenHashMap[LogicalPlan, PipelineInformation]()
+    val result = new mutable.OpenHashMap[LogicalPlanId, PipelineInformation]()
 
     val planStack = new mutable.Stack[(Boolean, LogicalPlan)]()
     val outputStack = new mutable.Stack[PipelineInformation]()
@@ -76,13 +76,13 @@ object SlotAllocation {
         case (None, None) =>
           val argument = if (argumentStack.isEmpty) None else Some(argumentStack.top)
           val output = allocate(current, nullable, argument)
-          result += (current -> output)
+          result += (current.assignedId -> output)
           outputStack.push(output)
 
         case (Some(_), None) =>
           val incomingPipeline = outputStack.pop()
           val output = allocate(current, nullable, incomingPipeline)
-          result += (current -> output)
+          result += (current.assignedId -> output)
           outputStack.push(output)
 
         case (Some(left), Some(right)) if (comingFrom eq left) && isAnApplyPlan(current) =>
@@ -99,7 +99,7 @@ object SlotAllocation {
           val rhsPipeline = outputStack.pop()
           val lhsPipeline = outputStack.pop()
           val output = allocate(current, nullable, lhsPipeline, rhsPipeline)
-          result += (current -> output)
+          result += (current.assignedId -> output)
           if (isAnApplyPlan(current))
             argumentStack.pop()
           outputStack.push(output)
@@ -295,4 +295,3 @@ object SlotAllocation {
 }
 
 class SlotAllocationFailed(str: String) extends InternalException(str)
-

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/SlotAllocationTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/SlotAllocationTest.scala
@@ -105,8 +105,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     allocations should have size 2
     val labelScanAllocations = allocations(allNodesScan.assignedId)
     labelScanAllocations should equal(
-      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), numberOfLongs = 1, numberOfReferences =
-        0))
+      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), numberOfLongs = 1, numberOfReferences = 0))
 
     val expandAllocations = allocations(expand.assignedId)
     expandAllocations should equal(
@@ -129,8 +128,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     allocations should have size 2
     val labelScanAllocations = allocations(allNodesScan.assignedId)
     labelScanAllocations should equal(
-      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), numberOfLongs = 1, numberOfReferences =
-        0))
+      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), numberOfLongs = 1, numberOfReferences = 0))
 
     val expandAllocations = allocations(expand.assignedId)
     expandAllocations should equal(
@@ -190,9 +188,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     allocations should have size 2
     val labelScanAllocations = allocations(allNodesScan.assignedId)
     labelScanAllocations should equal(
-      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), numberOfLongs = 1,
-        numberOfReferences =
-          0))
+      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), numberOfLongs = 1, numberOfReferences = 0))
 
     val expandAllocations = allocations(expand.assignedId)
     expandAllocations should equal(
@@ -246,9 +242,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     allocations should have size 2
     val labelScanAllocations = allocations(allNodesScan.assignedId)
     labelScanAllocations should equal(
-      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), numberOfLongs = 1,
-        numberOfReferences =
-          0))
+      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), numberOfLongs = 1, numberOfReferences = 0))
 
     val expandAllocations = allocations(skip.assignedId)
     expandAllocations shouldBe theSameInstanceAs(labelScanAllocations)
@@ -269,9 +263,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     // then
     allocations should have size 3
     allocations(lhs.assignedId) should equal(
-      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), numberOfLongs = 1,
-        numberOfReferences =
-          0))
+      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), numberOfLongs = 1, numberOfReferences = 0))
 
     val rhsPipeline = allocations(rhs.assignedId)
 
@@ -296,13 +288,10 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     // then
     allocations should have size 2
     allocations(leaf.assignedId) should equal(
-      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), numberOfLongs = 1,
-        numberOfReferences =
-          0))
+      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), numberOfLongs = 1, numberOfReferences = 0))
 
     allocations(distinct.assignedId) should equal(
-      PipelineInformation(Map("x" -> RefSlot(0, nullable = false, CTNode, "x")), numberOfLongs = 0, numberOfReferences =
-        1))
+      PipelineInformation(Map("x" -> RefSlot(0, nullable = false, CTNode, "x")), numberOfLongs = 0, numberOfReferences = 1))
   }
 
   test("optional travels through aggregation used for distinct") {
@@ -318,8 +307,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     // then
     allocations should have size 3
     allocations(leaf.assignedId) should equal(
-      PipelineInformation(Map("x" -> LongSlot(0, nullable = true, CTNode, "x")), numberOfLongs = 1, numberOfReferences =
-        0))
+      PipelineInformation(Map("x" -> LongSlot(0, nullable = true, CTNode, "x")), numberOfLongs = 1, numberOfReferences = 0))
 
     allocations(optional.assignedId) should be theSameInstanceAs allocations(leaf.assignedId)
     allocations(distinct.assignedId) should equal(PipelineInformation(numberOfLongs = 0, numberOfReferences = 2, slots = Map(
@@ -344,8 +332,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     // then
     allocations should have size 3
     allocations(leaf.assignedId) should equal(
-      PipelineInformation(Map("x" -> LongSlot(0, nullable = true, CTNode, "x")), numberOfLongs = 1, numberOfReferences =
-        0))
+      PipelineInformation(Map("x" -> LongSlot(0, nullable = true, CTNode, "x")), numberOfLongs = 1, numberOfReferences = 0))
 
     allocations(optional.assignedId) should be theSameInstanceAs allocations(leaf.assignedId)
     allocations(countStar.assignedId) should equal(

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/SlotAllocationTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/SlotAllocationTest.scala
@@ -39,69 +39,76 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
   test("only single allnodes scan") {
     // given
     val plan = AllNodesScan(x, Set.empty)(solved)
+    plan.assignIds()
 
     // when
     val allocations = SlotAllocation.allocateSlots(plan)
 
     // then
     allocations should have size 1
-    allocations(plan) should equal(PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), 1, 0))
+    allocations(plan.assignedId) should equal(
+      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), 1, 0))
   }
 
   test("limit should not introduce slots") {
     // given
     val plan = logicalPlans.Limit(AllNodesScan(x, Set.empty)(solved), literalInt(1), DoNotIncludeTies)(solved)
+    plan.assignIds()
 
     // when
     val allocations = SlotAllocation.allocateSlots(plan)
 
     // then
     allocations should have size 2
-    allocations(plan) should equal(PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), 1, 0))
+    allocations(plan.assignedId) should equal(
+      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), 1, 0))
   }
 
   test("single labelscan scan") {
     // given
     val plan = NodeByLabelScan(x, LABEL, Set.empty)(solved)
+    plan.assignIds()
 
     // when
     val allocations = SlotAllocation.allocateSlots(plan)
 
     // then
     allocations should have size 1
-    allocations(plan) should equal(PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), 1, 0))
+    allocations(plan.assignedId) should equal(PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), 1, 0))
   }
 
   test("labelscan with filtering") {
     // given
     val leaf = NodeByLabelScan(x, LABEL, Set.empty)(solved)
     val filter = Selection(Seq(True()(pos)), leaf)(solved)
+    filter.assignIds()
 
     // when
     val allocations = SlotAllocation.allocateSlots(filter)
 
     // then
     allocations should have size 2
-    allocations(leaf) should equal(PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), 1, 0))
-    allocations(filter) shouldBe theSameInstanceAs (allocations(leaf))
+    allocations(leaf.assignedId) should equal(PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), 1, 0))
+    allocations(filter.assignedId) shouldBe theSameInstanceAs(allocations(leaf.assignedId))
   }
 
   test("single node with expand") {
     // given
     val allNodesScan = AllNodesScan(x, Set.empty)(solved)
     val expand = Expand(allNodesScan, x, SemanticDirection.INCOMING, Seq.empty, z, r, ExpandAll)(solved)
+    expand.assignIds()
 
     // when
     val allocations = SlotAllocation.allocateSlots(expand)
 
     // then we'll end up with two pipelines
     allocations should have size 2
-    val labelScanAllocations = allocations(allNodesScan)
+    val labelScanAllocations = allocations(allNodesScan.assignedId)
     labelScanAllocations should equal(
       PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), numberOfLongs = 1, numberOfReferences =
         0))
 
-    val expandAllocations = allocations(expand)
+    val expandAllocations = allocations(expand.assignedId)
     expandAllocations should equal(
       PipelineInformation(Map(
         "x" -> LongSlot(0, nullable = false, CTNode, "x"),
@@ -113,18 +120,19 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     // given
     val allNodesScan = AllNodesScan(x, Set.empty)(solved)
     val expand = Expand(allNodesScan, x, SemanticDirection.INCOMING, Seq.empty, x, r, ExpandInto)(solved)
+    expand.assignIds()
 
     // when
     val allocations = SlotAllocation.allocateSlots(expand)
 
     // then we'll end up with two pipelines
     allocations should have size 2
-    val labelScanAllocations = allocations(allNodesScan)
+    val labelScanAllocations = allocations(allNodesScan.assignedId)
     labelScanAllocations should equal(
       PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), numberOfLongs = 1, numberOfReferences =
         0))
 
-    val expandAllocations = allocations(expand)
+    val expandAllocations = allocations(expand.assignedId)
     expandAllocations should equal(
       PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x"), "r" -> LongSlot(1, nullable = false,
         CTRelationship, "r")), numberOfLongs = 2, numberOfReferences = 0))
@@ -134,31 +142,33 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     // given
     val leaf = AllNodesScan(x, Set.empty)(solved)
     val plan = Optional(leaf)(solved)
+    plan.assignIds()
 
     // when
     val allocations = SlotAllocation.allocateSlots(plan)
 
     // then
     allocations should have size 2
-    allocations(plan) should equal(PipelineInformation(Map("x" -> LongSlot(0, nullable = true, CTNode, "x")), 1, 0))
+    allocations(plan.assignedId) should equal(PipelineInformation(Map("x" -> LongSlot(0, nullable = true, CTNode, "x")), 1, 0))
   }
 
   test("single node with optionalExpand ExpandAll") {
     // given
     val allNodesScan = AllNodesScan(x, Set.empty)(solved)
     val expand = OptionalExpand(allNodesScan, x, SemanticDirection.INCOMING, Seq.empty, z, r, ExpandAll)(solved)
+    expand.assignIds()
 
     // when
     val allocations = SlotAllocation.allocateSlots(expand)
 
     // then we'll end up with two pipelines
     allocations should have size 2
-    val labelScanAllocations = allocations(allNodesScan)
+    val labelScanAllocations = allocations(allNodesScan.assignedId)
     labelScanAllocations should equal(
       PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), numberOfLongs = 1, numberOfReferences =
         0))
 
-    val expandAllocations = allocations(expand)
+    val expandAllocations = allocations(expand.assignedId)
     expandAllocations should equal(
       PipelineInformation(Map(
         "x" -> LongSlot(0, nullable = false, CTNode, "x"),
@@ -171,19 +181,20 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     // given
     val allNodesScan = AllNodesScan(x, Set.empty)(solved)
     val expand = OptionalExpand(allNodesScan, x, SemanticDirection.INCOMING, Seq.empty, x, r, ExpandInto)(solved)
+    expand.assignIds()
 
     // when
     val allocations = SlotAllocation.allocateSlots(expand)
 
     // then we'll end up with two pipelines
     allocations should have size 2
-    val labelScanAllocations = allocations(allNodesScan)
+    val labelScanAllocations = allocations(allNodesScan.assignedId)
     labelScanAllocations should equal(
       PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), numberOfLongs = 1,
-                          numberOfReferences =
-                            0))
+        numberOfReferences =
+          0))
 
-    val expandAllocations = allocations(expand)
+    val expandAllocations = allocations(expand.assignedId)
     expandAllocations should equal(
       PipelineInformation(Map(
         "x" -> LongSlot(0, nullable = false, CTNode, "x"),
@@ -198,22 +209,23 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     val tempNode = IdName("r_NODES")
     val tempEdge = IdName("r_EDGES")
     val expand = VarExpand(allNodesScan, x, SemanticDirection.INCOMING, SemanticDirection.INCOMING, Seq.empty, z, r,
-                           varLength, ExpandAll, tempNode, tempEdge, True()(pos), True()(pos), Seq.empty)(solved)
+      varLength, ExpandAll, tempNode, tempEdge, True()(pos), True()(pos), Seq.empty)(solved)
+    expand.assignIds()
 
     // when
     val allocations = SlotAllocation.allocateSlots(expand)
 
     // then we'll end up with two pipelines
     allocations should have size 2
-    val labelScanAllocations = allocations(allNodesScan)
+    val labelScanAllocations = allocations(allNodesScan.assignedId)
     labelScanAllocations should equal(
       PipelineInformation(Map(
         "x" -> LongSlot(0, nullable = false, CTNode, "x"),
         "r_NODES" -> LongSlot(1, nullable = false, CTNode, "r_NODES"),
         "r_EDGES" -> LongSlot(2, nullable = false, CTRelationship, "r_EDGES")),
-                          numberOfLongs = 3, numberOfReferences = 0))
+        numberOfLongs = 3, numberOfReferences = 0))
 
-    val expandAllocations = allocations(expand)
+    val expandAllocations = allocations(expand.assignedId)
     expandAllocations should equal(
       PipelineInformation(Map(
         "x" -> LongSlot(0, nullable = false, CTNode, "x"),
@@ -225,19 +237,20 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     // given
     val allNodesScan = AllNodesScan(x, Set.empty)(solved)
     val skip = logicalPlans.Skip(allNodesScan, literalInt(42))(solved)
+    skip.assignIds()
 
     // when
     val allocations = SlotAllocation.allocateSlots(skip)
 
     // then
     allocations should have size 2
-    val labelScanAllocations = allocations(allNodesScan)
+    val labelScanAllocations = allocations(allNodesScan.assignedId)
     labelScanAllocations should equal(
       PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), numberOfLongs = 1,
-                          numberOfReferences =
-                            0))
+        numberOfReferences =
+          0))
 
-    val expandAllocations = allocations(skip)
+    val expandAllocations = allocations(skip.assignedId)
     expandAllocations shouldBe theSameInstanceAs(labelScanAllocations)
   }
 
@@ -248,18 +261,19 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     val seekExpression = SingleQueryExpression(literalInt(42))
     val rhs = NodeIndexSeek(z, label, Seq.empty, seekExpression, Set(x))(solved)
     val apply = Apply(lhs, rhs)(solved)
+    apply.assignIds()
 
     // when
     val allocations = SlotAllocation.allocateSlots(apply)
 
     // then
     allocations should have size 3
-    allocations(lhs) should equal(
+    allocations(lhs.assignedId) should equal(
       PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), numberOfLongs = 1,
-                          numberOfReferences =
-                            0))
+        numberOfReferences =
+          0))
 
-    val rhsPipeline = allocations(rhs)
+    val rhsPipeline = allocations(rhs.assignedId)
 
     rhsPipeline should equal(
       PipelineInformation(Map(
@@ -267,25 +281,26 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
         "z" -> LongSlot(1, nullable = false, CTNode, "z")
       ), numberOfLongs = 2, numberOfReferences = 0))
 
-    allocations(apply) shouldBe theSameInstanceAs(rhsPipeline)
+    allocations(apply.assignedId) shouldBe theSameInstanceAs(rhsPipeline)
   }
 
   test("aggregation used for distinct") {
     // given
     val leaf = NodeByLabelScan(x, LABEL, Set.empty)(solved)
     val distinct = Aggregation(leaf, Map("x" -> varFor("x")), Map.empty)(solved)
+    distinct.assignIds()
 
     // when
     val allocations = SlotAllocation.allocateSlots(distinct)
 
     // then
     allocations should have size 2
-    allocations(leaf) should equal(
+    allocations(leaf.assignedId) should equal(
       PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode, "x")), numberOfLongs = 1,
-                          numberOfReferences =
-                            0))
+        numberOfReferences =
+          0))
 
-    allocations(distinct) should equal(
+    allocations(distinct.assignedId) should equal(
       PipelineInformation(Map("x" -> RefSlot(0, nullable = false, CTNode, "x")), numberOfLongs = 0, numberOfReferences =
         1))
   }
@@ -295,18 +310,19 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     val leaf = NodeByLabelScan(x, LABEL, Set.empty)(solved)
     val optional = Optional(leaf)(solved)
     val distinct = Distinct(optional, Map("x" -> varFor("x"), "x.propertyKey" -> prop("x", "propertyKey")))(solved)
+    distinct.assignIds()
 
     // when
     val allocations = SlotAllocation.allocateSlots(distinct)
 
     // then
     allocations should have size 3
-    allocations(leaf) should equal(
+    allocations(leaf.assignedId) should equal(
       PipelineInformation(Map("x" -> LongSlot(0, nullable = true, CTNode, "x")), numberOfLongs = 1, numberOfReferences =
         0))
 
-    allocations(optional) should be theSameInstanceAs allocations(leaf)
-    allocations(distinct) should equal(PipelineInformation(numberOfLongs = 0, numberOfReferences = 2, slots = Map(
+    allocations(optional.assignedId) should be theSameInstanceAs allocations(leaf.assignedId)
+    allocations(distinct.assignedId) should equal(PipelineInformation(numberOfLongs = 0, numberOfReferences = 2, slots = Map(
       "x" -> RefSlot(0, nullable = true, CTNode, "x"),
       "x.propertyKey" -> RefSlot(1, nullable = true, CTAny, "x.propertyKey")
     )))
@@ -320,39 +336,42 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
       groupingExpressions = Map("x" -> varFor("x"),
         "x.propertyKey" -> prop("x", "propertyKey")),
       aggregationExpression = Map("count(*)" -> CountStar()(pos)))(solved)
+    countStar.assignIds()
 
     // when
     val allocations = SlotAllocation.allocateSlots(countStar)
 
     // then
     allocations should have size 3
-    allocations(leaf) should equal(
+    allocations(leaf.assignedId) should equal(
       PipelineInformation(Map("x" -> LongSlot(0, nullable = true, CTNode, "x")), numberOfLongs = 1, numberOfReferences =
         0))
 
-    allocations(optional) should be theSameInstanceAs allocations(leaf)
-    allocations(countStar) should equal(PipelineInformation(numberOfLongs = 0, numberOfReferences = 3, slots = Map(
-      "x" -> RefSlot(0, nullable = true, CTNode, "x"),
-      "x.propertyKey" -> RefSlot(1, nullable = true, CTAny, "x.propertyKey"),
-      "count(*)" -> RefSlot(2, nullable = true, CTAny, "count(*)")
-    )))
+    allocations(optional.assignedId) should be theSameInstanceAs allocations(leaf.assignedId)
+    allocations(countStar.assignedId) should equal(
+      PipelineInformation(numberOfLongs = 0, numberOfReferences = 3, slots = Map(
+        "x" -> RefSlot(0, nullable = true, CTNode, "x"),
+        "x.propertyKey" -> RefSlot(1, nullable = true, CTAny, "x.propertyKey"),
+        "count(*)" -> RefSlot(2, nullable = true, CTAny, "count(*)")
+      )))
   }
 
   test("labelscan with projection") {
     // given
     val leaf = NodeByLabelScan(x, LABEL, Set.empty)(solved)
     val projection = Projection(leaf, Map("x" -> varFor("x"), "x.propertyKey" -> prop("x", "propertyKey")))(solved)
+    projection.assignIds()
 
     // when
     val allocations = SlotAllocation.allocateSlots(projection)
 
     // then
     allocations should have size 2
-    allocations(leaf) should equal(PipelineInformation(numberOfLongs = 1, numberOfReferences = 1, slots = Map(
+    allocations(leaf.assignedId) should equal(PipelineInformation(numberOfLongs = 1, numberOfReferences = 1, slots = Map(
       "x" -> LongSlot(0, nullable = false, CTNode, "x"),
       "x.propertyKey" -> RefSlot(0, nullable = true, CTAny, "x.propertyKey")
     )))
-    allocations(projection) shouldBe theSameInstanceAs(allocations(leaf))
+    allocations(projection.assignedId) shouldBe theSameInstanceAs(allocations(leaf.assignedId))
   }
 
   test("cartesian product") {
@@ -360,19 +379,20 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     val lhs = NodeByLabelScan(x, LabelName("label1")(pos), Set.empty)(solved)
     val rhs = NodeByLabelScan(y, LabelName("label2")(pos), Set.empty)(solved)
     val Xproduct = CartesianProduct(lhs, rhs)(solved)
+    Xproduct.assignIds()
 
     // when
     val allocations = SlotAllocation.allocateSlots(Xproduct)
 
     // then
     allocations should have size 3
-    allocations(lhs) should equal(PipelineInformation(numberOfLongs = 1, numberOfReferences = 0, slots = Map(
+    allocations(lhs.assignedId) should equal(PipelineInformation(numberOfLongs = 1, numberOfReferences = 0, slots = Map(
       "x" -> LongSlot(0, nullable = false, CTNode, "x")
     )))
-    allocations(rhs) should equal(PipelineInformation(numberOfLongs = 1, numberOfReferences = 0, slots = Map(
+    allocations(rhs.assignedId) should equal(PipelineInformation(numberOfLongs = 1, numberOfReferences = 0, slots = Map(
       "y" -> LongSlot(0, nullable = false, CTNode, "y")
     )))
-    allocations(Xproduct) should equal(PipelineInformation(numberOfLongs = 2, numberOfReferences = 0, slots = Map(
+    allocations(Xproduct.assignedId) should equal(PipelineInformation(numberOfLongs = 2, numberOfReferences = 0, slots = Map(
       "x" -> LongSlot(0, nullable = false, CTNode, "x"),
       "y" -> LongSlot(1, nullable = false, CTNode, "y")
     )))
@@ -385,6 +405,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     val rhs = Expand(arg, x, SemanticDirection.INCOMING, Seq.empty, y, r, ExpandAll)(solved)
 
     val apply = Apply(lhs, rhs)(solved)
+    apply.assignIds()
 
     // when
     val allocations = SlotAllocation.allocateSlots(apply)
@@ -401,10 +422,10 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     ), numberOfLongs = 3, numberOfReferences = 0)
 
     allocations should have size 4
-    allocations(arg) should equal(lhsPipeline)
-    allocations(lhs) should equal(lhsPipeline)
-    allocations(apply) should equal(rhsPipeline)
-    allocations(rhs) should equal(rhsPipeline)
+    allocations(arg.assignedId) should equal(lhsPipeline)
+    allocations(lhs.assignedId) should equal(lhsPipeline)
+    allocations(apply.assignedId) should equal(rhsPipeline)
+    allocations(rhs.assignedId) should equal(rhsPipeline)
   }
 
   test("unwind and project") {
@@ -412,19 +433,20 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     val leaf = SingleRow()(solved)
     val unwind = UnwindCollection(leaf, IdName("x"), listOf(literalInt(1), literalInt(2), literalInt(3)))(solved)
     val produceResult = ProduceResult(Seq("x"), unwind)
+    produceResult.assignIds()
 
     // when
     val allocations = SlotAllocation.allocateSlots(produceResult)
 
     // then
     allocations should have size 3
-    allocations(leaf) should equal(PipelineInformation(Map.empty, 0, 0))
+    allocations(leaf.assignedId) should equal(PipelineInformation(Map.empty, 0, 0))
 
 
-    allocations(unwind) should equal(PipelineInformation(numberOfLongs = 0, numberOfReferences = 1, slots = Map(
+    allocations(unwind.assignedId) should equal(PipelineInformation(numberOfLongs = 0, numberOfReferences = 1, slots = Map(
       "x" -> RefSlot(0, nullable = true, CTAny, "x")
     )))
-    allocations(produceResult) shouldBe theSameInstanceAs(allocations(unwind))
+    allocations(produceResult.assignedId) shouldBe theSameInstanceAs(allocations(unwind.assignedId))
   }
 
   test("unwind and project and sort") {
@@ -435,46 +457,48 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     val unwind = UnwindCollection(leaf, xVarName, listOf(literalInt(1), literalInt(2), literalInt(3)))(solved)
     val sort = Sort(unwind, List(Ascending(xVarName)))(solved)
     val produceResult = ProduceResult(Seq("x"), sort)
+    produceResult.assignIds()
 
     // when
     val allocations = SlotAllocation.allocateSlots(produceResult)
 
     // then
     allocations should have size 4
-    allocations(leaf) should equal(PipelineInformation(Map.empty, 0, 0))
+    allocations(leaf.assignedId) should equal(PipelineInformation(Map.empty, 0, 0))
 
 
     val expectedPipeline = PipelineInformation(numberOfLongs = 0, numberOfReferences = 1, slots = Map(
       "x" -> RefSlot(0, nullable = true, CTAny, "x")
     ))
-    allocations(unwind) should equal(expectedPipeline)
-    allocations(sort) shouldBe theSameInstanceAs(allocations(unwind))
-    allocations(produceResult) shouldBe theSameInstanceAs(allocations(unwind))
+    allocations(unwind.assignedId) should equal(expectedPipeline)
+    allocations(sort.assignedId) shouldBe theSameInstanceAs(allocations(unwind.assignedId))
+    allocations(produceResult.assignedId) shouldBe theSameInstanceAs(allocations(unwind.assignedId))
   }
 
-  test("semi apply"){
+  test("semi apply") {
     // MATCH (x) WHERE (x) -[:r]-> (y) ....
-    testSemiApply(SemiApply(_,_))
+    testSemiApply(SemiApply(_, _))
   }
 
-  test("anti semi apply"){
+  test("anti semi apply") {
     // MATCH (x) WHERE NOT (x) -[:r]-> (y) ....
-    testSemiApply(AntiSemiApply(_,_))
+    testSemiApply(AntiSemiApply(_, _))
   }
 
   def testSemiApply(
-                 semiApplyBuilder: (LogicalPlan, LogicalPlan) =>
-                                    PlannerQuery with CardinalityEstimation => AbstractSemiApply
-               ):Unit = {
+                     semiApplyBuilder: (LogicalPlan, LogicalPlan) =>
+                       PlannerQuery with CardinalityEstimation => AbstractSemiApply
+                   ): Unit = {
     val lhs = NodeByLabelScan(x, LABEL, Set.empty)(solved)
     val arg = Argument(Set(x))(solved)()
     val rhs = Expand(arg, x, SemanticDirection.INCOMING, Seq.empty, y, r, ExpandAll)(solved)
     val semiApply = semiApplyBuilder(lhs, rhs)(solved)
+    semiApply.assignIds()
     val allocations = SlotAllocation.allocateSlots(semiApply)
 
     val lhsPipeline = PipelineInformation(Map(
       "x" -> LongSlot(0, nullable = false, CTNode, "x")),
-                                          numberOfLongs = 1, numberOfReferences = 0)
+      numberOfLongs = 1, numberOfReferences = 0)
 
     val argumentSide = lhsPipeline
 
@@ -485,16 +509,39 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     ), numberOfLongs = 3, numberOfReferences = 0)
 
     allocations should have size 4
-    allocations(semiApply) should equal(lhsPipeline)
-    allocations(lhs) should equal(lhsPipeline)
-    allocations(rhs) should equal(rhsPipeline)
-    allocations(arg) should equal(argumentSide)
+    allocations(semiApply.assignedId) should equal(lhsPipeline)
+    allocations(lhs.assignedId) should equal(lhsPipeline)
+    allocations(rhs.assignedId) should equal(rhsPipeline)
+    allocations(arg.assignedId) should equal(argumentSide)
+  }
+
+  test("singlerow on two sides of Apply") {
+    val sr1 = SingleRow()(solved)
+    val sr2 = SingleRow()(solved)
+    val pr1 = Projection(sr1, Map("x" -> literalInt(42)))(solved)
+    val pr2 = Projection(sr2, Map("y" -> literalInt(666)))(solved)
+    val apply = Apply(pr1, pr2)(solved)
+    apply.assignIds()
+
+    // when
+    val allocations = SlotAllocation.allocateSlots(apply)
+
+    // then
+    allocations should have size 5
+    val lhsPipeline = PipelineInformation(Map("x" -> RefSlot(0, nullable = true, CTAny, "x")), 0, 1)
+    val rhsPipeline = PipelineInformation(Map("x" -> RefSlot(0, nullable = true, CTAny, "x"), "y" -> RefSlot(1, nullable = true, CTAny, "y")), 0, 2)
+    allocations(sr1.assignedId) should equal(lhsPipeline)
+    allocations(pr1.assignedId) should equal(lhsPipeline)
+    allocations(sr2.assignedId) should equal(rhsPipeline)
+    allocations(pr2.assignedId) should equal(rhsPipeline)
+    allocations(apply.assignedId) should equal(rhsPipeline)
   }
 
   test("should allocate aggregation") {
     // Given MATCH (x)-[r:R]->(y) RETURN x, x.prop, count(r.prop)
     val labelScan = NodeByLabelScan(x, LABEL, Set.empty)(solved)
     val expand = Expand(labelScan, x, SemanticDirection.INCOMING, Seq.empty, y, r, ExpandAll)(solved)
+
     val grouping = Map(
       "x" -> varFor("x"),
       "x.prop" -> prop("x", "prop")
@@ -503,24 +550,25 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
       "count(r.prop)" -> FunctionInvocation(FunctionName("count")(pos), prop("r", "prop"))(pos)
     )
     val aggregation = Aggregation(expand, grouping, aggregations)(solved)
-
+    aggregation.assignIds()
+    
     // when
     val allocations = SlotAllocation.allocateSlots(aggregation)
 
     allocations should have size 3
-    allocations(expand) should equal(
+    allocations(expand.assignedId) should equal(
       PipelineInformation(Map(
         "x" -> LongSlot(0, nullable = false, CTNode, "x"),
         "r" -> LongSlot(1, nullable = false, CTRelationship, "r"),
         "y" -> LongSlot(2, nullable = false, CTNode, "y")
       ), numberOfLongs = 3, numberOfReferences = 0)
     )
-    allocations(aggregation) should equal(
+    allocations(aggregation.assignedId) should equal(
       PipelineInformation(Map(
         "x" -> RefSlot(0, nullable = false, CTNode, "x"),
         "x.prop" -> RefSlot(1, nullable = true, CTAny, "x.prop"),
         "count(r.prop)" -> RefSlot(2, nullable = true, CTAny, "count(r.prop)")
-        ), numberOfLongs = 0, numberOfReferences = 3)
+      ), numberOfLongs = 0, numberOfReferences = 3)
     )
   }
 }

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/SlotAllocationTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/SlotAllocationTest.scala
@@ -551,7 +551,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     )
     val aggregation = Aggregation(expand, grouping, aggregations)(solved)
     aggregation.assignIds()
-    
+
     // when
     val allocations = SlotAllocation.allocateSlots(aggregation)
 

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/PrimitiveExecutionContext.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/PrimitiveExecutionContext.scala
@@ -30,8 +30,8 @@ object PrimitiveExecutionContext {
 
 case class PrimitiveExecutionContext(pipeline: PipelineInformation) extends ExecutionContext {
 
-  private val longs = new Array[Long](pipeline.numberOfLongs)
-  private val refs = new Array[AnyValue](pipeline.numberOfReferences)
+  override val longs = new Array[Long](pipeline.numberOfLongs)
+  override val refs = new Array[AnyValue](pipeline.numberOfReferences)
 
   override def toString(): String = s"pipeLine: $pipeline, longs[${longs.length}]: $longs, refs[${refs.length}]: $refs"
 
@@ -71,11 +71,11 @@ case class PrimitiveExecutionContext(pipeline: PipelineInformation) extends Exec
     value
   }
 
-  override def +=(kv: (String, AnyValue)) = fail()
+  override def +=(kv: (String, AnyValue)): Nothing = fail()
 
-  override def -=(key: String) = fail()
+  override def -=(key: String): Nothing = fail()
 
-  override def get(key: String) = fail()
+  override def get(key: String): Nothing = fail()
 
   override def iterator =
     // This method implementation is for debug usage only (the debugger will invoke it when stepping).

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/SlottedPipeBuilder.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/SlottedPipeBuilder.scala
@@ -236,6 +236,9 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
       case Sort(_, sortItems) =>
         SortRegisterPipe(source, sortItems.map(translateColumnOrder(pipeline, _)), pipeline)(id = id)
 
+      case Eager(_) =>
+        EagerSlottedPipe(source, pipeline)(id)
+
       case _ =>
         throw new CantCompileQueryException(s"Unsupported logical plan operator: $plan")
     }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/SlottedPipeBuilder.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/SlottedPipeBuilder.scala
@@ -42,7 +42,7 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
                          expressionConverters: ExpressionConverters,
                          idMap: Map[LogicalPlan, Id],
                          monitors: Monitors,
-                         pipelines: Map[LogicalPlan, PipelineInformation],
+                         pipelines: Map[LogicalPlanId, PipelineInformation],
                          readOnly: Boolean,
                          rewriteAstExpression: (frontEndAst.Expression) => frontEndAst.Expression)
                         (implicit context: PipeExecutionBuilderContext, planContext: PlanContext)
@@ -55,7 +55,7 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
     implicit val table: SemanticTable = context.semanticTable
 
     val id = idMap.getOrElse(plan, new Id)
-    val pipelineInformation = pipelines(plan)
+    val pipelineInformation = pipelines(plan.assignedId)
 
     plan match {
       case AllNodesScan(IdName(column), _) =>
@@ -93,7 +93,7 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
     implicit val table: SemanticTable = context.semanticTable
 
     val id = idMap.getOrElse(plan, new Id)
-    val pipeline = pipelines(plan)
+    val pipeline = pipelines(plan.assignedId)
 
     plan match {
       case ProduceResult(columns, _) =>
@@ -141,7 +141,7 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
         val relOffset = pipeline.getReferenceOffsetFor(relName)
 
         // The node/edge predicates are evaluated on the incoming pipeline, not the produced one
-        val incomingPipeline = pipelines(sourcePlan)
+        val incomingPipeline = pipelines(sourcePlan.assignedId)
         val tempNodeOffset = incomingPipeline.getLongOffsetFor(tempNode)
         val tempEdgeOffset = incomingPipeline.getLongOffsetFor(tempEdge)
         val sizeOfTemporaryStorage = 2
@@ -294,7 +294,7 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
     implicit val table: SemanticTable = context.semanticTable
 
     val id = idMap.getOrElse(plan, new Id)
-    val pipeline = pipelines(plan)
+    val pipeline = pipelines(plan.assignedId)
 
     plan match {
       case Apply(_, _) =>
@@ -306,9 +306,8 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
 
       case _: CartesianProduct =>
         val lhsPlan = plan.lhs.get
-        val lhsLongCount = pipelines(lhsPlan).numberOfLongs
-        val lhsRefCount = pipelines(lhsPlan).numberOfReferences
-        CartesianProductSlottedPipe(lhs, rhs, lhsLongCount, lhsRefCount, pipeline)(id)
+        val lhsPipeline = pipelines(lhsPlan.assignedId)
+        CartesianProductSlottedPipe(lhs, rhs, lhsPipeline.numberOfLongs, lhsPipeline.numberOfReferences, pipeline)(id)
 
       case ConditionalApply(_, _, items) =>
         val (longIds , refIds) = items.partition(idName => pipeline.get(idName.name) match {

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/pipes/EagerSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/pipes/EagerSlottedPipe.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compatibility.v3_3.runtime.slotted.pipes
+
+import org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes.{Pipe, PipeWithSource, QueryState}
+import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.Id
+import org.neo4j.cypher.internal.compatibility.v3_3.runtime.slotted.PrimitiveExecutionContext
+import org.neo4j.cypher.internal.compatibility.v3_3.runtime.{ExecutionContext, PipelineInformation}
+
+case class EagerSlottedPipe(source: Pipe, pipelineInformation: PipelineInformation)(val id: Id = new Id)
+  extends PipeWithSource(source) {
+
+  override protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
+    input.map { inputRow =>
+      // this is necessary because Eager is the beginning of a new pipeline
+      val outputRow = PrimitiveExecutionContext(pipelineInformation)
+      inputRow.copyTo(outputRow)
+      outputRow
+    }.toIndexedSeq.iterator
+  }
+}


### PR DESCRIPTION
Eager exposed problems in register allocation. How pipeline information is sent between components is now based on a more stable id mechanism, that survives rewriting.