### PR TITLE
Increases coverage for CypherComparisonSupport

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/InternalExecutionResult.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/InternalExecutionResult.scala
@@ -47,6 +47,7 @@ trait InternalExecutionResult extends Iterator[Map[String, Any]] with QueryResul
 
   def planDescriptionRequested: Boolean
   def executionPlanDescription(): InternalPlanDescription
+  def executionPlanString(): String = executionPlanDescription().toString
 
   def queryType: InternalQueryType
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/RewindableExecutionResult.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/RewindableExecutionResult.scala
@@ -248,6 +248,8 @@ object RewindableExecutionResult {
     override def hasNext: Boolean = inner.hasNext
 
     override def withNotifications(notification: Notification*): InternalExecutionResult = this
+
+    override def executionPlanString(): String = inner.executionPlanDescription().toString
   }
 
   private case class InternalExecutionResultCompatibilityWrapperFor3_1(inner: v3_1.executionplan.InternalExecutionResult)
@@ -385,6 +387,8 @@ object RewindableExecutionResult {
     override def hasNext: Boolean = inner.hasNext
 
     override def withNotifications(notification: Notification*): InternalExecutionResult = this
+
+    override def executionPlanString(): String = inner.executionPlanDescription().toString
   }
 
   private case class InternalExecutionResultCompatibilityWrapperFor3_2(inner: v3_2.executionplan.InternalExecutionResult)
@@ -522,6 +526,8 @@ object RewindableExecutionResult {
     override def hasNext: Boolean = inner.hasNext
 
     override def withNotifications(notification: Notification*): InternalExecutionResult = this
+
+    override def executionPlanString(): String = inner.executionPlanDescription().toString
   }
 
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
@@ -20,7 +20,7 @@
 package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.ExecutionEngineFunSuite
-import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.{Planners, Runtimes, TestConfiguration}
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.{Configs, Planners, Runtimes, TestConfiguration}
 import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Versions.{V2_3, V3_2}
 
 class AggregationAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
@@ -43,7 +43,7 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
     val params = Map("param" -> 3)
 
     val result1 = executeWith(Configs.CommunityInterpreted, query1,
-      ignorePlans = Configs.AbsolutelyAll - Configs.Cost3_3, params = params).toList
+      expectedDifferentPlans = Configs.AbsolutelyAll - Configs.Cost3_3, params = params).toList
     val result2 = executeWith(Configs.CommunityInterpreted, query2, params = params).toList
 
     result1.size should equal(result2.size)
@@ -63,7 +63,7 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
     createNode("prop"-> Array(42))
     createNode("prop"-> Array(42))
     createNode("prop"-> Array(1337))
-    val result = executeWith(Configs.All, "MATCH (a) RETURN DISTINCT a.prop", ignorePlans = Configs.AllRulePlanners + Configs.Cost3_2)
+    val result = executeWith(Configs.All, "MATCH (a) RETURN DISTINCT a.prop", expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_2)
 
     result.toComparableResult.toSet should equal(Set(Map("a.prop" -> List(1337)), Map("a.prop" -> List(42))))
   }
@@ -73,7 +73,7 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
     val node2 = createLabeledNode("Person")
     val node3 = createNode()
     val result = executeWith(Configs.AllExceptSlotted, "MATCH (a:Person) WITH count(a) as c RETURN c",
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 )
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 )
     result.toList should equal(List(Map("c" -> 2L)))
   }
 
@@ -102,7 +102,7 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
     val r1 = relate(node1, node2)
 
     val result = executeWith(Configs.AllExceptSlotted, "MATCH (a)--(b) RETURN a.prop, count(a) ORDER BY a.prop",
-      ignorePlans = Configs.AllRulePlanners + TestConfiguration(V2_3 -> V3_2, Planners.all, Runtimes.all))
+      expectedDifferentPlans = Configs.AllRulePlanners + TestConfiguration(V2_3 -> V3_2, Planners.all, Runtimes.all))
     result.toList should equal(List(Map("a.prop" -> 1, "count(a)" -> 1), Map("a.prop" -> 2, "count(a)" -> 1)))
   }
 
