### PR TITLE
Store highId backwards scan happens only when necessary

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
@@ -680,7 +680,7 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord,HEAD
      */
     void openIdGenerator()
     {
-        idGenerator = idGeneratorFactory.open( getIdFileName(), getIdType(), scanForHighId(), recordFormat.getMaxId() );
+        idGenerator = idGeneratorFactory.open( getIdFileName(), getIdType(), () -> scanForHighId(), recordFormat.getMaxId() );
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MetaDataStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MetaDataStore.java
@@ -610,18 +610,23 @@ public class MetaDataStore extends CommonAbstractStore<MetaDataRecord,NoStoreHea
 
     private void setRecord( Position position, long value )
     {
-        long id = position.id;
-
         // We need to do a little special handling of high id in neostore since it's not updated in the same
         // way as other stores. Other stores always gets updates via commands where records are updated and
         // the one making the update can also track the high id in the event of recovery.
         // Here methods can be called directly, for example setLatestConstraintIntroducingTx where it's
         // unclear from the outside which record id that refers to, so here we need to manage high id ourselves.
-        setHighestPossibleIdInUse( id );
+        // Furthermore, we want the store to have a fixed size to accommodate the fixed number of fields it has. But,
+        // there is no guarantee that the field with the largest id will be called in a particular run. That means
+        // that to make sure we always have a proper max id, we must always set it to the highest possible value
+        // according to the enumeration of fields
+        Position[] values = Position.values();
+        long highestPossibleId = values[ values.length - 1 ].id;
+
+        setHighestPossibleIdInUse( highestPossibleId );
 
         MetaDataRecord record = new MetaDataRecord();
         record.initialize( true, value );
-        record.setId( id );
+        record.setId( position.id );
         updateRecord( record );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/BufferingIdGeneratorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/BufferingIdGeneratorFactory.java
@@ -55,14 +55,14 @@ public class BufferingIdGeneratorFactory implements IdGeneratorFactory
     }
 
     @Override
-    public IdGenerator open( File filename, IdType idType, long highId, long maxId )
+    public IdGenerator open( File filename, IdType idType, Supplier<Long> highId, long maxId )
     {
         IdTypeConfiguration typeConfiguration = idTypeConfigurationProvider.getIdTypeConfiguration( idType );
         return open( filename, typeConfiguration.getGrabSize(), idType, highId, maxId);
     }
 
     @Override
-    public IdGenerator open( File filename, int grabSize, IdType idType, long highId, long maxId )
+    public IdGenerator open( File filename, int grabSize, IdType idType, Supplier<Long> highId, long maxId )
     {
         assert boundaries != null : "Factory needs to be initialized before usage";
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/DefaultIdGeneratorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/DefaultIdGeneratorFactory.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.store.id;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.store.id.configuration.CommunityIdTypeConfigurationProvider;
@@ -46,14 +47,14 @@ public class DefaultIdGeneratorFactory implements IdGeneratorFactory
     }
 
     @Override
-    public IdGenerator open( File filename, IdType idType, long highId, long maxId )
+    public IdGenerator open( File filename, IdType idType, Supplier<Long> highId, long maxId )
     {
         IdTypeConfiguration idTypeConfiguration = idTypeConfigurationProvider.getIdTypeConfiguration( idType );
         return open( filename, idTypeConfiguration.getGrabSize(), idType, highId, maxId );
     }
 
     @Override
-    public IdGenerator open( File fileName, int grabSize, IdType idType, long highId, long maxId )
+    public IdGenerator open( File fileName, int grabSize, IdType idType, Supplier<Long> highId, long maxId )
     {
         IdTypeConfiguration idTypeConfiguration = idTypeConfigurationProvider.getIdTypeConfiguration( idType );
         IdGenerator generator = instantiate( fs, fileName, grabSize, maxId, idTypeConfiguration.allowAggressiveReuse(), highId );
@@ -62,7 +63,7 @@ public class DefaultIdGeneratorFactory implements IdGeneratorFactory
     }
 
     protected IdGenerator instantiate( FileSystemAbstraction fs, File fileName, int grabSize, long maxValue,
-            boolean aggressiveReuse, long highId )
+            boolean aggressiveReuse, Supplier<Long> highId )
     {
         return new IdGeneratorImpl( fs, fileName, grabSize, maxValue, aggressiveReuse, highId );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdContainer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdContainer.java
@@ -72,14 +72,20 @@ public class IdContainer
         this.aggressiveReuse = aggressiveReuse;
     }
 
