### PR TITLE
Missing arguments in plan description

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/procs/ProcedureCallExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/procs/ProcedureCallExecutionPlan.scala
@@ -29,7 +29,7 @@ import org.neo4j.cypher.internal.compatibility.v3_3.runtime.executionplan.{Execu
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.helpers.Counter
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes.{ExternalCSVResource, QueryState}
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.InternalPlanDescription.Arguments._
-import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.{Id, NoChildren, PlanDescriptionImpl}
+import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.{Argument, Id, NoChildren, PlanDescriptionImpl}
 import org.neo4j.cypher.internal.compiler.v3_3.ProcedurePlannerName
 import org.neo4j.cypher.internal.compiler.v3_3.spi.{GraphStatistics, PlanContext, ProcedureSignature}
 import org.neo4j.cypher.internal.frontend.v3_3.ast.Expression
@@ -121,19 +121,19 @@ case class ProcedureCallExecutionPlan(signature: ProcedureSignature,
 
   private def createProfilePlanGenerator(rowCounter: Counter) = () =>
     PlanDescriptionImpl(new Id, "ProcedureCall", NoChildren,
-                        arguments,
+                        Seq(createSignatureArgument, DbHits(1), Rows(rowCounter.counted)) ++ arguments,
                         resultSymbols.map(_._1).toSet
     )
 
-  private def arguments = Seq(createSignatureArgument,
-                              Runtime(runtimeUsed.toTextOutput),
-                              RuntimeImpl(runtimeUsed.name),
-                              Planner(plannerUsed.toTextOutput),
-                              PlannerImpl(plannerUsed.name),
-                              Version(CypherVersion.default.name))
+  private def arguments: Seq[Argument] = Seq(createSignatureArgument,
+                                                               Runtime(runtimeUsed.toTextOutput),
+                                                               RuntimeImpl(runtimeUsed.name),
+                                                               Planner(plannerUsed.toTextOutput),
+                                                               PlannerImpl(plannerUsed.name),
+                                                               Version(s"CYPHER ${CypherVersion.default.name}"))
 
 
-  private def createSignatureArgument =
+  private def createSignatureArgument: Argument =
     Signature(signature.name, Seq.empty, resultSymbols)
 
   override def notifications(planContext: PlanContext): Seq[InternalNotification] = Seq.empty

--- a/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionResultTest.java
+++ b/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionResultTest.java
@@ -207,7 +207,7 @@ public class ExecutionResultTest
     }
 
     @Test
-    public void shouldShowProcedureRuntimeInExecutionPlan()
+    public void shouldShowArgumentsExecutionPlan()
     {
         // Given
         Result result = db.execute( "EXPLAIN CALL db.labels" );
@@ -216,6 +216,26 @@ public class ExecutionResultTest
         Map<String,Object> arguments = result.getExecutionPlanDescription().getArguments();
 
         // Then
+        assertThat( arguments.get( "version" ), equalTo( "3.3" ) );
+        assertThat( arguments.get( "planner" ), equalTo( "PROCEDURE" ) );
+        assertThat( arguments.get( "planner-impl" ), equalTo( "PROCEDURE" ) );
+        assertThat( arguments.get( "runtime" ), equalTo( "PROCEDURE" ) );
+        assertThat( arguments.get( "runtime-impl" ), equalTo( "PROCEDURE" ) );
+    }
+
+    @Test
+    public void shouldShowArgumentsInProfileExecutionPlan()
+    {
+        // Given
+        Result result = db.execute( "PROFILE CALL db.labels" );
+
+        // When
+        Map<String,Object> arguments = result.getExecutionPlanDescription().getArguments();
+
+        // Then
+        assertThat( arguments.get( "version" ), equalTo( "3.3" ) );
+        assertThat( arguments.get( "planner" ), equalTo( "PROCEDURE" ) );
+        assertThat( arguments.get( "planner-impl" ), equalTo( "PROCEDURE" ) );
         assertThat( arguments.get( "runtime" ), equalTo( "PROCEDURE" ) );
         assertThat( arguments.get( "runtime-impl" ), equalTo( "PROCEDURE" ) );
     }

--- a/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionResultTest.java
+++ b/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionResultTest.java
@@ -174,6 +174,9 @@ public class ExecutionResultTest
         Map<String,Object> arguments = result.getExecutionPlanDescription().getArguments();
 
         // Then
+        assertThat( arguments.get( "version" ), equalTo( "CYPHER 3.3" ) );
+        assertThat( arguments.get( "planner" ), equalTo( "COST" ) );
+        assertThat( arguments.get( "planner-impl" ), equalTo( "IDP" ) );
         assertThat( arguments.get( "runtime" ), notNullValue() );
         assertThat( arguments.get( "runtime-impl" ), notNullValue() );
     }
