### PR TITLE
Upgraded Shiro and commons-digester

### DIFF
--- a/community/neo4j-harness/LICENSES.txt
+++ b/community/neo4j-harness/LICENSES.txt
@@ -11,8 +11,6 @@ Apache Software License, Version 2.0
   Apache HttpClient
   Apache HttpCore
   Caffeine cache
-  Commons BeanUtils
-  Commons Digester
   Commons IO
   Commons Lang
   ConcurrentLinkedHashMap

--- a/community/neo4j-harness/NOTICE.txt
+++ b/community/neo4j-harness/NOTICE.txt
@@ -34,8 +34,6 @@ Apache Software License, Version 2.0
   Apache HttpClient
   Apache HttpCore
   Caffeine cache
-  Commons BeanUtils
-  Commons Digester
   Commons IO
   Commons Lang
   ConcurrentLinkedHashMap

--- a/community/server-api/LICENSES.txt
+++ b/community/server-api/LICENSES.txt
@@ -5,8 +5,6 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 Apache Software License, Version 2.0
   Apache Commons Configuration
   Apache Commons Lang
-  Commons BeanUtils
-  Commons Digester
   Commons Lang
   Commons Logging
   Lucene Core

--- a/community/server-api/NOTICE.txt
+++ b/community/server-api/NOTICE.txt
@@ -28,8 +28,6 @@ Third-party licenses
 Apache Software License, Version 2.0
   Apache Commons Configuration
   Apache Commons Lang
-  Commons BeanUtils
-  Commons Digester
   Commons Lang
   Commons Logging
   Lucene Core

--- a/community/server-api/pom.xml
+++ b/community/server-api/pom.xml
@@ -80,10 +80,5 @@ the relevant Commercial Agreement.
       <artifactId>commons-configuration</artifactId>
     </dependency>
 
-    <!-- Added directly to avoid version clash in commons-configuration. -->
-    <dependency>
-      <groupId>commons-digester</groupId>
-      <artifactId>commons-digester</artifactId>
-    </dependency>
   </dependencies>
 </project>

--- a/community/server/LICENSES.txt
+++ b/community/server/LICENSES.txt
@@ -7,8 +7,6 @@ Apache Software License, Version 2.0
   Apache Commons Configuration
   Apache Commons Lang
   Caffeine cache
-  Commons BeanUtils
-  Commons Digester
   Commons IO
   Commons Lang
   Commons Logging

--- a/community/server/NOTICE.txt
+++ b/community/server/NOTICE.txt
@@ -30,8 +30,6 @@ Apache Software License, Version 2.0
   Apache Commons Configuration
   Apache Commons Lang
   Caffeine cache
-  Commons BeanUtils
-  Commons Digester
   Commons IO
   Commons Lang
   Commons Logging

--- a/community/server/pom.xml
+++ b/community/server/pom.xml
@@ -179,11 +179,6 @@
       <artifactId>commons-configuration</artifactId>
     </dependency>
 
-    <!-- Added directly to avoid version clash in commons-configuration. -->
-    <dependency>
-      <groupId>commons-digester</groupId>
-      <artifactId>commons-digester</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>commons-io</groupId>

--- a/enterprise/causal-clustering/LICENSES.txt
+++ b/enterprise/causal-clustering/LICENSES.txt
@@ -3,10 +3,19 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons BeanUtils
+  Apache Commons Collections
   Apache Commons Compress
+  Apache Shiro :: Cache
+  Apache Shiro :: Configuration :: Core
+  Apache Shiro :: Configuration :: OGDL
   Apache Shiro :: Core
+  Apache Shiro :: Cryptography :: Ciphers
+  Apache Shiro :: Cryptography :: Core
+  Apache Shiro :: Cryptography :: Hashing
+  Apache Shiro :: Event
+  Apache Shiro :: Lang
   Caffeine cache
-  Commons BeanUtils
   hazelcast-all
   Lucene codecs
   Lucene Common Analyzers

