### PR TITLE
Fixed planner issue involving distinct together with skip/limit

### DIFF
--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/steps/countStorePlanner.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/steps/countStorePlanner.scala
@@ -34,7 +34,7 @@ case object countStorePlanner {
         if groupingKeys.isEmpty && aggregatingExpressions.size == 1 =>
         val (columnName, exp) = aggregatingExpressions.head
         val countStorePlan = checkForValidQueryGraph(query, columnName, exp)
-        countStorePlan.map(p => projection(p, groupingKeys, distinct = false))
+        countStorePlan.map(p => projection(p, groupingKeys))
 
       case _ => None
     }

--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/steps/projection.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/steps/projection.scala
@@ -27,7 +27,7 @@ import org.neo4j.cypher.internal.v3_3.logical.plans.LogicalPlan
 
 object projection {
 
-  def apply(in: LogicalPlan, projs: Map[String, Expression], distinct: Boolean)
+  def apply(in: LogicalPlan, projs: Map[String, Expression])
            (implicit context: LogicalPlanningContext): LogicalPlan = {
 
     val (plan, projectionsMap) = PatternExpressionSolver()(in, projs)
@@ -39,9 +39,7 @@ object projection {
     }
     val projections: Set[(String, Expression)] = projectionsMap.toIndexedSeq.toSet
 
-    if (distinct) {
-      context.logicalPlanProducer.planDistinct(plan, projectionsMap, projs)
-    } else if (projections.subsetOf(projectAllCoveredIds) || projections == projectAllCoveredIds) {
+    if (projections.subsetOf(projectAllCoveredIds) || projections == projectAllCoveredIds) {
       context.logicalPlanProducer.planStarProjection(plan, projectionsMap, projs)
     } else {
       context.logicalPlanProducer.planRegularProjection(plan, projectionsMap, projs)

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/steps/ProjectionTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/steps/ProjectionTest.scala
@@ -41,7 +41,7 @@ class ProjectionTest extends CypherFunSuite with LogicalPlanningTestSupport {
     implicit val (context, startPlan) = queryGraphWith(projectionsMap = projections)
 
     // when
-    val result = projection(startPlan, projections, distinct = false)
+    val result = projection(startPlan, projections)
 
     // then
     result should equal(Projection(startPlan, projections)(solved))
@@ -54,7 +54,7 @@ class ProjectionTest extends CypherFunSuite with LogicalPlanningTestSupport {
     implicit val (context, startPlan) = queryGraphWith(projectionsMap = projections)
 
     // when
-    val result = projection(startPlan, projections, distinct = false)
+    val result = projection(startPlan, projections)
 
     // then
     result should equal(startPlan)
@@ -67,7 +67,7 @@ class ProjectionTest extends CypherFunSuite with LogicalPlanningTestSupport {
     implicit val (context, startPlan) = queryGraphWith(projectionsMap = projections)
 
     // when
-    val result = projection(startPlan, projections, distinct = false)
+    val result = projection(startPlan, projections)
 
     // then
     result should equal(Projection(startPlan, projections)(solved))

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
@@ -131,4 +131,54 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
     val result = executeWith(Configs.AllExceptSlotted, "MATCH (a)-[r]-(b) RETURN count(r) ORDER BY count(r)")
     result.toList should equal(List(Map("count(r)" -> 2)))
   }
+
+  test("should support DISTINCT followed by LIMIT and SKIP") {
+    val node1 = createNode(Map("prop" -> 1))
+    val node2 = createNode(Map("prop" -> 2))
+    val query = "MATCH (a) RETURN DISTINCT a ORDER BY a.prop SKIP 1 LIMIT 1"
+
+    val result = executeWith(Configs.All, query)
+
+    result.toList should equal(List(Map("a" -> node2)))
+  }
+
+  test("should support DISTINCT projection followed by LIMIT and SKIP") {
+    val node1 = createNode(Map("prop" -> 1))
+    val node2 = createNode(Map("prop" -> 2))
+    val query = "MATCH (a) RETURN DISTINCT a.prop ORDER BY a.prop SKIP 1 LIMIT 1"
+
+    val result = executeWith(Configs.All, query)
+
+    result.toList should equal(List(Map("a.prop" -> 2)))
+  }
+
+  test("should support DISTINCT projection followed by SKIP") {
+    val node1 = createNode(Map("prop" -> 1))
+    val node2 = createNode(Map("prop" -> 2))
+    val query = "MATCH (a) RETURN DISTINCT a.prop ORDER BY a.prop SKIP 1"
+
+    val result = executeWith(Configs.All, query)
+
+    result.toList should equal(List(Map("a.prop" -> 2)))
+  }
+
+  test("should support DISTINCT projection followed by LIMIT") {
+    val node1 = createNode(Map("prop" -> 1))
+    val node2 = createNode(Map("prop" -> 2))
+    val query = "MATCH (a) RETURN DISTINCT a.prop ORDER BY a.prop LIMIT 1"
+
+    val result = executeWith(Configs.All, query)
+
+    result.toList should equal(List(Map("a.prop" -> 1)))
+  }
+
+  test("should support DISTINCT followed by LIMIT and SKIP with no ORDER BY") {
+    val node1 = createNode(Map("prop" -> 1))
+    val node2 = createNode(Map("prop" -> 2))
+    val query = "MATCH (a) WITH DISTINCT a SKIP 1 LIMIT 1 RETURN count(a)"
+
+    val result = executeWith(Configs.Interpreted, query)
+
+    result.toList should equal(List(Map("count(a)" -> 1)))
+  }
 }


### PR DESCRIPTION
The new logical plan structure in 3.3 includes a separate Distinct operation, and this had an issue when combined with SKIP or LIMIT. It performed the DISTINCT after the SKIP/LIMIT, instead of before.