### PR TITLE
Extracts log reading for tooling into more reusable class

### DIFF
--- a/tools/src/main/java/org/neo4j/tools/dump/DumpLogicalLog.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/DumpLogicalLog.java
@@ -23,48 +23,29 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.nio.ByteBuffer;
 import java.util.TimeZone;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
-import org.neo4j.cursor.IOCursor;
 import org.neo4j.helpers.Args;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
-import org.neo4j.io.fs.StoreChannel;
-import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageCommandReaderFactory;
 import org.neo4j.kernel.impl.transaction.command.Command.NodeCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.PropertyCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.RelationshipCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.RelationshipGroupCommand;
 import org.neo4j.kernel.impl.transaction.command.Command.SchemaRuleCommand;
-import org.neo4j.kernel.impl.transaction.log.FilteringIOCursor;
-import org.neo4j.kernel.impl.transaction.log.LogEntryCursor;
-import org.neo4j.kernel.impl.transaction.log.LogVersionBridge;
-import org.neo4j.kernel.impl.transaction.log.LogVersionedStoreChannel;
-import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
-import org.neo4j.kernel.impl.transaction.log.PhysicalLogVersionedStoreChannel;
-import org.neo4j.kernel.impl.transaction.log.ReadAheadLogChannel;
-import org.neo4j.kernel.impl.transaction.log.ReadableClosablePositionAwareChannel;
-import org.neo4j.kernel.impl.transaction.log.ReaderLogVersionBridge;
+import org.neo4j.kernel.impl.transaction.log.LogPosition;
+import org.neo4j.kernel.impl.transaction.log.entry.CheckPoint;
 import org.neo4j.kernel.impl.transaction.log.entry.InvalidLogEntryHandler;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntry;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryCommand;
-import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
-import org.neo4j.kernel.impl.transaction.log.entry.LogHeader;
-import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
 import org.neo4j.storageengine.api.StorageCommand;
+import org.neo4j.tools.dump.TransactionLogAnalyzer.Monitor;
 import org.neo4j.tools.dump.inconsistency.ReportInconsistencies;
-import org.neo4j.tools.dump.log.TransactionLogEntryCursor;
-
 import static java.util.TimeZone.getTimeZone;
 import static org.neo4j.helpers.Format.DEFAULT_TIME_ZONE;