@@ -123,7 +123,7 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
   test("combine simple aggregation with sorting (can use node count store)") {
     val node1 = createNode()
     val node2 = createNode()
-    val result = executeWith(Configs.AllExceptSlotted, "MATCH (a) RETURN count(a) ORDER BY count(a)", ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3)
+    val result = executeWith(Configs.AllExceptSlotted, "MATCH (a) RETURN count(a) ORDER BY count(a)", expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3)
     result.toList should equal(List(Map("count(a)" -> 2)))
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/BuiltInProcedureAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/BuiltInProcedureAcceptanceTest.scala
@@ -21,6 +21,7 @@ package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.SyntaxException
 import org.neo4j.graphdb.{Label, Node, Relationship}
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
 
 import scala.collection.JavaConversions._
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeIndexAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeIndexAcceptanceTest.scala
@@ -21,6 +21,7 @@ package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.ExecutionEngineFunSuite
 import org.neo4j.graphdb.Node
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
 import org.neo4j.kernel.GraphDatabaseQueryService
 import org.scalatest.matchers.{MatchResult, Matcher}
 
@@ -43,7 +44,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
     graph should haveIndexes(":Person(firstname)", ":Person(firstname,lastname)")
 
     // When
-    executeWith(Configs.Procs, "DROP INDEX ON :Person(firstname , lastname)", ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+    executeWith(Configs.Procs, "DROP INDEX ON :Person(firstname , lastname)", expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
 
     // Then
     graph should haveIndexes(":Person(firstname)")
@@ -58,7 +59,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
     val n3 = createLabeledNode(Map("firstname" -> "Jake", "lastname" -> "Soap"), "User")
 
     // When
-    val result = executeWith(Configs.Interpreted, "MATCH (n:User) WHERE n.lastname = 'Soap' AND n.firstname = 'Joe' RETURN n", ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+    val result = executeWith(Configs.Interpreted, "MATCH (n:User) WHERE n.lastname = 'Soap' AND n.firstname = 'Joe' RETURN n", expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
 
     // Then
     result should use("NodeIndexSeek")
@@ -98,7 +99,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
     }
 
     // When
-    val result = executeWith(Configs.Interpreted, "MATCH (n:User) WHERE n.lastname = 'Soap' AND n.firstname = 'Joe' RETURN n", ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+    val result = executeWith(Configs.Interpreted, "MATCH (n:User) WHERE n.lastname = 'Soap' AND n.firstname = 'Joe' RETURN n", expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
 
     // Then
     result should useIndex(":User(firstname,lastname)")
@@ -162,7 +163,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
     graph.createIndex("Person", "firstname", "lastname")
     val n = graph.execute("CREATE (n:Person {firstname:'Joe', lastname:'Soap'}) RETURN n").columnAs("n").next().asInstanceOf[Node]
     graph.execute("MATCH (n:Person) SET n.lastname = 'Bloggs'")
-    val result = executeWith(Configs.Interpreted, "MATCH (n:Person) where n.firstname = 'Joe' and n.lastname = 'Bloggs' RETURN n", ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+    val result = executeWith(Configs.Interpreted, "MATCH (n:Person) where n.firstname = 'Joe' and n.lastname = 'Bloggs' RETURN n", expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
     result should use("NodeIndexSeek")
     result.toComparableResult should equal(List(Map("n" -> n)))
   }
@@ -173,7 +174,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
     graph.createIndex("Person", "firstname")
     graph.createIndex("Person", "firstname", "lastname")
     val result = executeWith(Configs.Interpreted, "MATCH (n:Person) WHERE n.firstname = 'Joe' AND n.lastname = 'Soap' RETURN n",
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
     result should useIndex(":Person(firstname,lastname)")
   }
 
@@ -192,7 +193,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
             |WHERE n.bar IN [0,1,2,3,4,5,6,7,8,9]
             |  AND n.baz IN [0,1,2,3,4,5,6,7,8,9]
             |RETURN n.idx as x
-            |ORDER BY x""".stripMargin, ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+            |ORDER BY x""".stripMargin, expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
 
     // Then
     result should useIndex(":Foo(bar,baz)")
@@ -212,7 +213,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
             |WHERE n.bar = 1
             |  AND n.baz IN [0,1,2,3,4,5,6,7,8,9]
             |RETURN n.baz as x
-            |ORDER BY x""".stripMargin, ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+            |ORDER BY x""".stripMargin, expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
 
     // Then
     result should useIndex(":Foo(bar,baz)")
@@ -232,7 +233,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
             |WHERE n.baz = 1
             |  AND n.bar IN [0,1,2,3,4,5,6,7,8,9]
             |RETURN n.bar as x
-            |ORDER BY x""".stripMargin, ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+            |ORDER BY x""".stripMargin, expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
 
     // Then
     result should useIndex(":Foo(bar,baz)")
@@ -249,7 +250,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
 
     // Then
     graph should haveIndexes(":L(foo,bar,baz)")
-    val result = executeWith(Configs.Interpreted, "MATCH (n:L {foo: 42, bar: 1337, baz: 1980}) RETURN count(n)", ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+    val result = executeWith(Configs.Interpreted, "MATCH (n:L {foo: 42, bar: 1337, baz: 1980}) RETURN count(n)", expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
     result.toComparableResult should equal(Seq(Map("count(n)" -> 1)))
     result should useIndex(":L(foo,bar,baz")
   }
@@ -264,15 +265,15 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
 
     // Then
     graph should haveIndexes(":L(foo,bar,baz)")
-    val result = executeWith(Configs.Interpreted, "MATCH (n:L {foo: 42, bar: 1337, baz: 1980}) RETURN count(n)", ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+    val result = executeWith(Configs.Interpreted, "MATCH (n:L {foo: 42, bar: 1337, baz: 1980}) RETURN count(n)", expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
     result.toComparableResult should equal(Seq(Map("count(n)" -> 1)))
     result should useIndex(":L(foo,bar,baz)")
   }
 
   test("should not fail on multiple attempts to create a composite index") {
     // Given
-    executeWith(Configs.Procs, "CREATE INDEX ON :Person(firstname, lastname)", ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
-    executeWith(Configs.Procs, "CREATE INDEX ON :Person(firstname, lastname)", ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+    executeWith(Configs.Procs, "CREATE INDEX ON :Person(firstname, lastname)", expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+    executeWith(Configs.Procs, "CREATE INDEX ON :Person(firstname, lastname)", expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
   }
 
   test("should not use range queries against a composite index") {
@@ -312,7 +313,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
         val query = s"MATCH (n:User) WHERE $predicates RETURN n"
         val result = try {
           if (valid)
-            executeWith(testConfig, query, ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+            executeWith(testConfig, query, expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
           else
             executeWith(testConfig, query)
         } catch {
@@ -347,7 +348,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
     val b = createLabeledNode(Map("p1" -> 1, "p2" -> 1), "X")
 
     // 2.3 excluded because the params syntax was not supported in that version
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Version2_3, "match (a), (b:X) where id(a) = $id AND b.p1 = a.p1 AND b.p2 = 1 return b", ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1, params = Map("id" -> a.getId))
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Version2_3, "match (a), (b:X) where id(a) = $id AND b.p1 = a.p1 AND b.p2 = 1 return b", expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1, params = Map("id" -> a.getId))
 
     result.toComparableResult should equal(Seq(Map("b" -> b)))
     result should useIndex(":X(p1,p2)")

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeNodeKeyConstraintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeNodeKeyConstraintAcceptanceTest.scala
@@ -288,7 +288,7 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
       TestConfiguration(V3_1 -> V3_2, Planners.all, Runtimes.Default) +
       TestConfiguration(Versions(Versions.Default, V2_3), Rule, Runtimes.Default)
     executeWith(config, "MATCH (p:Person {firstname: 'John', surname: 'Wood'}) REMOVE p.foo".fixNewLines,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
 
     // Then
     graph.inTx {
@@ -306,14 +306,14 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
       TestConfiguration(V3_1 -> V3_2, Planners.all, Runtimes.Default) +
       TestConfiguration(Versions(Versions.Default, V2_3), Rule, Runtimes.Default)
     executeWith(configWhen, "MATCH (p:Person {firstname: 'John', surname: 'Wood'}) DELETE p".fixNewLines,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
 
     // Then
     val configThen = TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Slotted)) +
       TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default) +
       TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
     executeWith(configThen, "MATCH (p:Person {firstname: 'John', surname: 'Wood'}) RETURN p".fixNewLines,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1) shouldBe empty
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1) shouldBe empty
   }
 
   test("Should be able to remove label when node key constraint") {
@@ -326,13 +326,13 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
       TestConfiguration(V3_1 -> V3_2, Planners.all, Runtimes.Default) +
       TestConfiguration(Versions(Versions.Default, V2_3), Rule, Runtimes.Default)
     executeWith(configWhen, "MATCH (p:Person {firstname: 'John', surname: 'Wood'}) REMOVE p:Person".fixNewLines,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
 
     // Then
     val configThen = TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Slotted)) +
       TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default) +
       TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
     executeWith(configThen, "MATCH (p:Person {firstname: 'John', surname: 'Wood'}) RETURN p".fixNewLines,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1) shouldBe empty
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1) shouldBe empty
   }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeUniquenessConstraintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeUniquenessConstraintAcceptanceTest.scala
@@ -25,34 +25,42 @@ import org.neo4j.cypher._
 import org.neo4j.cypher.internal.frontend.v3_3.helpers.StringHelper._
 import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService
 import org.neo4j.graphdb.config.Setting
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Versions.{Default, V3_2, V3_3}
 import org.neo4j.test.TestEnterpriseGraphDatabaseFactory
 
 import scala.collection.JavaConverters._
 import scala.collection.Map
 
-class CompositeUniquenessConstraintAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
+class CompositeUniquenessConstraintAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
 
   override protected def createGraphDatabase(config: Map[Setting[_], String] = databaseConfig()): GraphDatabaseCypherService = {
     new GraphDatabaseCypherService(new TestEnterpriseGraphDatabaseFactory().newImpermanentDatabase(config.asJava))
   }
 
   test("should be able to create and remove single property uniqueness constraint") {
+
+    val testconfiguration = TestConfiguration(Versions(V3_2, V3_3, Default), Planners.Cost, Runtimes(Runtimes.Interpreted, Runtimes.ProcedureOrSchema))
     // When
-    exec("CREATE CONSTRAINT ON (n:Person) ASSERT (n.email) IS UNIQUE")
+    executeWith(testconfiguration, "CREATE CONSTRAINT ON (n:Person) ASSERT (n.email) IS UNIQUE")
 
     // Then
     graph should haveConstraints("UNIQUENESS:Person(email)")
 
     // When
-    exec("DROP CONSTRAINT ON (n:Person) ASSERT (n.email) IS UNIQUE")
+    executeWith(testconfiguration, "DROP CONSTRAINT ON (n:Person) ASSERT (n.email) IS UNIQUE")
 
     // Then
     graph should not(haveConstraints("UNIQUENESS:Person(email)"))
   }
 
+  val singlePropertyUniquenessFailConf =
+    TestConfiguration(Versions(V3_2, V3_3, Default), Planners(Planners.Default, Planners.Cost), Runtimes.all)
+
   test("should fail to to create composite uniqueness constraints") {
     // When
-    expectError(
+
+    failWithError(singlePropertyUniquenessFailConf,
       "CREATE CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS UNIQUE",
       "Only single property uniqueness constraints are supported")
 
@@ -62,20 +70,11 @@ class CompositeUniquenessConstraintAcceptanceTest extends ExecutionEngineFunSuit
 
   test("should fail to to drop composite uniqueness constraints") {
     // When
-    expectError(
+    failWithError(singlePropertyUniquenessFailConf + TestScenario(Versions.Default, Planners.Default, Runtimes.ProcedureOrSchema),
       "DROP CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS UNIQUE",
       "Only single property uniqueness constraints are supported")
 
     // Then
     graph should not(haveConstraints("UNIQUENESS:Person(firstname,lastname)"))
-  }
-
-  private def expectError(query: String, expectedError: String) {
-    val error = intercept[CypherException](exec(query))
-    assertThat(error.getMessage, containsString(expectedError))
-  }
-
-  private def exec(query: String) {
-    executeWithCostPlannerAndInterpretedRuntimeOnly(query.fixNewLines).toList
   }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateAcceptanceTest.scala
@@ -21,6 +21,7 @@ package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.internal.compiler.v3_3.test_helpers.CreateTempFileTestSupport
 import org.neo4j.cypher.{ExecutionEngineFunSuite, QueryStatisticsTestSupport}
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
 
 class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with CypherComparisonSupport
   with CreateTempFileTestSupport {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
@@ -117,19 +117,23 @@ trait CypherComparisonSupport extends CypherTestSupport {
             }
             // It failed like expected, and we did not specify any message for this config
           }
-        case Failure(e: Throwable) => throw e
+        case Failure(e: Throwable) => {
+          if (expectedToFailWithSpecificMessage) {
+            fail(s"Unexpected exception in ${thisScenario.name}", e)
+          }
+        }
       }
     }
   }
 
   protected def executeWith(expectSucceed: TestConfiguration,
                             query: String,
-                            ignoreResults: TestConfiguration = Configs.Empty,
-                            ignorePlans: TestConfiguration = Configs.AllRulePlanners,
+                            expectedDifferentResults: TestConfiguration = Configs.Empty,
+                            expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners,
                             executeBefore: () => Unit = () => {},
                             params: Map[String, Any] = Map.empty): InternalExecutionResult = {
-    val compareResults = expectSucceed -  ignoreResults
-    val comparePlans = expectSucceed - ignorePlans
+    val compareResults = expectSucceed -  expectedDifferentResults
+    val comparePlans = expectSucceed - expectedDifferentPlans
     val baseScenario =
       if (expectSucceed.scenarios.nonEmpty) extractBaseScenario(expectSucceed, compareResults, comparePlans)
       else TestScenario(Versions.Default, Planners.Default, Runtimes.Interpreted)
@@ -142,7 +146,6 @@ trait CypherComparisonSupport extends CypherTestSupport {
     baseScenario.prepare()
     executeBefore()
     val baseResult = innerExecute(s"CYPHER ${baseScenario.preparserOptions} $query", params)
-    baseScenario.checkStateForSuccess(query)
     baseScenario.checkResultForSuccess(query, baseResult)
 
     positiveResults.foreach {
@@ -190,14 +193,12 @@ trait CypherComparisonSupport extends CypherTestSupport {
     if (expectedToSucceed) {
       tryResult match {
         case Success(thisResult) =>
-          scenario.checkStateForSuccess(query)
           scenario.checkResultForSuccess(query, thisResult)
           Some(scenario -> thisResult)
         case Failure(e) =>
           fail(s"Expected to succeed in ${scenario.name} but got exception", e)
       }
     } else {
-      scenario.checkStateForFailure(query)
       scenario.checkResultForFailure(query, tryResult)
       None
     }
@@ -206,7 +207,7 @@ trait CypherComparisonSupport extends CypherTestSupport {
   private def assertPlansSimilar(firstResult: InternalExecutionResult, thisResult: InternalExecutionResult, hint: String): Unit = {
     val currentOps = firstResult.executionPlanDescription().flatten.map(simpleName)
     val otherOps = thisResult.executionPlanDescription().flatten.map(simpleName)
-    withClue(hint + "\n" + thisResult.executionPlanDescription() + "\n Did not equal \n" + firstResult.executionPlanDescription()) {
+    withClue(hint + "\n" + thisResult.executionPlanString() + "\n Did not equal \n" + firstResult.executionPlanString()) {
       assert(currentOps equals otherOps)
     }
   }
@@ -214,12 +215,16 @@ trait CypherComparisonSupport extends CypherTestSupport {
   private def assertPlansNotSimilar(firstResult: InternalExecutionResult, thisResult: InternalExecutionResult, hint: String): Unit = {
     val currentOps = firstResult.executionPlanDescription().flatten.map(simpleName)
     val otherOps = thisResult.executionPlanDescription().flatten.map(simpleName)
-    withClue("Unexpectedly (but correctly!)\n" + hint + "\n" + thisResult.executionPlanDescription() + "\n equaled \n" + firstResult.executionPlanDescription()) {
+    withClue("Unexpectedly (but correctly!)\n" + hint + "\n" + thisResult.executionPlanString() + "\n equaled \n" + firstResult.executionPlanString()) {
       assert(!(currentOps equals otherOps))
     }
   }
 
   private def simpleName(plan: InternalPlanDescription): String = plan.name.replace("SetNodeProperty", "SetProperty").toLowerCase
+
+  @deprecated("Rewrite to use executeWith instead")
+  protected def assertResultsSameDeprecated(result1: InternalExecutionResult, result2: InternalExecutionResult, queryText: String, errorMsg: String, replaceNaNs: Boolean = false): Unit =
+    assertResultsSame(result1, result2, queryText, errorMsg, replaceNaNs)
 
   private def assertResultsSame(result1: InternalExecutionResult, result2: InternalExecutionResult, queryText: String, errorMsg: String, replaceNaNs: Boolean = false): Unit = {
     withClue(errorMsg) {
@@ -241,87 +246,13 @@ trait CypherComparisonSupport extends CypherTestSupport {
     }
   }
 
+  @deprecated("Rewrite to use executeWith instead")
+  protected def innerExecuteDeprecated(queryText: String, params: Map[String, Any]): InternalExecutionResult =
+    innerExecute(queryText, params)
+
   private def innerExecute(queryText: String, params: Map[String, Any]): InternalExecutionResult = {
     val innerResult = eengine.execute(queryText, params, graph.transactionalContext(query = queryText -> params))
-    rewindableResult(innerResult)
-  }
-
-  private def rewindableResult(result: Result): InternalExecutionResult = RewindableExecutionResult(result)
-
-  object Configs {
-
-    def Compiled: TestConfiguration = TestConfiguration(Versions.V3_3, Planners.Cost, Runtimes(Runtimes.CompiledSource, Runtimes.CompiledBytecode))
-
-    def Interpreted: TestConfiguration =
-      TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Slotted)) +
-        TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default) +
-        TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
-
-    def CommunityInterpreted: TestConfiguration =
-      TestScenario(Versions.Default, Planners.Default, Runtimes.Interpreted) +
-        TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default) +
-        TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
-
-    def SlottedInterpreted: TestConfiguration = TestScenario(Versions.Default, Planners.Default, Runtimes.Slotted)
-
-    def Cost2_3: TestConfiguration = TestScenario(Versions.V2_3, Planners.Cost, Runtimes.Default)
-
-    def Cost3_1: TestConfiguration = TestScenario(Versions.V3_1, Planners.Cost, Runtimes.Default)
-
-    def Cost3_2: TestConfiguration = TestScenario(Versions.V3_2, Planners.Cost, Runtimes.Default)
-
-    def Cost3_3: TestConfiguration = TestScenario(Versions.V3_3, Planners.Cost, Runtimes.Default)
-
-    def Rule2_3: TestConfiguration = TestScenario(Versions.V2_3, Planners.Rule, Runtimes.Default)
-
-    def Rule3_1: TestConfiguration = TestScenario(Versions.V3_1, Planners.Rule, Runtimes.Default)
-
-    def CurrentRulePlanner: TestConfiguration = TestScenario(Versions.latest, Planners.Rule, Runtimes.Default)
-
-    def Version2_3: TestConfiguration = TestConfiguration(Versions.V2_3, Planners.all, Runtimes.Default)
-
-    def Version3_1: TestConfiguration = TestConfiguration(Versions.V3_1, Planners.all, Runtimes.Default)
-
-    def Version3_2: TestConfiguration = TestConfiguration(Versions.V3_2, Planners.all, Runtimes.Default)
-
-    def Version3_3: TestConfiguration =
-      TestConfiguration(Versions.V3_3, Planners.Cost, Runtimes(Runtimes.CompiledSource, Runtimes.CompiledBytecode)) +
-        TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Slotted)) +
-        TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
-
-    def AllRulePlanners: TestConfiguration = TestConfiguration(Versions(Versions.V2_3, Versions.V3_1, Versions.V3_2, Versions.Default), Planners.Rule, Runtimes.Default)
-
-    def Cost: TestConfiguration =
-      TestConfiguration(Versions.V3_3, Planners.Cost, Runtimes(Runtimes.CompiledSource, Runtimes.CompiledBytecode)) +
-        TestConfiguration(Versions(Versions.V2_3, Versions.V3_1, Versions.Default), Planners.Cost, Runtimes.Default)
-
-    def BackwardsCompatibility: TestConfiguration = TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default)
-
-    def Procs: TestConfiguration = TestScenario(Versions.Default, Planners.Default, Runtimes.ProcedureOrSchema)
-
-    /*
-    If you are unsure what you need, this is a good start. It's not really all scenarios, but this is testing all
-    interesting scenarios.
-     */
-    def All: TestConfiguration =
-      TestConfiguration(Versions.V3_3, Planners.Cost, Runtimes(Runtimes.CompiledSource, Runtimes.CompiledBytecode)) +
-        TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Slotted)) +
-        TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default) +
-        TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
-
-    def AllExceptSlotted: TestConfiguration =
-      TestConfiguration(Versions.V3_3, Planners.Cost, Runtimes(Runtimes.CompiledSource, Runtimes.CompiledBytecode)) +
-        TestConfiguration(Versions.Default, Planners.Default, Runtimes.Interpreted) +
-        TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default) +
-        TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
-
-    def AbsolutelyAll: TestConfiguration =
-      TestConfiguration(Versions.V3_3, Planners.Cost, Runtimes(Runtimes.CompiledSource, Runtimes.CompiledBytecode)) +
-        TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Slotted, Runtimes.ProcedureOrSchema)) +
-        TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default) +
-        TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
-
-    def Empty: TestConfiguration = TestConfiguration.empty
+    RewindableExecutionResult(innerResult)
 
   }
 
@@ -452,7 +383,6 @@ object CypherComparisonSupport {
     }
 
     def checkResultForFailure(query: String, internalExecutionResult: Try[InternalExecutionResult]): Unit = {
-
       internalExecutionResult match {
         case Failure(_) => // not unexpected
         case Success(result) =>
@@ -463,30 +393,10 @@ object CypherComparisonSupport {
             case IPDPlanner(reportedPlanner) if planner.acceptedPlannerNames.contains(reportedPlanner) => reportedPlanner
           }
           if (maybeRuntime.isDefined && maybePlanner.isDefined) {
-            fail(s"unexpectedly succeeded using $name for query $query, with ${maybeRuntime.get} & ${maybePlanner.get}")
+            // We did not fall back
+            fail(s"Unexpectedly succeeded using $name for query $query, with ${maybeRuntime.get} & ${maybePlanner.get}")
           }
       }
-    }
-
-    def checkStateForSuccess(query: String): Unit = newRuntimeMonitor.trace.collect {
-      case UnableToCompileQuery(stackTrace) => fail(s"Failed to use the ${runtime.acceptedRuntimeName} runtime on: $query\n$stackTrace")
-    }
-
-    def checkStateForFailure(query: String): Unit = {
-      // Default and Procedure scenarios do not specify a particular runtime.
-      // We therefore expect a fallback, so do NOT check for a failure here
-      if (runtime == Runtimes.ProcedureOrSchema || runtime == Runtimes.Default)
-        return
-
-      val attempts: Option[NewPlanSeen] = newRuntimeMonitor.trace.collectFirst {
-        case event: NewPlanSeen => event
-      }
-      attempts.foreach(_ => {
-        val failures = newRuntimeMonitor.trace.collectFirst {
-          case failure: UnableToCompileQuery => failure
-        }
-        failures.orElse(fail(s"Unexpectedly used the ${runtime.acceptedRuntimeName} runtime on: $query"))
-      })
     }
 
     def +(other: TestConfiguration): TestConfiguration = other + this
@@ -522,6 +432,83 @@ object CypherComparisonSupport {
     }
 
     implicit def scenarioToTestConfiguration(scenario: TestScenario): TestConfiguration = TestConfiguration(scenario)
+  }
+
+  object Configs {
+
+    def Compiled: TestConfiguration = TestConfiguration(Versions.V3_3, Planners.Cost, Runtimes(Runtimes.CompiledSource, Runtimes.CompiledBytecode))
+
+    def Interpreted: TestConfiguration =
+      TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Slotted)) +
+        TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default) +
+        TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
+
+    def CommunityInterpreted: TestConfiguration =
+      TestScenario(Versions.Default, Planners.Default, Runtimes.Interpreted) +
+        TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default) +
+        TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
+
+    def SlottedInterpreted: TestConfiguration = TestScenario(Versions.Default, Planners.Default, Runtimes.Slotted)
+
+    def Cost2_3: TestConfiguration = TestScenario(Versions.V2_3, Planners.Cost, Runtimes.Default)
+
+    def Cost3_1: TestConfiguration = TestScenario(Versions.V3_1, Planners.Cost, Runtimes.Default)
+
+    def Cost3_2: TestConfiguration = TestScenario(Versions.V3_2, Planners.Cost, Runtimes.Default)
+
+    def Cost3_3: TestConfiguration = TestScenario(Versions.V3_3, Planners.Cost, Runtimes.Default)
+
+    def Rule2_3: TestConfiguration = TestScenario(Versions.V2_3, Planners.Rule, Runtimes.Default)
+
+    def Rule3_1: TestConfiguration = TestScenario(Versions.V3_1, Planners.Rule, Runtimes.Default)
+
+    def CurrentRulePlanner: TestConfiguration = TestScenario(Versions.latest, Planners.Rule, Runtimes.Default)
+
+    def Version2_3: TestConfiguration = TestConfiguration(Versions.V2_3, Planners.all, Runtimes.Default)
+
+    def Version3_1: TestConfiguration = TestConfiguration(Versions.V3_1, Planners.all, Runtimes.Default)
+
+    def Version3_2: TestConfiguration = TestConfiguration(Versions.V3_2, Planners.all, Runtimes.Default)
+
+    def Version3_3: TestConfiguration =
+      TestConfiguration(Versions.V3_3, Planners.Cost, Runtimes(Runtimes.CompiledSource, Runtimes.CompiledBytecode)) +
+        TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Slotted)) +
+        TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
+
+    def AllRulePlanners: TestConfiguration = TestConfiguration(Versions(Versions.V2_3, Versions.V3_1, Versions.V3_2, Versions.Default), Planners.Rule, Runtimes.Default)
+
+    def Cost: TestConfiguration =
+      TestConfiguration(Versions.V3_3, Planners.Cost, Runtimes(Runtimes.CompiledSource, Runtimes.CompiledBytecode)) +
+        TestConfiguration(Versions(Versions.V2_3, Versions.V3_1, Versions.Default), Planners.Cost, Runtimes.Default)
+
+    def BackwardsCompatibility: TestConfiguration = TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default)
+
+    def Procs: TestConfiguration = TestScenario(Versions.Default, Planners.Default, Runtimes.ProcedureOrSchema)
+
+    /*
+    If you are unsure what you need, this is a good start. It's not really all scenarios, but this is testing all
+    interesting scenarios.
+     */
+    def All: TestConfiguration =
+      TestConfiguration(Versions.V3_3, Planners.Cost, Runtimes(Runtimes.CompiledSource, Runtimes.CompiledBytecode)) +
+        TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Slotted)) +
+        TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default) +
+        TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
+
+    def AllExceptSlotted: TestConfiguration =
+      TestConfiguration(Versions.V3_3, Planners.Cost, Runtimes(Runtimes.CompiledSource, Runtimes.CompiledBytecode)) +
+        TestConfiguration(Versions.Default, Planners.Default, Runtimes.Interpreted) +
+        TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default) +
+        TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
+
+    def AbsolutelyAll: TestConfiguration =
+      TestConfiguration(Versions.V3_3, Planners.Cost, Runtimes(Runtimes.CompiledSource, Runtimes.CompiledBytecode)) +
+        TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Slotted, Runtimes.ProcedureOrSchema)) +
+        TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default) +
+        TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
+
+    def Empty: TestConfiguration = TestConfiguration.empty
+
   }
 
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
@@ -430,7 +430,11 @@ object CypherComparisonSupport {
     def name: String = {
       val versionName = if (version == Versions.Default) "<default version>" else version.name
       val plannerName = if (planner == Planners.Default) "<default planner>" else planner.preparserOption
-      val runtimeName = if (runtime == Runtimes.Default) "<default runtime>" else runtime.preparserOption
+      val runtimeName = runtime match {
+        case Runtimes.Default => "<default runtime>"
+        case Runtimes.ProcedureOrSchema => "<procedure or schema runtime>"
+        case _ => runtime.preparserOption
+      }
       s"${versionName} ${plannerName} ${runtimeName}"
     }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/DumpToStringAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/DumpToStringAcceptanceTest.scala
@@ -21,15 +21,16 @@ package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.WindowsStringSafe
 import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport}
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
 
