### PR TITLE
Added dumy javadoc generation to new cypher modules

### DIFF
--- a/enterprise/cypher/physical-planning/pom.xml
+++ b/enterprise/cypher/physical-planning/pom.xml
@@ -360,4 +360,39 @@
 
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>neo-full-build-with-javadoc</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>fullBuild</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>generate-dummy-javadocs-jar</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <configuration>
+                  <classifier>javadoc</classifier>
+                  <excludes>
+                    <exclude>**</exclude>
+                  </excludes>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/enterprise/cypher/slotted-runtime/pom.xml
+++ b/enterprise/cypher/slotted-runtime/pom.xml
@@ -375,4 +375,39 @@
 
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>neo-full-build-with-javadoc</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>fullBuild</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-jar-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>generate-dummy-javadocs-jar</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <configuration>
+                  <classifier>javadoc</classifier>
+                  <excludes>
+                    <exclude>**</exclude>
+                  </excludes>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
This PR let's the new cypher modules `physical-planning` and `slotted-runtime` generate dummy `javadoc.jar`s so they can be published to maven central.