-import static org.neo4j.kernel.impl.transaction.log.LogVersionBridge.NO_MORE_CHANNELS;
-import static org.neo4j.kernel.impl.transaction.log.ReadAheadChannel.DEFAULT_READ_AHEAD_SIZE;
-import static org.neo4j.kernel.impl.transaction.log.entry.LogHeader.LOG_HEADER_SIZE;
-import static org.neo4j.kernel.impl.transaction.log.entry.LogHeaderReader.readLogHeader;
 
 /**
  * Tool to represent logical logs in readable format for further analysis.
@@ -87,79 +68,35 @@ public class DumpLogicalLog
             Predicate<LogEntry[]> filter, Function<LogEntry,String> serializer,
             InvalidLogEntryHandler invalidLogEntryHandler ) throws IOException
     {
-        File file = new File( filenameOrDirectory );
-        printFile( file, out );
-        File firstFile;
-        LogVersionBridge bridge;
-        if ( file.isDirectory() )
+        TransactionLogAnalyzer.analyze( fileSystem, new File( filenameOrDirectory ), invalidLogEntryHandler, new Monitor()
         {
-            // Use natural log version bridging if a directory is supplied
-            final PhysicalLogFiles logFiles = new PhysicalLogFiles( file, fileSystem );
-            bridge = new ReaderLogVersionBridge( fileSystem, logFiles )
+            @Override
+            public void logFile( File file, long logVersion )
             {
-                @Override
-                public LogVersionedStoreChannel next( LogVersionedStoreChannel channel ) throws IOException
+                out.println( "=== " + file.getAbsolutePath() + " ===" );
+            }
+
+            @Override
+            public void transaction( LogEntry[] transactionEntries )
+            {
+                if ( filter == null || filter.test( transactionEntries ) )
                 {
-                    LogVersionedStoreChannel next = super.next( channel );
-                    if ( next != channel )
+                    for ( LogEntry entry : transactionEntries )
                     {
-                        printFile( logFiles.getLogFileForVersion( next.getVersion() ), out );
+                        out.println( serializer.apply( entry ) );
                     }
-                    return next;
-                }
-            };
-            firstFile = logFiles.getLogFileForVersion( logFiles.getLowestLogVersion() );
-        }
-        else
-        {
-            // Use no bridging, simple reading this single log file if a file is supplied
-            firstFile = file;
-            bridge = NO_MORE_CHANNELS;
-        }
-
-        StoreChannel fileChannel = fileSystem.open( firstFile, "r" );
-        ByteBuffer buffer = ByteBuffer.allocateDirect( LOG_HEADER_SIZE );
-
-        LogHeader logHeader;
-        try
-        {
-            logHeader = readLogHeader( buffer, fileChannel, false, firstFile );
-        }
-        catch ( IOException ex )
-        {
-            out.println( "Unable to read timestamp information, no records in logical log." );
-            out.println( ex.getMessage() );
-            fileChannel.close();
-            throw ex;
-        }
-        out.println( "Logical log format: " + logHeader.logFormatVersion + " version: " + logHeader.logVersion +
-                " with prev committed tx[" + logHeader.lastCommittedTxId + "]" );
-
-        PhysicalLogVersionedStoreChannel channel = new PhysicalLogVersionedStoreChannel(
-                fileChannel, logHeader.logVersion, logHeader.logFormatVersion );
-        ReadableClosablePositionAwareChannel logChannel = new ReadAheadLogChannel( channel, bridge,
-                DEFAULT_READ_AHEAD_SIZE );
-        LogEntryReader<ReadableClosablePositionAwareChannel> entryReader = new VersionAwareLogEntryReader<>(
-                new RecordStorageCommandReaderFactory(), invalidLogEntryHandler );
-
-        IOCursor<LogEntry> entryCursor = new LogEntryCursor( entryReader, logChannel );
-        TransactionLogEntryCursor transactionCursor = new TransactionLogEntryCursor( entryCursor );
-        try ( IOCursor<LogEntry[]> cursor = filter == null ? transactionCursor
-                                                           : new FilteringIOCursor<>( transactionCursor, filter ) )
-        {
-            while ( cursor.next() )
-            {
-                for ( LogEntry entry : cursor.get() )
-                {
-                    out.println( serializer.apply( entry ) );
                 }
             }
-        }
-    }
 
-    private static void printFile( File file, PrintStream out )
-    {
-        out.println( "=== " + file.getAbsolutePath() + " ===" );
+            @Override
+            public void checkpoint( CheckPoint checkpoint, LogPosition checkpointEntryPosition )
+            {
+                if ( filter == null || filter.test( new LogEntry[] {checkpoint} ) )
+                {
+                    out.println( serializer.apply( checkpoint ) );
+                }
+            }
+        } );
     }
 
     private static class TransactionRegexCriteria implements Predicate<LogEntry[]>
@@ -190,7 +127,7 @@ public class DumpLogicalLog
     public static class ConsistencyCheckOutputCriteria implements Predicate<LogEntry[]>, Function<LogEntry,String>
     {
         private final TimeZone timeZone;
-        private ReportInconsistencies inconsistencies;
+        private final ReportInconsistencies inconsistencies;
 
         public ConsistencyCheckOutputCriteria( String ccFile, TimeZone timeZone ) throws IOException
         {

--- a/tools/src/main/java/org/neo4j/tools/dump/TransactionLogAnalyzer.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/TransactionLogAnalyzer.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.tools.dump;
+
+import java.io.File;
+import java.io.IOException;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageCommandReaderFactory;
+import org.neo4j.kernel.impl.transaction.log.LogEntryCursor;
+import org.neo4j.kernel.impl.transaction.log.LogPosition;
+import org.neo4j.kernel.impl.transaction.log.LogPositionMarker;
+import org.neo4j.kernel.impl.transaction.log.LogVersionBridge;
+import org.neo4j.kernel.impl.transaction.log.LogVersionedStoreChannel;
+import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
+import org.neo4j.kernel.impl.transaction.log.ReadAheadLogChannel;
+import org.neo4j.kernel.impl.transaction.log.ReadableClosablePositionAwareChannel;
+import org.neo4j.kernel.impl.transaction.log.ReaderLogVersionBridge;
+import org.neo4j.kernel.impl.transaction.log.entry.CheckPoint;
+import org.neo4j.kernel.impl.transaction.log.entry.InvalidLogEntryHandler;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntry;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryCommand;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryCommit;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart;
+import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
+import org.neo4j.tools.dump.log.TransactionLogEntryCursor;
+import static org.neo4j.kernel.impl.transaction.log.LogVersionBridge.NO_MORE_CHANNELS;
+import static org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles.getLogVersion;
+import static org.neo4j.kernel.impl.transaction.log.entry.LogEntryByteCodes.CHECK_POINT;
+import static org.neo4j.tools.util.TransactionLogUtils.openVersionedChannel;
+
+/**
+ * Merely a utility which, given a store directory or log file, reads the transaction log(s) as a stream of transactions
+ * and invokes methods on {@link Monitor}.
+ */
+public class TransactionLogAnalyzer
+{
+    /**
+     * Receiving call-backs for all kinds of different events while analyzing the stream of transactions.
+     */
+    public interface Monitor
+    {
+        /**
+         * Called when transitioning to a new log file, crossing a log version bridge. This is also called for the
+         * first log file opened.
+         *
+         * @param file {@link File} pointing to the opened log file.
+         * @param logVersion log version.
+         */
+        default void logFile( File file, long logVersion )
+        {   // no-op by default
+        }
+
+        /**
+         * A complete transaction with {@link LogEntryStart}, one or more {@link LogEntryCommand} and {@link LogEntryCommit}.
+         *
+         * @param transactionEntries the log entries making up the transaction, including start/commit entries.
+         */
+        default void transaction( LogEntry[] transactionEntries )
+        {   // no-op by default
+        }
+
+        /**
+         * {@link CheckPoint} log entry in between transactions.
+         *
+         * @param checkpoint the {@link CheckPoint} log entry.
+         * @param checkpointEntryPosition {@link LogPosition} of the checkpoint entry itself.
+         */
+        default void checkpoint( CheckPoint checkpoint, LogPosition checkpointEntryPosition )
+        {   // no-op by default
+        }
+    }
+
+    public static Monitor all( Monitor... monitors )
+    {
+        return new CombinedMonitor( monitors );
+    }
+
+    /**
+     * Analyzes transactions found in log file(s) specified by {@code storeDirOrLogFile} calling methods on the supplied
+     * {@link Monitor} for each encountered data item.
+     *
+     * @param fileSystem {@link FileSystemAbstraction} to find the files on.
+     * @param storeDirOrLogFile {@link File} pointing either to a directory containing transaction log files, or directly
+     * pointing to a single transaction log file to analyze.
+     * @param invalidLogEntryHandler {@link InvalidLogEntryHandler} to pass in to the internal {@link LogEntryReader}.
+     * @param monitor {@link Monitor} receiving call-backs for all {@link Monitor#transaction(LogEntry[]) transactions},
+     * {@link Monitor#checkpoint(CheckPoint, LogPosition) checkpoints} and {@link Monitor#logFile(File, long) log file transitions}
+     * encountered during the analysis.
+     * @throws IOException on I/O error.
+     */
+    public static void analyze( FileSystemAbstraction fileSystem, File storeDirOrLogFile,
+            InvalidLogEntryHandler invalidLogEntryHandler, Monitor monitor )
+            throws IOException
+    {
+        File firstFile;
+        LogVersionBridge bridge;
+        if ( storeDirOrLogFile.isDirectory() )
+        {
+            // Use natural log version bridging if a directory is supplied
+            final PhysicalLogFiles logFiles = new PhysicalLogFiles( storeDirOrLogFile, fileSystem );
+            bridge = new ReaderLogVersionBridge( fileSystem, logFiles )
+            {
+                @Override
+                public LogVersionedStoreChannel next( LogVersionedStoreChannel channel ) throws IOException
+                {
+                    LogVersionedStoreChannel next = super.next( channel );
+                    if ( next != channel )
+                    {
+                        monitor.logFile( logFiles.getLogFileForVersion( next.getVersion() ), next.getVersion() );
+                    }
+                    return next;
+                }
+            };
+            long lowestLogVersion = logFiles.getLowestLogVersion();
+            firstFile = logFiles.getLogFileForVersion( lowestLogVersion );
+            monitor.logFile( firstFile, lowestLogVersion );
+        }
+        else
+        {
+            // Use no bridging, simply reading this single log file if a file is supplied
+            firstFile = storeDirOrLogFile;
+            monitor.logFile( firstFile, getLogVersion( firstFile ) );
+            bridge = NO_MORE_CHANNELS;
+        }
+
+        ReadAheadLogChannel channel = new ReadAheadLogChannel( openVersionedChannel( fileSystem, firstFile ), bridge );
+        LogEntryReader<ReadableClosablePositionAwareChannel> entryReader = new VersionAwareLogEntryReader<>(
+                new RecordStorageCommandReaderFactory(), invalidLogEntryHandler );
+        LogPositionMarker positionMarker = new LogPositionMarker();
+        try ( TransactionLogEntryCursor cursor = new TransactionLogEntryCursor( new LogEntryCursor( entryReader, channel ) ) )
+        {
+            channel.getCurrentPosition( positionMarker );
+            while ( cursor.next() )
+            {
+                LogEntry[] tx = cursor.get();
+                if ( tx.length == 1 && tx[0].getType() == CHECK_POINT )
+                {
+                    monitor.checkpoint( tx[0].as(), positionMarker.newPosition() );
+                }
+                else
+                {
+                    monitor.transaction( tx );
+                }
+            }
+        }
+    }
+
+    private static class CombinedMonitor implements Monitor
+    {
+        private final Monitor[] monitors;
+
+        CombinedMonitor( Monitor[] monitors )
+        {
+            this.monitors = monitors;
+        }
+
+        @Override
+        public void logFile( File file, long logVersion )
+        {
+            for ( Monitor monitor : monitors )
+            {
+                monitor.logFile( file, logVersion );
+            }
+        }
+
+        @Override
+        public void transaction( LogEntry[] transactionEntries )
+        {
+            for ( Monitor monitor : monitors )
+            {
+                monitor.transaction( transactionEntries );
+            }
+        }
+
+        @Override
+        public void checkpoint( CheckPoint checkpoint, LogPosition checkpointEntryPosition )
+        {
+            for ( Monitor monitor : monitors )
+            {
+                monitor.checkpoint( checkpoint, checkpointEntryPosition );
+            }
+        }
+    }
+}

