### PR TITLE
Revert usage of UTF8StringValue

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursor.java
@@ -209,7 +209,7 @@ class StorePropertyPayloadCursor
         assertOfType( STRING );
         readFromStore( stringRecordCursor );
         buffer.flip();
-        return Values.utf8Value( buffer.array().clone(), 0, buffer.limit() );
+        return Values.stringValue( UTF8.decode( buffer.array(), 0, buffer.limit() ) );
     }
 
     private Value shortArrayValue()


### PR DESCRIPTION
Using UTF8StringValue adds an extra copy to the core API and shows up as
regression in benchmarks. Reverts that change until we can come up with a
way of pleasing both Bolt and core API.