### PR TITLE
Make Read-Write eagerization type aware

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/Eagerness.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/Eagerness.scala
@@ -165,7 +165,7 @@ object Eagerness {
     val conflict =
       if (tail.queryGraph.writeOnly) false
       else (head.queryGraph overlaps tail.queryGraph) ||
-        (head.queryGraph.overlapsHorizon(tail.horizon, context.semanticTable)) ||
+        head.queryGraph.overlapsHorizon(tail.horizon, context.semanticTable) ||
         deleteReadOverlap(head.queryGraph, tail.queryGraph)
     if (conflict)
       true

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/Eagerness.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/Eagerness.scala
@@ -107,7 +107,7 @@ object Eagerness {
   def headWriteReadEagerize(inputPlan: LogicalPlan, query: PlannerQuery)
                        (implicit context: LogicalPlanningContext): LogicalPlan = {
     val alwaysEager = context.config.updateStrategy.alwaysEager
-    val conflictInHorizon = query.queryGraph.overlapsHorizon(query.horizon)
+    val conflictInHorizon = query.queryGraph.overlapsHorizon(query.horizon, context.semanticTable)
     if (alwaysEager || conflictInHorizon || query.tail.isDefined && writeReadConflictInHead(query, query.tail.get))
       context.logicalPlanProducer.planEager(inputPlan)
     else
@@ -117,7 +117,7 @@ object Eagerness {
   def tailWriteReadEagerize(inputPlan: LogicalPlan, query: PlannerQuery)
                              (implicit context: LogicalPlanningContext): LogicalPlan = {
     val alwaysEager = context.config.updateStrategy.alwaysEager
-    val conflictInHorizon = query.queryGraph.overlapsHorizon(query.horizon)
+    val conflictInHorizon = query.queryGraph.overlapsHorizon(query.horizon, context.semanticTable)
     if (alwaysEager || conflictInHorizon || query.tail.isDefined && writeReadConflictInTail(query, query.tail.get))
       context.logicalPlanProducer.planEager(inputPlan)
     else
@@ -165,7 +165,7 @@ object Eagerness {
     val conflict =
       if (tail.queryGraph.writeOnly) false
       else (head.queryGraph overlaps tail.queryGraph) ||
-        (head.queryGraph overlapsHorizon tail.horizon) ||
+        (head.queryGraph.overlapsHorizon(tail.horizon, context.semanticTable)) ||
         deleteReadOverlap(head.queryGraph, tail.queryGraph)
     if (conflict)
       true
@@ -176,8 +176,9 @@ object Eagerness {
   }
 
   @tailrec
-  def horizonReadWriteConflict(head: PlannerQuery, tail: PlannerQuery): Boolean = {
-    val conflict = tail.queryGraph.overlapsHorizon(head.horizon)
+  def horizonReadWriteConflict(head: PlannerQuery, tail: PlannerQuery)
+                              (implicit context: LogicalPlanningContext): Boolean = {
+    val conflict = tail.queryGraph.overlapsHorizon(head.horizon, context.semanticTable)
     if (conflict)
       true
     else if (tail.tail.isEmpty)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceTest.scala
@@ -56,7 +56,7 @@ class LoadCsvAcceptanceTest
     })
 
     val result = executeWithCostPlannerAndInterpretedRuntimeOnly(
-      s"""LOAD CSV WITH HEADERS FROM '${urls(0)}' AS row
+      s"""LOAD CSV WITH HEADERS FROM '${urls.head}' AS row
           | CREATE (user:User{userID: row.USERID})
           | CREATE (order:Order{orderID: row.OrderId})
           | CREATE (user)-[acc:ORDERED]->(order)
@@ -93,7 +93,7 @@ class LoadCsvAcceptanceTest
     })
 
     val result = executeWithCostPlannerAndInterpretedRuntimeOnly(
-      s"""LOAD CSV WITH HEADERS FROM '${urls(0)}' AS row
+      s"""LOAD CSV WITH HEADERS FROM '${urls.head}' AS row
          | WITH row.field1 as field, row.OrderId as order
          | MATCH (o) WHERE o.OrderId = order
          | SET o.field1 = field""".stripMargin)


### PR DESCRIPTION
Solves performance issue where LOAD CSV queries were eagerized when writing to a property which shared name with a csv column header.