-class DumpToStringAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
+class DumpToStringAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
 
   implicit val windowsSafe = WindowsStringSafe
 
   test("format node") {
     createNode(Map("prop1" -> "A", "prop2" -> 2))
 
-    executeWithAllPlannersAndRuntimesAndCompatibilityMode("match (n) return n").dumpToString() should
+    executeWith(Configs.All, ("match (n) return n")).dumpToString() should
       equal(
         """+----------------------------+
           || n                          |
@@ -43,7 +44,7 @@ class DumpToStringAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
   test("format relationship") {
     relate(createNode(), createNode(), "T", Map("prop1" -> "A", "prop2" -> 2))
 
-    executeWithAllPlannersAndRuntimesAndCompatibilityMode("match ()-[r]->() return r").dumpToString() should equal(
+    executeWith(Configs.All, "match ()-[r]->() return r").dumpToString() should equal(
       """+--------------------------+
         || r                        |
         |+--------------------------+
@@ -54,7 +55,7 @@ class DumpToStringAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
   }
 
   test("format collection of maps") {
-    executeWithAllPlannersAndRuntimesAndCompatibilityMode( """RETURN [{ inner: 'Map1' }, { inner: 'Map2' }]""").dumpToString() should
+    executeWith(Configs.All,  """RETURN [{ inner: 'Map1' }, { inner: 'Map2' }]""").dumpToString() should
       equal(
         """+----------------------------------------+
           || [{ inner: 'Map1' }, { inner: 'Map2' }] |

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
@@ -25,7 +25,7 @@ import org.neo4j.cypher.internal.compatibility.v3_3.runtime.helpers.Counter
 import org.neo4j.cypher.internal.compiler.v3_3.test_helpers.CreateTempFileTestSupport
 import org.neo4j.cypher.{ExecutionEngineFunSuite, QueryStatisticsTestSupport}
 import org.neo4j.graphdb.{Direction, Node}
-import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.{Planners, Runtimes, TestConfiguration, Versions}
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
 import org.neo4j.kernel.api.exceptions.ProcedureException
 import org.neo4j.kernel.api.proc
 import org.neo4j.kernel.api.proc.CallableProcedure.BasicProcedure
@@ -79,7 +79,7 @@ class EagerizationAcceptanceTest
                   |RETURN n.val AS nv, m.val AS mv
                 """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, ignoreResults = Configs.Rule2_3, ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3, expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
 
     result.toList should equal(List(Map("nv" -> 2, "mv" -> 2),
                                     Map("nv" -> 2, "mv" -> 2)))
@@ -102,7 +102,7 @@ class EagerizationAcceptanceTest
 
     val result = executeWith(
       Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
 
     result.toList should equal(List(Map("nv" -> 2, "mv" -> 2),
                                     Map("nv" -> 2, "mv" -> 2)))
@@ -122,8 +122,8 @@ class EagerizationAcceptanceTest
 
     val result = executeWith(
       Configs.CommunityInterpreted - Configs.Cost2_3,
-      ignoreResults = Configs.Rule2_3,
-      ignorePlans = Configs.Cost3_1 + Configs.AllRulePlanners,
+      expectedDifferentResults = Configs.Rule2_3,
+      expectedDifferentPlans = Configs.Cost3_1 + Configs.AllRulePlanners,
       query = query)
 
     result.toList should equal(List(Map("rv" -> 3), Map("rv" -> 3)))
@@ -144,8 +144,8 @@ class EagerizationAcceptanceTest
 
     val result = executeWith(
       Configs.CommunityInterpreted - Configs.Cost2_3,
-      ignoreResults = Configs.Rule2_3,
-      ignorePlans = Configs.Cost3_1 + Configs.AllRulePlanners,
+      expectedDifferentResults = Configs.Rule2_3,
+      expectedDifferentPlans = Configs.Cost3_1 + Configs.AllRulePlanners,
       query = query)
 
     result.toList should equal(List(Map("rv" -> 3), Map("rv" -> 3)))
@@ -211,7 +211,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (a), (b) CALL user.mkRel(a, b) YIELD relId WITH * MATCH ()-[rel]->() WHERE id(rel) = relId RETURN rel"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.AllRulePlanners - Configs.Cost2_3, query, ignoreResults = Configs.AbsolutelyAll)
+    val result = executeWith(Configs.CommunityInterpreted - Configs.AllRulePlanners - Configs.Cost2_3, query, expectedDifferentResults = Configs.AbsolutelyAll)
     result.size should equal(4)
 
     // Correct! Eagerization happens as part of query context operation
@@ -252,7 +252,7 @@ class EagerizationAcceptanceTest
     // only run against one scenario, otherwise count increments unpredictably due to fallback
     val result = executeWith(Configs.CommunityInterpreted - Configs.AllRulePlanners - Configs.Cost2_3, query,
       executeBefore = () => counter.reset(),
-      ignoreResults = Configs.AbsolutelyAll)
+      expectedDifferentResults = Configs.AbsolutelyAll)
 
     result.size should equal(4)
     counter.counted should equal(4)
@@ -593,7 +593,7 @@ class EagerizationAcceptanceTest
       """.stripMargin
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     assertStats(result, relationshipsDeleted = 2, relationshipsCreated = 1)
 
     // Merge should not be able to match on deleted relationship
@@ -614,7 +614,7 @@ class EagerizationAcceptanceTest
       """.stripMargin
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     assertStats(result, relationshipsDeleted = 1, relationshipsCreated = 1)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertNumberOfEagerness(query, 2)
@@ -634,7 +634,7 @@ class EagerizationAcceptanceTest
       """.stripMargin
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     assertStats(result, relationshipsDeleted = 2, relationshipsCreated = 1)
     result.toList should equal(List(Map("exists(t2.id)" -> false), Map("exists(t2.id)" -> false)))
     assertNumberOfEagerness(query, 2, optimalEagerCount = 1)
@@ -654,7 +654,7 @@ class EagerizationAcceptanceTest
       """.stripMargin
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     assertStats(result, relationshipsDeleted = 2, relationshipsCreated = 1)
     result.toList should equal(List(Map("exists(t2.id)" -> false), Map("exists(t2.id)" -> false)))
     assertNumberOfEagerness(query, 2, optimalEagerCount = 1)
@@ -674,7 +674,7 @@ class EagerizationAcceptanceTest
       """.stripMargin
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     assertStats(result, relationshipsDeleted = 2, relationshipsCreated = 1)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertNumberOfEagerness(query, 2)
@@ -699,7 +699,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH () CREATE () WITH * MATCH (n) RETURN count(*) AS count"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, ignoreResults = Configs.Rule2_3)
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3)
 
     assertStats(result, nodesCreated = 2)
     result.columnAs[Int]("count").next should equal(8)
@@ -713,7 +713,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (k) CREATE (l {prop: 44}) WITH * MATCH (m) CREATE (n {prop:45}) RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignoreResults = Configs.Rule2_3)
+      expectedDifferentResults = Configs.Rule2_3)
 
     result.columnAs[Long]("count(*)").next shouldBe 8
     assertStats(result, nodesCreated = 10, propertiesWritten = 10)
@@ -822,7 +822,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (n) WHERE (n)-->() CREATE (n)-[:T]->() RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 1, relationshipsCreated = 1)
     assertNumberOfEagerness(query, 0)
@@ -952,7 +952,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (a)-[:TYPE]-(b) MERGE (a)-[:TYPE]->(b) RETURN count(*) as count"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     assertStats(result, relationshipsCreated = 2)
     assertNumberOfEagerness(query, 1)
     result.columnAs[Int]("count").next should equal(4)
@@ -986,7 +986,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode(), "TYPE")
     val query = "MATCH ()-[:TYPE]->() CREATE (a)-[:TYPE]->(b) WITH * MATCH ()-[:TYPE]->() CREATE (c)-[:TYPE]->(d) RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, ignoreResults = Configs.Rule2_3)
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3)
     result.columnAs[Long]("count(*)").next shouldBe 8
     assertStats(result, nodesCreated = 20, relationshipsCreated = 10)
     assertNumberOfEagerness(query, 3, optimalEagerCount = 2)
@@ -1494,7 +1494,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (a), (b) MERGE (a)-[r:KNOWS]->(b) RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 4)
     assertNumberOfEagerness(query, 0)
@@ -1508,7 +1508,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON MATCH SET a.prop = 42 RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
@@ -1524,7 +1524,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON MATCH SET b:Foo RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 3, labelsAdded = 1)
 
@@ -1542,7 +1542,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON MATCH SET a:Bar RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 3, labelsAdded = 1)
     assertNumberOfEagerness(query, 1)
@@ -1558,7 +1558,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON CREATE SET b:Foo RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 3, labelsAdded = 2)
     //TODO this we need to consider not only overlap but also what known labels the node we set has
@@ -1575,7 +1575,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON CREATE SET a:Bar RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 3, labelsAdded = 2)
     assertNumberOfEagerness(query, 1)
@@ -1586,7 +1586,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (a:A) MERGE (a)-[:BAR]->(b:B) WITH a MATCH (a) WHERE (a)-[:FOO]->() RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     result.columnAs[Long]("count(*)").next shouldBe 0
     assertStats(result, relationshipsCreated = 1, nodesCreated = 1, labelsAdded = 1)
     assertNumberOfEagerness(query, 0)
@@ -1600,7 +1600,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:A) MERGE (a)-[:BAR]->(b:A) WITH a MATCH (a2) RETURN count (a2) AS nodes"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, ignoreResults = Configs.Rule2_3, ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3, expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     assertStats(result, nodesCreated = 2, relationshipsCreated = 2, labelsAdded = 2)
     result.toList should equal(List(Map("nodes" -> 15)))
     assertNumberOfEagerness(query, 1)
@@ -1632,7 +1632,7 @@ class EagerizationAcceptanceTest
     val query = "UNWIND range(0, 9) AS i MATCH (x) MERGE (m {v: i % 2}) ON CREATE SET m:Merged CREATE ({v: (i + 1) % 2}) RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     result.columnAs[Long]("count(*)").next shouldBe 20
     assertStats(result, nodesCreated = 22, propertiesWritten = 22, labelsAdded = 2)
     assertNumberOfEagerness(query, 2)
@@ -1645,7 +1645,7 @@ class EagerizationAcceptanceTest
     val query = "UNWIND range(0, 9) AS i MATCH (x) MATCH (m {v: i % 2}) CREATE ({v: (i + 1) % 2}) RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     result.columnAs[Long]("count(*)").next shouldBe 10
     assertStats(result, nodesCreated = 10, propertiesWritten = 10)
     assertNumberOfEagerness(query, 1)
@@ -1658,7 +1658,7 @@ class EagerizationAcceptanceTest
     val query = "UNWIND range(0, 9) AS i MATCH (x) WITH * CREATE ({v: i % 2}) MERGE (m {v: (i + 1) % 2}) ON CREATE SET m:Merged RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     result.columnAs[Long]("count(*)").next shouldBe 200
     assertStats(result, nodesCreated = 20, propertiesWritten = 20, labelsAdded = 0)
     assertNumberOfEagerness(query, 2)
@@ -1750,7 +1750,7 @@ class EagerizationAcceptanceTest
     val query = "UNWIND [0, 1] AS i MERGE (a {p: i % 2}) MERGE (b {p: (i + 1) % 2}) ON CREATE SET b:ShouldNotBeSet RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, nodesCreated = 2, propertiesWritten = 2, labelsAdded = 0)
     assertNumberOfEagerness(query, 1)
@@ -1760,7 +1760,7 @@ class EagerizationAcceptanceTest
     val query = "MERGE (city:City) MERGE (country:Country) MERGE (city)-[:IN]->(country) RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 2, labelsAdded = 2, relationshipsCreated = 1)
   }
@@ -1772,7 +1772,7 @@ class EagerizationAcceptanceTest
               |MERGE (src)-[r:IS_RELATED_TO ]->(dst)
               |ON CREATE SET r.p3 = 42""".stripMargin
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
 
     assertStats(result, relationshipsCreated = 1, propertiesWritten = 1)
     assertNumberOfEagerness(query,  0)
@@ -1853,7 +1853,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("B")
     val query = "MATCH (n:A) CREATE (m:C) WITH * MATCH (o:B), (p:C) SET p:B RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, ignoreResults = Configs.Rule2_3)
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3)
     result.columnAs[Long]("count(*)").next shouldBe 8
     assertStats(result, labelsAdded = 4, nodesCreated = 2)
     assertNumberOfEagerness(query, 2)
@@ -1927,7 +1927,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (b :Book {isbn : '123'}) SET b.isbn = '456' RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertNumberOfEagerness(query, 0)
   }
@@ -1939,7 +1939,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (a), (b :Book {isbn : '123'}) SET a.isbn = '456' RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
     assertNumberOfEagerness(query, 1)
@@ -1985,7 +1985,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (n {prop : 5})-[r]-() SET r.prop = 6 RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
     assertNumberOfEagerness(query, 0)
@@ -2007,7 +2007,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH ()-[r {prop : 3}]-() SET r.prop = 6 RETURN count(*) AS c"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     assertStats(result, propertiesWritten = 2)
     result.toList should equal(List(Map("c" -> 2)))
 
@@ -2020,7 +2020,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH ()-[r {prop1 : 3}]-() SET r.prop2 = 6 RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, propertiesWritten = 2)
     assertNumberOfEagerness(query, 0)
