### PR TITLE
Handle nested lists for UNWIND in compiled runtime

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/UnwindAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/UnwindAcceptance.feature
@@ -196,3 +196,16 @@ Feature: UnwindAcceptance
       | [:S] |
     And no side effects
 
+  Scenario: Nested primitive lists and UNWIND
+    Given an empty graph
+    When executing query:
+      """
+      UNWIND [[1],[2],[3]] AS i RETURN i
+      """
+    Then the result should be:
+      | i   |
+      | [1] |
+      | [2] |
+      | [3] |
+    And no side effects
+

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/LogicalPlanConverter.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/LogicalPlanConverter.scala
@@ -526,6 +526,10 @@ object LogicalPlanConverter {
         case CypherCodeGenType(symbols.ListType(innerType), ListReferenceType(innerReprType))
           if RepresentationType.isPrimitive(innerReprType) =>
           (CypherCodeGenType(innerType, innerReprType), UnwindPrimitiveCollection(opName, collection))
+        case CypherCodeGenType(symbols.ListType(innerType), ListReferenceType(innerReprType)) =>
+          (CypherCodeGenType(innerType, innerReprType), ir.UnwindCollection(opName, collection))
+        case CypherCodeGenType(symbols.ListType(innerType), _) =>
+          (CypherCodeGenType(innerType, ReferenceType), ir.UnwindCollection(opName, collection))
         case CypherCodeGenType(symbols.ListType(innerType), _) =>
           (CypherCodeGenType(innerType, ReferenceType), ir.UnwindCollection(opName, collection))
         case CypherCodeGenType(symbols.CTAny, _) =>

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/LogicalPlanConverter.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/LogicalPlanConverter.scala
@@ -530,8 +530,6 @@ object LogicalPlanConverter {
           (CypherCodeGenType(innerType, innerReprType), ir.UnwindCollection(opName, collection))
         case CypherCodeGenType(symbols.ListType(innerType), _) =>
           (CypherCodeGenType(innerType, ReferenceType), ir.UnwindCollection(opName, collection))
-        case CypherCodeGenType(symbols.ListType(innerType), _) =>
-          (CypherCodeGenType(innerType, ReferenceType), ir.UnwindCollection(opName, collection))
         case CypherCodeGenType(symbols.CTAny, _) =>
           (CypherCodeGenType(symbols.CTAny, ReferenceType), ir.UnwindCollection(opName, collection))
         case t =>


### PR DESCRIPTION
Fix a bug where we weren't properly handling types in nested lists.