### PR TITLE
Make sure built-in procedures close resources when done

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/procs/ProcedureExecutionResult.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/procs/ProcedureExecutionResult.scala
@@ -98,7 +98,9 @@ class ProcedureExecutionResult[E <: Exception](context: QueryContext,
   }
 
   override def executionPlanDescription(): InternalPlanDescription = executionMode match {
-    case ProfileMode if executionResults.hasNext => throw new ProfilerStatisticsNotReadyException()
+    case ProfileMode if executionResults.hasNext =>
+      completed(success = false)
+      throw new ProfilerStatisticsNotReadyException()
     case _ => executionPlanDescriptionGenerator()
   }
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/PipeDecorator.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/PipeDecorator.scala
@@ -30,7 +30,7 @@ trait PipeDecorator {
 
   def decorate(pipe: Pipe, iter: Iterator[ExecutionContext]): Iterator[ExecutionContext]
 
-  def decorate(plan: InternalPlanDescription, isProfileReady: => Boolean): InternalPlanDescription
+  def decorate(plan: InternalPlanDescription, verifyProfileReady: () => Unit): InternalPlanDescription
 
   /*
    * Returns the inner decorator of this decorator. The inner decorator is used for nested expressions
@@ -42,7 +42,7 @@ trait PipeDecorator {
 object NullPipeDecorator extends PipeDecorator {
   def decorate(pipe: Pipe, iter: Iterator[ExecutionContext]): Iterator[ExecutionContext] = iter
 
-  def decorate(plan: InternalPlanDescription, isProfileReady: => Boolean): InternalPlanDescription = plan
+  def decorate(plan: InternalPlanDescription, verifyProfileReady: () => Unit): InternalPlanDescription = plan
 
   def decorate(pipe: Pipe, state: QueryState): QueryState = state
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/profiler/Profiler.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/profiler/Profiler.scala
@@ -73,9 +73,8 @@ class Profiler(databaseInfo: DatabaseInfo = DatabaseInfo.COMMUNITY) extends Pipe
     databaseInfo.edition != Edition.community
   }
 
-  def decorate(plan: InternalPlanDescription, isProfileReady: => Boolean): InternalPlanDescription = {
-    if (!isProfileReady)
-      throw new ProfilerStatisticsNotReadyException()
+  def decorate(plan: InternalPlanDescription, verifyProfileReady: () => Unit): InternalPlanDescription = {
+    verifyProfileReady()
 
     plan map {
       input: InternalPlanDescription =>
@@ -101,8 +100,8 @@ class Profiler(databaseInfo: DatabaseInfo = DatabaseInfo.COMMUNITY) extends Pipe
 
     def decorate(pipe: Pipe, iter: Iterator[ExecutionContext]): Iterator[ExecutionContext] = iter
 
-    def decorate(plan: InternalPlanDescription, isProfileReady: => Boolean): InternalPlanDescription =
-      outerProfiler.decorate(plan, isProfileReady)
+    def decorate(plan: InternalPlanDescription, verifyProfileReady: () => Unit): InternalPlanDescription =
+      outerProfiler.decorate(plan, verifyProfileReady)
   }
 
   def registerParentPipe(pipe: Pipe): Unit =

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/profiler/ProfilerTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/profiler/ProfilerTest.scala
@@ -44,7 +44,7 @@ class ProfilerTest extends CypherFunSuite {
 
     //WHEN
     materialize(pipe.createResults(queryState))
-    val decoratedResult = profiler.decorate(planDescription, isProfileReady = true)
+    val decoratedResult = profiler.decorate(planDescription, verifyProfileReady = () => {})
 
     //THEN
     assertRecorded(decoratedResult, "foo", expectedRows = 10, expectedDbHits = 20)
@@ -62,7 +62,7 @@ class ProfilerTest extends CypherFunSuite {
 
     //WHEN
     materialize(pipe.createResults(queryState))
-    val decoratedResult = profiler.decorate(planDescription, isProfileReady = true)
+    val decoratedResult = profiler.decorate(planDescription, verifyProfileReady = () => {})
 
     //THEN
     assertRecorded(decoratedResult, "foo", expectedRows = 10, expectedDbHits = 20,
@@ -89,7 +89,7 @@ class ProfilerTest extends CypherFunSuite {
 
     //WHEN
     materialize(pipe3.createResults(queryState))
-    val decoratedResult = profiler.decorate(planDescription, isProfileReady = true)
+    val decoratedResult = profiler.decorate(planDescription, verifyProfileReady = () => {})
 
     //THEN
     assertRecorded(decoratedResult, "foo", expectedRows = 10, expectedDbHits = 25)
@@ -111,7 +111,7 @@ class ProfilerTest extends CypherFunSuite {
 
     //WHEN
     materialize(pipe3.createResults(queryState))
-    val decoratedResult = profiler.decorate(planDescription, isProfileReady = true)
+    val decoratedResult = profiler.decorate(planDescription, verifyProfileReady = () => {})
 
     //THEN
     assertRecorded(decoratedResult, "foo", expectedRows = 10, expectedDbHits = 25, expectedPageCacheHits = 2, expectedPageCacheMisses = 7)
@@ -138,7 +138,7 @@ class ProfilerTest extends CypherFunSuite {
 
     // WHEN we create the results,
     materialize(apply.createResults(queryState))
-    val decoratedResult = profiler.decorate(planDescription, isProfileReady = true)
+    val decoratedResult = profiler.decorate(planDescription, verifyProfileReady = () => {})
 
     // THEN
     assertRecorded(decoratedResult, "rhs", expectedRows = 10 * 20, expectedDbHits = 10 * 30)
@@ -166,7 +166,7 @@ class ProfilerTest extends CypherFunSuite {
 
     // WHEN we create the results,
     materialize(pipeUnderInspection.createResults(queryState))
-    val decoratedResult = profiler.decorate(planDescription, isProfileReady = true)
+    val decoratedResult = profiler.decorate(planDescription, verifyProfileReady = () => {})
 
     // THEN the ProjectionNewPipe has correctly recorded the dbhits
     assertRecorded(decoratedResult, "Projection", expectedRows = 1, expectedDbHits = DB_HITS)
@@ -193,7 +193,7 @@ class ProfilerTest extends CypherFunSuite {
 
     // WHEN we create the results,
     materialize(pipeUnderInspection.createResults(queryState))
-    val decoratedResult = profiler.decorate(planDescription, isProfileReady = true)
+    val decoratedResult = profiler.decorate(planDescription, verifyProfileReady = () => {})
 
     // THEN the ProjectionNewPipe has correctly recorded the page cache hits
     assertRecorded(decoratedResult, "Projection", expectedRows = 1, expectedDbHits = 2, expectedPageCacheHits = 3, expectedPageCacheMisses = 4)
@@ -228,7 +228,7 @@ class ProfilerTest extends CypherFunSuite {
       "innerInner" -> innerInnerPipe,
       "Projection" -> pipeUnderInspection
     )
-    val decoratedResult = profiler.decorate(description, isProfileReady = true)
+    val decoratedResult = profiler.decorate(description, verifyProfileReady = () => {})
 
     // THEN the ProjectionNewPipe has correctly recorded the dbhits
     assertRecorded(decoratedResult, "Projection", expectedRows = 1, expectedDbHits = DB_HITS * 2)

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
@@ -68,8 +68,10 @@ public class BuiltInProcedures
         Statement statement = tx.acquireStatement();
         try
         {
-            // Ownership of the reference to the acquired statement is transfered to the returned iterator stream
-            return TokenAccess.LABELS.inUse( statement ).map( LabelResult::new ).stream();
+            // Ownership of the reference to the acquired statement is transfered to the returned iterator stream,
+            // but we still want to eagerly consume the labels, so we can catch any exceptions,
+            List<LabelResult> labelResults = asList( TokenAccess.LABELS.inUse( statement ).map( LabelResult::new ) );
+            return labelResults.stream();
         }
         catch ( Throwable t )
         {
@@ -85,8 +87,11 @@ public class BuiltInProcedures
         Statement statement = tx.acquireStatement();
         try
         {
-            // Ownership of the reference to the acquired statement is transfered to the returned iterator stream
-            return TokenAccess.PROPERTY_KEYS.inUse( statement ).map( PropertyKeyResult::new ).stream();
+            // Ownership of the reference to the acquired statement is transfered to the returned iterator stream,
+            // but we still want to eagerly consume the labels, so we can catch any exceptions,
+            List<PropertyKeyResult> propertyKeys =
+                    asList( TokenAccess.PROPERTY_KEYS.inUse( statement ).map( PropertyKeyResult::new ) );
+            return propertyKeys.stream();
         }
         catch ( Throwable t )
         {
@@ -102,8 +107,11 @@ public class BuiltInProcedures
         Statement statement = tx.acquireStatement();
         try
         {
-            // Ownership of the reference to the acquired statement is transfered to the returned iterator stream
-            return TokenAccess.RELATIONSHIP_TYPES.inUse( statement ).map( RelationshipTypeResult::new ).stream();
+            // Ownership of the reference to the acquired statement is transfered to the returned iterator stream,
+            // but we still want to eagerly consume the labels, so we can catch any exceptions,
+            List<RelationshipTypeResult> relationshipTypes =
+                    asList( TokenAccess.RELATIONSHIP_TYPES.inUse( statement ).map( RelationshipTypeResult::new ) );
+            return relationshipTypes.stream();
         }
         catch ( Throwable t )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
@@ -65,9 +65,16 @@ public class BuiltInProcedures
     @Procedure( name = "db.labels", mode = READ )
     public Stream<LabelResult> listLabels()
     {
-        try ( Statement statement = tx.acquireStatement() )
+        Statement statement = tx.acquireStatement();
+        try
         {
+            // Ownership of the reference to the acquired statement is transfered to the returned iterator stream
             return TokenAccess.LABELS.inUse( statement ).map( LabelResult::new ).stream();
+        }
+        catch ( Throwable t )
+        {
+            statement.close();
+            throw t;
         }
     }
 
@@ -75,9 +82,16 @@ public class BuiltInProcedures
     @Procedure( name = "db.propertyKeys", mode = READ )
     public Stream<PropertyKeyResult> listPropertyKeys()
     {
-        try ( Statement statement = tx.acquireStatement() )
+        Statement statement = tx.acquireStatement();
+        try
         {
+            // Ownership of the reference to the acquired statement is transfered to the returned iterator stream
             return TokenAccess.PROPERTY_KEYS.inUse( statement ).map( PropertyKeyResult::new ).stream();
+        }
+        catch ( Throwable t )
+        {
+            statement.close();
+            throw t;
         }
     }
 
@@ -85,9 +99,16 @@ public class BuiltInProcedures
     @Procedure( name = "db.relationshipTypes", mode = READ )
     public Stream<RelationshipTypeResult> listRelationshipTypes()
     {
-        try ( Statement statement = tx.acquireStatement() )
+        Statement statement = tx.acquireStatement();
+        try
         {
+            // Ownership of the reference to the acquired statement is transfered to the returned iterator stream
             return TokenAccess.RELATIONSHIP_TYPES.inUse( statement ).map( RelationshipTypeResult::new ).stream();
+        }
+        catch ( Throwable t )
+        {
+            statement.close();
+            throw t;
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
@@ -65,18 +65,12 @@ public class BuiltInProcedures
     @Procedure( name = "db.labels", mode = READ )
     public Stream<LabelResult> listLabels()
     {
-        Statement statement = tx.acquireStatement();
-        try
+        try ( Statement statement = tx.acquireStatement() )
         {
             // Ownership of the reference to the acquired statement is transfered to the returned iterator stream,
             // but we still want to eagerly consume the labels, so we can catch any exceptions,
             List<LabelResult> labelResults = asList( TokenAccess.LABELS.inUse( statement ).map( LabelResult::new ) );
             return labelResults.stream();
-        }
-        catch ( Throwable t )
-        {
-            statement.close();
-            throw t;
         }
     }
 
@@ -84,19 +78,14 @@ public class BuiltInProcedures
     @Procedure( name = "db.propertyKeys", mode = READ )
     public Stream<PropertyKeyResult> listPropertyKeys()
     {
-        Statement statement = tx.acquireStatement();
-        try
+        try ( Statement statement = tx.acquireStatement() )
         {
             // Ownership of the reference to the acquired statement is transfered to the returned iterator stream,
             // but we still want to eagerly consume the labels, so we can catch any exceptions,
             List<PropertyKeyResult> propertyKeys =
                     asList( TokenAccess.PROPERTY_KEYS.inUse( statement ).map( PropertyKeyResult::new ) );
-            return propertyKeys.stream();
-        }
-        catch ( Throwable t )
-        {
             statement.close();
-            throw t;
+            return propertyKeys.stream();
         }
     }
 
@@ -104,19 +93,13 @@ public class BuiltInProcedures
     @Procedure( name = "db.relationshipTypes", mode = READ )
     public Stream<RelationshipTypeResult> listRelationshipTypes()
     {
-        Statement statement = tx.acquireStatement();
-        try
+        try ( Statement statement = tx.acquireStatement() )
         {
             // Ownership of the reference to the acquired statement is transfered to the returned iterator stream,
             // but we still want to eagerly consume the labels, so we can catch any exceptions,
             List<RelationshipTypeResult> relationshipTypes =
                     asList( TokenAccess.RELATIONSHIP_TYPES.inUse( statement ).map( RelationshipTypeResult::new ) );
             return relationshipTypes.stream();
-        }
-        catch ( Throwable t )
-        {
-            statement.close();
-            throw t;
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TokenAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TokenAccess.java
@@ -129,7 +129,7 @@ public abstract class TokenAccess<R>
 
     private abstract static class TokenIterator<T> extends PrefetchingResourceIterator<T>
     {
-        final Statement statement;
+        Statement statement;
         final TokenAccess<T> access;
         final Iterator<Token> tokens;
 
@@ -143,7 +143,11 @@ public abstract class TokenAccess<R>
         @Override
         public void close()
         {
-            statement.close();
+            if ( statement != null )
+            {
+                statement.close();
+                statement = null;
+            }
         }
 
         static <T> ResourceIterator<T> inUse( Statement statement, TokenAccess<T> access )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
@@ -671,7 +671,11 @@ class ReflectiveProcedureCompiler
             @Override
             public void close() throws Exception
             {
-                closeable.close();
+                if ( closeable != null )
+                {
+                    closeable.close();
+                    closeable = null;
+                }
             }
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -61,9 +61,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.kernel.api.proc.Context.KERNEL_TRANSACTION;
 import static org.neo4j.kernel.api.proc.Context.SECURITY_CONTEXT;
@@ -231,6 +234,75 @@ public class BuiltInProceduresTest
         assertThat( call( "dbms.components" ), contains(
                 record( "Neo4j Kernel", singletonList( "1.3.37" ), "enterprise" )
         ) );
+    }
+
+    @Test
+    public void shouldCloseStatementIfExceptionIsThrownDbLabels() throws Throwable
+    {
+        // Given
+        RuntimeException runtimeException = new RuntimeException();
+        when( read.labelsGetAllTokens() ).thenThrow( runtimeException );
+
+        // When
+        try
+        {
+            call( "db.labels" );
+            fail( "Procedure call should have failed" );
+        }
+        catch ( ProcedureException e )
+        {
+            assertThat( e.getCause(), is( runtimeException ) );
+            // expected
+        }
+
+        // Then
+        verify( statement ).close();
+    }
+
+    @Test
+    public void shouldCloseStatementIfExceptionIsThrownDbPropertyKeys() throws Throwable
+    {
+        // Given
+        RuntimeException runtimeException = new RuntimeException();
+        when( read.propertyKeyGetAllTokens() ).thenThrow( runtimeException );
+
+        // When
+        try
+        {
+            call( "db.propertyKeys" );
+            fail( "Procedure call should have failed" );
+        }
+        catch ( ProcedureException e )
+        {
+            assertThat( e.getCause(), is( runtimeException ) );
+            // expected
+        }
+
+        // Then
+        verify( statement ).close();
+    }
+
+    @Test
+    public void shouldCloseStatementIfExceptionIsThrownDRelationshipTypes() throws Throwable
+    {
+        // Given
+        RuntimeException runtimeException = new RuntimeException();
+        when( read.relationshipTypesGetAllTokens() ).thenThrow( runtimeException );
+
+        // When
+        try
+        {
+            call( "db.relationshipTypes" );
+            fail( "Procedure call should have failed" );
+        }
+        catch ( ProcedureException e )
+        {
+            assertThat( e.getCause(), is( runtimeException ) );
+            // expected
+        }
+
+        // Then
+        verify( statement ).close();
     }
 
     private Matcher<Object[]> record( Object... fields )

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProcedureCallSupportAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProcedureCallSupportAcceptanceTest.scala
@@ -87,4 +87,26 @@ class ProcedureCallSupportAcceptanceTest extends ProcedureCallAcceptanceTest {
       map("one", "alpha", "newTwo", "beta")
     ))
   }
+
+  test("should be able to execute union of multiple token accessing procedures") {
+    val a = createLabeledNode("Foo")
+    val b = createLabeledNode("Bar")
+    relate(a, b, "REL", Map("prop" -> 1))
+
+    val query =
+      "CALL db.labels() YIELD label RETURN label as result " +
+      "UNION " +
+      "CALL db.relationshipTypes() YIELD relationshipType RETURN relationshipType as result " +
+      "UNION " +
+      "CALL db.propertyKeys() YIELD propertyKey RETURN propertyKey as result"
+
+    val result = graph.execute(query)
+
+    result.columnAs[String]("result").stream().toArray.toList shouldEqual List(
+      "Foo",
+      "Bar",
+      "REL",
+      "prop"
+    )
+  }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProfilerAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProfilerAcceptanceTest.scala
@@ -179,6 +179,17 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
     result.close() // ensure that the transaction is closed
   }
 
+  test("unfinished profiler complains [using CALL within larger query]") {
+    //GIVEN
+    createLabeledNode("Person")
+    val result = graph.execute("PROFILE CALL db.labels() YIELD label WITH label as r RETURN r")
+
+    //WHEN THEN
+    val ex = intercept[QueryExecutionException](result.getExecutionPlanDescription)
+    ex.getCause.getCause shouldBe a [ProfilerStatisticsNotReadyException]
+    result.close() // ensure that the transaction is closed
+  }
+
   test("tracks number of rows") {
     //GIVEN
     // due to the cost model, we need a bunch of nodes for the planner to pick a plan that does lookup by id

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/CompiledExecutionResult.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/CompiledExecutionResult.scala
@@ -50,9 +50,12 @@ class CompiledExecutionResult(taskCloser: TaskCloser,
     compiledCode.accept(visitor)
 
   override def executionPlanDescription(): InternalPlanDescription = {
-    if (!taskCloser.isClosed) throw new ProfilerStatisticsNotReadyException
-
-    compiledCode.executionPlanDescription()
+    if (!taskCloser.isClosed) {
+      completed(success = false)
+      throw new ProfilerStatisticsNotReadyException
+    }
+    else
+      compiledCode.executionPlanDescription()
   }
 
   override def queryStatistics() = InternalQueryStatistics()


### PR DESCRIPTION
The first two commits are backports from 3.3 and should be forward-merged with a null commit. The last commit is applicable to both 3.2 and 3.3