### PR TITLE
Populate the bloom fulltext index on startup

### DIFF
--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/AsyncFulltextIndexOperation.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/AsyncFulltextIndexOperation.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.fulltext;
+
+/**
+ * A fulltext index operation that is possibly in-flight, and whose completion can be waited for.
+ */
+public interface AsyncFulltextIndexOperation
+{
+    /**
+     * Wait for the index operation to complete. Returns immediately if the operation has already completed.
+     */
+    void awaitCompletion();
+}

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextFactory.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextFactory.java
@@ -70,8 +70,13 @@ public class FulltextFactory
     public void createFulltextIndex( String identifier, FulltextProvider.FulltextIndexType type, List<String> properties, FulltextProvider provider )
             throws IOException
     {
+        // First delete any existing index, since we don't know if whatever it might contain actually matches our
+        // current configuration:
+        File indexRootFolder = new File( indexDir, identifier );
+        fileSystem.deleteRecursively( indexRootFolder );
+
         LuceneIndexStorageBuilder storageBuilder = LuceneIndexStorageBuilder.create();
-        storageBuilder.withFileSystem( fileSystem ).withIndexFolder( new File( indexDir, identifier ) );
+        storageBuilder.withFileSystem( fileSystem ).withIndexFolder( indexRootFolder );
         provider.register( new LuceneFulltext( storageBuilder.build(), partitionFactory, properties, analyzer, identifier, type ) );
     }
 }

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextProvider.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextProvider.java
@@ -79,6 +79,11 @@ public class FulltextProvider implements AutoCloseable
         db.registerTransactionEventHandler( fulltextTransactionEventUpdater );
     }
 
+    public void awaitPopulation() throws IOException
+    {
+        applier.writeBarrier().await();
+    }
+
     /**
      * Closes the provider and all associated resources.
      */

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextProvider.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextProvider.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.logging.Log;
 
 /**
@@ -50,12 +51,13 @@ public class FulltextProvider implements AutoCloseable
      * Creates a provider of fulltext indices for the given database. This is the entry point for all fulltext index operations.
      * @param db Database that this provider should work with.
      * @param log For logging errors.
+     * @param availabilityGuard Used for waiting with populating the index until the database is available.
      */
-    public FulltextProvider( GraphDatabaseService db, Log log )
+    public FulltextProvider( GraphDatabaseService db, Log log, AvailabilityGuard availabilityGuard )
     {
         this.db = db;
         this.log = log;
-        applier = new FulltextUpdateApplier( log );
+        applier = new FulltextUpdateApplier( log, availabilityGuard );
         applier.start();
         fulltextTransactionEventUpdater = new FulltextTransactionEventUpdater( this, log, applier );
         nodeProperties = new HashSet<>();

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextProvider.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextProvider.java
@@ -53,7 +53,7 @@ public class FulltextProvider implements AutoCloseable
      * @param db Database that this provider should work with.
      * @param log For logging errors.
      * @param availabilityGuard Used for waiting with populating the index until the database is available.
-     * @param scheduler
+     * @param scheduler For background work.
      */
     public FulltextProvider( GraphDatabaseService db, Log log, AvailabilityGuard availabilityGuard,
                              JobScheduler scheduler )
@@ -84,6 +84,13 @@ public class FulltextProvider implements AutoCloseable
         db.registerTransactionEventHandler( fulltextTransactionEventUpdater );
     }
 