@@ -2043,7 +2043,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH ()-[r]-() WHERE exists(r.prop) SET r.prop = 'foo' RETURN count(*)"
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, propertiesWritten = 2)
     assertNumberOfEagerness(query, 0)
@@ -2055,7 +2055,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH ()-[r]-() WHERE exists(r.prop1) SET r.prop2 = 'foo'"
 
-    assertStats(executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1), propertiesWritten = 2)
+    assertStats(executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1), propertiesWritten = 2)
     assertNumberOfEagerness(query, 0)
   }
 
@@ -2068,7 +2068,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH ()-[r {prop: 42}]-(), (:L)-[r2]-() SET r2.prop = 42"
 
     assertNumberOfEagerness(query, 1)
-    assertStats(executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1), propertiesWritten = 2)
+    assertStats(executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1), propertiesWritten = 2)
   }
 
   test("setting property in tail should be eager if overlap") {
@@ -2091,7 +2091,7 @@ class EagerizationAcceptanceTest
     createNode("prop" -> 42)
     val query = "MATCH (n {prop: 42}) CREATE (m) WITH * MATCH (o) SET n.prop = 42 RETURN count(*) as count"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, ignoreResults = Configs.Rule2_3)
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3)
     result.columnAs[Int]("count").next should equal(12)
     assertStats(result, propertiesWritten = 12, nodesCreated = 2)
     assertNumberOfEagerness(query, 1)