--- a/enterprise/causal-clustering/NOTICE.txt
+++ b/enterprise/causal-clustering/NOTICE.txt
@@ -25,10 +25,19 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons BeanUtils
+  Apache Commons Collections
   Apache Commons Compress
+  Apache Shiro :: Cache
+  Apache Shiro :: Configuration :: Core
+  Apache Shiro :: Configuration :: OGDL
   Apache Shiro :: Core
+  Apache Shiro :: Cryptography :: Ciphers
+  Apache Shiro :: Cryptography :: Core
+  Apache Shiro :: Cryptography :: Hashing
+  Apache Shiro :: Event
+  Apache Shiro :: Lang
   Caffeine cache
-  Commons BeanUtils
   hazelcast-all
   Lucene codecs
   Lucene Common Analyzers

--- a/enterprise/ha/LICENSES.txt
+++ b/enterprise/ha/LICENSES.txt
@@ -3,11 +3,20 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons BeanUtils
+  Apache Commons Collections
   Apache Commons Compress
   Apache Commons Lang
+  Apache Shiro :: Cache
+  Apache Shiro :: Configuration :: Core
+  Apache Shiro :: Configuration :: OGDL
   Apache Shiro :: Core
+  Apache Shiro :: Cryptography :: Ciphers
+  Apache Shiro :: Cryptography :: Core
+  Apache Shiro :: Cryptography :: Hashing
+  Apache Shiro :: Event
+  Apache Shiro :: Lang
   Caffeine cache
-  Commons BeanUtils
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core

--- a/enterprise/ha/NOTICE.txt
+++ b/enterprise/ha/NOTICE.txt
@@ -25,11 +25,20 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons BeanUtils
+  Apache Commons Collections
   Apache Commons Compress
   Apache Commons Lang
+  Apache Shiro :: Cache
+  Apache Shiro :: Configuration :: Core
+  Apache Shiro :: Configuration :: OGDL
   Apache Shiro :: Core
+  Apache Shiro :: Cryptography :: Ciphers
+  Apache Shiro :: Cryptography :: Core
+  Apache Shiro :: Cryptography :: Hashing
+  Apache Shiro :: Event
+  Apache Shiro :: Lang
   Caffeine cache
-  Commons BeanUtils
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core

--- a/enterprise/metrics/LICENSES.txt
+++ b/enterprise/metrics/LICENSES.txt
@@ -3,6 +3,8 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons BeanUtils
+  Apache Commons Collections
   Graphite Integration for Metrics
   Metrics Core
 ------------------------------------------------------------------------------

--- a/enterprise/metrics/NOTICE.txt
+++ b/enterprise/metrics/NOTICE.txt
@@ -25,6 +25,8 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons BeanUtils
+  Apache Commons Collections
   Graphite Integration for Metrics
   Metrics Core
 

--- a/enterprise/neo4j-enterprise/LICENSES.txt
+++ b/enterprise/neo4j-enterprise/LICENSES.txt
@@ -3,11 +3,20 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons BeanUtils
+  Apache Commons Collections
   Apache Commons Compress
   Apache Commons Lang
+  Apache Shiro :: Cache
+  Apache Shiro :: Configuration :: Core
+  Apache Shiro :: Configuration :: OGDL
   Apache Shiro :: Core
+  Apache Shiro :: Cryptography :: Ciphers
+  Apache Shiro :: Cryptography :: Core
+  Apache Shiro :: Cryptography :: Hashing
+  Apache Shiro :: Event
+  Apache Shiro :: Lang
   Caffeine cache
-  Commons BeanUtils
   ConcurrentLinkedHashMap
   Graphite Integration for Metrics
   hazelcast-all

--- a/enterprise/neo4j-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-enterprise/NOTICE.txt
@@ -25,11 +25,20 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons BeanUtils
+  Apache Commons Collections
   Apache Commons Compress
   Apache Commons Lang
+  Apache Shiro :: Cache
+  Apache Shiro :: Configuration :: Core
+  Apache Shiro :: Configuration :: OGDL
   Apache Shiro :: Core