+    /**
+     * Wait for the asynchronous background population, if one is on-going, to complete.
+     *
+     * Such population, where the entire store is scanned for data to write to the index, will be started if the index
+     * needs to recover after an unclean shut-down, or a configuration change.
+     * @throws IOException If it was not possible to wait for the population to finish, for some reason.
+     */
     public void awaitPopulation() throws IOException
     {
         applier.writeBarrier().awaitCompletion();

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextProvider.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextProvider.java
@@ -83,7 +83,7 @@ public class FulltextProvider implements AutoCloseable
 
     public void awaitPopulation() throws IOException
     {
-        applier.writeBarrier().await();
+        applier.writeBarrier().awaitCompletion();
     }
 
     /**

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextProvider.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextProvider.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.logging.Log;
+import org.neo4j.scheduler.JobScheduler;
 
 /**
  * Provider class that manages and provides fulltext indices. This is the main entry point for the fulltext addon.
@@ -52,12 +53,14 @@ public class FulltextProvider implements AutoCloseable
      * @param db Database that this provider should work with.
      * @param log For logging errors.
      * @param availabilityGuard Used for waiting with populating the index until the database is available.
+     * @param scheduler
      */
-    public FulltextProvider( GraphDatabaseService db, Log log, AvailabilityGuard availabilityGuard )
+    public FulltextProvider( GraphDatabaseService db, Log log, AvailabilityGuard availabilityGuard,
+                             JobScheduler scheduler )
     {
         this.db = db;
         this.log = log;
-        applier = new FulltextUpdateApplier( log, availabilityGuard );
+        applier = new FulltextUpdateApplier( log, availabilityGuard, scheduler );
         applier.start();
         fulltextTransactionEventUpdater = new FulltextTransactionEventUpdater( this, log, applier );
         nodeProperties = new HashSet<>();

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextProvider.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextProvider.java
@@ -58,13 +58,25 @@ public class FulltextProvider implements AutoCloseable
         applier = new FulltextUpdateApplier( log );
         applier.start();
         fulltextTransactionEventUpdater = new FulltextTransactionEventUpdater( this, log, applier );
-        db.registerTransactionEventHandler( fulltextTransactionEventUpdater );
         nodeProperties = new HashSet<>();
         relationshipProperties = new HashSet<>();
         writableNodeIndices = new HashSet<>();
         writableRelationshipIndices = new HashSet<>();
         nodeIndices = new HashMap<>();
         relationshipIndices = new HashMap<>();
+    }
+
+    public void init() throws IOException
+    {
+        for ( WritableFulltext index : writableNodeIndices )
+        {
+            applier.populateNodes( index, db );
+        }
+        for ( WritableFulltext index : writableRelationshipIndices )
+        {
+            applier.populateRelationships( index, db );
+        }
+        db.registerTransactionEventHandler( fulltextTransactionEventUpdater );
     }
 
     /**

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextTransactionEventUpdater.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextTransactionEventUpdater.java
@@ -19,18 +19,14 @@
  */
 package org.neo4j.kernel.api.impl.fulltext;
 
-import org.apache.lucene.document.Document;
-
 import java.io.IOException;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
-import org.neo4j.graphdb.Entity;
+import org.neo4j.concurrent.BinaryLatch;
 import org.neo4j.graphdb.NotFoundException;
-import org.neo4j.graphdb.event.PropertyEntry;
 import org.neo4j.graphdb.event.TransactionData;
 import org.neo4j.graphdb.event.TransactionEventHandler;
 import org.neo4j.logging.Log;
@@ -40,11 +36,14 @@ class FulltextTransactionEventUpdater implements TransactionEventHandler<Object>
 
     private final FulltextProvider fulltextProvider;
     private final Log log;
+    private final FulltextUpdateApplier applier;
 
-    FulltextTransactionEventUpdater( FulltextProvider fulltextProvider, Log log )
+    FulltextTransactionEventUpdater( FulltextProvider fulltextProvider, Log log,
+                                     FulltextUpdateApplier applier )
     {
         this.fulltextProvider = fulltextProvider;
         this.log = log;
+        this.applier = applier;
     }
 
     @Override
@@ -87,77 +86,32 @@ class FulltextTransactionEventUpdater implements TransactionEventHandler<Object>
     @Override
     public void afterCommit( TransactionData data, Object state )
     {
-        //update node indices
         try
         {
+            List<BinaryLatch> completions = new ArrayList<>();
+            //update node indices
             for ( WritableFulltext nodeIndex : fulltextProvider.writableNodeIndices() )
             {
                 Map<Long,Map<String,Object>> nodeMap = ((Map<Long,Map<String,Object>>[]) state)[0];
-                removePropertyData( data.removedNodeProperties(), nodeMap, nodeIndex );
-                updatePropertyData( nodeMap, nodeIndex );
-                refreshIndex( nodeIndex );
+                completions.add( applier.removePropertyData( data.removedNodeProperties(), nodeMap, nodeIndex ) );
+                completions.add( applier.updatePropertyData( nodeMap, nodeIndex ) );
             }
             //update relationship indices
             for ( WritableFulltext relationshipIndex : fulltextProvider.writableRelationshipIndices() )
             {
                 Map<Long,Map<String,Object>> relationshipMap = ((Map<Long,Map<String,Object>>[]) state)[1];
-                removePropertyData( data.removedRelationshipProperties(), relationshipMap, relationshipIndex );
-                updatePropertyData( relationshipMap, relationshipIndex );
-                refreshIndex( relationshipIndex );
+                completions.add( applier.removePropertyData( data.removedRelationshipProperties(), relationshipMap, relationshipIndex ) );
+                completions.add( applier.updatePropertyData( relationshipMap, relationshipIndex ) );
+            }
+
+            for ( BinaryLatch completion : completions )
+            {
+                completion.await();
             }
         }
         catch ( IOException e )
         {
             log.error( "Unable to update fulltext index", e );
-        }
-    }
-
-    private <E extends Entity> void updatePropertyData( Map<Long,Map<String,Object>> state, WritableFulltext index ) throws IOException
-    {
-        for ( Map.Entry<Long,Map<String,Object>> stateEntry : state.entrySet() )
-        {
-            Set<String> indexedProperties = index.properties();
-            if ( !Collections.disjoint( indexedProperties, stateEntry.getValue().keySet() ) )
-            {
-                long entityId = stateEntry.getKey();
-                Map<String,Object> allProperties =
-                        stateEntry.getValue().entrySet().stream().filter( entry -> indexedProperties.contains( entry.getKey() ) ).collect(
-                                Collectors.toMap( Map.Entry::getKey, Map.Entry::getValue ) );
-                if ( !allProperties.isEmpty() )
-                {
-                    Document document = LuceneFulltextDocumentStructure.documentRepresentingProperties( entityId, allProperties );
-                    index.getIndexWriter().updateDocument( LuceneFulltextDocumentStructure.newTermForChangeOrRemove( entityId ), document );
-                }
-            }
-        }
-    }
-
-    private <E extends Entity> void removePropertyData( Iterable<PropertyEntry<E>> propertyEntries, Map<Long,Map<String,Object>> state,
-            WritableFulltext index ) throws IOException
-    {
-        for ( PropertyEntry<E> propertyEntry : propertyEntries )
-        {
-            if ( index.properties().contains( propertyEntry.key() ) )
-            {
-                long entityId = propertyEntry.entity().getId();
-                Map<String,Object> allProperties = state.get( entityId );
-                if ( allProperties == null || allProperties.isEmpty() )
-                {
-                    index.getIndexWriter().deleteDocuments( LuceneFulltextDocumentStructure.newTermForChangeOrRemove( entityId ) );
-                }
-            }
-        }
-    }
-
-    private void refreshIndex( WritableFulltext index )
-    {
-        try
-        {
-            index.maybeRefreshBlocking();
-        }
-        catch ( IOException e )
-        {
-            log.error( "Failed to refresh fulltext after updates", e );
         }
     }
 

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextUpdateApplier.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextUpdateApplier.java
@@ -51,7 +51,7 @@ class FulltextUpdateApplier
     private final ApplierThread workerThread;
     private final Log log;
 
-    public FulltextUpdateApplier( Log log )
+    FulltextUpdateApplier( Log log )
     {
         this.log = log;
         workQueue = new LinkedBlockingQueue<>();
@@ -216,7 +216,7 @@ class FulltextUpdateApplier
         private LinkedBlockingQueue<FulltextIndexUpdate> workQueue;
         private final Log log;
 
-        public ApplierThread( LinkedBlockingQueue<FulltextIndexUpdate> workQueue, Log log )
+        ApplierThread( LinkedBlockingQueue<FulltextIndexUpdate> workQueue, Log log )
         {
             super( "Fulltext Index Add-On Applier Thread" );
             this.workQueue = workQueue;

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextUpdateApplier.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextUpdateApplier.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.fulltext;
+
+import org.apache.lucene.document.Document;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.neo4j.concurrent.BinaryLatch;
+import org.neo4j.graphdb.Entity;
+import org.neo4j.graphdb.event.PropertyEntry;
+import org.neo4j.helpers.collection.Pair;
+import org.neo4j.kernel.api.impl.schema.writer.PartitionedIndexWriter;
+import org.neo4j.logging.Log;
+
+import static org.neo4j.kernel.api.impl.fulltext.LuceneFulltextDocumentStructure.documentRepresentingProperties;
+import static org.neo4j.kernel.api.impl.fulltext.LuceneFulltextDocumentStructure.newTermForChangeOrRemove;
+
+class FulltextUpdateApplier
+{
+    private static final FulltextIndexUpdate STOP_SIGNAL = () -> null;
+    private final LinkedBlockingQueue<FulltextIndexUpdate> workQueue;
+    private final ApplierThread workerThread;
+    private final Log log;
+
+    public FulltextUpdateApplier( Log log )
+    {
+        this.log = log;
+        workQueue = new LinkedBlockingQueue<>();
+        workerThread = new ApplierThread( workQueue, log );
+    }
+
+    <E extends Entity> BinaryLatch updatePropertyData( Map<Long,Map<String,Object>> state, WritableFulltext index ) throws
+            IOException
+    {
+        BinaryLatch completedLatch = new BinaryLatch();
+        FulltextIndexUpdate update = () ->
+        {
+            for ( Map.Entry<Long,Map<String,Object>> stateEntry : state.entrySet() )
+            {
+                Set<String> indexedProperties = index.properties();
+                if ( !Collections.disjoint( indexedProperties, stateEntry.getValue().keySet() ) )
+                {
+                    long entityId = stateEntry.getKey();
+                    Stream<Map.Entry<String,Object>> entryStream = stateEntry.getValue().entrySet().stream();
+                    Predicate<Map.Entry<String,Object>> relevantForIndex =
+                            entry -> indexedProperties.contains( entry.getKey() );
+                    Map<String,Object> allProperties = entryStream.filter( relevantForIndex ).collect(
+                            Collectors.toMap( Map.Entry::getKey, Map.Entry::getValue ) );
+
+                    if ( !allProperties.isEmpty() )
+                    {
+                        Document document = documentRepresentingProperties( entityId, allProperties );
+                        PartitionedIndexWriter indexWriter = index.getIndexWriter();
+                        indexWriter.updateDocument( newTermForChangeOrRemove( entityId ), document );
+                    }
+                }
+            }
+            return Pair.of( index, completedLatch );
+        };
+
+        enqueueUpdate( update );
+        return completedLatch;
+    }
+
+    <E extends Entity> BinaryLatch removePropertyData( Iterable<PropertyEntry<E>> propertyEntries,
+                                                Map<Long,Map<String,Object>> state,
+                                                WritableFulltext index ) throws IOException
+    {
+        BinaryLatch completedLatch = new BinaryLatch();
+        FulltextIndexUpdate update = () ->
+        {
+            for ( PropertyEntry<E> propertyEntry : propertyEntries )
+            {
+                if ( index.properties().contains( propertyEntry.key() ) )
+                {
+                    long entityId = propertyEntry.entity().getId();
+                    Map<String,Object> allProperties = state.get( entityId );
+                    if ( allProperties == null || allProperties.isEmpty() )
+                    {
+                        index.getIndexWriter().deleteDocuments( newTermForChangeOrRemove( entityId ) );
+                    }
+                }
+            }
+            return Pair.of( index, completedLatch );
+        };
+
+        enqueueUpdate( update );
+        return completedLatch;
+    }
+
+    private void enqueueUpdate( FulltextIndexUpdate update ) throws IOException
+    {
+        try
+        {
+            workQueue.put( update );
+        }
+        catch ( InterruptedException e )
+        {
+            throw new IOException( "Fulltext index update failed.", e );
+        }
+    }
+
+    public void start()
+    {
+        workerThread.start();
+    }
+
+    public void stop()
+    {
+        boolean enqueued;
+        do
+        {
+            enqueued = workQueue.offer( STOP_SIGNAL );
+        }
+        while ( !enqueued );
+
+        try
+        {
+            workerThread.join();
+        }
+        catch ( InterruptedException e )
+        {
+            log.error( "Interrupted before " + workerThread.getName() + " could shut down.", e );
+        }
+    }
+
+    private interface FulltextIndexUpdate
+    {
+        Pair<WritableFulltext, BinaryLatch> applyUpdateAndReturnIndex() throws IOException;
+    }
+
+    private static class ApplierThread extends Thread
+    {
+        private LinkedBlockingQueue<FulltextIndexUpdate> workQueue;
+        private final Log log;
+
+        public ApplierThread( LinkedBlockingQueue<FulltextIndexUpdate> workQueue, Log log )
+        {
+            super( "Fulltext Index Add-On Applier Thread" );
+            this.workQueue = workQueue;
+            this.log = log;
+            setDaemon( true );
+        }
+
+        @Override
+        public void run()
+        {
+            FulltextIndexUpdate update;
+            while ( (update = getNextUpdate()) != STOP_SIGNAL )
+            {
+                Pair<WritableFulltext,BinaryLatch> updateProgress = applyUpdate( update );
+                refreshIndex( updateProgress.first() );
+                updateProgress.other().release();
+            }
+        }
+
+        private FulltextIndexUpdate getNextUpdate()
+        {
+            FulltextIndexUpdate update = null;
+            do
+            {
+                try
+                {
+                    update = workQueue.take();
+                }
+                catch ( InterruptedException e )
+                {
+                    log.debug( getName() + " decided to ignore an interrupt.", e );
+                }
+            }
+            while ( update == null );
+            return update;
+        }
+
+        private Pair<WritableFulltext,BinaryLatch> applyUpdate( FulltextIndexUpdate update )
+        {
+            try
+            {
+                return update.applyUpdateAndReturnIndex();
+            }
+            catch ( IOException e )
+            {
+                log.error( "Failed to apply fulltext index update.", e );
+            }
+            return null;
+        }
+
+        private void refreshIndex( WritableFulltext index )
+        {
+            try
+            {
+                if ( index != null )
+                {
+                    index.maybeRefreshBlocking();
+                }
+            }
+            catch ( IOException e )
+            {
+                log.error( "Failed to refresh fulltext after updates", e );
+            }
+        }
+    }
+}

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextUpdateApplier.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextUpdateApplier.java
@@ -123,6 +123,13 @@ class FulltextUpdateApplier
         return completedLatch;
     }
 
+    BinaryLatch writeBarrier() throws IOException
+    {
+        BinaryLatch barrierLatch = new BinaryLatch();
+        enqueueUpdate( () -> Pair.of( null, barrierLatch ) );
+        return barrierLatch;
+    }
+
     BinaryLatch populateNodes( WritableFulltext index, GraphDatabaseService db ) throws IOException
     {
         return enqueuePopulateIndex( index, db, db::getAllNodes );

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextUpdateApplier.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextUpdateApplier.java
@@ -46,6 +46,7 @@ import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.api.impl.schema.writer.PartitionedIndexWriter;
 import org.neo4j.logging.Log;
 
+import static org.neo4j.kernel.api.impl.fulltext.LuceneFulltextDocumentStructure.documentForPopulation;
 import static org.neo4j.kernel.api.impl.fulltext.LuceneFulltextDocumentStructure.documentRepresentingProperties;
 import static org.neo4j.kernel.api.impl.fulltext.LuceneFulltextDocumentStructure.newTermForChangeOrRemove;
 
@@ -168,7 +169,7 @@ class FulltextUpdateApplier
                     Map<String,Object> properties = entity.getProperties( indexedPropertyKeys );
                     if ( !properties.isEmpty() )
                     {
-                        documents.add( documentRepresentingProperties( entityId, properties ) );
+                        documents.add( documentForPopulation( entityId, properties ) );
                     }
 
                     if ( documents.size() > POPULATING_BATCH_SIZE )

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextUpdateApplier.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextUpdateApplier.java
@@ -286,7 +286,7 @@ class FulltextUpdateApplier
             {
                 isAvailable = availabilityGuard.isAvailable( 100 );
             }
-            while ( !isAvailable && !availabilityGuard.isShutdown() );
+            while ( !isAvailable );
         }
 
         private FulltextIndexUpdate drainQueueAndApplyUpdates(

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextUpdateApplier.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextUpdateApplier.java
@@ -24,7 +24,7 @@ import org.apache.lucene.document.Document;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.IdentityHashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -271,7 +271,7 @@ class FulltextUpdateApplier
         {
             Thread.currentThread().setName( APPLIER_THREAD_NAME );
             waitForDatabaseToBeAvailable();
-            Set<WritableFulltext> refreshableSet = Collections.newSetFromMap( new IdentityHashMap<>() );
+            Set<WritableFulltext> refreshableSet = new HashSet<>();
             List<BinaryLatch> latches = new ArrayList<>();
 
             FulltextIndexUpdate update;

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextUpdateApplier.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/FulltextUpdateApplier.java
@@ -5,17 +5,17 @@
  * This file is part of Neo4j.
  *
  * Neo4j is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * GNU Affero General Public License for more details.
  *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 package org.neo4j.kernel.api.impl.fulltext;
 

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/LuceneFulltextDocumentStructure.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/LuceneFulltextDocumentStructure.java
@@ -36,7 +36,6 @@ import static org.apache.lucene.document.Field.Store.NO;
 
 class LuceneFulltextDocumentStructure
 {
-
     private static final ThreadLocal<DocWithId> perThreadDocument = ThreadLocal.withInitial( DocWithId::new );
 
     private LuceneFulltextDocumentStructure()
@@ -60,14 +59,6 @@ class LuceneFulltextDocumentStructure
     static Field encodeValueField( String propertyKey, Value value )
     {
         return LuceneFulltextFieldEncoding.encodeField( propertyKey, value );
-    }
-
-    public static Document documentForPopulation( long entityId, Map<String,Object> properties )
-    {
-        DocWithId docWithId = new DocWithId();
-        docWithId.setId( entityId );
-        docWithId.setValues( properties );
-        return docWithId.document;
     }
 
     private static class DocWithId

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/LuceneFulltextDocumentStructure.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/LuceneFulltextDocumentStructure.java
@@ -62,6 +62,14 @@ class LuceneFulltextDocumentStructure
         return LuceneFulltextFieldEncoding.encodeField( propertyKey, value );
     }
 
+    public static Document documentForPopulation( long entityId, Map<String,Object> properties )
+    {
+        DocWithId docWithId = new DocWithId();
+        docWithId.setId( entityId );
+        docWithId.setValues( properties );
+        return docWithId.document;
+    }
+
     private static class DocWithId
     {
         private final Document document;

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/WritableFulltext.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/WritableFulltext.java
@@ -27,17 +27,14 @@ import org.neo4j.kernel.api.impl.schema.writer.PartitionedIndexWriter;
 
 class WritableFulltext extends WritableAbstractDatabaseIndex<LuceneFulltext>
 {
-    private final LuceneFulltext luceneFulltext;
-
     WritableFulltext( LuceneFulltext luceneFulltext )
     {
         super( luceneFulltext );
-        this.luceneFulltext = luceneFulltext;
     }
 
     PartitionedIndexWriter getIndexWriter() throws IOException
     {
-        return luceneFulltext.getIndexWriter( this );
+        return luceneIndex.getIndexWriter( this );
     }
 
     Set<String> properties()

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/WritableFulltext.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/WritableFulltext.java
@@ -20,11 +20,9 @@
 package org.neo4j.kernel.api.impl.fulltext;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Set;
 
 import org.neo4j.kernel.api.impl.index.WritableAbstractDatabaseIndex;
-import org.neo4j.kernel.api.impl.index.partition.AbstractIndexPartition;
 import org.neo4j.kernel.api.impl.schema.writer.PartitionedIndexWriter;
 
 class WritableFulltext extends WritableAbstractDatabaseIndex<LuceneFulltext>

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/WritableFulltext.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/WritableFulltext.java
@@ -27,14 +27,18 @@ import org.neo4j.kernel.api.impl.schema.writer.PartitionedIndexWriter;
 
 class WritableFulltext extends WritableAbstractDatabaseIndex<LuceneFulltext>
 {
-    WritableFulltext( LuceneFulltext luceneFulltext )
+
+    private PartitionedIndexWriter indexWriter;
+
+    WritableFulltext( LuceneFulltext luceneFulltext ) throws IOException
     {
         super( luceneFulltext );
+        indexWriter = luceneIndex.getIndexWriter( this );
     }
 
-    PartitionedIndexWriter getIndexWriter() throws IOException
+    PartitionedIndexWriter getIndexWriter()
     {
-        return luceneIndex.getIndexWriter( this );
+        return indexWriter;
     }
 
     Set<String> properties()

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomKernelExtension.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomKernelExtension.java
@@ -69,6 +69,7 @@ class BloomKernelExtension extends LifecycleAdapter
         fulltextFactory.createFulltextIndex( BLOOM_NODES, FulltextProvider.FulltextIndexType.NODES, properties, provider );
         fulltextFactory.createFulltextIndex( BLOOM_RELATIONSHIPS, FulltextProvider.FulltextIndexType.RELATIONSHIPS, properties, provider );
 
+        provider.init();
         procedures.registerComponent( FulltextProvider.class, context -> provider, true );
         procedures.registerProcedure( BloomProcedures.class );
     }

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomKernelExtensionFactory.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomKernelExtensionFactory.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.api.impl.fulltext.integrations.bloom;
 
+import java.io.File;
+
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.AvailabilityGuard;
@@ -28,11 +30,12 @@ import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.spi.KernelContext;
 import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.scheduler.JobScheduler;
 
 /**
  * A {@link KernelExtensionFactory} for the bloom fulltext addon.
  *
- * @see BloomProcedure
+ * @see BloomProcedures
  * @see LoadableBloomFulltextConfig
  */
 public class BloomKernelExtensionFactory extends KernelExtensionFactory<BloomKernelExtensionFactory.Dependencies>
@@ -53,6 +56,8 @@ public class BloomKernelExtensionFactory extends KernelExtensionFactory<BloomKer
         LogService logService();
 
         AvailabilityGuard availabilityGuard();
+
+        JobScheduler scheduler();
     }
 
     BloomKernelExtensionFactory()
@@ -63,7 +68,15 @@ public class BloomKernelExtensionFactory extends KernelExtensionFactory<BloomKer
     @Override
     public Lifecycle newInstance( KernelContext context, Dependencies dependencies ) throws Throwable
     {
-        return new BloomKernelExtension( dependencies.fileSystem(), context.storeDir(), dependencies.getConfig(), dependencies.db(),
-                dependencies.procedures(), dependencies.logService(), dependencies.availabilityGuard() );
+        FileSystemAbstraction fs = dependencies.fileSystem();
+        File storeDir = context.storeDir();
+        Config config = dependencies.getConfig();
+        GraphDatabaseService db = dependencies.db();
+        Procedures procedures = dependencies.procedures();
+        LogService logService = dependencies.logService();
+        AvailabilityGuard availabilityGuard = dependencies.availabilityGuard();
+        JobScheduler scheduler = dependencies.scheduler();
+        return new BloomKernelExtension(
+                fs, storeDir, config, db, procedures, logService, availabilityGuard, scheduler );
     }
 }

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomKernelExtensionFactory.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomKernelExtensionFactory.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.api.impl.fulltext.integrations.bloom;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.logging.LogService;
@@ -50,6 +51,8 @@ public class BloomKernelExtensionFactory extends KernelExtensionFactory<BloomKer
         Procedures procedures();
 
         LogService logService();
+
+        AvailabilityGuard availabilityGuard();
     }
 
     BloomKernelExtensionFactory()
@@ -61,6 +64,6 @@ public class BloomKernelExtensionFactory extends KernelExtensionFactory<BloomKer
     public Lifecycle newInstance( KernelContext context, Dependencies dependencies ) throws Throwable
     {
         return new BloomKernelExtension( dependencies.fileSystem(), context.storeDir(), dependencies.getConfig(), dependencies.db(),
-                dependencies.procedures(), dependencies.logService() );
+                dependencies.procedures(), dependencies.logService(), dependencies.availabilityGuard() );
     }
 }

--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomProcedures.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomProcedures.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.api.impl.fulltext.integrations.bloom;
 
+import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Spliterator;
@@ -46,6 +47,13 @@ public class BloomProcedures
 {
     @Context
     public FulltextProvider provider;
+
+    @Description( "Await the completion of any background index population or updates" )
+    @Procedure( name = "db.fulltext.bloomAwaitPopulation", mode = READ )
+    public void awaitPopulation() throws IOException
+    {
+        provider.awaitPopulation();
+    }
 
     @Description( "Queries the bloom index for nodes" )
     @Procedure( name = "db.fulltext.bloomFulltextNodes", mode = READ )

--- a/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/FulltextAnalyzerTest.java
+++ b/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/FulltextAnalyzerTest.java
@@ -63,6 +63,7 @@ public class FulltextAnalyzerTest
         try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ); )
         {
             fulltextFactory.createFulltextIndex( "bloomNodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
+            provider.init();
 
             long firstID;
             long secondID;
@@ -100,6 +101,7 @@ public class FulltextAnalyzerTest
         try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ); )
         {
             fulltextFactory.createFulltextIndex( "bloomNodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
+            provider.init();
 
             long firstID;
             long secondID;

--- a/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/LuceneFulltextUpdaterTest.java
+++ b/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/LuceneFulltextUpdaterTest.java
@@ -24,6 +24,7 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.time.Clock;
 import java.util.Arrays;
 
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
@@ -32,23 +33,26 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.kernel.impl.logging.LogService;
-import org.neo4j.kernel.impl.logging.NullLogService;
+import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.NullLog;
 import org.neo4j.test.rule.DatabaseRule;
 import org.neo4j.test.rule.EmbeddedDatabaseRule;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 import org.neo4j.test.rule.fs.FileSystemRule;
 
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.neo4j.kernel.api.impl.fulltext.FulltextProvider.FulltextIndexType;
+import static org.neo4j.kernel.api.impl.fulltext.FulltextProvider.FulltextIndexType.NODES;
+import static org.neo4j.kernel.api.impl.fulltext.FulltextProvider.FulltextIndexType.RELATIONSHIPS;
 
 public class LuceneFulltextUpdaterTest
 {
     public static final StandardAnalyzer ANALYZER = new StandardAnalyzer();
-    private static final LogService LOG_SERVICE = NullLogService.getInstance();
+    private static final Log LOG = NullLog.getInstance();
 
     @ClassRule
     public static FileSystemRule fileSystemRule = new DefaultFileSystemRule();
@@ -60,15 +64,17 @@ public class LuceneFulltextUpdaterTest
     private static final Label LABEL = Label.label( "label" );
     private static final RelationshipType RELTYPE = RelationshipType.withName( "type" );
 
+    private AvailabilityGuard availabilityGuard = new AvailabilityGuard( Clock.systemDefaultZone(), LOG );
+
     @Test
     public void shouldFindNodeWithString() throws Exception
     {
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
         FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
         {
-            fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
+            fulltextFactory.createFulltextIndex( "nodes", NODES, singletonList( "prop" ), provider );
             provider.init();
 
             long firstID;
@@ -86,7 +92,7 @@ public class LuceneFulltextUpdaterTest
                 tx.success();
             }
 
-            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", FulltextIndexType.NODES ) )
+            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", NODES ) )
             {
 
                 assertEquals( firstID, reader.query( "hello" ).next() );
@@ -103,9 +109,9 @@ public class LuceneFulltextUpdaterTest
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
         FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
         {
-            fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
+            fulltextFactory.createFulltextIndex( "nodes", NODES, singletonList( "prop" ), provider );
             provider.init();
 
             long firstID;
@@ -122,7 +128,7 @@ public class LuceneFulltextUpdaterTest
                 tx.success();
             }
 
-            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", FulltextIndexType.NODES ) )
+            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", NODES ) )
             {
                 PrimitiveLongIterator node1prop = reader.query( "1" );
                 assertEquals( firstID, node1prop.next() );
@@ -140,9 +146,9 @@ public class LuceneFulltextUpdaterTest
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
         FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
         {
-            fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
+            fulltextFactory.createFulltextIndex( "nodes", NODES, singletonList( "prop" ), provider );
             provider.init();
 
             long firstID;
@@ -159,7 +165,7 @@ public class LuceneFulltextUpdaterTest
                 tx.success();
             }
 
-            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", FulltextIndexType.NODES ) )
+            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", NODES ) )
             {
                 PrimitiveLongIterator sant = reader.query( "true" );
                 assertEquals( firstID, sant.next() );
@@ -177,9 +183,9 @@ public class LuceneFulltextUpdaterTest
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
         FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
         {
-            fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
+            fulltextFactory.createFulltextIndex( "nodes", NODES, singletonList( "prop" ), provider );
             provider.init();
 
             long firstID;
@@ -200,7 +206,7 @@ public class LuceneFulltextUpdaterTest
                 tx.success();
             }
 
-            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", FulltextIndexType.NODES ) )
+            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", NODES ) )
             {
                 PrimitiveLongIterator strings = reader.query( "live" );
                 assertEquals( firstID, strings.next() );
@@ -222,9 +228,9 @@ public class LuceneFulltextUpdaterTest
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
         FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
         {
-            fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
+            fulltextFactory.createFulltextIndex( "nodes", NODES, singletonList( "prop" ), provider );
             provider.init();
 
             long firstID;
@@ -251,7 +257,7 @@ public class LuceneFulltextUpdaterTest
                 tx.success();
             }
 
-            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", FulltextIndexType.NODES ) )
+            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", NODES ) )
             {
 
                 assertFalse( reader.query( "hello" ).hasNext() );
@@ -273,9 +279,9 @@ public class LuceneFulltextUpdaterTest
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
         FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
         {
-            fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
+            fulltextFactory.createFulltextIndex( "nodes", NODES, singletonList( "prop" ), provider );
             provider.init();
 
             long firstID;
@@ -301,7 +307,7 @@ public class LuceneFulltextUpdaterTest
                 tx.success();
             }
 
-            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", FulltextIndexType.NODES ) )
+            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", NODES ) )
             {
 
                 assertFalse( reader.query( "hello" ).hasNext() );
@@ -318,9 +324,9 @@ public class LuceneFulltextUpdaterTest
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
         FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
         {
-            fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop", "prop2" ), provider );
+            fulltextFactory.createFulltextIndex( "nodes", NODES, Arrays.asList( "prop", "prop2" ), provider );
             provider.init();
 
             long firstID;
@@ -364,7 +370,7 @@ public class LuceneFulltextUpdaterTest
                 tx.success();
             }
 
-            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", FulltextIndexType.NODES ) )
+            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", NODES ) )
             {
 
                 PrimitiveLongIterator hello = reader.query( "hello" );
@@ -383,9 +389,9 @@ public class LuceneFulltextUpdaterTest
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
         FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
         {
-            fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
+            fulltextFactory.createFulltextIndex( "nodes", NODES, singletonList( "prop" ), provider );
             provider.init();
 
             long firstID;
@@ -402,7 +408,7 @@ public class LuceneFulltextUpdaterTest
                 tx.success();
             }
 
-            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", FulltextIndexType.NODES ) )
+            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", NODES ) )
             {
 
                 PrimitiveLongIterator hello = reader.query( "hello" );
@@ -419,9 +425,9 @@ public class LuceneFulltextUpdaterTest
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
         FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
         {
-            fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop", "prop2" ), provider );
+            fulltextFactory.createFulltextIndex( "nodes", NODES, Arrays.asList( "prop", "prop2" ), provider );
             provider.init();
 
             long firstID;
@@ -444,7 +450,7 @@ public class LuceneFulltextUpdaterTest
             }
 
             PrimitiveLongIterator iterator;
-            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", FulltextIndexType.NODES ) )
+            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", NODES ) )
             {
 
                 iterator = reader.query( "tomtar", "karl" );
@@ -461,9 +467,9 @@ public class LuceneFulltextUpdaterTest
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
         FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
         {
-            fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "first", "last" ), provider );
+            fulltextFactory.createFulltextIndex( "nodes", NODES, Arrays.asList( "first", "last" ), provider );
             provider.init();
 
             long firstID;
@@ -492,7 +498,7 @@ public class LuceneFulltextUpdaterTest
                 tx.success();
             }
 
-            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", FulltextIndexType.NODES ) )
+            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", NODES ) )
             {
 
                 PrimitiveLongIterator iterator = reader.query( "Tom", "Hanks" );
@@ -510,10 +516,10 @@ public class LuceneFulltextUpdaterTest
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
         FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
         {
-            fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
-            fulltextFactory.createFulltextIndex( "relationships", FulltextIndexType.RELATIONSHIPS, Arrays.asList( "prop" ), provider );
+            fulltextFactory.createFulltextIndex( "nodes", NODES, singletonList( "prop" ), provider );
+            fulltextFactory.createFulltextIndex( "relationships", RELATIONSHIPS, singletonList( "prop" ), provider );
             provider.init();
 
             long firstNodeID;
@@ -539,7 +545,7 @@ public class LuceneFulltextUpdaterTest
                 tx.success();
             }
 
-            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", FulltextIndexType.NODES ) )
+            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", NODES ) )
             {
 
                 PrimitiveLongIterator hello = reader.query( "hello" );
@@ -551,7 +557,7 @@ public class LuceneFulltextUpdaterTest
                 PrimitiveLongIterator different = reader.query( "different" );
                 assertFalse( different.hasNext() );
             }
-            try ( ReadOnlyFulltext reader = provider.getReader( "relationships", FulltextIndexType.RELATIONSHIPS ) )
+            try ( ReadOnlyFulltext reader = provider.getReader( "relationships", RELATIONSHIPS ) )
             {
 
                 PrimitiveLongIterator hello = reader.query( "hello" );
@@ -572,9 +578,9 @@ public class LuceneFulltextUpdaterTest
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
         FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
         {
-            fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
+            fulltextFactory.createFulltextIndex( "nodes", NODES, singletonList( "prop" ), provider );
             provider.init();
 
             long firstID;
@@ -592,7 +598,7 @@ public class LuceneFulltextUpdaterTest
                 tx.success();
             }
 
-            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", FulltextIndexType.NODES ) )
+            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", NODES ) )
             {
 
                 assertEquals( firstID, reader.fuzzyQuery( "hella" ).next() );
@@ -613,9 +619,9 @@ public class LuceneFulltextUpdaterTest
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
         FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
         {
-            fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
+            fulltextFactory.createFulltextIndex( "nodes", NODES, singletonList( "prop" ), provider );
             provider.init();
 
             long firstID;
@@ -640,7 +646,7 @@ public class LuceneFulltextUpdaterTest
                 tx.success();
             }
 
-            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", FulltextIndexType.NODES ) )
+            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", NODES ) )
             {
 
                 PrimitiveLongIterator zebra = reader.fuzzyQuery( "zebra" );
@@ -659,10 +665,10 @@ public class LuceneFulltextUpdaterTest
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
         FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
         {
-            fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
-            fulltextFactory.createFulltextIndex( "relationships", FulltextIndexType.RELATIONSHIPS, Arrays.asList( "prop" ), provider );
+            fulltextFactory.createFulltextIndex( "nodes", NODES, singletonList( "prop" ), provider );
+            fulltextFactory.createFulltextIndex( "relationships", RELATIONSHIPS, singletonList( "prop" ), provider );
             provider.init();
 
             try ( Transaction tx = db.beginTx() )
@@ -680,12 +686,12 @@ public class LuceneFulltextUpdaterTest
 
                 tx.success();
             }
-            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", FulltextIndexType.NODES ) )
+            try ( ReadOnlyFulltext reader = provider.getReader( "nodes", NODES ) )
             {
                 PrimitiveLongIterator zebra = reader.query( "zebra" );
                 assertFalse( zebra.hasNext() );
             }
-            try ( ReadOnlyFulltext reader = provider.getReader( "relationships", FulltextIndexType.RELATIONSHIPS ) )
+            try ( ReadOnlyFulltext reader = provider.getReader( "relationships", RELATIONSHIPS ) )
             {
 
                 PrimitiveLongIterator zebra = reader.query( "zebra" );

--- a/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/LuceneFulltextUpdaterTest.java
+++ b/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/LuceneFulltextUpdaterTest.java
@@ -69,6 +69,7 @@ public class LuceneFulltextUpdaterTest
         try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
+            provider.init();
 
             long firstID;
             long secondID;
@@ -105,6 +106,7 @@ public class LuceneFulltextUpdaterTest
         try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
+            provider.init();
 
             long firstID;
             long secondID;
@@ -141,6 +143,7 @@ public class LuceneFulltextUpdaterTest
         try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
+            provider.init();
 
             long firstID;
             long secondID;
@@ -177,6 +180,7 @@ public class LuceneFulltextUpdaterTest
         try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
+            provider.init();
 
             long firstID;
             long secondID;
@@ -221,6 +225,7 @@ public class LuceneFulltextUpdaterTest
         try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
+            provider.init();
 
             long firstID;
             long secondID;
@@ -271,6 +276,7 @@ public class LuceneFulltextUpdaterTest
         try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
+            provider.init();
 
             long firstID;
             long secondID;
@@ -315,6 +321,7 @@ public class LuceneFulltextUpdaterTest
         try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop", "prop2" ), provider );
+            provider.init();
 
             long firstID;
             long secondID;
@@ -379,6 +386,7 @@ public class LuceneFulltextUpdaterTest
         try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
+            provider.init();
 
             long firstID;
             try ( Transaction tx = db.beginTx() )
@@ -414,6 +422,7 @@ public class LuceneFulltextUpdaterTest
         try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop", "prop2" ), provider );
+            provider.init();
 
             long firstID;
             long secondID;
@@ -455,6 +464,7 @@ public class LuceneFulltextUpdaterTest
         try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "first", "last" ), provider );
+            provider.init();
 
             long firstID;
             long secondID;
@@ -504,6 +514,7 @@ public class LuceneFulltextUpdaterTest
         {
             fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
             fulltextFactory.createFulltextIndex( "relationships", FulltextIndexType.RELATIONSHIPS, Arrays.asList( "prop" ), provider );
+            provider.init();
 
             long firstNodeID;
             long secondNodeID;
@@ -564,6 +575,7 @@ public class LuceneFulltextUpdaterTest
         try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
+            provider.init();
 
             long firstID;
             long secondID;
@@ -604,6 +616,7 @@ public class LuceneFulltextUpdaterTest
         try ( FulltextProvider provider = new FulltextProvider( db, LOG_SERVICE.getInternalLog( FulltextProvider.class ) ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
+            provider.init();
 
             long firstID;
             long secondID;
@@ -650,6 +663,7 @@ public class LuceneFulltextUpdaterTest
         {
             fulltextFactory.createFulltextIndex( "nodes", FulltextIndexType.NODES, Arrays.asList( "prop" ), provider );
             fulltextFactory.createFulltextIndex( "relationships", FulltextIndexType.RELATIONSHIPS, Arrays.asList( "prop" ), provider );
+            provider.init();
 
             try ( Transaction tx = db.beginTx() )
             {

--- a/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/LuceneFulltextUpdaterTest.java
+++ b/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/LuceneFulltextUpdaterTest.java
@@ -20,10 +20,10 @@
 package org.neo4j.kernel.api.impl.fulltext;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.io.File;
 import java.time.Clock;
 import java.util.Arrays;
 
@@ -33,15 +33,14 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.NullLog;
+import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.test.rule.DatabaseRule;
 import org.neo4j.test.rule.EmbeddedDatabaseRule;
-import org.neo4j.test.rule.TestDirectory;
-import org.neo4j.test.rule.fs.DefaultFileSystemRule;
-import org.neo4j.test.rule.fs.FileSystemRule;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
@@ -54,10 +53,6 @@ public class LuceneFulltextUpdaterTest
     public static final StandardAnalyzer ANALYZER = new StandardAnalyzer();
     private static final Log LOG = NullLog.getInstance();
 
-    @ClassRule
-    public static FileSystemRule fileSystemRule = new DefaultFileSystemRule();
-    @Rule
-    public TestDirectory testDirectory = TestDirectory.testDirectory( fileSystemRule );
     @Rule
     public DatabaseRule dbRule = new EmbeddedDatabaseRule().startLazily();
 
@@ -70,9 +65,12 @@ public class LuceneFulltextUpdaterTest
     public void shouldFindNodeWithString() throws Exception
     {
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
-        FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
+        JobScheduler scheduler = dbRule.resolveDependency( JobScheduler.class );
+        FileSystemAbstraction fs = dbRule.resolveDependency( FileSystemAbstraction.class );
+        File storeDir = dbRule.getStoreDir();
+        FulltextFactory fulltextFactory = new FulltextFactory( fs, storeDir, ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard, scheduler ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", NODES, singletonList( "prop" ), provider );
             provider.init();
@@ -107,9 +105,12 @@ public class LuceneFulltextUpdaterTest
     public void shouldFindNodeWithNumber() throws Exception
     {
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
-        FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
+        JobScheduler scheduler = dbRule.resolveDependency( JobScheduler.class );
+        FileSystemAbstraction fs = dbRule.resolveDependency( FileSystemAbstraction.class );
+        File storeDir = dbRule.getStoreDir();
+        FulltextFactory fulltextFactory = new FulltextFactory( fs, storeDir, ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard, scheduler ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", NODES, singletonList( "prop" ), provider );
             provider.init();
@@ -144,9 +145,12 @@ public class LuceneFulltextUpdaterTest
     public void shouldFindNodeWithBoolean() throws Exception
     {
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
-        FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
+        JobScheduler scheduler = dbRule.resolveDependency( JobScheduler.class );
+        FileSystemAbstraction fs = dbRule.resolveDependency( FileSystemAbstraction.class );
+        File storeDir = dbRule.getStoreDir();
+        FulltextFactory fulltextFactory = new FulltextFactory( fs, storeDir, ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard, scheduler ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", NODES, singletonList( "prop" ), provider );
             provider.init();
@@ -181,9 +185,12 @@ public class LuceneFulltextUpdaterTest
     public void shouldFindNodeWithArrays() throws Exception
     {
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
-        FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
+        JobScheduler scheduler = dbRule.resolveDependency( JobScheduler.class );
+        FileSystemAbstraction fs = dbRule.resolveDependency( FileSystemAbstraction.class );
+        File storeDir = dbRule.getStoreDir();
+        FulltextFactory fulltextFactory = new FulltextFactory( fs, storeDir, ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard, scheduler ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", NODES, singletonList( "prop" ), provider );
             provider.init();
@@ -226,9 +233,12 @@ public class LuceneFulltextUpdaterTest
     public void shouldRepresentPropertyChanges() throws Exception
     {
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
-        FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
+        JobScheduler scheduler = dbRule.resolveDependency( JobScheduler.class );
+        FileSystemAbstraction fs = dbRule.resolveDependency( FileSystemAbstraction.class );
+        File storeDir = dbRule.getStoreDir();
+        FulltextFactory fulltextFactory = new FulltextFactory( fs, storeDir, ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard, scheduler ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", NODES, singletonList( "prop" ), provider );
             provider.init();
@@ -277,9 +287,12 @@ public class LuceneFulltextUpdaterTest
     public void shouldNotFindRemovedNodes() throws Exception
     {
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
-        FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
+        JobScheduler scheduler = dbRule.resolveDependency( JobScheduler.class );
+        FileSystemAbstraction fs = dbRule.resolveDependency( FileSystemAbstraction.class );
+        File storeDir = dbRule.getStoreDir();
+        FulltextFactory fulltextFactory = new FulltextFactory( fs, storeDir, ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard, scheduler ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", NODES, singletonList( "prop" ), provider );
             provider.init();
@@ -322,9 +335,12 @@ public class LuceneFulltextUpdaterTest
     public void shouldNotFindRemovedProperties() throws Exception
     {
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
-        FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
+        JobScheduler scheduler = dbRule.resolveDependency( JobScheduler.class );
+        FileSystemAbstraction fs = dbRule.resolveDependency( FileSystemAbstraction.class );
+        File storeDir = dbRule.getStoreDir();
+        FulltextFactory fulltextFactory = new FulltextFactory( fs, storeDir, ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard, scheduler ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", NODES, Arrays.asList( "prop", "prop2" ), provider );
             provider.init();
@@ -387,9 +403,12 @@ public class LuceneFulltextUpdaterTest
     public void shouldOnlyIndexIndexedProperties() throws Exception
     {
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
-        FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
+        JobScheduler scheduler = dbRule.resolveDependency( JobScheduler.class );
+        FileSystemAbstraction fs = dbRule.resolveDependency( FileSystemAbstraction.class );
+        File storeDir = dbRule.getStoreDir();
+        FulltextFactory fulltextFactory = new FulltextFactory( fs, storeDir, ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard, scheduler ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", NODES, singletonList( "prop" ), provider );
             provider.init();
@@ -423,9 +442,12 @@ public class LuceneFulltextUpdaterTest
     public void shouldSearchAcrossMultipleProperties() throws Exception
     {
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
-        FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
+        JobScheduler scheduler = dbRule.resolveDependency( JobScheduler.class );
+        FileSystemAbstraction fs = dbRule.resolveDependency( FileSystemAbstraction.class );
+        File storeDir = dbRule.getStoreDir();
+        FulltextFactory fulltextFactory = new FulltextFactory( fs, storeDir, ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard, scheduler ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", NODES, Arrays.asList( "prop", "prop2" ), provider );
             provider.init();
@@ -465,9 +487,12 @@ public class LuceneFulltextUpdaterTest
     public void shouldOrderResultsBasedOnRelevance() throws Exception
     {
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
-        FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
+        JobScheduler scheduler = dbRule.resolveDependency( JobScheduler.class );
+        FileSystemAbstraction fs = dbRule.resolveDependency( FileSystemAbstraction.class );
+        File storeDir = dbRule.getStoreDir();
+        FulltextFactory fulltextFactory = new FulltextFactory( fs, storeDir, ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard, scheduler ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", NODES, Arrays.asList( "first", "last" ), provider );
             provider.init();
@@ -514,9 +539,12 @@ public class LuceneFulltextUpdaterTest
     public void shouldDifferentiateNodesAndRelationships() throws Exception
     {
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
-        FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
+        JobScheduler scheduler = dbRule.resolveDependency( JobScheduler.class );
+        FileSystemAbstraction fs = dbRule.resolveDependency( FileSystemAbstraction.class );
+        File storeDir = dbRule.getStoreDir();
+        FulltextFactory fulltextFactory = new FulltextFactory( fs, storeDir, ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard, scheduler ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", NODES, singletonList( "prop" ), provider );
             fulltextFactory.createFulltextIndex( "relationships", RELATIONSHIPS, singletonList( "prop" ), provider );
@@ -576,9 +604,12 @@ public class LuceneFulltextUpdaterTest
     public void fuzzyQueryShouldBeFuzzy() throws Exception
     {
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
-        FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
+        JobScheduler scheduler = dbRule.resolveDependency( JobScheduler.class );
+        FileSystemAbstraction fs = dbRule.resolveDependency( FileSystemAbstraction.class );
+        File storeDir = dbRule.getStoreDir();
+        FulltextFactory fulltextFactory = new FulltextFactory( fs, storeDir, ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard, scheduler ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", NODES, singletonList( "prop" ), provider );
             provider.init();
@@ -617,9 +648,12 @@ public class LuceneFulltextUpdaterTest
     public void fuzzyQueryShouldReturnExactMatchesFirst() throws Exception
     {
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
-        FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
+        JobScheduler scheduler = dbRule.resolveDependency( JobScheduler.class );
+        FileSystemAbstraction fs = dbRule.resolveDependency( FileSystemAbstraction.class );
+        File storeDir = dbRule.getStoreDir();
+        FulltextFactory fulltextFactory = new FulltextFactory( fs, storeDir, ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard, scheduler ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", NODES, singletonList( "prop" ), provider );
             provider.init();
@@ -663,9 +697,12 @@ public class LuceneFulltextUpdaterTest
     public void shouldNotReturnNonMatches() throws Exception
     {
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
-        FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
+        JobScheduler scheduler = dbRule.resolveDependency( JobScheduler.class );
+        FileSystemAbstraction fs = dbRule.resolveDependency( FileSystemAbstraction.class );
+        File storeDir = dbRule.getStoreDir();
+        FulltextFactory fulltextFactory = new FulltextFactory( fs, storeDir, ANALYZER );
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard, scheduler ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", NODES, singletonList( "prop" ), provider );
             fulltextFactory.createFulltextIndex( "relationships", RELATIONSHIPS, singletonList( "prop" ), provider );
@@ -704,7 +741,10 @@ public class LuceneFulltextUpdaterTest
     public void shouldPopulateIndexWithExistingNodesAndRelationships() throws Exception
     {
         GraphDatabaseAPI db = dbRule.getGraphDatabaseAPI();
-        FulltextFactory fulltextFactory = new FulltextFactory( fileSystemRule, testDirectory.graphDbDir(), ANALYZER );
+        JobScheduler scheduler = dbRule.resolveDependency( JobScheduler.class );
+        FileSystemAbstraction fs = dbRule.resolveDependency( FileSystemAbstraction.class );
+        File storeDir = dbRule.getStoreDir();
+        FulltextFactory fulltextFactory = new FulltextFactory( fs, storeDir, ANALYZER );
 
         long firstNodeID;
         long secondNodeID;
@@ -730,7 +770,7 @@ public class LuceneFulltextUpdaterTest
             tx.success();
         }
 
-        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard ) )
+        try ( FulltextProvider provider = new FulltextProvider( db, LOG, availabilityGuard, scheduler ) )
         {
             fulltextFactory.createFulltextIndex( "nodes", NODES, singletonList( "prop" ), provider );
             fulltextFactory.createFulltextIndex( "relationships", RELATIONSHIPS, singletonList( "prop" ), provider );

--- a/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomFulltextIndexBenchmarks.java
+++ b/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomFulltextIndexBenchmarks.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.fulltext.integrations.bloom;
+
+import org.junit.After;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+import org.neo4j.test.rule.fs.FileSystemRule;
+
+@Ignore( "These are rudimentary benchmarks, but implemented via the jUnit framework to make them easy to run " +
+         "from an IDE." )
+public class BloomFulltextIndexBenchmarks
+{
+    private static final String[] WORDS =
+            ("dui nunc mattis enim ut tellus elementum sagittis vitae et leo duis ut diam quam nulla porttitor " +
+             "massa id neque aliquam vestibulum morbi blandit cursus risus at ultrices mi tempus imperdiet nulla " +
+             "malesuada pellentesque elit eget gravida cum sociis natoque penatibus et magnis dis parturient " +
+             "montes nascetur ridiculus mus mauris").split( " " );
+
+    @Rule
+    public final FileSystemRule fs = new DefaultFileSystemRule();
+    @Rule
+    public final TestDirectory testDirectory = TestDirectory.testDirectory();
+
+    private TestGraphDatabaseFactory factory;
+    private GraphDatabaseService db;
+
+    private void createTestGraphDatabaseFactory()
+    {
+        factory = new TestGraphDatabaseFactory();
+        factory.setFileSystem( fs.get() );
+    }
+
+    private void configureBloomExtension()
+    {
+        factory.addKernelExtensions( Collections.singletonList( new BloomKernelExtensionFactory() ) );
+    }
+
+    private static void clearAndCreateRandomSentence( ThreadLocalRandom rng, StringBuilder sb )
+    {
+        sb.setLength( 0 );
+        int wordCount = rng.nextInt( 3, 7 );
+        for ( int k = 0; k < wordCount; k++ )
+        {
+            sb.append( WORDS[rng.nextInt( WORDS.length )] ).append( ' ' );
+        }
+        sb.setLength( sb.length() - 1 );
+    }
+
+    @Test
+    public void fiveHundredThousandOnlineUpdates() throws Exception
+    {
+        createTestGraphDatabaseFactory();
+        configureBloomExtension();
+        GraphDatabaseBuilder builder = factory.newEmbeddedDatabaseBuilder( testDirectory.graphDbDir() );
+        builder.setConfig( LoadableBloomFulltextConfig.bloom_indexed_properties, "prop" );
+        db = builder.newGraphDatabase();
+
+        int trials = 50;
+        int threadCount = 10;
+        int updatesPerThread = 1000;
+        int updatesPerIteration = 10;
+        int iterationsPerThread = updatesPerThread / updatesPerIteration;
+
+        Runnable work = () ->
+        {
+            ThreadLocalRandom rng = ThreadLocalRandom.current();
+            StringBuilder sb = new StringBuilder();
+            for ( int i = 0; i < iterationsPerThread; i++ )
+            {
+                try ( Transaction tx = db.beginTx() )
+                {
+                    for ( int j = 0; j < updatesPerIteration; j++ )
+                    {
+                        clearAndCreateRandomSentence( rng, sb );
+                        db.createNode().setProperty( "prop", sb.toString() );
+                    }
+                    tx.success();
+                }
+            }
+        };
+
+        for ( int i = 0; i < trials; i++ )
+        {
+            long startMillis = System.currentTimeMillis();
+            Thread[] threads = new Thread[threadCount];
+            for ( int j = 0; j < threadCount; j++ )
+            {
+                threads[j] = new Thread( work );
+            }
+            for ( Thread thread : threads )
+            {
+                thread.start();
+            }
+            for ( Thread thread : threads )
+            {
+                thread.join();
+            }
+            long elapsedMillis = System.currentTimeMillis() - startMillis;
+            System.out.printf( "online update elapsed: %s ms.%n", elapsedMillis );
+        }
+    }
+
+    @Test
+    public void fiveHundredThousandNodesForPopulation() throws Exception
+    {
+        // First create the data
+        createTestGraphDatabaseFactory();
+        GraphDatabaseBuilder builder = factory.newEmbeddedDatabaseBuilder( testDirectory.graphDbDir() );
+        db = builder.newGraphDatabase();
+        try ( Transaction tx = db.beginTx() )
+        {
+            ThreadLocalRandom rng = ThreadLocalRandom.current();
+            StringBuilder sb = new StringBuilder();
+            for ( int i = 0; i < 500_000; i++ )
+            {
+                clearAndCreateRandomSentence( rng, sb );
+                db.createNode().setProperty( "prop", sb.toString() );
+            }
+            tx.success();
+        }
+        db.shutdown();
+
+        // Then measure startup performance
+        configureBloomExtension();
+        builder = factory.newEmbeddedDatabaseBuilder( testDirectory.graphDbDir() );
+        builder.setConfig( LoadableBloomFulltextConfig.bloom_indexed_properties, "prop" );
+
+        for ( int i = 0; i < 50; i++ )
+        {
+            long startMillis = System.currentTimeMillis();
+            db = builder.newGraphDatabase();
+            db.execute( "CALL db.fulltext.bloomAwaitPopulation" ).close();
+            long elapsedMillis = System.currentTimeMillis() - startMillis;
+            System.out.printf( "startup populate elapsed: %s ms.%n", elapsedMillis );
+            db.shutdown();
+        }
+        db = null;
+    }
+
+    @After
+    public void after() throws Exception
+    {
+        if ( db != null )
+        {
+            db.shutdown();
+        }
+    }
+}

--- a/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomIT.java
+++ b/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomIT.java
@@ -37,6 +37,7 @@ import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.config.InvalidSettingException;
 import org.neo4j.graphdb.config.Setting;
+import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.kernel.api.impl.fulltext.FulltextProvider;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.mockito.matcher.RootCauseMatcher;
@@ -46,6 +47,7 @@ import org.neo4j.test.rule.fs.FileSystemRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class BloomIT
 {
@@ -65,8 +67,18 @@ public class BloomIT
     @Before
     public void before() throws Exception
     {
+        createTestGraphDatabaseFactory();
+        configureBloomExtension();
+    }
+
+    private void createTestGraphDatabaseFactory()
+    {
         factory = new TestGraphDatabaseFactory();
         factory.setFileSystem( fs.get() );
+    }
+
+    private void configureBloomExtension()
+    {
         factory.addKernelExtensions( Collections.singletonList( new BloomKernelExtensionFactory() ) );
     }
 

--- a/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomIT.java
+++ b/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomIT.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.api.impl.fulltext.integrations.bloom;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -28,6 +29,7 @@ import org.junit.rules.ExpectedException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
@@ -312,6 +314,71 @@ public class BloomIT
             {
                 assertThat( Iterators.count( result ), is( 2L ) );
             }
+        }
+    }
+
+    @Ignore( "This is more of a rudimentary write-throughput benchmark, which we can delete or turn into a proper " +
+             "benchmark at a later date")
+    @Test
+    public void fiveHundredThousandUpdates() throws Exception
+    {
+        GraphDatabaseBuilder builder = factory.newEmbeddedDatabaseBuilder( testDirectory.graphDbDir() );
+        builder.setConfig( LoadableBloomFulltextConfig.bloom_indexed_properties, "prop" );
+        db = builder.newGraphDatabase();
+
+        int trials = 50;
+        int threadCount = 10;
+        int updatesPerThread = 1000;
+        int updatesPerIteration = 10;
+        int iterationsPerThread = updatesPerThread / updatesPerIteration;
+        String[] words =
+                ("dui nunc mattis enim ut tellus elementum sagittis vitae et leo duis ut diam quam nulla porttitor " +
+                 "massa id neque aliquam vestibulum morbi blandit cursus risus at ultrices mi tempus imperdiet nulla " +
+                 "malesuada pellentesque elit eget gravida cum sociis natoque penatibus et magnis dis parturient " +
+                 "montes nascetur ridiculus mus mauris").split( " " );
+
+        Runnable work = () ->
+        {
+            ThreadLocalRandom rng = ThreadLocalRandom.current();
+            StringBuilder sb = new StringBuilder();
+            for ( int i = 0; i < iterationsPerThread; i++ )
+            {
+                try ( Transaction tx = db.beginTx() )
+                {
+                    for ( int j = 0; j < updatesPerIteration; j++ )
+                    {
+                        sb.setLength( 0 );
+                        int wordCount = rng.nextInt( 3, 7 );
+                        for ( int k = 0; k < wordCount; k++ )
+                        {
+                            sb.append( words[rng.nextInt( words.length )] ).append( ' ' );
+                        }
+                        sb.setLength( sb.length() - 1 );
+                        db.createNode().setProperty( "prop", sb.toString() );
+                    }
+                    tx.success();
+                }
+            }
+        };
+
+        for ( int i = 0; i < trials; i++ )
+        {
+            long startMillis = System.currentTimeMillis();
+            Thread[] threads = new Thread[threadCount];
+            for ( int j = 0; j < threadCount; j++ )
+            {
+                threads[j] = new Thread( work );
+            }
+            for ( Thread thread : threads )
+            {
+                thread.start();
+            }
+            for ( Thread thread : threads )
+            {
+                thread.join();
+            }
+            long elapsedMillis = System.currentTimeMillis() - startMillis;
+            System.out.printf( "elapsed: %s ms.%n", elapsedMillis );
         }
     }
 

--- a/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomIT.java
+++ b/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomIT.java
@@ -318,7 +318,7 @@ public class BloomIT
     }
 
     @Ignore( "This is more of a rudimentary write-throughput benchmark, which we can delete or turn into a proper " +
-             "benchmark at a later date")
+             "benchmark at a later date" )
     @Test
     public void fiveHundredThousandUpdates() throws Exception
     {

--- a/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomIT.java
+++ b/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomIT.java
@@ -156,12 +156,7 @@ public class BloomIT
         builder.setConfig( LoadableBloomFulltextConfig.bloom_analyzer, "org.apache.lucene.analysis.da.DanishAnalyzer" );
         db = builder.newGraphDatabase();
 
-        try ( Transaction tx = db.beginTx() )
-        {
-            Node node = db.createNode();
-            node.setProperty( "prop", "Something else" ); // To wait for fulltext index population to finish
-            tx.success();
-        }
+        db.execute( "CALL db.fulltext.bloomAwaitPopulation" ).close();
 
         Result result = db.execute( String.format( NODES, "Roskildevej" ) );
         assertTrue( result.hasNext() );

--- a/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomIT.java
+++ b/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomIT.java
@@ -44,7 +44,6 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.mockito.matcher.RootCauseMatcher;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
-import org.neo4j.test.rule.fs.FileSystemRule;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
This builds on #9888, and together with #10014 should give us functional completeness, though we'd ideally like to only rebuild the index when it's strictly necessary, e.g. if relevant configurations have changed.