### PR TITLE
Fix statement close in db.propertyKeys()

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
@@ -67,8 +67,6 @@ public class BuiltInProcedures
     {
         try ( Statement statement = tx.acquireStatement() )
         {
-            // Ownership of the reference to the acquired statement is transfered to the returned iterator stream,
-            // but we still want to eagerly consume the labels, so we can catch any exceptions,
             List<LabelResult> labelResults = asList( TokenAccess.LABELS.inUse( statement ).map( LabelResult::new ) );
             return labelResults.stream();
         }
@@ -80,11 +78,8 @@ public class BuiltInProcedures
     {
         try ( Statement statement = tx.acquireStatement() )
         {
-            // Ownership of the reference to the acquired statement is transfered to the returned iterator stream,
-            // but we still want to eagerly consume the labels, so we can catch any exceptions,
             List<PropertyKeyResult> propertyKeys =
                     asList( TokenAccess.PROPERTY_KEYS.inUse( statement ).map( PropertyKeyResult::new ) );
-            statement.close();
             return propertyKeys.stream();
         }
     }
@@ -95,8 +90,6 @@ public class BuiltInProcedures
     {
         try ( Statement statement = tx.acquireStatement() )
         {
-            // Ownership of the reference to the acquired statement is transfered to the returned iterator stream,
-            // but we still want to eagerly consume the labels, so we can catch any exceptions,
             List<RelationshipTypeResult> relationshipTypes =
                     asList( TokenAccess.RELATIONSHIP_TYPES.inUse( statement ).map( RelationshipTypeResult::new ) );
             return relationshipTypes.stream();

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProcedureCallSupportAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProcedureCallSupportAcceptanceTest.scala
@@ -98,7 +98,9 @@ class ProcedureCallSupportAcceptanceTest extends ProcedureCallAcceptanceTest {
       "UNION " +
       "CALL db.relationshipTypes() YIELD relationshipType RETURN relationshipType as result " +
       "UNION " +
-      "CALL db.propertyKeys() YIELD propertyKey RETURN propertyKey as result"
+      "CALL db.propertyKeys() YIELD propertyKey RETURN propertyKey as result " +
+      "UNION " +
+      "CALL db.labels() YIELD label RETURN label as result"
 
     val result = graph.execute(query)
 


### PR DESCRIPTION
An extra statement close sneaked in that was not covered by the
test case.