### PR TITLE
Order writes to native schema number index

### DIFF
--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/full/FullCheckIntegrationTest.java
@@ -576,7 +576,7 @@ public class FullCheckIntegrationTest
                 for ( long nodeId : indexedNodes )
                 {
                     NodeUpdates updates = storeView.nodeAsUpdates( nodeId );
-                    for ( IndexEntryUpdate update : updates.forIndexKeys( asList( descriptor ) ) )
+                    for ( IndexEntryUpdate<?> update : updates.forIndexKeys( asList( descriptor ) ) )
                     {
                         updater.process( IndexEntryUpdate.remove( nodeId, descriptor, update.values() ) );
                     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexEntryUpdate.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexEntryUpdate.java
@@ -32,6 +32,8 @@ import static java.lang.String.format;
  * Subclasses of this represent events related to property changes due to property or label addition, deletion or
  * update.
  * This is of use in populating indexes that might be relevant to node label and property combinations.
+ *
+ * @param <INDEX_KEY> {@link LabelSchemaSupplier} specifying the schema
  */
 public class IndexEntryUpdate<INDEX_KEY extends LabelSchemaSupplier>
 {
@@ -94,7 +96,7 @@ public class IndexEntryUpdate<INDEX_KEY extends LabelSchemaSupplier>
             return false;
         }
 
-        IndexEntryUpdate that = (IndexEntryUpdate) o;
+        IndexEntryUpdate<?> that = (IndexEntryUpdate<?>) o;
 
         if ( entityId != that.entityId )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexPopulator.java
@@ -20,7 +20,7 @@
 package org.neo4j.kernel.api.index;
 
 import java.io.IOException;
-import java.util.Collection;
+import java.util.List;
 
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
@@ -62,7 +62,7 @@ public interface IndexPopulator
      * pass over the index in {@link #verifyDeferredConstraints(PropertyAccessor)}.
      * @throws IOException on I/O error.
      */
-    void add( Collection<? extends IndexEntryUpdate<?>> updates )
+    void add( List<? extends IndexEntryUpdate<?>> updates )
             throws IndexEntryConflictException, IOException;
 
     /**
@@ -85,7 +85,7 @@ public interface IndexPopulator
      * Simultaneously as population progresses there might be incoming updates
      * from committing transactions, which needs to be applied as well. This populator will only receive updates
      * for nodes that it already has seen. Updates coming in here must be applied idempotently as the same data
-     * may have been {@link #add(Collection) added previously}.
+     * may have been {@link #add(List) added previously}.
      * Updates can come in two different {@link IndexEntryUpdate#updateMode()} modes}.
      * <ol>
      *   <li>{@link UpdateMode#ADDED} means that there's an added property to a node already seen by this
@@ -162,7 +162,7 @@ public interface IndexPopulator
         }
 
         @Override
-        public void add( Collection<? extends IndexEntryUpdate<?>> updates ) throws IndexEntryConflictException,
+        public void add( List<? extends IndexEntryUpdate<?>> updates ) throws IndexEntryConflictException,
                 IOException
         {
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexUpdater.java
@@ -33,7 +33,7 @@ import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
  */
 public interface IndexUpdater extends AutoCloseable
 {
-    void process( IndexEntryUpdate update ) throws IOException, IndexEntryConflictException;
+    void process( IndexEntryUpdate<?> update ) throws IOException, IndexEntryConflictException;
 
     @Override
     void close() throws IOException, IndexEntryConflictException;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/BatchingMultipleIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/BatchingMultipleIndexPopulator.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.kernel.impl.api.index;
 
-import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -158,7 +158,7 @@ public class BatchingMultipleIndexPopulator extends MultipleIndexPopulator
     protected void flush( IndexPopulation population )
     {
         activeTasks.incrementAndGet();
-        Collection<IndexEntryUpdate<?>> batch = population.takeCurrentBatch();
+        List<IndexEntryUpdate<?>> batch = population.takeCurrentBatch();
 
         executor.execute( () ->
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationJob.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexPopulationJob.java
@@ -162,7 +162,7 @@ public class IndexPopulationJob implements Runnable
      *
      * @param update {@link IndexEntryUpdate} to queue.
      */
-    public void update( IndexEntryUpdate update )
+    public void update( IndexEntryUpdate<?> update )
     {
         multiPopulator.queue( update );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexStoreView.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexStoreView.java
@@ -72,6 +72,7 @@ public interface IndexStoreView extends PropertyAccessor, PropertyLoader
 
     void incrementIndexUpdates( long indexId, long updatesDelta );
 
+    @SuppressWarnings( "rawtypes" )
     StoreScan EMPTY_SCAN = new StoreScan()
     {
         @Override
@@ -115,6 +116,7 @@ public interface IndexStoreView extends PropertyAccessor, PropertyLoader
             return Values.NO_VALUE;
         }
 
+        @SuppressWarnings( "unchecked" )
         @Override
         public <FAILURE extends Exception> StoreScan<FAILURE> visitNodes( int[] labelIds,
                 IntPredicate propertyKeyIdFilter, Visitor<NodeUpdates,FAILURE> propertyUpdateVisitor,
@@ -151,6 +153,5 @@ public interface IndexStoreView extends PropertyAccessor, PropertyLoader
         public void incrementIndexUpdates( long indexId, long updatesDelta )
         {
         }
-
     };
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/MultipleIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/MultipleIndexPopulator.java
@@ -157,7 +157,7 @@ public class MultipleIndexPopulator implements IndexPopulator
     }
 
     @Override
-    public void add( Collection<? extends IndexEntryUpdate<?>> updates )
+    public void add( List<? extends IndexEntryUpdate<?>> updates )
     {
         throw new UnsupportedOperationException( "Can't populate directly using this populator implementation. " );
     }
@@ -548,13 +548,13 @@ public class MultipleIndexPopulator implements IndexPopulator
             return batchedUpdates.size() >= BATCH_SIZE;
         }
 
-        Collection<IndexEntryUpdate<?>> takeCurrentBatch()
+        List<IndexEntryUpdate<?>> takeCurrentBatch()
         {
             if ( batchedUpdates.isEmpty() )
             {
                 return Collections.emptyList();
             }
-            Collection<IndexEntryUpdate<?>> batch = batchedUpdates;
+            List<IndexEntryUpdate<?>> batch = batchedUpdates;
             batchedUpdates = new ArrayList<>( BATCH_SIZE );
             return batch;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/MultipleIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/MultipleIndexPopulator.java
@@ -93,7 +93,7 @@ public class MultipleIndexPopulator implements IndexPopulator
 
     // Concurrency queue since multiple concurrent threads may enqueue updates into it. It is important for this queue
     // to have fast #size() method since it might be drained in batches
-    protected final Queue<IndexEntryUpdate> queue = new LinkedBlockingQueue<>();
+    protected final Queue<IndexEntryUpdate<?>> queue = new LinkedBlockingQueue<>();
 
     // Populators are added into this list. The same thread adding populators will later call #indexAllNodes.
     // Multiple concurrent threads might fail individual populations.
@@ -187,13 +187,15 @@ public class MultipleIndexPopulator implements IndexPopulator
      *
      * @param update {@link IndexEntryUpdate} to queue.
      */
-    public void queue( IndexEntryUpdate update )
+    public void queue( IndexEntryUpdate<?> update )
     {
         queue.add( update );
     }
 
     /**
      * Called if forced failure from the outside
+     *
+     * @param failure index population failure.
      */
     public void fail( Throwable failure )
     {
@@ -279,7 +281,7 @@ public class MultipleIndexPopulator implements IndexPopulator
     }
 
     @Override
-    public void includeSample( IndexEntryUpdate update )
+    public void includeSample( IndexEntryUpdate<?> update )
     {
         throw new UnsupportedOperationException( "Multiple index populator can't perform index sampling." );
     }
@@ -383,7 +385,7 @@ public class MultipleIndexPopulator implements IndexPopulator
                 do
                 {
                     // no need to check for null as nobody else is emptying this queue
-                    IndexEntryUpdate update = queue.poll();
+                    IndexEntryUpdate<?> update = queue.poll();
                     storeScan.acceptUpdate( updater, update, currentlyIndexedNodeId );
                 }
                 while ( !queue.isEmpty() );
@@ -421,7 +423,7 @@ public class MultipleIndexPopulator implements IndexPopulator
         }
 
         @Override
-        public void process( IndexEntryUpdate update )
+        public void process( IndexEntryUpdate<?> update )
         {
             Pair<IndexPopulation,IndexUpdater> pair = populationsWithUpdaters.get( update.indexKey().schema() );
             if ( pair != null )
@@ -510,7 +512,7 @@ public class MultipleIndexPopulator implements IndexPopulator
                     populator, failure( t ), indexCountsRemover, logProvider ) );
         }
 
-        private void onUpdate( IndexEntryUpdate update )
+        private void onUpdate( IndexEntryUpdate<?> update )
         {
             populator.includeSample( update );
             if ( batch( update ) )
@@ -602,7 +604,7 @@ public class MultipleIndexPopulator implements IndexPopulator
         }
 
         @Override
-        public void acceptUpdate( MultipleIndexUpdater updater, IndexEntryUpdate update, long currentlyIndexedNodeId )
+        public void acceptUpdate( MultipleIndexUpdater updater, IndexEntryUpdate<?> update, long currentlyIndexedNodeId )
         {
             delegate.acceptUpdate( updater, update, currentlyIndexedNodeId );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
@@ -69,7 +69,7 @@ public class PopulatingIndexProxy implements IndexProxy
                 return new PopulatingIndexUpdater()
                 {
                     @Override
-                    public void process( IndexEntryUpdate update ) throws IOException, IndexEntryConflictException
+                    public void process( IndexEntryUpdate<?> update ) throws IOException, IndexEntryConflictException
                     {
                         job.update( update );
                     }
@@ -78,7 +78,7 @@ public class PopulatingIndexProxy implements IndexProxy
                 return new PopulatingIndexUpdater()
                 {
                     @Override
-                    public void process( IndexEntryUpdate update ) throws IOException, IndexEntryConflictException
+                    public void process( IndexEntryUpdate<?> update ) throws IOException, IndexEntryConflictException
                     {
                         throw new IllegalArgumentException( "Unsupported update mode: " + mode );
                     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/StoreScan.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/StoreScan.java
@@ -30,7 +30,7 @@ public interface StoreScan<FAILURE extends Exception>
 
     void stop();
 
-    void acceptUpdate( MultipleIndexPopulator.MultipleIndexUpdater updater, IndexEntryUpdate update,
+    void acceptUpdate( MultipleIndexPopulator.MultipleIndexUpdater updater, IndexEntryUpdate<?> update,
             long currentlyIndexedNodeId );
 
     PopulationProgress getProgress();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/TentativeConstraintIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/TentativeConstraintIndexProxy.java
@@ -76,7 +76,7 @@ public class TentativeConstraintIndexProxy extends AbstractDelegatingIndexProxy
                 return new DelegatingIndexUpdater( target.accessor.newUpdater( mode ) )
                 {
                     @Override
-                    public void process( IndexEntryUpdate update )
+                    public void process( IndexEntryUpdate<?> update )
                             throws IOException, IndexEntryConflictException
                     {
                         try

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/updater/DelegatingIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/updater/DelegatingIndexUpdater.java
@@ -35,7 +35,7 @@ public abstract class DelegatingIndexUpdater implements IndexUpdater
     }
 
     @Override
-    public void process( IndexEntryUpdate update ) throws IOException, IndexEntryConflictException
+    public void process( IndexEntryUpdate<?> update ) throws IOException, IndexEntryConflictException
     {
         delegate.process( update );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/updater/SwallowingIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/updater/SwallowingIndexUpdater.java
@@ -30,7 +30,7 @@ public final class SwallowingIndexUpdater implements IndexUpdater
     public static final IndexUpdater INSTANCE = new SwallowingIndexUpdater();
 
     @Override
-    public void process( IndexEntryUpdate update )
+    public void process( IndexEntryUpdate<?> update )
     {
         // intentionally swallow this update
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/updater/UniquePropertyIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/updater/UniquePropertyIndexUpdater.java
@@ -37,10 +37,10 @@ import org.neo4j.kernel.impl.util.diffsets.DiffSets;
 public abstract class UniquePropertyIndexUpdater implements IndexUpdater
 {
     private final Map<Object, DiffSets<Long>> referenceCount = new HashMap<>();
-    private final ArrayList<IndexEntryUpdate> updates = new ArrayList<>();
+    private final ArrayList<IndexEntryUpdate<?>> updates = new ArrayList<>();
 
     @Override
-    public void process( IndexEntryUpdate update )
+    public void process( IndexEntryUpdate<?> update )
     {
         // build uniqueness verification state
         switch ( update.updateMode() )
@@ -70,7 +70,7 @@ public abstract class UniquePropertyIndexUpdater implements IndexUpdater
         flushUpdates( updates );
     }
 
-    protected abstract void flushUpdates( Iterable<IndexEntryUpdate> updates )
+    protected abstract void flushUpdates( Iterable<IndexEntryUpdate<?>> updates )
             throws IOException, IndexEntryConflictException;
 
     private DiffSets<Long> propertyValueDiffSet( Object value )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/updater/UpdateCountingIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/updater/UpdateCountingIndexUpdater.java
@@ -41,7 +41,7 @@ public class UpdateCountingIndexUpdater implements IndexUpdater
     }
 
     @Override
-    public void process( IndexEntryUpdate update ) throws IOException, IndexEntryConflictException
+    public void process( IndexEntryUpdate<?> update ) throws IOException, IndexEntryConflictException
     {
         delegate.process( update );
         updates++;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeNonUniqueSchemaNumberIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeNonUniqueSchemaNumberIndexPopulator.java
@@ -49,7 +49,7 @@ class NativeNonUniqueSchemaNumberIndexPopulator<KEY extends SchemaNumberKey, VAL
     }
 
     @Override
-    public void includeSample( IndexEntryUpdate update )
+    public void includeSample( IndexEntryUpdate<?> update )
     {
         if ( updateSampling )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndex.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndex.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.index.schema;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.function.Consumer;
 
 import org.neo4j.index.internal.gbptree.GBPTree;
@@ -29,12 +30,23 @@ import org.neo4j.index.internal.gbptree.Layout;
 import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.kernel.api.index.IndexEntryUpdate;
+import org.neo4j.values.storable.Values;
 
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_READER;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_MONITOR;
 
 class NativeSchemaNumberIndex<KEY extends SchemaNumberKey, VALUE extends SchemaNumberValue>
 {
+    static final Comparator<IndexEntryUpdate<?>> BY_VALUE_COMPARATOR = ( o1, o2 ) ->
+    {
+        // At this point we know that these are single-value numeric updates, so just have this simple assertion
+        assert o1.values().length == 1;
+        assert o2.values().length == 1;
+
+        return Values.COMPARATOR.compare( o1.values()[0], o2.values()[0] );
+    };
+
     final PageCache pageCache;
     final File storeFile;
     final Layout<KEY,VALUE> layout;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexPopulator.java
@@ -23,7 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import org.neo4j.concurrent.Work;
@@ -106,7 +106,7 @@ public abstract class NativeSchemaNumberIndexPopulator<KEY extends SchemaNumberK
     }
 
     @Override
-    public void add( Collection<? extends IndexEntryUpdate<?>> updates ) throws IndexEntryConflictException, IOException
+    public void add( List<? extends IndexEntryUpdate<?>> updates ) throws IndexEntryConflictException, IOException
     {
         applyWithWorkSync( updates );
     }
@@ -124,7 +124,7 @@ public abstract class NativeSchemaNumberIndexPopulator<KEY extends SchemaNumberK
         return new IndexUpdater()
         {
             private boolean closed;
-            private final Collection<IndexEntryUpdate<?>> updates = new ArrayList<>();
+            private final List<IndexEntryUpdate<?>> updates = new ArrayList<>();
 
             @Override
             public void process( IndexEntryUpdate<?> update ) throws IOException, IndexEntryConflictException
@@ -179,7 +179,7 @@ public abstract class NativeSchemaNumberIndexPopulator<KEY extends SchemaNumberK
         }
     }
 
-    private void applyWithWorkSync( Collection<? extends IndexEntryUpdate<?>> updates ) throws IOException
+    private void applyWithWorkSync( List<? extends IndexEntryUpdate<?>> updates ) throws IOException
     {
         try
         {
@@ -265,9 +265,9 @@ public abstract class NativeSchemaNumberIndexPopulator<KEY extends SchemaNumberK
     private static class IndexUpdateWork<KEY extends SchemaNumberKey, VALUE extends SchemaNumberValue>
             implements Work<IndexUpdateApply<KEY,VALUE>,IndexUpdateWork<KEY,VALUE>>
     {
-        private final Collection<? extends IndexEntryUpdate<?>> updates;
+        private final List<? extends IndexEntryUpdate<?>> updates;
 
-        IndexUpdateWork( Collection<? extends IndexEntryUpdate<?>> updates )
+        IndexUpdateWork( List<? extends IndexEntryUpdate<?>> updates )
         {
             this.updates = updates;
         }
@@ -275,7 +275,8 @@ public abstract class NativeSchemaNumberIndexPopulator<KEY extends SchemaNumberK
         @Override
         public IndexUpdateWork<KEY,VALUE> combine( IndexUpdateWork<KEY,VALUE> work )
         {
-            ArrayList<IndexEntryUpdate<?>> combined = new ArrayList<>( updates );
+            List<IndexEntryUpdate<?>> combined = new ArrayList<>( updates.size() + work.updates.size() );
+            combined.addAll( updates );
             combined.addAll( work.updates );
             return new IndexUpdateWork<>( combined );
         }
@@ -283,6 +284,7 @@ public abstract class NativeSchemaNumberIndexPopulator<KEY extends SchemaNumberK
         @Override
         public void apply( IndexUpdateApply<KEY,VALUE> indexUpdateApply ) throws Exception
         {
+            updates.sort( BY_VALUE_COMPARATOR );
             for ( IndexEntryUpdate<?> indexEntryUpdate : updates )
             {
                 indexUpdateApply.process( indexEntryUpdate );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexPopulator.java
@@ -127,7 +127,7 @@ public abstract class NativeSchemaNumberIndexPopulator<KEY extends SchemaNumberK
             private final Collection<IndexEntryUpdate<?>> updates = new ArrayList<>();
 
             @Override
-            public void process( IndexEntryUpdate update ) throws IOException, IndexEntryConflictException
+            public void process( IndexEntryUpdate<?> update ) throws IOException, IndexEntryConflictException
             {
                 assertOpen();
                 updates.add( update );
@@ -256,7 +256,7 @@ public abstract class NativeSchemaNumberIndexPopulator<KEY extends SchemaNumberK
             this.conflictDetectingValueMerger = conflictDetectingValueMerger;
         }
 
-        public void process( IndexEntryUpdate indexEntryUpdate ) throws Exception
+        public void process( IndexEntryUpdate<?> indexEntryUpdate ) throws Exception
         {
             NativeSchemaNumberIndexUpdater.processUpdate( treeKey, treeValue, indexEntryUpdate, writer, conflictDetectingValueMerger );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexUpdater.java
@@ -59,7 +59,7 @@ class NativeSchemaNumberIndexUpdater<KEY extends SchemaNumberKey, VALUE extends 
     }
 
     @Override
-    public void process( IndexEntryUpdate update ) throws IOException, IndexEntryConflictException
+    public void process( IndexEntryUpdate<?> update ) throws IOException, IndexEntryConflictException
     {
         assertOpen();
         processUpdate( treeKey, treeValue, update, writer, conflictDetectingValueMerger );
@@ -84,7 +84,7 @@ class NativeSchemaNumberIndexUpdater<KEY extends SchemaNumberKey, VALUE extends 
     }
 
     static <KEY extends SchemaNumberKey, VALUE extends SchemaNumberValue> void processUpdate( KEY treeKey, VALUE treeValue,
-            IndexEntryUpdate update, Writer<KEY,VALUE> writer, ConflictDetectingValueMerger<KEY,VALUE> conflictDetectingValueMerger )
+            IndexEntryUpdate<?> update, Writer<KEY,VALUE> writer, ConflictDetectingValueMerger<KEY,VALUE> conflictDetectingValueMerger )
             throws IOException, IndexEntryConflictException
     {
         switch ( update.updateMode() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexUpdater.java
@@ -91,12 +91,18 @@ class NativeSchemaNumberIndexUpdater<KEY extends SchemaNumberKey, VALUE extends 
     @Override
     public void close() throws IOException, IndexEntryConflictException
     {
-        applyBatchedUpdates();
-        if ( manageClosingOfWriter )
+        try
         {
-            writer.close();
+            applyBatchedUpdates();
         }
-        closed = true;
+        finally
+        {
+            if ( manageClosingOfWriter )
+            {
+                writer.close();
+            }
+            closed = true;
+        }
     }
 
     private void assertOpen()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeUniqueSchemaNumberIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeUniqueSchemaNumberIndexPopulator.java
@@ -42,7 +42,7 @@ class NativeUniqueSchemaNumberIndexPopulator<KEY extends SchemaNumberKey, VALUE 
     }
 
     @Override
-    public void includeSample( IndexEntryUpdate update )
+    public void includeSample( IndexEntryUpdate<?> update )
     {
         sampler.increment( 1 );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SchemaNumberKey.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/SchemaNumberKey.java
@@ -64,7 +64,7 @@ class SchemaNumberKey extends ValueWriter.Adapter<RuntimeException>
         entityIdIsSpecialTieBreaker = false;
     }
 
-    private static NumberValue assertValidSingleNumber( Value... values )
+    static NumberValue assertValidSingleNumber( Value... values )
     {
         // TODO: support multiple values, right?
         if ( values.length > 1 )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulator.java
@@ -21,7 +21,7 @@ package org.neo4j.kernel.impl.index.schema.fusion;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.List;
 
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexEntryUpdate;
@@ -67,10 +67,10 @@ class FusionIndexPopulator implements IndexPopulator
     }
 
     @Override
-    public void add( Collection<? extends IndexEntryUpdate<?>> updates ) throws IndexEntryConflictException, IOException
+    public void add( List<? extends IndexEntryUpdate<?>> updates ) throws IndexEntryConflictException, IOException
     {
-        Collection<IndexEntryUpdate<?>> luceneBatch = new ArrayList<>();
-        Collection<IndexEntryUpdate<?>> nativeBatch = new ArrayList<>();
+        List<IndexEntryUpdate<?>> luceneBatch = new ArrayList<>();
+        List<IndexEntryUpdate<?>> nativeBatch = new ArrayList<>();
         for ( IndexEntryUpdate<?> update : updates )
         {
             selector.select( nativeBatch, luceneBatch, update.values() ).add( update );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulator.java
@@ -122,7 +122,7 @@ class FusionIndexPopulator implements IndexPopulator
     }
 
     @Override
-    public void includeSample( IndexEntryUpdate update )
+    public void includeSample( IndexEntryUpdate<?> update )
     {
         selector.select( nativePopulator, lucenePopulator, update.values() ).includeSample( update );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexUpdater.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexUpdater.java
@@ -40,7 +40,7 @@ class FusionIndexUpdater implements IndexUpdater
     }
 
     @Override
-    public void process( IndexEntryUpdate update ) throws IOException, IndexEntryConflictException
+    public void process( IndexEntryUpdate<?> update ) throws IOException, IndexEntryConflictException
     {
         switch ( update.updateMode() )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/LabelScanViewNodeStoreScan.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/LabelScanViewNodeStoreScan.java
@@ -35,7 +35,7 @@ import org.neo4j.kernel.impl.store.PropertyStore;
 /**
  * Store scan view that will try to minimize amount of scanned nodes by using label scan store {@link LabelScanStore}
  * as a source of known labeled node ids.
- * @param <FAILURE>
+ * @param <FAILURE> type of exception thrown on failure
  */
 public class LabelScanViewNodeStoreScan<FAILURE extends Exception> extends StoreViewNodeStoreScan<FAILURE>
 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/NodeStoreScan.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/NodeStoreScan.java
@@ -34,7 +34,7 @@ import static org.neo4j.kernel.impl.store.record.RecordLoad.FORCE;
 /**
  * Node scanner that will perform some sort of process over set of nodes
  * from nodeStore {@link NodeStore} based on node ids supplied by underlying store aware id iterator.
- * @param <FAILURE>
+ * @param <FAILURE> type of exception thrown on failure
  */
 public abstract class NodeStoreScan<FAILURE extends Exception> implements StoreScan<FAILURE>
 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/StoreViewNodeStoreScan.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/storeview/StoreViewNodeStoreScan.java
@@ -144,7 +144,7 @@ public class StoreViewNodeStoreScan<FAILURE extends Exception> extends NodeStore
     }
 
     @Override
-    public void acceptUpdate( MultipleIndexPopulator.MultipleIndexUpdater updater, IndexEntryUpdate update,
+    public void acceptUpdate( MultipleIndexPopulator.MultipleIndexUpdater updater, IndexEntryUpdate<?> update,
             long currentlyIndexedNodeId )
     {
         if ( update.getEntityId() <= currentlyIndexedNodeId )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
@@ -1306,7 +1306,7 @@ public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvide
         private final int batchSize = 1_000;
         private final IndexPopulator populator;
         private final IndexDescriptor index;
-        private Collection<IndexEntryUpdate<?>> batchedUpdates = new ArrayList<>( batchSize );
+        private List<IndexEntryUpdate<?>> batchedUpdates = new ArrayList<>( batchSize );
 
         IndexPopulatorWithSchema( IndexPopulator populator, IndexDescriptor index )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/CompositeIndexAccessorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/CompositeIndexAccessorCompatibility.java
@@ -133,7 +133,7 @@ public abstract class CompositeIndexAccessorCompatibility extends IndexAccessorC
         }
     }
 
-    private static IndexEntryUpdate add( long nodeId, LabelSchemaDescriptor schema, Object value1, Object value2 )
+    private static IndexEntryUpdate<LabelSchemaDescriptor> add( long nodeId, LabelSchemaDescriptor schema, Object value1, Object value2 )
     {
         return IndexEntryUpdate.add( nodeId, schema, Values.of( value1 ), Values.of( value2 ) );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexAccessorCompatibility.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexAccessorCompatibility.java
@@ -86,12 +86,12 @@ public abstract class IndexAccessorCompatibility extends IndexProviderCompatibil
         PrimitiveLongIterator results( IndexReader reader ) throws Exception;
     }
 
-    void updateAndCommit( List<IndexEntryUpdate> updates )
+    void updateAndCommit( List<IndexEntryUpdate<?>> updates )
             throws IOException, IndexEntryConflictException
     {
         try ( IndexUpdater updater = accessor.newUpdater( IndexUpdateMode.ONLINE ) )
         {
-            for ( IndexEntryUpdate update : updates )
+            for ( IndexEntryUpdate<?> update : updates )
             {
                 updater.process( update );
             }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexEntryUpdateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexEntryUpdateTest.java
@@ -42,8 +42,8 @@ public class IndexEntryUpdateTest
     @Test
     public void indexEntryUpdatesShouldBeEqual()
     {
-        IndexEntryUpdate a = IndexEntryUpdate.add( 0, SchemaDescriptorFactory.forLabel( 3, 4 ), singleValue );
-        IndexEntryUpdate b = IndexEntryUpdate.add( 0, SchemaDescriptorFactory.forLabel( 3, 4 ), singleValue );
+        IndexEntryUpdate<?> a = IndexEntryUpdate.add( 0, SchemaDescriptorFactory.forLabel( 3, 4 ), singleValue );
+        IndexEntryUpdate<?> b = IndexEntryUpdate.add( 0, SchemaDescriptorFactory.forLabel( 3, 4 ), singleValue );
         assertThat( a, equalTo( b ) );
         assertThat( a.hashCode(), equalTo( b.hashCode() ) );
     }
@@ -51,8 +51,8 @@ public class IndexEntryUpdateTest
     @Test
     public void addShouldRetainValues()
     {
-        IndexEntryUpdate single = IndexEntryUpdate.add( 0, SchemaDescriptorFactory.forLabel( 3, 4 ), singleValue );
-        IndexEntryUpdate multi = IndexEntryUpdate.add( 0, SchemaDescriptorFactory.forLabel( 3, 4, 5 ), multiValue );
+        IndexEntryUpdate<?> single = IndexEntryUpdate.add( 0, SchemaDescriptorFactory.forLabel( 3, 4 ), singleValue );
+        IndexEntryUpdate<?> multi = IndexEntryUpdate.add( 0, SchemaDescriptorFactory.forLabel( 3, 4, 5 ), multiValue );
         assertThat( single, not( equalTo( multi ) ) );
         assertThat( single.values(), equalTo( new Object[]{singleValue} ) );
         assertThat( multi.values(), equalTo( multiValue ) );
@@ -61,8 +61,8 @@ public class IndexEntryUpdateTest
     @Test
     public void removeShouldRetainValues()
     {
-        IndexEntryUpdate single = IndexEntryUpdate.remove( 0, SchemaDescriptorFactory.forLabel( 3, 4 ), singleValue );
-        IndexEntryUpdate multi = IndexEntryUpdate
+        IndexEntryUpdate<?> single = IndexEntryUpdate.remove( 0, SchemaDescriptorFactory.forLabel( 3, 4 ), singleValue );
+        IndexEntryUpdate<?> multi = IndexEntryUpdate
                 .remove( 0, SchemaDescriptorFactory.forLabel( 3, 4, 5 ), multiValue );
         assertThat( single, not( equalTo( multi ) ) );
         assertThat( single.values(), equalTo( new Object[]{singleValue} ) );
@@ -72,7 +72,7 @@ public class IndexEntryUpdateTest
     @Test
     public void addShouldThrowIfAskedForChanged() throws Exception
     {
-        IndexEntryUpdate single = IndexEntryUpdate.add( 0, SchemaDescriptorFactory.forLabel( 3, 4 ), singleValue );
+        IndexEntryUpdate<?> single = IndexEntryUpdate.add( 0, SchemaDescriptorFactory.forLabel( 3, 4 ), singleValue );
         thrown.expect( UnsupportedOperationException.class );
         single.beforeValues();
     }
@@ -80,7 +80,7 @@ public class IndexEntryUpdateTest
     @Test
     public void removeShouldThrowIfAskedForChanged() throws Exception
     {
-        IndexEntryUpdate single = IndexEntryUpdate.remove( 0, SchemaDescriptorFactory.forLabel( 3, 4 ), singleValue );
+        IndexEntryUpdate<?> single = IndexEntryUpdate.remove( 0, SchemaDescriptorFactory.forLabel( 3, 4 ), singleValue );
         thrown.expect( UnsupportedOperationException.class );
         single.beforeValues();
     }
@@ -88,17 +88,17 @@ public class IndexEntryUpdateTest
     @Test
     public void updatesShouldEqualRegardlessOfCreationMethod()
     {
-        IndexEntryUpdate singleAdd = IndexEntryUpdate.add( 0, SchemaDescriptorFactory.forLabel( 3, 4 ), singleValue );
+        IndexEntryUpdate<?> singleAdd = IndexEntryUpdate.add( 0, SchemaDescriptorFactory.forLabel( 3, 4 ), singleValue );
         Value[] singleAsArray = {singleValue};
-        IndexEntryUpdate multiAdd = IndexEntryUpdate
+        IndexEntryUpdate<?> multiAdd = IndexEntryUpdate
                 .add( 0, SchemaDescriptorFactory.forLabel( 3, 4 ), singleAsArray );
-        IndexEntryUpdate singleRemove = IndexEntryUpdate
+        IndexEntryUpdate<?> singleRemove = IndexEntryUpdate
                 .remove( 0, SchemaDescriptorFactory.forLabel( 3, 4 ), singleValue );
-        IndexEntryUpdate multiRemove = IndexEntryUpdate
+        IndexEntryUpdate<?> multiRemove = IndexEntryUpdate
                 .remove( 0, SchemaDescriptorFactory.forLabel( 3, 4 ), singleAsArray );
-        IndexEntryUpdate singleChange = IndexEntryUpdate
+        IndexEntryUpdate<?> singleChange = IndexEntryUpdate
                 .change( 0, SchemaDescriptorFactory.forLabel( 3, 4 ), singleValue, singleValue );
-        IndexEntryUpdate multiChange = IndexEntryUpdate
+        IndexEntryUpdate<?> multiChange = IndexEntryUpdate
                 .change( 0, SchemaDescriptorFactory.forLabel( 3, 4 ), singleAsArray, singleAsArray );
         assertThat( singleAdd, equalTo( multiAdd ) );
         assertThat( singleRemove, equalTo( multiRemove ) );
@@ -109,10 +109,10 @@ public class IndexEntryUpdateTest
     public void changedShouldRetainValues() throws Exception
     {
         Value singleAfter = Values.of( "Hello" );
-        IndexEntryUpdate singleChange = IndexEntryUpdate
+        IndexEntryUpdate<?> singleChange = IndexEntryUpdate
                 .change( 0, SchemaDescriptorFactory.forLabel( 3, 4 ), singleValue, singleAfter );
         Value[] multiAfter = {Values.of( "Hello" ), Values.of( "Hi" )};
-        IndexEntryUpdate multiChange = IndexEntryUpdate
+        IndexEntryUpdate<?> multiChange = IndexEntryUpdate
                 .change( 0, SchemaDescriptorFactory.forLabel( 3, 4, 5 ), multiValue, multiAfter );
         assertThat( new Object[]{singleValue}, equalTo( singleChange.beforeValues() ) );
         assertThat( new Object[]{singleAfter}, equalTo( singleChange.values() ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/BatchingMultipleIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/BatchingMultipleIndexPopulatorTest.java
@@ -94,8 +94,8 @@ public class BatchingMultipleIndexPopulatorTest
         IndexUpdater updater = mock( IndexUpdater.class );
         when( populator.newPopulatingUpdater( any() ) ).thenReturn( updater );
 
-        IndexEntryUpdate update1 = add( 1, index1.schema(), "foo" );
-        IndexEntryUpdate update2 = add( 2, index1.schema(), "bar" );
+        IndexEntryUpdate<?> update1 = add( 1, index1.schema(), "foo" );
+        IndexEntryUpdate<?> update2 = add( 2, index1.schema(), "bar" );
         batchingPopulator.queue( update1 );
         batchingPopulator.queue( update2 );
 
@@ -128,9 +128,9 @@ public class BatchingMultipleIndexPopulatorTest
         when( populator2.newPopulatingUpdater( any() ) ).thenReturn( updater2 );
 
         batchingPopulator.indexAllNodes();
-        IndexEntryUpdate update1 = add( 1, index1.schema(), "foo" );
-        IndexEntryUpdate update2 = add( 2, index42.schema(), "bar" );
-        IndexEntryUpdate update3 = add( 3, index1.schema(), "baz" );
+        IndexEntryUpdate<?> update1 = add( 1, index1.schema(), "foo" );
+        IndexEntryUpdate<?> update2 = add( 2, index42.schema(), "bar" );
+        IndexEntryUpdate<?> update3 = add( 3, index1.schema(), "baz" );
         batchingPopulator.queue( update1 );
         batchingPopulator.queue( update2 );
         batchingPopulator.queue( update3 );
@@ -437,10 +437,9 @@ public class BatchingMultipleIndexPopulatorTest
         }
 
         @Override
-        public void acceptUpdate( MultipleIndexPopulator.MultipleIndexUpdater updater, IndexEntryUpdate update,
+        public void acceptUpdate( MultipleIndexPopulator.MultipleIndexUpdater updater, IndexEntryUpdate<?> update,
                 long currentlyIndexedNodeId )
         {
-
         }
 
         @Override
@@ -452,7 +451,6 @@ public class BatchingMultipleIndexPopulatorTest
         @Override
         public void configure( Collection<MultipleIndexPopulator.IndexPopulation> populations )
         {
-
         }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/CollectingIndexUpdater.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/CollectingIndexUpdater.java
@@ -26,10 +26,10 @@ import org.neo4j.kernel.api.index.IndexUpdater;
 
 public abstract class CollectingIndexUpdater implements IndexUpdater
 {
-    protected final ArrayList<IndexEntryUpdate> updates = new ArrayList<>();
+    protected final ArrayList<IndexEntryUpdate<?>> updates = new ArrayList<>();
 
     @Override
-    public void process( IndexEntryUpdate update )
+    public void process( IndexEntryUpdate<?> update )
     {
         if ( null != update )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexCRUDIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexCRUDIT.java
@@ -25,10 +25,10 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -210,7 +210,7 @@ public class IndexCRUDIT
         }
 
         @Override
-        public void add( Collection<? extends IndexEntryUpdate<?>> updates )
+        public void add( List<? extends IndexEntryUpdate<?>> updates )
         {
             updatesCommitted.addAll( updates );
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexCRUDIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexCRUDIT.java
@@ -65,7 +65,6 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.neo4j.graphdb.DynamicLabel.label;
 import static org.neo4j.helpers.collection.Iterators.asSet;
 import static org.neo4j.helpers.collection.MapUtil.map;
 import static org.neo4j.kernel.impl.api.index.SchemaIndexTestHelper.singleInstanceSchemaIndexProviderFactory;
@@ -150,7 +149,7 @@ public class IndexCRUDIT
     private final KernelExtensionFactory<?> mockedIndexProviderFactory =
             singleInstanceSchemaIndexProviderFactory( "none", mockedIndexProvider );
     private ThreadToStatementContextBridge ctxSupplier;
-    private final Label myLabel = label( "MYLABEL" );
+    private final Label myLabel = Label.label( "MYLABEL" );
 
     private Node createNode( Map<String, Object> properties, Label ... labels )
     {
@@ -166,7 +165,6 @@ public class IndexCRUDIT
         }
     }
 
-    @SuppressWarnings( "deprecation" )
     @Before
     public void before() throws Exception
     {
@@ -203,7 +201,7 @@ public class IndexCRUDIT
 
     private class GatheringIndexWriter extends IndexAccessor.Adapter implements IndexPopulator
     {
-        private final Set<IndexEntryUpdate> updatesCommitted = new HashSet<>();
+        private final Set<IndexEntryUpdate<?>> updatesCommitted = new HashSet<>();
         private final Map<Object,Set<Long>> indexSamples = new HashMap<>();
 
         @Override
@@ -252,7 +250,7 @@ public class IndexCRUDIT
         }
 
         @Override
-        public void includeSample( IndexEntryUpdate update )
+        public void includeSample( IndexEntryUpdate<?> update )
         {
             addValueToSample( update.getEntityId(), update.values()[0] );
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
@@ -159,7 +160,7 @@ public class IndexPopulationJobTest
         verify( populator ).create();
         verify( populator ).configureSampling( false );
         verify( populator ).includeSample( update );
-        verify( populator, times( 2 ) ).add( any( Collection.class) );
+        verify( populator, times( 2 ) ).add( any( List.class) );
         verify( populator ).sampleResult();
         verify( populator ).close( true );
 
@@ -208,7 +209,7 @@ public class IndexPopulationJobTest
         verify( populator ).configureSampling( false );
         verify( populator ).includeSample( update1 );
         verify( populator ).includeSample( update2 );
-        verify( populator, times( 2 ) ).add( Matchers.anyCollection() );
+        verify( populator, times( 2 ) ).add( Matchers.anyList() );
         verify( populator ).sampleResult();
         verify( populator ).close( true );
 
@@ -276,7 +277,7 @@ public class IndexPopulationJobTest
     {
         // GIVEN
         IndexPopulator failingPopulator = mock( IndexPopulator.class );
-        doThrow( new RuntimeException( "BORK BORK" ) ).when( failingPopulator ).add( any(Collection.class) );
+        doThrow( new RuntimeException( "BORK BORK" ) ).when( failingPopulator ).add( any(List.class) );
 
         FlippableIndexProxy index = new FlippableIndexProxy();
 
@@ -466,7 +467,7 @@ public class IndexPopulationJobTest
         }
 
         @Override
-        public void add( Collection<? extends IndexEntryUpdate<?>> updates )
+        public void add( List<? extends IndexEntryUpdate<?>> updates )
         {
             for ( IndexEntryUpdate<?> update : updates )
             {
@@ -537,7 +538,7 @@ public class IndexPopulationJobTest
         }
 
         @Override
-        public void add( Collection<? extends IndexEntryUpdate<?>> updates )
+        public void add( List<? extends IndexEntryUpdate<?>> updates )
         {
             for ( IndexEntryUpdate<?> update : updates )
             {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexRecoveryIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexRecoveryIT.java
@@ -178,7 +178,7 @@ public class IndexRecoveryIT
         // rotate logs
         rotateLogsAndCheckPoint();
         // make updates
-        Set<IndexEntryUpdate> expectedUpdates = createSomeBananas( myLabel );
+        Set<IndexEntryUpdate<?>> expectedUpdates = createSomeBananas( myLabel );
 
         // And Given
         killDb();
@@ -254,7 +254,6 @@ public class IndexRecoveryIT
                 .thenReturn( StoreMigrationParticipant.NOT_PARTICIPATING );
     }
 
-    @SuppressWarnings( "deprecation" )
     private void startDb()
     {
         if ( db != null )
@@ -329,9 +328,9 @@ public class IndexRecoveryIT
         }
     }
 
-    private Set<IndexEntryUpdate> createSomeBananas( Label label )
+    private Set<IndexEntryUpdate<?>> createSomeBananas( Label label )
     {
-        Set<IndexEntryUpdate> updates = new HashSet<>();
+        Set<IndexEntryUpdate<?>> updates = new HashSet<>();
         try ( Transaction tx = db.beginTx() )
         {
             ThreadToStatementContextBridge ctxSupplier = db.getDependencyResolver().resolveDependency(
@@ -355,8 +354,8 @@ public class IndexRecoveryIT
 
     public static class GatheringIndexWriter extends IndexAccessor.Adapter
     {
-        private final Set<IndexEntryUpdate> regularUpdates = new HashSet<>();
-        private final Set<IndexEntryUpdate> batchedUpdates = new HashSet<>();
+        private final Set<IndexEntryUpdate<?>> regularUpdates = new HashSet<>();
+        private final Set<IndexEntryUpdate<?>> batchedUpdates = new HashSet<>();
 
         @Override
         public IndexUpdater newUpdater( final IndexUpdateMode mode )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
@@ -224,7 +224,7 @@ public class IndexingServiceTest
 
         CountDownLatch latch = new CountDownLatch( 1 );
         AwaitAnswer<Void> awaitAnswer = afterAwaiting( latch );
-        doAnswer( awaitAnswer ).when( populator ).add( any( Collection.class ) );
+        doAnswer( awaitAnswer ).when( populator ).add( any( List.class ) );
 
         IndexingService indexingService =
                 newIndexingServiceWithMockedDependencies( populator, accessor, withData( addNodeUpdate( 1, "value1" ) ) );
@@ -252,7 +252,7 @@ public class IndexingServiceTest
         InOrder order = inOrder( populator, accessor, updater);
         order.verify( populator ).create();
         order.verify( populator ).includeSample( add( 1, "value1" ) );
-        order.verify( populator, times( 2 ) ).add( any( Collection.class ) );
+        order.verify( populator, times( 2 ) ).add( any( List.class ) );
 
         // invoked from indexAllNodes(), empty because the id we added (2) is bigger than the one we indexed (1)
         //
@@ -1084,7 +1084,7 @@ public class IndexingServiceTest
         }
 
         @Override
-        public void add( Collection<? extends IndexEntryUpdate<?>> updates )
+        public void add( List<? extends IndexEntryUpdate<?>> updates )
                 throws IndexEntryConflictException, IOException
         {
             latch.waitForAllToStart();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
@@ -236,7 +236,7 @@ public class IndexingServiceTest
         IndexProxy proxy = indexingService.getIndexProxy( 0 );
         assertEquals( InternalIndexState.POPULATING, proxy.getState() );
 
-        IndexEntryUpdate value2 = add( 2, "value2" );
+        IndexEntryUpdate<?> value2 = add( 2, "value2" );
         try ( IndexUpdater updater = proxy.newUpdater( IndexUpdateMode.ONLINE ) )
         {
             updater.process( value2 );
@@ -1225,7 +1225,7 @@ public class IndexingServiceTest
 
                 @Override
                 public void acceptUpdate( MultipleIndexPopulator.MultipleIndexUpdater updater,
-                        IndexEntryUpdate update,
+                        IndexEntryUpdate<?> update,
                         long currentlyIndexedNodeId )
                 {
                     // no-op

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/MultipleIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/MultipleIndexPopulatorTest.java
@@ -210,7 +210,7 @@ public class MultipleIndexPopulatorTest
 
     @Test
     public void closeMultipleIndexPopulator()
-            throws IOException, IndexEntryConflictException
+            throws IOException
     {
         IndexPopulator indexPopulator1 = createIndexPopulator();
         IndexPopulator indexPopulator2 = createIndexPopulator();
@@ -316,7 +316,7 @@ public class MultipleIndexPopulatorTest
 
         IndexUpdater multipleIndexUpdater =
                 multipleIndexPopulator.newPopulatingUpdater( mock( PropertyAccessor.class ) );
-        IndexEntryUpdate propertyUpdate = createIndexEntryUpdate( index1 );
+        IndexEntryUpdate<?> propertyUpdate = createIndexEntryUpdate( index1 );
         multipleIndexUpdater.process( propertyUpdate );
 
         checkPopulatorFailure( indexPopulator2 );
@@ -335,7 +335,7 @@ public class MultipleIndexPopulatorTest
         IndexUpdater multipleIndexUpdater =
                 multipleIndexPopulator.newPopulatingUpdater( mock( PropertyAccessor.class ) );
 
-        IndexEntryUpdate propertyUpdate = createIndexEntryUpdate( index1 );
+        IndexEntryUpdate<?> propertyUpdate = createIndexEntryUpdate( index1 );
         multipleIndexUpdater.process( propertyUpdate );
 
         verifyZeroInteractions( indexUpdater1 );
@@ -345,7 +345,7 @@ public class MultipleIndexPopulatorTest
     public void testPropertyUpdateFailure()
             throws IOException, IndexEntryConflictException
     {
-        IndexEntryUpdate propertyUpdate = createIndexEntryUpdate( index1 );
+        IndexEntryUpdate<?> propertyUpdate = createIndexEntryUpdate( index1 );
         IndexUpdater indexUpdater1 = mock( IndexUpdater.class );
         IndexPopulator indexPopulator1 = createIndexPopulator( indexUpdater1 );
 
@@ -367,8 +367,8 @@ public class MultipleIndexPopulatorTest
             throws IOException, IndexEntryConflictException
     {
         PropertyAccessor propertyAccessor = mock( PropertyAccessor.class );
-        IndexEntryUpdate update1 = add( 1, index1, "foo" );
-        IndexEntryUpdate update2 = add( 2, index1, "bar" );
+        IndexEntryUpdate<?> update1 = add( 1, index1, "foo" );
+        IndexEntryUpdate<?> update2 = add( 2, index1, "bar" );
         IndexUpdater updater = mock( IndexUpdater.class );
         IndexPopulator populator = createIndexPopulator( updater );
 
@@ -387,7 +387,7 @@ public class MultipleIndexPopulatorTest
         checkPopulatorFailure( populator );
     }
 
-    private IndexEntryUpdate createIndexEntryUpdate( LabelSchemaDescriptor schemaDescriptor )
+    private IndexEntryUpdate<?> createIndexEntryUpdate( LabelSchemaDescriptor schemaDescriptor )
     {
         return add( 1, schemaDescriptor, "theValue" );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndex.java
@@ -22,7 +22,7 @@ package org.neo4j.kernel.impl.api.index.inmemory;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collection;
+import java.util.List;
 
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.collection.BoundedIterable;
@@ -115,7 +115,7 @@ class InMemoryIndex
         }
 
         @Override
-        public void add( Collection<? extends IndexEntryUpdate<?>> updates )
+        public void add( List<? extends IndexEntryUpdate<?>> updates )
                 throws IndexEntryConflictException, IOException
         {
             for ( IndexEntryUpdate<?> update : updates )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndex.java
@@ -118,7 +118,7 @@ class InMemoryIndex
         public void add( Collection<? extends IndexEntryUpdate<?>> updates )
                 throws IndexEntryConflictException, IOException
         {
-            for ( IndexEntryUpdate update : updates )
+            for ( IndexEntryUpdate<?> update : updates )
             {
                 InMemoryIndex.this.add( update.getEntityId(), update.values(), false );
             }
@@ -159,7 +159,7 @@ class InMemoryIndex
         }
 
         @Override
-        public void includeSample( IndexEntryUpdate update )
+        public void includeSample( IndexEntryUpdate<?> update )
         {
         }
 
@@ -252,7 +252,7 @@ class InMemoryIndex
         }
 
         @Override
-        public void process( IndexEntryUpdate update ) throws IOException, IndexEntryConflictException
+        public void process( IndexEntryUpdate<?> update ) throws IOException, IndexEntryConflictException
         {
             switch ( update.updateMode() )
             {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UniqueInMemoryIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UniqueInMemoryIndex.java
@@ -50,10 +50,10 @@ class UniqueInMemoryIndex extends InMemoryIndex
         return new UniquePropertyIndexUpdater()
         {
             @Override
-            protected void flushUpdates( Iterable<IndexEntryUpdate> updates )
+            protected void flushUpdates( Iterable<IndexEntryUpdate<?>> updates )
                     throws IOException, IndexEntryConflictException
             {
-                for ( IndexEntryUpdate update : updates )
+                for ( IndexEntryUpdate<?> update : updates )
                 {
                     switch ( update.updateMode() )
                     {
@@ -67,7 +67,7 @@ class UniqueInMemoryIndex extends InMemoryIndex
                             break;
                     }
                 }
-                for ( IndexEntryUpdate update : updates )
+                for ( IndexEntryUpdate<?> update : updates )
                 {
                     switch ( update.updateMode() )
                     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UpdateCapturingIndexAccessor.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UpdateCapturingIndexAccessor.java
@@ -37,9 +37,9 @@ import org.neo4j.storageengine.api.schema.IndexReader;
 public class UpdateCapturingIndexAccessor implements IndexAccessor
 {
     private final IndexAccessor actual;
-    private final Collection<IndexEntryUpdate> updates = new ArrayList<>();
+    private final Collection<IndexEntryUpdate<?>> updates = new ArrayList<>();
 
-    public UpdateCapturingIndexAccessor( IndexAccessor actual, Collection<IndexEntryUpdate> initialUpdates )
+    public UpdateCapturingIndexAccessor( IndexAccessor actual, Collection<IndexEntryUpdate<?>> initialUpdates )
     {
         this.actual = actual;
         if ( initialUpdates != null )
@@ -101,7 +101,7 @@ public class UpdateCapturingIndexAccessor implements IndexAccessor
         actual.verifyDeferredConstraints( propertyAccessor );
     }
 
-    public Collection<IndexEntryUpdate> snapshot()
+    public Collection<IndexEntryUpdate<?>> snapshot()
     {
         return new ArrayList<>( updates );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UpdateCapturingIndexProvider.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UpdateCapturingIndexProvider.java
@@ -40,9 +40,9 @@ public class UpdateCapturingIndexProvider extends SchemaIndexProvider
 {
     private final SchemaIndexProvider actual;
     private final Map<Long,UpdateCapturingIndexAccessor> indexes = new ConcurrentHashMap<>();
-    private final Map<Long,Collection<IndexEntryUpdate>> initialUpdates;
+    private final Map<Long,Collection<IndexEntryUpdate<?>>> initialUpdates;
 
-    public UpdateCapturingIndexProvider( SchemaIndexProvider actual, Map<Long,Collection<IndexEntryUpdate>> initialUpdates )
+    public UpdateCapturingIndexProvider( SchemaIndexProvider actual, Map<Long,Collection<IndexEntryUpdate<?>>> initialUpdates )
     {
         super( actual );
         this.actual = actual;
@@ -81,9 +81,9 @@ public class UpdateCapturingIndexProvider extends SchemaIndexProvider
         return actual.storeMigrationParticipant( fs, pageCache );
     }
 
-    public Map<Long,Collection<IndexEntryUpdate>> snapshot()
+    public Map<Long,Collection<IndexEntryUpdate<?>>> snapshot()
     {
-        Map<Long,Collection<IndexEntryUpdate>> result = new HashMap<>();
+        Map<Long,Collection<IndexEntryUpdate<?>>> result = new HashMap<>();
         indexes.forEach( ( indexId, index ) -> result.put( indexId, index.snapshot() ) );
         return result;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UpdateCapturingIndexUpdater.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UpdateCapturingIndexUpdater.java
@@ -29,16 +29,16 @@ import org.neo4j.kernel.api.index.IndexUpdater;
 public class UpdateCapturingIndexUpdater implements IndexUpdater
 {
     private final IndexUpdater actual;
-    private final Collection<IndexEntryUpdate> updatesTarget;
+    private final Collection<IndexEntryUpdate<?>> updatesTarget;
 
-    public UpdateCapturingIndexUpdater( IndexUpdater actual, Collection<IndexEntryUpdate> updatesTarget )
+    public UpdateCapturingIndexUpdater( IndexUpdater actual, Collection<IndexEntryUpdate<?>> updatesTarget )
     {
         this.actual = actual;
         this.updatesTarget = updatesTarget;
     }
 
     @Override
-    public void process( IndexEntryUpdate update ) throws IOException, IndexEntryConflictException
+    public void process( IndexEntryUpdate<?> update ) throws IOException, IndexEntryConflictException
     {
         actual.process( update );
         updatesTarget.add( update );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexPopulatorTest.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -546,7 +545,7 @@ public abstract class NativeSchemaNumberIndexPopulatorTest<KEY extends SchemaNum
             throws IOException, IndexEntryConflictException
     {
         boolean useUpdater = true;
-        Collection<IndexEntryUpdate<IndexDescriptor>> populatorBatch = new ArrayList<>();
+        List<IndexEntryUpdate<IndexDescriptor>> populatorBatch = new ArrayList<>();
         IndexUpdater updater = populator.newPopulatingUpdater( null_property_accessor );
         for ( IndexEntryUpdate<IndexDescriptor> update : updates )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProviderTest.java
@@ -127,22 +127,23 @@ public class NativeSchemaNumberIndexProviderTest
 
         // when
         IndexDescriptor descriptor = descriptorUnique();
-        try ( IndexAccessor accessor = provider.getOnlineAccessor( indexId, descriptor, samplingConfig() );
-              IndexUpdater indexUpdater = accessor.newUpdater( IndexUpdateMode.ONLINE ) )
+        try ( IndexAccessor accessor = provider.getOnlineAccessor( indexId, descriptor, samplingConfig() ) )
         {
-            Value value = Values.intValue( 1 );
-            indexUpdater.process( IndexEntryUpdate.add( 1, descriptor.schema(), value ) );
-
-            // then
-            try
+            boolean failed = false;
+            try ( IndexUpdater indexUpdater = accessor.newUpdater( IndexUpdateMode.ONLINE ) )
             {
+                Value value = Values.intValue( 1 );
+                indexUpdater.process( IndexEntryUpdate.add( 1, descriptor.schema(), value ) );
+
+                // then
                 indexUpdater.process( IndexEntryUpdate.add( 2, descriptor.schema(), value ) );
-                fail( "Should have failed" );
             }
             catch ( IndexEntryConflictException e )
             {
                 // good
+                failed = true;
             }
+            assertTrue( failed );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulatorTest.java
@@ -23,7 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Collection;
+import java.util.List;
 
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexEntryUpdate;
@@ -181,7 +181,7 @@ public class FusionIndexPopulatorTest
     private void verifyAddWithCorrectPopulator( IndexPopulator correctPopulator, IndexPopulator wrongPopulator, Value... numberValues )
             throws IndexEntryConflictException, IOException
     {
-        Collection<IndexEntryUpdate<LabelSchemaDescriptor>> update = asList( add( numberValues ) );
+        List<IndexEntryUpdate<LabelSchemaDescriptor>> update = asList( add( numberValues ) );
         fusionIndexPopulator.add( update );
         verify( correctPopulator, times( 1 ) ).add( update );
         verify( wrongPopulator, times( 0 ) ).add( update );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NodeStoreScanTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NodeStoreScanTest.java
@@ -61,19 +61,19 @@ public class NodeStoreScanTest
 
         final PercentageSupplier percentageSupplier = new PercentageSupplier();
 
-        final NodeStoreScan scan = new NodeStoreScan( nodeStore, locks,  total )
+        final NodeStoreScan<RuntimeException> scan = new NodeStoreScan<RuntimeException>( nodeStore, locks,  total )
         {
             private int read;
 
             @Override
-            public void acceptUpdate( MultipleIndexPopulator.MultipleIndexUpdater updater, IndexEntryUpdate update,
+            public void acceptUpdate( MultipleIndexPopulator.MultipleIndexUpdater updater, IndexEntryUpdate<?> update,
                     long currentlyIndexedNodeId )
             {
                 // no-op
             }
 
             @Override
-            public void configure( Collection populations )
+            public void configure( Collection<MultipleIndexPopulator.IndexPopulation> populations )
             {
                 // no-op
             }
@@ -96,7 +96,7 @@ public class NodeStoreScanTest
 
     private static class PercentageSupplier implements Supplier<Float>
     {
-        private StoreScan storeScan;
+        private StoreScan<?> storeScan;
 
         @Override
         public Float get()
@@ -106,7 +106,7 @@ public class NodeStoreScanTest
             return (float) progress.getCompleted() / (float) progress.getTotal();
         }
 
-        public void setStoreScan( StoreScan storeScan )
+        public void setStoreScan( StoreScan<?> storeScan )
         {
             this.storeScan = storeScan;
         }

--- a/community/kernel/src/test/java/org/neo4j/test/mockito/matcher/ListMatcher.java
+++ b/community/kernel/src/test/java/org/neo4j/test/mockito/matcher/ListMatcher.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.test.mockito.matcher;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+import java.util.Collection;
+import java.util.List;
+
+import static java.util.Arrays.asList;
+
+/**
+ * An org.hamcrest Matcher that matches {@link Collection collections}.
+ * @param <T> The parameter of the Collection to match
+ */
+public class ListMatcher<T> extends TypeSafeMatcher<List<T>>
+{
+    private final List<T> toMatch;
+
+    private ListMatcher( List<T> toMatch )
+    {
+        this.toMatch = toMatch;
+    }
+
+    @Override
+    protected boolean matchesSafely( List<T> objects )
+    {
+        return IterableMatcher.itemsMatches( toMatch, objects );
+    }
+
+    @Override
+    public void describeTo( Description description )
+    {
+        description.appendValueList( "Collection [",  ",", "]", toMatch );
+    }
+
+    public static <T> ListMatcher<T> matchesList( List<T> toMatch )
+    {
+        return new ListMatcher<>( toMatch );
+    }
+
+    @SafeVarargs
+    public static <T> ListMatcher<T> matchesList( T... toMatch )
+    {
+        return new ListMatcher<>( asList( toMatch ) );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
@@ -132,7 +132,7 @@ import static org.neo4j.kernel.api.index.IndexEntryUpdate.add;
 import static org.neo4j.kernel.impl.api.index.SchemaIndexTestHelper.singleInstanceSchemaIndexProviderFactory;
 import static org.neo4j.kernel.impl.store.RecordStore.getRecord;
 import static org.neo4j.kernel.impl.store.record.RecordLoad.NORMAL;
-import static org.neo4j.test.mockito.matcher.CollectionMatcher.matchesCollection;
+import static org.neo4j.test.mockito.matcher.ListMatcher.matchesList;
 import static org.neo4j.test.mockito.matcher.Neo4jMatchers.hasProperty;
 import static org.neo4j.test.mockito.matcher.Neo4jMatchers.inTx;
 
@@ -930,7 +930,7 @@ public class BatchInsertTest
         verify( provider ).start();
         verify( provider ).getPopulator( anyLong(), any( IndexDescriptor.class ), any( IndexSamplingConfig.class ) );
         verify( populator ).create();
-        verify( populator ).add( argThat( matchesCollection( add( nodeId, internalIndex.schema(), Values.of( "Jakewins" ) ) ) ) );
+        verify( populator ).add( argThat( matchesList( add( nodeId, internalIndex.schema(), Values.of( "Jakewins" ) ) ) ) );
         verify( populator ).verifyDeferredConstraints( any( PropertyAccessor.class ) );
         verify( populator ).close( true );
         verify( provider ).stop();
@@ -964,7 +964,7 @@ public class BatchInsertTest
         verify( provider ).start();
         verify( provider ).getPopulator( anyLong(), any( IndexDescriptor.class ), any( IndexSamplingConfig.class ) );
         verify( populator ).create();
-        verify( populator ).add( argThat( matchesCollection( add( nodeId, internalUniqueIndex.schema(), Values.of( "Jakewins" ) ) ) ) );
+        verify( populator ).add( argThat( matchesList( add( nodeId, internalUniqueIndex.schema(), Values.of( "Jakewins" ) ) ) ) );
         verify( populator ).verifyDeferredConstraints( any( PropertyAccessor.class ) );
         verify( populator ).close( true );
         verify( provider ).stop();
@@ -998,7 +998,7 @@ public class BatchInsertTest
         verify( provider ).start();
         verify( provider ).getPopulator( anyLong(), any( IndexDescriptor.class ), any( IndexSamplingConfig.class ) );
         verify( populator ).create();
-        verify( populator ).add( argThat( matchesCollection(
+        verify( populator ).add( argThat( matchesList(
                 add( jakewins, internalIndex.schema(), Values.of( "Jakewins" ) ),
                 add( boggle, internalIndex.schema(), Values.of( "b0ggl3" ) ) ) ) );
         verify( populator ).verifyDeferredConstraints( any( PropertyAccessor.class ) );

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexAccessor.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexAccessor.java
@@ -59,10 +59,10 @@ public class LuceneIndexAccessor implements IndexAccessor
         switch ( mode )
         {
         case ONLINE:
-            return new LuceneIndexUpdater( writer, false );
+            return new LuceneIndexUpdater( false );
 
         case RECOVERY:
-            return new LuceneIndexUpdater( writer, true );
+            return new LuceneIndexUpdater( true );
 
         default:
             throw new IllegalArgumentException( "Unsupported update mode: " + mode );
@@ -123,17 +123,15 @@ public class LuceneIndexAccessor implements IndexAccessor
     private class LuceneIndexUpdater implements IndexUpdater
     {
         private final boolean isRecovery;
-        private final LuceneIndexWriter writer;
         private boolean hasChanges;
 
-        private LuceneIndexUpdater( LuceneIndexWriter indexWriter, boolean isRecovery )
+        private LuceneIndexUpdater( boolean isRecovery )
         {
             this.isRecovery = isRecovery;
-            this.writer = indexWriter;
         }
 
         @Override
-        public void process( IndexEntryUpdate update ) throws IOException
+        public void process( IndexEntryUpdate<?> update ) throws IOException
         {
             // we do not support adding partial entries
             assert update.indexKey().schema().equals( descriptor.schema() );

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/LuceneIndexPopulatingUpdater.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/LuceneIndexPopulatingUpdater.java
@@ -46,7 +46,7 @@ public abstract class LuceneIndexPopulatingUpdater implements IndexUpdater
     }
 
     @Override
-    public void process( IndexEntryUpdate update ) throws IOException, IndexEntryConflictException
+    public void process( IndexEntryUpdate<?> update ) throws IOException, IndexEntryConflictException
     {
         long nodeId = update.getEntityId();
 
@@ -76,19 +76,19 @@ public abstract class LuceneIndexPopulatingUpdater implements IndexUpdater
      *
      * @param update the update being processed.
      */
-    protected abstract void added( IndexEntryUpdate update );
+    protected abstract void added( IndexEntryUpdate<?> update );
 
     /**
      * Method is invoked when {@link IndexEntryUpdate} with {@link UpdateMode#CHANGED} is processed.
      *
      * @param update the update being processed.
      */
-    protected abstract void changed( IndexEntryUpdate update );
+    protected abstract void changed( IndexEntryUpdate<?> update );
 
     /**
      * Method is invoked when {@link IndexEntryUpdate} with {@link UpdateMode#REMOVED} is processed.
      *
      * @param update the update being processed.
      */
-    protected abstract void removed( IndexEntryUpdate update );
+    protected abstract void removed( IndexEntryUpdate<?> update );
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/LuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/LuceneIndexPopulator.java
@@ -94,7 +94,7 @@ public abstract class LuceneIndexPopulator implements IndexPopulator
 
     private boolean updatesForCorrectIndex( Collection<? extends IndexEntryUpdate<?>> updates )
     {
-        for ( IndexEntryUpdate update : updates )
+        for ( IndexEntryUpdate<?> update : updates )
         {
             if ( !update.indexKey().schema().equals( luceneIndex.getDescriptor().schema() ) )
             {
@@ -104,7 +104,7 @@ public abstract class LuceneIndexPopulator implements IndexPopulator
         return true;
     }
 
-    private static Document updateAsDocument( IndexEntryUpdate update )
+    private static Document updateAsDocument( IndexEntryUpdate<?> update )
     {
         return LuceneDocumentStructure.documentRepresentingProperties( update.getEntityId(), update.values() );
     }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/LuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/LuceneIndexPopulator.java
@@ -23,6 +23,7 @@ import org.apache.lucene.document.Document;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 
 import org.neo4j.io.IOUtils;
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
@@ -60,7 +61,7 @@ public abstract class LuceneIndexPopulator implements IndexPopulator
     }
 
     @Override
-    public void add( Collection<? extends IndexEntryUpdate<?>> updates ) throws IndexEntryConflictException, IOException
+    public void add( List<? extends IndexEntryUpdate<?>> updates ) throws IndexEntryConflictException, IOException
     {
         assert updatesForCorrectIndex( updates );
         // Lucene documents stored in a ThreadLocal and reused so we can't create an eager collection of documents here

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueLuceneIndexPopulatingUpdater.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueLuceneIndexPopulatingUpdater.java
@@ -38,14 +38,14 @@ public class NonUniqueLuceneIndexPopulatingUpdater extends LuceneIndexPopulating
     }
 
     @Override
-    protected void added( IndexEntryUpdate update )
+    protected void added( IndexEntryUpdate<?> update )
     {
         String encodedValue = LuceneDocumentStructure.encodedStringValuesForSampling( update.values() );
         sampler.include( encodedValue );
     }
 
     @Override
-    protected void changed( IndexEntryUpdate update )
+    protected void changed( IndexEntryUpdate<?> update )
     {
         String encodedValueBefore = LuceneDocumentStructure.encodedStringValuesForSampling( update.beforeValues() );
         sampler.exclude( encodedValueBefore );
@@ -55,7 +55,7 @@ public class NonUniqueLuceneIndexPopulatingUpdater extends LuceneIndexPopulating
     }
 
     @Override
-    protected void removed( IndexEntryUpdate update )
+    protected void removed( IndexEntryUpdate<?> update )
     {
         String removedValue = LuceneDocumentStructure.encodedStringValuesForSampling( update.values() );
         sampler.exclude( removedValue );

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueLuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueLuceneIndexPopulator.java
@@ -70,7 +70,7 @@ public class NonUniqueLuceneIndexPopulator extends LuceneIndexPopulator
     }
 
     @Override
-    public void includeSample( IndexEntryUpdate update )
+    public void includeSample( IndexEntryUpdate<?> update )
     {
         if ( updateSampling )
         {

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/UniqueLuceneIndexPopulatingUpdater.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/UniqueLuceneIndexPopulatingUpdater.java
@@ -56,20 +56,20 @@ public class UniqueLuceneIndexPopulatingUpdater extends LuceneIndexPopulatingUpd
     }
 
     @Override
-    protected void added( IndexEntryUpdate update )
+    protected void added( IndexEntryUpdate<?> update )
     {
         sampler.increment( 1 );
         updatedValueTuples.add( update.values() );
     }
 
     @Override
-    protected void changed( IndexEntryUpdate update )
+    protected void changed( IndexEntryUpdate<?> update )
     {
         updatedValueTuples.add( update.values() );
     }
 
     @Override
-    protected void removed( IndexEntryUpdate update )
+    protected void removed( IndexEntryUpdate<?> update )
     {
         sampler.increment( -1 );
     }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/UniqueLuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/UniqueLuceneIndexPopulator.java
@@ -61,7 +61,7 @@ public class UniqueLuceneIndexPopulator extends LuceneIndexPopulator
     }
 
     @Override
-    public void includeSample( IndexEntryUpdate update )
+    public void includeSample( IndexEntryUpdate<?> update )
     {
         sampler.increment( 1 );
     }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexPopulationIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexPopulationIT.java
@@ -60,17 +60,17 @@ public class LuceneSchemaIndexPopulationIT
     @Rule
     public final DefaultFileSystemRule fileSystemRule = new DefaultFileSystemRule();
 
-    private int affectedNodes;
+    private final int affectedNodes;
     private final IndexDescriptor descriptor = IndexDescriptorFactory.uniqueForLabel( 0, 0 );
 
     @Before
-    public void before() throws Exception
+    public void before()
     {
         System.setProperty( "luceneSchemaIndex.maxPartitionSize", "10" );
     }
 
     @After
-    public void after() throws IOException
+    public void after()
     {
         System.setProperty( "luceneSchemaIndex.maxPartitionSize", "" );
     }
@@ -136,7 +136,7 @@ public class LuceneSchemaIndexPopulationIT
         }
     }
 
-    private IndexEntryUpdate add( long nodeId, Object value )
+    private IndexEntryUpdate<?> add( long nodeId, Object value )
     {
         return IndexEntryUpdate.add( nodeId, descriptor.schema(), Values.of( value ) );
     }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/AccessUniqueDatabaseIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/AccessUniqueDatabaseIndexTest.java
@@ -142,24 +142,24 @@ public class AccessUniqueDatabaseIndexTest
         return new LuceneIndexAccessor( luceneIndex, index );
     }
 
-    private PartitionedIndexStorage getIndexStorage() throws IOException
+    private PartitionedIndexStorage getIndexStorage()
     {
         IndexStorageFactory storageFactory =
                 new IndexStorageFactory( directoryFactory, fileSystemRule.get(), indexDirectory );
         return storageFactory.indexStorageOf( 1, false );
     }
 
-    private IndexEntryUpdate add( long nodeId, Object propertyValue )
+    private IndexEntryUpdate<?> add( long nodeId, Object propertyValue )
     {
         return IndexQueryHelper.add( nodeId, index.schema(), propertyValue );
     }
 
-    private IndexEntryUpdate change( long nodeId, Object oldValue, Object newValue )
+    private IndexEntryUpdate<?> change( long nodeId, Object oldValue, Object newValue )
     {
         return IndexQueryHelper.change( nodeId, index.schema(), oldValue, newValue );
     }
 
-    private IndexEntryUpdate remove( long nodeId, Object oldValue )
+    private IndexEntryUpdate<?> remove( long nodeId, Object oldValue )
     {
         return IndexQueryHelper.remove( nodeId, index.schema(), oldValue );
     }
@@ -170,12 +170,12 @@ public class AccessUniqueDatabaseIndexTest
                 Values.stringValue( propertyValue ) );
     }
 
-    private void updateAndCommit( IndexAccessor accessor, Iterable<IndexEntryUpdate> updates )
+    private void updateAndCommit( IndexAccessor accessor, Iterable<IndexEntryUpdate<?>> updates )
             throws IOException, IndexEntryConflictException
     {
         try ( IndexUpdater updater = accessor.newUpdater( IndexUpdateMode.ONLINE ) )
         {
-            for ( IndexEntryUpdate update : updates )
+            for ( IndexEntryUpdate<?> update : updates )
             {
                 updater.process( update );
             }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DatabaseCompositeIndexAccessorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DatabaseCompositeIndexAccessorTest.java
@@ -121,6 +121,7 @@ public class DatabaseCompositeIndexAccessorTest
         );
     }
 
+    @SuppressWarnings( "unchecked" )
     private static IOFunction<DirectoryFactory,LuceneIndexAccessor>[] arg(
             IOFunction<DirectoryFactory,LuceneIndexAccessor> foo )
     {
@@ -260,31 +261,30 @@ public class DatabaseCompositeIndexAccessorTest
         }
     }
 
-    private IndexEntryUpdate add( long nodeId, Object... values )
+    private IndexEntryUpdate<?> add( long nodeId, Object... values )
     {
         return IndexQueryHelper.add( nodeId, indexDescriptor.schema(), values );
     }
 
-    private IndexEntryUpdate remove( long nodeId, Object... values )
+    private IndexEntryUpdate<?> remove( long nodeId, Object... values )
     {
         return IndexQueryHelper.remove( nodeId, indexDescriptor.schema(), values );
     }
 
-    private IndexEntryUpdate change( long nodeId, Object[] valuesBefore, Object[] valuesAfter )
+    private IndexEntryUpdate<?> change( long nodeId, Object[] valuesBefore, Object[] valuesAfter )
     {
         return IndexQueryHelper.change( nodeId, indexDescriptor.schema(), valuesBefore, valuesAfter );
     }
 
-    private void updateAndCommit( List<IndexEntryUpdate> nodePropertyUpdates )
+    private void updateAndCommit( List<IndexEntryUpdate<?>> nodePropertyUpdates )
             throws IOException, IndexEntryConflictException
     {
         try ( IndexUpdater updater = accessor.newUpdater( IndexUpdateMode.ONLINE ) )
         {
-            for ( IndexEntryUpdate update : nodePropertyUpdates )
+            for ( IndexEntryUpdate<?> update : nodePropertyUpdates )
             {
                 updater.process( update );
             }
         }
     }
-
 }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DatabaseIndexAccessorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DatabaseIndexAccessorTest.java
@@ -329,27 +329,27 @@ public class DatabaseIndexAccessorTest
         }
     }
 
-    private IndexEntryUpdate add( long nodeId, Object value )
+    private IndexEntryUpdate<?> add( long nodeId, Object value )
     {
         return IndexQueryHelper.add( nodeId, index.schema(), value );
     }
 
-    private IndexEntryUpdate remove( long nodeId, Object value )
+    private IndexEntryUpdate<?> remove( long nodeId, Object value )
     {
         return IndexQueryHelper.remove( nodeId, index.schema(), value );
     }
 
-    private IndexEntryUpdate change( long nodeId, Object valueBefore, Object valueAfter )
+    private IndexEntryUpdate<?> change( long nodeId, Object valueBefore, Object valueAfter )
     {
         return IndexQueryHelper.change( nodeId, index.schema(), valueBefore, valueAfter );
     }
 
-    private void updateAndCommit( List<IndexEntryUpdate> nodePropertyUpdates )
+    private void updateAndCommit( List<IndexEntryUpdate<?>> nodePropertyUpdates )
             throws IOException, IndexEntryConflictException
     {
         try ( IndexUpdater updater = accessor.newUpdater( IndexUpdateMode.ONLINE ) )
         {
-            for ( IndexEntryUpdate update : nodePropertyUpdates )
+            for ( IndexEntryUpdate<?> update : nodePropertyUpdates )
             {
                 updater.process( update );
             }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexIT.java
@@ -64,16 +64,16 @@ public class LuceneSchemaIndexIT
     @Rule
     public final DefaultFileSystemRule fileSystemRule = new DefaultFileSystemRule();
 
-    private IndexDescriptor descriptor = IndexDescriptorFactory.forLabel( 0, 0 );
+    private final IndexDescriptor descriptor = IndexDescriptorFactory.forLabel( 0, 0 );
 
     @Before
-    public void before() throws Exception
+    public void before()
     {
         System.setProperty( "luceneSchemaIndex.maxPartitionSize", "10" );
     }
 
     @After
-    public void after() throws IOException
+    public void after()
     {
         System.setProperty( "luceneSchemaIndex.maxPartitionSize", "" );
     }
@@ -123,7 +123,7 @@ public class LuceneSchemaIndexIT
     }
 
     @Test
-    public void updateMultiplePartitionedIndex() throws IOException, IndexEntryConflictException
+    public void updateMultiplePartitionedIndex() throws IOException
     {
         try ( SchemaIndex index = LuceneSchemaIndexBuilder.create( descriptor )
                 .withFileSystem( fileSystemRule.get() )
@@ -308,9 +308,8 @@ public class LuceneSchemaIndexIT
         }
     }
 
-    private IndexEntryUpdate add( long nodeId, Object value )
+    private IndexEntryUpdate<?> add( long nodeId, Object value )
     {
         return IndexEntryUpdate.add( nodeId, descriptor.schema(), Values.of( value ) );
     }
-
 }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexPopulatorTest.java
@@ -256,17 +256,17 @@ public class LuceneSchemaIndexPopulatorTest
         }
     }
 
-    private IndexEntryUpdate add( long nodeId, Object value )
+    private IndexEntryUpdate<?> add( long nodeId, Object value )
     {
         return IndexQueryHelper.add( nodeId, index.schema(), value );
     }
 
-    private IndexEntryUpdate change( long nodeId, Object valueBefore, Object valueAfter )
+    private IndexEntryUpdate<?> change( long nodeId, Object valueBefore, Object valueAfter )
     {
         return IndexQueryHelper.change( nodeId, index.schema(), valueBefore, valueAfter );
     }
 
-    private IndexEntryUpdate remove( long nodeId, Object removedValue )
+    private IndexEntryUpdate<?> remove( long nodeId, Object removedValue )
     {
         return IndexQueryHelper.remove( nodeId, index.schema(), removedValue );
     }
@@ -305,13 +305,13 @@ public class LuceneSchemaIndexPopulatorTest
 
     private static void updatePopulator(
             IndexPopulator populator,
-            Iterable<IndexEntryUpdate> updates,
+            Iterable<IndexEntryUpdate<?>> updates,
             PropertyAccessor accessor )
             throws IOException, IndexEntryConflictException
     {
         try ( IndexUpdater updater = populator.newPopulatingUpdater( accessor ) )
         {
-            for ( IndexEntryUpdate update :  updates )
+            for ( IndexEntryUpdate<?> update :  updates )
             {
                 updater.process( update );
             }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueDatabaseIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueDatabaseIndexPopulatorTest.java
@@ -63,7 +63,7 @@ public class NonUniqueDatabaseIndexPopulatorTest
 
     private SchemaIndex index;
     private NonUniqueLuceneIndexPopulator populator;
-    private LabelSchemaDescriptor labelSchemaDescriptor = SchemaDescriptorFactory.forLabel( 0, 0 );
+    private final LabelSchemaDescriptor labelSchemaDescriptor = SchemaDescriptorFactory.forLabel( 0, 0 );
 
     @Before
     public void setUp() throws Exception
@@ -102,7 +102,7 @@ public class NonUniqueDatabaseIndexPopulatorTest
     {
         populator = newPopulator();
 
-        List<IndexEntryUpdate> updates = Arrays.asList(
+        List<IndexEntryUpdate<?>> updates = Arrays.asList(
                 add( 1, labelSchemaDescriptor, "aaa" ),
                 add( 2, labelSchemaDescriptor, "bbb" ),
                 add( 3, labelSchemaDescriptor, "ccc" ) );
@@ -119,7 +119,7 @@ public class NonUniqueDatabaseIndexPopulatorTest
     {
         populator = newPopulator();
 
-        List<IndexEntryUpdate> updates = Arrays.asList(
+        List<IndexEntryUpdate<?>> updates = Arrays.asList(
                 add( 1, labelSchemaDescriptor, "foo" ),
                 add( 2, labelSchemaDescriptor, "bar" ),
                 add( 3, labelSchemaDescriptor, "foo" ) );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/UniqueDatabaseIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/UniqueDatabaseIndexPopulatorTest.java
@@ -513,7 +513,7 @@ public class UniqueDatabaseIndexPopulatorTest
     {
         LabelSchemaDescriptor schemaDescriptor = SchemaDescriptorFactory.forLabel( 1, 1 );
         populator = newPopulator();
-        List<IndexEntryUpdate> updates = Arrays.asList(
+        List<IndexEntryUpdate<?>> updates = Arrays.asList(
                 add( 1, schemaDescriptor, "foo" ),
                 add( 2, schemaDescriptor, "bar" ),
                 add( 3, schemaDescriptor, "baz" ),

--- a/community/neo4j/src/test/java/schema/MultiIndexPopulationConcurrentUpdatesIT.java
+++ b/community/neo4j/src/test/java/schema/MultiIndexPopulationConcurrentUpdatesIT.java
@@ -428,22 +428,22 @@ public class MultiIndexPopulationConcurrentUpdatesIT
         {
             StoreScan<FAILURE> storeScan = super.visitNodes( labelIds, propertyKeyIdFilter, propertyUpdatesVisitor,
                     labelUpdateVisitor, forceStoreScan );
-            return new LabelScanViewNodeStoreWrapper( nodeStore, locks, propertyStore, getLabelScanStore(),
+            return new LabelScanViewNodeStoreWrapper<>( nodeStore, locks, propertyStore, getLabelScanStore(),
                     element -> false, propertyUpdatesVisitor, labelIds, propertyKeyIdFilter,
-                    (LabelScanViewNodeStoreScan) storeScan, updates );
+                    (LabelScanViewNodeStoreScan<FAILURE>) storeScan, updates );
         }
     }
 
-    private class LabelScanViewNodeStoreWrapper extends LabelScanViewNodeStoreScan
+    private class LabelScanViewNodeStoreWrapper<FAILURE extends Exception> extends LabelScanViewNodeStoreScan<FAILURE>
     {
-        private final LabelScanViewNodeStoreScan delegate;
+        private final LabelScanViewNodeStoreScan<FAILURE> delegate;
         private final List<NodeUpdates> updates;
 
         LabelScanViewNodeStoreWrapper( NodeStore nodeStore, LockService locks,
                 PropertyStore propertyStore,
-                LabelScanStore labelScanStore, Visitor labelUpdateVisitor,
-                Visitor propertyUpdatesVisitor, int[] labelIds, IntPredicate propertyKeyIdFilter,
-                LabelScanViewNodeStoreScan delegate,
+                LabelScanStore labelScanStore, Visitor<NodeLabelUpdate,FAILURE> labelUpdateVisitor,
+                Visitor<NodeUpdates,FAILURE> propertyUpdatesVisitor, int[] labelIds, IntPredicate propertyKeyIdFilter,
+                LabelScanViewNodeStoreScan<FAILURE> delegate,
                 List<NodeUpdates> updates )
         {
             super( nodeStore, locks, propertyStore, labelScanStore, labelUpdateVisitor,
@@ -453,7 +453,7 @@ public class MultiIndexPopulationConcurrentUpdatesIT
         }
 
         @Override
-        public void acceptUpdate( MultipleIndexPopulator.MultipleIndexUpdater updater, IndexEntryUpdate update,
+        public void acceptUpdate( MultipleIndexPopulator.MultipleIndexUpdater updater, IndexEntryUpdate<?> update,
                 long currentlyIndexedNodeId )
         {
             delegate.acceptUpdate( updater, update, currentlyIndexedNodeId );
@@ -501,7 +501,7 @@ public class MultiIndexPopulationConcurrentUpdatesIT
                         for ( int labelId : labelsNameIdMap.values() )
                         {
                             LabelSchemaDescriptor schema = SchemaDescriptorFactory.forLabel( labelId, propertyId );
-                            for ( IndexEntryUpdate indexUpdate :
+                            for ( IndexEntryUpdate<?> indexUpdate :
                                     update.forIndexKeys( Collections.singleton( schema ) ) )
                             {
                                 switch ( indexUpdate.updateMode() )

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
@@ -25,9 +25,9 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -438,7 +438,7 @@ public class SchemaIndexHaIT
         }
 
         @Override
-        public void add( Collection<? extends IndexEntryUpdate<?>> updates )
+        public void add( List<? extends IndexEntryUpdate<?>> updates )
                 throws IndexEntryConflictException, IOException
         {
             delegate.add( updates );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
@@ -473,7 +473,7 @@ public class SchemaIndexHaIT
         }
 
         @Override
-        public void includeSample( IndexEntryUpdate update )
+        public void includeSample( IndexEntryUpdate<?> update )
         {
             delegate.includeSample( update );
         }


### PR DESCRIPTION
Because it's more sympathetic to the GBPTree writer.