### PR TITLE
Revert "Changes how MarshlandPool works with inner transactions"

### DIFF
--- a/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/ShortestPath.java
+++ b/community/graph-algo/src/main/java/org/neo4j/graphalgo/impl/path/ShortestPath.java
@@ -162,7 +162,7 @@ public class ShortestPath implements PathFinder<Path>
                 goOneStep( endData, startData, hits, startData, stopAsap );
             }
             Collection<Hit> least = hits.least();
-            return least != null ? filterPaths( hitsToPaths( least, start, end, stopAsap ) ) : Collections.emptyList();
+            return least != null ? filterPaths( hitsToPaths( least, start, end, stopAsap, maxResultCount ) ) : Collections.emptyList();
         }
     }
 
@@ -601,7 +601,7 @@ public class ShortestPath implements PathFinder<Path>
         }
     }
 
-    private static Collection<Path> hitsToPaths( Collection<Hit> depthHits, Node start, Node end, boolean stopAsap )
+    private static Collection<Path> hitsToPaths( Collection<Hit> depthHits, Node start, Node end, boolean stopAsap, int maxResultCount )
     {
         LinkedHashMap<String,Path> paths = new LinkedHashMap<>();
         for ( Hit hit : depthHits )
@@ -609,6 +609,10 @@ public class ShortestPath implements PathFinder<Path>
             for ( Path path : hitToPaths( hit, start, end, stopAsap ) )
             {
                 paths.put( path.toString(), path );
+                if ( paths.size() >= maxResultCount )
+                {
+                    break;
+                }
             }
         }
         return paths.values();

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/path/TestShortestPath.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/path/TestShortestPath.java
@@ -60,6 +60,7 @@ import static org.neo4j.graphdb.Direction.BOTH;
 import static org.neo4j.graphdb.Direction.INCOMING;
 import static org.neo4j.graphdb.Direction.OUTGOING;
 import static org.neo4j.graphdb.PathExpanders.allTypesAndDirections;
+import static org.neo4j.helpers.collection.Iterables.count;
 
 public class TestShortestPath extends Neo4jAlgoTestCase
 {
@@ -467,6 +468,24 @@ public class TestShortestPath extends Neo4jAlgoTestCase
         final Node end = graph.getNode( "end" );
         assertThat( new ShortestPath( 2, allTypesAndDirections(), 42 ).findSinglePath( start, end ).length(), is( 2 ) );
         assertThat( new ShortestPath( 3, allTypesAndDirections(), 42 ).findSinglePath( start, end ).length(), is( 2 ) );
+    }
+
+    @Test
+    public void shouldMakeSureResultLimitIsRespectedForMultiPathHits() throws Exception
+    {
+        /*       _____
+         *      /     \
+         *    (a)-----(b)
+         *      \_____/
+         */
+        for ( int i = 0; i < 3; i++ )
+        {
+            graph.makeEdge( "a", "b" );
+        }
+
+        Node a = graph.getNode( "a" );
+        Node b = graph.getNode( "b" );
+        testShortestPathFinder( finder -> assertEquals( 1, count( finder.findAllPaths( a, b ) ) ), allTypesAndDirections(), 2, 1 );
     }
 
     private void testShortestPathFinder( PathFinderTester tester, PathExpander expander, int maxDepth )

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/pool/MarshlandPool.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/pool/MarshlandPool.java
@@ -63,8 +63,8 @@ public class MarshlandPool<T> implements Pool<T>
     };
 
     // Used to reclaim objects from dead threads
-    private final Set<LocalSlotReference<T>> slotReferences =
-            newSetFromMap( new ConcurrentHashMap<LocalSlotReference<T>, Boolean>() );
+    private final Set<LocalSlotReference> slotReferences =
+            newSetFromMap( new ConcurrentHashMap<LocalSlotReference, Boolean>() );
     private final ReferenceQueue<LocalSlot<T>> objectsFromDeadThreads = new ReferenceQueue<>();
 
     public MarshlandPool( Factory<T> objectFactory )
@@ -84,22 +84,22 @@ public class MarshlandPool<T> implements Pool<T>
         LocalSlot<T> localSlot = puddle.get();
 
         T object = localSlot.object;
