### PR TITLE
Allow not comparing plans again in CypherComparisonSupport

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
@@ -43,7 +43,7 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
     val params = Map("param" -> 3)
 
     val result1 = executeWith(Configs.CommunityInterpreted, query1,
-      ignorePlans = Configs.AbsolutelyAll - Configs.Cost3_3, params = params).toList
+      ignorePlans = Some(Configs.AbsolutelyAll - Configs.Cost3_3), params = params).toList
     val result2 = executeWith(Configs.CommunityInterpreted, query2, params = params).toList
 
     result1.size should equal(result2.size)
@@ -63,7 +63,7 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
     createNode("prop"-> Array(42))
     createNode("prop"-> Array(42))
     createNode("prop"-> Array(1337))
-    val result = executeWith(Configs.All, "MATCH (a) RETURN DISTINCT a.prop", ignorePlans = Configs.AllRulePlanners + Configs.Cost3_2)
+    val result = executeWith(Configs.All, "MATCH (a) RETURN DISTINCT a.prop", ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_2))
 
     result.toComparableResult.toSet should equal(Set(Map("a.prop" -> List(1337)), Map("a.prop" -> List(42))))
   }
@@ -73,7 +73,7 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
     val node2 = createLabeledNode("Person")
     val node3 = createNode()
     val result = executeWith(Configs.AllExceptSlotted, "MATCH (a:Person) WITH count(a) as c RETURN c",
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 )
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3) )
     result.toList should equal(List(Map("c" -> 2L)))
   }
 
@@ -102,7 +102,7 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
     val r1 = relate(node1, node2)
 
     val result = executeWith(Configs.AllExceptSlotted, "MATCH (a)--(b) RETURN a.prop, count(a) ORDER BY a.prop",
-      ignorePlans = Configs.AllRulePlanners + TestConfiguration(V2_3 -> V3_2, Planners.all, Runtimes.all))
+      ignorePlans = Some(Configs.AllRulePlanners + TestConfiguration(V2_3 -> V3_2, Planners.all, Runtimes.all)))
     result.toList should equal(List(Map("a.prop" -> 1, "count(a)" -> 1), Map("a.prop" -> 2, "count(a)" -> 1)))
   }
 
@@ -123,7 +123,7 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
   test("combine simple aggregation with sorting (can use node count store)") {
     val node1 = createNode()
     val node2 = createNode()
-    val result = executeWith(Configs.AllExceptSlotted, "MATCH (a) RETURN count(a) ORDER BY count(a)", ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3)
+    val result = executeWith(Configs.AllExceptSlotted, "MATCH (a) RETURN count(a) ORDER BY count(a)", ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3))
     result.toList should equal(List(Map("count(a)" -> 2)))
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeIndexAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeIndexAcceptanceTest.scala
@@ -43,7 +43,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
     graph should haveIndexes(":Person(firstname)", ":Person(firstname,lastname)")
 
     // When
-    executeWith(Configs.Procs, "DROP INDEX ON :Person(firstname , lastname)", ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+    executeWith(Configs.Procs, "DROP INDEX ON :Person(firstname , lastname)", ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1))
 
     // Then
     graph should haveIndexes(":Person(firstname)")
@@ -58,7 +58,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
     val n3 = createLabeledNode(Map("firstname" -> "Jake", "lastname" -> "Soap"), "User")
 
     // When
-    val result = executeWith(Configs.Interpreted, "MATCH (n:User) WHERE n.lastname = 'Soap' AND n.firstname = 'Joe' RETURN n", ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+    val result = executeWith(Configs.Interpreted, "MATCH (n:User) WHERE n.lastname = 'Soap' AND n.firstname = 'Joe' RETURN n", ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1))
 
     // Then
     result should use("NodeIndexSeek")
@@ -98,7 +98,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
     }
 
     // When
-    val result = executeWith(Configs.Interpreted, "MATCH (n:User) WHERE n.lastname = 'Soap' AND n.firstname = 'Joe' RETURN n", ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+    val result = executeWith(Configs.Interpreted, "MATCH (n:User) WHERE n.lastname = 'Soap' AND n.firstname = 'Joe' RETURN n", ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1))
 
     // Then
     result should useIndex(":User(firstname,lastname)")