+  Apache Shiro :: Cryptography :: Ciphers
+  Apache Shiro :: Cryptography :: Core
+  Apache Shiro :: Cryptography :: Hashing
+  Apache Shiro :: Event
+  Apache Shiro :: Lang
   Caffeine cache
-  Commons BeanUtils
   ConcurrentLinkedHashMap
   Graphite Integration for Metrics
   hazelcast-all

--- a/enterprise/neo4j-harness-enterprise/LICENSES.txt
+++ b/enterprise/neo4j-harness-enterprise/LICENSES.txt
@@ -3,14 +3,22 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons BeanUtils
+  Apache Commons Collections
   Apache Commons Compress
   Apache Commons Configuration
   Apache Commons Lang
   Apache Commons Logging
+  Apache Shiro :: Cache
+  Apache Shiro :: Configuration :: Core
+  Apache Shiro :: Configuration :: OGDL
   Apache Shiro :: Core
+  Apache Shiro :: Cryptography :: Ciphers
+  Apache Shiro :: Cryptography :: Core
+  Apache Shiro :: Cryptography :: Hashing
+  Apache Shiro :: Event
+  Apache Shiro :: Lang
   Caffeine cache
-  Commons BeanUtils
-  Commons Digester
   Commons IO
   Commons Lang
   ConcurrentLinkedHashMap

--- a/enterprise/neo4j-harness-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-harness-enterprise/NOTICE.txt
@@ -25,14 +25,22 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons BeanUtils
+  Apache Commons Collections
   Apache Commons Compress
   Apache Commons Configuration
   Apache Commons Lang
   Apache Commons Logging
+  Apache Shiro :: Cache
+  Apache Shiro :: Configuration :: Core
+  Apache Shiro :: Configuration :: OGDL
   Apache Shiro :: Core
+  Apache Shiro :: Cryptography :: Ciphers
+  Apache Shiro :: Cryptography :: Core
+  Apache Shiro :: Cryptography :: Hashing
+  Apache Shiro :: Event
+  Apache Shiro :: Lang
   Caffeine cache
-  Commons BeanUtils
-  Commons Digester
   Commons IO
   Commons Lang
   ConcurrentLinkedHashMap

--- a/enterprise/query-logging/LICENSES.txt
+++ b/enterprise/query-logging/LICENSES.txt
@@ -3,6 +3,8 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons BeanUtils
+  Apache Commons Collections
   Lucene Core
   Lucene Memory
   Netty/All-in-One

--- a/enterprise/query-logging/NOTICE.txt
+++ b/enterprise/query-logging/NOTICE.txt
@@ -25,6 +25,8 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons BeanUtils
+  Apache Commons Collections
   Lucene Core
   Lucene Memory
   Netty/All-in-One

--- a/enterprise/security/LICENSES.txt
+++ b/enterprise/security/LICENSES.txt
@@ -3,10 +3,19 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons BeanUtils
+  Apache Commons Collections
   Apache Commons Compress
+  Apache Shiro :: Cache
+  Apache Shiro :: Configuration :: Core
+  Apache Shiro :: Configuration :: OGDL
   Apache Shiro :: Core
+  Apache Shiro :: Cryptography :: Ciphers
+  Apache Shiro :: Cryptography :: Core
+  Apache Shiro :: Cryptography :: Hashing
+  Apache Shiro :: Event
+  Apache Shiro :: Lang
   Caffeine cache
-  Commons BeanUtils
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core

--- a/enterprise/security/NOTICE.txt
+++ b/enterprise/security/NOTICE.txt
@@ -25,10 +25,19 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons BeanUtils
+  Apache Commons Collections
   Apache Commons Compress
+  Apache Shiro :: Cache
+  Apache Shiro :: Configuration :: Core
+  Apache Shiro :: Configuration :: OGDL
   Apache Shiro :: Core
+  Apache Shiro :: Cryptography :: Ciphers
+  Apache Shiro :: Cryptography :: Core
+  Apache Shiro :: Cryptography :: Hashing
+  Apache Shiro :: Event
+  Apache Shiro :: Lang
   Caffeine cache