-    // initialize the id generator and performs a simple validation
-    public void init()
+    /**
+     * Initializes the id generator and performs a simple validation. Returns true if the initialization restored
+     * properly on disk state, false otherwise (such as creating an id file from scratch).
+     * Will throw {@link InvalidIdGeneratorException} if the id file is found to be damaged or unclean.
+     */
+    public boolean init()
     {
+        boolean result = true;
         try
         {
             if ( !fs.fileExists( file ) )
             {
                 createEmptyIdFile( fs, file, 0, false );
+                result = false;
             }
 
             fileChannel = fs.open( file, "rw" );
@@ -93,6 +99,7 @@ public class IdContainer
         {
             throw new UnderlyingStorageException( "Unable to init id file " + file, e );
         }
+        return result;
     }
 
     public boolean isClosed()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGeneratorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGeneratorFactory.java
@@ -20,12 +20,13 @@
 package org.neo4j.kernel.impl.store.id;
 
 import java.io.File;
+import java.util.function.Supplier;
 
 public interface IdGeneratorFactory
 {
-    IdGenerator open( File filename, IdType idType, long highId, long maxId );
+    IdGenerator open( File filename, IdType idType, Supplier<Long> highId, long maxId );
 
-    IdGenerator open( File filename, int grabSize, IdType idType, long highId, long maxId );
+    IdGenerator open( File filename, int grabSize, IdType idType, Supplier<Long> highId, long maxId );
 
     void create( File filename, long highId, boolean throwIfFileExists );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/ReadOnlyIdGeneratorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/ReadOnlyIdGeneratorFactory.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.store.id;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * {@link IdGeneratorFactory} managing read-only {@link IdGenerator} instances which basically only can access
@@ -32,13 +33,13 @@ public class ReadOnlyIdGeneratorFactory implements IdGeneratorFactory
     private final Map<IdType,IdGenerator> idGenerators = new HashMap<>();
 
     @Override
-    public IdGenerator open( File filename, IdType idType, long highId, long maxId )
+    public IdGenerator open( File filename, IdType idType, Supplier<Long> highId, long maxId )
     {
         return open( filename, 0, idType, highId, maxId );
     }
 
     @Override
-    public IdGenerator open( File filename, int grabSize, IdType idType, long highId, long maxId )
+    public IdGenerator open( File filename, int grabSize, IdType idType, Supplier<Long> highId, long maxId )
     {
         IdGenerator generator = new ReadOnlyIdGenerator( highId );
         idGenerators.put( idType, generator );
@@ -61,9 +62,9 @@ public class ReadOnlyIdGeneratorFactory implements IdGeneratorFactory
     {
         private final long highId;
 
-        ReadOnlyIdGenerator( long highId )
+        ReadOnlyIdGenerator( Supplier<Long> highId )
         {
-            this.highId = highId;
+            this.highId = highId.get();
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingIdGeneratorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingIdGeneratorFactory.java
@@ -22,6 +22,7 @@ package org.neo4j.unsafe.impl.batchimport.store;
 import java.io.File;
 import java.util.EnumMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.store.id.IdGenerator;
@@ -46,13 +47,13 @@ public class BatchingIdGeneratorFactory implements IdGeneratorFactory
     }
 
     @Override
-    public IdGenerator open( File filename, IdType idType, long highId, long maxId )
+    public IdGenerator open( File filename, IdType idType, Supplier<Long> highId, long maxId )
     {
         return open( filename, 0, idType, highId, maxId );
     }
 
     @Override
-    public IdGenerator open( File fileName, int grabSize, IdType idType, long highId, long maxId )
+    public IdGenerator open( File fileName, int grabSize, IdType idType, Supplier<Long> highId, long maxId )
     {
         return idGenerators.computeIfAbsent( idType, k -> new BatchingIdGenerator( fs, fileName, highId ) );
     }
@@ -74,12 +75,12 @@ public class BatchingIdGeneratorFactory implements IdGeneratorFactory
         private final FileSystemAbstraction fs;
         private final File fileName;
 
-        BatchingIdGenerator( FileSystemAbstraction fs, File fileName, long highId )
+        BatchingIdGenerator( FileSystemAbstraction fs, File fileName, Supplier<Long> highId )
         {
             this.fs = fs;
             this.fileName = fileName;
             this.idSequence = new BatchingIdSequence();
-            this.idSequence.set( highId );
+            this.idSequence.set( highId.get() );
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/graphdb/LabelsAcceptanceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/LabelsAcceptanceTest.java
@@ -19,9 +19,6 @@
  */
 package org.neo4j.graphdb;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -30,8 +27,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Stream;
+
 import javax.annotation.Nonnull;
+
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.cursor.Cursor;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
@@ -697,7 +699,7 @@ public class LabelsAcceptanceTest
                     idTypeConfigurationProvider = new CommunityIdTypeConfigurationProvider();
 
             @Override
-            public IdGenerator open( File fileName, int grabSize, IdType idType, long highId, long maxId )
+            public IdGenerator open( File fileName, int grabSize, IdType idType, Supplier<Long> highId, long maxId )
             {
                 if ( idType == IdType.LABEL_TOKEN )
                 {
@@ -719,7 +721,7 @@ public class LabelsAcceptanceTest
                     }
                     return generator;
                 }
-                return super.open( fileName, grabSize, idType, Long.MAX_VALUE, Long.MAX_VALUE );
+                return super.open( fileName, grabSize, idType, () -> Long.MAX_VALUE, Long.MAX_VALUE );
             }
         };
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/JumpingIdGeneratorFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/JumpingIdGeneratorFactory.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 
 import org.neo4j.kernel.impl.store.id.IdGenerator;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
@@ -44,13 +45,13 @@ public class JumpingIdGeneratorFactory implements IdGeneratorFactory
     }
 
     @Override
-    public IdGenerator open( File fileName, int grabSize, IdType idType, long highId, long maxId )
+    public IdGenerator open( File fileName, int grabSize, IdType idType, Supplier<Long> highId, long maxId )
     {
         return get( idType );
     }
 
     @Override
-    public IdGenerator open( File filename, IdType idType, long highId, long maxId )
+    public IdGenerator open( File filename, IdType idType, Supplier<Long> highId, long maxId )
     {
         return get( idType );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestCrashWithRebuildSlow.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestCrashWithRebuildSlow.java
@@ -19,10 +19,6 @@
  */
 package org.neo4j.kernel.impl.core;
 
-import org.hamcrest.Matchers;
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
@@ -30,6 +26,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreTest.java
@@ -19,6 +19,12 @@
  */
 package org.neo4j.kernel.impl.store;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.OpenOption;
+import java.util.Arrays;
+import java.util.function.Supplier;
+
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -26,11 +32,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.RuleChain;
 import org.mockito.InOrder;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.OpenOption;
-import java.util.Arrays;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -121,7 +122,7 @@ public class CommonAbstractStoreTest
     @Before
     public void setUpMocks() throws IOException
     {
-        when( idGeneratorFactory.open( any( File.class ), eq( idType ), anyInt(), anyInt() ) )
+        when( idGeneratorFactory.open( any( File.class ), eq( idType ), any( Supplier.class ), anyInt() ) )
                 .thenReturn( idGenerator );
 
         when( pageFile.pageSize() ).thenReturn( PAGE_SIZE );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/FreeIdsAfterRecoveryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/FreeIdsAfterRecoveryTest.java
@@ -19,11 +19,11 @@
  */
 package org.neo4j.kernel.impl.store;
 
+import java.io.File;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
-
-import java.io.File;
 
 import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
@@ -65,7 +65,7 @@ public class FreeIdsAfterRecoveryTest
 
         // populating its .id file with a bunch of ids
         File nodeIdFile = new File( directory.directory(), StoreFile.NODE_STORE.fileName( StoreFileType.ID ) );
-        IdGeneratorImpl idGenerator = new IdGeneratorImpl( fileSystemRule.get(), nodeIdFile, 10, 10_000, false, highId );
+        IdGeneratorImpl idGenerator = new IdGeneratorImpl( fileSystemRule.get(), nodeIdFile, 10, 10_000, false, () -> highId );
         for ( long id = 0; id < 15; id++ )
         {
             idGenerator.freeId( id );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorImplContractTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorImplContractTest.java
@@ -19,11 +19,11 @@
  */
 package org.neo4j.kernel.impl.store;
 
+import java.io.File;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
-
-import java.io.File;
 
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.kernel.impl.AbstractNeo4jTestCase;
@@ -58,7 +58,7 @@ public class IdGeneratorImplContractTest extends IdGeneratorContractTest
     @Override
     protected IdGenerator openIdGenerator( int grabSize )
     {
-        return new IdGeneratorImpl( fs, idGeneratorFile(), grabSize, 1000, false, 0 );
+        return new IdGeneratorImpl( fs, idGeneratorFile(), grabSize, 1000, false, () -> 0L );
     }
 
     @After

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorRebuildFailureEmulationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorRebuildFailureEmulationTest.java
@@ -19,6 +19,10 @@
  */
 package org.neo4j.kernel.impl.store;
 
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -27,10 +31,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
-
-import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorTest.java
@@ -19,11 +19,6 @@
  */
 package org.neo4j.kernel.impl.store;
 
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -34,6 +29,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -116,21 +116,21 @@ public class IdGeneratorTest
     public void grabSizeCannotBeZero() throws Exception
     {
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-        new IdGeneratorImpl( fs, idGeneratorFile(), 0, 100, false, 0 ).close();
+        new IdGeneratorImpl( fs, idGeneratorFile(), 0, 100, false, () -> 0L ).close();
     }
 
     @Test( expected = IllegalArgumentException.class )
     public void grabSizeCannotBeNegative() throws Exception
     {
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-        new IdGeneratorImpl( fs, idGeneratorFile(), -1, 100, false, 0 ).close();
+        new IdGeneratorImpl( fs, idGeneratorFile(), -1, 100, false, () -> 0L ).close();
     }
 
     @Test( expected = IllegalStateException.class )
     public void createIdGeneratorMustRefuseOverwritingExistingFile() throws IOException
     {
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1008, 1000, false, 0 );
+        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1008, 1000, false, () -> 0L );
         try
         {
             IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, true );
@@ -170,12 +170,12 @@ public class IdGeneratorTest
     public void mustOverwriteExistingFileIfRequested() throws Exception
     {
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1008, 1000, false, 0 );
+        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1008, 1000, false, () -> 0L );
         long[] firstFirstIds = new long[]{idGenerator.nextId(), idGenerator.nextId(), idGenerator.nextId()};
         idGenerator.close();
 
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-        idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1008, 1000, false, 0 );
+        idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1008, 1000, false, () -> 0L );
         long[] secondFirstIds = new long[]{idGenerator.nextId(), idGenerator.nextId(), idGenerator.nextId()};
         idGenerator.close();
 
@@ -189,10 +189,10 @@ public class IdGeneratorTest
         try
         {
             IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-            IdGenerator idGen = new IdGeneratorImpl( fs, idGeneratorFile(), 3, 1000, false, 0 );
+            IdGenerator idGen = new IdGeneratorImpl( fs, idGeneratorFile(), 3, 1000, false, () -> 0L );
             try
             {
-                new IdGeneratorImpl( fs, idGeneratorFile(), 3, 1000, false, 0 );
+                new IdGeneratorImpl( fs, idGeneratorFile(), 3, 1000, false, () -> 0L );
                 fail( "Opening sticky id generator should throw exception" );
             }
             catch ( StoreFailureException e )
@@ -216,7 +216,7 @@ public class IdGeneratorTest
         try
         {
             IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-            IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 3, 1000, false, 0 );
+            IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 3, 1000, false, () -> 0L );
             for ( long i = 0; i < 7; i++ )
             {
                 assertEquals( i, idGenerator.nextId() );
@@ -227,7 +227,7 @@ public class IdGeneratorTest
             assertEquals( 7L, idGenerator.nextId() );
             idGenerator.freeId( 6 );
             closeIdGenerator( idGenerator );
-            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 5, 1000, false, 0 );
+            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 5, 1000, false, () -> 0L );
             idGenerator.freeId( 2 );
             idGenerator.freeId( 4 );
             assertEquals( 1L, idGenerator.nextId() );