@@ -162,7 +162,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
     graph.createIndex("Person", "firstname", "lastname")
     val n = graph.execute("CREATE (n:Person {firstname:'Joe', lastname:'Soap'}) RETURN n").columnAs("n").next().asInstanceOf[Node]
     graph.execute("MATCH (n:Person) SET n.lastname = 'Bloggs'")
-    val result = executeWith(Configs.Interpreted, "MATCH (n:Person) where n.firstname = 'Joe' and n.lastname = 'Bloggs' RETURN n", ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+    val result = executeWith(Configs.Interpreted, "MATCH (n:Person) where n.firstname = 'Joe' and n.lastname = 'Bloggs' RETURN n", ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1))
     result should use("NodeIndexSeek")
     result.toComparableResult should equal(List(Map("n" -> n)))
   }
@@ -173,7 +173,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
     graph.createIndex("Person", "firstname")
     graph.createIndex("Person", "firstname", "lastname")
     val result = executeWith(Configs.Interpreted, "MATCH (n:Person) WHERE n.firstname = 'Joe' AND n.lastname = 'Soap' RETURN n",
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1))
     result should useIndex(":Person(firstname,lastname)")
   }
 
@@ -192,7 +192,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
             |WHERE n.bar IN [0,1,2,3,4,5,6,7,8,9]
             |  AND n.baz IN [0,1,2,3,4,5,6,7,8,9]
             |RETURN n.idx as x
-            |ORDER BY x""".stripMargin, ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+            |ORDER BY x""".stripMargin, ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1))
 
     // Then
     result should useIndex(":Foo(bar,baz)")
@@ -212,7 +212,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
             |WHERE n.bar = 1
             |  AND n.baz IN [0,1,2,3,4,5,6,7,8,9]
             |RETURN n.baz as x
-            |ORDER BY x""".stripMargin, ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+            |ORDER BY x""".stripMargin, ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1))
 
     // Then
     result should useIndex(":Foo(bar,baz)")
@@ -232,7 +232,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
             |WHERE n.baz = 1
             |  AND n.bar IN [0,1,2,3,4,5,6,7,8,9]
             |RETURN n.bar as x
-            |ORDER BY x""".stripMargin, ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+            |ORDER BY x""".stripMargin, ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1))
 
     // Then
     result should useIndex(":Foo(bar,baz)")
@@ -249,7 +249,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
 
     // Then
     graph should haveIndexes(":L(foo,bar,baz)")
-    val result = executeWith(Configs.Interpreted, "MATCH (n:L {foo: 42, bar: 1337, baz: 1980}) RETURN count(n)", ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+    val result = executeWith(Configs.Interpreted, "MATCH (n:L {foo: 42, bar: 1337, baz: 1980}) RETURN count(n)", ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1))
     result.toComparableResult should equal(Seq(Map("count(n)" -> 1)))
     result should useIndex(":L(foo,bar,baz")
   }
@@ -264,15 +264,15 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
 
     // Then
     graph should haveIndexes(":L(foo,bar,baz)")