-  Commons BeanUtils
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core

--- a/enterprise/security/pom.xml
+++ b/enterprise/security/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.apache.shiro</groupId>
       <artifactId>shiro-core</artifactId>
-      <version>1.3.2</version>
+      <version>1.4.0</version>
     </dependency>
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>

--- a/enterprise/security/pom.xml
+++ b/enterprise/security/pom.xml
@@ -70,17 +70,14 @@
     <dependency>
       <groupId>org.apache.shiro</groupId>
       <artifactId>shiro-core</artifactId>
-      <version>1.4.0</version>
     </dependency>
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
-      <version>2.3.3</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-nop</artifactId>
-      <version>1.7.22</version>
     </dependency>
 
     <!-- Test dependencies -->
@@ -176,7 +173,6 @@
     <dependency>
       <groupId>org.apache.directory.server</groupId>
       <artifactId>apacheds-server-integ</artifactId>
-      <version>2.0.0-M21</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -197,7 +193,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
-      <version>19.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/enterprise/server-enterprise/LICENSES.txt
+++ b/enterprise/server-enterprise/LICENSES.txt
@@ -3,13 +3,21 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons BeanUtils
+  Apache Commons Collections
   Apache Commons Compress
   Apache Commons Configuration
   Apache Commons Lang
+  Apache Shiro :: Cache
+  Apache Shiro :: Configuration :: Core
+  Apache Shiro :: Configuration :: OGDL
   Apache Shiro :: Core
+  Apache Shiro :: Cryptography :: Ciphers
+  Apache Shiro :: Cryptography :: Core
+  Apache Shiro :: Cryptography :: Hashing
+  Apache Shiro :: Event
+  Apache Shiro :: Lang
   Caffeine cache
-  Commons BeanUtils
-  Commons Digester
   Commons IO
   Commons Lang
   Commons Logging

--- a/enterprise/server-enterprise/NOTICE.txt
+++ b/enterprise/server-enterprise/NOTICE.txt
@@ -25,13 +25,21 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons BeanUtils
+  Apache Commons Collections
   Apache Commons Compress
   Apache Commons Configuration
   Apache Commons Lang
+  Apache Shiro :: Cache
+  Apache Shiro :: Configuration :: Core
+  Apache Shiro :: Configuration :: OGDL
   Apache Shiro :: Core
+  Apache Shiro :: Cryptography :: Ciphers
+  Apache Shiro :: Cryptography :: Core
+  Apache Shiro :: Cryptography :: Hashing
+  Apache Shiro :: Event
+  Apache Shiro :: Lang
   Caffeine cache
-  Commons BeanUtils
-  Commons Digester
   Commons IO
   Commons Lang
   Commons Logging

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/LICENSES.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/LICENSES.txt
@@ -8,8 +8,6 @@ Apache Software License, Version 2.0
   Apache Commons Lang
   Caffeine cache
   ColorBrewer
-  Commons BeanUtils
-  Commons Digester
   Commons IO
   Commons Lang
   Commons Logging

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
@@ -31,8 +31,6 @@ Apache Software License, Version 2.0
   Apache Commons Lang
   Caffeine cache
   ColorBrewer
-  Commons BeanUtils
-  Commons Digester
   Commons IO
   Commons Lang
   Commons Logging

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/LICENSES.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/LICENSES.txt
@@ -3,14 +3,22 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons BeanUtils
+  Apache Commons Collections
   Apache Commons Compress
   Apache Commons Configuration
   Apache Commons Lang
+  Apache Shiro :: Cache
+  Apache Shiro :: Configuration :: Core
+  Apache Shiro :: Configuration :: OGDL
   Apache Shiro :: Core
+  Apache Shiro :: Cryptography :: Ciphers
+  Apache Shiro :: Cryptography :: Core
+  Apache Shiro :: Cryptography :: Hashing
+  Apache Shiro :: Event
+  Apache Shiro :: Lang
   Caffeine cache
   ColorBrewer
