### PR TITLE
Changes schema index directory structure for fusion index

### DIFF
--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/IndexOpAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/IndexOpAcceptanceTest.scala
@@ -28,6 +28,8 @@ import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.kernel.api.exceptions.schema.{DropIndexFailureException, NoSuchIndexException}
 import org.neo4j.kernel.impl.api.index.SchemaIndexProviderMap
 import org.neo4j.test.TestGraphDatabaseFactory
+import org.neo4j.kernel.api.impl.schema.NativeLuceneFusionSchemaIndexProviderFactory
+import org.neo4j.kernel.api.impl.schema.LuceneSchemaIndexProviderFactory
 
 class IndexOpAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport {
 
@@ -111,8 +113,9 @@ class IndexOpAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistics
     } finally {
       tx.close()
     }
-    val indexDirectory = graph.getDependencyResolver.resolveDependency( classOf[SchemaIndexProviderMap] )
-            .getDefaultProvider.directoryStructure.directoryForIndex( 1 )
+    
+    val indexDirectory = NativeLuceneFusionSchemaIndexProviderFactory.subProviderDirectoryStructure( storeDir )
+        .forProvider( LuceneSchemaIndexProviderFactory.PROVIDER_DESCRIPTOR ).directoryForIndex( 1 )
     graph.shutdown()
 
     val stream = new FileOutputStream( new File( indexDirectory, "failure-message" ) )

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/IndexOpAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/IndexOpAcceptanceTest.scala
@@ -113,7 +113,7 @@ class IndexOpAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistics
     } finally {
       tx.close()
     }
-    
+
     val indexDirectory = NativeLuceneFusionSchemaIndexProviderFactory.subProviderDirectoryStructure( storeDir )
         .forProvider( LuceneSchemaIndexProviderFactory.PROVIDER_DESCRIPTOR ).directoryForIndex( 1 )
     graph.shutdown()

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/IndexOpAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/IndexOpAcceptanceTest.scala
@@ -26,6 +26,7 @@ import org.neo4j.cypher.ExecutionEngineHelper.createEngine
 import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService
 import org.neo4j.graphdb.GraphDatabaseService
 import org.neo4j.kernel.api.exceptions.schema.{DropIndexFailureException, NoSuchIndexException}
+import org.neo4j.kernel.impl.api.index.SchemaIndexProviderMap
 import org.neo4j.test.TestGraphDatabaseFactory
 
 class IndexOpAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport {
@@ -110,9 +111,11 @@ class IndexOpAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistics
     } finally {
       tx.close()
     }
+    val indexDirectory = graph.getDependencyResolver.resolveDependency( classOf[SchemaIndexProviderMap] )
+            .getDefaultProvider.directoryStructure.directoryForIndex( 1 )
     graph.shutdown()
 
-    val stream = new FileOutputStream("target/test-data/test-impermanent-db/schema/index/lucene/1/failure-message")
+    val stream = new FileOutputStream( new File( indexDirectory, "failure-message" ) )
     stream.write(65)
     stream.close()
 

--- a/community/jmx/src/main/java/org/neo4j/jmx/impl/StoreSizeBean.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/impl/StoreSizeBean.java
@@ -195,7 +195,14 @@ public final class StoreSizeBean extends ManagementBeanProvider
             // Add schema index
             MutableLong schemaSize = new MutableLong();
             schemaIndexProviderMap.accept( provider ->
-                    schemaSize.add( FileUtils.size( fs, provider.directoryStructure().rootDirectory() ) ) );
+            {
+                File rootDirectory = provider.directoryStructure().rootDirectory();
+                if ( rootDirectory != null )
+                {
+                    schemaSize.add( FileUtils.size( fs, rootDirectory ) );
+                }
+                // else this provider didn't have any persistent storage
+            } );
             size += schemaSize.longValue();
 
             // Add label index

--- a/community/jmx/src/main/java/org/neo4j/jmx/impl/StoreSizeBean.java
+++ b/community/jmx/src/main/java/org/neo4j/jmx/impl/StoreSizeBean.java
@@ -195,7 +195,7 @@ public final class StoreSizeBean extends ManagementBeanProvider
             // Add schema index
             MutableLong schemaSize = new MutableLong();
             schemaIndexProviderMap.accept( provider ->
-                    schemaSize.add( FileUtils.size( fs, provider.getSchemaIndexStoreDirectory( storePath ) ) ) );
+                    schemaSize.add( FileUtils.size( fs, provider.directoryStructure().rootDirectory() ) ) );
             size += schemaSize.longValue();
 
             // Add label index

--- a/community/jmx/src/test/java/org/neo4j/jmx/impl/StoreSizeBeanTest.java
+++ b/community/jmx/src/test/java/org/neo4j/jmx/impl/StoreSizeBeanTest.java
@@ -35,6 +35,7 @@ import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.jmx.StoreSize;
 import org.neo4j.kernel.NeoStoreDataSource;