-    val result = executeWith(Configs.Interpreted, "MATCH (n:L {foo: 42, bar: 1337, baz: 1980}) RETURN count(n)", ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+    val result = executeWith(Configs.Interpreted, "MATCH (n:L {foo: 42, bar: 1337, baz: 1980}) RETURN count(n)", ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1))
     result.toComparableResult should equal(Seq(Map("count(n)" -> 1)))
     result should useIndex(":L(foo,bar,baz)")
   }
 
   test("should not fail on multiple attempts to create a composite index") {
     // Given
-    executeWith(Configs.Procs, "CREATE INDEX ON :Person(firstname, lastname)", ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
-    executeWith(Configs.Procs, "CREATE INDEX ON :Person(firstname, lastname)", ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+    executeWith(Configs.Procs, "CREATE INDEX ON :Person(firstname, lastname)", ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1))
+    executeWith(Configs.Procs, "CREATE INDEX ON :Person(firstname, lastname)", ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1))
   }
 
   test("should not use range queries against a composite index") {
@@ -312,7 +312,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
         val query = s"MATCH (n:User) WHERE $predicates RETURN n"
         val result = try {
           if (valid)
-            executeWith(testConfig, query, ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+            executeWith(testConfig, query, ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1))
           else
             executeWith(testConfig, query)
         } catch {
@@ -347,7 +347,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
     val b = createLabeledNode(Map("p1" -> 1, "p2" -> 1), "X")
 
     // 2.3 excluded because the params syntax was not supported in that version
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Version2_3, "match (a), (b:X) where id(a) = $id AND b.p1 = a.p1 AND b.p2 = 1 return b", ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1, params = Map("id" -> a.getId))
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Version2_3, "match (a), (b:X) where id(a) = $id AND b.p1 = a.p1 AND b.p2 = 1 return b", ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1), params = Map("id" -> a.getId))
 
     result.toComparableResult should equal(Seq(Map("b" -> b)))
     result should useIndex(":X(p1,p2)")

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeNodeKeyConstraintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeNodeKeyConstraintAcceptanceTest.scala
@@ -288,7 +288,7 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
       TestConfiguration(V3_1 -> V3_2, Planners.all, Runtimes.Default) +
       TestConfiguration(Versions(Versions.Default, V2_3), Rule, Runtimes.Default)
     executeWith(config, "MATCH (p:Person {firstname: 'John', surname: 'Wood'}) REMOVE p.foo".fixNewLines,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
 
     // Then
     graph.inTx {
@@ -306,14 +306,14 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
       TestConfiguration(V3_1 -> V3_2, Planners.all, Runtimes.Default) +
       TestConfiguration(Versions(Versions.Default, V2_3), Rule, Runtimes.Default)
     executeWith(configWhen, "MATCH (p:Person {firstname: 'John', surname: 'Wood'}) DELETE p".fixNewLines,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
 
     // Then
     val configThen = TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Slotted)) +
       TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default) +
       TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
     executeWith(configThen, "MATCH (p:Person {firstname: 'John', surname: 'Wood'}) RETURN p".fixNewLines,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1) shouldBe empty
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)) shouldBe empty
   }
 
   test("Should be able to remove label when node key constraint") {
@@ -326,13 +326,13 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
       TestConfiguration(V3_1 -> V3_2, Planners.all, Runtimes.Default) +
       TestConfiguration(Versions(Versions.Default, V2_3), Rule, Runtimes.Default)
     executeWith(configWhen, "MATCH (p:Person {firstname: 'John', surname: 'Wood'}) REMOVE p:Person".fixNewLines,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
 
     // Then
     val configThen = TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Slotted)) +
       TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default) +
       TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
     executeWith(configThen, "MATCH (p:Person {firstname: 'John', surname: 'Wood'}) RETURN p".fixNewLines,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1) shouldBe empty
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)) shouldBe empty
   }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
@@ -79,7 +79,7 @@ class EagerizationAcceptanceTest
                   |RETURN n.val AS nv, m.val AS mv
                 """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, ignoreResults = Configs.Rule2_3, ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, ignoreResults = Configs.Rule2_3, ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
 
     result.toList should equal(List(Map("nv" -> 2, "mv" -> 2),
                                     Map("nv" -> 2, "mv" -> 2)))
@@ -102,7 +102,7 @@ class EagerizationAcceptanceTest
 
     val result = executeWith(
       Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
 
     result.toList should equal(List(Map("nv" -> 2, "mv" -> 2),
                                     Map("nv" -> 2, "mv" -> 2)))
@@ -123,7 +123,7 @@ class EagerizationAcceptanceTest
     val result = executeWith(
       Configs.CommunityInterpreted - Configs.Cost2_3,
       ignoreResults = Configs.Rule2_3,
-      ignorePlans = Configs.Cost3_1 + Configs.AllRulePlanners,
+      ignorePlans = Some(Configs.Cost3_1 + Configs.AllRulePlanners),
       query = query)
 
     result.toList should equal(List(Map("rv" -> 3), Map("rv" -> 3)))
@@ -145,7 +145,7 @@ class EagerizationAcceptanceTest
     val result = executeWith(
       Configs.CommunityInterpreted - Configs.Cost2_3,
       ignoreResults = Configs.Rule2_3,
-      ignorePlans = Configs.Cost3_1 + Configs.AllRulePlanners,
+      ignorePlans = Some(Configs.Cost3_1 + Configs.AllRulePlanners),
       query = query)
 
     result.toList should equal(List(Map("rv" -> 3), Map("rv" -> 3)))
@@ -593,7 +593,7 @@ class EagerizationAcceptanceTest
       """.stripMargin
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     assertStats(result, relationshipsDeleted = 2, relationshipsCreated = 1)
 
     // Merge should not be able to match on deleted relationship