@@ -2112,7 +2112,7 @@ class EagerizationAcceptanceTest
         |SET m.prop = 42
         |RETURN count(*) as count""".stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, ignoreResults = Configs.Rule2_3)
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3)
     result.columnAs[Int]("count").next should equal(14)
     assertStats(result, propertiesWritten = 14, nodesCreated = 3)
     assertNumberOfEagerness(query, 1)
@@ -2268,7 +2268,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Foo")
     val query = "MATCH (n) CREATE (m:Foo) WITH * MATCH (o:Foo) REMOVE n:Foo RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, ignoreResults = Configs.Rule2_3)
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3)
     result.columnAs[Long]("count(*)").next shouldBe 8
     assertNumberOfEagerness(query, 2)
     assertStats(result, labelsAdded = 2, labelsRemoved = 2, nodesCreated = 2)
@@ -2640,7 +2640,7 @@ class EagerizationAcceptanceTest
 
     cookies.foreach { case (name, node)  =>
       val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-        ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1 + Configs.Cost3_2,
+        expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1 + Configs.Cost3_2,
         params = Map("cookie" -> name))
       assertStats(result, nodesDeleted = 1, relationshipsDeleted = 2)
     }
@@ -2690,7 +2690,7 @@ class EagerizationAcceptanceTest
                   |RETURN labels
                 """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, ignoreResults = Configs.Rule2_3)
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3)
     result.toList should equal(List(Map("labels" -> List()), Map("labels" -> List())))
     assertStats(result, labelsAdded = 2)
     assertNumberOfEagerness(query, 1)
