### PR TITLE
Disable parameter extraction for GraphUrls for now

### DIFF
--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/ast/rewriters/LiteralReplacementTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/ast/rewriters/LiteralReplacementTest.scala
@@ -38,6 +38,10 @@ class LiteralReplacementTest extends CypherFunSuite  {
     assertDoesNotRewrite("MATCH n RETURN n[\"name\"]")
   }
 
+  test("should not extract string literals in graph urls") {
+    assertDoesNotRewrite("WITH GRAPH foo AT 'blub' MATCH (n) RETURN n")
+  }
+
   test("should extract literals in return clause") {
     assertRewrite(s"RETURN 1 as result", s"RETURN {`  AUTOINT0`} as result", Map("  AUTOINT0" -> 1))
     assertRewrite(s"RETURN 1.1 as result", s"RETURN {`  AUTODOUBLE0`} as result", Map("  AUTODOUBLE0" -> 1.1))

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/rewriters/literalReplacement.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/rewriters/literalReplacement.scala
@@ -53,6 +53,8 @@ object literalReplacement {
       acc => (r.properties.treeFold(acc)(literalMatcher), None)
     case ast.ContainerIndex(_, _: ast.StringLiteral) =>
       acc => (acc, None)
+    case _: ast.GraphUrl =>
+      acc => (acc, None)
     case l: ast.StringLiteral =>
       acc =>
         if (acc.contains(l)) (acc, None) else {


### PR DESCRIPTION
It is getting in our way in CAPS and we don't need extraction there