### PR TITLE
Re-enables previous accidental disable of parallel index population

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/BatchingMultipleIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/BatchingMultipleIndexPopulator.java
@@ -150,20 +150,12 @@ public class BatchingMultipleIndexPopulator extends MultipleIndexPopulator
     }
 
     /**
-     * Insert all batched updates into corresponding indexes.
-     */
-    @Override
-    protected void flushAll()
-    {
-        populations.forEach( this::flush );
-    }
-
-    /**
      * Insert the given batch of updates into the index defined by the given {@link IndexPopulation}.
      *
      * @param population the index population.
      */
-    private void flush( IndexPopulation population )
+    @Override
+    protected void flush( IndexPopulation population )
     {
         activeTasks.incrementAndGet();
         Collection<IndexEntryUpdate<?>> batch = population.takeCurrentBatch();


### PR DESCRIPTION
Now in BatchingMultipleIndexPopulator the index scan takes advantage of
the parallel execution available by its executor. In a previous commit this
was accidentally disabled.