-        if ( object != null && localSlot.acquire() )
+        if ( object != null )
         {
+            localSlot.set( null );
             return object;
         }
 
         // Try the reference queue, containing objects from dead threads
-        @SuppressWarnings( "unchecked" )
-        LocalSlotReference<T> slotReference = (LocalSlotReference<T>) objectsFromDeadThreads.poll();
+        LocalSlotReference<T> slotReference = (LocalSlotReference) objectsFromDeadThreads.poll();
         if ( slotReference != null && slotReference.object != null )
         {
             slotReferences.remove( slotReference );
-            return localSlot.assignIfNotAssigned( slotReference.object );
+            return slotReference.object;
         }
 
         // Fall back to the delegate pool
-        return localSlot.assignIfNotAssigned( pool.acquire() );
+        return pool.acquire();
     }
 
     @Override
@@ -108,35 +108,40 @@ public class MarshlandPool<T> implements Pool<T>
         // Return it locally if possible
         LocalSlot<T> localSlot = puddle.get();
 
-        if ( !localSlot.release( obj ) )
-        {   // Fall back to the delegate pool
+        if ( localSlot.object == null )
+        {
+            localSlot.set( obj );
+        }
+
+        // Fall back to the delegate pool
+        else
+        {
             pool.release( obj );
         }
-        // else it was released back into the slot
     }
 
     /**
      * Dispose of all objects in this pool, releasing them back to the delegate pool
      */
