### PR TITLE
Handle EntityNotFoundException in compiled runtime

### DIFF
--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/codegen/Fields.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/codegen/Fields.scala
@@ -29,4 +29,5 @@ case class Fields(closer: FieldReference,
                   tracer: FieldReference,
                   params: FieldReference,
                   closeable: FieldReference,
-                  queryContext: FieldReference)
+                  queryContext: FieldReference,
+                  skip: FieldReference)

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/codegen/GeneratedQueryStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/codegen/GeneratedQueryStructure.scala
@@ -202,7 +202,8 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
       tracer = clazz.field(typeRef[QueryExecutionTracer], "tracer"),
       params = clazz.field(typeRef[MapValue], "params"),
       closeable = clazz.field(typeRef[Completable], "closeable"),
-      queryContext = clazz.field(typeRef[QueryContext], "queryContext"))
+      queryContext = clazz.field(typeRef[QueryContext], "queryContext"),
+      skip = clazz.field(typeRef[Boolean], "skip"))
   }
 
   def method[O <: AnyRef, R](name: String, params: TypeReference*)

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_3/GeneratedMethodStructureTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_3/GeneratedMethodStructureTest.scala
@@ -177,7 +177,7 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
       m.declareAndInitialize("from", CodeGenType.primitiveNode)
       m.declareAndInitialize("to", CodeGenType.primitiveNode)
       val local = m.generator.declare(typeRef[RelationshipIterator], "iter")
-      Templates.handleKernelExceptions(m.generator, m.fields.ro, m.finalizers) { body =>
+      Templates.handleKernelExceptions(m.generator, m.fields, m.finalizers) { body =>
         body.assign(local, Expression.invoke(Methods.allConnectingRelationships,
                                              Expression.get(m.generator.self(), m.fields.ro), body.load("from"),
                                              Templates.outgoing,
@@ -188,7 +188,7 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
       m.declareAndInitialize("from", CodeGenType.primitiveNode)
       m.declareAndInitialize("to", CodeGenType.primitiveNode)
       val local = m.generator.declare(typeRef[RelationshipIterator], "iter")
-      Templates.handleKernelExceptions(m.generator, m.fields.ro, m.finalizers) { body =>
+      Templates.handleKernelExceptions(m.generator, m.fields, m.finalizers) { body =>
         body.assign(local, Expression.invoke(Methods.connectingRelationships,
                                              Expression.get(m.generator.self(), m.fields.ro), body.load("from"),
                                              Templates.outgoing,
@@ -235,7 +235,8 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
         tracer = body.field(typeRef[QueryExecutionTracer], "tracer"),
         params = body.field(typeRef[util.Map[String, Object]], "params"),
         closeable = body.field(typeRef[Completable], "closeable"),
-        queryContext = body.field(typeRef[QueryContext], "queryContext"))
+        queryContext = body.field(typeRef[QueryContext], "queryContext"),
+        skip = body.field(typeRef[Boolean], "skip"))
       // the "COLUMNS" static field
       body.staticField(typeRef[util.List[String]], "COLUMNS", Templates.asList[String](Seq.empty))
       using(body.generate(MethodDeclaration.method(typeRef[Unit], "foo"))) { methodBody =>


### PR DESCRIPTION
The compiled wasn't catching and ignoring EntityNotFoundException as is
done in the interpreted runtime, this leads to unwanted behaviour when
another thread is deleting nodes and relationship while the query is
running.