### PR TITLE
faster hashcode for ArrayValue

### DIFF
--- a/community/values/src/main/java/org/neo4j/values/storable/BooleanArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/BooleanArray.java
@@ -26,7 +26,7 @@ import org.neo4j.values.SequenceValue;
 
 import static java.lang.String.format;
 
-abstract class BooleanArray extends ArrayValue
+public abstract class BooleanArray extends ArrayValue
 {
     abstract boolean[] value();
 

--- a/community/values/src/main/java/org/neo4j/values/storable/ByteArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ByteArray.java
@@ -26,7 +26,7 @@ import org.neo4j.values.SequenceValue;
 
 import static java.lang.String.format;
 
-abstract class ByteArray extends IntegralArray
+public abstract class ByteArray extends IntegralArray
 {
     abstract byte[] value();
 

--- a/community/values/src/main/java/org/neo4j/values/storable/CharArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/CharArray.java
@@ -73,7 +73,7 @@ abstract class CharArray extends TextArray
     @Override
     public int computeHash()
     {
-        return TextValues.hash( value() );
+        return NumberValues.hash( value() );
     }
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/CharArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/CharArray.java
@@ -26,7 +26,7 @@ import org.neo4j.values.SequenceValue;
 
 import static java.lang.String.format;
 
-abstract class CharArray extends TextArray
+public abstract class CharArray extends TextArray
 {
     abstract char[] value();
 

--- a/community/values/src/main/java/org/neo4j/values/storable/FloatArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/FloatArray.java
@@ -26,7 +26,7 @@ import org.neo4j.values.SequenceValue;
 
 import static java.lang.String.format;
 
-abstract class FloatArray extends FloatingPointArray
+public abstract class FloatArray extends FloatingPointArray
 {
     abstract float[] value();
 

--- a/community/values/src/main/java/org/neo4j/values/storable/IntArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/IntArray.java
@@ -26,7 +26,7 @@ import org.neo4j.values.SequenceValue;
 
 import static java.lang.String.format;
 
-abstract class IntArray extends IntegralArray
+public abstract class IntArray extends IntegralArray
 {
     abstract int[] value();
 

--- a/community/values/src/main/java/org/neo4j/values/storable/NumberValues.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/NumberValues.java
@@ -24,7 +24,7 @@ import java.util.Arrays;
 
 /**
  * Static methods for computing the hashCode of primitive numbers and arrays of primitive numbers.
- *
+ * <p>
  * Also compares Value typed number arrays.
  */
 @SuppressWarnings( "WeakerAccess" )
@@ -32,6 +32,24 @@ public final class NumberValues
 {
     private NumberValues()
     {
+    }
+
+    /*
+     * Using the fact that the hashcode ∑x_i * 31^(i-1) can be expressed as
+     * a dot product, [v_1, v_2, v_2, ...] • [1, 31, 31^2,...]. By expressing
+     * it in that way the compiler is smart enough to better parallelize the
+     * computation of the hash code.
+     */
+    private static final int MAX_LENGTH = 10000;
+    private static final int[] COEFFICIENTS = new int[MAX_LENGTH + 1];
+
+    static
+    {
+        COEFFICIENTS[0] = 1;
+        for ( int i = 1; i <= MAX_LENGTH; ++i )
+        {
+            COEFFICIENTS[i] = 31 * COEFFICIENTS[i - 1];
+        }
     }
 
     private static final long NON_DOUBLE_LONG = 0xFFE0_0000_0000_0000L; // doubles are exact integers up to 53 bits
@@ -49,52 +67,109 @@ public final class NumberValues
             return hash( asLong );
         }
         long bits = Double.doubleToLongBits( number );
-        return (int)(bits ^ (bits >>> 32));
+        return (int) (bits ^ (bits >>> 32));
     }
 
+    /*
+     * This is a slightly silly optimization but by turning the computation
+     * of the hashcode into a dot product we trick the jit compiler to use SIMD
+     * instructions and performance doubles.
+     */
     public static int hash( byte[] values )
     {
-        int result = 1;
-        for ( byte value : values )
+        final int max = values.length;
+        int result = COEFFICIENTS[max];
+        for ( int i = 0; i < values.length && i < COEFFICIENTS.length - 1; ++i )
         {
-            int elementHash = NumberValues.hash( value );
-            result = 31 * result + elementHash;
+            result += COEFFICIENTS[max - i - 1] * values[i];
         }
         return result;
     }
 
     public static int hash( short[] values )
     {
-        int result = 1;
-        for ( short value : values )
+        final int max = values.length;
+        int result = COEFFICIENTS[max];
+        for ( int i = 0; i < values.length && i < COEFFICIENTS.length - 1; ++i )
         {
-            int elementHash = NumberValues.hash( value );
-            result = 31 * result + elementHash;
+            result += COEFFICIENTS[max - i - 1] * values[i];
+        }
+        return result;
+    }
+
+    public static int hash( char[] values )
+    {
+        final int max = values.length;
+        int result = COEFFICIENTS[max];
+        for ( int i = 0; i < values.length && i < COEFFICIENTS.length - 1; ++i )
+        {
+            result += COEFFICIENTS[max - i - 1] * values[i];
         }
         return result;
     }
 
     public static int hash( int[] values )
     {
-        int result = 1;
-        for ( int value : values )
+        final int max = values.length;
+        int result = COEFFICIENTS[max];
+        for ( int i = 0; i < values.length && i < COEFFICIENTS.length - 1; ++i )
         {
-            int elementHash = NumberValues.hash( value );
-            result = 31 * result + elementHash;
+            result += COEFFICIENTS[max - i - 1] * values[i];
         }
         return result;
     }
 
     public static int hash( long[] values )
     {
-        int result = 1;
-        for ( long value : values )
+        final int max = values.length;
+        int result = COEFFICIENTS[max];
+        for ( int i = 0; i < values.length && i < COEFFICIENTS.length - 1; ++i )
         {
-            int elementHash = NumberValues.hash( value );
-            result = 31 * result + elementHash;
+            result += COEFFICIENTS[max - i - 1] * NumberValues.hash( values[i] );
         }
         return result;
     }
+
+    public static int hash( Object[] values )
+    {
+        return Arrays.hashCode( values );
+    }
+
+    //19000
+    /*
+     * This is identical to Arrays.hashCode but without
+     * null checks, so only use if certain that there are no
+     * null values
+     */
+//    public static int hash( Object[] values )
+//    {
+//        int result = 1;
+//        for ( Object element : values )
+//        {
+//            result = 31 * result + element.hashCode();
+//        }
+//        return result;
+//    }
+
+//16922.201
+//    public static int hash( Object[] a )
+//    {
+//        int result = 1;
+//        int i = 0;
+//        for ( ; i + 3 < a.length; i += 4 )
+//        {
+//            result = 31 * 31 * 31 * 31 * result
+//                     + 31 * 31 * 31 * a[i].hashCode()
+//                     + 31 * 31 * a[i + 1].hashCode()
+//                     + 31 * a[i + 2].hashCode()
+//                     + a[i + 3].hashCode();
+//        }
+//        for ( ; i < a.length; i++ )
+//        {
+//            result = 31 * result + a[i].hashCode();
+//        }
+//        return result;
+//    }
 
     public static int hash( float[] values )
     {
@@ -167,7 +242,7 @@ public final class NumberValues
     // Tested by PropertyValueComparisonTest
     public static int compareDoubleAgainstLong( double lhs, long rhs )
     {
-        if  ( (NON_DOUBLE_LONG & rhs ) != NON_DOUBLE_LONG )
+        if ( (NON_DOUBLE_LONG & rhs) != NON_DOUBLE_LONG )
         {
             if ( Double.isNaN( lhs ) )
             {
@@ -185,7 +260,7 @@ public final class NumberValues
     // Tested by PropertyValueComparisonTest
     public static int compareLongAgainstDouble( long lhs, double rhs )
     {
-        return - compareDoubleAgainstLong( rhs, lhs );
+        return -compareDoubleAgainstLong( rhs, lhs );
     }
 
     public static boolean numbersEqual( IntegralArray lhs, IntegralArray rhs )

--- a/community/values/src/main/java/org/neo4j/values/storable/NumberValues.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/NumberValues.java
@@ -42,6 +42,7 @@ public final class NumberValues
      */
     static final int MAX_LENGTH = 10000;
     private static final int[] COEFFICIENTS = new int[MAX_LENGTH + 1];
+    private static final long NON_DOUBLE_LONG = 0xFFE0_0000_0000_0000L; // doubles are exact integers up to 53 bits
 
     static
     {
@@ -54,11 +55,18 @@ public final class NumberValues
         }
     }
 
-    private static final long NON_DOUBLE_LONG = 0xFFE0_0000_0000_0000L; // doubles are exact integers up to 53 bits
-
+    /*
+     * For equality semantics it is important that the hashcode of a long
+     * is the same as the hashcode of an int as long as the long can fit in 32 bits.
+     */
     public static int hash( long number )
     {
-        return (int) (number ^ (number >>> 32));
+        int asInt = (int) number;
+        if ( asInt == number )
+        {
+            return asInt;
+        }
+        return Long.hashCode( number );
     }
 
     public static int hash( double number )
@@ -79,7 +87,7 @@ public final class NumberValues
      */
     public static int hash( byte[] values )
     {
-        final int max = Math.min(values.length, MAX_LENGTH);
+        final int max = Math.min( values.length, MAX_LENGTH );
         int result = COEFFICIENTS[max];
         for ( int i = 0; i < values.length && i < COEFFICIENTS.length - 1; ++i )
         {
@@ -90,7 +98,7 @@ public final class NumberValues
 
     public static int hash( short[] values )
     {
-        final int max = Math.min(values.length, MAX_LENGTH);
+        final int max = Math.min( values.length, MAX_LENGTH );
         int result = COEFFICIENTS[max];
         for ( int i = 0; i < values.length && i < COEFFICIENTS.length - 1; ++i )
         {
@@ -101,7 +109,7 @@ public final class NumberValues
 
     public static int hash( char[] values )
     {
-        final int max = Math.min(values.length, MAX_LENGTH);
+        final int max = Math.min( values.length, MAX_LENGTH );
         int result = COEFFICIENTS[max];
         for ( int i = 0; i < values.length && i < COEFFICIENTS.length - 1; ++i )
         {
@@ -112,7 +120,7 @@ public final class NumberValues
 
     public static int hash( int[] values )
     {
-        final int max = Math.min(values.length, MAX_LENGTH);
+        final int max = Math.min( values.length, MAX_LENGTH );
         int result = COEFFICIENTS[max];
         for ( int i = 0; i < values.length && i < COEFFICIENTS.length - 1; ++i )
         {
@@ -123,7 +131,7 @@ public final class NumberValues
 
     public static int hash( long[] values )
     {
-        final int max = Math.min(values.length, MAX_LENGTH);
+        final int max = Math.min( values.length, MAX_LENGTH );
         int result = COEFFICIENTS[max];
         for ( int i = 0; i < values.length && i < COEFFICIENTS.length - 1; ++i )
         {

--- a/community/values/src/main/java/org/neo4j/values/storable/NumberValues.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/NumberValues.java
@@ -132,11 +132,6 @@ public final class NumberValues
         return result;
     }
 
-    public static int hash( Object[] values )
-    {
-        return Arrays.hashCode( values );
-    }
-
     public static int hash( float[] values )
     {
         int result = 1;

--- a/community/values/src/main/java/org/neo4j/values/storable/NumberValues.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/NumberValues.java
@@ -36,15 +36,17 @@ public final class NumberValues
 
     /*
      * Using the fact that the hashcode ∑x_i * 31^(i-1) can be expressed as
-     * a dot product, [v_1, v_2, v_2, ...] • [1, 31, 31^2,...]. By expressing
+     * a dot product, [1, v_1, v_2, v_2, ..., v_n] • [31^n, 31^{n-1}, ..., 31, 1]. By expressing
      * it in that way the compiler is smart enough to better parallelize the
      * computation of the hash code.
      */
-    private static final int MAX_LENGTH = 10000;
+    static final int MAX_LENGTH = 10000;
     private static final int[] COEFFICIENTS = new int[MAX_LENGTH + 1];
 
     static
     {
+        //We are defining the coefficient vector backwards, [1, 31, 31^2,...]
+        //makes it easier and faster do find the starting position later
         COEFFICIENTS[0] = 1;
         for ( int i = 1; i <= MAX_LENGTH; ++i )
         {
@@ -77,7 +79,7 @@ public final class NumberValues
      */
     public static int hash( byte[] values )
     {
-        final int max = values.length;
+        final int max = Math.min(values.length, MAX_LENGTH);
         int result = COEFFICIENTS[max];
         for ( int i = 0; i < values.length && i < COEFFICIENTS.length - 1; ++i )
         {
@@ -88,7 +90,7 @@ public final class NumberValues
 
     public static int hash( short[] values )
     {
-        final int max = values.length;
+        final int max = Math.min(values.length, MAX_LENGTH);
         int result = COEFFICIENTS[max];
         for ( int i = 0; i < values.length && i < COEFFICIENTS.length - 1; ++i )
         {
@@ -99,7 +101,7 @@ public final class NumberValues
 
     public static int hash( char[] values )
     {
-        final int max = values.length;
+        final int max = Math.min(values.length, MAX_LENGTH);
         int result = COEFFICIENTS[max];
         for ( int i = 0; i < values.length && i < COEFFICIENTS.length - 1; ++i )
         {
@@ -110,7 +112,7 @@ public final class NumberValues
 
     public static int hash( int[] values )
     {
-        final int max = values.length;
+        final int max = Math.min(values.length, MAX_LENGTH);
         int result = COEFFICIENTS[max];
         for ( int i = 0; i < values.length && i < COEFFICIENTS.length - 1; ++i )
         {
@@ -121,7 +123,7 @@ public final class NumberValues
 
     public static int hash( long[] values )
     {
-        final int max = values.length;
+        final int max = Math.min(values.length, MAX_LENGTH);
         int result = COEFFICIENTS[max];
         for ( int i = 0; i < values.length && i < COEFFICIENTS.length - 1; ++i )
         {
@@ -134,42 +136,6 @@ public final class NumberValues
     {
         return Arrays.hashCode( values );
     }
-
-    //19000
-    /*
-     * This is identical to Arrays.hashCode but without
-     * null checks, so only use if certain that there are no
-     * null values
-     */
-//    public static int hash( Object[] values )
-//    {
-//        int result = 1;
-//        for ( Object element : values )
-//        {
-//            result = 31 * result + element.hashCode();
-//        }
-//        return result;
-//    }
-
-//16922.201
-//    public static int hash( Object[] a )
-//    {
-//        int result = 1;
-//        int i = 0;
-//        for ( ; i + 3 < a.length; i += 4 )
-//        {
-//            result = 31 * 31 * 31 * 31 * result
-//                     + 31 * 31 * 31 * a[i].hashCode()
-//                     + 31 * 31 * a[i + 1].hashCode()
-//                     + 31 * a[i + 2].hashCode()
-//                     + a[i + 3].hashCode();
-//        }
-//        for ( ; i < a.length; i++ )
-//        {
-//            result = 31 * result + a[i].hashCode();
-//        }
-//        return result;
-//    }
 
     public static int hash( float[] values )
     {

--- a/community/values/src/main/java/org/neo4j/values/storable/ShortArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ShortArray.java
@@ -26,7 +26,7 @@ import org.neo4j.values.SequenceValue;
 
 import static java.lang.String.format;
 
-abstract class ShortArray extends IntegralArray
+public abstract class ShortArray extends IntegralArray
 {
     abstract short[] value();
 

--- a/community/values/src/main/java/org/neo4j/values/storable/StringArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringArray.java
@@ -78,7 +78,7 @@ public abstract class StringArray extends TextArray
     @Override
     public int computeHash()
     {
-        return NumberValues.hash( value() );
+        return Arrays.hashCode( value() );
     }
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/StringArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringArray.java
@@ -78,7 +78,7 @@ public abstract class StringArray extends TextArray
     @Override
     public int computeHash()
     {
-        return TextValues.hash( value() );
+        return NumberValues.hash( value() );
     }
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/TextValues.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TextValues.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.values.storable;
 
-import java.util.Arrays;
-
 /**
  * Static methods for comparing and hashing chars, Strings and Text values.
  */
@@ -62,15 +60,5 @@ public final class TextValues
             x = a.length() - b.length();
         }
         return x;
-    }
-
-    public static int hash( char[] value )
-    {
-        return Arrays.hashCode( value );
-    }
-
-    public static int hash( String[] value )
-    {
-        return Arrays.hashCode( value );
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/virtual/ListValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/ListValue.java
@@ -264,7 +264,7 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
         @Override
         public int computeHash()
         {
-            return NumberValues.hash( values );
+            return Arrays.hashCode( values );
         }
     }
 

--- a/community/values/src/main/java/org/neo4j/values/virtual/ListValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/ListValue.java
@@ -31,6 +31,7 @@ import org.neo4j.values.AnyValueWriter;
 import org.neo4j.values.SequenceValue;
 import org.neo4j.values.VirtualValue;
 import org.neo4j.values.storable.ArrayValue;
+import org.neo4j.values.storable.NumberValues;
 import org.neo4j.values.storable.Values;
 
 import static org.neo4j.values.virtual.ArrayHelpers.containsNull;
@@ -263,7 +264,7 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
         @Override
         public int computeHash()
         {
-            return Arrays.hashCode( values );
+            return NumberValues.hash( values );
         }
     }
 

--- a/community/values/src/test/java/org/neo4j/values/storable/NumberValuesTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/NumberValuesTest.java
@@ -21,8 +21,13 @@ package org.neo4j.values.storable;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.neo4j.values.storable.NumberValues.MAX_LENGTH;
 import static org.neo4j.values.storable.NumberValues.hash;
 
 public class NumberValuesTest
@@ -47,4 +52,99 @@ public class NumberValuesTest
         assertThat( hash( 1337d ), equalTo( hash( 1337L ) ) );
     }
 
+    @Test
+    public void shouldGiveSameResultsAsBuiltInHashForInts()
+    {
+        int[] ints = new int[32];
+        Random r = ThreadLocalRandom.current();
+        for ( int i = 0; i < 32; i++ )
+        {
+            ints[i] = r.nextInt();
+        }
+
+        assertThat(hash(ints), equalTo(Arrays.hashCode( ints )));
+    }
+
+    @Test
+    public void shouldGiveSameResultsAsBuiltInHashForBytes()
+    {
+        byte[] bytes = new byte[32];
+        Random r = ThreadLocalRandom.current();
+        for ( int i = 0; i < 32; i++ )
+        {
+            bytes[i] = (byte)r.nextInt();
+        }
+
+        assertThat(hash(bytes), equalTo(Arrays.hashCode( bytes )));
+    }
+
+    @Test
+    public void shouldGiveSameResultsAsBuiltInHashForShorts()
+    {
+        short[] shorts = new short[32];
+        Random r = ThreadLocalRandom.current();
+        for ( int i = 0; i < 32; i++ )
+        {
+            shorts[i] = (short)r.nextInt();
+        }
+
+        assertThat(hash(shorts), equalTo(Arrays.hashCode( shorts )));
+    }
+
+    @Test
+    public void shouldGiveSameResultsAsBuiltInHashForLongs()
+    {
+        long[] longs = new long[32];
+        Random r = ThreadLocalRandom.current();
+        for ( int i = 0; i < 32; i++ )
+        {
+            longs[i] = (long)r.nextInt();
+        }
+
+        assertThat(hash(longs), equalTo(Arrays.hashCode( longs )));
+    }
+
+    @Test
+    public void shouldHandleBigIntArrays()
+    {
+        int[] big = new int[NumberValues.MAX_LENGTH + 1];
+        int[] slightlySmaller = new int[MAX_LENGTH];
+        Arrays.fill( big, 1337 );
+        Arrays.fill( slightlySmaller, 1337 );
+
+        assertThat( hash( big ), equalTo( hash( slightlySmaller ) ) );
+    }
+
+    @Test
+    public void shouldHandleBigByteArrays()
+    {
+        byte[] big = new byte[NumberValues.MAX_LENGTH + 1];
+        byte[] slightlySmaller = new byte[MAX_LENGTH];
+        Arrays.fill( big, (byte) 1337 );
+        Arrays.fill( slightlySmaller, (byte) 1337 );
+
+        assertThat( hash( big ), equalTo( hash( slightlySmaller ) ) );
+    }
+
+    @Test
+    public void shouldHandleBigShortArrays()
+    {
+        short[] big = new short[NumberValues.MAX_LENGTH + 1];
+        short[] slightlySmaller = new short[MAX_LENGTH];
+        Arrays.fill( big, (short) 1337 );
+        Arrays.fill( slightlySmaller, (short) 1337 );
+
+        assertThat( hash( big ), equalTo( hash( slightlySmaller ) ) );
+    }
+
+    @Test
+    public void shouldHandleBigLongArrays()
+    {
+        long[] big = new long[NumberValues.MAX_LENGTH + 1];
+        long[] slightlySmaller = new long[MAX_LENGTH];
+        Arrays.fill( big, 1337L );
+        Arrays.fill( slightlySmaller, 1337L );
+
+        assertThat( hash( big ), equalTo( hash( slightlySmaller ) ) );
+    }
 }

--- a/community/values/src/test/java/org/neo4j/values/storable/NumberValuesTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/NumberValuesTest.java
@@ -21,13 +21,11 @@ package org.neo4j.values.storable;
 
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.neo4j.values.storable.NumberValues.MAX_LENGTH;
 import static org.neo4j.values.storable.NumberValues.hash;
 
 public class NumberValuesTest
@@ -36,14 +34,14 @@ public class NumberValuesTest
     @Test
     public void shouldHashNaN()
     {
-        assertThat( hash( Double.NaN ), equalTo( Double.hashCode( Double.NaN ) ) );
+        assertThat( hash( Double.NaN ), equalTo( hash( Float.NaN ) ) );
     }
 
     @Test
     public void shouldHashInfinite()
     {
-        assertThat( hash( Double.NEGATIVE_INFINITY ), equalTo( Double.hashCode( Double.NEGATIVE_INFINITY ) ) );
-        assertThat( hash( Double.POSITIVE_INFINITY ), equalTo( Double.hashCode( Double.POSITIVE_INFINITY ) ) );
+        assertThat( hash( Double.NEGATIVE_INFINITY ), equalTo( hash( Float.NEGATIVE_INFINITY ) ) );
+        assertThat( hash( Double.POSITIVE_INFINITY ), equalTo( hash( Float.POSITIVE_INFINITY ) ) );
     }
 
     @Test
@@ -53,98 +51,36 @@ public class NumberValuesTest
     }
 
     @Test
-    public void shouldGiveSameResultsAsBuiltInHashForInts()
+    public void shouldGiveSameResultEvenWhenArraysContainDifferentTypes()
     {
         int[] ints = new int[32];
+        long[] longs = new long[32];
+
         Random r = ThreadLocalRandom.current();
         for ( int i = 0; i < 32; i++ )
         {
-            ints[i] = r.nextInt();
+            int nextInt = r.nextInt();
+            ints[i] = nextInt;
+            longs[i] = nextInt;
         }
 
-        assertThat(hash(ints), equalTo(Arrays.hashCode( ints )));
+        assertThat( hash( ints ), equalTo( hash( longs ) ) );
     }
 
     @Test
-    public void shouldGiveSameResultsAsBuiltInHashForBytes()
+    public void shouldGiveSameResultEvenWhenArraysContainDifferentTypes2()
     {
         byte[] bytes = new byte[32];
-        Random r = ThreadLocalRandom.current();
-        for ( int i = 0; i < 32; i++ )
-        {
-            bytes[i] = (byte)r.nextInt();
-        }
-
-        assertThat(hash(bytes), equalTo(Arrays.hashCode( bytes )));
-    }
-
-    @Test
-    public void shouldGiveSameResultsAsBuiltInHashForShorts()
-    {
         short[] shorts = new short[32];
+
         Random r = ThreadLocalRandom.current();
         for ( int i = 0; i < 32; i++ )
         {
-            shorts[i] = (short)r.nextInt();
+            byte nextByte = ((Number)(r.nextInt())).byteValue();
+            bytes[i] = nextByte;
+            shorts[i] = nextByte;
         }
 
-        assertThat(hash(shorts), equalTo(Arrays.hashCode( shorts )));
-    }
-
-    @Test
-    public void shouldGiveSameResultsAsBuiltInHashForLongs()
-    {
-        long[] longs = new long[32];
-        Random r = ThreadLocalRandom.current();
-        for ( int i = 0; i < 32; i++ )
-        {
-            longs[i] = (long)r.nextInt();
-        }
-
-        assertThat(hash(longs), equalTo(Arrays.hashCode( longs )));
-    }
-
-    @Test
-    public void shouldHandleBigIntArrays()
-    {
-        int[] big = new int[NumberValues.MAX_LENGTH + 1];
-        int[] slightlySmaller = new int[MAX_LENGTH];
-        Arrays.fill( big, 1337 );
-        Arrays.fill( slightlySmaller, 1337 );
-
-        assertThat( hash( big ), equalTo( hash( slightlySmaller ) ) );
-    }
-
-    @Test
-    public void shouldHandleBigByteArrays()
-    {
-        byte[] big = new byte[NumberValues.MAX_LENGTH + 1];
-        byte[] slightlySmaller = new byte[MAX_LENGTH];
-        Arrays.fill( big, (byte) 1337 );
-        Arrays.fill( slightlySmaller, (byte) 1337 );
-
-        assertThat( hash( big ), equalTo( hash( slightlySmaller ) ) );
-    }
-
-    @Test
-    public void shouldHandleBigShortArrays()
-    {
-        short[] big = new short[NumberValues.MAX_LENGTH + 1];
-        short[] slightlySmaller = new short[MAX_LENGTH];
-        Arrays.fill( big, (short) 1337 );
-        Arrays.fill( slightlySmaller, (short) 1337 );
-
-        assertThat( hash( big ), equalTo( hash( slightlySmaller ) ) );
-    }
-
-    @Test
-    public void shouldHandleBigLongArrays()
-    {
-        long[] big = new long[NumberValues.MAX_LENGTH + 1];
-        long[] slightlySmaller = new long[MAX_LENGTH];
-        Arrays.fill( big, 1337L );
-        Arrays.fill( slightlySmaller, 1337L );
-
-        assertThat( hash( big ), equalTo( hash( slightlySmaller ) ) );
+        assertThat( hash( bytes ), equalTo( hash( shorts ) ) );
     }
 }

--- a/community/values/src/test/java/org/neo4j/values/storable/NumberValuesTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/NumberValuesTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.storable;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.neo4j.values.storable.NumberValues.hash;
+
+public class NumberValuesTest
+{
+
+    @Test
+    public void shouldHashNaN()
+    {
+        assertThat( hash( Double.NaN ), equalTo( Double.hashCode( Double.NaN ) ) );
+    }
+
+    @Test
+    public void shouldHashInfinite()
+    {
+        assertThat( hash( Double.NEGATIVE_INFINITY ), equalTo( Double.hashCode( Double.NEGATIVE_INFINITY ) ) );
+        assertThat( hash( Double.POSITIVE_INFINITY ), equalTo( Double.hashCode( Double.POSITIVE_INFINITY ) ) );
+    }
+
+    @Test
+    public void shouldHashIntegralDoubleAsLong()
+    {
+        assertThat( hash( 1337d ), equalTo( hash( 1337L ) ) );
+    }
+
+}

--- a/community/values/src/test/java/org/neo4j/values/storable/NumberValuesTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/NumberValuesTest.java
@@ -68,6 +68,17 @@ public class NumberValuesTest
     }
 
     @Test
+    public void shouldGiveSameHashForLongsAndInts()
+    {
+        Random r = ThreadLocalRandom.current();
+        for ( int i = 0; i < 1_000_000; i++ )
+        {
+            int anInt = r.nextInt();
+            assertThat( anInt, equalTo( hash( (long) anInt ) ) );
+        }
+    }
+
+    @Test
     public void shouldGiveSameResultEvenWhenArraysContainDifferentTypes2()
     {
         byte[] bytes = new byte[32];
@@ -76,7 +87,7 @@ public class NumberValuesTest
         Random r = ThreadLocalRandom.current();
         for ( int i = 0; i < 32; i++ )
         {
-            byte nextByte = ((Number)(r.nextInt())).byteValue();
+            byte nextByte = ((Number) (r.nextInt())).byteValue();
             bytes[i] = nextByte;
             shorts[i] = nextByte;
         }


### PR DESCRIPTION
By implementing the hash code as a dot product we can achieve higher parallelizability which makes some hash code computations roughly two times faster.