+import org.neo4j.kernel.api.index.IndexDirectoryStructure;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.index.SchemaIndexProvider.Descriptor;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
@@ -253,12 +254,16 @@ public class StoreSizeBeanTest
         {
             File schemaIndex = new File( storeDir, "schemaIndex" );
             createFileOfSize( schemaIndex, 2 );
-            when( schemaIndexProvider.getSchemaIndexStoreDirectory( any() ) ).thenReturn( schemaIndex );
+            IndexDirectoryStructure directoryStructure = mock( IndexDirectoryStructure.class );
+            when( directoryStructure.rootDirectory() ).thenReturn( schemaIndex );
+            when( schemaIndexProvider.directoryStructure() ).thenReturn( directoryStructure );
         }
         {
             File schemaIndex = new File( storeDir, "schemaIndex2" );
             createFileOfSize( schemaIndex, 3 );
-            when( schemaIndexProvider2.getSchemaIndexStoreDirectory( any() ) ).thenReturn( schemaIndex );
+            IndexDirectoryStructure directoryStructure = mock( IndexDirectoryStructure.class );
+            when( directoryStructure.rootDirectory() ).thenReturn( schemaIndex );
+            when( schemaIndexProvider2.directoryStructure() ).thenReturn( directoryStructure );
         }
 
         // Label scan store

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexDirectoryStructure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexDirectoryStructure.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.index;
+
+import java.io.File;
+
+import org.neo4j.kernel.api.index.SchemaIndexProvider.Descriptor;
+
+import static org.neo4j.io.fs.FileUtils.path;
+
+/**
+ * Dictates how directory structure looks for a {@link SchemaIndexProvider} and its indexes. Generally there's a
+ * {@link #rootDirectory() root directory} which contains all index directories in some shape and form.
+ * For getting a directory (which must be a sub-directory to the root directory) for a particular index there's the
+ * {@link #directoryForIndex(long)} method.
+ *
+ * These instances are created from a {@link Factory} which typically gets passed into a {@link SchemaIndexProvider} constructor,
+ * which then a {@link IndexDirectoryStructure} given its {@link Descriptor}.
+ */
+public abstract class IndexDirectoryStructure
+{
+    /**
+     * Creates an {@link IndexDirectoryStructure} for a {@link Descriptor} for a {@link SchemaIndexProvider}.
+     */
+    public interface Factory
+    {
+        IndexDirectoryStructure forProvider( SchemaIndexProvider.Descriptor descriptor );
+    }
+
+    private static class SubDirectoryByIndexId extends IndexDirectoryStructure
+    {
+        private final File providerRootFolder;
+
+        private SubDirectoryByIndexId( File providerRootFolder )
+        {
+            this.providerRootFolder = providerRootFolder;
+        }
+
+        @Override
+        public File rootDirectory()
+        {
+            return providerRootFolder;
+        }
+
+        @Override
+        public File directoryForIndex( long indexId )
+        {
+            return path( providerRootFolder, String.valueOf( indexId ) );
+        }
+    }
+
+    /**
+     * Returns the base schema index directory, i.e.
+     *
+     * <pre>
+     * &lt;db&gt;/schema/index/
+     * </pre>
+     *
+     * @param databaseStoreDir database store directory, i.e. {@code db} in the example above, where e.g. {@code nodestore} lives.
+     * @return the base directory of schema indexing.
+     */
+    static final File baseSchemaIndexFolder( File databaseStoreDir )
+    {
+        return path( databaseStoreDir, "schema", "index" );
+    }
+
+    /**
+     * @param databaseStoreDir store directory of database, i.e. {@code db} in the example above.
+     * @return {@link Factory} for creating {@link IndexDirectoryStructure} returning directories looking something like:
+     *
+     * <pre>
+     * &lt;db&gt;/schema/index/&lt;providerKey&gt;/&lt;indexId&gt;/
+     * </pre>
+     */
+    public static Factory directoriesByProviderKey( File databaseStoreDir )
+    {
+        return descriptor -> new SubDirectoryByIndexId(
+                path( baseSchemaIndexFolder( databaseStoreDir ), fileNameFriendly( descriptor.getKey() ) ) );
+    }
+
+    /**
+    * @param databaseStoreDir store directory of database, i.e. {@code db} in the example above.
+    * @return {@link Factory} for creating {@link IndexDirectoryStructure} returning directories looking something like:
+    *
+    * <pre>
+    * &lt;db&gt;/schema/index/&lt;providerKey&gt;-&lt;providerVersion&gt;/&lt;indexId&gt;/
+    * </pre>
+    */
+    public static Factory directoriesByProvider( File databaseStoreDir )
+    {
+        return descriptor -> new SubDirectoryByIndexId(
+                path( baseSchemaIndexFolder( databaseStoreDir ), fileNameFriendly( descriptor ) ) );
+    }
+
+    /**
+     * @param directoryStructure existing {@link IndexDirectoryStructure}.
+     * @return a {@link Factory} returning an already existing {@link IndexDirectoryStructure}.
+     */
+    public static Factory given( IndexDirectoryStructure directoryStructure )
+    {
+        return descriptor -> directoryStructure;
+    }
+
+    /**
+     * Useful when combining multiple {@link SchemaIndexProvider} into one.
+     *
+     * @param parentStructure {@link IndexDirectoryStructure} of the parent.
+     * @return {@link Factory} creating {@link IndexDirectoryStructure} looking something like:
+     *
+     * <pre>
+     * &lt;db&gt;/schema/index/.../&lt;indexId&gt;/&lt;childProviderKey&gt;-&lt;childProviderVersion&gt;/
+     * </pre>
+     */
+    public static Factory directoriesBySubProvider( IndexDirectoryStructure parentStructure )
+    {
+        return new Factory()
+        {
+            @Override
+            public IndexDirectoryStructure forProvider( Descriptor descriptor )
+            {
+                return new IndexDirectoryStructure()
+                {
+                    @Override
+                    public File rootDirectory()
+                    {
+                        return parentStructure.rootDirectory();
+                    }
+
+                    @Override
+                    public File directoryForIndex( long indexId )
+                    {
+                        return path( parentStructure.directoryForIndex( indexId ), fileNameFriendly( descriptor ) );
+                    }
+                };
+            }
+        };
+    }
+
+    private static String fileNameFriendly( String name )
+    {
+        return name.replaceAll( "\\+", "_" );
+    }
+
+    private static String fileNameFriendly( Descriptor descriptor )
+    {
+        return fileNameFriendly( descriptor.getKey() + "-" + descriptor.getVersion() );
+    }
+
+    private static final IndexDirectoryStructure NO_DIRECTORY_STRUCTURE = new IndexDirectoryStructure()
+    {
+        @Override
+        public File rootDirectory()
+        {
+            return null; // meaning there's no persistent storage
+        }
+
+        @Override
+        public File directoryForIndex( long indexId )
+        {
+            return null; // meaning there's no persistent storage
+        }
+    };
+
+    /**
+     * Useful for some in-memory index providers or similar.
+     */
+    public static final Factory NONE = descriptor -> NO_DIRECTORY_STRUCTURE;
+
+    /**
+     * Returns root directory. Must be above all sub-directories returned from {@link #directoryForIndex(long)}.
+     * Returns something equivalent to:
+     *
+     * <pre>
+     * &lt;db&gt;/schema/index/&lt;provider&gt;/
+     * </pre>
+     *
+     * @return {@link File} denoting root directory for this provider.
+     * May return {@code null} if there's no root directory, i.e. no persistent storage at all.
+     */
+    public abstract File rootDirectory();
+
+    /**
+     * Returns a sub-directory (somewhere under {@link #rootDirectory()}) for a specific index id, looking something equivalent to:
+     *
+     * <pre>
+     * &lt;db&gt;/schema/index/&lt;provider&gt;/&lt;indexId&gt;/
+     * </pre>
+     *
+     * I.e. the root of the schema indexes for this specific provider.
+     *
+     * @param indexId index id to return directory for.
+     * @return {@link File} denoting directory for the specific {@code indexId} for this provider.
+     * May return {@code null} if there's no root directory, i.e. no persistent storage at all.
+     */
+    public abstract File directoryForIndex( long indexId );
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexDirectoryStructure.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexDirectoryStructure.java
@@ -32,7 +32,7 @@ import static org.neo4j.io.fs.FileUtils.path;
  * {@link #directoryForIndex(long)} method.
  *
  * These instances are created from a {@link Factory} which typically gets passed into a {@link SchemaIndexProvider} constructor,
- * which then a {@link IndexDirectoryStructure} given its {@link Descriptor}.
+ * which then creates a {@link IndexDirectoryStructure} given its {@link Descriptor}.
  */
 public abstract class IndexDirectoryStructure
 {
@@ -76,7 +76,7 @@ public abstract class IndexDirectoryStructure
      * @param databaseStoreDir database store directory, i.e. {@code db} in the example above, where e.g. {@code nodestore} lives.
      * @return the base directory of schema indexing.
      */
-    static final File baseSchemaIndexFolder( File databaseStoreDir )
+    static File baseSchemaIndexFolder( File databaseStoreDir )
     {
         return path( databaseStoreDir, "schema", "index" );
     }
@@ -184,7 +184,7 @@ public abstract class IndexDirectoryStructure
     public static final Factory NONE = descriptor -> NO_DIRECTORY_STRUCTURE;
 
     /**
-     * Returns root directory. Must be above all sub-directories returned from {@link #directoryForIndex(long)}.
+     * Returns root directory. Must be parent (one or more steps) to all sub-directories returned from {@link #directoryForIndex(long)}.
      * Returns something equivalent to:
      *
      * <pre>

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProvider.java
@@ -49,7 +49,6 @@ public class NativeSchemaNumberIndexProvider extends SchemaIndexProvider
 {
     public static final String KEY = "native";
     public static final Descriptor NATIVE_PROVIDER_DESCRIPTOR = new Descriptor( KEY, "1.0" );
-    private static final String INDEX_FILE_NAME = "index";
 
     private final PageCache pageCache;
     private final FileSystemAbstraction fs;
@@ -171,7 +170,12 @@ public class NativeSchemaNumberIndexProvider extends SchemaIndexProvider
 
     private File nativeIndexFileFromIndexId( long indexId )
     {
-        return new File( directoryStructure().directoryForIndex( indexId ), INDEX_FILE_NAME );
+        return new File( directoryStructure().directoryForIndex( indexId ), indexFileName( indexId ) );
+    }
+
+    private static String indexFileName( long indexId )
+    {
+        return "index-" + indexId;
     }
 
     private class ReadOnlyMetaNumberLayout extends Layout.ReadOnlyMetaLayout

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProvider.java
@@ -28,6 +28,7 @@ import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.IndexAccessor;
+import org.neo4j.kernel.api.index.IndexDirectoryStructure;
 import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
@@ -48,9 +49,10 @@ public class NativeSchemaNumberIndexProvider extends SchemaIndexProvider
 {
     public static final String KEY = "native";
     public static final Descriptor NATIVE_PROVIDER_DESCRIPTOR = new Descriptor( KEY, "1.0" );
+    private static final String INDEX_FILE_NAME = "index";
+
     private final PageCache pageCache;
     private final FileSystemAbstraction fs;
-    private final File nativeSchemaIndexBaseDir;
     private final Log log;
     private final RecoveryCleanupWorkCollector recoveryCleanupWorkCollector;
     private final boolean readOnly;
@@ -58,10 +60,16 @@ public class NativeSchemaNumberIndexProvider extends SchemaIndexProvider
     public NativeSchemaNumberIndexProvider( PageCache pageCache, FileSystemAbstraction fs, File storeDir, LogProvider logging,
             RecoveryCleanupWorkCollector recoveryCleanupWorkCollector, boolean readOnly )
     {
-        super( NATIVE_PROVIDER_DESCRIPTOR, 0 );
+        this( pageCache, fs, IndexDirectoryStructure.directoriesByProvider( storeDir ), logging,
+                recoveryCleanupWorkCollector, readOnly );
+    }
+
+    public NativeSchemaNumberIndexProvider( PageCache pageCache, FileSystemAbstraction fs, IndexDirectoryStructure.Factory directoryStructure,
+            LogProvider logging, RecoveryCleanupWorkCollector recoveryCleanupWorkCollector, boolean readOnly )
+    {
+        super( NATIVE_PROVIDER_DESCRIPTOR, 0, directoryStructure );
         this.pageCache = pageCache;
         this.fs = fs;
-        this.nativeSchemaIndexBaseDir = getSchemaIndexStoreDirectory( storeDir );
         this.log = logging.getLog( getClass() );
         this.recoveryCleanupWorkCollector = recoveryCleanupWorkCollector;
         this.readOnly = readOnly;
@@ -170,7 +178,7 @@ public class NativeSchemaNumberIndexProvider extends SchemaIndexProvider
 
     private File nativeIndexFileFromIndexId( long indexId )
     {
-        return new File( nativeSchemaIndexBaseDir, Long.toString( indexId ) );
+        return new File( directoryStructure().directoryForIndex( indexId ), INDEX_FILE_NAME );
     }
 
     private class ReadOnlyMetaNumberLayout extends Layout.ReadOnlyMetaLayout

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProvider.java
@@ -57,13 +57,6 @@ public class NativeSchemaNumberIndexProvider extends SchemaIndexProvider
     private final RecoveryCleanupWorkCollector recoveryCleanupWorkCollector;
     private final boolean readOnly;
 
-    public NativeSchemaNumberIndexProvider( PageCache pageCache, FileSystemAbstraction fs, File storeDir, LogProvider logging,
-            RecoveryCleanupWorkCollector recoveryCleanupWorkCollector, boolean readOnly )
-    {
-        this( pageCache, fs, IndexDirectoryStructure.directoriesByProvider( storeDir ), logging,
-                recoveryCleanupWorkCollector, readOnly );
-    }
-
     public NativeSchemaNumberIndexProvider( PageCache pageCache, FileSystemAbstraction fs, IndexDirectoryStructure.Factory directoryStructure,
             LogProvider logging, RecoveryCleanupWorkCollector recoveryCleanupWorkCollector, boolean readOnly )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexAccessor.java
@@ -31,6 +31,7 @@ import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.PropertyAccessor;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
+import org.neo4j.kernel.impl.index.schema.fusion.FusionSchemaIndexProvider.DropAction;
 import org.neo4j.kernel.impl.index.schema.fusion.FusionSchemaIndexProvider.Selector;
 import org.neo4j.storageengine.api.schema.IndexReader;
 
@@ -42,12 +43,17 @@ class FusionIndexAccessor implements IndexAccessor
     private final IndexAccessor nativeAccessor;
     private final IndexAccessor luceneAccessor;
     private final Selector selector;
+    private final long indexId;
+    private final DropAction dropAction;
 
-    FusionIndexAccessor( IndexAccessor nativeAccessor, IndexAccessor luceneAccessor, Selector selector )
+    FusionIndexAccessor( IndexAccessor nativeAccessor, IndexAccessor luceneAccessor, Selector selector,
+            long indexId, DropAction dropAction )
     {
         this.nativeAccessor = nativeAccessor;
         this.luceneAccessor = luceneAccessor;
         this.selector = selector;
+        this.indexId = indexId;
+        this.dropAction = dropAction;
     }
 
     @Override
@@ -61,6 +67,7 @@ class FusionIndexAccessor implements IndexAccessor
         {
             luceneAccessor.drop();
         }
+        dropAction.drop( indexId );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulator.java
@@ -28,6 +28,7 @@ import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.PropertyAccessor;
+import org.neo4j.kernel.impl.index.schema.fusion.FusionSchemaIndexProvider.DropAction;
 import org.neo4j.kernel.impl.index.schema.fusion.FusionSchemaIndexProvider.Selector;
 import org.neo4j.storageengine.api.schema.IndexSample;
 
@@ -38,12 +39,17 @@ class FusionIndexPopulator implements IndexPopulator
     private final IndexPopulator nativePopulator;
     private final IndexPopulator lucenePopulator;
     private final Selector selector;
+    private final long indexId;
+    private final DropAction dropAction;
 
-    FusionIndexPopulator( IndexPopulator nativePopulator, IndexPopulator lucenePopulator, Selector selector )
+    FusionIndexPopulator( IndexPopulator nativePopulator, IndexPopulator lucenePopulator, Selector selector,
+            long indexId, DropAction dropAction )
     {
         this.nativePopulator = nativePopulator;
         this.lucenePopulator = lucenePopulator;
         this.selector = selector;
+        this.indexId = indexId;
+        this.dropAction = dropAction;
     }
 
     @Override
@@ -64,6 +70,7 @@ class FusionIndexPopulator implements IndexPopulator
         {
             lucenePopulator.drop();
         }
+        dropAction.drop( indexId );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSchemaIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSchemaIndexProvider.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.IndexAccessor;
+import org.neo4j.kernel.api.index.IndexDirectoryStructure;
 import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
@@ -49,10 +50,11 @@ public class FusionSchemaIndexProvider extends SchemaIndexProvider
     private final SchemaIndexProvider luceneProvider;
     private final Selector selector;
 
-    public FusionSchemaIndexProvider( SchemaIndexProvider nativeProvider, SchemaIndexProvider luceneProvider, Selector selector,
+    public FusionSchemaIndexProvider( IndexDirectoryStructure.Factory directoryStructure,
+            SchemaIndexProvider nativeProvider, SchemaIndexProvider luceneProvider, Selector selector,
             SchemaIndexProvider.Descriptor descriptor, int priority )
     {
-        super( descriptor, priority );
+        super( descriptor, priority, directoryStructure );
         this.nativeProvider = nativeProvider;
         this.luceneProvider = luceneProvider;
         this.selector = selector;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSchemaIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSchemaIndexProvider.java
@@ -50,9 +50,9 @@ public class FusionSchemaIndexProvider extends SchemaIndexProvider
     private final SchemaIndexProvider luceneProvider;
     private final Selector selector;
 
-    public FusionSchemaIndexProvider( IndexDirectoryStructure.Factory directoryStructure,
-            SchemaIndexProvider nativeProvider, SchemaIndexProvider luceneProvider, Selector selector,
-            SchemaIndexProvider.Descriptor descriptor, int priority )
+    public FusionSchemaIndexProvider( SchemaIndexProvider nativeProvider,
+            SchemaIndexProvider luceneProvider, Selector selector, SchemaIndexProvider.Descriptor descriptor,
+            int priority, IndexDirectoryStructure.Factory directoryStructure )
     {
         super( descriptor, priority, directoryStructure );
         this.nativeProvider = nativeProvider;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSchemaIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSchemaIndexProvider.java
@@ -49,15 +49,17 @@ public class FusionSchemaIndexProvider extends SchemaIndexProvider
     private final SchemaIndexProvider nativeProvider;
     private final SchemaIndexProvider luceneProvider;
     private final Selector selector;
+    private final DropAction dropAction;
 
     public FusionSchemaIndexProvider( SchemaIndexProvider nativeProvider,
             SchemaIndexProvider luceneProvider, Selector selector, SchemaIndexProvider.Descriptor descriptor,
-            int priority, IndexDirectoryStructure.Factory directoryStructure )
+            int priority, IndexDirectoryStructure.Factory directoryStructure, FileSystemAbstraction fs )
     {
         super( descriptor, priority, directoryStructure );
         this.nativeProvider = nativeProvider;
         this.luceneProvider = luceneProvider;
         this.selector = selector;
+        this.dropAction = new FileSystemDropAction( fs, directoryStructure() );
     }
 
     @Override
@@ -65,7 +67,7 @@ public class FusionSchemaIndexProvider extends SchemaIndexProvider
     {
         return new FusionIndexPopulator(
                 nativeProvider.getPopulator( indexId, descriptor, samplingConfig ),
-                luceneProvider.getPopulator( indexId, descriptor, samplingConfig ), selector );
+                luceneProvider.getPopulator( indexId, descriptor, samplingConfig ), selector, indexId, dropAction );
     }
 
     @Override
@@ -74,7 +76,7 @@ public class FusionSchemaIndexProvider extends SchemaIndexProvider
     {
         return new FusionIndexAccessor(
                 nativeProvider.getOnlineAccessor( indexId, descriptor, samplingConfig ),
-                luceneProvider.getOnlineAccessor( indexId, descriptor, samplingConfig ), selector );
+                luceneProvider.getOnlineAccessor( indexId, descriptor, samplingConfig ), selector, indexId, dropAction );
     }
 
     @Override
@@ -136,5 +138,41 @@ public class FusionSchemaIndexProvider extends SchemaIndexProvider
                 first.indexSize() + other.indexSize(),
                 first.uniqueValues() + other.uniqueValues(),
                 first.sampleSize() + other.sampleSize() );
+    }
+
+    /**
+     * As an interface because this is actually dependent on whether or not an index lives on a {@link FileSystemAbstraction}
+     * or a page cache. At the time of writing this there's only the possibility to put these on the file system,
+     * but there will be a possibility to put these in the page cache file management instead and having this abstracted
+     * will help when making that switch/decision.
+     */
+    @FunctionalInterface
+    interface DropAction
+    {
+        /**
+         * Deletes the index directory and everything in it, as last part of dropping an index.
+         *
+         * @param indexId the index id, for which directory to drop.
+         * @throws IOException on I/O error.
+         */
+        void drop( long indexId ) throws IOException;
+    }
+
+    private static class FileSystemDropAction implements DropAction
+    {
+        private final FileSystemAbstraction fs;
+        private final IndexDirectoryStructure directoryStructure;
+
+        FileSystemDropAction( FileSystemAbstraction fs, IndexDirectoryStructure directoryStructure )
+        {
+            this.fs = fs;
+            this.directoryStructure = directoryStructure;
+        }
+
+        @Override
+        public void drop( long indexId ) throws IOException
+        {
+            fs.deleteRecursively( directoryStructure.directoryForIndex( indexId ) );
+        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/SchemaIndexMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/SchemaIndexMigrator.java
@@ -57,8 +57,12 @@ public class SchemaIndexMigrator extends AbstractStoreMigrationParticipant
         RecordFormats to = RecordFormatSelector.selectForVersion( versionToMigrateTo );
         if ( !from.hasSameCapabilities( to, CapabilityType.INDEX ) )
         {
-            schemaIndexDirectory = schemaIndexProvider.getSchemaIndexStoreDirectory( storeDir );
-            deleteObsoleteIndexes = true;
+            schemaIndexDirectory = schemaIndexProvider.directoryStructure().rootDirectory();
+            if ( schemaIndexDirectory != null )
+            {
+                deleteObsoleteIndexes = true;
+            }
+            // else this schema index provider doesn't have any persistent storage to delete.
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexDirectoryStructureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/index/IndexDirectoryStructureTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.index;
+
+import org.junit.Test;
+
+import java.io.File;
+
+import org.neo4j.kernel.api.index.SchemaIndexProvider.Descriptor;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.io.fs.FileUtils.path;
+import static org.neo4j.kernel.api.index.IndexDirectoryStructure.baseSchemaIndexFolder;
+import static org.neo4j.kernel.api.index.IndexDirectoryStructure.directoriesByProvider;
+import static org.neo4j.kernel.api.index.IndexDirectoryStructure.directoriesByProviderKey;
+import static org.neo4j.kernel.api.index.IndexDirectoryStructure.directoriesBySubProvider;
+
+public class IndexDirectoryStructureTest
+{
+    private final Descriptor provider = new Descriptor( "test", "0.5" );
+    private final File databaseStoreDir = new File( "db" ).getAbsoluteFile();
+    private final File baseIndexDirectory = baseSchemaIndexFolder( databaseStoreDir );
+    private final long indexId = 15;
+
+    @Test
+    public void shouldSeeCorrectDirectoriesForProviderKey() throws Exception
+    {
+        assertCorrectDirectories( directoriesByProviderKey( databaseStoreDir ).forProvider( provider ),
+                path( baseIndexDirectory, provider.getKey() ),
+                path( baseIndexDirectory, provider.getKey(), String.valueOf( indexId ) ) );
+    }
+
+    @Test
+    public void shouldSeeCorrectDirectoriesForProvider() throws Exception
+    {
+        assertCorrectDirectories( directoriesByProvider( databaseStoreDir ).forProvider( provider ),
+                path( baseIndexDirectory, provider.getKey() + "-" + provider.getVersion() ),
+                path( baseIndexDirectory, provider.getKey() + "-" +  provider.getVersion(), String.valueOf( indexId ) ) );
+    }
+
+    @Test
+    public void shouldSeeCorrectDirectoriesForSubProvider() throws Exception
+    {
+        IndexDirectoryStructure parentStructure = directoriesByProvider( databaseStoreDir ).forProvider( provider );
+        Descriptor subProvider = new Descriptor( "sub", "0.3" );
+        assertCorrectDirectories( directoriesBySubProvider( parentStructure ).forProvider( subProvider ),
+                path( baseIndexDirectory, provider.getKey() + "-" + provider.getVersion() ),
+                path( baseIndexDirectory, provider.getKey() + "-" + provider.getVersion(),
+                        String.valueOf( indexId ), subProvider.getKey() + "-" + subProvider.getVersion() ) );
+    }
+
+    @Test
+    public void shouldHandleWeirdCharactersInProviderKey() throws Exception
+    {
+        Descriptor providerWithWeirdName = new Descriptor( "native+lucene", "1.0" );
+        assertCorrectDirectories( directoriesByProvider( databaseStoreDir ).forProvider( providerWithWeirdName ),
+                path( baseIndexDirectory, "native_lucene-1.0" ),
+                path( baseIndexDirectory, "native_lucene-1.0", String.valueOf( indexId ) ) );
+    }
+
+    private void assertCorrectDirectories( IndexDirectoryStructure directoryStructure,
+            File expectedRootDirectory, File expectedIndexDirectory )
+    {
+        // when
+        File rootDirectory = directoryStructure.rootDirectory();
+        File indexDirectory = directoryStructure.directoryForIndex( indexId );
+
+        // then
+        assertEquals( expectedRootDirectory, rootDirectory );
+        assertEquals( expectedIndexDirectory, indexDirectory );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/ControlledPopulationSchemaIndexProvider.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/ControlledPopulationSchemaIndexProvider.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.IndexAccessor;
+import org.neo4j.kernel.api.index.IndexDirectoryStructure;
 import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
@@ -55,7 +56,7 @@ public class ControlledPopulationSchemaIndexProvider extends SchemaIndexProvider
 
     public ControlledPopulationSchemaIndexProvider()
     {
-        super( PROVIDER_DESCRIPTOR, 10 );
+        super( PROVIDER_DESCRIPTOR, 10, IndexDirectoryStructure.NONE );
         setInitialIndexState( initialIndexState );
         when( mockedWriter.newReader() ).thenReturn( IndexReader.EMPTY );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndexProvider.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndexProvider.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.IndexAccessor;
+import org.neo4j.kernel.api.index.IndexDirectoryStructure;
 import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
@@ -50,7 +51,7 @@ public class InMemoryIndexProvider extends SchemaIndexProvider
 
     private InMemoryIndexProvider( int prio, Map<Long, InMemoryIndex> indexes )
     {
-        super( InMemoryIndexProviderFactory.PROVIDER_DESCRIPTOR, prio );
+        super( InMemoryIndexProviderFactory.PROVIDER_DESCRIPTOR, prio, IndexDirectoryStructure.NONE );
         this.indexes = indexes;
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProviderTest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 
-import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
@@ -51,6 +50,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import static org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector.IMMEDIATE;
+import static org.neo4j.kernel.api.index.IndexDirectoryStructure.directoriesByProvider;
 
 public class NativeSchemaNumberIndexProviderTest
 {
@@ -385,12 +387,12 @@ public class NativeSchemaNumberIndexProviderTest
 
     private NativeSchemaNumberIndexProvider newProvider()
     {
-        return new NativeSchemaNumberIndexProvider( pageCache(), fs(), baseDir(), logging, RecoveryCleanupWorkCollector.IMMEDIATE, false );
+        return new NativeSchemaNumberIndexProvider( pageCache(), fs(), directoriesByProvider( baseDir() ), logging, IMMEDIATE, false );
     }
 
     private NativeSchemaNumberIndexProvider newReadOnlyProvider()
     {
-        return new NativeSchemaNumberIndexProvider( pageCache(), fs(), baseDir(), logging, RecoveryCleanupWorkCollector.IMMEDIATE, true );
+        return new NativeSchemaNumberIndexProvider( pageCache(), fs(), directoriesByProvider( baseDir() ), logging, IMMEDIATE, true );
     }
 
     private PageCache pageCache()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProviderTest.java
@@ -66,8 +66,7 @@ public class NativeSchemaNumberIndexProviderTest
     @Before
     public void setup() throws IOException
     {
-        File baseDir = rules.directory().absolutePath();
-        File nativeSchemaIndexStoreDirectory = newProvider().getSchemaIndexStoreDirectory( baseDir );
+        File nativeSchemaIndexStoreDirectory = newProvider().directoryStructure().rootDirectory();
         rules.fileSystem().mkdirs( nativeSchemaIndexStoreDirectory );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexAccessorTest.java
@@ -30,6 +30,7 @@ import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.impl.index.schema.NativeSelector;
+import org.neo4j.kernel.impl.index.schema.fusion.FusionSchemaIndexProvider.DropAction;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.sameInstance;
@@ -53,13 +54,15 @@ public class FusionIndexAccessorTest
     private IndexAccessor nativeAccessor;
     private IndexAccessor luceneAccessor;
     private FusionIndexAccessor fusionIndexAccessor;
+    private final long indexId = 10;
+    private final DropAction dropAction = mock( DropAction.class );
 
     @Before
     public void setup()
     {
         nativeAccessor = mock( IndexAccessor.class );
         luceneAccessor = mock( IndexAccessor.class );
-        fusionIndexAccessor = new FusionIndexAccessor( nativeAccessor, luceneAccessor, new NativeSelector() );
+        fusionIndexAccessor = new FusionIndexAccessor( nativeAccessor, luceneAccessor, new NativeSelector(), indexId, dropAction );
     }
 
     /* drop */
@@ -73,6 +76,7 @@ public class FusionIndexAccessorTest
         // then
         verify( nativeAccessor, times( 1 ) ).drop();
         verify( luceneAccessor, times( 1 ) ).drop();
+        verify( dropAction ).drop( indexId );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexPopulatorTest.java
@@ -30,6 +30,7 @@ import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.kernel.impl.index.schema.NativeSelector;
+import org.neo4j.kernel.impl.index.schema.fusion.FusionSchemaIndexProvider.DropAction;
 import org.neo4j.values.storable.Value;
 
 import static org.hamcrest.Matchers.sameInstance;
@@ -55,13 +56,15 @@ public class FusionIndexPopulatorTest
     private IndexPopulator nativePopulator;
     private IndexPopulator lucenePopulator;
     private FusionIndexPopulator fusionIndexPopulator;
+    private final long indexId = 8;
+    private final DropAction dropAction = mock( DropAction.class );
 
     @Before
     public void mockComponents()
     {
         nativePopulator = mock( IndexPopulator.class );
         lucenePopulator = mock( IndexPopulator.class );
-        fusionIndexPopulator = new FusionIndexPopulator( nativePopulator, lucenePopulator, new NativeSelector() );
+        fusionIndexPopulator = new FusionIndexPopulator( nativePopulator, lucenePopulator, new NativeSelector(), indexId, dropAction );
     }
 
     /* create */
@@ -116,6 +119,7 @@ public class FusionIndexPopulatorTest
         // then
         verify( nativePopulator, times( 1 ) ).drop();
         verify( lucenePopulator, times( 1 ) ).drop();
+        verify( dropAction ).drop( indexId );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSchemaIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSchemaIndexProviderTest.java
@@ -43,6 +43,7 @@ import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.helpers.ArrayUtil.array;
+import static org.neo4j.kernel.api.index.IndexDirectoryStructure.NONE;
 
 public class FusionSchemaIndexProviderTest
 {
@@ -249,7 +250,7 @@ public class FusionSchemaIndexProviderTest
 
     private FusionSchemaIndexProvider fusionProvider()
     {
-        return new FusionSchemaIndexProvider( nativeProvider, luceneProvider, new NativeSelector(), DESCRIPTOR, 10 );
+        return new FusionSchemaIndexProvider( NONE, nativeProvider, luceneProvider, new NativeSelector(), DESCRIPTOR, 10 );
     }
 
     private void setInitialState( SchemaIndexProvider mockedProvider, InternalIndexState state )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSchemaIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSchemaIndexProviderTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
@@ -250,7 +251,8 @@ public class FusionSchemaIndexProviderTest
 
     private FusionSchemaIndexProvider fusionProvider()
     {
-        return new FusionSchemaIndexProvider( nativeProvider, luceneProvider, new NativeSelector(), DESCRIPTOR, 10, NONE );
+        return new FusionSchemaIndexProvider( nativeProvider, luceneProvider, new NativeSelector(), DESCRIPTOR, 10, NONE,
+                mock( FileSystemAbstraction.class ) );
     }
 
     private void setInitialState( SchemaIndexProvider mockedProvider, InternalIndexState state )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSchemaIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionSchemaIndexProviderTest.java
@@ -250,7 +250,7 @@ public class FusionSchemaIndexProviderTest
 
     private FusionSchemaIndexProvider fusionProvider()
     {
-        return new FusionSchemaIndexProvider( NONE, nativeProvider, luceneProvider, new NativeSelector(), DESCRIPTOR, 10 );
+        return new FusionSchemaIndexProvider( nativeProvider, luceneProvider, new NativeSelector(), DESCRIPTOR, 10, NONE );
     }
 
     private void setInitialState( SchemaIndexProvider mockedProvider, InternalIndexState state )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/SchemaIndexMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/SchemaIndexMigratorTest.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.api.index.IndexDirectoryStructure;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.impl.store.format.standard.StandardV2_3;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
@@ -47,6 +48,10 @@ public class SchemaIndexMigratorTest
     @Test
     public void schemaAndLabelIndexesRemovedAfterSuccessfulMigration() throws IOException
     {
+        IndexDirectoryStructure directoryStructure = mock( IndexDirectoryStructure.class );
+        File indexProviderRootDirectory = new File( storeDir, "just-some-directory" );
+        when( directoryStructure.rootDirectory() ).thenReturn( indexProviderRootDirectory );
+        when( schemaIndexProvider.directoryStructure() ).thenReturn( directoryStructure );
         when( schemaIndexProvider.getProviderDescriptor() )
                 .thenReturn( new SchemaIndexProvider.Descriptor( "key", "version" ) );
 
@@ -55,6 +60,6 @@ public class SchemaIndexMigratorTest
 
         migrator.moveMigratedFiles( migrationDir, storeDir, StandardV2_3.STORE_VERSION, StandardV3_0.STORE_VERSION );
 
-        verify( fs ).deleteRecursively( schemaIndexProvider.getSchemaIndexStoreDirectory( storeDir ) );
+        verify( fs ).deleteRecursively( indexProviderRootDirectory );
     }
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/builder/AbstractLuceneIndexBuilder.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/builder/AbstractLuceneIndexBuilder.java
@@ -84,19 +84,7 @@ public abstract class AbstractLuceneIndexBuilder<T extends AbstractLuceneIndexBu
      */
     public T withIndexRootFolder( File indexRootFolder )
     {
-        storageBuilder.withIndexRootFolder( indexRootFolder );
-        return (T) this;
-    }
-
-    /**
-     * Specify index identifier
-     *
-     * @param indexIdentifier identifier
-     * @return index builder
-     */
-    public T withIndexIdentifier( String indexIdentifier )
-    {
-        storageBuilder.withIndexIdentifier( indexIdentifier );
+        storageBuilder.withIndexFolder( indexRootFolder );
         return (T) this;
     }
 

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/builder/LuceneIndexStorageBuilder.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/builder/LuceneIndexStorageBuilder.java
@@ -36,7 +36,6 @@ public class LuceneIndexStorageBuilder
     private DirectoryFactory directoryFactory = DirectoryFactory.PERSISTENT;
     private FileSystemAbstraction fileSystem;
     private File indexRootFolder;
-    private String indexIdentifier;
     private PartitionedIndexStorage indexStorage;
     private boolean archiveFailed;
 
@@ -66,23 +65,9 @@ public class LuceneIndexStorageBuilder
             Objects.requireNonNull( directoryFactory );
             Objects.requireNonNull( fileSystem );
             Objects.requireNonNull( indexRootFolder );
-            Objects.requireNonNull( indexIdentifier );
-            indexStorage =
-                    new PartitionedIndexStorage( directoryFactory, fileSystem, indexRootFolder, indexIdentifier, archiveFailed );
+            indexStorage = new PartitionedIndexStorage( directoryFactory, fileSystem, indexRootFolder, archiveFailed );
         }
         return indexStorage;
-    }
-
-    /**
-     * Specify index identifier
-     *
-     * @param indexIdentifier identifier
-     * @return index storage builder
-     */
-    public LuceneIndexStorageBuilder withIndexIdentifier( String indexIdentifier )
-    {
-        this.indexIdentifier = indexIdentifier;
-        return this;
     }
 
     /**
@@ -115,7 +100,7 @@ public class LuceneIndexStorageBuilder
      * @param indexRootFolder root folder
      * @return index storage builder
      */
-    public LuceneIndexStorageBuilder withIndexRootFolder( File indexRootFolder )
+    public LuceneIndexStorageBuilder withIndexFolder( File indexRootFolder )
     {
         this.indexRootFolder = indexRootFolder;
         return this;

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/IndexStorageFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/IndexStorageFactory.java
@@ -19,25 +19,24 @@
  */
 package org.neo4j.kernel.api.impl.index.storage;
 
-import java.io.File;
-
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.api.index.IndexDirectoryStructure;
 
 public class IndexStorageFactory
 {
     private final DirectoryFactory dirFactory;
     private final FileSystemAbstraction fileSystem;
-    private final File indexRootFolder;
+    private final IndexDirectoryStructure structure;
 
-    public IndexStorageFactory( DirectoryFactory dirFactory, FileSystemAbstraction fileSystem, File indexRootFolder )
+    public IndexStorageFactory( DirectoryFactory dirFactory, FileSystemAbstraction fileSystem, IndexDirectoryStructure structure )
     {
         this.dirFactory = dirFactory;
         this.fileSystem = fileSystem;
-        this.indexRootFolder = indexRootFolder;
+        this.structure = structure;
     }
 
     public PartitionedIndexStorage indexStorageOf( long indexId, boolean archiveFailed )
     {
-        return new PartitionedIndexStorage( dirFactory, fileSystem, indexRootFolder, String.valueOf( indexId ), archiveFailed );
+        return new PartitionedIndexStorage( dirFactory, fileSystem, structure.directoryForIndex( indexId ), archiveFailed );
     }
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/PartitionedIndexStorage.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/PartitionedIndexStorage.java
@@ -60,11 +60,11 @@ public class PartitionedIndexStorage
     private final FailureStorage failureStorage;
 
     public PartitionedIndexStorage( DirectoryFactory directoryFactory, FileSystemAbstraction fileSystem,
-                                    File rootFolder, String identifier, boolean archiveFailed )
+            File rootFolder, boolean archiveFailed )
     {
         this.fileSystem = fileSystem;
         this.archiveFailed = archiveFailed;
-        this.folderLayout = new IndexFolderLayout( rootFolder, identifier );
+        this.folderLayout = new IndexFolderLayout( rootFolder );
         this.directoryFactory = directoryFactory;
         this.failureStorage = new FailureStorage( fileSystem, folderLayout );
     }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/layout/IndexFolderLayout.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/layout/IndexFolderLayout.java
@@ -30,9 +30,9 @@ public class IndexFolderLayout implements FolderLayout
 {
     private final File indexFolder;
 
-    public IndexFolderLayout( File rootDirectory, String identifier )
+    public IndexFolderLayout( File rootDirectory )
     {
-        this.indexFolder = new File( rootDirectory, identifier );
+        this.indexFolder = rootDirectory;
     }
 
     @Override

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexProvider.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexProvider.java
@@ -58,13 +58,6 @@ public class LuceneSchemaIndexProvider extends SchemaIndexProvider
     private final FileSystemAbstraction fileSystem;
 
     public LuceneSchemaIndexProvider( FileSystemAbstraction fileSystem, DirectoryFactory directoryFactory,
-            File storeDir, LogProvider logging, Config config,
-            OperationalMode operationalMode )
-    {
-        this( fileSystem, directoryFactory, IndexDirectoryStructure.directoriesByProviderKey( storeDir ), logging, config, operationalMode );
-    }
-
-    public LuceneSchemaIndexProvider( FileSystemAbstraction fileSystem, DirectoryFactory directoryFactory,
             IndexDirectoryStructure.Factory directoryStructureFactory, LogProvider logging, Config config,
             OperationalMode operationalMode )
     {
@@ -74,6 +67,11 @@ public class LuceneSchemaIndexProvider extends SchemaIndexProvider
         this.config = config;
         this.operationalMode = operationalMode;
         this.log = logging.getLog( getClass() );
+    }
+
+    public static IndexDirectoryStructure.Factory defaultDirectoryStructure( File storeDir )
+    {
+        return IndexDirectoryStructure.directoriesByProviderKey( storeDir );
     }
 
     /**

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexProviderFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexProviderFactory.java
@@ -24,6 +24,7 @@ import java.io.File;
 import org.neo4j.helpers.Service;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.impl.index.storage.DirectoryFactory;
+import org.neo4j.kernel.api.index.IndexDirectoryStructure;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
@@ -34,6 +35,7 @@ import org.neo4j.kernel.impl.spi.KernelContext;
 import org.neo4j.logging.LogProvider;
 
 import static org.neo4j.kernel.api.impl.index.LuceneKernelExtensions.directoryFactory;
+import static org.neo4j.kernel.api.index.IndexDirectoryStructure.directoriesByProviderKey;
 
 @Service.Implementation( KernelExtensionFactory.class )
 public class LuceneSchemaIndexProviderFactory extends
@@ -73,8 +75,15 @@ public class LuceneSchemaIndexProviderFactory extends
     public static LuceneSchemaIndexProvider create( FileSystemAbstraction fileSystemAbstraction, File storeDir,
             LogProvider logProvider, Config config, OperationalMode operationalMode )
     {
+        return create( fileSystemAbstraction, directoriesByProviderKey( storeDir ), logProvider, config, operationalMode );
+    }
+
+    public static LuceneSchemaIndexProvider create( FileSystemAbstraction fileSystemAbstraction,
+            IndexDirectoryStructure.Factory directoryStructure, LogProvider logProvider, Config config, OperationalMode operationalMode )
+    {
         boolean ephemeral = config.get( GraphDatabaseFacadeFactory.Configuration.ephemeral );
         DirectoryFactory directoryFactory = directoryFactory( ephemeral, fileSystemAbstraction );
-        return new LuceneSchemaIndexProvider( fileSystemAbstraction, directoryFactory, storeDir, logProvider, config, operationalMode );
+        return new LuceneSchemaIndexProvider( fileSystemAbstraction, directoryFactory, directoryStructure,
+                logProvider, config, operationalMode );
     }
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionSchemaIndexProviderFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionSchemaIndexProviderFactory.java
@@ -87,7 +87,7 @@ public class NativeLuceneFusionSchemaIndexProviderFactory
         boolean useNativeIndex = config.get( GraphDatabaseSettings.enable_native_schema_index );
         int priority = useNativeIndex ? PRIORITY : 0;
         return new FusionSchemaIndexProvider( nativeProvider,
-                luceneProvider, new NativeSelector(), DESCRIPTOR, priority, directoriesByProvider( storeDir ) );
+                luceneProvider, new NativeSelector(), DESCRIPTOR, priority, directoriesByProvider( storeDir ), fs );
     }
 
     public static IndexDirectoryStructure.Factory subProviderDirectoryStructure( File storeDir )

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionSchemaIndexProviderFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionSchemaIndexProviderFactory.java
@@ -86,8 +86,8 @@ public class NativeLuceneFusionSchemaIndexProviderFactory
                 operationalMode );
         boolean useNativeIndex = config.get( GraphDatabaseSettings.enable_native_schema_index );
         int priority = useNativeIndex ? PRIORITY : 0;
-        return new FusionSchemaIndexProvider( directoriesByProvider( storeDir ),
-                nativeProvider, luceneProvider, new NativeSelector(), DESCRIPTOR, priority );
+        return new FusionSchemaIndexProvider( nativeProvider,
+                luceneProvider, new NativeSelector(), DESCRIPTOR, priority, directoriesByProvider( storeDir ) );
     }
 
     public static IndexDirectoryStructure.Factory subProviderDirectoryStructure( File storeDir )

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionSchemaIndexProviderFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionSchemaIndexProviderFactory.java
@@ -26,6 +26,7 @@ import org.neo4j.helpers.Service;
 import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.api.index.IndexDirectoryStructure;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
@@ -36,6 +37,9 @@ import org.neo4j.kernel.impl.index.schema.fusion.FusionSchemaIndexProvider;
 import org.neo4j.kernel.impl.spi.KernelContext;
 import org.neo4j.logging.LogProvider;
 
+import static org.neo4j.kernel.api.index.IndexDirectoryStructure.directoriesByProvider;
+import static org.neo4j.kernel.api.index.IndexDirectoryStructure.directoriesBySubProvider;
+
 @Service.Implementation( KernelExtensionFactory.class )
 public class NativeLuceneFusionSchemaIndexProviderFactory
         extends KernelExtensionFactory<NativeLuceneFusionSchemaIndexProviderFactory.Dependencies>
@@ -43,7 +47,7 @@ public class NativeLuceneFusionSchemaIndexProviderFactory
     public static final String KEY = LuceneSchemaIndexProviderFactory.KEY + "+" + NativeSchemaNumberIndexProvider.KEY;
     private static final int PRIORITY = LuceneSchemaIndexProvider.PRIORITY + 1;
 
-    private static final SchemaIndexProvider.Descriptor DESCRIPTOR = new SchemaIndexProvider.Descriptor( KEY, "0.1" );
+    private static final SchemaIndexProvider.Descriptor DESCRIPTOR = new SchemaIndexProvider.Descriptor( KEY, "1.0" );
 
     public interface Dependencies extends LuceneSchemaIndexProviderFactory.Dependencies
     {
@@ -74,14 +78,22 @@ public class NativeLuceneFusionSchemaIndexProviderFactory
             LogProvider logProvider, Config config, OperationalMode operationalMode,
             RecoveryCleanupWorkCollector recoveryCleanupWorkCollector )
     {
+        IndexDirectoryStructure.Factory childDirectoryStructure = subProviderDirectoryStructure( storeDir );
         boolean readOnly = isReadOnly( config, operationalMode );
         NativeSchemaNumberIndexProvider nativeProvider =
-                new NativeSchemaNumberIndexProvider( pageCache, fs, storeDir, logProvider, recoveryCleanupWorkCollector, readOnly );
-        LuceneSchemaIndexProvider luceneProvider = LuceneSchemaIndexProviderFactory.create( fs, storeDir, logProvider, config,
+                new NativeSchemaNumberIndexProvider( pageCache, fs, childDirectoryStructure, logProvider, recoveryCleanupWorkCollector, readOnly );
+        LuceneSchemaIndexProvider luceneProvider = LuceneSchemaIndexProviderFactory.create( fs, childDirectoryStructure, logProvider, config,
                 operationalMode );
         boolean useNativeIndex = config.get( GraphDatabaseSettings.enable_native_schema_index );
         int priority = useNativeIndex ? PRIORITY : 0;
-        return new FusionSchemaIndexProvider( nativeProvider, luceneProvider, new NativeSelector(), DESCRIPTOR, priority );
+        return new FusionSchemaIndexProvider( directoriesByProvider( storeDir ),
+                nativeProvider, luceneProvider, new NativeSelector(), DESCRIPTOR, priority );
+    }
+
+    public static IndexDirectoryStructure.Factory subProviderDirectoryStructure( File storeDir )
+    {
+        IndexDirectoryStructure parentDirectoryStructure = directoriesByProvider( storeDir ).forProvider( DESCRIPTOR );
+        return directoriesBySubProvider( parentDirectoryStructure );
     }
 
     private static boolean isReadOnly( Config config, OperationalMode operationalMode )

--- a/community/lucene-index/src/test/java/org/neo4j/index/lucene/ConstraintIndexFailureIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/lucene/ConstraintIndexFailureIT.java
@@ -41,6 +41,8 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.neo4j.graphdb.Label.label;
+import static org.neo4j.kernel.api.impl.schema.LuceneSchemaIndexProviderFactory.PROVIDER_DESCRIPTOR;
+import static org.neo4j.kernel.api.impl.schema.NativeLuceneFusionSchemaIndexProviderFactory.subProviderDirectoryStructure;
 
 public class ConstraintIndexFailureIT
 {
@@ -108,11 +110,12 @@ public class ConstraintIndexFailureIT
 
     private void storeIndexFailure( String failure ) throws IOException
     {
-        File luceneRootDirectory = new File( storeDir.directory(), "schema/index/lucene" );
+        File luceneIndexDirectory = subProviderDirectoryStructure( storeDir.directory() )
+                .forProvider( PROVIDER_DESCRIPTOR ).directoryForIndex( 1 );
         PartitionedIndexStorage indexStorage = LuceneIndexStorageBuilder.create()
                 .withFileSystem( fileSystemRule.get() )
-                .withIndexRootFolder( luceneRootDirectory )
-                .withIndexIdentifier( "1" ).build();
+                .withIndexFolder( luceneIndexDirectory )
+                .build();
         indexStorage.storeIndexFailure( failure );
     }
 }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/DatabaseIndexIntegrationTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/DatabaseIndexIntegrationTest.java
@@ -139,8 +139,8 @@ public class DatabaseIndexIntegrationTest
 
     private WritableTestDatabaseIndex createTestLuceneIndex( DirectoryFactory dirFactory, File folder ) throws IOException
     {
-        PartitionedIndexStorage indexStorage = new PartitionedIndexStorage( dirFactory, fileSystemRule.get(), folder,
-                "test", false );
+        PartitionedIndexStorage indexStorage = new PartitionedIndexStorage(
+                dirFactory, fileSystemRule.get(), folder, false );
         WritableTestDatabaseIndex index = new WritableTestDatabaseIndex( indexStorage );
         index.create();
         index.open();

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexPopulationIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexPopulationIT.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
@@ -91,8 +92,7 @@ public class LuceneSchemaIndexPopulationIT
     {
         try ( SchemaIndex uniqueIndex = LuceneSchemaIndexBuilder.create( descriptor )
                 .withFileSystem( fileSystemRule.get() )
-                .withIndexRootFolder( testDir.directory( "partitionIndex" + affectedNodes ) )
-                .withIndexIdentifier( "uniqueIndex" + affectedNodes )
+                .withIndexRootFolder( new File( testDir.directory( "partitionIndex" + affectedNodes ), "uniqueIndex" + affectedNodes ) )
                 .build() )
         {
             uniqueIndex.open();

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexUniquenessVerificationIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexUniquenessVerificationIT.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -70,7 +71,7 @@ public class LuceneSchemaIndexUniquenessVerificationIT
     @Rule
     public final DefaultFileSystemRule fileSystemRule = new DefaultFileSystemRule();
 
-    private int nodesToCreate = DOCS_PER_PARTITION * 2 + 1;
+    private final int nodesToCreate = DOCS_PER_PARTITION * 2 + 1;
 
     private SchemaIndex index;
     private static final long MAX_LONG_VALUE = Long.MAX_VALUE >> 10;
@@ -84,10 +85,9 @@ public class LuceneSchemaIndexUniquenessVerificationIT
         Factory<IndexWriterConfig> configFactory = new TestConfigFactory();
         index = LuceneSchemaIndexBuilder.create( descriptor )
                 .withFileSystem( fileSystemRule.get() )
-                .withIndexRootFolder( testDir.directory( "uniquenessVerification" ) )
+                .withIndexRootFolder( new File( testDir.directory( "uniquenessVerification" ), "index" ) )
                 .withWriterConfig( configFactory )
                 .withDirectoryFactory( DirectoryFactory.PERSISTENT )
-                .withIndexIdentifier( "index" )
                 .build();
 
         index.create();

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/storage/FailureStorageTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/storage/FailureStorageTest.java
@@ -41,14 +41,13 @@ public class FailureStorageTest
     @Rule
     public final EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
     private IndexFolderLayout indexFolderLayout;
-    private final String indexIdentifier = "1";
 
     @Before
     public void before()
     {
         File rootDirectory = new File( "dir" );
         fs.get().mkdirs( rootDirectory );
-        indexFolderLayout = new IndexFolderLayout( rootDirectory, indexIdentifier );
+        indexFolderLayout = new IndexFolderLayout( rootDirectory );
     }
 
     @Test

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/storage/PartitionedIndexStorageTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/storage/PartitionedIndexStorageTest.java
@@ -56,8 +56,6 @@ import static org.neo4j.helpers.collection.Iterators.asSet;
 
 public class PartitionedIndexStorageTest
 {
-    private static final String INDEX_ID = "testIndex";
-
     @Rule
     public final DefaultFileSystemRule fsRule = new DefaultFileSystemRule();
     @Rule
@@ -70,7 +68,7 @@ public class PartitionedIndexStorageTest
     public void createIndexStorage() throws Exception
     {
         fs = fsRule.get();
-        storage = new PartitionedIndexStorage( getOrCreateDirFactory( fs ), fs, testDir.graphDbDir(), INDEX_ID, false );
+        storage = new PartitionedIndexStorage( getOrCreateDirFactory( fs ), fs, testDir.graphDbDir(), false );
     }
 
     @Test
@@ -184,7 +182,7 @@ public class PartitionedIndexStorageTest
                 } )
         {
             PartitionedIndexStorage myStorage = new PartitionedIndexStorage( getOrCreateDirFactory( scramblingFs ),
-                    scramblingFs, testDir.graphDbDir(), INDEX_ID, false );
+                    scramblingFs, testDir.graphDbDir(), false );
             File parent = myStorage.getIndexFolder();
             int directoryCount = 10;
             for ( int i = 0; i < directoryCount; i++ )

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/storage/layout/IndexFolderLayoutTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/storage/layout/IndexFolderLayoutTest.java
@@ -35,8 +35,7 @@ public class IndexFolderLayoutTest
         IndexFolderLayout indexLayout = createTestIndex();
         File indexFolder = indexLayout.getIndexFolder();
 
-        assertEquals( indexRoot, indexFolder.getParentFile() );
-        assertEquals( "testIndex", indexFolder.getName() );
+        assertEquals( indexRoot, indexFolder );
     }
 
     @Test
@@ -56,7 +55,6 @@ public class IndexFolderLayoutTest
 
     private IndexFolderLayout createTestIndex()
     {
-        return new IndexFolderLayout( indexRoot, "testIndex" );
+        return new IndexFolderLayout( indexRoot );
     }
-
 }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/AccessUniqueDatabaseIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/AccessUniqueDatabaseIndexTest.java
@@ -42,6 +42,10 @@ import org.neo4j.values.storable.Values;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
+
+import static org.neo4j.kernel.api.impl.schema.LuceneSchemaIndexProviderFactory.PROVIDER_DESCRIPTOR;
+import static org.neo4j.kernel.api.index.IndexDirectoryStructure.directoriesByProviderKey;
+
 import static org.junit.Assert.assertEquals;
 
 public class AccessUniqueDatabaseIndexTest
@@ -49,7 +53,7 @@ public class AccessUniqueDatabaseIndexTest
     @Rule
     public final EphemeralFileSystemRule fileSystemRule = new EphemeralFileSystemRule();
     private final DirectoryFactory directoryFactory = new DirectoryFactory.InMemoryDirectoryFactory();
-    private final File indexDirectory = new File( "index1" );
+    private final File storeDirectory = new File( "db" );
     private final IndexDescriptor index = IndexDescriptorFactory.uniqueForLabel( 1000, 100 );
 
     @Test
@@ -144,8 +148,8 @@ public class AccessUniqueDatabaseIndexTest
 
     private PartitionedIndexStorage getIndexStorage()
     {
-        IndexStorageFactory storageFactory =
-                new IndexStorageFactory( directoryFactory, fileSystemRule.get(), indexDirectory );
+        IndexStorageFactory storageFactory = new IndexStorageFactory( directoryFactory, fileSystemRule.get(),
+                directoriesByProviderKey( storeDirectory ).forProvider( PROVIDER_DESCRIPTOR ) );
         return storageFactory.indexStorageOf( 1, false );
     }
 

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DatabaseCompositeIndexAccessorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DatabaseCompositeIndexAccessorTest.java
@@ -97,8 +97,7 @@ public class DatabaseCompositeIndexAccessorTest
                     SchemaIndex index = LuceneSchemaIndexBuilder.create( indexDescriptor )
                             .withFileSystem( fileSystemRule.get() )
                             .withDirectoryFactory( dirFactory1 )
-                            .withIndexRootFolder( dir )
-                            .withIndexIdentifier( "1" )
+                            .withIndexRootFolder( new File( dir, "1" ) )
                             .build();
 
                     index.create();
@@ -110,8 +109,7 @@ public class DatabaseCompositeIndexAccessorTest
                     SchemaIndex index = LuceneSchemaIndexBuilder.create( uniqueIndexDescriptor )
                             .withFileSystem( fileSystemRule.get() )
                             .withDirectoryFactory( dirFactory1 )
-                            .withIndexRootFolder( dir )
-                            .withIndexIdentifier( "testIndex" )
+                            .withIndexRootFolder( new File( dir, "testIndex" ) )
                             .build();
 
                     index.create();

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DatabaseIndexAccessorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DatabaseIndexAccessorTest.java
@@ -98,8 +98,7 @@ public class DatabaseIndexAccessorTest
                     SchemaIndex index = LuceneSchemaIndexBuilder.create( GENERAL_INDEX )
                             .withFileSystem( fileSystemRule.get() )
                             .withDirectoryFactory( dirFactory1 )
-                            .withIndexRootFolder( dir )
-                            .withIndexIdentifier( "1" )
+                            .withIndexRootFolder( new File( dir, "1" ) )
                             .build();
 
                     index.create();
@@ -111,8 +110,7 @@ public class DatabaseIndexAccessorTest
                     SchemaIndex index = LuceneSchemaIndexBuilder.create( UNIQUE_INDEX )
                             .withFileSystem( fileSystemRule.get() )
                             .withDirectoryFactory( dirFactory1 )
-                            .withIndexRootFolder( dir )
-                            .withIndexIdentifier( "testIndex" )
+                            .withIndexRootFolder( new File( dir, "testIndex" ) )
                             .build();
 
                     index.create();

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexRecoveryIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexRecoveryIT.java
@@ -52,6 +52,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.helpers.collection.Iterators.asUniqueSet;
+import static org.neo4j.kernel.api.impl.schema.LuceneSchemaIndexProvider.defaultDirectoryStructure;
 
 public class LuceneIndexRecoveryIT
 {
@@ -320,8 +321,8 @@ public class LuceneIndexRecoveryIT
             public Lifecycle newInstance( KernelContext context, LuceneSchemaIndexProviderFactory.Dependencies dependencies )
                     throws Throwable
             {
-                return new LuceneSchemaIndexProvider( fs.get(),directoryFactory, context
-                        .storeDir(), dependencies.getLogging().getInternalLogProvider(), dependencies.getConfig(),
+                return new LuceneSchemaIndexProvider( fs.get(),directoryFactory, defaultDirectoryStructure( context.storeDir() ),
+                        dependencies.getLogging().getInternalLogProvider(), dependencies.getConfig(),
                         context.databaseInfo().operationalMode )
                 {
                     @Override
@@ -345,7 +346,7 @@ public class LuceneIndexRecoveryIT
             public Lifecycle newInstance( KernelContext context, LuceneSchemaIndexProviderFactory.Dependencies dependencies )
                     throws Throwable
             {
-                return new LuceneSchemaIndexProvider( fs.get(), directoryFactory, context.storeDir(),
+                return new LuceneSchemaIndexProvider( fs.get(), directoryFactory, defaultDirectoryStructure( context.storeDir() ),
                         dependencies.getLogging().getInternalLogProvider(), dependencies.getConfig(),
                         context.databaseInfo().operationalMode )
                 {

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexBuilderTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexBuilderTest.java
@@ -50,8 +50,7 @@ public class LuceneSchemaIndexBuilderTest
                 .withFileSystem( fileSystemRule.get() )
                 .withConfig( getReadOnlyConfig() )
                 .withOperationalMode( OperationalMode.single )
-                .withIndexRootFolder( testDir.graphDbDir() )
-                .withIndexIdentifier( "a" )
+                .withIndexRootFolder( testDir.directory( "a" ) )
                 .build() )
         {
             assertTrue( "Builder should construct read only index.", schemaIndex.isReadOnly() );
@@ -65,8 +64,7 @@ public class LuceneSchemaIndexBuilderTest
                 .withConfig( getDefaultConfig() )
                 .withFileSystem( fileSystemRule.get() )
                 .withOperationalMode( OperationalMode.single )
-                .withIndexRootFolder( testDir.graphDbDir() )
-                .withIndexIdentifier( "b" )
+                .withIndexRootFolder( testDir.directory( "b" ) )
                 .build() )
         {
             assertFalse( "Builder should construct writable index.", schemaIndex.isReadOnly() );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexCorruptionTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexCorruptionTest.java
@@ -53,6 +53,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import static org.neo4j.kernel.api.impl.schema.LuceneSchemaIndexProvider.defaultDirectoryStructure;
 import static org.neo4j.logging.AssertableLogProvider.inLog;
 
 public class LuceneSchemaIndexCorruptionTest
@@ -122,7 +123,7 @@ public class LuceneSchemaIndexCorruptionTest
         DirectoryFactory directoryFactory = mock( DirectoryFactory.class );
         File indexRootFolder = testDirectory.graphDbDir();
         AtomicReference<FaultyIndexStorageFactory> reference = new AtomicReference<>();
-        return new LuceneSchemaIndexProvider( fs.get(), directoryFactory, indexRootFolder, logProvider,
+        return new LuceneSchemaIndexProvider( fs.get(), directoryFactory, defaultDirectoryStructure( indexRootFolder ), logProvider,
                 Config.defaults(), OperationalMode.single )
         {
             @Override

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexIT.java
@@ -127,8 +127,7 @@ public class LuceneSchemaIndexIT
     {
         try ( SchemaIndex index = LuceneSchemaIndexBuilder.create( descriptor )
                 .withFileSystem( fileSystemRule.get() )
-                .withIndexRootFolder( testDir.directory() )
-                .withIndexIdentifier( "partitionedIndexForUpdates" )
+                .withIndexRootFolder( testDir.directory( "partitionedIndexForUpdates" ) )
                 .build() )
         {
             index.create();
@@ -150,8 +149,7 @@ public class LuceneSchemaIndexIT
         File crudOperation = testDir.directory( "indexCRUDOperation" );
         try ( SchemaIndex crudIndex = LuceneSchemaIndexBuilder.create( descriptor )
                 .withFileSystem( fileSystemRule.get() )
-                .withIndexRootFolder( crudOperation )
-                .withIndexIdentifier( "crudIndex" )
+                .withIndexRootFolder( new File( crudOperation, "crudIndex" ) )
                 .build() )
         {
             crudIndex.open();
@@ -174,8 +172,7 @@ public class LuceneSchemaIndexIT
     {
         try ( SchemaIndex failedIndex = LuceneSchemaIndexBuilder.create( descriptor )
                 .withFileSystem( fileSystemRule.get() )
-                .withIndexRootFolder( testDir.directory( "failedIndexFolder" ) )
-                .withIndexIdentifier( "failedIndex" )
+                .withIndexRootFolder( new File( testDir.directory( "failedIndexFolder" ), "failedIndex" ) )
                 .build() )
         {
             failedIndex.open();
@@ -199,8 +196,7 @@ public class LuceneSchemaIndexIT
         {
             reopenIndex = LuceneSchemaIndexBuilder.create( descriptor )
                     .withFileSystem( fileSystemRule.get() )
-                    .withIndexRootFolder( testDir.directory( "reopenIndexFolder" ) )
-                    .withIndexIdentifier( "reopenIndex" )
+                    .withIndexRootFolder( new File( testDir.directory( "reopenIndexFolder" ), "reopenIndex" ) )
                     .build();
             reopenIndex.open();
 
@@ -253,8 +249,7 @@ public class LuceneSchemaIndexIT
     {
         SchemaIndex index = LuceneSchemaIndexBuilder.create( descriptor )
                 .withFileSystem( fileSystemRule.get() )
-                .withIndexRootFolder( testDir.directory() )
-                .withIndexIdentifier( "testIndex" )
+                .withIndexRootFolder( testDir.directory( "testIndex" ) )
                 .build();
         index.create();
         index.open();

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexPopulatorTest.java
@@ -61,6 +61,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.neo4j.helpers.collection.Iterators.asSet;
+import static org.neo4j.kernel.api.impl.schema.LuceneSchemaIndexProvider.defaultDirectoryStructure;
 
 public class LuceneSchemaIndexPopulatorTest
 {
@@ -85,7 +86,7 @@ public class LuceneSchemaIndexPopulatorTest
         directory = new RAMDirectory();
         DirectoryFactory directoryFactory = new DirectoryFactory.Single(
                 new DirectoryFactory.UncloseableDirectory( directory ) );
-        provider = new LuceneSchemaIndexProvider( fs.get(), directoryFactory, testDir.directory( "folder" ),
+        provider = new LuceneSchemaIndexProvider( fs.get(), directoryFactory, defaultDirectoryStructure( testDir.directory( "folder" ) ),
                 NullLogProvider.getInstance(), Config.defaults(), OperationalMode.single );
         indexStoreView = mock( IndexStoreView.class );
         IndexSamplingConfig samplingConfig = new IndexSamplingConfig( Config.defaults() );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexProviderTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexProviderTest.java
@@ -42,6 +42,8 @@ import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 
+import static org.neo4j.kernel.api.impl.schema.LuceneSchemaIndexProvider.defaultDirectoryStructure;
+
 /**
  * Additional tests for stuff not already covered by {@link LuceneSchemaIndexProviderCompatibilitySuiteTest}
  */
@@ -121,7 +123,7 @@ public class LuceneSchemaIndexProviderTest
     private LuceneSchemaIndexProvider getLuceneSchemaIndexProvider( Config config, DirectoryFactory directoryFactory,
                                                                     FileSystemAbstraction fs, File graphDbDir )
     {
-        return new LuceneSchemaIndexProvider(
-                fs, directoryFactory, graphDbDir, NullLogProvider.getInstance(), config, OperationalMode.single );
+        return new LuceneSchemaIndexProvider( fs, directoryFactory, defaultDirectoryStructure( graphDbDir ),
+                NullLogProvider.getInstance(), config, OperationalMode.single );
     }
 }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexTest.java
@@ -26,6 +26,7 @@ import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.UUID;
 
@@ -138,10 +139,9 @@ public class LuceneSchemaIndexTest
     {
         LuceneSchemaIndexBuilder builder = LuceneSchemaIndexBuilder.create( descriptor );
         return builder
-                .withIndexRootFolder( testDir.directory( "index" ) )
+                .withIndexRootFolder( new File( testDir.directory( "index" ), "testIndex" ) )
                 .withDirectoryFactory( dirFactory )
                 .withFileSystem( fs.get() )
-                .withIndexIdentifier( "testIndex" )
                 .build();
     }
 

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/ReadOnlyLuceneSchemaIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/ReadOnlyLuceneSchemaIndexTest.java
@@ -55,7 +55,7 @@ public class ReadOnlyLuceneSchemaIndexTest
     public void setUp()
     {
         PartitionedIndexStorage indexStorage = new PartitionedIndexStorage( DirectoryFactory.PERSISTENT,
-                fileSystemRule.get(), testDirectory.directory(), "1", false );
+                fileSystemRule.get(), testDirectory.directory(), false );
         Config config = Config.defaults();
         IndexSamplingConfig samplingConfig = new IndexSamplingConfig( config );
         luceneSchemaIndex = new ReadOnlyDatabaseSchemaIndex( indexStorage, IndexDescriptorFactory.forLabel( 0, 0 ),

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueDatabaseIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueDatabaseIndexPopulatorTest.java
@@ -69,8 +69,7 @@ public class NonUniqueDatabaseIndexPopulatorTest
     public void setUp() throws Exception
     {
         File folder = testDir.directory( "folder" );
-        PartitionedIndexStorage indexStorage = new PartitionedIndexStorage( dirFactory, fileSystemRule.get(), folder,
-                "testIndex", false );
+        PartitionedIndexStorage indexStorage = new PartitionedIndexStorage( dirFactory, fileSystemRule.get(), folder, false );
 
         index = LuceneSchemaIndexBuilder.create( IndexDescriptorFactory.forSchema( labelSchemaDescriptor ) )
                 .withIndexStorage( indexStorage )

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/UniqueDatabaseIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/UniqueDatabaseIndexPopulatorTest.java
@@ -81,7 +81,6 @@ public class UniqueDatabaseIndexPopulatorTest
 
     private static final int LABEL_ID = 1;
     private static final int PROPERTY_KEY_ID = 2;
-    private static final String INDEX_IDENTIFIER = "42";
 
     private final DirectoryFactory directoryFactory = new DirectoryFactory.InMemoryDirectoryFactory();
     private static final IndexDescriptor descriptor = IndexDescriptorFactory
@@ -98,8 +97,7 @@ public class UniqueDatabaseIndexPopulatorTest
     public void setUp() throws Exception
     {
         File folder = testDir.directory( "folder" );
-        indexStorage = new PartitionedIndexStorage( directoryFactory, fileSystemRule.get(),
-                                                    folder, INDEX_IDENTIFIER, false );
+        indexStorage = new PartitionedIndexStorage( directoryFactory, fileSystemRule.get(), folder, false );
         index = LuceneSchemaIndexBuilder.create( descriptor )
                 .withIndexStorage( indexStorage )
                 .build();

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintCreationIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintCreationIT.java
@@ -45,7 +45,7 @@ public class ConstraintCreationIT
     public EmbeddedDatabaseRule dbRule = new EmbeddedDatabaseRule();
 
     private static final Label LABEL = Label.label( "label1" );
-    private static final String INDEX_IDENTIFIER = "1";
+    private static final long indexId = 1;
 
     @Test
     public void shouldNotLeaveLuceneIndexFilesHangingAroundIfConstraintCreationFails()
@@ -83,8 +83,8 @@ public class ConstraintCreationIT
 
         SchemaIndexProvider schemaIndexProvider =
                 db.getDependencyResolver().resolveDependency( SchemaIndexProviderMap.class ).getDefaultProvider();
-        File schemaStoreDir = schemaIndexProvider.getSchemaIndexStoreDirectory( db.getStoreDir() );
+        File indexDir = schemaIndexProvider.directoryStructure().directoryForIndex( indexId );
 
-        assertFalse( new IndexFolderLayout( schemaStoreDir, INDEX_IDENTIFIER ).getIndexFolder().exists() );
+        assertFalse( new IndexFolderLayout( indexDir ).getIndexFolder().exists() );
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
@@ -86,6 +86,7 @@ import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.helpers.collection.Iterators.asSet;
 import static org.neo4j.helpers.collection.Iterators.asUniqueSet;
 import static org.neo4j.io.fs.FileUtils.deleteRecursively;
+import static org.neo4j.kernel.api.index.IndexDirectoryStructure.given;
 import static org.neo4j.kernel.impl.ha.ClusterManager.allSeesAllAsAvailable;
 import static org.neo4j.kernel.impl.ha.ClusterManager.masterAvailable;
 
@@ -501,7 +502,7 @@ public class SchemaIndexHaIT
 
         ControlledSchemaIndexProvider( SchemaIndexProvider delegate )
         {
-            super( CONTROLLED_PROVIDER_DESCRIPTOR, 100 /*we want it to always win*/ );
+            super( CONTROLLED_PROVIDER_DESCRIPTOR, 100 /*we want it to always win*/, given( delegate.directoryStructure() ) );
             this.delegate = delegate;
         }
 


### PR DESCRIPTION
The lucene schema index provider puts its indexes in:

  `<db>/schema/index/lucene/<indexId>/...`

this commit doesn't change this, but the fusion index provider,
i.e. the combination of lucene+native gets a new structure driven by the need
to one day be able to do efficient background migration of schema indexes
and for convenience in the wild. The new structure looks like this:

  `<db>/schema/index/<providerKey>/<providerVersion>/<indexId>/...`

Including the sub-provider directory and specifically for this fusion index (for indexId 5):

  `<db>/schema/index/lucene_native/0.1/5/lucene/...`
  `<db>/schema/index/lucene_native/0.1/5/native/...`

This has two benefits:

- all index data related to one index lives in one directory
- indexes on disk are also versions, just like providers are

Since the fusion index also uses a lucene schema index provider internally,
this structure has been made pluggable and given to a SchemaIndexProvider
at construction time. See IndexDirectoryStructure. This class has all knowledge
about the base schema root directory and various directory structure implementations
collected in one place.

NOTE This change does not require any migration, except for databases recently
created, where the fusion index is enabled by default. Although no releases
has had the fusion index in them so that is not a problem.