@@ -614,7 +614,7 @@ class EagerizationAcceptanceTest
       """.stripMargin
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     assertStats(result, relationshipsDeleted = 1, relationshipsCreated = 1)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertNumberOfEagerness(query, 2)
@@ -634,7 +634,7 @@ class EagerizationAcceptanceTest
       """.stripMargin
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     assertStats(result, relationshipsDeleted = 2, relationshipsCreated = 1)
     result.toList should equal(List(Map("exists(t2.id)" -> false), Map("exists(t2.id)" -> false)))
     assertNumberOfEagerness(query, 2, optimalEagerCount = 1)
@@ -654,7 +654,7 @@ class EagerizationAcceptanceTest
       """.stripMargin
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     assertStats(result, relationshipsDeleted = 2, relationshipsCreated = 1)
     result.toList should equal(List(Map("exists(t2.id)" -> false), Map("exists(t2.id)" -> false)))
     assertNumberOfEagerness(query, 2, optimalEagerCount = 1)
@@ -674,7 +674,7 @@ class EagerizationAcceptanceTest
       """.stripMargin
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     assertStats(result, relationshipsDeleted = 2, relationshipsCreated = 1)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertNumberOfEagerness(query, 2)
@@ -822,7 +822,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (n) WHERE (n)-->() CREATE (n)-[:T]->() RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 1, relationshipsCreated = 1)
     assertNumberOfEagerness(query, 0)
@@ -952,7 +952,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (a)-[:TYPE]-(b) MERGE (a)-[:TYPE]->(b) RETURN count(*) as count"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     assertStats(result, relationshipsCreated = 2)
     assertNumberOfEagerness(query, 1)
     result.columnAs[Int]("count").next should equal(4)
@@ -1494,7 +1494,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (a), (b) MERGE (a)-[r:KNOWS]->(b) RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 4)
     assertNumberOfEagerness(query, 0)
@@ -1508,7 +1508,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON MATCH SET a.prop = 42 RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
@@ -1524,7 +1524,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON MATCH SET b:Foo RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 3, labelsAdded = 1)
 
@@ -1542,7 +1542,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON MATCH SET a:Bar RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 3, labelsAdded = 1)
     assertNumberOfEagerness(query, 1)
@@ -1558,7 +1558,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON CREATE SET b:Foo RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 3, labelsAdded = 2)
     //TODO this we need to consider not only overlap but also what known labels the node we set has
@@ -1575,7 +1575,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON CREATE SET a:Bar RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 3, labelsAdded = 2)
     assertNumberOfEagerness(query, 1)
@@ -1586,7 +1586,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (a:A) MERGE (a)-[:BAR]->(b:B) WITH a MATCH (a) WHERE (a)-[:FOO]->() RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     result.columnAs[Long]("count(*)").next shouldBe 0
     assertStats(result, relationshipsCreated = 1, nodesCreated = 1, labelsAdded = 1)
     assertNumberOfEagerness(query, 0)