-  Commons BeanUtils
-  Commons Digester
   Commons IO
   Commons Lang
   Commons Logging

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/NOTICE.txt
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/NOTICE.txt
@@ -25,14 +25,22 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons BeanUtils
+  Apache Commons Collections
   Apache Commons Compress
   Apache Commons Configuration
   Apache Commons Lang
+  Apache Shiro :: Cache
+  Apache Shiro :: Configuration :: Core
+  Apache Shiro :: Configuration :: OGDL
   Apache Shiro :: Core
+  Apache Shiro :: Cryptography :: Ciphers
+  Apache Shiro :: Cryptography :: Core
+  Apache Shiro :: Cryptography :: Hashing
+  Apache Shiro :: Event
+  Apache Shiro :: Lang
   Caffeine cache
   ColorBrewer
-  Commons BeanUtils
-  Commons Digester
   Commons IO
   Commons Lang
   Commons Logging

--- a/pom.xml
+++ b/pom.xml
@@ -576,6 +576,12 @@
         <version>1.10</version>
         <type>jar</type>
         <scope>compile</scope>
+        <exclusions>
+          <exclusion>
+            <artifactId>commons-digester</artifactId>
+            <groupId>commons-digester</groupId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <!-- Added (directly) to avoid version clash in commons-configuration. -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -549,17 +549,29 @@
         <scope>compile</scope>
         <exclusions>
           <exclusion>
-            <artifactId>commons-digester</artifactId>
-            <groupId>commons-digester</groupId>
+            <artifactId>commons-digester3</artifactId>
+            <groupId>commons-digester3</groupId>
           </exclusion>
         </exclusions>
       </dependency>
       <!-- Added (directly) to avoid version clash in commons-configuration. -->
       <dependency>
-        <groupId>commons-digester</groupId>
-        <artifactId>commons-digester</artifactId>
-        <version>2.1</version>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-digeste3r</artifactId>
+        <version>3.2</version>
         <type>jar</type>
+        <scope>compile</scope>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>commons-beanutils</groupId>
+        <artifactId>commons-beanutils</artifactId>
+        <version>1.9.3</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -576,12 +576,6 @@
         <version>1.10</version>
         <type>jar</type>
         <scope>compile</scope>
-        <exclusions>
-          <exclusion>
-            <artifactId>commons-digester3</artifactId>
-            <groupId>commons-digester3</groupId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <!-- Added (directly) to avoid version clash in commons-configuration. -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -447,6 +447,22 @@
           </exclusion>
         </exclusions>
       </dependency>
+      <dependency>
+        <groupId>org.apache.shiro</groupId>
+        <artifactId>shiro-core</artifactId>
+        <version>1.4.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.github.ben-manes.caffeine</groupId>
+        <artifactId>caffeine</artifactId>
+        <version>2.3.3</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-nop</artifactId>
+        <version>1.7.22</version>
+      </dependency>
+
       <!-- testing -->
       <dependency>
         <groupId>org.neo4j.driver</groupId>
@@ -454,6 +470,19 @@
         <version>1.4.3</version>
         <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>org.apache.directory.server</groupId>
+        <artifactId>apacheds-server-integ</artifactId>
+        <version>2.0.0-M21</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava-testlib</artifactId>
+        <version>19.0</version>
+        <scope>test</scope>
+      </dependency>
+
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -586,7 +586,7 @@
       <!-- Added (directly) to avoid version clash in commons-configuration. -->
       <dependency>
         <groupId>org.apache.commons</groupId>
-        <artifactId>commons-digeste3r</artifactId>
+        <artifactId>commons-digester3</artifactId>
         <version>3.2</version>
         <type>jar</type>
         <scope>compile</scope>


### PR DESCRIPTION
changelog: Upgraded shiro-core version to 1.4.0 and  commons-digester to  commons-digester3 3.2. 
This upgrade is due to a security problem with commons-beanutils-1.8.3. See https://nvd.nist.gov/vuln/detail/CVE-2014-0114 for more details.