@@ -243,7 +243,7 @@ public class IdGeneratorTest
             assertEquals( 9L, idGenerator.nextId() );
             idGenerator.freeId( 9 );
             closeIdGenerator( idGenerator );
-            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 3, 1000, false, 0 );
+            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 3, 1000, false, () -> 0L );
             assertEquals( 6L, idGenerator.nextId() );
             assertEquals( 8L, idGenerator.nextId() );
             assertEquals( 9L, idGenerator.nextId() );
@@ -272,7 +272,7 @@ public class IdGeneratorTest
         try
         {
             IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-            IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 3, 1000, false, 0 );
+            IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 3, 1000, false, () -> 0L );
             for ( long i = 0; i < 7; i++ )
             {
                 assertEquals( i, idGenerator.nextId() );
@@ -298,12 +298,12 @@ public class IdGeneratorTest
                 idGenerator.freeId( i );
             }
             closeIdGenerator( idGenerator );
-            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 2, 1000, false, 0 );
+            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 2, 1000, false, () -> 0L );
             assertEquals( 5L, idGenerator.nextId() );
             assertEquals( 6L, idGenerator.nextId() );
             assertEquals( 3L, idGenerator.nextId() );
             closeIdGenerator( idGenerator );
-            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 30, 1000, false, 0 );
+            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 30, 1000, false, () -> 0L );
 
             assertEquals( 0L, idGenerator.nextId() );
             assertEquals( 1L, idGenerator.nextId() );
@@ -327,7 +327,7 @@ public class IdGeneratorTest
         try
         {
             IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-            IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 2, 1000, false, 0 );
