### PR TITLE
Only perform check on conflicting mode when `@PerformsWrites` is present

### DIFF
--- a/community/procedure-compiler/integration-tests/src/test/java/org/neo4j/tooling/procedure/ProcedureTest.java
+++ b/community/procedure-compiler/integration-tests/src/test/java/org/neo4j/tooling/procedure/ProcedureTest.java
@@ -80,6 +80,21 @@ public class ProcedureTest
     }
 
     @Test
+    public void calls_procedures_with_different_modes_returning_void()
+    {
+        try ( Driver driver = GraphDatabase.driver( graphDb.boltURI(), configuration() );
+                Session session = driver.session() )
+        {
+            session.run( "CALL " + procedureNamespace + ".performsWrites()" );
+            session.run( "CALL " + procedureNamespace + ".defaultMode()" );
+            session.run( "CALL " + procedureNamespace + ".readMode()" );
+            session.run( "CALL " + procedureNamespace + ".writeMode()" );
+            session.run( "CALL " + procedureNamespace + ".schemaMode()" );
+            session.run( "CALL " + procedureNamespace + ".dbmsMode()" );
+        }
+    }
+
+    @Test
     public void calls_procedures_with_simple_input_type_returning_record_with_primitive_fields()
     {
         try ( Driver driver = GraphDatabase.driver( graphDb.boltURI(), configuration() );

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/ProcedureVisitor.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/visitors/ProcedureVisitor.java
@@ -22,7 +22,6 @@ package org.neo4j.tooling.procedure.visitors;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ElementVisitor;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
@@ -33,7 +32,7 @@ import javax.lang.model.util.Elements;
 import javax.lang.model.util.SimpleElementVisitor8;
 import javax.lang.model.util.Types;
 
-import org.neo4j.procedure.Name;
+import org.neo4j.procedure.PerformsWrites;
 import org.neo4j.tooling.procedure.compilerutils.TypeMirrorUtils;
 import org.neo4j.tooling.procedure.messages.CompilationMessage;
 import org.neo4j.tooling.procedure.messages.ReturnTypeError;
@@ -102,7 +101,11 @@ public class ProcedureVisitor extends SimpleElementVisitor8<Stream<CompilationMe
 
     private Stream<CompilationMessage> validatePerformsWriteUsage( ExecutableElement executableElement )
     {
-        return performsWriteVisitor.visit( executableElement );
+        if ( executableElement.getAnnotation( PerformsWrites.class ) != null )
+        {
+            return performsWriteVisitor.visit( executableElement );
+        }
+        return Stream.empty();
     }
 
 }

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/valid/Procedures.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/valid/Procedures.java
@@ -27,7 +27,14 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.procedure.Name;
+import org.neo4j.procedure.PerformsWrites;
 import org.neo4j.procedure.Procedure;
+
+import static org.neo4j.procedure.Mode.DBMS;
+import static org.neo4j.procedure.Mode.DEFAULT;
+import static org.neo4j.procedure.Mode.READ;
+import static org.neo4j.procedure.Mode.SCHEMA;
+import static org.neo4j.procedure.Mode.WRITE;
 
 public class Procedures
 {
@@ -213,5 +220,36 @@ public class Procedures
             @Name( "foo" ) Map<String,List<List<Map<String,Map<String,List<Path>>>>>> input )
     {
         return Stream.of( new Records.GenericTypesWrapper() );
+    }
+
+    @Procedure
+    @PerformsWrites
+    public void performsWrites()
+    {
+    }
+
+    @Procedure( mode = DEFAULT )
+    public void defaultMode()
+    {
+    }
+
+    @Procedure( mode = READ )
+    public void readMode()
+    {
+    }
+
+    @Procedure( mode = WRITE )
+    public void writeMode()
+    {
+    }
+
+    @Procedure( mode = SCHEMA )
+    public void schemaMode()
+    {
+    }
+
+    @Procedure( mode = DBMS )
+    public void dbmsMode()
+    {
     }
 }


### PR DESCRIPTION
Fixes an issue where the compiler would complain about conflicting modes even when not using `@PerformsWrites`