@@ -2707,7 +2707,7 @@ class EagerizationAcceptanceTest
                   |RETURN labels
                 """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, ignoreResults = Configs.Rule2_3)
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3)
     result.toList should equal(List(Map("labels" -> List("Foo")), Map("labels" -> List("Foo"))))
     assertStats(result, labelsRemoved = 2)
     assertNumberOfEagerness(query, 1)
@@ -2723,7 +2723,7 @@ class EagerizationAcceptanceTest
                   |RETURN labels(n), labels(m)
                 """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, ignoreResults = Configs.Rule2_3)
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3)
     result.toList should equal(List(Map("labels(n)" -> List("Foo"), "labels(m)" -> List("Foo")),
                                     Map("labels(n)" -> List("Foo"), "labels(m)" -> List("Foo"))))
     assertStats(result, labelsAdded = 2)
@@ -2758,7 +2758,7 @@ class EagerizationAcceptanceTest
                   |RETURN labels(n), labels(m)
                 """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, ignoreResults = Configs.Rule2_3, query = query)
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, expectedDifferentResults = Configs.Rule2_3, query = query)
     result.toList should equal(List(Map("labels(n)" -> List(), "labels(m)" -> List()),
                                     Map("labels(n)" -> List(), "labels(m)" -> List())))
     assertStats(result, labelsRemoved = 2)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionResultAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionResultAcceptanceTest.scala
@@ -19,20 +19,18 @@
  */
 package org.neo4j.internal.cypher.acceptance
 
-import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport}
+import org.neo4j.cypher.ExecutionEngineFunSuite
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
 import org.neo4j.kernel.api.KernelTransaction
 import org.neo4j.kernel.api.security.SecurityContext._
 
-class ExecutionResultAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
+class ExecutionResultAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport{
 
   test("closing the result without exhausting it should not fail the transaction") {
     val query = "UNWIND [1, 2, 3] as x RETURN x"
 
-    Seq(
-      s"CYPHER runtime=compiled $query",
-      s"CYPHER runtime=interpreted $query",
-      s"CYPHER 2.3 $query"
-    ).foreach(q => {
+    Configs.All.scenarios.map(s =>
+    s"CYPHER ${s.preparserOptions} $query").foreach(q => {
       val tx = graph.beginTransaction(KernelTransaction.Type.`explicit`, AUTH_DISABLED)
       val result = eengine.execute(q, Map.empty[String, Object], graph.transactionalContext(query = q -> Map.empty))
       tx.success()

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExplainAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExplainAcceptanceTest.scala
@@ -20,6 +20,7 @@
 package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.ExecutionEngineFunSuite
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
 
 class ExplainAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
 
@@ -67,7 +68,7 @@ class ExplainAcceptanceTest extends ExecutionEngineFunSuite with CypherCompariso
                   |
                   |RETURN count(*), count(distinct bknEnd), avg(size(bookings)),avg(size(perDays));""".stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted, query, ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3)
+    val result = executeWith(Configs.CommunityInterpreted, query, expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3)
     val plan = result.executionPlanDescription().toString
     result.close()
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExpressionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExpressionAcceptanceTest.scala
@@ -20,6 +20,7 @@
 package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher._
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
 
 class ExpressionAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
 
