### PR TITLE
Does not delete store files on failed import

### DIFF
--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -38,7 +38,6 @@ import org.neo4j.helpers.ArrayUtil;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.Strings;
 import org.neo4j.helpers.collection.IterableWrapper;
-import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.io.IOUtils;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
@@ -47,10 +46,6 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.logging.StoreLogService;
-import org.neo4j.kernel.impl.storemigration.ExistingTargetStrategy;
-import org.neo4j.kernel.impl.storemigration.FileOperation;
-import org.neo4j.kernel.impl.storemigration.StoreFile;
-import org.neo4j.kernel.impl.storemigration.StoreFileType;
 import org.neo4j.kernel.impl.util.Converters;
 import org.neo4j.kernel.impl.util.OsBeanUtil;
 import org.neo4j.kernel.impl.util.Validator;
@@ -536,22 +531,13 @@ public class ImportTool
             }
 
             life.shutdown();
+
             if ( !success )
             {
-                try
-                {
-                    StoreFile.fileOperation( FileOperation.DELETE, fs, storeDir, null,
-                            Iterables.<StoreFile,StoreFile>iterable( StoreFile.values() ),
-                            false, ExistingTargetStrategy.FAIL, StoreFileType.values() );
-                }
-                catch ( IOException e )
-                {
-                    err.println( "Unable to delete store files after an aborted import " + e );
-                    if ( enableStacktrace )
-                    {
-                        e.printStackTrace();
-                    }
-                }
+                err.println( "WARNING Import failed. The store files in " + storeDir.getAbsolutePath() +
+                        " are left as they are, although they are likely in an unusable state. " +
+                        "Starting a database on these store files will likely fail or observe inconsistent records so " +
+                        "start at your own risk or delete the store manually" );
             }
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -144,7 +144,6 @@ public class ParallelBatchImporter implements BatchImporter
         NodeLabelsCache nodeLabelsCache = null;
         long startTime = currentTimeMillis();
         CountingStoreUpdateMonitor storeUpdateMonitor = new CountingStoreUpdateMonitor();
-        boolean success = false;
         long totalTimeMillis;
         try ( BatchingNeoStores neoStore = getBatchingNeoStores();
               CountsAccessor.Updater countsUpdater = neoStore.getCountsStore().reset(
@@ -235,7 +234,6 @@ public class ParallelBatchImporter implements BatchImporter
                     storeUpdateMonitor.toString() +
                     format( "%n" ) +
                     "Peak memory usage: " + bytes( peakMemoryUsage ) );
-            success = true;
         }
         catch ( Throwable t )
         {
@@ -254,10 +252,7 @@ public class ParallelBatchImporter implements BatchImporter
             }
         }
 
-        if ( success )
-        {
-            log.info( "Import completed successfully, took " + Format.duration( totalTimeMillis ) + ". " + storeUpdateMonitor );
-        }
+        log.info( "Import completed successfully, took " + Format.duration( totalTimeMillis ) + ". " + storeUpdateMonitor );
     }
 
     private BatchingNeoStores getBatchingNeoStores()

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -144,6 +144,8 @@ public class ParallelBatchImporter implements BatchImporter
         NodeLabelsCache nodeLabelsCache = null;
         long startTime = currentTimeMillis();
         CountingStoreUpdateMonitor storeUpdateMonitor = new CountingStoreUpdateMonitor();
+        boolean success = false;
+        long totalTimeMillis;
         try ( BatchingNeoStores neoStore = getBatchingNeoStores();
               CountsAccessor.Updater countsUpdater = neoStore.getCountsStore().reset(
                     neoStore.getLastCommittedTransactionId() );
@@ -227,13 +229,13 @@ public class ParallelBatchImporter implements BatchImporter
                     neoStore.getRelationshipTypeRepository().getHighId(), countsUpdater, numberArrayFactory ) );
 
             // We're done, do some final logging about it
-            long totalTimeMillis = currentTimeMillis() - startTime;
+            totalTimeMillis = currentTimeMillis() - startTime;
             executionMonitor.done( totalTimeMillis,
                     format( "%n" ) +
                     storeUpdateMonitor.toString() +
                     format( "%n" ) +
                     "Peak memory usage: " + bytes( peakMemoryUsage ) );
-            log.info( "Import completed, took " + Format.duration( totalTimeMillis ) + ". " + storeUpdateMonitor );
+            success = true;
         }
         catch ( Throwable t )
         {
@@ -250,6 +252,11 @@ public class ParallelBatchImporter implements BatchImporter
             {
                 nodeLabelsCache.close();
             }
+        }
+
+        if ( success )
+        {
+            log.info( "Import completed successfully, took " + Format.duration( totalTimeMillis ) + ". " + storeUpdateMonitor );
         }
     }
 


### PR DESCRIPTION
The store files are very likely in an invalid state, but could be able to start
if opening a db on them, which would see very strange and inconsistent data.
Therefore logs failure/success and also tells user about this fact.