### PR TITLE
Removes resolves of SchemaIndexProvider directly

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -413,9 +413,6 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
         SchemaIndexProvider defaultIndexProvider =
                 dependencyResolver.resolveDependency( SchemaIndexProvider.class, indexProviderSelection );
 
-        // todo do we really need to have this dependency?
-        dependencies.satisfyDependency( defaultIndexProvider );
-
         schemaIndexProviderMap =
                 new DefaultSchemaIndexProviderMap( defaultIndexProvider, indexProviderSelection.lowerPrioritizedCandidates() );
         dependencies.satisfyDependency( schemaIndexProviderMap );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/DefaultSchemaIndexProviderMap.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/DefaultSchemaIndexProviderMap.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.transaction.state;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
@@ -46,6 +47,7 @@ public class DefaultSchemaIndexProviderMap implements SchemaIndexProviderMap
         for ( SchemaIndexProvider provider : additionalIndexProviders )
         {
             Descriptor providerDescriptor = provider.getProviderDescriptor();
+            Objects.requireNonNull( providerDescriptor );
             SchemaIndexProvider existing = indexProviders.putIfAbsent( providerDescriptor, provider );
             if ( existing != null )
             {

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintCreationIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintCreationIT.java
@@ -31,6 +31,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.api.impl.index.storage.layout.IndexFolderLayout;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
+import org.neo4j.kernel.impl.api.index.SchemaIndexProviderMap;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.rule.EmbeddedDatabaseRule;
 
@@ -81,7 +82,7 @@ public class ConstraintCreationIT
         }
 
         SchemaIndexProvider schemaIndexProvider =
-                db.getDependencyResolver().resolveDependency( SchemaIndexProvider.class );
+                db.getDependencyResolver().resolveDependency( SchemaIndexProviderMap.class ).getDefaultProvider();
         File schemaStoreDir = schemaIndexProvider.getSchemaIndexStoreDirectory( db.getStoreDir() );
 
         assertFalse( new IndexFolderLayout( schemaStoreDir, INDEX_IDENTIFIER ).getIndexFolder().exists() );

--- a/community/neo4j/src/test/java/schema/MultiIndexPopulationConcurrentUpdatesIT.java
+++ b/community/neo4j/src/test/java/schema/MultiIndexPopulationConcurrentUpdatesIT.java
@@ -48,7 +48,6 @@ import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexPopulationFailedKernelException;
 import org.neo4j.kernel.api.impl.schema.LuceneSchemaIndexProviderFactory;
 import org.neo4j.kernel.api.index.IndexEntryUpdate;
-import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 import org.neo4j.kernel.api.schema.LabelSchemaDescriptor;
@@ -71,7 +70,6 @@ import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.SchemaStorage;
 import org.neo4j.kernel.impl.store.record.IndexRule;
-import org.neo4j.kernel.impl.transaction.state.DefaultSchemaIndexProviderMap;
 import org.neo4j.kernel.impl.transaction.state.DirectIndexUpdates;
 import org.neo4j.kernel.impl.transaction.state.storeview.DynamicIndexStoreView;
 import org.neo4j.kernel.impl.transaction.state.storeview.LabelScanViewNodeStoreScan;
@@ -245,7 +243,7 @@ public class MultiIndexPopulationConcurrentUpdatesIT
         {
             DynamicIndexStoreView storeView = dynamicIndexStoreViewWrapper( updates, neoStores, labelScanStore );
 
-            SchemaIndexProviderMap providerMap = new DefaultSchemaIndexProviderMap( getSchemaIndexProvider() );
+            SchemaIndexProviderMap providerMap = getSchemaIndexProvider();
             JobScheduler scheduler = getJobScheduler();
             StatementTokenNameLookup tokenNameLookup = new StatementTokenNameLookup( statement.readOperations() );
 
@@ -398,9 +396,9 @@ public class MultiIndexPopulationConcurrentUpdatesIT
         return embeddedDatabase.resolveDependency( ThreadToStatementContextBridge.class );
     }
 
-    private SchemaIndexProvider getSchemaIndexProvider()
+    private SchemaIndexProviderMap getSchemaIndexProvider()
     {
-        return embeddedDatabase.resolveDependency( SchemaIndexProvider.class );
+        return embeddedDatabase.resolveDependency( SchemaIndexProviderMap.class );
     }
 
     private JobScheduler getJobScheduler()

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitStoreMigrationTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitStoreMigrationTest.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
-import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.store.MetaDataStore;
@@ -68,7 +67,6 @@ public class HighLimitStoreMigrationTest
     {
         FileSystemAbstraction fileSystem = fileSystemRule.get();
         PageCache pageCache = pageCacheRule.getPageCache( fileSystem );
-        SchemaIndexProvider schemaIndexProvider = mock( SchemaIndexProvider.class );
 
         StoreMigrator migrator = new StoreMigrator( fileSystem, pageCache, Config.defaults(), NullLogService.getInstance() );
 
@@ -104,5 +102,4 @@ public class HighLimitStoreMigrationTest
         fileSystem.create( neoStoreFile ).close();
         return neoStoreFile;
     }
-
 }


### PR DESCRIPTION
Instead forces use of SchemaIndexProviderMap where care has to be taken for
multiple providers, which is good to consider. In many cases, especially in tests
it's still just about the default index, which can easily be retrieved from that map.

This exposed (now fixed) an issue in StoreSizeBean where it didn't include index sizes
from all providers when calculating schema index size.