@@ -85,7 +86,7 @@ class ExpressionAcceptanceTest extends ExecutionEngineFunSuite with CypherCompar
     relate(actor, createLabeledNode(Map("title" -> "Movie 2"), "Movie"))
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Version2_3, """MATCH (actor:Actor)-->(movie:Movie)
-            |RETURN actor{ .name, movies: collect(movie{.title}) }""".stripMargin, ignorePlans = Configs.AbsolutelyAll)
+            |RETURN actor{ .name, movies: collect(movie{.title}) }""".stripMargin, expectedDifferentPlans = Configs.AbsolutelyAll)
     result.toList should equal(
       List(Map("actor" ->
         Map("name" -> "Actor 1", "movies" -> Seq(

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/IdAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/IdAcceptanceTest.scala
@@ -21,6 +21,7 @@ package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher._
 import org.neo4j.graphdb.Relationship
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
 
 class IdAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcAcceptanceTest.scala
@@ -19,53 +19,42 @@
  */
 package org.neo4j.internal.cypher.acceptance
 
+import org.neo4j.cypher.ExecutionEngineFunSuite
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.InternalPlanDescription.Arguments.EstimatedRows
-import org.neo4j.cypher.{ExecutionEngineFunSuite, LdbcQueries, NewPlannerTestSupport}
 
 /**
- * Runs the 14 LDBC queries and checks so that the result is what is expected.
- */
-class LdbcAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
-  import org.neo4j.cypher.LdbcQueries._
+  * Runs the 14 LDBC queries and checks so that the result is what is expected.
+  */
+class LdbcAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
+
+  import LdbcQueries._
 
   LDBC_QUERIES.foreach { ldbcQuery =>
     test(ldbcQuery.name) {
-      try {
-        //given
-        eengine.execute(ldbcQuery.createQuery, ldbcQuery.createParams)
-        ldbcQuery.constraintQueries.foreach(updateWithBothPlannersAndCompatibilityMode(_))
+      // given
+      eengine.execute(ldbcQuery.createQuery, ldbcQuery.createParams)
+      ldbcQuery.constraintQueries.foreach(query => eengine.execute(query, Map.empty[String, Any]))
 
-        //when
-        val result = if (ldbcQuery.supportedInCompiledRuntime)
-          executeWithAllPlannersAndRuntimesAndCompatibilityMode(ldbcQuery.query, ldbcQuery.params.toSeq: _*).toComparableResult
-        else
-          executeWithAllPlannersAndCompatibilityMode(ldbcQuery.query, ldbcQuery.params.toSeq: _*).toComparableResult
+      // when
+      val result =
+        executeWith(ldbcQuery.expectedToSucceedIn, ldbcQuery.query, params = ldbcQuery.params,
+          expectedDifferentPlans = ldbcQuery.expectedDifferentPlans)
+          .toComparableResult
 
-        //then
-        result should equal(ldbcQuery.expectedResult)
-
-      } catch {
-        case e: Throwable =>
-          System.err.println(
-            s"""|QUERY *************
-                |${ldbcQuery.query}
-                |
-                |PREPARE QUERY *************
-                |${ldbcQuery.createQuery}
-                |
-                |""".stripMargin)
-          throw e
-      }
+      //then
+      result should equal(ldbcQuery.expectedResult)
     }
   }
 
   test("LDBC query 12 should not get a bad plan because of lost precision in selectivity calculation") {
-    updateWithBothPlannersAndCompatibilityMode(LdbcQueries.Query12.createQuery, LdbcQueries.Query12.createParams.toSeq: _*)
-    LdbcQueries.Query12.constraintQueries.foreach(updateWithBothPlannersAndCompatibilityMode(_))
+    // given
+    val ldbcQuery = LdbcQueries.Query12
+    eengine.execute(ldbcQuery.createQuery, ldbcQuery.createParams)
+    ldbcQuery.constraintQueries.foreach(query => eengine.execute(query, Map.empty[String, Any]))
 
     val updatedLdbc12 =
-      """MATCH (:Person {id:{1}})-[:KNOWS]-(friend:Person)
+      """PROFILE MATCH (:Person {id:{1}})-[:KNOWS]-(friend:Person)
         |MATCH (friend)<-[:COMMENT_HAS_CREATOR]-(comment:Comment)-[:REPLY_OF_POST]->(:Post)-[:POST_HAS_TAG]->(tag:Tag)-[:HAS_TYPE]->(tagClass:TagClass)-[:IS_SUBCLASS_OF*0..]->(baseTagClass:TagClass)
         |WHERE tagClass.name = {2} OR baseTagClass.name = {2}
         |RETURN friend.id AS friendId, friend.firstName AS friendFirstName, friend.lastName AS friendLastName, collect(DISTINCT tag.name) AS tagNames, count(DISTINCT comment) AS count
@@ -75,11 +64,13 @@ class LdbcAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupp
 
     val params: Map[String, Any] = Map("1" -> 0, "2" -> 1, "3" -> 10)
 
-    val result = executeWithAllPlannersAndCompatibilityMode(s"PROFILE $updatedLdbc12", params.toSeq:_*)
+    val result =
+    // when
+      executeWith(ldbcQuery.expectedToSucceedIn, ldbcQuery.query, params = params, expectedDifferentPlans = ldbcQuery.expectedDifferentPlans)
 
     // no precision loss resulting in insane numbers
-    all (collectEstimations(result.executionPlanDescription())) should be > 0.0
-    all (collectEstimations(result.executionPlanDescription())) should be < 10.0
+    all(collectEstimations(result.executionPlanDescription())) should be > 0.0
+    all(collectEstimations(result.executionPlanDescription())) should be < 10.0
   }
 
   private def collectEstimations(plan: InternalPlanDescription): Seq[Double] = {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcQueries.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcQueries.scala
@@ -5,17 +5,17 @@
  * This file is part of Neo4j.
  *
  * Neo4j is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Affero General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 package org.neo4j.internal.cypher.acceptance
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcQueries.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcQueries.scala
@@ -17,9 +17,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher
+package org.neo4j.internal.cypher.acceptance
 
 import org.joda.time.{DateTime, DateTimeZone}
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.{Configs, TestConfiguration}
 
 /**
  * These are the 14 LDBC stream that runs in the LDBC projects. The stream are (semi-)generated so the idea is rather
@@ -58,7 +59,8 @@ object LdbcQueries {
       "CREATE INDEX ON :Person(birthday_day)"
     )
 
-    def supportedInCompiledRuntime: Boolean = false
+    def expectedToSucceedIn: TestConfiguration
+    def expectedDifferentPlans: TestConfiguration
   }
 
   object Query1 extends LdbcQuery {
@@ -197,6 +199,10 @@ object LdbcQueries {
           "emails" -> Seq.empty, "browser" -> "browser31", "companies" -> Seq.empty)
       )
     }
+
+    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+
+    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners
   }
 
   object Query2 extends LdbcQuery {
@@ -290,6 +296,10 @@ object LdbcQueries {
         "messageContent" -> "[f2Post3] content", "messageDate" -> 2, "personFirstName" -> "f2"),
       Map("personId" -> 2, "messageId" -> 13, "personLastName" -> "last2-ᚠさ丵פش",
         "messageContent" -> "[f2Comment1] content", "messageDate" -> 2, "personFirstName" -> "f2"))
+
+    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+
+    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners + Configs.Cost2_3
   }
 
   object Query3 extends LdbcQuery {
@@ -423,6 +433,10 @@ object LdbcQueries {
     def expectedResult = List(
       Map("friendLastName" -> "last2-ᚠさ丵פش", "friendId" -> 2, "friendFirstName" -> "f2", "yCount" -> 1, "xyCount" -> 2, "xCount" -> 1),
       Map("friendLastName" -> "last6-ᚠさ丵פش", "friendId" -> 6, "friendFirstName" -> "ff6", "yCount" -> 1, "xyCount" -> 2, "xCount" -> 1))
+
+    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+
+    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1 + Configs.Cost3_2
   }
 
   object Query4 extends LdbcQuery {
@@ -511,6 +525,10 @@ object LdbcQueries {
       Map("tagName" -> "tag2-ᚠさ丵פش", "postCount" -> 3),
       Map("tagName" -> "tag3-ᚠさ丵פش", "postCount" -> 2),
       Map("tagName" -> "tag5-ᚠさ丵פش", "postCount" -> 1))
+
+    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+
+    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1 + Configs.Cost3_2
   }
 
   object Query5 extends LdbcQuery {
@@ -610,6 +628,9 @@ object LdbcQueries {
 
     def expectedResult = List(Map("forumName" -> "forum1-ᚠさ丵פش", "postCount" -> 1), Map("forumName" -> "forum3-ᚠさ丵פش", "postCount" -> 1), Map("forumName" -> "forum1-ᚠさ丵פش", "postCount" -> 0))
 
+    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+
+    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_2
   }
 
   object Query6 extends LdbcQuery {
@@ -686,7 +707,9 @@ object LdbcQueries {
 
     def expectedResult = List(Map("tagName" -> "tag2-ᚠさ丵פش", "postCount" -> 2), Map("tagName" -> "tag5-ᚠさ丵פش", "postCount" -> 2), Map("tagName" -> "tag1-ᚠさ丵פش", "postCount" -> 1))
 
+    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
 
+    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1 + Configs.Cost3_2
   }
 
   object Query7 extends LdbcQuery {
@@ -800,6 +823,10 @@ object LdbcQueries {
     def expectedResult = List(
       Map("isNew" -> true, "likeTime" -> 946681800000L, "personId" -> 8, "latencyAsMilli" -> 480000, "messageId" -> 2,
         "personLastName" -> "last8-ᚠさ丵פش", "messageContent" -> "person1post2", "personFirstName" -> "s8"))
+
+    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+
+    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1 + Configs.Cost3_2
   }
 
   object Query8 extends LdbcQuery {
@@ -895,7 +922,9 @@ object LdbcQueries {
       Map("personId" -> 3, "commentContent" -> "C01", "commentId" -> 10, "personLastName" -> "three-ᚠさ丵פش", "commentCreationDate" -> 1, "personFirstName" -> "friend"),
       Map("personId" -> 3, "commentContent" -> "C11", "commentId" -> 11, "personLastName" -> "three-ᚠさ丵פش", "commentCreationDate" -> 1, "personFirstName" -> "friend"))
 
-    override def supportedInCompiledRuntime = true
+    override def expectedToSucceedIn: TestConfiguration = Configs.AllExceptSlotted
+
+    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners + Configs.Cost2_3
   }
 
   object Query9 extends LdbcQuery {
@@ -992,6 +1021,10 @@ object LdbcQueries {
         "personFirstName" -> "friend", "messageCreationDate" -> 4),
       Map("personId" -> 2, "messageId" -> 311,
         "personLastName" -> "two-ᚠさ丵פش", "messageContent" -> "C311", "personFirstName" -> "friend", "messageCreationDate" -> 4))
+
+    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+
+    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_2
   }
 
   object Query10 extends LdbcQuery {
@@ -1113,6 +1146,10 @@ object LdbcQueries {
       Map("personId" -> 21, "personGender" -> "male",
         "personLastName" -> "two one-ᚠさ丵פش", "commonInterestScore" -> -1, "personFirstName" -> "friendfriend",
         "personCityName" -> "city0"))
+
+    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+
+    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners
   }
 
   object Query11 extends LdbcQuery {
@@ -1182,6 +1219,10 @@ object LdbcQueries {
         "friendFirstName" -> "friend", "workFromYear" -> 2),
       Map("friendLastName" -> "one one-ᚠさ丵פش", "friendId" -> 11, "companyName" -> "company zero",
         "friendFirstName" -> "friend friend", "workFromYear" -> 3))
+
+    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+
+    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_2
   }
 
   object Query12 extends LdbcQuery {
@@ -1323,6 +1364,10 @@ object LdbcQueries {
       Map("friendLastName" -> "2", "tagNames" -> Seq.empty, "friendId" -> 2, "count" -> 0, "friendFirstName" -> "f"),
       Map("friendLastName" -> "3", "tagNames" -> Seq.empty, "friendId" -> 3, "count" -> 0, "friendFirstName" -> "f"),
       Map("friendLastName" -> "4", "tagNames" -> Seq.empty, "friendId" -> 4, "count" -> 0, "friendFirstName" -> "f"))
+
+    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+
+    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1 + Configs.Cost3_2
   }
 
   object Query13 extends LdbcQuery {
@@ -1364,6 +1409,10 @@ object LdbcQueries {
     def params = Map("1" -> 0, "2" -> 5)
 
     def expectedResult = List(Map("pathLength" -> 5))
+
+    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+
+    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners
   }
 
   object Query14 extends LdbcQuery {
@@ -1467,6 +1516,10 @@ object LdbcQueries {
       Map("weight" -> 4.5, "pathNodeIds" -> List(0, 1, 7, 4, 6, 5)),
       Map("weight" -> 4.0, "pathNodeIds" -> List(0, 1, 2, 4, 8, 5)),
       Map("weight" -> 3.0, "pathNodeIds" -> List(0, 1, 2, 4, 6, 5)))
+
+    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+
+    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners
   }
 
   object Query14_v2 extends LdbcQuery {
@@ -1495,6 +1548,10 @@ object LdbcQueries {
       Map("weight" -> 4.5, "pathNodeIds" -> List(0, 1, 7, 4, 6, 5)),
       Map("weight" -> 4.0, "pathNodeIds" -> List(0, 1, 2, 4, 8, 5)),
       Map("weight" -> 3.0, "pathNodeIds" -> List(0, 1, 2, 4, 6, 5)))
+
+    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+
+    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners
   }
 
   val LDBC_QUERIES = Seq(

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -23,6 +23,7 @@ import org.neo4j.cypher._
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.commands.expressions.PathImpl
 import org.neo4j.graphdb._
 import org.neo4j.helpers.collection.Iterators.single
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
@@ -92,7 +93,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
         |RETURN a, b, COLLECT( DISTINCT c) as c
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted, query, ignorePlans = Configs.AbsolutelyAll)
+    val result = executeWith(Configs.CommunityInterpreted, query, expectedDifferentPlans = Configs.AbsolutelyAll)
     result.size should be(0)
     result.hasNext should be(false)
 
@@ -176,7 +177,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
         |""".stripMargin
 
     val result = executeWith(Configs.Interpreted, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3)
     result.toList should equal(List(Map("n" -> n, "rel1" -> null, "rel2" -> null, "n1" -> null, "n2" -> null)))
   }
 