--- a/tools/src/main/java/org/neo4j/tools/dump/log/TransactionLogEntryCursor.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/log/TransactionLogEntryCursor.java
@@ -25,7 +25,8 @@ import java.util.List;
 
 import org.neo4j.cursor.IOCursor;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntry;
-import org.neo4j.kernel.impl.transaction.log.entry.LogEntryByteCodes;
+import static org.neo4j.kernel.impl.transaction.log.entry.LogEntryByteCodes.CHECK_POINT;
+import static org.neo4j.kernel.impl.transaction.log.entry.LogEntryByteCodes.TX_1P_COMMIT;
 
 /**
  * Groups {@link LogEntry} instances transaction by transaction
@@ -63,9 +64,10 @@ public class TransactionLogEntryCursor implements IOCursor<LogEntry[]>
         return !transaction.isEmpty();
     }
 
-    private boolean isBreakPoint( LogEntry entry )
+    private static boolean isBreakPoint( LogEntry entry )
     {
-        return entry.getType() == LogEntryByteCodes.TX_1P_COMMIT;
+        byte type = entry.getType();
+        return type == TX_1P_COMMIT || type == CHECK_POINT;
     }
 
     @Override

--- a/tools/src/main/java/org/neo4j/tools/util/TransactionLogUtils.java
+++ b/tools/src/main/java/org/neo4j/tools/util/TransactionLogUtils.java
@@ -27,6 +27,7 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.kernel.impl.transaction.log.LogEntryCursor;
 import org.neo4j.kernel.impl.transaction.log.LogVersionBridge;
+import org.neo4j.kernel.impl.transaction.log.LogVersionedStoreChannel;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogVersionedStoreChannel;
 import org.neo4j.kernel.impl.transaction.log.ReadAheadLogChannel;
@@ -65,12 +66,26 @@ public class TransactionLogUtils
     public static LogEntryCursor openLogEntryCursor( FileSystemAbstraction fileSystem, File file,
             LogVersionBridge readerLogVersionBridge ) throws IOException
     {
+        LogVersionedStoreChannel channel = openVersionedChannel( fileSystem, file );
+        ReadableLogChannel logChannel = new ReadAheadLogChannel( channel, readerLogVersionBridge );
+        LogEntryReader<ReadableClosablePositionAwareChannel> logEntryReader = new VersionAwareLogEntryReader<>();
+        return new LogEntryCursor( logEntryReader, logChannel );
+    }
+
+    /**
+     * Opens a file in given {@code fileSystem} as a {@link LogVersionedStoreChannel}.
+     *
+     * @param fileSystem {@link FileSystemAbstraction} containing the file to open.
+     * @param file file to open as a channel.
+     * @return {@link LogVersionedStoreChannel} for the file. Its version is determined by its log header.
+     * @throws IOException on I/O error.
+     */
+    public static LogVersionedStoreChannel openVersionedChannel( FileSystemAbstraction fileSystem, File file ) throws IOException
+    {
         StoreChannel fileChannel = fileSystem.open( file, "r" );
         LogHeader logHeader = readLogHeader( ByteBuffer.allocateDirect( LOG_HEADER_SIZE ), fileChannel, true, file );
         PhysicalLogVersionedStoreChannel channel =
                 new PhysicalLogVersionedStoreChannel( fileChannel, logHeader.logVersion, logHeader.logFormatVersion );
-        ReadableLogChannel logChannel = new ReadAheadLogChannel( channel, readerLogVersionBridge );
-        LogEntryReader<ReadableClosablePositionAwareChannel> logEntryReader = new VersionAwareLogEntryReader<>();
-        return new LogEntryCursor( logEntryReader, logChannel );
+        return channel;
     }
 }

