### PR TITLE
Fixed flaky StartClientIT

### DIFF
--- a/community/shell/src/test/resources/testshell.txt
+++ b/community/shell/src/test/resources/testshell.txt
@@ -1,3 +1,3 @@
 mknode
 cd -a 0
-set "foo" "bar"
+set "testshell_foo" "testshell_bar"


### PR DESCRIPTION
It sometimes failed because created nodes did not have ID zero. Replaced node by ID lookup with query that finds node by property.