### PR TITLE
Fix NullPointerException in ExecutionPlanWrapper.

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionPlan.scala
@@ -35,5 +35,6 @@ trait ExecutionPlan {
 
   def isStale(lastCommittedTxId: LastCommittedTxIdProvider, ctx: TransactionalContextWrapper): Boolean
 
-  def plannerInfo: PlannerInfo
+  // This is to force eager calculation
+  val plannerInfo: PlannerInfo
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/Compatibility.scala
@@ -127,7 +127,7 @@ trait Compatibility {
     def isStale(lastCommittedTxId: LastCommittedTxIdProvider, ctx: TransactionalContextWrapper): Boolean =
       inner.isStale(lastCommittedTxId, TransactionBoundGraphStatistics(ctx.readOperations))
 
-    override def plannerInfo = new PlannerInfo(inner.plannerUsed.name, inner.runtimeUsed.name, emptyList[IndexUsage])
+    override val plannerInfo = new PlannerInfo(inner.plannerUsed.name, inner.runtimeUsed.name, emptyList[IndexUsage])
 
 
     override def run(transactionalContext: TransactionalContextWrapper, executionMode: CypherExecutionMode, params: MapValue): Result = {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/Compatibility.scala
@@ -131,7 +131,7 @@ trait Compatibility {
     def isStale(lastCommittedTxId: LastCommittedTxIdProvider, ctx: TransactionalContextWrapperV3_3): Boolean =
       inner.isStale(lastCommittedTxId, TransactionBoundGraphStatistics(ctx.readOperations))
 
-    override def plannerInfo = new PlannerInfo(inner.plannerUsed.name, inner.runtimeUsed.name, emptyList[IndexUsage])
+    override val plannerInfo = new PlannerInfo(inner.plannerUsed.name, inner.runtimeUsed.name, emptyList[IndexUsage])
 
 
     override def run(transactionalContext: TransactionalContextWrapperV3_3, executionMode: CypherExecutionMode, params: MapValue): Result = {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/CostCompatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/CostCompatibility.scala
@@ -53,7 +53,7 @@ case class CostCompatibility[C <: CompilerContext, T <: Transformer[C, Compilati
       case CypherRuntime.default => None
       case CypherRuntime.interpreted => Some(InterpretedRuntimeName)
       case CypherRuntime.compiled => Some(CompiledRuntimeName)
-      case _ => throw new IllegalArgumentException("Runtime is not supported in Cypher 2.3")
+      case _ => throw new IllegalArgumentException("Runtime is not supported in Cypher 3.2")
     }
 
     val maybeUpdateStrategy = updateStrategy match {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/Compatibility.scala
@@ -193,7 +193,7 @@ trait Compatibility[CONTEXT <: CommunityRuntimeContext,
     def isStale(lastCommittedTxId: LastCommittedTxIdProvider, ctx: TransactionalContextWrapper): Boolean =
       inner.isStale(lastCommittedTxId, TransactionBoundGraphStatistics(ctx.readOperations))
 
-    override def plannerInfo: PlannerInfo = {
+    override val plannerInfo: PlannerInfo = {
       new PlannerInfo(inner.plannerUsed.name, inner.runtimeUsed.name, inner.plannedIndexUsage.map {
         case SchemaIndexSeekUsage(identifier, labelId, label, propertyKeys) => schemaIndexUsage(identifier, labelId, label, propertyKeys: _*)
         case SchemaIndexScanUsage(identifier, labelId, label, propertyKey) => schemaIndexUsage(identifier, labelId, label, propertyKey)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_2/CompatibilityTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_2/CompatibilityTest.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compatibility.v3_2
+
+import org.mockito.Mockito._
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
+import org.neo4j.cypher.internal.compiler.v3_2.executionplan.{SchemaIndexSeekUsage, ExecutionPlan => ExecutionPlan_v3_2}
+import org.neo4j.cypher.internal.frontend.v3_2.InputPosition
+import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.spi.v3_2.TransactionBoundQueryContext.IndexSearchMonitor
+import org.neo4j.cypher.internal.spi.v3_3.{TransactionalContextWrapper => TransactionalContextWrapperV3_3}
+import org.neo4j.kernel.api.ReadOperations
+import org.neo4j.kernel.impl.query.QueryExecutionMonitor
+
+class CompatibilityTest extends CypherFunSuite {
+
+  test("make sure that ExecutionPlanWrapper uses TC at creation time") {
+    val searchMonitor = mock[IndexSearchMonitor]
+    val executionMonitor = mock[QueryExecutionMonitor]
+    val executionPlan = mock[ExecutionPlan_v3_2](withSettings.defaultAnswer(RETURNS_DEEP_STUBS))
+    when(executionPlan.runtimeUsed.name).thenReturn("Satia's favorite runtime")
+    when(executionPlan.plannerUsed.name).thenReturn("Satia's favorite planner")
+    when(executionPlan.plannedIndexUsage).thenReturn(Seq(SchemaIndexSeekUsage("id", "label", Seq())))
+
+    var txClosed = false
+
+    val contextWrapper = mock[TransactionalContextWrapperV3_3]
+    when(contextWrapper.readOperations).thenAnswer(new Answer[ReadOperations] {
+      override def answer(invocationOnMock: InvocationOnMock): ReadOperations = {
+        if(txClosed)
+          null
+        else
+          mock[ReadOperations]
+      }
+    })
+
+    // When
+    val executionPlanWrapper = new ExecutionPlanWrapper(executionPlan, contextWrapper, Set(), InputPosition.NONE,
+      searchMonitor, executionMonitor)
+    // and when
+    txClosed = true
+
+    // then does not fail
+    executionPlanWrapper.plannerInfo
+  }
+
+}


### PR DESCRIPTION
In rare situations, the wrapping of older query plans would fail
because a transaction had been closed. By eagerly using the transaction,
we make sure not to fail like this.