--- a/tools/src/test/java/org/neo4j/tools/dump/TransactionLogAnalyzerTest.java
+++ b/tools/src/test/java/org/neo4j/tools/dump/TransactionLogAnalyzerTest.java
@@ -240,6 +240,7 @@ public class TransactionLogAnalyzerTest
     private void writeCheckpoint() throws IOException
     {
         transactionLogWriter.checkPoint( writer.getCurrentPosition( new LogPositionMarker() ).newPosition() );
+        writer.prepareForFlush().flush();
         monitor.expectCheckpointAfter( lastCommittedTxId.get() );
     }
 

--- a/tools/src/test/java/org/neo4j/tools/dump/TransactionLogAnalyzerTest.java
+++ b/tools/src/test/java/org/neo4j/tools/dump/TransactionLogAnalyzerTest.java
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.tools.dump;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.kernel.impl.transaction.DeadSimpleLogVersionRepository;
+import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.command.Command;
+import org.neo4j.kernel.impl.transaction.log.FlushablePositionAwareChannel;
+import org.neo4j.kernel.impl.transaction.log.LogHeaderCache;
+import org.neo4j.kernel.impl.transaction.log.LogPosition;
+import org.neo4j.kernel.impl.transaction.log.LogPositionMarker;
+import org.neo4j.kernel.impl.transaction.log.LogVersionRepository;
+import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile;
+import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
+import org.neo4j.kernel.impl.transaction.log.PhysicalTransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.log.TransactionLogWriter;
+import org.neo4j.kernel.impl.transaction.log.entry.CheckPoint;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntry;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryCommand;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryCommit;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart;
+import org.neo4j.kernel.impl.transaction.log.entry.LogEntryWriter;
+import org.neo4j.kernel.lifecycle.LifeRule;
+import org.neo4j.storageengine.api.StorageCommand;
+import org.neo4j.test.rule.RandomRule;
+import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+import org.neo4j.test.rule.fs.FileSystemRule;
+import org.neo4j.tools.dump.TransactionLogAnalyzer.Monitor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.io.ByteUnit.mebiBytes;
+import static org.neo4j.kernel.impl.transaction.log.PhysicalLogFile.NO_MONITOR;
+import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_ID;
+import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_LOG_VERSION;
+import static org.neo4j.kernel.impl.transaction.log.entry.InvalidLogEntryHandler.STRICT;
+
+public class TransactionLogAnalyzerTest
+{
+    private final FileSystemRule<DefaultFileSystemAbstraction> fs = new DefaultFileSystemRule();
+    private final TestDirectory directory = TestDirectory.testDirectory( fs );
+    private final LifeRule life = new LifeRule( true );
+    private final RandomRule random = new RandomRule();
+
+    @Rule
+    public final RuleChain rules = RuleChain.outerRule( random ).around( fs ).around( directory ).around( life );
+
+    private PhysicalLogFile logFile;
+    private FlushablePositionAwareChannel writer;
+    private TransactionLogWriter transactionLogWriter;
+    private AtomicLong lastCommittedTxId;
+    private VerifyingMonitor monitor;
+    private LogVersionRepository logVersionRepository;
+    private PhysicalLogFiles logFiles;
+
+    @Before
+    public void before()
+    {
+        lastCommittedTxId = new AtomicLong( BASE_TX_ID );
+        logVersionRepository = new DeadSimpleLogVersionRepository( BASE_TX_LOG_VERSION );
+        logFiles = new PhysicalLogFiles( directory.absolutePath(), fs );
+        logFile = life.add( new PhysicalLogFile( fs, logFiles, mebiBytes( 1 ),
+                lastCommittedTxId::get, logVersionRepository, NO_MONITOR, new LogHeaderCache( 10 ) ) );
+        writer = logFile.getWriter();
+        transactionLogWriter = new TransactionLogWriter( new LogEntryWriter( writer ) );
+        monitor = new VerifyingMonitor();
+    }
+
+    @After
+    public void after()
+    {
+        life.shutdown();
+    }
+
+    @Test
+    public void shouldSeeTransactionsInOneLogFile() throws Exception
+    {
+        // given
+        writeTransactions( 5 );
+
+        // when
+        TransactionLogAnalyzer.analyze( fs, directory.absolutePath(), STRICT, monitor );
+
+        // then
+        assertEquals( 1, monitor.logFiles );
+        assertEquals( 5, monitor.transactions );
+    }
+
+    @Test
+    public void shouldSeeCheckpointsInBetweenTransactionsInOneLogFile() throws Exception
+    {
+        // given
+        writeTransactions( 3 ); // txs 2, 3, 4
+        writeCheckpoint();
+        writeTransactions( 2 ); // txs 5, 6
+        writeCheckpoint();
+        writeTransactions( 4 ); // txs 7, 8, 9, 10
+
+        // when
+        TransactionLogAnalyzer.analyze( fs, directory.absolutePath(), STRICT, monitor );
+
+        // then
+        assertEquals( 1, monitor.logFiles );
+        assertEquals( 2, monitor.checkpoints );
+        assertEquals( 9, monitor.transactions );
+    }
+
+    @Test
+    public void shouldSeeLogFileTransitions() throws Exception
+    {
+        // given
+        writeTransactions( 1 );
+        rotate();
+        writeTransactions( 1 );
+        rotate();
+        writeTransactions( 1 );
+
+        // when
+        TransactionLogAnalyzer.analyze( fs, directory.absolutePath(), STRICT, monitor );
+
+        // then
+        assertEquals( 3, monitor.logFiles );
+        assertEquals( 0, monitor.checkpoints );
+        assertEquals( 3, monitor.transactions );
+    }
+
+    @Test
+    public void shouldSeeLogFileTransitionsTransactionsAndCheckpointsInMultipleLogFiles() throws Exception
+    {
+        // given
+        int expectedTransactions = 0;
+        int expectedCheckpoints = 0;
+        int expectedLogFiles = 1;
+        for ( int i = 0; i < 30; i++ )
+        {
+            float chance = random.nextFloat();
+            if ( chance < 0.5 )
+            {   // tx
+                int count = random.nextInt( 1, 5 );
+                writeTransactions( count );
+                expectedTransactions += count;
+            }
+            else if ( chance < 0.75 )
+            {   // checkpoint
+                writeCheckpoint();
+                expectedCheckpoints++;
+            }
+            else
+            {   // rotate
+                rotate();
+                expectedLogFiles++;
+            }
+        }
+
+        // when
+        TransactionLogAnalyzer.analyze( fs, directory.absolutePath(), STRICT, monitor );
+
+        // then
+        assertEquals( expectedLogFiles, monitor.logFiles );
+        assertEquals( expectedCheckpoints, monitor.checkpoints );
+        assertEquals( expectedTransactions, monitor.transactions );
+    }
+
+    @Test
+    public void shouldAnalyzeSingleLogWhenExplicitlySelected() throws Exception
+    {
+        // given
+        writeTransactions( 2 ); // txs 2, 3
+        long version = rotate();
+        writeTransactions( 3 ); // txs 4, 5, 6
+        writeCheckpoint();
+        writeTransactions( 4 ); // txs 7, 8, 9, 10
+        rotate();
+        writeTransactions( 2 ); // txs 11, 12
+
+        // when
+        monitor.nextExpectedTxId = 4;
+        monitor.nextExpectedLogVersion = version;
+        TransactionLogAnalyzer.analyze( fs, logFiles.getLogFileForVersion( version ), STRICT, monitor );
+
+        // then
+        assertEquals( 1, monitor.logFiles );
+        assertEquals( 1, monitor.checkpoints );
+        assertEquals( 7, monitor.transactions );
+    }
+
+    private long rotate() throws IOException
+    {
+        logFile.rotate();
+        return logVersionRepository.getCurrentLogVersion();
+    }
+
+    private static void assertTransaction( LogEntry[] transactionEntries, long expectedId )
+    {
+        assertTrue( Arrays.toString( transactionEntries ), transactionEntries[0] instanceof LogEntryStart );
+        assertTrue( transactionEntries[1] instanceof LogEntryCommand );
+        LogEntryCommand command = transactionEntries[1].as();
+        assertEquals( expectedId, ((Command.NodeCommand)command.getXaCommand()).getKey() );
+        assertTrue( transactionEntries[2] instanceof LogEntryCommit );
+        LogEntryCommit commit = transactionEntries[2].as();
+        assertEquals( expectedId, commit.getTxId() );
+    }
+
+    private void writeCheckpoint() throws IOException
+    {
+        transactionLogWriter.checkPoint( writer.getCurrentPosition( new LogPositionMarker() ).newPosition() );
+        monitor.expectCheckpointAfter( lastCommittedTxId.get() );
+    }
+
+    private void writeTransactions( int count ) throws IOException
+    {
+        for ( int i = 0; i < count; i++ )
+        {
+            long id = lastCommittedTxId.incrementAndGet();
+            transactionLogWriter.append( tx( id ), id );
+        }
+        writer.prepareForFlush().flush();
+    }
+
+    private TransactionRepresentation tx( long nodeId )
+    {
+        List<StorageCommand> commands = new ArrayList<>();
+        commands.add( new Command.NodeCommand( new NodeRecord( nodeId ), new NodeRecord( nodeId )
+                .initialize( true, nodeId, false, nodeId, 0 ) ) );
+        PhysicalTransactionRepresentation tx = new PhysicalTransactionRepresentation( commands );
+        tx.setHeader( new byte[0], 0, 0, 0, 0, 0, 0 );
+        return tx;
+    }
+
+    private static class VerifyingMonitor implements Monitor
+    {
+        private int transactions;
+        private int checkpoints;
+        private int logFiles;
+        private long nextExpectedTxId = BASE_TX_ID + 1;
+        private final Deque<Long> expectedCheckpointsAt = new ArrayDeque<>();
+        private long nextExpectedLogVersion = BASE_TX_LOG_VERSION;
+
+        void expectCheckpointAfter( long txId )
+        {
+            expectedCheckpointsAt.addLast( txId );
+        }
+
+        @Override
+        public void logFile( File file, long logVersion )
+        {
+            logFiles++;
+            assertEquals( nextExpectedLogVersion++, logVersion );
+        }
+
+        @Override
+        public void transaction( LogEntry[] transactionEntries )
+        {
+            transactions++;
+            assertTransaction( transactionEntries, nextExpectedTxId++ );
+        }
+
+        @Override
+        public void checkpoint( CheckPoint checkpoint, LogPosition checkpointEntryPosition )
+        {
+            checkpoints++;
+            Long expected = expectedCheckpointsAt.poll();
+            assertNotNull( "Unexpected checkpoint", expected );
+            assertEquals( expected.longValue(), nextExpectedTxId - 1 );
+        }
+    }
+}

