### PR TITLE
Handle <null> as return value in procedures and udf

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/expressions/AggregationFunctionInvocation.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/expressions/AggregationFunctionInvocation.scala
@@ -33,7 +33,9 @@ case class AggregationFunctionInvocation(signature: UserFunctionSignature, argum
   override def createAggregationFunction: AggregationFunction = new AggregationFunction {
     private var inner: UserDefinedAggregator = null
 
-    override def result(state: QueryState): AnyValue = valueConverter(aggregator(state).result)
+    override def result(state: QueryState): AnyValue = {
+      valueConverter(aggregator(state).result)
+    }
 
     override def apply(data: ExecutionContext, state: QueryState): Unit = {
       val argValues = arguments.map(arg => {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/expressions/FunctionInvocation.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/expressions/FunctionInvocation.scala
@@ -25,7 +25,6 @@ import org.neo4j.cypher.internal.compatibility.v3_3.runtime.mutation.GraphElemen
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes.QueryState
 import org.neo4j.cypher.internal.v3_3.logical.plans.UserFunctionSignature
 import org.neo4j.values._
-import org.neo4j.values.storable.Values
 
 case class FunctionInvocation(signature: UserFunctionSignature, arguments: IndexedSeq[Expression])
   extends Expression with GraphElementPropertyFunctions {
@@ -37,7 +36,7 @@ case class FunctionInvocation(signature: UserFunctionSignature, arguments: Index
       query.asObject(arg(ctx, state))
     })
     val result = query.callFunction(signature.name, argValues, signature.allowed)
-    if (result == null) Values.NO_VALUE else valueConverter(result)
+    valueConverter(result)
   }
 
   override def rewrite(f: (Expression) => Expression) =

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/expressions/FunctionInvocation.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/expressions/FunctionInvocation.scala
@@ -25,6 +25,7 @@ import org.neo4j.cypher.internal.compatibility.v3_3.runtime.mutation.GraphElemen
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes.QueryState
 import org.neo4j.cypher.internal.v3_3.logical.plans.UserFunctionSignature
 import org.neo4j.values._
+import org.neo4j.values.storable.Values
 
 case class FunctionInvocation(signature: UserFunctionSignature, arguments: IndexedSeq[Expression])
   extends Expression with GraphElementPropertyFunctions {
@@ -36,7 +37,7 @@ case class FunctionInvocation(signature: UserFunctionSignature, arguments: Index
       query.asObject(arg(ctx, state))
     })
     val result = query.callFunction(signature.name, argValues, signature.allowed)
-    valueConverter(result)
+    if (result == null) Values.NO_VALUE else valueConverter(result)
   }
 
   override def rewrite(f: (Expression) => Expression) =

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/helpers/ValueConversion.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/helpers/ValueConversion.scala
@@ -34,20 +34,24 @@ import org.neo4j.values.virtual.{MapValue, VirtualValues}
 import scala.collection.JavaConverters._
 
 object ValueConversion {
-  def getValueConverter(cType: CypherType): Any => AnyValue = cType match {
-    case symbols.CTNode => n => ValueUtils.fromNodeProxy(n.asInstanceOf[Node])
-    case symbols.CTRelationship => r => ValueUtils.fromRelationshipProxy(r.asInstanceOf[Relationship])
-    case symbols.CTBoolean => b => Values.booleanValue(b.asInstanceOf[Boolean])
-    case symbols.CTFloat => d => Values.doubleValue(d.asInstanceOf[Double])
-    case symbols.CTInteger => l => Values.longValue(l.asInstanceOf[Long])
-    case symbols.CTNumber => l => Values.numberValue(l.asInstanceOf[Number])
-    case symbols.CTString => l => Values.stringValue(l.asInstanceOf[String])
-    case symbols.CTPath => p => ValueUtils.asPathValue(p.asInstanceOf[Path])
-    case symbols.CTMap => m => ValueUtils.asMapValue(m.asInstanceOf[java.util.Map[String, AnyRef]])
-    case symbols.ListType(_)  => l => ValueUtils.asListValue(l.asInstanceOf[java.util.Collection[_]])
-    case symbols.CTAny => o => ValueUtils.of(o)
-    case symbols.CTPoint => o => ValueUtils.asPointValue(o.asInstanceOf[Point])
-    case symbols.CTGeometry => o => ValueUtils.asPointValue(o.asInstanceOf[Geometry])
+  def getValueConverter(cType: CypherType): Any => AnyValue = {
+    val converter: Any => AnyValue = cType match {
+      case symbols.CTNode => n => ValueUtils.fromNodeProxy(n.asInstanceOf[Node])
+      case symbols.CTRelationship => r => ValueUtils.fromRelationshipProxy(r.asInstanceOf[Relationship])
+      case symbols.CTBoolean => b => Values.booleanValue(b.asInstanceOf[Boolean])
+      case symbols.CTFloat => d => Values.doubleValue(d.asInstanceOf[Double])
+      case symbols.CTInteger => l => Values.longValue(l.asInstanceOf[Long])
+      case symbols.CTNumber => l => Values.numberValue(l.asInstanceOf[Number])
+      case symbols.CTString => l => Values.stringValue(l.asInstanceOf[String])
+      case symbols.CTPath => p => ValueUtils.asPathValue(p.asInstanceOf[Path])
+      case symbols.CTMap => m => ValueUtils.asMapValue(m.asInstanceOf[java.util.Map[String, AnyRef]])
+      case symbols.ListType(_)  => l => ValueUtils.asListValue(l.asInstanceOf[java.util.Collection[_]])
+      case symbols.CTAny => o => ValueUtils.of(o)
+      case symbols.CTPoint => o => ValueUtils.asPointValue(o.asInstanceOf[Point])
+      case symbols.CTGeometry => o => ValueUtils.asPointValue(o.asInstanceOf[Geometry])
+    }
+
+    (v) => if (v == null) Values.NO_VALUE else converter(v)
   }
 
   def asValues(params: Map[String, Any]): MapValue = VirtualValues.map(Eagerly.immutableMapValues(params, asValue).asJava)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/ProcedureCallPipe.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/ProcedureCallPipe.scala
@@ -57,10 +57,7 @@ case class ProcedureCallPipe(source: Pipe,
     case PassThroughRow => internalCreateResultsByPassingThrough _
   }
 
-  override protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
-
-    rowProcessor(input, state)
-  }
+  override protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = rowProcessor(input, state)
 
   private def internalCreateResultsByAppending(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     val qtx = state.query

--- a/community/kernel/src/main/java/org/neo4j/helpers/ValueUtils.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/ValueUtils.java
@@ -19,8 +19,10 @@
  */
 package org.neo4j.helpers;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -92,6 +94,16 @@ public final class ValueUtils
             else if ( object instanceof Collection<?> )
             {
                 return asListValue( (Collection<?>) object );
+            }
+            else if ( object instanceof Iterator<?> )
+            {
+                ArrayList<Object> objects = new ArrayList<>();
+                Iterator<?> iterator = (Iterator<?>) object;
+                while ( iterator.hasNext() )
+                {
+                    objects.add( iterator.next() );
+                }
+                return asListValue( objects );
             }
             else if ( object instanceof Stream<?> )
             {

--- a/community/kernel/src/test/java/org/neo4j/helpers/ValueUtilsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/ValueUtilsTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.helpers;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.values.AnyValue;
+import org.neo4j.values.virtual.ListValue;
+import org.neo4j.values.virtual.MapValue;
+import org.neo4j.values.virtual.VirtualValues;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.neo4j.values.storable.Values.intValue;
+import static org.neo4j.values.storable.Values.stringValue;
+
+public class ValueUtilsTest
+{
+    @Test
+    public void shouldHandleCollection()
+    {
+        // Given
+        Collection<Integer> collection = Arrays.asList( 1, 2, 3 );
+
+        // When
+
+        AnyValue of = ValueUtils.of( collection );
+
+        // Then
+        assertThat( of, instanceOf( ListValue.class ) );
+        ListValue listValue = (ListValue) of;
+        assertThat( listValue.value( 0 ), equalTo( intValue( 1 ) ) );
+        assertThat( listValue.value( 1 ), equalTo( intValue( 2 ) ) );
+        assertThat( listValue.value( 2 ), equalTo( intValue( 3 ) ) );
+        assertThat( listValue.size(), equalTo( 3 ) );
+    }
+
+    @Test
+    public void shouldHandleIterator()
+    {
+        // Given
+        Iterator<Integer> iterator = Arrays.asList( 1, 2, 3 ).iterator();
+
+        // When
+        AnyValue of = ValueUtils.of( iterator );
+
+        // Then
+        assertThat( of, instanceOf( ListValue.class ) );
+        ListValue listValue = (ListValue) of;
+        assertThat( listValue.value( 0 ), equalTo( intValue( 1 ) ) );
+        assertThat( listValue.value( 1 ), equalTo( intValue( 2 ) ) );
+        assertThat( listValue.value( 2 ), equalTo( intValue( 3 ) ) );
+        assertThat( listValue.size(), equalTo( 3 ) );
+    }
+
+    @Test
+    public void shouldHandleMaps()
+    {
+        // Given
+        Map<String,Object> map = MapUtil.map( "a", Arrays.asList( "foo", 42 ) );
+
+        // When
+        AnyValue anyValue = ValueUtils.of( map );
+
+        // Then
+        assertThat( anyValue, instanceOf( MapValue.class ) );
+        MapValue mapValue = (MapValue) anyValue;
+        assertThat( mapValue.get( "a" ), equalTo( VirtualValues.list( stringValue( "foo" ), intValue( 42 ) ) ) );
+        assertThat( mapValue.size(), equalTo( 1 ) );
+    }
+}

--- a/integrationtests/src/test/java/org/neo4j/procedure/UserAggregationFunctionIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/UserAggregationFunctionIT.java
@@ -192,6 +192,18 @@ public class UserAggregationFunctionIT
     }
 
     @Test
+    public void shouldHandleNullPath()
+    {
+        // When
+        Result result = db.execute(
+                "MATCH p=()-[:T*]->() WITH org.neo4j.procedure.longestPath(p) AS longest RETURN longest");
+
+        // Then
+        assertThat( result.next(), equalTo( map( "longest", null ) ) );
+        assertFalse( result.hasNext() );
+    }
+
+    @Test
     public void shouldHandleNumberArgumentAggregationFunction()
     {
         // Given, When

--- a/integrationtests/src/test/java/org/neo4j/procedure/UserFunctionIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/UserFunctionIT.java
@@ -974,7 +974,7 @@ public class UserFunctionIT
             long count = 0L;
             for ( Node node : nodes )
             {
-                if (node != null)
+                if ( node != null )
                 {
                     count++;
                 }


### PR DESCRIPTION
Procedures, user-defined functions, and user-defined aggregation functions wasn't properly handling null as a return value. Also wasn't supporting iterators as input from parameters.