### PR TITLE
Never namespace graph variables

### DIFF
--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/helpers/StatementHelper.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/helpers/StatementHelper.scala
@@ -20,20 +20,21 @@
 package org.neo4j.cypher.internal.compiler.v3_3.helpers
 
 import org.neo4j.cypher.internal.frontend.v3_3.ast.Statement
-import org.neo4j.cypher.internal.frontend.v3_3.{Scope, SemanticCheckResult, SemanticState}
+import org.neo4j.cypher.internal.frontend.v3_3.{Scope, SemanticCheckResult, SemanticFeature, SemanticState}
 import org.scalatest.Assertions
 
 object StatementHelper extends Assertions {
 
   implicit class RichStatement(ast: Statement) {
-    def semanticState: SemanticState = ast.semanticCheck(SemanticState.clean) match {
-      case SemanticCheckResult(state, errors) =>
-        if (errors.isEmpty) {
-          state
-        } else
-          fail(s"Failure during semantic checking of $ast with errors $errors")
-    }
+    def semanticState(features: SemanticFeature*): SemanticState =
+      ast.semanticCheck(SemanticState.clean.withFeatures(features: _*)) match {
+        case SemanticCheckResult(state, errors) =>
+          if (errors.isEmpty) {
+            state
+          } else
+            fail(s"Failure during semantic checking of $ast with errors $errors")
+      }
 
-    def scope: Scope = semanticState.scopeTree
+    def scope: Scope = semanticState().scopeTree
   }
 }

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/rewriters/Namespacer.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/rewriters/Namespacer.scala
@@ -56,11 +56,27 @@ object Namespacer extends Phase[BaseContext, BaseState, BaseState] {
   private def returnAliases(statement: Statement): Set[Ref[Variable]] =
     statement.treeFold(Set.empty[Ref[Variable]]) {
 
+      case With(_, _, GraphReturnItems(_, items), _, _, _, _) =>
+        val gVars = extractGraphVars(items)
+        acc => (acc ++ gVars, Some(identity))
+
       // ignore variable in StartItem that represents index names and key names
-      case Return(_, ReturnItems(_, items), _, _, _, _, _) =>
+      case Return(_, ReturnItems(_, items), graphItems, _, _, _, _) =>
         val variables = items.map(_.alias.map(Ref[Variable]).get)
-        acc => (acc ++ variables, Some(identity))
+        val gVars = graphItems.map(_.items).map(extractGraphVars).getOrElse(Seq.empty)
+        acc => (acc ++ variables ++ gVars, Some(identity))
     }
+
+  private def extractGraphVars(items: Seq[GraphReturnItem]): Seq[Ref[Variable]] = {
+    items.flatMap { item =>
+      item.graphs.flatMap {
+        case g: GraphAs =>
+          Seq(g.ref, g.as.get).map(Ref[Variable])
+        case x =>
+          x.as.map(Ref[Variable])
+      }
+    }
+  }
 
   private def variableRenamings(statement: Statement, variableDefinitions: Map[SymbolUse, SymbolUse],
                                 ambiguousNames: Set[String], protectedVariables: Set[Ref[Variable]]): VariableRenamings =

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/rewriters/normalizeGraphReturnItems.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/rewriters/normalizeGraphReturnItems.scala
@@ -28,7 +28,7 @@ case object normalizeGraphReturnItems extends Rewriter {
     case item: SourceGraphAs => item
     case item: TargetGraphAs => item
     case graphItem@GraphAs(ref, None, _) =>
-      graphItem.copy(as = Some(ref))(graphItem.position)
+      graphItem.copy(as = Some(Variable(ref.name)(ref.position)))(graphItem.position)
     case graphItem: SingleGraphAs if graphItem.as.isEmpty =>
       val pos = graphItem.position.bumped()
       graphItem.withNewName(Variable(FreshIdNameGenerator.name(pos))(pos)).asGenerated

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/package.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/package.scala
@@ -93,7 +93,9 @@ package object v3_3 {
 
     // Only run a check if a given feature is *not* enabled
     def unlessFeatureEnabled(feature: SemanticFeature): SemanticCheck =
-      (s: SemanticState) => if(!s.features(feature)) check(s) else SemanticCheckResult.success(s)
+      (s: SemanticState) =>
+        if (!s.features(feature)) check(s)
+        else SemanticCheckResult.success(s)
   }
 }
 


### PR DESCRIPTION
Graph variables are only introduced in a projection clause, and have
duplication of names checked at that point.

- Do not re-use variable instance when normalising