### PR TITLE
Using a predicate to allow more precise assertions for plans in CypherComparisonSupport

### DIFF
--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryPlanTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryPlanTestSupport.scala
@@ -45,14 +45,17 @@ trait QueryPlanTestSupport {
     }
   }
 
-  def use(operators: String*): Matcher[InternalExecutionResult] = new Matcher[InternalExecutionResult] {
-    override def apply(result: InternalExecutionResult): MatchResult = {
-      val plan: InternalPlanDescription = result.executionPlanDescription()
+  def useOperators(operators: String*): Matcher[InternalPlanDescription] = new Matcher[InternalPlanDescription] {
+    override def apply(plan: InternalPlanDescription): MatchResult = {
       MatchResult(
         matches = operators.forall(plan.find(_).nonEmpty),
         rawFailureMessage = s"Metadata: ${plan.arguments}\nPlan should use ${operators.mkString(",")}:\n$plan",
         rawNegatedFailureMessage = s"Plan should not use ${operators.mkString(",")}:\n$plan")
     }
+  }
+
+  def use(operators: String*): Matcher[InternalExecutionResult] = new Matcher[InternalExecutionResult] {
+    override def apply(result: InternalExecutionResult): MatchResult = useOperators(operators:_*)(result.executionPlanDescription())
   }
 
   def useIndex(otherText: String*): Matcher[InternalExecutionResult] = useOperationWith("NodeIndexSeek", otherText: _*)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
@@ -20,7 +20,7 @@
 package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.ExecutionEngineFunSuite
-import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.{Configs, Planners, Runtimes, TestConfiguration}
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
 import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Versions.{V2_3, V3_2}
 
 class AggregationAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
@@ -42,8 +42,7 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
                    |RETURN id(selectedFriendship) AS friendshipId, selectedFriendship.propFive AS propertyValue""".stripMargin
     val params = Map("param" -> 3)
 
-    val result1 = executeWith(Configs.CommunityInterpreted, query1,
-      expectedDifferentPlans = Configs.AbsolutelyAll - Configs.Cost3_3, params = params).toList
+    val result1 = executeWith(Configs.CommunityInterpreted, query1, params = params).toList
     val result2 = executeWith(Configs.CommunityInterpreted, query2, params = params).toList
 
     result1.size should equal(result2.size)
@@ -63,7 +62,7 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
     createNode("prop"-> Array(42))
     createNode("prop"-> Array(42))
     createNode("prop"-> Array(1337))
-    val result = executeWith(Configs.All, "MATCH (a) RETURN DISTINCT a.prop", expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_2)
+    val result = executeWith(Configs.All, "MATCH (a) RETURN DISTINCT a.prop")
 
     result.toComparableResult.toSet should equal(Set(Map("a.prop" -> List(1337)), Map("a.prop" -> List(42))))
   }
@@ -72,8 +71,7 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
     val node1 = createLabeledNode("Person")
     val node2 = createLabeledNode("Person")
     val node3 = createNode()
-    val result = executeWith(Configs.AllExceptSlotted, "MATCH (a:Person) WITH count(a) as c RETURN c",
-      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 )
+    val result = executeWith(Configs.AllExceptSlotted, "MATCH (a:Person) WITH count(a) as c RETURN c")
     result.toList should equal(List(Map("c" -> 2L)))
   }
 
@@ -101,8 +99,7 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
     val node2 = createNode(Map("prop" -> 2))
     val r1 = relate(node1, node2)
 
-    val result = executeWith(Configs.AllExceptSlotted, "MATCH (a)--(b) RETURN a.prop, count(a) ORDER BY a.prop",
-      expectedDifferentPlans = Configs.AllRulePlanners + TestConfiguration(V2_3 -> V3_2, Planners.all, Runtimes.all))
+    val result = executeWith(Configs.AllExceptSlotted, "MATCH (a)--(b) RETURN a.prop, count(a) ORDER BY a.prop")
     result.toList should equal(List(Map("a.prop" -> 1, "count(a)" -> 1), Map("a.prop" -> 2, "count(a)" -> 1)))
   }
 
@@ -123,7 +120,7 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
   test("combine simple aggregation with sorting (can use node count store)") {
     val node1 = createNode()
     val node2 = createNode()
-    val result = executeWith(Configs.AllExceptSlotted, "MATCH (a) RETURN count(a) ORDER BY count(a)", expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3)
+    val result = executeWith(Configs.AllExceptSlotted, "MATCH (a) RETURN count(a) ORDER BY count(a)")
     result.toList should equal(List(Map("count(a)" -> 2)))
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeIndexAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeIndexAcceptanceTest.scala
@@ -44,7 +44,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
     graph should haveIndexes(":Person(firstname)", ":Person(firstname,lastname)")
 
     // When
-    executeWith(Configs.Procs, "DROP INDEX ON :Person(firstname , lastname)", expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+    executeWith(Configs.Procs, "DROP INDEX ON :Person(firstname , lastname)")
 
     // Then
     graph should haveIndexes(":Person(firstname)")
@@ -59,7 +59,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
     val n3 = createLabeledNode(Map("firstname" -> "Jake", "lastname" -> "Soap"), "User")
 
     // When
-    val result = executeWith(Configs.Interpreted, "MATCH (n:User) WHERE n.lastname = 'Soap' AND n.firstname = 'Joe' RETURN n", expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+    val result = executeWith(Configs.Interpreted, "MATCH (n:User) WHERE n.lastname = 'Soap' AND n.firstname = 'Joe' RETURN n")
 
     // Then
     result should use("NodeIndexSeek")
@@ -99,7 +99,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
     }
 
     // When
-    val result = executeWith(Configs.Interpreted, "MATCH (n:User) WHERE n.lastname = 'Soap' AND n.firstname = 'Joe' RETURN n", expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+    val result = executeWith(Configs.Interpreted, "MATCH (n:User) WHERE n.lastname = 'Soap' AND n.firstname = 'Joe' RETURN n")
 
     // Then
     result should useIndex(":User(firstname,lastname)")
@@ -163,7 +163,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
     graph.createIndex("Person", "firstname", "lastname")
     val n = graph.execute("CREATE (n:Person {firstname:'Joe', lastname:'Soap'}) RETURN n").columnAs("n").next().asInstanceOf[Node]
     graph.execute("MATCH (n:Person) SET n.lastname = 'Bloggs'")
-    val result = executeWith(Configs.Interpreted, "MATCH (n:Person) where n.firstname = 'Joe' and n.lastname = 'Bloggs' RETURN n", expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+    val result = executeWith(Configs.Interpreted, "MATCH (n:Person) where n.firstname = 'Joe' and n.lastname = 'Bloggs' RETURN n")
     result should use("NodeIndexSeek")
     result.toComparableResult should equal(List(Map("n" -> n)))
   }
@@ -173,8 +173,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
     executeWith(Configs.Interpreted - Configs.Cost2_3, "CREATE (n:Person {firstname:'Joe', lastname:'Soap'})")
     graph.createIndex("Person", "firstname")
     graph.createIndex("Person", "firstname", "lastname")
-    val result = executeWith(Configs.Interpreted, "MATCH (n:Person) WHERE n.firstname = 'Joe' AND n.lastname = 'Soap' RETURN n",
-      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+    val result = executeWith(Configs.Interpreted, "MATCH (n:Person) WHERE n.firstname = 'Joe' AND n.lastname = 'Soap' RETURN n")
     result should useIndex(":Person(firstname,lastname)")
   }
 
@@ -193,7 +192,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
             |WHERE n.bar IN [0,1,2,3,4,5,6,7,8,9]
             |  AND n.baz IN [0,1,2,3,4,5,6,7,8,9]
             |RETURN n.idx as x
-            |ORDER BY x""".stripMargin, expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+            |ORDER BY x""".stripMargin)
 
     // Then
     result should useIndex(":Foo(bar,baz)")
@@ -213,7 +212,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
             |WHERE n.bar = 1
             |  AND n.baz IN [0,1,2,3,4,5,6,7,8,9]
             |RETURN n.baz as x
-            |ORDER BY x""".stripMargin, expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+            |ORDER BY x""".stripMargin)
 
     // Then
     result should useIndex(":Foo(bar,baz)")
@@ -233,7 +232,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
             |WHERE n.baz = 1
             |  AND n.bar IN [0,1,2,3,4,5,6,7,8,9]
             |RETURN n.bar as x
-            |ORDER BY x""".stripMargin, expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+            |ORDER BY x""".stripMargin)
 
     // Then
     result should useIndex(":Foo(bar,baz)")
@@ -250,7 +249,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
 
     // Then
     graph should haveIndexes(":L(foo,bar,baz)")
-    val result = executeWith(Configs.Interpreted, "MATCH (n:L {foo: 42, bar: 1337, baz: 1980}) RETURN count(n)", expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+    val result = executeWith(Configs.Interpreted, "MATCH (n:L {foo: 42, bar: 1337, baz: 1980}) RETURN count(n)")
     result.toComparableResult should equal(Seq(Map("count(n)" -> 1)))
     result should useIndex(":L(foo,bar,baz")
   }
@@ -265,15 +264,15 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
 
     // Then
     graph should haveIndexes(":L(foo,bar,baz)")
-    val result = executeWith(Configs.Interpreted, "MATCH (n:L {foo: 42, bar: 1337, baz: 1980}) RETURN count(n)", expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+    val result = executeWith(Configs.Interpreted, "MATCH (n:L {foo: 42, bar: 1337, baz: 1980}) RETURN count(n)")
     result.toComparableResult should equal(Seq(Map("count(n)" -> 1)))
     result should useIndex(":L(foo,bar,baz)")
   }
 
   test("should not fail on multiple attempts to create a composite index") {
     // Given
-    executeWith(Configs.Procs, "CREATE INDEX ON :Person(firstname, lastname)", expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
-    executeWith(Configs.Procs, "CREATE INDEX ON :Person(firstname, lastname)", expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+    executeWith(Configs.Procs, "CREATE INDEX ON :Person(firstname, lastname)")
+    executeWith(Configs.Procs, "CREATE INDEX ON :Person(firstname, lastname)")
   }
 
   test("should not use range queries against a composite index") {
@@ -313,7 +312,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
         val query = s"MATCH (n:User) WHERE $predicates RETURN n"
         val result = try {
           if (valid)
-            executeWith(testConfig, query, expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1)
+            executeWith(testConfig, query)
           else
             executeWith(testConfig, query)
         } catch {
@@ -348,7 +347,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
     val b = createLabeledNode(Map("p1" -> 1, "p2" -> 1), "X")
 
     // 2.3 excluded because the params syntax was not supported in that version
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Version2_3, "match (a), (b:X) where id(a) = $id AND b.p1 = a.p1 AND b.p2 = 1 return b", expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1, params = Map("id" -> a.getId))
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Version2_3, "match (a), (b:X) where id(a) = $id AND b.p1 = a.p1 AND b.p2 = 1 return b", params = Map("id" -> a.getId))
 
     result.toComparableResult should equal(Seq(Map("b" -> b)))
     result should useIndex(":X(p1,p2)")

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeNodeKeyConstraintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeNodeKeyConstraintAcceptanceTest.scala
@@ -287,8 +287,7 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
     val config = TestScenario(Versions.Default, Planners.Default, Interpreted) +
       TestConfiguration(V3_1 -> V3_2, Planners.all, Runtimes.Default) +
       TestConfiguration(Versions(Versions.Default, V2_3), Rule, Runtimes.Default)
-    executeWith(config, "MATCH (p:Person {firstname: 'John', surname: 'Wood'}) REMOVE p.foo".fixNewLines,
-      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
+    executeWith(config, "MATCH (p:Person {firstname: 'John', surname: 'Wood'}) REMOVE p.foo".fixNewLines)
 
     // Then
     graph.inTx {
@@ -305,15 +304,13 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
     val configWhen = TestScenario(Versions.Default, Planners.Default, Interpreted) +
       TestConfiguration(V3_1 -> V3_2, Planners.all, Runtimes.Default) +
       TestConfiguration(Versions(Versions.Default, V2_3), Rule, Runtimes.Default)
-    executeWith(configWhen, "MATCH (p:Person {firstname: 'John', surname: 'Wood'}) DELETE p".fixNewLines,
-      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
+    executeWith(configWhen, "MATCH (p:Person {firstname: 'John', surname: 'Wood'}) DELETE p".fixNewLines)
 
     // Then
     val configThen = TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Slotted)) +
       TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default) +
       TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
-    executeWith(configThen, "MATCH (p:Person {firstname: 'John', surname: 'Wood'}) RETURN p".fixNewLines,
-      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1) shouldBe empty
+    executeWith(configThen, "MATCH (p:Person {firstname: 'John', surname: 'Wood'}) RETURN p".fixNewLines)  shouldBe empty
   }
 
   test("Should be able to remove label when node key constraint") {
@@ -325,14 +322,12 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
     val configWhen = TestScenario(Versions.Default, Planners.Default, Interpreted) +
       TestConfiguration(V3_1 -> V3_2, Planners.all, Runtimes.Default) +
       TestConfiguration(Versions(Versions.Default, V2_3), Rule, Runtimes.Default)
-    executeWith(configWhen, "MATCH (p:Person {firstname: 'John', surname: 'Wood'}) REMOVE p:Person".fixNewLines,
-      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
+    executeWith(configWhen, "MATCH (p:Person {firstname: 'John', surname: 'Wood'}) REMOVE p:Person".fixNewLines)
 
     // Then
     val configThen = TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Slotted)) +
       TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default) +
       TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
-    executeWith(configThen, "MATCH (p:Person {firstname: 'John', surname: 'Wood'}) RETURN p".fixNewLines,
-      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1) shouldBe empty
+    executeWith(configThen, "MATCH (p:Person {firstname: 'John', surname: 'Wood'}) RETURN p".fixNewLines)  shouldBe empty
   }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExplainAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExplainAcceptanceTest.scala
@@ -68,7 +68,7 @@ class ExplainAcceptanceTest extends ExecutionEngineFunSuite with CypherCompariso
                   |
                   |RETURN count(*), count(distinct bknEnd), avg(size(bookings)),avg(size(perDays));""".stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted, query, expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost2_3)
+    val result = executeWith(Configs.CommunityInterpreted, query)
     val plan = result.executionPlanDescription().toString
     result.close()
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExpressionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExpressionAcceptanceTest.scala
@@ -86,7 +86,7 @@ class ExpressionAcceptanceTest extends ExecutionEngineFunSuite with CypherCompar
     relate(actor, createLabeledNode(Map("title" -> "Movie 2"), "Movie"))
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Version2_3, """MATCH (actor:Actor)-->(movie:Movie)
-            |RETURN actor{ .name, movies: collect(movie{.title}) }""".stripMargin, expectedDifferentPlans = Configs.AbsolutelyAll)
+            |RETURN actor{ .name, movies: collect(movie{.title}) }""".stripMargin)
     result.toList should equal(
       List(Map("actor" ->
         Map("name" -> "Actor 1", "movies" -> Seq(

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ForeachAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ForeachAcceptanceTest.scala
@@ -101,8 +101,7 @@ class ForeachAcceptanceTest extends ExecutionEngineFunSuite with CypherCompariso
         |RETURN e.foo, i.foo, p.foo""".stripMargin
 
     // when
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
 
     // then
     assertStats(result, nodesCreated = 2, relationshipsCreated = 1, labelsAdded = 2, propertiesWritten = 3)