+            IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 2, 1000, false, () -> 0L );
             closeIdGenerator( idGenerator );
             try
             {
@@ -345,7 +345,7 @@ public class IdGeneratorTest
             catch ( IllegalStateException e )
             { // good
             }
-            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 2, 1000, false, 0 );
+            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 2, 1000, false, () -> 0L );
             assertEquals( 0L, idGenerator.nextId() );
             assertEquals( 1L, idGenerator.nextId() );
             assertEquals( 2L, idGenerator.nextId() );
@@ -384,7 +384,7 @@ public class IdGeneratorTest
         try
         {
             IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-            IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 128, capacity * 2, false, 0 );
+            IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 128, capacity * 2, false, () -> 0L );
             for ( int i = 0; i < capacity; i++ )
             {
                 idGenerator.nextId();
@@ -396,7 +396,7 @@ public class IdGeneratorTest
                 freedIds.put( i, this );
             }
             closeIdGenerator( idGenerator );
-            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 2000, capacity * 2, false, 0 );
+            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 2000, capacity * 2, false, () -> 0L );
             long oldId = -1;
             for ( int i = 0; i < capacity - 1; i += 2 )
             {
@@ -421,7 +421,7 @@ public class IdGeneratorTest
         try
         {
             IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-            IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 128, capacity * 2, false, 0 );
+            IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 128, capacity * 2, false, () -> 0L );
             for ( int i = 0; i < capacity; i++ )
             {
                 idGenerator.nextId();
@@ -433,7 +433,7 @@ public class IdGeneratorTest
                 freedIds.put( i, this );
             }
             closeIdGenerator( idGenerator );
-            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 2000, capacity * 2, false, 0 );
+            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 2000, capacity * 2, false, () -> 0L );
             for ( int i = 0; i < capacity; i += 2 )
             {
                 assertEquals( this, freedIds.remove( idGenerator.nextId() ) );
@@ -458,7 +458,7 @@ public class IdGeneratorTest
         int capacity = random.nextInt( 1024 ) + 1024;
         int grabSize = random.nextInt( 128 ) + 128;
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), grabSize, capacity * 2, false, 0 );
+        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), grabSize, capacity * 2, false, () -> 0L );
         List<Long> idsTaken = new ArrayList<>();
         float releaseIndex = 0.25f;
         float closeIndex = 0.05f;
@@ -482,7 +482,7 @@ public class IdGeneratorTest
                 {
                     closeIdGenerator( idGenerator );
                     grabSize = random.nextInt( 128 ) + 128;
-                    idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), grabSize, capacity * 2, false, 0 );
+                    idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), grabSize, capacity * 2, false, () -> 0L );
                 }
             }
             closeIdGenerator( idGenerator );
@@ -505,7 +505,7 @@ public class IdGeneratorTest
             PropertyKeyTokenRecordFormat recordFormat = new PropertyKeyTokenRecordFormat();
             IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
             IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1,
-                    recordFormat.getMaxId(), false, 0 );
+                    recordFormat.getMaxId(), false, () -> 0L );
             idGenerator.setHighId( recordFormat.getMaxId() );
             long id = idGenerator.nextId();
             assertEquals( recordFormat.getMaxId(), id );
@@ -519,7 +519,7 @@ public class IdGeneratorTest
             { // good, capacity exceeded
             }
             closeIdGenerator( idGenerator );
-            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, recordFormat.getMaxId(), false, 0 );
+            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, recordFormat.getMaxId(), false, () -> 0L );
             assertEquals( recordFormat.getMaxId() + 1, idGenerator.getHighId() );
             id = idGenerator.nextId();
             assertEquals( recordFormat.getMaxId(), id );
@@ -566,7 +566,7 @@ public class IdGeneratorTest
         deleteIdGeneratorFile();
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
         long maxValue = format.getMaxId();
-        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, maxValue - 1, false, 0 );
+        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, maxValue - 1, false, () -> 0L );
         long id = maxValue - 2;
         idGenerator.setHighId( id );
         assertEquals( id, idGenerator.nextId() );
@@ -594,7 +594,7 @@ public class IdGeneratorTest
     {
         deleteIdGeneratorFile();
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, format.getMaxId(), false, 0 );
+        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, format.getMaxId(), false, () -> 0L );
         long id = (long) Math.pow( 2, 32 ) - 3;
         idGenerator.setHighId( id );
         assertEquals( id, idGenerator.nextId() );
@@ -610,7 +610,7 @@ public class IdGeneratorTest
     public void makeSureMagicMinusOneCannotBeReturnedEvenIfFreed() throws Exception
     {
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, new NodeRecordFormat().getMaxId(), false, 0 );
+        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, new NodeRecordFormat().getMaxId(), false, () -> 0L );
         long magicMinusOne = (long) Math.pow( 2, 32 ) - 1;
         idGenerator.setHighId( magicMinusOne );
         assertEquals( magicMinusOne + 1, idGenerator.nextId() );
@@ -618,7 +618,7 @@ public class IdGeneratorTest
         idGenerator.freeId( magicMinusOne );
         closeIdGenerator( idGenerator );
 
-        idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, new NodeRecordFormat().getMaxId(), false, 0 );
+        idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, new NodeRecordFormat().getMaxId(), false, () -> 0L );
         assertEquals( magicMinusOne - 1, idGenerator.nextId() );
         assertEquals( magicMinusOne + 2, idGenerator.nextId() );
         closeIdGenerator( idGenerator );
@@ -696,7 +696,7 @@ public class IdGeneratorTest
     public void delete() throws Exception
     {
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-        IdGeneratorImpl idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 10, 1000, false, 0 );
+        IdGeneratorImpl idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 10, 1000, false, () -> 0L );
         long id = idGenerator.nextId();
         idGenerator.nextId();
         idGenerator.freeId( id );
@@ -704,7 +704,7 @@ public class IdGeneratorTest
         idGenerator.delete();
         assertFalse( idGeneratorFile().exists() );
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-        idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 10, 1000, false, 0 );
+        idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 10, 1000, false, () -> 0L );
         assertEquals( id, idGenerator.nextId() );
         idGenerator.close();
     }
