### PR TITLE
Do not raise error on missing context graphs

### DIFF
--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/GraphReturnItems.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/GraphReturnItems.scala
@@ -99,7 +99,8 @@ final case class GraphReturnItems(includeExisting: Boolean, items: Seq[GraphRetu
           newSourceName.map(source => newTargetName.map(target => ContextGraphs(source, target)).getOrElse(ContextGraphs(source, source)))
         optNewContextGraphs match {
           case Some(newContextGraphs) => s.updateContextGraphs(newContextGraphs)
-          case None => Left(SemanticError("No context graphs available", position))
+            // If there are no context graphs that's fine -- use the ambient graph
+          case None => Right(s)
         }
       }
     }


### PR DESCRIPTION
Regular Cypher queries (that do not handle anything pertaining
to multiple graphs) are supposed to be unaffected by multiple
graphs features, and simply use the ambient graph for all
context graph purposes.