-    @SuppressWarnings( "unchecked" )
     public void disposeAll()
     {
-        for ( LocalSlotReference<T> slotReference : slotReferences )
+        for ( LocalSlotReference slotReference : slotReferences )
         {
-            LocalSlot<T> slot = slotReference.get();
+            LocalSlot<T> slot = (LocalSlot) slotReference.get();
             if ( slot != null )
             {
-                T obj = slot.clear();
+                T obj = slot.object;
                 if ( obj != null )
                 {
+                    slot.set( null );
                     pool.release( obj );
                 }
             }
         }
 
-        for ( LocalSlotReference<T> reference = (LocalSlotReference<T>) objectsFromDeadThreads.poll();
+        for ( LocalSlotReference<T> reference = (LocalSlotReference) objectsFromDeadThreads.poll();
             reference != null;
-            reference = (LocalSlotReference<T>) objectsFromDeadThreads.poll() )
+            reference = (LocalSlotReference) objectsFromDeadThreads.poll() )
         {
             T instance = reference.object;
             if ( instance != null )
@@ -154,11 +159,11 @@ public class MarshlandPool<T> implements Pool<T>
     /**
      * This is used to trigger the GC to notify us whenever the thread local has been garbage collected.
      */
-    private static class LocalSlotReference<T> extends WeakReference<LocalSlot<T>>
+    private static class LocalSlotReference<T> extends WeakReference<LocalSlot>
     {
         private T object;
 
-        private LocalSlotReference( LocalSlot<T> referent, ReferenceQueue<? super LocalSlot<T>> q )
+        private LocalSlotReference( LocalSlot referent, ReferenceQueue<? super LocalSlot> q )
         {
             super( referent, q );
         }
@@ -170,82 +175,14 @@ public class MarshlandPool<T> implements Pool<T>
     private static class LocalSlot<T>
     {
         private T object;
-        private final LocalSlotReference<T> phantomReference;
-        private boolean acquired;
+        private final LocalSlotReference phantomReference;
 
         LocalSlot( ReferenceQueue<LocalSlot<T>> referenceQueue )
         {
-            phantomReference = new LocalSlotReference<>( this, referenceQueue );
+            phantomReference = new LocalSlotReference( this, referenceQueue );
         }
 
-        T clear()
-        {
-            T result = acquired ? null : object;
-            set( null );
-            acquired = false;
-            return result;
-        }
-
-        /**
-         * Will assign {@code obj} to this slot if not already assigned.
-         * When calling this method this slot may be in different states:
-         * <ul>
-         * <li>object = null, acquired = false: initial assignment</li>
-         * <li>object != null, acquired = true: already assigned, but someone has it already</li>
-         * </ul>
-         *
-         * @param obj instance to assign
-         * @return the {@code obj} for convenience for the caller
-         */
-        T assignIfNotAssigned( T obj )
-        {
-            if ( object == null )
-            {
-                boolean wasAcquired = acquire();
-                assert wasAcquired;
-                set( obj );
-            }
-            else
-            {
-                assert acquired;
-            }
-            return obj;
-        }
-
-        /**
-         * Marks this slot as not acquired anymore. This will only succeed if the released object matches the
-         * object in this slot.
-         *
-         * @param obj the object to release and to match with this slot object.
-         * @return whether or not {@code obj} matches the slot object.
-         */
-        boolean release( T obj )
-        {
-            if ( obj == object )
-            {
-                assert acquired;
-                acquired = false;
-                return true;
-            }
-            return false;
-        }
-
-        /**
-         * Marks this slot as acquired. Object must have been assigned at this point.
-         *
-         * @return {@code true} if this slot wasn't acquired when calling this method, otherwise {@code false}.
-         */
-        boolean acquire()
-        {
-            if ( acquired )
-            {
-                return false;
-            }
-            acquired = true;
-            return true;
-        }
-
-        private void set( T obj )
+        public void set( T obj )
         {
             phantomReference.object = obj;
             this.object = obj;

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/pool/MarshlandPoolTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/pool/MarshlandPoolTest.java
@@ -23,10 +23,8 @@ import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Mockito.any;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -58,7 +56,7 @@ public class MarshlandPoolTest
     {
         // Given
         Pool<Object> delegatePool = mock( Pool.class );
-        when( delegatePool.acquire() ).thenReturn( 1337, 1338L, 1339L );
+        when(delegatePool.acquire()).thenReturn( 1337 );
 
         final MarshlandPool<Object> pool = new MarshlandPool<>( delegatePool );
 
@@ -96,53 +94,6 @@ public class MarshlandPoolTest
         verify( delegatePool, times( 1 ) ).acquire();
         verify( delegatePool, times( 1 ) ).release( any() );
         verifyNoMoreInteractions( delegatePool );
-    }
-
-    /*
-     * This test is about how the LocalSlot works with nested use, i.e. that acquiring an instance from the local slot
-     * and while having it (before releasing it) acquiring a "nested" instance which gets released before releasing the
-     * first one. The test is about how that interacts with the delegate pool and that the nested instance should not
-     * take precedence over the first instance in the local slot.
-     */
-    @Test
-    public void shouldHaveNestedUsageFallBackToDelegatePool() throws Exception
-    {
-        // given
-        Pool<Integer> delegatePool = mock( Pool.class );
-        when( delegatePool.acquire() ).thenReturn( 5, 6 );
-        MarshlandPool<Integer> pool = new MarshlandPool<>( delegatePool );
-
-        // when
-        Integer top = pool.acquire();
-        assertEquals( 5, top.intValue() );
-        verify( delegatePool, times( 1 ) ).acquire();
-
-        // do this a couple of times, just to verify that too
-        int hoops = 2;
-        for ( int i = 1; i <= hoops; i++ )
-        {
-            // and when w/o releasing the top one, acquire a nested
-            Integer nested = pool.acquire();
-            assertEquals( 6, nested.intValue() );
-            verify( delegatePool, times( 1 + i ) ).acquire();
-
-            // releasing the nested
-            pool.release( nested );
-            verify( delegatePool, times( i ) ).release( nested );
-        }
-
-        // when finally releasing the top one
-        verify( delegatePool, times( hoops ) ).release( anyInt() );
-        pool.release( top );
-        verify( delegatePool, times( hoops ) ).release( anyInt() );
-
-        // then the next acquire should see the top one
-        verify( delegatePool, times( 1 + hoops ) ).acquire();
-        Integer topAgain = pool.acquire();
-        verify( delegatePool, times( 1 + hoops ) ).acquire();
-        assertEquals( 5, topAgain.intValue() );
-        pool.release( topAgain );
-        verify( delegatePool, times( hoops ) ).release( anyInt() );
     }
 
     private void assertPoolEventuallyReturns( Pool<Object> pool, int expected ) throws InterruptedException

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/CoreBootstrapperIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/CoreBootstrapperIT.java
@@ -48,8 +48,16 @@ import org.neo4j.test.rule.PageCacheRule;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+import static java.lang.Integer.parseInt;
 import static java.util.UUID.randomUUID;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.record_id_batch_size;
 import static org.neo4j.helpers.collection.Iterators.asSet;
 
 public class CoreBootstrapperIT
@@ -80,8 +88,9 @@ public class CoreBootstrapperIT
         CoreSnapshot snapshot = bootstrapper.bootstrap( membership );
 
         // then
-        assertEquals( nodeCount, ((IdAllocationState) snapshot.get( CoreStateType.ID_ALLOCATION ))
-                .firstUnallocated( IdType.NODE ) );
+        int recordIdBatchSize = parseInt( record_id_batch_size.getDefaultValue() );
+        assertThat( ((IdAllocationState) snapshot.get( CoreStateType.ID_ALLOCATION )).firstUnallocated( IdType.NODE ),
+                allOf( greaterThanOrEqualTo( (long) nodeCount ), lessThanOrEqualTo( (long) nodeCount + recordIdBatchSize ) ) );
 
         /* Bootstrapped state is created in RAFT land at index -1 and term -1. */
         assertEquals( 0, snapshot.prevIndex() );

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeNodeKeyConstraintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeNodeKeyConstraintAcceptanceTest.scala
@@ -127,13 +127,13 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
 
   test("composite NODE KEY constraint should fail when we have nodes with same properties") {
     // When
-    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User")
-    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Smoke"), "User")
-    createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User")
+    val a = createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User").getId
+    val b = createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Smoke"), "User").getId
+    val c = createLabeledNode(Map("firstname" -> "Joe", "lastname" -> "Soap"), "User").getId
 
     // Then
     val query = "CREATE CONSTRAINT ON (n:User) ASSERT (n.firstname,n.lastname) IS NODE KEY"
-    val errorMessage = "Both Node(0) and Node(2) have the label `User` and properties `firstname` = 'Joe', `lastname` = 'Soap'"
+    val errorMessage = "Both Node(%d) and Node(%d) have the label `User` and properties `firstname` = 'Joe', `lastname` = 'Soap'".format(a, c)
     failWithError(Configs.AbsolutelyAll - Configs.AllRulePlanners - Configs.Version3_1 - Configs.Version2_3, query, errorMessage)
   }
 
@@ -166,8 +166,8 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
   }
 
   test("trying to add a composite node key constraint when duplicates exist") {
-    createLabeledNode(Map("name" -> "A", "surname" -> "B"), "Person")
-    createLabeledNode(Map("name" -> "A", "surname" -> "B"), "Person")
+    val a = createLabeledNode(Map("name" -> "A", "surname" -> "B"), "Person").getId
+    val b = createLabeledNode(Map("name" -> "A", "surname" -> "B"), "Person").getId
 
     val config = TestConfiguration(V3_3, Cost, Runtimes(CompiledSource, CompiledBytecode)) +
         TestConfiguration(Versions.Default, Planners.Default, Runtimes(Interpreted, Slotted, ProcedureOrSchema)) +
@@ -175,14 +175,14 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
     failWithError(
       config,
       "CREATE CONSTRAINT ON (person:Person) ASSERT (person.name, person.surname) IS NODE KEY",
-      String.format("Unable to create CONSTRAINT ON ( person:Person ) ASSERT (person.name, person.surname) IS NODE KEY:%n" +
-        "Both Node(0) and Node(1) have the label `Person` and properties `name` = 'A', `surname` = 'B'")
+      ("Unable to create CONSTRAINT ON ( person:Person ) ASSERT (person.name, person.surname) IS NODE KEY:%s" +
+        "Both Node(%d) and Node(%d) have the label `Person` and properties `name` = 'A', `surname` = 'B'").format(String.format("%n"), a, b)
     )
   }
 
   test("trying to add a node key constraint when duplicates exist") {
-    createLabeledNode(Map("name" -> "A"), "Person")
-    createLabeledNode(Map("name" -> "A"), "Person")
+    val a = createLabeledNode(Map("name" -> "A"), "Person").getId
+    val b = createLabeledNode(Map("name" -> "A"), "Person").getId
 
     val config = TestConfiguration(V3_3, Cost, Runtimes(CompiledSource, CompiledBytecode)) +
         TestConfiguration(Versions.Default, Planners.Default, Runtimes(Interpreted, Slotted, ProcedureOrSchema)) +
@@ -190,8 +190,8 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
     failWithError(
       config,
       "CREATE CONSTRAINT ON (person:Person) ASSERT (person.name) IS NODE KEY",
-      String.format("Unable to create CONSTRAINT ON ( person:Person ) ASSERT person.name IS NODE KEY:%n" +
-        "Both Node(0) and Node(1) have the label `Person` and property `name` = 'A'")
+      ("Unable to create CONSTRAINT ON ( person:Person ) ASSERT person.name IS NODE KEY:%s" +
+        "Both Node(%d) and Node(%d) have the label `Person` and property `name` = 'A'").format(String.format("%n"), a, b)
     )
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -200,13 +200,13 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
   }
 
   test("should handle all shortest paths") {
-    createDiamond()
+    val (a, b, c, d) = createDiamond()
 
     val result = executeWith(Configs.CommunityInterpreted,
       """
-    match (a), (d) where id(a) = 0 and id(d) = 3
+    match (a), (d) where id(a) = %d and id(d) = %d
     match p = allShortestPaths( (a)-[*]->(d) )
-    return p""")
+    return p""".format(a.getId, d.getId))
 
     result.toList.size should equal(2)
   }
@@ -457,7 +457,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     val result = executeWith(Configs.Interpreted, "MATCH (n:User) WHERE exists(n.email) RETURN n")
 
     // then
-    result.toList should equal(List(Map("n" -> nodes.head), Map("n" -> nodes(1))))
+    result.toSet should equal(Set(Map("n" -> nodes.head), Map("n" -> nodes(1))))
     result.executionPlanDescription().toString should include("NodeIndexScan")
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekByRangeAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekByRangeAcceptanceTest.scala
@@ -1098,7 +1098,7 @@ class NodeIndexSeekByRangeAcceptanceTest extends ExecutionEngineFunSuite with Cy
         plan should useOperators(IndexSeekByRange.name)
       }, Configs.AllRulePlanners), params = Map("param" -> matchingChar))
 
-    result.toList should equal(List(Map("prop" -> matchingChar), Map("prop" -> matchingChar.toString)))
+    result.toSet should equal(Set(Map("prop" -> matchingChar), Map("prop" -> matchingChar.toString)))
   }
 
   test("should plan range index seeks matching strings against character properties (coerced to string wrt the inequality)") {
@@ -1122,7 +1122,7 @@ class NodeIndexSeekByRangeAcceptanceTest extends ExecutionEngineFunSuite with Cy
         plan should useOperators(IndexSeekByRange.name)
       }, Configs.AllRulePlanners), params = Map("param" -> matchingChar.toString))
 
-    result.toList should equal(List(Map("prop" -> matchingChar), Map("prop" -> matchingChar.toString)))
+    result.toSet should equal(Set(Map("prop" -> matchingChar), Map("prop" -> matchingChar.toString)))
   }
 
   test("rule planner should plan index seek for inequality match") {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternExpressionImplementationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternExpressionImplementationAcceptanceTest.scala
@@ -67,9 +67,9 @@ class PatternExpressionImplementationAcceptanceTest extends ExecutionEngineFunSu
         .map(_.mapValues {
           case l: Seq[Any] => l.toSet
           case x => x
-        }).toList
+        }).toSet
 
-      result should equal(List(
+      result should equal(Set(
         Map("p" -> Set(new PathImpl(start, rel2, c), new PathImpl(start, rel1, c))),
         Map("p" -> 42),
         Map("p" -> Set(new PathImpl(start2, rel4, d), new PathImpl(start2, rel3, d))),

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
@@ -558,6 +558,10 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
     val a2 = createLabeledNode("A")
     val a3 = createLabeledNode("A")
     val a4 = createLabeledNode("A")
+    println( a1 )
+    println( a2 )
+    println( a3 )
+    println( a4 )
 
     relate(a1, a2, "T")
     relate(a2, a3, "T")
@@ -570,8 +574,8 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
         |UNWIND nodes(p)[1..-1] as n
         |RETURN id(n) as n, count(*) as c""".stripMargin)
 
-    result.toList should equal(List(
-      Map("n" -> 5, "c" -> 4), Map("n" -> 6, "c" -> 4)
+    result.toSet should equal(Set(
+      Map("n" -> a2.getId, "c" -> 4), Map("n" -> a3.getId, "c" -> 4)
     ))
 
     result.close()

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
@@ -558,10 +558,6 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
     val a2 = createLabeledNode("A")
     val a3 = createLabeledNode("A")
     val a4 = createLabeledNode("A")
-    println( a1 )
-    println( a2 )
-    println( a3 )
-    println( a4 )
 
     relate(a1, a2, "T")
     relate(a2, a3, "T")

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartAcceptanceTest.scala
@@ -152,7 +152,7 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
   test("START r=rel(0,1) RETURN r") {
     val rel1 = relate(createNode(), createNode()).getId
     val rel2 = relate(createNode(), createNode()).getId
-    val result = executeWithAllPlannersAndCompatibilityMode("START r=rel(0,1) RETURN id(r)").toList
+    val result = executeWithAllPlannersAndCompatibilityMode("START r=rel(%d,%d) RETURN id(r)".format(rel1, rel2)).toList
 
     result should equal(List(Map("id(r)"-> rel1),Map("id(r)"-> rel2)))
   }
@@ -168,7 +168,7 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
   test("START r=rel(0),rr=rel(1) RETURN r") {
     val rel1 = relate(createNode(), createNode()).getId
     val rel2 = relate(createNode(), createNode()).getId
-    val result = executeWithAllPlannersAndCompatibilityMode("START r=rel(0),rr=rel(1) RETURN id(r), id(rr)").toList
+    val result = executeWithAllPlannersAndCompatibilityMode("START r=rel(%d),rr=rel(%d) RETURN id(r), id(rr)".format(rel1, rel2)).toList
 
     result should equal(List(Map("id(r)"-> rel1, "id(rr)"-> rel2)))
   }
@@ -267,10 +267,10 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     val bd = relate(b, d)
     val ce = relate(c, e)
     val result = executeWithAllPlannersAndCompatibilityMode(
-      """start a=node(0), ab=relationship(0), bd=relationship(2)
+      """start a=node(%d), ab=relationship(%d), bd=relationship(%d)
         |match (a)-[ab]->(b)-[bd]->(d)
         |return b, d
-      """.stripMargin)
+      """.format(a.getId, ab.getId, bd.getId).stripMargin)
 
     result.toList should equal(List(Map("b" -> b, "d" -> d)))
   }
@@ -284,10 +284,10 @@ class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     val ac = relate(a, c)
     val ad = relate(a, d)
     val result = executeWithAllPlannersAndCompatibilityMode(
-      """start a=node(0), ab=relationship(0, 1)
+      """start a=node(%d), ab=relationship(%d, %d)
         |match (a)-[ab]->(b)
         |return b
-      """.stripMargin)
+      """.format(a.getId, ab.getId, ac.getId).stripMargin)
 
     result.toSet should equal(Set(Map("b" -> c), Map("b" -> b)))
   }

--- a/tools/src/test/java/org/neo4j/tools/applytx/DatabaseRebuildToolTest.java
+++ b/tools/src/test/java/org/neo4j/tools/applytx/DatabaseRebuildToolTest.java
@@ -34,6 +34,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
@@ -195,7 +196,9 @@ public class DatabaseRebuildToolTest
 
     private void databaseWithSomeTransactions( File dir )
     {
-        GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( dir );
+        GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( dir )
+                .setConfig( GraphDatabaseSettings.record_id_batch_size, "1" )
+                .newGraphDatabase();
         Node[] nodes = new Node[10];
         for ( int i = 0; i < nodes.length; i++ )
         {


### PR DESCRIPTION
This reverts commit a966220998c8b8b5ba870e923aadd4090cc1a3ba.

This wasn't a strictly necessary change, mostly made to not require changing many tests relying on certain id ordering.