@@ -1600,7 +1600,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:A) MERGE (a)-[:BAR]->(b:A) WITH a MATCH (a2) RETURN count (a2) AS nodes"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, ignoreResults = Configs.Rule2_3, ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, ignoreResults = Configs.Rule2_3, ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     assertStats(result, nodesCreated = 2, relationshipsCreated = 2, labelsAdded = 2)
     result.toList should equal(List(Map("nodes" -> 15)))
     assertNumberOfEagerness(query, 1)
@@ -1632,7 +1632,7 @@ class EagerizationAcceptanceTest
     val query = "UNWIND range(0, 9) AS i MATCH (x) MERGE (m {v: i % 2}) ON CREATE SET m:Merged CREATE ({v: (i + 1) % 2}) RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     result.columnAs[Long]("count(*)").next shouldBe 20
     assertStats(result, nodesCreated = 22, propertiesWritten = 22, labelsAdded = 2)
     assertNumberOfEagerness(query, 2)
@@ -1645,7 +1645,7 @@ class EagerizationAcceptanceTest
     val query = "UNWIND range(0, 9) AS i MATCH (x) MATCH (m {v: i % 2}) CREATE ({v: (i + 1) % 2}) RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     result.columnAs[Long]("count(*)").next shouldBe 10
     assertStats(result, nodesCreated = 10, propertiesWritten = 10)
     assertNumberOfEagerness(query, 1)
@@ -1658,7 +1658,7 @@ class EagerizationAcceptanceTest
     val query = "UNWIND range(0, 9) AS i MATCH (x) WITH * CREATE ({v: i % 2}) MERGE (m {v: (i + 1) % 2}) ON CREATE SET m:Merged RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     result.columnAs[Long]("count(*)").next shouldBe 200
     assertStats(result, nodesCreated = 20, propertiesWritten = 20, labelsAdded = 0)
     assertNumberOfEagerness(query, 2)
@@ -1750,7 +1750,7 @@ class EagerizationAcceptanceTest
     val query = "UNWIND [0, 1] AS i MERGE (a {p: i % 2}) MERGE (b {p: (i + 1) % 2}) ON CREATE SET b:ShouldNotBeSet RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, nodesCreated = 2, propertiesWritten = 2, labelsAdded = 0)
     assertNumberOfEagerness(query, 1)
@@ -1760,7 +1760,7 @@ class EagerizationAcceptanceTest
     val query = "MERGE (city:City) MERGE (country:Country) MERGE (city)-[:IN]->(country) RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 2, labelsAdded = 2, relationshipsCreated = 1)
   }
@@ -1772,7 +1772,7 @@ class EagerizationAcceptanceTest
               |MERGE (src)-[r:IS_RELATED_TO ]->(dst)
               |ON CREATE SET r.p3 = 42""".stripMargin
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
 
     assertStats(result, relationshipsCreated = 1, propertiesWritten = 1)
     assertNumberOfEagerness(query,  0)
@@ -1927,7 +1927,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (b :Book {isbn : '123'}) SET b.isbn = '456' RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertNumberOfEagerness(query, 0)
   }
@@ -1939,7 +1939,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (a), (b :Book {isbn : '123'}) SET a.isbn = '456' RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
     assertNumberOfEagerness(query, 1)
@@ -1985,7 +1985,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (n {prop : 5})-[r]-() SET r.prop = 6 RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
@@ -2007,7 +2007,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH ()-[r {prop : 3}]-() SET r.prop = 6 RETURN count(*) AS c"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     assertStats(result, propertiesWritten = 2)
     result.toList should equal(List(Map("c" -> 2)))
 
@@ -2020,7 +2020,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH ()-[r {prop1 : 3}]-() SET r.prop2 = 6 RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, propertiesWritten = 2)
     assertNumberOfEagerness(query, 0)
@@ -2043,7 +2043,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH ()-[r]-() WHERE exists(r.prop) SET r.prop = 'foo' RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, propertiesWritten = 2)
     assertNumberOfEagerness(query, 0)
@@ -2055,7 +2055,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH ()-[r]-() WHERE exists(r.prop1) SET r.prop2 = 'foo'"
 
-    assertStats(executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1), propertiesWritten = 2)
+    assertStats(executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1)), propertiesWritten = 2)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -2068,7 +2068,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH ()-[r {prop: 42}]-(), (:L)-[r2]-() SET r2.prop = 42"
 
     assertNumberOfEagerness(query, 1)
-    assertStats(executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1), propertiesWritten = 2)
+    assertStats(executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1)), propertiesWritten = 2)
   }
 
   test("setting property in tail should be eager if overlap") {
@@ -2640,7 +2640,7 @@ class EagerizationAcceptanceTest
 
     cookies.foreach { case (name, node)  =>
       val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-        ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1 + Configs.Cost3_2,
+        ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1 + Configs.Cost3_2),
         params = Map("cookie" -> name))
       assertStats(result, nodesDeleted = 1, relationshipsDeleted = 2)
     }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExplainAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExplainAcceptanceTest.scala
@@ -67,7 +67,7 @@ class ExplainAcceptanceTest extends ExecutionEngineFunSuite with CypherCompariso
                   |
                   |RETURN count(*), count(distinct bknEnd), avg(size(bookings)),avg(size(perDays));""".stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted, query, ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3)