@@ -717,7 +717,7 @@ public class IdGeneratorTest
         {
             IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
             final int grabSize = 10, rounds = 10;
-            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), grabSize, 1000, true, 0 );
+            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), grabSize, 1000, true, () -> 0L );
 
             for ( int i = 0; i < rounds; i++ )
             {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NodeStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NodeStoreTest.java
@@ -19,12 +19,6 @@
  */
 package org.neo4j.kernel.impl.store;
 
-import org.apache.commons.lang3.mutable.MutableBoolean;
-import org.junit.After;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -32,7 +26,14 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Supplier;
 import java.util.stream.LongStream;
+
+import org.apache.commons.lang3.mutable.MutableBoolean;
+import org.junit.After;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveLongSet;
@@ -377,7 +378,7 @@ public class NodeStoreTest
         {
             @Override
             protected IdGenerator instantiate( FileSystemAbstraction fs, File fileName, int grabSize, long maxValue,
-                    boolean aggressiveReuse, long highId )
+                    boolean aggressiveReuse, Supplier<Long> highId )
             {
                 return spy( super.instantiate( fs, fileName, grabSize, maxValue, aggressiveReuse, highId ) );
             }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/BufferingIdGeneratorFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/BufferingIdGeneratorFactoryTest.java
@@ -19,11 +19,11 @@
  */
 package org.neo4j.kernel.impl.store.id;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.util.function.Supplier;
+
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.kernel.impl.api.KernelTransactionsSnapshot;
 import org.neo4j.kernel.impl.store.id.configuration.CommunityIdTypeConfigurationProvider;
@@ -53,7 +53,7 @@ public class BufferingIdGeneratorFactoryTest
                 actual, IdReuseEligibility.ALWAYS, new CommunityIdTypeConfigurationProvider() );
         bufferingIdGeneratorFactory.initialize( boundaries );
         IdGenerator idGenerator = bufferingIdGeneratorFactory.open(
-                new File( "doesnt-matter" ), 10, IdType.STRING_BLOCK, 0, Integer.MAX_VALUE );
+                new File( "doesnt-matter" ), 10, IdType.STRING_BLOCK, () -> 0L, Integer.MAX_VALUE );
 
         // WHEN
         idGenerator.freeId( 7 );
@@ -85,7 +85,7 @@ public class BufferingIdGeneratorFactoryTest
         bufferingIdGeneratorFactory.initialize( boundaries );
 
         IdGenerator idGenerator = bufferingIdGeneratorFactory.open(
-                new File( "doesnt-matter" ), 10, IdType.STRING_BLOCK, 0, Integer.MAX_VALUE );
+                new File( "doesnt-matter" ), 10, IdType.STRING_BLOCK, () -> 0L, Integer.MAX_VALUE );
 
         // WHEN
         idGenerator.freeId( 7 );
@@ -130,13 +130,13 @@ public class BufferingIdGeneratorFactoryTest
         private final IdGenerator[] generators = new IdGenerator[IdType.values().length];
 
         @Override
-        public IdGenerator open( File filename, IdType idType, long highId, long maxId )
+        public IdGenerator open( File filename, IdType idType, Supplier<Long> highId, long maxId )
         {
             return open( filename, 0, idType, highId, maxId );
         }
 
         @Override
-        public IdGenerator open( File filename, int grabSize, IdType idType, long highId, long maxId )
+        public IdGenerator open( File filename, int grabSize, IdType idType, Supplier<Long> highId, long maxId )
         {
             return generators[idType.ordinal()] = mock( IdGenerator.class );
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/IdContainerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/IdContainerTest.java
@@ -19,11 +19,11 @@
  */
 package org.neo4j.kernel.impl.store.id;
 
+import java.io.File;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.io.File;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.store.InvalidIdGeneratorException;
@@ -35,6 +35,7 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 
@@ -138,6 +139,36 @@ public class IdContainerTest
         assertEquals( 30, idContainer.getInitialHighId() );
 
         idContainer.close( 30 );
+    }
+
+    @Test
+    public void shouldReturnFalseOnInitIfTheFileWasCreated() throws Exception
+    {
+        // When
+        // An IdContainer is created with no underlying file
+        IdContainer idContainer = new IdContainer( fs, file, 100, false );
+
+        // Then
+        // Init should return false
+        assertFalse( idContainer.init() );
+    }
+
+    @Test
+    public void shouldReturnTrueOnInitIfAProperFileWasThere() throws Exception
+    {
+        // Given
+        // A properly created and closed id file
+        IdContainer idContainer = new IdContainer( fs, file, 100, false );
+        idContainer.init();
+        idContainer.close( 100 );
+
+        // When
+        // An IdContainer is created over it
+        idContainer = new IdContainer( fs, file, 100, false );
+
+        // Then
+        // init() should return true
+        assertTrue( idContainer.init() );
     }
 
     private void createEmptyFile()

--- a/community/kernel/src/test/java/org/neo4j/test/impl/EphemeralIdGenerator.java
+++ b/community/kernel/src/test/java/org/neo4j/test/impl/EphemeralIdGenerator.java
@@ -26,6 +26,7 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 
 import org.neo4j.kernel.impl.store.id.IdGenerator;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
@@ -44,13 +45,13 @@ public class EphemeralIdGenerator implements IdGenerator
                 idTypeConfigurationProvider = new CommunityIdTypeConfigurationProvider();
 
         @Override
-        public IdGenerator open( File filename, IdType idType, long highId, long maxId )
+        public IdGenerator open( File filename, IdType idType, Supplier<Long> highId, long maxId )
         {
             return open( filename, 0, idType, highId, maxId );
         }
 
         @Override
-        public IdGenerator open( File fileName, int grabSize, IdType idType, long highId, long maxId )
+        public IdGenerator open( File fileName, int grabSize, IdType idType, Supplier<Long> highId, long maxId )
         {
             IdGenerator generator = generators.get( idType );
             if ( generator == null )

--- a/community/udc/src/test/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollectorTest.java
+++ b/community/udc/src/test/java/org/neo4j/ext/udc/impl/DefaultUdcInformationCollectorTest.java
@@ -19,9 +19,6 @@
  */
 package org.neo4j.ext.udc.impl;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -31,7 +28,11 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
+
+import org.junit.Rule;
+import org.junit.Test;
 
 import org.neo4j.ext.udc.UdcConstants;
 import org.neo4j.kernel.NeoStoreDataSource;
@@ -225,13 +226,13 @@ public class DefaultUdcInformationCollectorTest
         }
 
         @Override
