### PR TITLE
Fusion index enabled by default

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -411,7 +411,7 @@ public class GraphDatabaseSettings implements LoadableConfig
 
     @Internal
     public static final Setting<Boolean> enable_native_schema_index =
-            setting( "unsupported.dbms.enable_native_schema_index", BOOLEAN, FALSE );
+            setting( "unsupported.dbms.enable_native_schema_index", BOOLEAN, TRUE );
 
     // Store settings
     @Description( "Make Neo4j keep the logical transaction logs for being able to backup the database. " +


### PR DESCRIPTION
Fusion index is a combination of Lucene+native indexing. The native index
can currently only handle numbers, more efficiently than Lucene can.
Other values still go to Lucene.

Existing indexes will not automatically be migrated, but instead new
indexes will be created with the fusion index provider.