### PR TITLE
Defaults record id batch size to 20

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -499,7 +499,7 @@ public class GraphDatabaseSettings implements LoadableConfig
             "Remaining ids are freed back to id generator on clean shutdown." )
     @Internal
     public static final Setting<Integer> record_id_batch_size = buildSetting( "unsupported.dbms.record_id_batch_size", INTEGER,
-            "1" ).constraint( range( 1, 1_000 ) ).build();
+            "20" ).constraint( range( 1, 1_000 ) ).build();
 
     @Description( "An identifier that uniquely identifies this graph database instance within this JVM. " +
             "Defaults to an auto-generated number depending on how many instance are started in this JVM." )

--- a/integrationtests/src/test/java/org/neo4j/TransactionGuardIntegrationTest.java
+++ b/integrationtests/src/test/java/org/neo4j/TransactionGuardIntegrationTest.java
@@ -600,6 +600,7 @@ public class TransactionGuardIntegrationTest
                 customClockEnterpriseFacadeFactory )
                 .newImpermanentDatabaseBuilder( storeDir );
         configMap.forEach( databaseBuilder::setConfig );
+        databaseBuilder.setConfig( GraphDatabaseSettings.record_id_batch_size, "1" );
 
         GraphDatabaseAPI database = (GraphDatabaseAPI) databaseBuilder.newGraphDatabase();
         cleanupRule.add( database );


### PR DESCRIPTION
Because it will be enough to remove id generation as a contention point
entirely for most scenarios.

The setting is `unsupported.dbms.record_id_batch_size`