-        public IdGenerator open( File filename, IdType idType, long highId, long maxId )
+        public IdGenerator open( File filename, IdType idType, Supplier<Long> highId, long maxId )
         {
             return open( filename, 0, idType, highId, maxId );
         }
 
         @Override
-        public IdGenerator open( File fileName, int grabSize, IdType idType, long highId, long maxId )
+        public IdGenerator open( File fileName, int grabSize, IdType idType, Supplier<Long> highId, long maxId )
         {
             return get( idType );
         }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CoreBootstrapper.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CoreBootstrapper.java
@@ -180,7 +180,7 @@ public class CoreBootstrapper
 
     private long getHighId( File coreDir, DefaultIdGeneratorFactory factory, IdType idType, String store )
     {
-        IdGenerator idGenerator = factory.open( new File( coreDir, idFile( store ) ), idType, -1, Long.MAX_VALUE );
+        IdGenerator idGenerator = factory.open( new File( coreDir, idFile( store ) ), idType, () -> -1L, Long.MAX_VALUE );
         long highId = idGenerator.getHighId();
         idGenerator.close();
         return highId;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/FreeIdFilteredIdGeneratorFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/FreeIdFilteredIdGeneratorFactory.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
 
 import org.neo4j.kernel.impl.store.id.IdGenerator;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
@@ -41,7 +42,7 @@ public class FreeIdFilteredIdGeneratorFactory implements IdGeneratorFactory
     }
 
     @Override
-    public IdGenerator open( File filename, IdType idType, long highId, long maxId )
+    public IdGenerator open( File filename, IdType idType, Supplier<Long> highId, long maxId )
     {
         FreeIdFilteredIdGenerator freeIdFilteredIdGenerator =
                 new FreeIdFilteredIdGenerator( delegate.open( filename, idType, highId, maxId ), freeIdCondition );
@@ -50,7 +51,7 @@ public class FreeIdFilteredIdGeneratorFactory implements IdGeneratorFactory
     }
 
     @Override