+    val result = executeWith(Configs.CommunityInterpreted, query, ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3))
     val plan = result.executionPlanDescription().toString
     result.close()
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExpressionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExpressionAcceptanceTest.scala
@@ -85,7 +85,7 @@ class ExpressionAcceptanceTest extends ExecutionEngineFunSuite with CypherCompar
     relate(actor, createLabeledNode(Map("title" -> "Movie 2"), "Movie"))
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Version2_3, """MATCH (actor:Actor)-->(movie:Movie)
-            |RETURN actor{ .name, movies: collect(movie{.title}) }""".stripMargin, ignorePlans = Configs.AbsolutelyAll)
+            |RETURN actor{ .name, movies: collect(movie{.title}) }""".stripMargin, ignorePlans = Some(Configs.AbsolutelyAll))
     result.toList should equal(
       List(Map("actor" ->
         Map("name" -> "Actor 1", "movies" -> Seq(

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -92,7 +92,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
         |RETURN a, b, COLLECT( DISTINCT c) as c
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted, query, ignorePlans = Configs.AbsolutelyAll)
+    val result = executeWith(Configs.CommunityInterpreted, query, ignorePlans = Some(Configs.AbsolutelyAll))
     result.size should be(0)
     result.hasNext should be(false)
 
@@ -176,7 +176,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
         |""".stripMargin
 
     val result = executeWith(Configs.Interpreted, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3))
     result.toList should equal(List(Map("n" -> n, "rel1" -> null, "rel2" -> null, "n1" -> null, "n2" -> null)))
   }
 
@@ -246,7 +246,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
                   |RETURN paths""".stripMargin
 
     val result = executeWith(Configs.CommunityInterpreted, query,
-      ignorePlans = Configs.AbsolutelyAll,
+      ignorePlans = Some(Configs.AbsolutelyAll),
       params = Map("0" -> node1.getId, "1" -> node2.getId))
     graph.inTx(
       result.toSet should equal(
@@ -261,7 +261,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     val q = "match (n) optional match (n)-[r]->(m) return length(filter(x in collect(r) WHERE x <> null)) as cn"
 
     executeWith(Configs.CommunityInterpreted, q,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3).toList should equal (List(Map("cn" -> 0)))
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3)).toList should equal (List(Map("cn" -> 0)))
   }
 
   // Not TCK material -- index hints
@@ -296,7 +296,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     // when
     val result = executeWith(Configs.Interpreted,
       "MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name STARTS WITH 'Jac' RETURN n",
-      ignorePlans = Configs.AllRulePlanners)
+      ignorePlans = Some(Configs.AllRulePlanners))
 
     // then
     result.toList should equal(List(Map("n" -> jake)))
@@ -339,7 +339,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
   test("id in where leads to empty result") {
     // when
     val result = executeWith(Configs.All, "MATCH (n) WHERE id(n)=1337 RETURN n",
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3))
 
     // then DOESN'T THROW EXCEPTION
     result shouldBe empty
@@ -347,7 +347,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
 
   test("should not fail if asking for a non existent node id with WHERE") {
     executeWith(Configs.Interpreted, "match (n) where id(n) in [0,1] return n",
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3).toList
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3)).toList
     // should not throw an exception
   }
 
@@ -394,7 +394,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     // when
     val result = executeWith(Configs.Interpreted,
       "match (a:Label), (b:Label) where a.property = b.property return *",
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3)
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3))
 
     // then does not throw exceptions
     assert(result.toSet === Set(
@@ -492,7 +492,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
         |RETURN host""".stripMargin
 
     //WHEN
