### PR TITLE
Improved GBPTree file handling

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/GBPTreeFileUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/GBPTreeFileUtil.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+
+import org.neo4j.index.internal.gbptree.GBPTree;
+
+/**
+ * Utilities for common operations around a {@link GBPTree}.
+ */
+public interface GBPTreeFileUtil
+{
+    /**
+     * Deletes store file backing a {@link GBPTree}.
+     * Undefined behaviour if storeFile is a directory.
+     *
+     * @param storeFile the {@link File} to delete.
+     * @throws NoSuchFileException if the {@code storeFile} doesn't exist according to the {@code pageCache}.
+     * @throws IOException on failure to delete existing {@code storeFile}.
+     */
+    void deleteFile( File storeFile ) throws IOException;
+
+    /**
+     * Deletes store file backing a {@link GBPTree}, if it exists according to the {@code pageCache}.
+     * Undefined behaviour if storeFile is a directory.
+     *
+     * @param storeFile the {@link File} to delete.
+     * @throws IOException on failure to delete existing {@code storeFile}.
+     */
+    void deleteFileIfPresent( File storeFile ) throws IOException;
+
+    /**
+     * Checks whether or not {@code storeFile} exists according to {@code pageCache}.
+     * Undefined behaviour if storeFile is a directory.
+     *
+     * @param storeFile the {@link File} to check for existence.
+     * @return {@code true} if {@code storeFile} exists according to {@code pageCache}, otherwise {@code false}.
+     */
+    boolean storeFileExists( File storeFile );
+
+    /**
+     * Creates the directory named by this abstract pathname, including any
+     * necessary but nonexistent parent directories.
+     *
+     * @param dir the directory path to create
+     * @throws IOException on failure to create directories.
+     */
+    void mkdirs( File dir ) throws IOException;
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
@@ -43,7 +43,7 @@ import org.neo4j.kernel.api.labelscan.AllEntriesLabelScanReader;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.labelscan.LabelScanWriter;
 import org.neo4j.kernel.impl.api.scan.FullStoreChangeStream;
-import org.neo4j.kernel.impl.index.GBPTreeUtil;
+import org.neo4j.kernel.impl.index.GBPTreeFileUtil;
 import org.neo4j.kernel.impl.store.UnderlyingStorageException;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.storageengine.api.schema.LabelScanReader;
@@ -131,6 +131,11 @@ public class NativeLabelScanStore implements LabelScanStore
     private final int pageSize;
 
     /**
+     * Used for all file operations on the gbpTree file.
+     */
+    private final GBPTreeFileUtil gbpTreeUtil;
+
+    /**
      * The index which backs this label scan store. Instantiated in {@link #init()} and considered
      * started after call to {@link #start()}.
      */
@@ -186,6 +191,7 @@ public class NativeLabelScanStore implements LabelScanStore
         this.monitors = monitors;
         this.monitor = monitors.newMonitor( Monitor.class );
         this.recoveryCleanupWorkCollector = recoveryCleanupWorkCollector;
+        this.gbpTreeUtil = new GBPTreePageCacheFileUtil( pageCache );
     }
 
     /**
@@ -342,7 +348,7 @@ public class NativeLabelScanStore implements LabelScanStore
     @Override
     public boolean hasStore() throws IOException
     {
-        return GBPTreeUtil.storeFileExists( pageCache, storeFile );
+        return gbpTreeUtil.storeFileExists( storeFile );
     }
 
     @Override
@@ -402,7 +408,7 @@ public class NativeLabelScanStore implements LabelScanStore
             index.close();
             index = null;
         }
-        GBPTreeUtil.delete( pageCache, storeFile );
+        gbpTreeUtil.deleteFile( storeFile );
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/GBPTreeFileSystemFileUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/GBPTreeFileSystemFileUtil.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.schema;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.impl.index.GBPTreeFileUtil;
+
+public class GBPTreeFileSystemFileUtil implements GBPTreeFileUtil
+{
+    private final FileSystemAbstraction fs;
+
+    public GBPTreeFileSystemFileUtil( FileSystemAbstraction fs )
+    {
+        this.fs = fs;
+    }
+
+    @Override
+    public void deleteFile( File storeFile ) throws IOException
+    {
+        fs.deleteFileOrThrow( storeFile );
+    }
+
+    @Override
+    public void deleteFileIfPresent( File storeFile ) throws IOException
+    {
+        try
+        {
+            deleteFile( storeFile );
+        }
+        catch ( NoSuchFileException e )
+        {
+            // File does not exist, we don't need to delete
+        }
+    }
+
+    @Override
+    public boolean storeFileExists( File storeFile )
+    {
+        return fs.fileExists( storeFile );
+    }
+
+    @Override
+    public void mkdirs( File dir ) throws IOException
+    {
+        fs.mkdirs( dir );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndex.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndex.java
@@ -30,6 +30,7 @@ import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.kernel.impl.index.GBPTreeFileUtil;
 
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_READER;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_MONITOR;
@@ -39,16 +40,16 @@ class NativeSchemaNumberIndex<KEY extends SchemaNumberKey, VALUE extends SchemaN
     final PageCache pageCache;
     final File storeFile;
     final Layout<KEY,VALUE> layout;
-    final FileSystemAbstraction fs;
+    final GBPTreeFileUtil gbpTreeFileUtil;
 
     GBPTree<KEY,VALUE> tree;
 
     NativeSchemaNumberIndex( PageCache pageCache, FileSystemAbstraction fs, File storeFile, Layout<KEY,VALUE> layout )
     {
         this.pageCache = pageCache;
-        this.fs = fs;
         this.storeFile = storeFile;
         this.layout = layout;
+        this.gbpTreeFileUtil = new GBPTreeFileSystemFileUtil( fs );
     }
 
     void instantiateTree( RecoveryCleanupWorkCollector recoveryCleanupWorkCollector, Consumer<PageCursor> headerWriter )
@@ -63,7 +64,7 @@ class NativeSchemaNumberIndex<KEY extends SchemaNumberKey, VALUE extends SchemaN
     {
         // This will create the directory on the "normal" file system.
         // When native index is put on blockdevice, page cache file system should be used instead.
-        fs.mkdirs( storeFile.getParentFile() );
+        gbpTreeFileUtil.mkdirs( storeFile.getParentFile() );
     }
 
     void closeTree() throws IOException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexAccessor.java
@@ -35,7 +35,6 @@ import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.PropertyAccessor;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
-import org.neo4j.kernel.impl.index.GBPTreeUtil;
 import org.neo4j.storageengine.api.schema.IndexReader;
 
 import static org.neo4j.helpers.collection.Iterators.asResourceIterator;
@@ -59,7 +58,7 @@ public class NativeSchemaNumberIndexAccessor<KEY extends SchemaNumberKey, VALUE 
     public void drop() throws IOException
     {
         closeTree();
-        GBPTreeUtil.delete( pageCache, storeFile );
+        gbpTreeFileUtil.deleteFile( storeFile );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexPopulator.java
@@ -41,7 +41,6 @@ import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.PropertyAccessor;
-import org.neo4j.kernel.impl.index.GBPTreeUtil;
 
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_WRITER;
 
@@ -78,7 +77,7 @@ public abstract class NativeSchemaNumberIndexPopulator<KEY extends SchemaNumberK
     @Override
     public synchronized void create() throws IOException
     {
-        GBPTreeUtil.deleteIfPresent( pageCache, storeFile );
+        gbpTreeFileUtil.deleteFileIfPresent( storeFile );
         instantiateTree( RecoveryCleanupWorkCollector.IMMEDIATE, new NativeSchemaIndexHeaderWriter( BYTE_POPULATING ) );
         instantiateWriter();
         workSync = new WorkSync<>( new IndexUpdateApply<>( treeKey, treeValue, singleTreeWriter, conflictDetectingValueMerger ) );
@@ -97,7 +96,7 @@ public abstract class NativeSchemaNumberIndexPopulator<KEY extends SchemaNumberK
         {
             closeWriter();
             closeTree();
-            GBPTreeUtil.deleteIfPresent( pageCache, storeFile );
+            gbpTreeFileUtil.deleteFileIfPresent( storeFile );
         }
         finally
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/AbstractGBPTreeFileUtilTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/AbstractGBPTreeFileUtilTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * This test is inherited on blockdevice to test that behaviour is unified between product and blockdevice.
+ */
+public abstract class AbstractGBPTreeFileUtilTest
+{
+    private GBPTreeFileUtil fileUtil;
+    private File existingFile;
+    private File nonExistingFile;
+    private File nonExistingDirectory;
+
+    @Before
+    public void setup() throws IOException
+    {
+        this.fileUtil = getGBPTreeFileUtil();
+        this.existingFile = existingFile( "existing_file" );
+        this.nonExistingFile = nonExistingFile( "non_existing_file" );
+        this.nonExistingDirectory = nonExistingDirectory( "non_existing_directory" );
+    }
+
+    @After
+    public void cleanUp()
+    {
+    }
+
+    protected abstract GBPTreeFileUtil getGBPTreeFileUtil();
+
+    protected abstract File existingFile( String fileName ) throws IOException;
+
+    protected abstract File nonExistingFile( String fileName );
+
+    protected abstract File nonExistingDirectory( String directoryName );
+
+    protected abstract void assertFileDoesNotExist( File file );
+
+    protected abstract void assertDirectoryExist( File directory );
+
+    /* deleteFile( File storeFile ) */
+
+    @Test
+    public void fileMustNotExistAfterDeleteFile() throws Exception
+    {
+        // given
+        // when
+        fileUtil.deleteFile( existingFile );
+
+        // then
+        assertFileDoesNotExist( existingFile );
+    }
+
+    @Test
+    public void deleteFileMustThrowIfFileIsMissing() throws Exception
+    {
+        // given
+        // when
+        try
+        {
+            fileUtil.deleteFile( nonExistingFile );
+            fail( "Should have failed" );
+        }
+        catch ( NoSuchFileException e )
+        {
+            // then
+        }
+    }
+
+    /* deleteIfPresent( File storeFile ) */
+
+    @Test
+    public void deleteFileIfPresentMustDeleteFileIfPresent() throws Exception
+    {
+        // given
+        // when
+        fileUtil.deleteFileIfPresent( existingFile );
+
+        // then
+        assertFileDoesNotExist( existingFile );
+    }
+
+    @Test
+    public void deleteFileIfPresentMustNotThrowIfFileIsMissing() throws Exception
+    {
+        // given
+        // when
+        fileUtil.deleteFileIfPresent( nonExistingFile );
+
+        // then
+        // this should be fine
+    }
+
+    /* boolean storeFileExists( File storeFile ) */
+
+    @Test
+    public void storeFileExistsMustReturnTrueForExistingFile() throws Exception
+    {
+        assertTrue( fileUtil.storeFileExists( existingFile ) );
+    }
+
+    @Test
+    public void storeFileExistsMustReturnFalseForNonExistingFile() throws Exception
+    {
+        assertFalse( fileUtil.storeFileExists( nonExistingFile ) );
+    }
+
+    /* mkdirs( File dir ) */
+
+    @Test
+    public void directoryMustExistAfterMkdirs() throws Exception
+    {
+        // given
+        // when
+        fileUtil.mkdirs( nonExistingDirectory );
+
+        // then
+        assertDirectoryExist( nonExistingDirectory );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/GBPTreeFileUtilTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/GBPTreeFileUtilTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.impl.index.labelscan.GBPTreePageCacheFileUtil;
+import org.neo4j.kernel.impl.index.schema.GBPTreeFileSystemFileUtil;
+import org.neo4j.test.rule.PageCacheAndDependenciesRule;
+import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith( Parameterized.class )
+public class GBPTreeFileUtilTest extends AbstractGBPTreeFileUtilTest
+{
+    @ClassRule
+    public static PageCacheAndDependenciesRule pageCacheAndDependenciesRule = new PageCacheAndDependenciesRule(
+            DefaultFileSystemRule::new, GBPTreeFileUtilTest.class
+    );
+
+    private static FileSystemAbstraction fs;
+    private static TestDirectory directory;
+
+    @BeforeClass
+    public static void extractFileSystem()
+    {
+        fs = pageCacheAndDependenciesRule.fileSystem();
+        directory = pageCacheAndDependenciesRule.directory();
+    }
+
+    @Parameterized.Parameters( name = "{0}" )
+    public static Collection<GBPTreeFileUtil> fileUtils()
+    {
+        return Arrays.asList(
+                new GBPTreePageCacheFileUtil( pageCacheAndDependenciesRule.pageCache() ),
+                new GBPTreeFileSystemFileUtil( pageCacheAndDependenciesRule.fileSystem() ) );
+    }
+
+    @Parameterized.Parameter
+    public GBPTreeFileUtil gbpTreeFileUtil;
+
+    @Override
+    protected GBPTreeFileUtil getGBPTreeFileUtil()
+    {
+        return gbpTreeFileUtil;
+    }
+
+    @Override
+    protected File existingFile( String fileName ) throws IOException
+    {
+        File file = directory.file( fileName );
+        fs.create( file );
+        return file;
+    }
+
+    @Override
+    protected File nonExistingFile( String fileName )
+    {
+        return directory.file( fileName );
+    }
+
+    @Override
+    protected File nonExistingDirectory( String directoryName )
+    {
+        return new File( directory.absolutePath(), directoryName );
+    }
+
+    @Override
+    protected void assertFileDoesNotExist( File file )
+    {
+        assertFalse( fs.fileExists( file ) );
+    }
+
+    @Override
+    protected void assertDirectoryExist( File directory )
+    {
+        assertTrue( fs.fileExists( directory ) );
+        assertTrue( fs.isDirectory( directory ) );
+    }
+}


### PR DESCRIPTION
Introduce interface GBPTreeFileUtil that gathers file operations
used inside of components built on top of GBPTree, label index
and schema index.

Implementation decide how those file operations should be carried out.
Specifically if it should be done using normal file system or file system
provided by page cache.