-    public IdGenerator open( File filename, int grabSize, IdType idType, long highId, long maxId )
+    public IdGenerator open( File filename, int grabSize, IdType idType, Supplier<Long> highId, long maxId )
     {
         FreeIdFilteredIdGenerator freeIdFilteredIdGenerator =
                 new FreeIdFilteredIdGenerator( delegate.open( filename, grabSize, idType, highId, maxId ),

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdGenerator.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdGenerator.java
@@ -21,6 +21,7 @@ package org.neo4j.causalclustering.core.state.machines.id;
 
 import java.io.File;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.store.id.IdContainer;
@@ -44,11 +45,11 @@ class ReplicatedIdGenerator implements IdGenerator
     private IdContainer idContainer;
     private final ReentrantLock idContainerLock = new ReentrantLock();
 
-    ReplicatedIdGenerator( FileSystemAbstraction fs, File file, IdType idType, long highId,
+    ReplicatedIdGenerator( FileSystemAbstraction fs, File file, IdType idType, Supplier<Long> highId,
             ReplicatedIdRangeAcquirer acquirer, LogProvider logProvider, int grabSize, boolean aggressiveReuse )
     {
         this.idType = idType;
-        this.highId = highId;
+        this.highId = highId.get();
         this.acquirer = acquirer;
         this.log = logProvider.getLog( getClass() );
         idContainer = new IdContainer( fs, file, grabSize, aggressiveReuse );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdGeneratorFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdGeneratorFactory.java
@@ -22,6 +22,7 @@ package org.neo4j.causalclustering.core.state.machines.id;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.store.id.IdGenerator;
@@ -49,20 +50,20 @@ public class ReplicatedIdGeneratorFactory implements IdGeneratorFactory
     }
 
     @Override
-    public IdGenerator open( File filename, IdType idType, long highId, long maxId )
+    public IdGenerator open( File filename, IdType idType, Supplier<Long> highId, long maxId )
     {
         IdTypeConfiguration idTypeConfiguration = idTypeConfigurationProvider.getIdTypeConfiguration( idType );
         return openGenerator( filename, idTypeConfiguration.getGrabSize(), idType, highId, idTypeConfiguration.allowAggressiveReuse() );
     }
 
     @Override
-    public IdGenerator open( File fileName, int grabSize, IdType idType, long highId, long maxId )
+    public IdGenerator open( File fileName, int grabSize, IdType idType, Supplier<Long> highId, long maxId )
     {
         IdTypeConfiguration idTypeConfiguration = idTypeConfigurationProvider.getIdTypeConfiguration( idType );
         return openGenerator( fileName, grabSize, idType, highId, idTypeConfiguration.allowAggressiveReuse() );
     }
 
-    private IdGenerator openGenerator( File file, int grabSize, IdType idType, long highId, boolean aggressiveReuse )
+    private IdGenerator openGenerator( File file, int grabSize, IdType idType, Supplier<Long> highId, boolean aggressiveReuse )
     {
         ReplicatedIdGenerator other = generators.get( idType );
         if ( other != null )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
@@ -117,7 +117,7 @@ import static org.neo4j.kernel.impl.factory.CommunityEditionModule.createLockMan
 public class EnterpriseReadReplicaEditionModule extends EditionModule
 {
     EnterpriseReadReplicaEditionModule( final PlatformModule platformModule,
-            final DiscoveryServiceFactory discoveryServiceFactory, MemberId myself )
+                                        final DiscoveryServiceFactory discoveryServiceFactory, MemberId myself )
     {
         LogService logging = platformModule.logging;
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/FreeIdFilteredIdGeneratorFactoryTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/FreeIdFilteredIdGeneratorFactoryTest.java
@@ -19,9 +19,10 @@
  */
 package org.neo4j.causalclustering.core.state.machines.id;
 
-import org.junit.Test;
-
 import java.io.File;
+import java.util.function.Supplier;
+
+import org.junit.Test;
 
 import org.neo4j.kernel.impl.store.id.IdGenerator;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
@@ -29,6 +30,8 @@ import org.neo4j.kernel.impl.store.id.IdType;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -44,9 +47,10 @@ public class FreeIdFilteredIdGeneratorFactoryTest
         IdType idType = IdType.NODE;
         long highId = 1L;
         long maxId = 10L;
-        IdGenerator idGenerator = filteredGenerator.open( file, idType, highId, maxId );
+        Supplier<Long> highIdSupplier = () -> highId;
+        IdGenerator idGenerator = filteredGenerator.open( file, idType, highIdSupplier, maxId );
 
-        verify( idGeneratorFactory ).open( file, idType, highId, maxId );
+        verify( idGeneratorFactory ).open( eq( file ), eq( idType ), any( Supplier.class ), eq( maxId ) );
         assertThat( idGenerator, instanceOf( FreeIdFilteredIdGenerator.class ) );
     }
 
@@ -58,9 +62,10 @@ public class FreeIdFilteredIdGeneratorFactoryTest
         long highId = 1L;
         long maxId = 10L;
         int grabSize = 5;
-        IdGenerator idGenerator = filteredGenerator.open( file, grabSize, idType, highId, maxId );
+        Supplier<Long> highIdSupplier = () -> highId;
+        IdGenerator idGenerator = filteredGenerator.open( file, grabSize, idType, highIdSupplier, maxId );
 
-        verify( idGeneratorFactory ).open( file, grabSize, idType, highId, maxId );
+        verify( idGeneratorFactory ).open( file, grabSize, idType, highIdSupplier, maxId );
         assertThat( idGenerator, instanceOf( FreeIdFilteredIdGenerator.class ) );
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdGeneratorTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdGeneratorTest.java
@@ -19,15 +19,15 @@
  */
 package org.neo4j.causalclustering.core.state.machines.id;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.mockito.Mockito;
-
 import java.io.File;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mockito;
 
 import org.neo4j.causalclustering.core.consensus.RaftMachine;
 import org.neo4j.causalclustering.core.consensus.state.ExposedRaftState;
@@ -87,7 +87,7 @@ public class ReplicatedIdGeneratorTest extends IdGeneratorContractTest
     protected IdGenerator openIdGenerator( int grabSize )
     {
         ReplicatedIdGenerator replicatedIdGenerator =
-            new ReplicatedIdGenerator( fs, file, IdType.NODE, 0, stubAcquirer(), logProvider, grabSize, true );
+            new ReplicatedIdGenerator( fs, file, IdType.NODE, () -> 0L, stubAcquirer(), logProvider, grabSize, true );
         return new FreeIdFilteredIdGenerator( replicatedIdGenerator, idReusabilityCondition );
     }
 
@@ -96,7 +96,7 @@ public class ReplicatedIdGeneratorTest extends IdGeneratorContractTest
     {
         ReplicatedIdRangeAcquirer rangeAcquirer = simpleRangeAcquirer( IdType.NODE, 0, 1024 );
 
-        ReplicatedIdGenerator idGenerator = new ReplicatedIdGenerator( fs, file, IdType.NODE, 0, rangeAcquirer, logProvider,
+        ReplicatedIdGenerator idGenerator = new ReplicatedIdGenerator( fs, file, IdType.NODE, () -> 0L, rangeAcquirer, logProvider,
                 10, true );
 
         assertTrue( fs.fileExists( file ) );
@@ -107,7 +107,7 @@ public class ReplicatedIdGeneratorTest extends IdGeneratorContractTest
     {
         ReplicatedIdRangeAcquirer rangeAcquirer = simpleRangeAcquirer( IdType.NODE, 0, 1024 );
 
-        ReplicatedIdGenerator idGenerator = new ReplicatedIdGenerator( fs, file, IdType.NODE, 0, rangeAcquirer, logProvider,
+        ReplicatedIdGenerator idGenerator = new ReplicatedIdGenerator( fs, file, IdType.NODE, () -> 0L, rangeAcquirer, logProvider,
                 10, true );
 
         Set<Long> idsGenerated = collectGeneratedIds( idGenerator, 1024 );
@@ -124,8 +124,8 @@ public class ReplicatedIdGeneratorTest extends IdGeneratorContractTest
     {
         ReplicatedIdRangeAcquirer rangeAcquirer = simpleRangeAcquirer( IdType.NODE, 0, 1024 );
 
-        int burnedIds = 23;
-        ReplicatedIdGenerator idGenerator = new ReplicatedIdGenerator( fs, file, IdType.NODE, burnedIds, rangeAcquirer, logProvider,
+        long burnedIds = 23L;
+        ReplicatedIdGenerator idGenerator = new ReplicatedIdGenerator( fs, file, IdType.NODE, () -> burnedIds, rangeAcquirer, logProvider,
                 10, true );
 
         Set<Long> idsGenerated = collectGeneratedIds( idGenerator, 1024 - burnedIds );
@@ -143,7 +143,7 @@ public class ReplicatedIdGeneratorTest extends IdGeneratorContractTest
         ReplicatedIdRangeAcquirer rangeAcquirer = mock( ReplicatedIdRangeAcquirer.class );
         when( rangeAcquirer.acquireIds( IdType.NODE ) ).thenReturn( allocation( 3, 21, 21 ) );
         ReplicatedIdGenerator idGenerator =
-                new ReplicatedIdGenerator( fs, file, IdType.NODE, 42, rangeAcquirer, logProvider, 10,
+                new ReplicatedIdGenerator( fs, file, IdType.NODE, () -> 42L, rangeAcquirer, logProvider, 10,
                         true );
 
         idGenerator.nextId();
@@ -154,9 +154,9 @@ public class ReplicatedIdGeneratorTest extends IdGeneratorContractTest
     {
         ReplicatedIdRangeAcquirer rangeAcquirer = simpleRangeAcquirer( IdType.NODE, 0, 1024 );
 
-        int burnedIds = 23;
+        long burnedIds = 23L;
         IdGenerator idGenerator = new FreeIdFilteredIdGenerator(
-                new ReplicatedIdGenerator( fs, file, IdType.NODE, burnedIds, rangeAcquirer, logProvider, 10, true ),
+                new ReplicatedIdGenerator( fs, file, IdType.NODE, () -> burnedIds, rangeAcquirer, logProvider, 10, true ),
                 idReusabilityCondition );
 
         idGenerator.freeId( 10 );
@@ -178,8 +178,8 @@ public class ReplicatedIdGeneratorTest extends IdGeneratorContractTest
     {
         ReplicatedIdRangeAcquirer rangeAcquirer = simpleRangeAcquirer( IdType.NODE, 0, 1024 );
 
-        int burnedIds = 23;
-        ReplicatedIdGenerator idGenerator = new ReplicatedIdGenerator( fs, file, IdType.NODE, burnedIds, rangeAcquirer, logProvider,
+        long burnedIds = 23L;
+        ReplicatedIdGenerator idGenerator = new ReplicatedIdGenerator( fs, file, IdType.NODE, () -> burnedIds, rangeAcquirer, logProvider,
                 10, true );
 
         assertEquals( 23, idGenerator.nextId() );
@@ -199,9 +199,9 @@ public class ReplicatedIdGeneratorTest extends IdGeneratorContractTest
 
         IdReusabilityCondition idReusabilityCondition = getIdReusabilityCondition();
 
-        int burnedIds = 23;
+        long burnedIds = 23L;
         FreeIdFilteredIdGenerator idGenerator = new FreeIdFilteredIdGenerator(
-                new ReplicatedIdGenerator( fs, file, IdType.NODE, burnedIds, rangeAcquirer, logProvider, 10, true ),
+                new ReplicatedIdGenerator( fs, file, IdType.NODE, () -> burnedIds, rangeAcquirer, logProvider, 10, true ),
                 idReusabilityCondition );
 
         idGenerator.freeId( 10 );
@@ -224,7 +224,7 @@ public class ReplicatedIdGeneratorTest extends IdGeneratorContractTest
         return new IdReusabilityCondition( commandIndexTracker, raftMachine, myself );
     }
 
-    private Set<Long> collectGeneratedIds( ReplicatedIdGenerator idGenerator, int expectedIds )
+    private Set<Long> collectGeneratedIds( ReplicatedIdGenerator idGenerator, long expectedIds )
     {
         Set<Long> idsGenerated = new HashSet<>();
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdRangeAcquirerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/ReplicatedIdRangeAcquirerTest.java
@@ -19,10 +19,6 @@
  */
 package org.neo4j.causalclustering.core.state.machines.id;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.mockito.Mockito;
-
 import java.io.File;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -31,7 +27,9 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import org.neo4j.causalclustering.core.consensus.LeaderLocator;
+import org.junit.Rule;
+import org.junit.Test;
+
 import org.neo4j.causalclustering.core.replication.DirectReplicator;
 import org.neo4j.causalclustering.core.state.storage.InMemoryStateStorage;
 import org.neo4j.causalclustering.identity.MemberId;
@@ -117,9 +115,7 @@ public class ReplicatedIdRangeAcquirerTest
         ReplicatedIdRangeAcquirer acquirer = new ReplicatedIdRangeAcquirer( replicator, idAllocationStateMachine,
                 allocationSizes, member, NullLogProvider.getInstance() );
 
-        LeaderLocator leaderLocator = Mockito.mock( LeaderLocator.class );
-
-        return new ReplicatedIdGenerator( fs, file, IdType.ARRAY_BLOCK, initialHighId, acquirer,
+        return new ReplicatedIdGenerator( fs, file, IdType.ARRAY_BLOCK, () -> initialHighId, acquirer,
                 NullLogProvider.getInstance(), 10, true );
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/id/HaIdGeneratorFactoryTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/id/HaIdGeneratorFactoryTest.java
@@ -19,11 +19,11 @@
  */
 package org.neo4j.kernel.ha.id;
 
+import java.io.File;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.io.File;
 
 import org.neo4j.com.ComException;
 import org.neo4j.com.RequestContext;
@@ -53,7 +53,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.kernel.impl.store.id.IdRangeIterator.VALUE_REPRESENTING_NULL;
 
 
@@ -192,7 +191,7 @@ public class HaIdGeneratorFactoryTest
         File idFile = new File( "my.id" );
         // ... opening an id generator as master
         fac.create( idFile, 10, true );
-        IdGenerator idGenerator = fac.open( idFile, 10, IdType.NODE, 10, Standard.LATEST_RECORD_FORMATS.node().getMaxId() );
+        IdGenerator idGenerator = fac.open( idFile, 10, IdType.NODE, () -> 10L, Standard.LATEST_RECORD_FORMATS.node().getMaxId() );
         assertTrue( fs.fileExists( idFile ) );
         idGenerator.close();
 
@@ -213,7 +212,7 @@ public class HaIdGeneratorFactoryTest
         fac.create( idFile, 10, true );
 
         // WHEN
-        IdGenerator idGenerator = fac.open( idFile, 10, IdType.NODE, 10, Standard.LATEST_RECORD_FORMATS.node().getMaxId() );
+        IdGenerator idGenerator = fac.open( idFile, 10, IdType.NODE, () -> 10L, Standard.LATEST_RECORD_FORMATS.node().getMaxId() );
 
         // THEN
         assertFalse( "Id file should've been deleted by now", fs.fileExists( idFile ) );
@@ -271,7 +270,7 @@ public class HaIdGeneratorFactoryTest
     private IdGenerator switchToSlave()
     {
         fac.switchToSlave();
-        IdGenerator gen = fac.open( new File( "someFile" ), 10, IdType.NODE, 1, Standard.LATEST_RECORD_FORMATS.node().getMaxId() );
+        IdGenerator gen = fac.open( new File( "someFile" ), 10, IdType.NODE, () -> 1L, Standard.LATEST_RECORD_FORMATS.node().getMaxId() );
         masterDelegate.setDelegate( master );
         return gen;
     }


### PR DESCRIPTION
During startup, the store needs to determine the high id it has. The source
 of that truth is in two places - the id generator file and the store, which
 via a backwards scan can determine (after recovery) which record is the
 highest in use. This last operation happened always and the result was
 compared with id generator and if the id generator was clean, it was
 effectively thrown away. In a store that is large and has lots of
 deleted records at the end, that backwards scan can take a long time
 and its result is probably not used after all.
This change makes that backwards scan happen only if the id generator
 is found to be unreliable, which currently means just created. The
 result is reduced startup time after a clean shutdown, without loss
 of safety.