-    val result = executeWith(Configs.Interpreted, query, ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3)
+    val result = executeWith(Configs.Interpreted, query, ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3))
     //THEN
     result.toList should equal(List(Map("host" -> host), Map("host" -> null)))
   }
@@ -539,9 +539,9 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
 
     //WHEN
     val first = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1).length
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1)).length
     val second = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1).length
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1)).length
     val check = executeWith(Configs.All, "MATCH (f:Folder) RETURN f.name").toSet
 
     //THEN
@@ -575,9 +575,9 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     //WHEN
 
     val first = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1).length
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1)).length
     val second = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1).length
+      ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1)).length
     val check = executeWith(Configs.All, "MATCH (f:Folder) RETURN f.name").toSet
 
     //THEN
@@ -610,7 +610,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
 
   // Not sure if TCK material -- is this test just for `columns()`?
   test("columns should be in the provided order") {
-    val result = executeWith(Configs.All, "MATCH (p),(o),(n),(t),(u),(s) RETURN p,o,n,t,u,s", ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3)
+    val result = executeWith(Configs.All, "MATCH (p),(o),(n),(t),(u),(s) RETURN p,o,n,t,u,s", ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3))
 
     result.columns should equal(List("p", "o", "n", "t", "u", "s"))
   }
@@ -687,7 +687,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     // When
     val res =
       executeWith(Configs.AllExceptSlotted, "UNWIND {p} AS n MATCH (n)<-[:PING_DAY]-(p:Ping) RETURN count(p) as c",
-        ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1, params = Map("p" -> List(node1, node2)))
+        ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1), params = Map("p" -> List(node1, node2)))
 
     //Then
     res.toList should equal(List(Map("c" -> 2)))
@@ -707,7 +707,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
       executeWith(Configs.AllExceptSlotted, """UNWIND {p1} AS n1
                 |UNWIND {p2} AS n2
                 |MATCH (n1)<-[:PING_DAY]-(n2) RETURN n1.prop, n2.prop""".stripMargin,
-        ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1,
+        ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1),
         params = Map("p1" -> List(node1), "p2" -> List(node2)))
 
     //Then

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UnionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UnionAcceptanceTest.scala
@@ -65,7 +65,7 @@ class UnionAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonS
     // TODO we expect this test to succeed with 3.2.4
     val expectedToWorkIn = Configs.CommunityInterpreted -
       TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.Cost, Runtimes.Default)
-    val result = executeWith(expectedToWorkIn, query, ignorePlans = Configs.AbsolutelyAll)
+    val result = executeWith(expectedToWorkIn, query, ignorePlans = Some(Configs.AbsolutelyAll))
     val expected = List(Map("A" -> "b", "B" -> "a"), Map("A" -> "a", "B" -> "b"))
 
     result.toList should equal(expected)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueIndexAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueIndexAcceptanceTest.scala
@@ -150,7 +150,7 @@ class UniqueIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
       //WHEN
       val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3,
         "PROFILE MATCH (n:Person {name: 'Andres'}) MERGE (n)-[:KNOWS]->(m:Person {name: 'Maria'}) RETURN n.name",
-        ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+        ignorePlans = Some(Configs.AllRulePlanners + Configs.Cost3_1))
 
       //THEN
       result shouldNot use("NodeIndexSeek")


### PR DESCRIPTION
Comparing plans is not always desired and especially when porting tests
form NewPlannerTestSupport we might want to increase coverage for
result comparison but not plan comparison. Thus, this commit changes
the API to allow not comparing plans at all.