--- a/tools/src/test/java/org/neo4j/tools/dump/log/TransactionLogEntryCursorTest.java
+++ b/tools/src/test/java/org/neo4j/tools/dump/log/TransactionLogEntryCursorTest.java
@@ -32,6 +32,7 @@ import org.neo4j.kernel.impl.transaction.log.entry.LogEntry;
 
 import static junit.framework.TestCase.assertFalse;
 import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -98,8 +99,12 @@ public class TransactionLogEntryCursorTest
         List<LogEntry> recordSet2 = makeTransaction( CHECK_POINT );
         TransactionLogEntryCursor transactionCursor = getTransactionLogEntryCursor( recordSet1, recordSet2 );
 
-        assertTrue( transactionCursor.next() );
-        assertThat( "All 4 checkpoints should be provided.", transactionCursor.get(), arrayWithSize( 4 ) );
+        for ( int i = 0; i < 4; i++ )
+        {
+            assertTrue( transactionCursor.next() );
+            assertThat( transactionCursor.get(), arrayWithSize( 1 ) );
+            assertThat( transactionCursor.get()[0].getType(), equalTo( CHECK_POINT ) );
+        }
     }
 
     private TransactionLogEntryCursor getTransactionLogEntryCursor( List<LogEntry>...txEntries )


### PR DESCRIPTION
It's now much easier to write a quick transaction log stream analyzer.
DumpLogicalLog also uses this analyzer internally.

Also actually tests this pretty important functionality.