@@ -138,8 +137,7 @@ class ForeachAcceptanceTest extends ExecutionEngineFunSuite with CypherCompariso
          |  MERGE (a)-[:FOO]->(b))""".stripMargin
 
     // when
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
 
     // then
     assertStats(result, nodesCreated = 2, relationshipsCreated = 1)
@@ -153,8 +151,7 @@ class ForeachAcceptanceTest extends ExecutionEngineFunSuite with CypherCompariso
         |FOREACH (x IN CASE WHEN condition THEN nodes ELSE [] END | CREATE (a)-[:X]->(x) );""".stripMargin
 
     // when
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1 + Configs.Cost3_2)
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
 
     // then
     assertStats(result, nodesCreated = 2, relationshipsCreated = 1)
@@ -171,8 +168,7 @@ class ForeachAcceptanceTest extends ExecutionEngineFunSuite with CypherCompariso
         |   MERGE (x)-[:FOOBAR]->(m) );""".stripMargin
 
     // when
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
-      expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
 
     // then
     assertStats(result, relationshipsCreated = 1)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcAcceptanceTest.scala
@@ -38,8 +38,7 @@ class LdbcAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSu
 
       // when
       val result =
-        executeWith(ldbcQuery.expectedToSucceedIn, ldbcQuery.query, params = ldbcQuery.params,
-          expectedDifferentPlans = ldbcQuery.expectedDifferentPlans)
+        executeWith(ldbcQuery.expectedToSucceedIn, ldbcQuery.query, params = ldbcQuery.params)
           .toComparableResult
 
       //then
@@ -66,7 +65,7 @@ class LdbcAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSu
 
     val result =
     // when
-      executeWith(ldbcQuery.expectedToSucceedIn, ldbcQuery.query, params = params, expectedDifferentPlans = ldbcQuery.expectedDifferentPlans)
+      executeWith(ldbcQuery.expectedToSucceedIn, ldbcQuery.query, params = params)
 
     // no precision loss resulting in insane numbers
     all(collectEstimations(result.executionPlanDescription())) should be > 0.0

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcQueries.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcQueries.scala
@@ -60,7 +60,6 @@ object LdbcQueries {
     )
 
     def expectedToSucceedIn: TestConfiguration
-    def expectedDifferentPlans: TestConfiguration
   }
 
   object Query1 extends LdbcQuery {
@@ -202,7 +201,6 @@ object LdbcQueries {
 
     override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
 
-    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners
   }
 
   object Query2 extends LdbcQuery {
@@ -299,7 +297,6 @@ object LdbcQueries {
 
     override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
 
-    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners + Configs.Cost2_3
   }
 
   object Query3 extends LdbcQuery {
@@ -436,7 +433,6 @@ object LdbcQueries {
 
     override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
 
-    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1 + Configs.Cost3_2
   }
 
   object Query4 extends LdbcQuery {
@@ -528,7 +524,6 @@ object LdbcQueries {
 
     override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
 
-    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1 + Configs.Cost3_2
   }
 
   object Query5 extends LdbcQuery {
@@ -630,7 +625,6 @@ object LdbcQueries {
 
     override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
 
-    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_2
   }
 
   object Query6 extends LdbcQuery {
@@ -709,7 +703,6 @@ object LdbcQueries {
 
     override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
 
-    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1 + Configs.Cost3_2
   }
 
   object Query7 extends LdbcQuery {
@@ -826,7 +819,6 @@ object LdbcQueries {
 
     override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
 
-    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1 + Configs.Cost3_2
   }
 
   object Query8 extends LdbcQuery {
@@ -924,7 +916,6 @@ object LdbcQueries {
 
     override def expectedToSucceedIn: TestConfiguration = Configs.AllExceptSlotted
 
-    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners + Configs.Cost2_3
   }
 
   object Query9 extends LdbcQuery {
@@ -1024,7 +1015,6 @@ object LdbcQueries {
 
     override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
 
-    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_2
   }
 
   object Query10 extends LdbcQuery {
@@ -1149,7 +1139,6 @@ object LdbcQueries {
 
     override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
 
-    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners
   }
 
   object Query11 extends LdbcQuery {
@@ -1222,7 +1211,6 @@ object LdbcQueries {
 
     override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
 
-    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_2
   }
 
   object Query12 extends LdbcQuery {
@@ -1367,7 +1355,6 @@ object LdbcQueries {
 
     override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
 
-    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1 + Configs.Cost3_2
   }
 
   object Query13 extends LdbcQuery {
@@ -1412,7 +1399,6 @@ object LdbcQueries {
 
     override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
 
-    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners
   }
 
   object Query14 extends LdbcQuery {
@@ -1519,7 +1505,6 @@ object LdbcQueries {
 
     override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
 
-    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners
   }
 
   object Query14_v2 extends LdbcQuery {
@@ -1551,7 +1536,6 @@ object LdbcQueries {
 
     override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
 
-    override def expectedDifferentPlans: TestConfiguration = Configs.AllRulePlanners
   }
 
   val LDBC_QUERIES = Seq(

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UnionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UnionAcceptanceTest.scala
@@ -65,7 +65,7 @@ class UnionAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonS
     // TODO we expect this test to succeed with 3.2.4
     val expectedToWorkIn = Configs.CommunityInterpreted -
       TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.Cost, Runtimes.Default)
-    val result = executeWith(expectedToWorkIn, query, expectedDifferentPlans = Configs.AbsolutelyAll)
+    val result = executeWith(expectedToWorkIn, query)
     val expected = List(Map("A" -> "b", "B" -> "a"), Map("A" -> "a", "B" -> "b"))
 
     result.toList should equal(expected)


### PR DESCRIPTION
Instead of comparing similarity of plans, we expect test writers
to provide an explicit predicate or assertion that will be evaluated
on the plans. You still have to specify if there is a subset of the
configuration where you expect the predicate/assertion to fail.

This introduces the use of the aforementioned predicate in
EagerizationAcceptanceTest and UniqueIndexAcceptanceTest. These are
the ones that previously have been using succeedWithAndAssertPlansAreSimilar.

This PR is based on https://github.com/neo4j/neo4j/pull/10044