@@ -246,7 +247,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
                   |RETURN paths""".stripMargin
 
     val result = executeWith(Configs.CommunityInterpreted, query,
-      ignorePlans = Configs.AbsolutelyAll,
+      expectedDifferentPlans = Configs.AbsolutelyAll,
       params = Map("0" -> node1.getId, "1" -> node2.getId))
     graph.inTx(
       result.toSet should equal(
@@ -261,7 +262,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     val q = "match (n) optional match (n)-[r]->(m) return length(filter(x in collect(r) WHERE x <> null)) as cn"
 
     executeWith(Configs.CommunityInterpreted, q,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3).toList should equal (List(Map("cn" -> 0)))
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3).toList should equal (List(Map("cn" -> 0)))
   }
 
   // Not TCK material -- index hints
@@ -296,7 +297,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     // when
     val result = executeWith(Configs.Interpreted,
       "MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name STARTS WITH 'Jac' RETURN n",
-      ignorePlans = Configs.AllRulePlanners)
+      expectedDifferentPlans = Configs.AllRulePlanners)
 
     // then
     result.toList should equal(List(Map("n" -> jake)))
@@ -339,7 +340,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
   test("id in where leads to empty result") {
     // when
     val result = executeWith(Configs.All, "MATCH (n) WHERE id(n)=1337 RETURN n",
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3)
 
     // then DOESN'T THROW EXCEPTION
     result shouldBe empty
@@ -347,7 +348,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
 
   test("should not fail if asking for a non existent node id with WHERE") {
     executeWith(Configs.Interpreted, "match (n) where id(n) in [0,1] return n",
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3).toList
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3).toList
     // should not throw an exception
   }
 
@@ -394,7 +395,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     // when
     val result = executeWith(Configs.Interpreted,
       "match (a:Label), (b:Label) where a.property = b.property return *",
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3)
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3)
 
     // then does not throw exceptions
     assert(result.toSet === Set(
@@ -492,7 +493,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
         |RETURN host""".stripMargin
 
     //WHEN
-    val result = executeWith(Configs.Interpreted, query, ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3)
+    val result = executeWith(Configs.Interpreted, query, expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3)
     //THEN
     result.toList should equal(List(Map("host" -> host), Map("host" -> null)))
   }
@@ -539,9 +540,9 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
 
     //WHEN
     val first = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1).length
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1).length
     val second = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1).length
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1).length
     val check = executeWith(Configs.All, "MATCH (f:Folder) RETURN f.name").toSet
 
     //THEN
@@ -575,9 +576,9 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     //WHEN
 
     val first = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1).length
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1).length
     val second = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1).length
+      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1).length
     val check = executeWith(Configs.All, "MATCH (f:Folder) RETURN f.name").toSet
 
     //THEN
@@ -610,7 +611,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
 
   // Not sure if TCK material -- is this test just for `columns()`?
   test("columns should be in the provided order") {
-    val result = executeWith(Configs.All, "MATCH (p),(o),(n),(t),(u),(s) RETURN p,o,n,t,u,s", ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3)
+    val result = executeWith(Configs.All, "MATCH (p),(o),(n),(t),(u),(s) RETURN p,o,n,t,u,s", expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3)
 
     result.columns should equal(List("p", "o", "n", "t", "u", "s"))
   }
@@ -687,7 +688,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     // When
     val res =
       executeWith(Configs.AllExceptSlotted, "UNWIND {p} AS n MATCH (n)<-[:PING_DAY]-(p:Ping) RETURN count(p) as c",
-        ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1, params = Map("p" -> List(node1, node2)))
+        expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1, params = Map("p" -> List(node1, node2)))
 
     //Then
     res.toList should equal(List(Map("c" -> 2)))
@@ -707,7 +708,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
       executeWith(Configs.AllExceptSlotted, """UNWIND {p1} AS n1
                 |UNWIND {p2} AS n2
                 |MATCH (n1)<-[:PING_DAY]-(n2) RETURN n1.prop, n2.prop""".stripMargin,
-        ignorePlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1,
+        expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1,
         params = Map("p1" -> List(node1), "p2" -> List(node2)))
 
     //Then

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeAcceptanceTest.scala
@@ -20,6 +20,7 @@
 package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.{ExecutionEngineFunSuite, QueryStatisticsTestSupport}
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
 
 class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport
   with CypherComparisonSupport {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekByRangeAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekByRangeAcceptanceTest.scala
@@ -21,7 +21,7 @@ package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes.{IndexSeekByRange, UniqueIndexSeekByRange}
 import org.neo4j.cypher.{ExecutionEngineFunSuite, SyntaxException}
-import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.{Planners, Runtimes, TestScenario, Versions}
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
 
 /**
   * These tests are testing the actual index implementation, thus they should all check the actual result.

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UnionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UnionAcceptanceTest.scala
@@ -65,7 +65,7 @@ class UnionAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonS
     // TODO we expect this test to succeed with 3.2.4
     val expectedToWorkIn = Configs.CommunityInterpreted -
       TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.Cost, Runtimes.Default)
-    val result = executeWith(expectedToWorkIn, query, ignorePlans = Configs.AbsolutelyAll)
+    val result = executeWith(expectedToWorkIn, query, expectedDifferentPlans = Configs.AbsolutelyAll)
     val expected = List(Map("A" -> "b", "B" -> "a"), Map("A" -> "a", "B" -> "b"))
 
     result.toList should equal(expected)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueIndexAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueIndexAcceptanceTest.scala
@@ -23,6 +23,7 @@ import org.neo4j.cypher.internal.helpers.{NodeKeyConstraintCreator, UniquenessCo
 import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService
 import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport}
 import org.neo4j.graphdb.config.Setting
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
 import org.neo4j.test.TestEnterpriseGraphDatabaseFactory
 
 import scala.collection.JavaConverters._
@@ -150,7 +151,7 @@ class UniqueIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
       //WHEN
       val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3,
         "PROFILE MATCH (n:Person {name: 'Andres'}) MERGE (n)-[:KNOWS]->(m:Person {name: 'Maria'}) RETURN n.name",
-        ignorePlans = Configs.AllRulePlanners + Configs.Cost3_1)
+        expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
 
       //THEN
       result shouldNot use("NodeIndexSeek")

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UpdateReportingAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UpdateReportingAcceptanceTest.scala
@@ -20,6 +20,7 @@
 package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.ExecutionEngineFunSuite
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
 
 class UpdateReportingAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
   test("creating a node gets reported as such") {


### PR DESCRIPTION
This PR ports a couple of tests from NewPlannerTestSupport to CypherComparisonSupport.
It also introduces a few minor internal changes (like error messages) in CypherComparisonSupport itself.

Introducing InternalExecutionResult.executionPlanString() to avoid NPE when lifting
Lifting of previous versions execution Plans is not fully implemented.
A lot of cases simply pass null to the new objects of the plan
description. This leads to NullPointerExceptions when invoking toString.
Since the String is not used to assert but simply to show a user the
difference, we can avoid this by invoking toString on the non-lifted
plan description.