@@ -188,6 +191,9 @@ public class ExecutionResultTest
         Map<String,Object> arguments = result.getExecutionPlanDescription().getArguments();
 
         // Then
+        assertThat( arguments.get( "version" ), equalTo( "CYPHER 3.3" ) );
+        assertThat( arguments.get( "planner" ), equalTo( "COST" ) );
+        assertThat( arguments.get( "planner-impl" ), equalTo( "IDP" ) );
         assertThat( arguments.get( "runtime" ), equalTo( "COMPILED" ) );
         assertThat( arguments.get( "runtime-impl" ), equalTo( "COMPILED" ) );
     }
@@ -202,6 +208,9 @@ public class ExecutionResultTest
         Map<String,Object> arguments = result.getExecutionPlanDescription().getArguments();
 
         // Then
+        assertThat( arguments.get( "version" ), equalTo( "CYPHER 3.3" ) );
+        assertThat( arguments.get( "planner" ), equalTo( "COST" ) );
+        assertThat( arguments.get( "planner-impl" ), equalTo( "IDP" ) );
         assertThat( arguments.get( "runtime" ), equalTo( "INTERPRETED" ) );
         assertThat( arguments.get( "runtime-impl" ), equalTo( "INTERPRETED" ) );
     }
@@ -216,7 +225,7 @@ public class ExecutionResultTest
         Map<String,Object> arguments = result.getExecutionPlanDescription().getArguments();
 
         // Then
-        assertThat( arguments.get( "version" ), equalTo( "3.3" ) );
+        assertThat( arguments.get( "version" ), equalTo( "CYPHER 3.3" ) );
         assertThat( arguments.get( "planner" ), equalTo( "PROCEDURE" ) );
         assertThat( arguments.get( "planner-impl" ), equalTo( "PROCEDURE" ) );
         assertThat( arguments.get( "runtime" ), equalTo( "PROCEDURE" ) );
@@ -233,7 +242,24 @@ public class ExecutionResultTest
         Map<String,Object> arguments = result.getExecutionPlanDescription().getArguments();
 
         // Then
-        assertThat( arguments.get( "version" ), equalTo( "3.3" ) );
+        assertThat( arguments.get( "version" ), equalTo( "CYPHER 3.3" ) );
+        assertThat( arguments.get( "planner" ), equalTo( "PROCEDURE" ) );
+        assertThat( arguments.get( "planner-impl" ), equalTo( "PROCEDURE" ) );
+        assertThat( arguments.get( "runtime" ), equalTo( "PROCEDURE" ) );
+        assertThat( arguments.get( "runtime-impl" ), equalTo( "PROCEDURE" ) );
+    }
+
+    @Test
+    public void shouldShowArgumentsInSchemaExecutionPlan()
+    {
+        // Given
+        Result result = db.execute( "EXPLAIN CREATE INDEX on :L(prop)" );
+
+        // When
+        Map<String,Object> arguments = result.getExecutionPlanDescription().getArguments();
+
+        // Then
+        assertThat( arguments.get( "version" ), equalTo( "CYPHER 3.3" ) );
         assertThat( arguments.get( "planner" ), equalTo( "PROCEDURE" ) );
         assertThat( arguments.get( "planner-impl" ), equalTo( "PROCEDURE" ) );
         assertThat( arguments.get( "runtime" ), equalTo( "PROCEDURE" ) );


### PR DESCRIPTION
Procedures and schema plan descriptions are missing `version`, `planner`, and `runtime` arguments in execution plan.