### PR TITLE
Fix db.schema over Core API

### DIFF
--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/BaseToObjectValueWriter.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/BaseToObjectValueWriter.java
@@ -94,7 +94,16 @@ public abstract class BaseToObjectValueWriter<E extends Exception> implements An
     @Override
     public void writeNode( long nodeId, TextArray ignore, MapValue properties ) throws RuntimeException
     {
-        writeValue( newNodeProxyById( nodeId ) );
+        if ( nodeId >= 0 )
+        {
+            writeValue( newNodeProxyById( nodeId ) );
+        }
+    }
+
+    @Override
+    public void writeVirtualNodeHack( Object node )
+    {
+        writeValue( node );
     }
 
     @Override
@@ -107,7 +116,16 @@ public abstract class BaseToObjectValueWriter<E extends Exception> implements An
     public void writeEdge( long edgeId, long startNodeId, long endNodeId, TextValue type, MapValue properties )
             throws RuntimeException
     {
-        writeValue( newRelationshipProxyById( edgeId ) );
+        if ( edgeId >= 0 )
+        {
+            writeValue( newRelationshipProxyById( edgeId ) );
+        }
+    }
+
+    @Override
+    public void writeVirtualEdgeHack( Object relationship )
+    {
+        writeValue( relationship );
     }
 
     @Override

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/NodeProxyWrappingNodeValue.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/NodeProxyWrappingNodeValue.java
@@ -64,6 +64,12 @@ public class NodeProxyWrappingNodeValue extends NodeValue
             p = VirtualValues.EMPTY_MAP;
 
         }
+
+        if ( id() < 0 )
+        {
+            writer.writeVirtualNodeHack( node );
+        }
+
         writer.writeNode( node.getId(), l, p );
     }
 

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/RelationshipProxyWrappingEdgeValue.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/javacompat/RelationshipProxyWrappingEdgeValue.java
@@ -61,6 +61,12 @@ public class RelationshipProxyWrappingEdgeValue extends EdgeValue
             p = VirtualValues.EMPTY_MAP;
 
         }
+
+        if ( id() < 0 )
+        {
+            writer.writeVirtualEdgeHack( relationship );
+        }
+
         writer.writeEdge( id(), startNode().id(), endNode().id(), type(), p );
     }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/helpers/RuntimeTextValueConverter.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/helpers/RuntimeTextValueConverter.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compatibility.v3_3.runtime.helpers
 
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.commands.values.KeyToken
 import org.neo4j.cypher.internal.spi.v3_3.QueryContext
-import org.neo4j.graphdb.{Node, Path, Relationship}
+import org.neo4j.graphdb.{Entity, Node, Path, Relationship}
 
 import scala.collection.Map
 
@@ -34,7 +34,7 @@ class RuntimeTextValueConverter(scalaValues: RuntimeScalaValueConverter)(implici
   def asTextValue(a: Any): String = {
     val scalaValue = scalaValues.asShallowScalaValue(a)
     scalaValue match {
-      case node: Node => s"$node${props(node)}"
+      case node: Node => s"Node[${node.getId}]${props(node)}"
       case relationship: Relationship => s":${relationship.getType.name()}[${relationship.getId}]${props(relationship)}"
       case path: Path => path.toString
       case map: Map[_, _] => makeString(map)
@@ -52,15 +52,17 @@ class RuntimeTextValueConverter(scalaValues: RuntimeScalaValueConverter)(implici
 
   private def props(n: Node): String = {
     val ops = context.nodeOps
-    val properties = ops.propertyKeyIds(n.getId)
+    val properties = if (isVirtualEntityHack(n)) Iterator.empty else ops.propertyKeyIds(n.getId)
     val keyValStrings = properties.map(pkId => s"${context.getPropertyKeyName(pkId)}:${asTextValue(ops.getProperty(n.getId, pkId).asObject())}")
     keyValStrings.mkString("{", ",", "}")
   }
 
   private def props(r: Relationship): String = {
     val ops = context.relationshipOps
-    val properties = ops.propertyKeyIds(r.getId)
+    val properties = if (isVirtualEntityHack(r)) Iterator.empty else ops.propertyKeyIds(r.getId)
     val keyValStrings = properties.map(pkId => s"${context.getPropertyKeyName(pkId)}:${asTextValue(ops.getProperty(r.getId, pkId).asObject())}")
     keyValStrings.mkString("{", ",", "}")
   }
+
+  private def isVirtualEntityHack(entity:Entity): Boolean = entity.getId < 0
 }

--- a/community/values/src/main/java/org/neo4j/values/AnyValueWriter.java
+++ b/community/values/src/main/java/org/neo4j/values/AnyValueWriter.java
@@ -32,7 +32,6 @@ import org.neo4j.values.virtual.NodeValue;
  */
 public interface AnyValueWriter<E extends Exception> extends ValueWriter<E>
 {
-
     void writeNodeReference( long nodeId ) throws E;
 
     void writeNode( long nodeId, TextArray labels, MapValue properties ) throws E;
@@ -54,4 +53,14 @@ public interface AnyValueWriter<E extends Exception> extends ValueWriter<E>
     void beginPoint( CoordinateReferenceSystem coordinateReferenceSystem ) throws E;
 
     void endPoint() throws E;
+
+    default void writeVirtualNodeHack( Object node )
+    {
+        // do nothing, this is an ugly hack.
+    }
+
+    default void writeVirtualEdgeHack( Object relationship )
+    {
+        // do nothing, this is an ugly hack.
+    }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/BuiltInProcedureAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/BuiltInProcedureAcceptanceTest.scala
@@ -21,7 +21,7 @@ package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.SyntaxException
 
-class BuiltInProcedureAcceptanceTest extends ProcedureCallAcceptanceTest {
+class BuiltInProcedureAcceptanceTest extends ProcedureCallAcceptanceTest with CypherComparisonSupport {
 
   test("should be able to filter as part of call") {
     // Given
@@ -37,6 +37,20 @@ class BuiltInProcedureAcceptanceTest extends ProcedureCallAcceptanceTest {
       List(
         Map("label" -> "B"),
         Map("label" -> "C")))
+  }
+
+  test("db.schema should not throw an exception") {
+    val neo = createLabeledNode("Neo")
+    val d1 = createLabeledNode("Department")
+    val e1 = createLabeledNode("Employee")
+    relate(e1, d1, "WORKS_AT", "Hallo")
+    relate(d1, neo, "PART_OF", "Hallo")
+
+    val query = "CALL db.schema()"
+    val result = succeedWith(Configs.Procs, query)
+    println(result.dumpToString())
+
+    // TODO this is not the proper acceptance test yet
   }
 
   test("should not be able to filter as part of standalone call") {


### PR DESCRIPTION
To make this fix, we had to introduce a hack for virtual nodes

The `db.schema` procedure has been implemented using a hack where virtual
nodes and relationships were created with negative ids. This was done
in order to display the results as a graph in the browser, and has been
working well as long as we have been using the Core API types in Cypher.

Upon introducing the Value types, this did not work anymore, as the hacked
virtual node information was lost during conversions.

This commit introduces a hack to pass on the hacked Core API Node/Relationship
implementations to the surface if they have negative id numbers. It should/can
be removed when we introduce support for full stack virtual nodes.

We are not proud...