### PR TITLE
Label and schema index log internal recovery

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
@@ -226,12 +226,14 @@ public class ConsistencyCheckService
         } ) );
 
         // Bootstrap kernel extensions
+        Monitors monitors = new Monitors();
         LifeSupport life = new LifeSupport();
         KernelExtensions extensions = life.add( instantiateKernelExtensions( storeDir,
                 fileSystem, config, new SimpleLogService( logProvider, logProvider ), pageCache,
                 RECOVERY_PREVENTING_COLLECTOR,
                 // May be enterprise edition, but in consistency checker we only care about the operational mode
-                COMMUNITY ) );
+                COMMUNITY,
+                monitors ) );
 
         try ( NeoStores neoStores = factory.openAllNeoStores() )
         {
@@ -240,7 +242,7 @@ public class ConsistencyCheckService
             SchemaIndexProviderMap indexes = loadSchemaIndexProviders( extensions );
 
             LabelScanStore labelScanStore =
-                    new NativeLabelScanStore( pageCache, storeDir, FullStoreChangeStream.EMPTY, true, new Monitors(),
+                    new NativeLabelScanStore( pageCache, storeDir, FullStoreChangeStream.EMPTY, true, monitors,
                             RecoveryCleanupWorkCollector.IMMEDIATE );
             life.add( labelScanStore );
 

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/internal/SchemaIndexExtensionLoader.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/internal/SchemaIndexExtensionLoader.java
@@ -40,6 +40,7 @@ import org.neo4j.kernel.impl.spi.SimpleKernelContext;
 import org.neo4j.kernel.impl.transaction.state.DefaultSchemaIndexProviderMap;
 import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+import org.neo4j.kernel.monitoring.Monitors;
 
 /**
  * Utility for loading {@link SchemaIndexProvider} instances from {@link KernelExtensions}.
@@ -63,10 +64,10 @@ public class SchemaIndexExtensionLoader
     @SuppressWarnings( "unchecked" )
     public static KernelExtensions instantiateKernelExtensions( File storeDir, FileSystemAbstraction fileSystem,
             Config config, LogService logService, PageCache pageCache,
-            RecoveryCleanupWorkCollector recoveryCollector, DatabaseInfo databaseInfo )
+            RecoveryCleanupWorkCollector recoveryCollector, DatabaseInfo databaseInfo, Monitors monitors )
     {
         Dependencies deps = new Dependencies();
-        deps.satisfyDependencies( fileSystem, config, logService, pageCache, recoveryCollector );
+        deps.satisfyDependencies( fileSystem, config, logService, pageCache, recoveryCollector, monitors );
         @SuppressWarnings( "rawtypes" )
         Iterable kernelExtensions = Service.load( KernelExtensionFactory.class );
         KernelContext kernelContext = new SimpleKernelContext( storeDir, databaseInfo, deps );

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/GraphStoreFixture.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/GraphStoreFixture.java
@@ -183,17 +183,18 @@ public abstract class GraphStoreFixture extends ConfigurablePageCacheRule implem
             IndexStoreView indexStoreView =
                     new NeoStoreIndexStoreView( LockService.NO_LOCK_SERVICE, nativeStores.getRawNeoStores() );
 
-            LabelScanStore labelScanStore = startLabelScanStore( pageCache, indexStoreView );
-            SchemaIndexProviderMap indexes = createIndexes( pageCache, fileSystem, directory, config, logProvider );
+            Monitors monitors = new Monitors();
+            LabelScanStore labelScanStore = startLabelScanStore( pageCache, indexStoreView, monitors );
+            SchemaIndexProviderMap indexes = createIndexes( pageCache, fileSystem, directory, config, logProvider, monitors);
             directStoreAccess = new DirectStoreAccess( nativeStores, labelScanStore, indexes );
         }
         return directStoreAccess;
     }
 
-    private LabelScanStore startLabelScanStore( PageCache pageCache, IndexStoreView indexStoreView )
+    private LabelScanStore startLabelScanStore( PageCache pageCache, IndexStoreView indexStoreView, Monitors monitors )
     {
         NativeLabelScanStore labelScanStore =
-                new NativeLabelScanStore( pageCache, directory, new FullLabelStream( indexStoreView ), false, new Monitors(),
+                new NativeLabelScanStore( pageCache, directory, new FullLabelStream( indexStoreView ), false, monitors,
                         RecoveryCleanupWorkCollector.IMMEDIATE );
         try
         {
@@ -208,11 +209,11 @@ public abstract class GraphStoreFixture extends ConfigurablePageCacheRule implem
     }
 
     private SchemaIndexProviderMap createIndexes( PageCache pageCache, FileSystemAbstraction fileSystem, File storeDir,
-            Config config, LogProvider logProvider )
+            Config config, LogProvider logProvider, Monitors monitors )
     {
         LogService logService = new SimpleLogService( logProvider, logProvider );
         KernelExtensions extensions = life.add( instantiateKernelExtensions( storeDir, fileSystem, config, logService,
-                pageCache, RECOVERY_PREVENTING_COLLECTOR, DatabaseInfo.COMMUNITY ) );
+                pageCache, RECOVERY_PREVENTING_COLLECTOR, DatabaseInfo.COMMUNITY, monitors ) );
         return loadSchemaIndexProviders( extensions );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/LoggingMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/LoggingMonitor.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.index;
+
+import java.util.Map;
+
+import org.neo4j.kernel.api.schema.index.IndexDescriptor;
+import org.neo4j.logging.Log;
+
+import static java.lang.String.format;
+
+public class LoggingMonitor implements SchemaIndexProvider.Monitor
+{
+    private final Log log;
+
+    public LoggingMonitor( Log log )
+    {
+        this.log = log;
+    }
+
+    @Override
+    public void failedToOpenIndex( long indexId, IndexDescriptor indexDescriptor, String action, Exception cause )
+    {
+        log.error( "Failed to open index:" + indexId + ". " + action, cause );
+    }
+
+    @Override
+    public void recoveryCompleted( long indexId, IndexDescriptor indexDescriptor, Map<String,Object> data )
+    {
+        StringBuilder builder =
+                new StringBuilder(
+                        "Schema index recovery completed: indexId: " + indexId + " descriptor: " + indexDescriptor.toString() );
+        data.forEach( ( key, value ) -> builder.append( format( " %s: %s", key, value ) ) );
+        log.info( builder.toString() );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/SchemaIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/SchemaIndexProvider.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.api.index;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Map;
 
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.collection.Iterators;
@@ -92,6 +93,28 @@ import org.neo4j.kernel.lifecycle.LifecycleAdapter;
  */
 public abstract class SchemaIndexProvider extends LifecycleAdapter implements Comparable<SchemaIndexProvider>
 {
+    public interface Monitor
+    {
+        Monitor EMPTY = new Monitor.Adaptor();
+
+        class Adaptor implements Monitor
+        {
+            @Override
+            public void failedToOpenIndex( long indexId, IndexDescriptor indexDescriptor, String action, Exception cause )
+            {   // no-op
+            }
+
+            @Override
+            public void recoveryCompleted( long indexId, IndexDescriptor indexDescriptor, Map<String,Object> data )
+            {   // no-op
+            }
+        }
+
+        void failedToOpenIndex( long indexId, IndexDescriptor indexDescriptor, String action, Exception cause );
+
+        void recoveryCompleted( long indexId, IndexDescriptor indexDescriptor, Map<String,Object> data );
+    }
+
     public static final SchemaIndexProvider NO_INDEX_PROVIDER =
             new SchemaIndexProvider( new Descriptor( "no-index-provider", "1.0" ), -1, IndexDirectoryStructure.NONE )
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeNonUniqueSchemaNumberIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeNonUniqueSchemaNumberIndexPopulator.java
@@ -27,11 +27,11 @@ import org.neo4j.index.internal.gbptree.Layout;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.IndexEntryUpdate;
+import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.index.sampling.DefaultNonUniqueIndexSampler;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.kernel.impl.api.index.sampling.NonUniqueIndexSampler;
-import org.neo4j.logging.Log;
 import org.neo4j.storageengine.api.schema.IndexSample;
 
 /**
@@ -45,9 +45,9 @@ class NativeNonUniqueSchemaNumberIndexPopulator<KEY extends SchemaNumberKey, VAL
     private NonUniqueIndexSampler sampler;
 
     NativeNonUniqueSchemaNumberIndexPopulator( PageCache pageCache, FileSystemAbstraction fs, File storeFile, Layout<KEY,VALUE> layout,
-            IndexSamplingConfig samplingConfig, Log log, IndexDescriptor descriptor, long indexId )
+            IndexSamplingConfig samplingConfig, SchemaIndexProvider.Monitor monitor, IndexDescriptor descriptor, long indexId )
     {
-        super( pageCache, fs, storeFile, layout, log, descriptor, indexId );
+        super( pageCache, fs, storeFile, layout, monitor, descriptor, indexId );
         this.samplingConfig = samplingConfig;
         this.sampler = new DefaultNonUniqueIndexSampler( samplingConfig.sampleSizeLimit() );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeNonUniqueSchemaNumberIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeNonUniqueSchemaNumberIndexPopulator.java
@@ -27,9 +27,11 @@ import org.neo4j.index.internal.gbptree.Layout;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.IndexEntryUpdate;
+import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.index.sampling.DefaultNonUniqueIndexSampler;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.kernel.impl.api.index.sampling.NonUniqueIndexSampler;
+import org.neo4j.logging.Log;
 import org.neo4j.storageengine.api.schema.IndexSample;
 
 /**
@@ -43,9 +45,9 @@ class NativeNonUniqueSchemaNumberIndexPopulator<KEY extends SchemaNumberKey, VAL
     private NonUniqueIndexSampler sampler;
 
     NativeNonUniqueSchemaNumberIndexPopulator( PageCache pageCache, FileSystemAbstraction fs, File storeFile, Layout<KEY,VALUE> layout,
-            IndexSamplingConfig samplingConfig )
+            IndexSamplingConfig samplingConfig, Log log, IndexDescriptor descriptor, long indexId )
     {
-        super( pageCache, fs, storeFile, layout );
+        super( pageCache, fs, storeFile, layout, log, descriptor, indexId );
         this.samplingConfig = samplingConfig;
         this.sampler = new DefaultNonUniqueIndexSampler( samplingConfig.sampleSizeLimit() );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndex.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndex.java
@@ -30,10 +30,12 @@ import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.impl.index.GBPTreeFileUtil;
+import org.neo4j.logging.Log;
 
+import static org.neo4j.helpers.Format.duration;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_READER;
-import static org.neo4j.index.internal.gbptree.GBPTree.NO_MONITOR;
 
 class NativeSchemaNumberIndex<KEY extends SchemaNumberKey, VALUE extends SchemaNumberValue>
 {
@@ -41,23 +43,50 @@ class NativeSchemaNumberIndex<KEY extends SchemaNumberKey, VALUE extends SchemaN
     final File storeFile;
     final Layout<KEY,VALUE> layout;
     final GBPTreeFileUtil gbpTreeFileUtil;
+    private final Log log;
+    private final IndexDescriptor descriptor;
+    private final long indexId;
 
     GBPTree<KEY,VALUE> tree;
 
-    NativeSchemaNumberIndex( PageCache pageCache, FileSystemAbstraction fs, File storeFile, Layout<KEY,VALUE> layout )
+    NativeSchemaNumberIndex( PageCache pageCache, FileSystemAbstraction fs, File storeFile, Layout<KEY,VALUE> layout, Log log,
+            IndexDescriptor descriptor, long indexId )
     {
         this.pageCache = pageCache;
         this.storeFile = storeFile;
         this.layout = layout;
         this.gbpTreeFileUtil = new GBPTreeFileSystemFileUtil( fs );
+        this.log = log;
+        this.descriptor = descriptor;
+        this.indexId = indexId;
     }
 
     void instantiateTree( RecoveryCleanupWorkCollector recoveryCleanupWorkCollector, Consumer<PageCursor> headerWriter )
             throws IOException
     {
         ensureDirectoryExist();
-        tree = new GBPTree<>( pageCache, storeFile, layout, 0, NO_MONITOR, NO_HEADER_READER, headerWriter,
-                recoveryCleanupWorkCollector );
+        GBPTree.Monitor monitor = treeMonitor();
+        tree = new GBPTree<>( pageCache, storeFile, layout, 0, monitor, NO_HEADER_READER, headerWriter, recoveryCleanupWorkCollector );
+    }
+
+    private GBPTree.Monitor treeMonitor( )
+    {
+        return new GBPTree.Monitor.Adaptor()
+        {
+            @Override
+            public void cleanupFinished( long numberOfPagesVisited, long numberOfCleanedCrashPointers, long durationMillis )
+            {
+                log.info( String.format(
+                        "%s Schema index recovery completed. Number of pages visited: %d. Number of cleaned crashed pointers: %d. Time " +
+                                "spent: %s.",
+                        indexDescription(), numberOfPagesVisited, numberOfCleanedCrashPointers, duration( durationMillis ) ) );
+            }
+        };
+    }
+
+    private String indexDescription()
+    {
+        return String.format( "[indexId:%d, descriptor:'%s']", indexId, descriptor );
     }
 
     private void ensureDirectoryExist() throws IOException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexAccessor.java
@@ -34,9 +34,9 @@ import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.PropertyAccessor;
+import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
-import org.neo4j.logging.Log;
 import org.neo4j.storageengine.api.schema.IndexReader;
 
 import static org.neo4j.helpers.collection.Iterators.asResourceIterator;
@@ -49,10 +49,10 @@ public class NativeSchemaNumberIndexAccessor<KEY extends SchemaNumberKey, VALUE 
     private final NativeSchemaNumberIndexUpdater<KEY,VALUE> singleUpdater;
 
     NativeSchemaNumberIndexAccessor( PageCache pageCache, FileSystemAbstraction fs, File storeFile,
-            Layout<KEY,VALUE> layout, RecoveryCleanupWorkCollector recoveryCleanupWorkCollector, Log log, IndexDescriptor descriptor,
-            long indexId ) throws IOException
+            Layout<KEY,VALUE> layout, RecoveryCleanupWorkCollector recoveryCleanupWorkCollector, SchemaIndexProvider.Monitor monitor,
+            IndexDescriptor descriptor, long indexId ) throws IOException
     {
-        super( pageCache, fs, storeFile, layout, log, descriptor, indexId );
+        super( pageCache, fs, storeFile, layout, monitor, descriptor, indexId );
         singleUpdater = new NativeSchemaNumberIndexUpdater<>( layout.newKey(), layout.newValue() );
         instantiateTree( recoveryCleanupWorkCollector, NO_HEADER_WRITER );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexAccessor.java
@@ -34,7 +34,9 @@ import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.PropertyAccessor;
+import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
+import org.neo4j.logging.Log;
 import org.neo4j.storageengine.api.schema.IndexReader;
 
 import static org.neo4j.helpers.collection.Iterators.asResourceIterator;
@@ -47,9 +49,10 @@ public class NativeSchemaNumberIndexAccessor<KEY extends SchemaNumberKey, VALUE 
     private final NativeSchemaNumberIndexUpdater<KEY,VALUE> singleUpdater;
 
     NativeSchemaNumberIndexAccessor( PageCache pageCache, FileSystemAbstraction fs, File storeFile,
-            Layout<KEY,VALUE> layout, RecoveryCleanupWorkCollector recoveryCleanupWorkCollector ) throws IOException
+            Layout<KEY,VALUE> layout, RecoveryCleanupWorkCollector recoveryCleanupWorkCollector, Log log, IndexDescriptor descriptor,
+            long indexId ) throws IOException
     {
-        super( pageCache, fs, storeFile, layout );
+        super( pageCache, fs, storeFile, layout, log, descriptor, indexId );
         singleUpdater = new NativeSchemaNumberIndexUpdater<>( layout.newKey(), layout.newValue() );
         instantiateTree( recoveryCleanupWorkCollector, NO_HEADER_WRITER );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexPopulator.java
@@ -41,8 +41,8 @@ import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.PropertyAccessor;
+import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
-import org.neo4j.logging.Log;
 
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_WRITER;
 
@@ -68,10 +68,10 @@ public abstract class NativeSchemaNumberIndexPopulator<KEY extends SchemaNumberK
     private byte[] failureBytes;
     private boolean dropped;
 
-    NativeSchemaNumberIndexPopulator( PageCache pageCache, FileSystemAbstraction fs, File storeFile, Layout<KEY,VALUE> layout, Log log,
-            IndexDescriptor descriptor, long indexId )
+    NativeSchemaNumberIndexPopulator( PageCache pageCache, FileSystemAbstraction fs, File storeFile, Layout<KEY,VALUE> layout,
+            SchemaIndexProvider.Monitor monitor, IndexDescriptor descriptor, long indexId )
     {
-        super( pageCache, fs, storeFile, layout, log, descriptor, indexId );
+        super( pageCache, fs, storeFile, layout, monitor, descriptor, indexId );
         this.treeKey = layout.newKey();
         this.treeValue = layout.newValue();
         this.conflictDetectingValueMerger = new ConflictDetectingValueMerger<>();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexPopulator.java
@@ -41,6 +41,8 @@ import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.PropertyAccessor;
+import org.neo4j.kernel.api.schema.index.IndexDescriptor;
+import org.neo4j.logging.Log;
 
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_WRITER;
 
@@ -66,9 +68,10 @@ public abstract class NativeSchemaNumberIndexPopulator<KEY extends SchemaNumberK
     private byte[] failureBytes;
     private boolean dropped;
 
-    NativeSchemaNumberIndexPopulator( PageCache pageCache, FileSystemAbstraction fs, File storeFile, Layout<KEY,VALUE> layout )
+    NativeSchemaNumberIndexPopulator( PageCache pageCache, FileSystemAbstraction fs, File storeFile, Layout<KEY,VALUE> layout, Log log,
+            IndexDescriptor descriptor, long indexId )
     {
-        super( pageCache, fs, storeFile, layout );
+        super( pageCache, fs, storeFile, layout, log, descriptor, indexId );
         this.treeKey = layout.newKey();
         this.treeValue = layout.newValue();
         this.conflictDetectingValueMerger = new ConflictDetectingValueMerger<>();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProvider.java
@@ -79,9 +79,11 @@ public class NativeSchemaNumberIndexProvider extends SchemaIndexProvider
         switch ( descriptor.type() )
         {
         case GENERAL:
-            return new NativeNonUniqueSchemaNumberIndexPopulator<>( pageCache, fs, storeFile, new NonUniqueNumberLayout(), samplingConfig );
+            return new NativeNonUniqueSchemaNumberIndexPopulator<>( pageCache, fs, storeFile, new NonUniqueNumberLayout(), samplingConfig,
+                    log, descriptor, indexId );
         case UNIQUE:
-            return new NativeUniqueSchemaNumberIndexPopulator<>( pageCache, fs, storeFile, new UniqueNumberLayout() );
+            return new NativeUniqueSchemaNumberIndexPopulator<>( pageCache, fs, storeFile, new UniqueNumberLayout(), log, descriptor,
+                    indexId );
         default:
             throw new UnsupportedOperationException( "Can not create index populator of type " + descriptor.type() );
         }
@@ -104,7 +106,8 @@ public class NativeSchemaNumberIndexProvider extends SchemaIndexProvider
         default:
             throw new UnsupportedOperationException( "Can not create index accessor of type " + descriptor.type() );
         }
-        return new NativeSchemaNumberIndexAccessor<>( pageCache, fs, storeFile, layout, recoveryCleanupWorkCollector );
+        return new NativeSchemaNumberIndexAccessor<>( pageCache, fs, storeFile, layout, recoveryCleanupWorkCollector, log, descriptor,
+                indexId );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProvider.java
@@ -35,8 +35,6 @@ import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.kernel.impl.storemigration.StoreMigrationParticipant;
-import org.neo4j.logging.Log;
-import org.neo4j.logging.LogProvider;
 
 import static org.neo4j.kernel.impl.index.schema.NativeSchemaNumberIndexPopulator.BYTE_FAILED;
 import static org.neo4j.kernel.impl.index.schema.NativeSchemaNumberIndexPopulator.BYTE_ONLINE;
@@ -52,17 +50,18 @@ public class NativeSchemaNumberIndexProvider extends SchemaIndexProvider
 
     private final PageCache pageCache;
     private final FileSystemAbstraction fs;
-    private final Log log;
+    private final Monitor monitor;
     private final RecoveryCleanupWorkCollector recoveryCleanupWorkCollector;
     private final boolean readOnly;
 
-    public NativeSchemaNumberIndexProvider( PageCache pageCache, FileSystemAbstraction fs, IndexDirectoryStructure.Factory directoryStructure,
-            LogProvider logging, RecoveryCleanupWorkCollector recoveryCleanupWorkCollector, boolean readOnly )
+    public NativeSchemaNumberIndexProvider( PageCache pageCache, FileSystemAbstraction fs,
+            IndexDirectoryStructure.Factory directoryStructure, Monitor monitor, RecoveryCleanupWorkCollector recoveryCleanupWorkCollector,
+            boolean readOnly )
     {
         super( NATIVE_PROVIDER_DESCRIPTOR, 0, directoryStructure );
         this.pageCache = pageCache;
         this.fs = fs;
-        this.log = logging.getLog( getClass() );
+        this.monitor = monitor;
         this.recoveryCleanupWorkCollector = recoveryCleanupWorkCollector;
         this.readOnly = readOnly;
     }
@@ -80,9 +79,9 @@ public class NativeSchemaNumberIndexProvider extends SchemaIndexProvider
         {
         case GENERAL:
             return new NativeNonUniqueSchemaNumberIndexPopulator<>( pageCache, fs, storeFile, new NonUniqueNumberLayout(), samplingConfig,
-                    log, descriptor, indexId );
+                    monitor, descriptor, indexId );
         case UNIQUE:
-            return new NativeUniqueSchemaNumberIndexPopulator<>( pageCache, fs, storeFile, new UniqueNumberLayout(), log, descriptor,
+            return new NativeUniqueSchemaNumberIndexPopulator<>( pageCache, fs, storeFile, new UniqueNumberLayout(), monitor, descriptor,
                     indexId );
         default:
             throw new UnsupportedOperationException( "Can not create index populator of type " + descriptor.type() );
@@ -106,7 +105,7 @@ public class NativeSchemaNumberIndexProvider extends SchemaIndexProvider
         default:
             throw new UnsupportedOperationException( "Can not create index accessor of type " + descriptor.type() );
         }
-        return new NativeSchemaNumberIndexAccessor<>( pageCache, fs, storeFile, layout, recoveryCleanupWorkCollector, log, descriptor,
+        return new NativeSchemaNumberIndexAccessor<>( pageCache, fs, storeFile, layout, recoveryCleanupWorkCollector, monitor, descriptor,
                 indexId );
     }
 
@@ -158,7 +157,7 @@ public class NativeSchemaNumberIndexProvider extends SchemaIndexProvider
         }
         catch ( IOException e )
         {
-            log.error( "Failed to open index:" + indexId + ", requesting re-population.", e );
+            monitor.failedToOpenIndex( indexId, descriptor, "Requesting re-population.", e );
             return InternalIndexState.POPULATING;
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeUniqueSchemaNumberIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeUniqueSchemaNumberIndexPopulator.java
@@ -25,9 +25,9 @@ import org.neo4j.index.internal.gbptree.Layout;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.IndexEntryUpdate;
+import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.index.sampling.UniqueIndexSampler;
-import org.neo4j.logging.Log;
 import org.neo4j.storageengine.api.schema.IndexSample;
 
 /**
@@ -39,9 +39,9 @@ class NativeUniqueSchemaNumberIndexPopulator<KEY extends SchemaNumberKey, VALUE 
     private final UniqueIndexSampler sampler;
 
     NativeUniqueSchemaNumberIndexPopulator( PageCache pageCache, FileSystemAbstraction fs, File storeFile, Layout<KEY,VALUE> layout,
-            Log log, IndexDescriptor descriptor, long indexId )
+            SchemaIndexProvider.Monitor monitor, IndexDescriptor descriptor, long indexId )
     {
-        super( pageCache, fs, storeFile, layout, log, descriptor, indexId );
+        super( pageCache, fs, storeFile, layout, monitor, descriptor, indexId );
         this.sampler = new UniqueIndexSampler();
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeUniqueSchemaNumberIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeUniqueSchemaNumberIndexPopulator.java
@@ -25,7 +25,9 @@ import org.neo4j.index.internal.gbptree.Layout;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.IndexEntryUpdate;
+import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.index.sampling.UniqueIndexSampler;
+import org.neo4j.logging.Log;
 import org.neo4j.storageengine.api.schema.IndexSample;
 
 /**
@@ -36,9 +38,10 @@ class NativeUniqueSchemaNumberIndexPopulator<KEY extends SchemaNumberKey, VALUE 
 {
     private final UniqueIndexSampler sampler;
 
-    NativeUniqueSchemaNumberIndexPopulator( PageCache pageCache, FileSystemAbstraction fs, File storeFile, Layout<KEY,VALUE> layout )
+    NativeUniqueSchemaNumberIndexPopulator( PageCache pageCache, FileSystemAbstraction fs, File storeFile, Layout<KEY,VALUE> layout,
+            Log log, IndexDescriptor descriptor, long indexId )
     {
-        super( pageCache, fs, storeFile, layout );
+        super( pageCache, fs, storeFile, layout, log, descriptor, indexId );
         this.sampler = new UniqueIndexSampler();
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/RecordStorageEngine.java
@@ -40,6 +40,7 @@ import org.neo4j.kernel.api.exceptions.schema.ConstraintValidationException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.labelscan.LabelScanWriter;
+import org.neo4j.kernel.api.labelscan.LoggingMonitor;
 import org.neo4j.kernel.api.txstate.TransactionCountingStateVisitor;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.BatchTransactionApplier;
@@ -203,6 +204,7 @@ public class RecordStorageEngine implements StorageEngine, Lifecycle
 
             NeoStoreIndexStoreView neoStoreIndexStoreView = new NeoStoreIndexStoreView( lockService, neoStores );
             Boolean readOnly = config.get( GraphDatabaseSettings.read_only ) && operationalMode == OperationalMode.single;
+            monitors.addMonitorListener( new LoggingMonitor( logProvider.getLog( NativeLabelScanStore.class ) ) );
             labelScanStore = new NativeLabelScanStore( pageCache, storeDir, new FullLabelStream( neoStoreIndexStoreView ),
                     readOnly, monitors, recoveryCleanupWorkCollector );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeNonUniqueSchemaNumberIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeNonUniqueSchemaNumberIndexPopulatorTest.java
@@ -45,7 +45,8 @@ public class NativeNonUniqueSchemaNumberIndexPopulatorTest
     NativeSchemaNumberIndexPopulator<SchemaNumberKey,SchemaNumberValue> createPopulator( PageCache pageCache, FileSystemAbstraction fs,
             File indexFile, Layout<SchemaNumberKey,SchemaNumberValue> layout, IndexSamplingConfig samplingConfig )
     {
-        return new NativeNonUniqueSchemaNumberIndexPopulator<>( pageCache, fs, indexFile, layout, samplingConfig );
+        return new NativeNonUniqueSchemaNumberIndexPopulator<>( pageCache, fs, indexFile, layout, samplingConfig, log, indexDescriptor,
+                indexId );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeNonUniqueSchemaNumberIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeNonUniqueSchemaNumberIndexPopulatorTest.java
@@ -45,7 +45,7 @@ public class NativeNonUniqueSchemaNumberIndexPopulatorTest
     NativeSchemaNumberIndexPopulator<SchemaNumberKey,SchemaNumberValue> createPopulator( PageCache pageCache, FileSystemAbstraction fs,
             File indexFile, Layout<SchemaNumberKey,SchemaNumberValue> layout, IndexSamplingConfig samplingConfig )
     {
-        return new NativeNonUniqueSchemaNumberIndexPopulator<>( pageCache, fs, indexFile, layout, samplingConfig, log, indexDescriptor,
+        return new NativeNonUniqueSchemaNumberIndexPopulator<>( pageCache, fs, indexFile, layout, samplingConfig, monitor, indexDescriptor,
                 indexId );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexAccessorTest.java
@@ -83,7 +83,7 @@ public abstract class NativeSchemaNumberIndexAccessorTest<KEY extends SchemaNumb
     @Before
     public void setupAccessor() throws IOException
     {
-        accessor = new NativeSchemaNumberIndexAccessor<>( pageCache, fs, indexFile, layout, IMMEDIATE );
+        accessor = new NativeSchemaNumberIndexAccessor<>( pageCache, fs, indexFile, layout, IMMEDIATE, log, indexDescriptor, indexId );
     }
 
     @After

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexAccessorTest.java
@@ -83,7 +83,7 @@ public abstract class NativeSchemaNumberIndexAccessorTest<KEY extends SchemaNumb
     @Before
     public void setupAccessor() throws IOException
     {
-        accessor = new NativeSchemaNumberIndexAccessor<>( pageCache, fs, indexFile, layout, IMMEDIATE, log, indexDescriptor, indexId );
+        accessor = new NativeSchemaNumberIndexAccessor<>( pageCache, fs, indexFile, layout, IMMEDIATE, monitor, indexDescriptor, indexId );
     }
 
     @After

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProviderTest.java
@@ -35,6 +35,8 @@ import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.index.IndexPopulator;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.InternalIndexState;
+import org.neo4j.kernel.api.index.LoggingMonitor;
+import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
 import org.neo4j.kernel.configuration.Config;
@@ -50,7 +52,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import static org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector.IMMEDIATE;
 import static org.neo4j.kernel.api.index.IndexDirectoryStructure.directoriesByProvider;
 
@@ -64,6 +65,7 @@ public class NativeSchemaNumberIndexProviderTest
     private static final int propId = 1;
     private NativeSchemaNumberIndexProvider provider;
     private final AssertableLogProvider logging = new AssertableLogProvider();
+    private SchemaIndexProvider.Monitor monitor = new LoggingMonitor( logging.getLog( "test" ) );
 
     @Before
     public void setup() throws IOException
@@ -387,12 +389,12 @@ public class NativeSchemaNumberIndexProviderTest
 
     private NativeSchemaNumberIndexProvider newProvider()
     {
-        return new NativeSchemaNumberIndexProvider( pageCache(), fs(), directoriesByProvider( baseDir() ), logging, IMMEDIATE, false );
+        return new NativeSchemaNumberIndexProvider( pageCache(), fs(), directoriesByProvider( baseDir() ), monitor, IMMEDIATE, false );
     }
 
     private NativeSchemaNumberIndexProvider newReadOnlyProvider()
     {
-        return new NativeSchemaNumberIndexProvider( pageCache(), fs(), directoriesByProvider( baseDir() ), logging, IMMEDIATE, true );
+        return new NativeSchemaNumberIndexProvider( pageCache(), fs(), directoriesByProvider( baseDir() ), monitor, IMMEDIATE, true );
     }
 
     private PageCache pageCache()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeUniqueSchemaNumberIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeUniqueSchemaNumberIndexPopulatorTest.java
@@ -47,7 +47,7 @@ public class NativeUniqueSchemaNumberIndexPopulatorTest extends NativeSchemaNumb
             PageCache pageCache, FileSystemAbstraction fs, File indexFile,
             Layout<SchemaNumberKey,SchemaNumberValue> layout, IndexSamplingConfig samplingConfig )
     {
-        return new NativeUniqueSchemaNumberIndexPopulator<>( pageCache, fs, indexFile, layout, log, indexDescriptor, indexId );
+        return new NativeUniqueSchemaNumberIndexPopulator<>( pageCache, fs, indexFile, layout, monitor, indexDescriptor, indexId );
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeUniqueSchemaNumberIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeUniqueSchemaNumberIndexPopulatorTest.java
@@ -47,7 +47,7 @@ public class NativeUniqueSchemaNumberIndexPopulatorTest extends NativeSchemaNumb
             PageCache pageCache, FileSystemAbstraction fs, File indexFile,
             Layout<SchemaNumberKey,SchemaNumberValue> layout, IndexSamplingConfig samplingConfig )
     {
-        return new NativeUniqueSchemaNumberIndexPopulator<>( pageCache, fs, indexFile, layout );
+        return new NativeUniqueSchemaNumberIndexPopulator<>( pageCache, fs, indexFile, layout, log, indexDescriptor, indexId );
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SchemaNumberIndexTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SchemaNumberIndexTestUtil.java
@@ -38,9 +38,8 @@ import org.neo4j.index.internal.gbptree.Layout;
 import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.IndexEntryUpdate;
+import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
-import org.neo4j.logging.Log;
-import org.neo4j.logging.NullLog;
 import org.neo4j.test.rule.PageCacheRule;
 import org.neo4j.test.rule.RandomRule;
 import org.neo4j.test.rule.TestDirectory;
@@ -73,7 +72,7 @@ public abstract class SchemaNumberIndexTestUtil<KEY extends SchemaNumberKey,VALU
     Layout<KEY,VALUE> layout;
     File indexFile;
     PageCache pageCache;
-    Log log = NullLog.getInstance();
+    SchemaIndexProvider.Monitor monitor = SchemaIndexProvider.Monitor.EMPTY;
     long indexId = 1;
 
     @Before

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SchemaNumberIndexTestUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/SchemaNumberIndexTestUtil.java
@@ -39,6 +39,8 @@ import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.NullLog;
 import org.neo4j.test.rule.PageCacheRule;
 import org.neo4j.test.rule.RandomRule;
 import org.neo4j.test.rule.TestDirectory;
@@ -50,7 +52,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.rules.RuleChain.outerRule;
-
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_READER;
 import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_WRITER;
 import static org.neo4j.test.rule.PageCacheRule.config;
@@ -72,6 +73,8 @@ public abstract class SchemaNumberIndexTestUtil<KEY extends SchemaNumberKey,VALU
     Layout<KEY,VALUE> layout;
     File indexFile;
     PageCache pageCache;
+    Log log = NullLog.getInstance();
+    long indexId = 1;
 
     @Before
     public void setup()

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexProvider.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexProvider.java
@@ -42,8 +42,6 @@ import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.kernel.impl.factory.OperationalMode;
 import org.neo4j.kernel.impl.storemigration.StoreMigrationParticipant;
 import org.neo4j.kernel.impl.storemigration.participant.SchemaIndexMigrator;
-import org.neo4j.logging.Log;
-import org.neo4j.logging.LogProvider;
 
 import static org.neo4j.kernel.api.schema.index.IndexDescriptor.Type.UNIQUE;
 
@@ -52,21 +50,21 @@ public class LuceneSchemaIndexProvider extends SchemaIndexProvider
     static final int PRIORITY = 1;
 
     private final IndexStorageFactory indexStorageFactory;
-    private final Log log;
     private final Config config;
     private final OperationalMode operationalMode;
     private final FileSystemAbstraction fileSystem;
+    private final Monitor monitor;
 
     public LuceneSchemaIndexProvider( FileSystemAbstraction fileSystem, DirectoryFactory directoryFactory,
-            IndexDirectoryStructure.Factory directoryStructureFactory, LogProvider logging, Config config,
+            IndexDirectoryStructure.Factory directoryStructureFactory, Monitor monitor, Config config,
             OperationalMode operationalMode )
     {
         super( LuceneSchemaIndexProviderFactory.PROVIDER_DESCRIPTOR, PRIORITY, directoryStructureFactory );
+        this.monitor = monitor;
         this.indexStorageFactory = buildIndexStorageFactory( fileSystem, directoryFactory );
         this.fileSystem = fileSystem;
         this.config = config;
         this.operationalMode = operationalMode;
-        this.log = logging.getLog( getClass() );
     }
 
     public static IndexDirectoryStructure.Factory defaultDirectoryStructure( File storeDir )
@@ -141,7 +139,7 @@ public class LuceneSchemaIndexProvider extends SchemaIndexProvider
         }
         catch ( IOException e )
         {
-            log.error( "Failed to open index:" + indexId + ", requesting re-population.", e );
+            monitor.failedToOpenIndex( indexId, descriptor, "Requesting re-population.", e );
             return InternalIndexState.POPULATING;
         }
     }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionSchemaIndexProviderFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/NativeLuceneFusionSchemaIndexProviderFactory.java
@@ -27,6 +27,7 @@ import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.index.IndexDirectoryStructure;
+import org.neo4j.kernel.api.index.LoggingMonitor;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
@@ -35,7 +36,8 @@ import org.neo4j.kernel.impl.index.schema.NativeSchemaNumberIndexProvider;
 import org.neo4j.kernel.impl.index.schema.NativeSelector;
 import org.neo4j.kernel.impl.index.schema.fusion.FusionSchemaIndexProvider;
 import org.neo4j.kernel.impl.spi.KernelContext;
-import org.neo4j.logging.LogProvider;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.Log;
 
 import static org.neo4j.kernel.api.index.IndexDirectoryStructure.directoriesByProvider;
 import static org.neo4j.kernel.api.index.IndexDirectoryStructure.directoriesBySubProvider;
@@ -67,22 +69,25 @@ public class NativeLuceneFusionSchemaIndexProviderFactory
         PageCache pageCache = dependencies.pageCache();
         File storeDir = context.storeDir();
         FileSystemAbstraction fs = dependencies.fileSystem();
-        LogProvider logProvider = dependencies.getLogging().getInternalLogProvider();
+        Log log = dependencies.getLogService().getInternalLogProvider().getLog( FusionSchemaIndexProvider.class );
+        Monitors monitors = dependencies.monitors();
+        monitors.addMonitorListener( new LoggingMonitor( log ), KEY );
+        SchemaIndexProvider.Monitor monitor = monitors.newMonitor( SchemaIndexProvider.Monitor.class, KEY );
         Config config = dependencies.getConfig();
         OperationalMode operationalMode = context.databaseInfo().operationalMode;
         RecoveryCleanupWorkCollector recoveryCleanupWorkCollector = dependencies.recoveryCleanupWorkCollector();
-        return newInstance( pageCache, storeDir, fs, logProvider, config, operationalMode, recoveryCleanupWorkCollector );
+        return newInstance( pageCache, storeDir, fs, monitor, config, operationalMode, recoveryCleanupWorkCollector );
     }
 
     public static FusionSchemaIndexProvider newInstance( PageCache pageCache, File storeDir, FileSystemAbstraction fs,
-            LogProvider logProvider, Config config, OperationalMode operationalMode,
+            SchemaIndexProvider.Monitor monitor, Config config, OperationalMode operationalMode,
             RecoveryCleanupWorkCollector recoveryCleanupWorkCollector )
     {
         IndexDirectoryStructure.Factory childDirectoryStructure = subProviderDirectoryStructure( storeDir );
         boolean readOnly = isReadOnly( config, operationalMode );
         NativeSchemaNumberIndexProvider nativeProvider =
-                new NativeSchemaNumberIndexProvider( pageCache, fs, childDirectoryStructure, logProvider, recoveryCleanupWorkCollector, readOnly );
-        LuceneSchemaIndexProvider luceneProvider = LuceneSchemaIndexProviderFactory.create( fs, childDirectoryStructure, logProvider, config,
+                new NativeSchemaNumberIndexProvider( pageCache, fs, childDirectoryStructure, monitor, recoveryCleanupWorkCollector, readOnly );
+        LuceneSchemaIndexProvider luceneProvider = LuceneSchemaIndexProviderFactory.create( fs, childDirectoryStructure, monitor, config,
                 operationalMode );
         boolean useNativeIndex = config.get( GraphDatabaseSettings.enable_native_schema_index );
         int priority = useNativeIndex ? PRIORITY : 0;

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/NonUniqueIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/explicit/NonUniqueIndexTest.java
@@ -54,7 +54,6 @@ import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
 import org.neo4j.logging.LogProvider;
-import org.neo4j.logging.NullLogProvider;
 import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.test.rule.PageCacheAndDependenciesRule;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
@@ -165,7 +164,7 @@ public class NonUniqueIndexTest
     {
         FileSystemAbstraction fs = resources.fileSystem();
         File storeDir = resources.directory().graphDbDir();
-        NullLogProvider logProvider = NullLogProvider.getInstance();
+        SchemaIndexProvider.Monitor monitor = SchemaIndexProvider.Monitor.EMPTY;
         OperationalMode operationalMode = OperationalMode.single;
         PageCache pageCache = resources.pageCache();
         Boolean useFusionIndex = config.get( GraphDatabaseSettings.enable_native_schema_index );
@@ -173,11 +172,11 @@ public class NonUniqueIndexTest
         if ( useFusionIndex )
         {
             indexProvider = NativeLuceneFusionSchemaIndexProviderFactory
-                    .newInstance( pageCache, storeDir, fs, logProvider, config, operationalMode, RecoveryCleanupWorkCollector.IMMEDIATE );
+                    .newInstance( pageCache, storeDir, fs, monitor, config, operationalMode, RecoveryCleanupWorkCollector.IMMEDIATE );
         }
         else
         {
-            indexProvider = LuceneSchemaIndexProviderFactory.create( fs, storeDir, logProvider, config, operationalMode );
+            indexProvider = LuceneSchemaIndexProviderFactory.create( fs, storeDir, monitor, config, operationalMode );
         }
         IndexSamplingConfig samplingConfig = new IndexSamplingConfig( config );
         try ( IndexAccessor accessor = indexProvider.getOnlineAccessor( indexId,

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionSchemaIndexProviderCompatibilitySuiteTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/FusionSchemaIndexProviderCompatibilitySuiteTest.java
@@ -30,7 +30,6 @@ import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.factory.OperationalMode;
-import org.neo4j.logging.NullLogProvider;
 
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
@@ -39,10 +38,10 @@ public class FusionSchemaIndexProviderCompatibilitySuiteTest extends IndexProvid
     @Override
     protected SchemaIndexProvider createIndexProvider( PageCache pageCache, FileSystemAbstraction fs, File graphDbDir )
     {
-        NullLogProvider logProvider = NullLogProvider.getInstance();
+        SchemaIndexProvider.Monitor monitor = SchemaIndexProvider.Monitor.EMPTY;
         Config config = Config.defaults( stringMap( GraphDatabaseSettings.enable_native_schema_index.name(), Settings.TRUE ) );
         return NativeLuceneFusionSchemaIndexProviderFactory
-                .newInstance( pageCache, graphDbDir, fs, logProvider, config, OperationalMode.single,
+                .newInstance( pageCache, graphDbDir, fs, monitor, config, OperationalMode.single,
                         RecoveryCleanupWorkCollector.IMMEDIATE );
     }
 }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexRecoveryIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneIndexRecoveryIT.java
@@ -25,7 +25,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -90,7 +90,7 @@ public class LuceneIndexRecoveryIT
         waitForIndex( index );
 
         long nodeId = createNode( myLabel, 12 );
-        try ( Transaction tx = db.beginTx() )
+        try ( Transaction ignored = db.beginTx() )
         {
             assertNotNull( db.getNodeById( nodeId ) );
         }
@@ -103,7 +103,7 @@ public class LuceneIndexRecoveryIT
         startDb( createLuceneIndexFactory() );
 
         // Then
-        try ( Transaction tx = db.beginTx() )
+        try ( Transaction ignored = db.beginTx() )
         {
             assertNotNull( db.getNodeById( nodeId ) );
         }
@@ -177,7 +177,7 @@ public class LuceneIndexRecoveryIT
         // When
         startDb( createAlwaysInitiallyPopulatingLuceneIndexFactory() );
 
-        try ( Transaction tx = db.beginTx() )
+        try ( Transaction ignored = db.beginTx() )
         {
             IndexDefinition index = db.schema().getIndexes().iterator().next();
             waitForIndex( index );
@@ -220,7 +220,7 @@ public class LuceneIndexRecoveryIT
 
         TestGraphDatabaseFactory factory = new TestGraphDatabaseFactory();
         factory.setFileSystem( fs.get() );
-        factory.setKernelExtensions( Arrays.asList( indexProviderFactory ) );
+        factory.setKernelExtensions( Collections.singletonList( indexProviderFactory ) );
         db = (GraphDatabaseAPI) factory.newImpermanentDatabase();
     }
 
@@ -315,9 +315,8 @@ public class LuceneIndexRecoveryIT
             public Lifecycle newInstance( KernelContext context, LuceneSchemaIndexProviderFactory.Dependencies dependencies )
                     throws Throwable
             {
-                return new LuceneSchemaIndexProvider( fs.get(),directoryFactory, defaultDirectoryStructure( context.storeDir() ),
-                        dependencies.getLogging().getInternalLogProvider(), dependencies.getConfig(),
-                        context.databaseInfo().operationalMode )
+                return new LuceneSchemaIndexProvider( fs.get(), directoryFactory, defaultDirectoryStructure( context.storeDir() ),
+                        SchemaIndexProvider.Monitor.EMPTY, dependencies.getConfig(), context.databaseInfo().operationalMode )
                 {
                     @Override
                     public InternalIndexState getInitialState( long indexId, IndexDescriptor descriptor )
@@ -341,8 +340,7 @@ public class LuceneIndexRecoveryIT
                     throws Throwable
             {
                 return new LuceneSchemaIndexProvider( fs.get(), directoryFactory, defaultDirectoryStructure( context.storeDir() ),
-                        dependencies.getLogging().getInternalLogProvider(), dependencies.getConfig(),
-                        context.databaseInfo().operationalMode )
+                        SchemaIndexProvider.Monitor.EMPTY, dependencies.getConfig(), context.databaseInfo().operationalMode )
                 {
                     @Override
                     public int compareTo( SchemaIndexProvider o )

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexCorruptionTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexCorruptionTest.java
@@ -37,6 +37,8 @@ import org.neo4j.kernel.api.impl.index.storage.IndexStorageFactory;
 import org.neo4j.kernel.api.impl.index.storage.PartitionedIndexStorage;
 import org.neo4j.kernel.api.index.IndexDirectoryStructure;
 import org.neo4j.kernel.api.index.InternalIndexState;
+import org.neo4j.kernel.api.index.LoggingMonitor;
+import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
 import org.neo4j.kernel.configuration.Config;
@@ -52,7 +54,6 @@ import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.kernel.api.impl.schema.LuceneSchemaIndexProvider.defaultDirectoryStructure;
 import static org.neo4j.logging.AssertableLogProvider.inLog;
 
@@ -63,6 +64,7 @@ public class LuceneSchemaIndexCorruptionTest
     @Rule
     public final EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
     private final AssertableLogProvider logProvider = new AssertableLogProvider();
+    private final SchemaIndexProvider.Monitor monitor = new LoggingMonitor( logProvider.getLog( "test" ) );
 
     @Test
     public void shouldRequestIndexPopulationIfTheIndexIsCorrupt() throws Exception
@@ -123,7 +125,7 @@ public class LuceneSchemaIndexCorruptionTest
         DirectoryFactory directoryFactory = mock( DirectoryFactory.class );
         File indexRootFolder = testDirectory.graphDbDir();
         AtomicReference<FaultyIndexStorageFactory> reference = new AtomicReference<>();
-        return new LuceneSchemaIndexProvider( fs.get(), directoryFactory, defaultDirectoryStructure( indexRootFolder ), logProvider,
+        return new LuceneSchemaIndexProvider( fs.get(), directoryFactory, defaultDirectoryStructure( indexRootFolder ), monitor,
                 Config.defaults(), OperationalMode.single )
         {
             @Override

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexPopulatorTest.java
@@ -32,7 +32,6 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -44,13 +43,13 @@ import org.neo4j.kernel.api.index.IndexQueryHelper;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.index.InternalIndexState;
 import org.neo4j.kernel.api.index.PropertyAccessor;
+import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.index.IndexStoreView;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.kernel.impl.factory.OperationalMode;
-import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 import org.neo4j.values.storable.Value;
@@ -58,6 +57,7 @@ import org.neo4j.values.storable.Values;
 
 import static java.lang.Long.parseLong;
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.neo4j.helpers.collection.Iterators.asSet;
@@ -87,7 +87,7 @@ public class LuceneSchemaIndexPopulatorTest
         DirectoryFactory directoryFactory = new DirectoryFactory.Single(
                 new DirectoryFactory.UncloseableDirectory( directory ) );
         provider = new LuceneSchemaIndexProvider( fs.get(), directoryFactory, defaultDirectoryStructure( testDir.directory( "folder" ) ),
-                NullLogProvider.getInstance(), Config.defaults(), OperationalMode.single );
+                SchemaIndexProvider.Monitor.EMPTY, Config.defaults(), OperationalMode.single );
         indexStoreView = mock( IndexStoreView.class );
         IndexSamplingConfig samplingConfig = new IndexSamplingConfig( Config.defaults() );
         indexPopulator = provider.getPopulator( indexId, index, samplingConfig );
@@ -149,7 +149,7 @@ public class LuceneSchemaIndexPopulatorTest
         addUpdate( indexPopulator, 1, "value" );
         addUpdate( indexPopulator, 2, "value" );
         addUpdate( indexPopulator, 3, "value" );
-        updatePopulator( indexPopulator, asList( remove( 2, "value" ) ), indexStoreView );
+        updatePopulator( indexPopulator, singletonList( remove( 2, "value" ) ), indexStoreView );
 
         // THEN
         assertIndexedValues(
@@ -162,7 +162,7 @@ public class LuceneSchemaIndexPopulatorTest
         // WHEN
         addUpdate( indexPopulator, 1, "1" );
         addUpdate( indexPopulator, 2, "2" );
-        updatePopulator( indexPopulator, asList( change( 1, "1", "1a" ) ), indexStoreView );
+        updatePopulator( indexPopulator, singletonList( change( 1, "1", "1a" ) ), indexStoreView );
         addUpdate( indexPopulator, 3, "3" );
 
         // THEN
@@ -196,7 +196,7 @@ public class LuceneSchemaIndexPopulatorTest
         // WHEN
         addUpdate( indexPopulator, 1, "1" );
         addUpdate( indexPopulator, 2, "2" );
-        updatePopulator( indexPopulator, asList( remove( 2, "2" ) ), indexStoreView );
+        updatePopulator( indexPopulator, singletonList( remove( 2, "2" ) ), indexStoreView );
         addUpdate( indexPopulator, 3, "3" );
 
         // THEN
@@ -300,7 +300,7 @@ public class LuceneSchemaIndexPopulatorTest
     private static void addUpdate( IndexPopulator populator, long nodeId, Object value )
             throws IOException, IndexEntryConflictException
     {
-        populator.add( Collections.singletonList( IndexQueryHelper.add( nodeId, index.schema(), value ) ) );
+        populator.add( singletonList( IndexQueryHelper.add( nodeId, index.schema(), value ) ) );
     }
 
     private static void updatePopulator(

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexProviderCompatibilitySuiteTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexProviderCompatibilitySuiteTest.java
@@ -26,10 +26,10 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.impl.index.storage.DirectoryFactory;
 import org.neo4j.kernel.api.index.IndexProviderCompatibilityTestSuite;
+import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.factory.OperationalMode;
-import org.neo4j.logging.NullLogProvider;
 
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
@@ -39,9 +39,9 @@ public class LuceneSchemaIndexProviderCompatibilitySuiteTest extends IndexProvid
     protected LuceneSchemaIndexProvider createIndexProvider( PageCache pageCache, FileSystemAbstraction fs, File graphDbDir )
     {
         DirectoryFactory.InMemoryDirectoryFactory directoryFactory = new DirectoryFactory.InMemoryDirectoryFactory();
-        NullLogProvider logging = NullLogProvider.getInstance();
+        SchemaIndexProvider.Monitor monitor = SchemaIndexProvider.Monitor.EMPTY;
         Config config = Config.defaults( stringMap( GraphDatabaseSettings.enable_native_schema_index.name(), Settings.FALSE ) );
         OperationalMode mode = OperationalMode.single;
-        return LuceneSchemaIndexProviderFactory.create( fs, graphDbDir, logging, config, mode );
+        return LuceneSchemaIndexProviderFactory.create( fs, graphDbDir, monitor, config, mode );
     }
 }

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexProviderTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexProviderTest.java
@@ -31,6 +31,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.impl.index.storage.DirectoryFactory;
 import org.neo4j.kernel.api.index.IndexAccessor;
+import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
 import org.neo4j.kernel.configuration.Config;
@@ -38,7 +39,6 @@ import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.kernel.impl.factory.OperationalMode;
-import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 
@@ -124,6 +124,6 @@ public class LuceneSchemaIndexProviderTest
                                                                     FileSystemAbstraction fs, File graphDbDir )
     {
         return new LuceneSchemaIndexProvider( fs, directoryFactory, defaultDirectoryStructure( graphDbDir ),
-                NullLogProvider.getInstance(), config, OperationalMode.single );
+                SchemaIndexProvider.Monitor.EMPTY, config, OperationalMode.single );
     }
 }

--- a/community/neo4j/src/test/java/recovery/RecoveryCleanupIT.java
+++ b/community/neo4j/src/test/java/recovery/RecoveryCleanupIT.java
@@ -153,8 +153,8 @@ public class RecoveryCleanupIT
         // then
         logProvider.assertContainsMessageMatching( Matchers.stringContainsInOrder( Iterables.asIterable(
                 "Schema index recovery completed",
-                "pages visited",
                 "cleaned crashed pointers",
+                "pages visited",
                 "Time spent" ) ) );
     }
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
@@ -72,7 +72,6 @@ import org.neo4j.kernel.impl.index.schema.fusion.FusionSchemaIndexProvider;
 import org.neo4j.kernel.impl.spi.KernelContext;
 import org.neo4j.kernel.impl.storemigration.StoreMigrationParticipant;
 import org.neo4j.kernel.lifecycle.Lifecycle;
-import org.neo4j.logging.NullLogProvider;
 import org.neo4j.storageengine.api.schema.IndexSample;
 import org.neo4j.test.DoubleLatch;
 import org.neo4j.test.ha.ClusterRule;
@@ -561,13 +560,13 @@ public class SchemaIndexHaIT
             PageCache pageCache = deps.pageCache();
             File storeDir = context.storeDir();
             DefaultFileSystemAbstraction fs = fileSystemRule.get();
-            NullLogProvider logProvider = NullLogProvider.getInstance();
+            SchemaIndexProvider.Monitor monitor = SchemaIndexProvider.Monitor.EMPTY;
             Config config = deps.config();
             OperationalMode operationalMode = context.databaseInfo().operationalMode;
             RecoveryCleanupWorkCollector recoveryCleanupWorkCollector = deps.recoveryCleanupWorkCollector();
 
             FusionSchemaIndexProvider fusionSchemaIndexProvider = NativeLuceneFusionSchemaIndexProviderFactory
-                    .newInstance( pageCache, storeDir, fs, logProvider, config, operationalMode, recoveryCleanupWorkCollector );
+                    .newInstance( pageCache, storeDir, fs, monitor, config, operationalMode, recoveryCleanupWorkCollector );
 
             if ( injectLatchPredicate.test( deps.db() ) )
             {


### PR DESCRIPTION
Log report of crashed pointer cleanup of underlying GBPTree to label and schema index.

This logging was accidentally removed from label index at time when lucene label scan store was removed. This PR re-introduces it and also add recovery logging for native schema index.