### PR TITLE
Update DatabaseSchemaState backing map

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/SchemaState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/SchemaState.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.impl.api;
 
-import java.util.Map;
 import java.util.function.Function;
 
 public interface SchemaState
@@ -28,9 +27,7 @@ public interface SchemaState
 
     <K, V> V getOrCreate( K key, Function<K, V> creator );
 
-    void replace( Map<Object, Object> updates );
-
-    <K, V> void apply( Map<K, V> updates );
+    <K, V> void put( K key, V value );
 
     void clear();
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DatabaseSchemaStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DatabaseSchemaStateTest.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.impl.api;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.logging.AssertableLogProvider;
 
 import static org.junit.Assert.assertEquals;
@@ -30,11 +29,14 @@ import static org.neo4j.logging.AssertableLogProvider.inLog;
 
 public class DatabaseSchemaStateTest
 {
+    private final AssertableLogProvider logProvider = new AssertableLogProvider();
+    private DatabaseSchemaState stateStore;
+
     @Test
     public void should_apply_updates_correctly()
     {
         // GIVEN
-        stateStore.apply( MapUtil.stringMap( "key", "created_value" ) );
+        stateStore.put( "key", "created_value" );
 
         // WHEN
         String result = stateStore.get( "key" );
@@ -47,7 +49,7 @@ public class DatabaseSchemaStateTest
     public void should_flush()
     {
         // GIVEN
-        stateStore.apply( MapUtil.stringMap( "key", "created_value" ) );
+        stateStore.put( "key", "created_value" );
 
         // WHEN
         stateStore.clear();
@@ -57,13 +59,8 @@ public class DatabaseSchemaStateTest
         assertEquals( null, result );
 
         // AND ALSO
-        logProvider.assertExactly(
-                inLog( DatabaseSchemaState.class ).debug( "Schema state store has been cleared." )
-        );
+        logProvider.assertExactly( inLog( DatabaseSchemaState.class ).debug( "Schema state store has been cleared." ) );
     }
-
-    private DatabaseSchemaState stateStore;
-    private final AssertableLogProvider logProvider = new AssertableLogProvider();
 
     @Before
     public void before()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
@@ -38,7 +38,6 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.helpers.collection.Pair;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.api.KernelAPI;
@@ -173,7 +172,7 @@ public class IndexPopulationJobTest
         // GIVEN
         String value = "Taylor";
         createNode( map( name, value ), FIRST );
-        stateHolder.apply( MapUtil.stringMap( "key", "original_value" ) );
+        stateHolder.put( "key", "original_value" );
         IndexPopulator populator = spy( inMemoryPopulator( false ) );
         IndexPopulationJob job = newIndexPopulationJob( populator, new FlippableIndexProxy(), false );
 


### PR DESCRIPTION
Use plain CHM instead of map guarded by fair ReentrantReadWriteLock.
Update api a bit to provide expected atomicity.