### PR TITLE
Bump ancestor pom version to 46

### DIFF
--- a/community/cypher/compatibility-suite/src/main/resources/FeatureResults.g4
+++ b/community/cypher/compatibility-suite/src/main/resources/FeatureResults.g4
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2016 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.neo4j.build</groupId>
     <artifactId>parent-central</artifactId>
-    <version>42</version>
+    <version>46</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
to get rid of broken docs-maven-plugin.
This is a bump from 42 to 46, in which version the broken plugin was dropped. I don't have a perfect grasp of changes between 42..45, which are so far only used with 3.3 branch.