### PR TITLE
Fix store copy of growing files

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileChunk.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileChunk.java
@@ -23,9 +23,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
-
 import org.neo4j.causalclustering.core.state.storage.SafeChannelMarshal;
 import org.neo4j.causalclustering.messaging.EndOfStreamException;
 import org.neo4j.causalclustering.messaging.marshalling.ChannelMarshal;
@@ -41,6 +38,10 @@ public class FileChunk
 
     static FileChunk create( byte[] bytes, boolean last )
     {
+        if ( !last && bytes.length != MAX_SIZE )
+        {
+            throw new IllegalArgumentException( "All chunks except for the last must be of max size." );
+        }
         return new FileChunk( last ? bytes.length : USE_MAX_SIZE_AND_EXPECT_MORE_CHUNKS, bytes );
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileSender.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/FileSender.java
@@ -27,25 +27,30 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
 
+import static org.neo4j.causalclustering.catchup.storecopy.FileChunk.MAX_SIZE;
+import static org.neo4j.causalclustering.catchup.storecopy.FileSender.State.FINISHED;
+import static org.neo4j.causalclustering.catchup.storecopy.FileSender.State.FULL_PENDING;
+import static org.neo4j.causalclustering.catchup.storecopy.FileSender.State.LAST_PENDING;
+import static org.neo4j.causalclustering.catchup.storecopy.FileSender.State.PRE_INIT;
+
 class FileSender implements ChunkedInput<FileChunk>
 {
     private final ReadableByteChannel channel;
     private final ByteBuffer byteBuffer;
-    private boolean endOfInput = false;
-    private boolean sentChunk = false;
-    private byte[] preFetchedBytes;
+
+    private byte[] nextBytes;
+    private State state = PRE_INIT;
 
     FileSender( ReadableByteChannel channel ) throws IOException
     {
         this.channel = channel;
-        byteBuffer = ByteBuffer.allocateDirect( FileChunk.MAX_SIZE );
-        preFetchedBytes = prefetch();
+        this.byteBuffer = ByteBuffer.allocateDirect( MAX_SIZE );
     }
 
     @Override
     public boolean isEndOfInput() throws Exception
     {
-        return endOfInput && preFetchedBytes == null && sentChunk;
+        return state == FINISHED;
     }
 
     @Override
@@ -57,20 +62,52 @@ class FileSender implements ChunkedInput<FileChunk>
     @Override
     public FileChunk readChunk( ByteBufAllocator allocator ) throws Exception
     {
-        if ( isEndOfInput() )
+        if ( state == FINISHED )
         {
             return null;
         }
-        else
+        else if ( state == PRE_INIT )
         {
-            sentChunk = true;
+            nextBytes = prefetch();
+            if ( nextBytes == null )
+            {
+                state = FINISHED;
+                return FileChunk.create( new byte[0], true );
+            }
+            else
+            {
+                state = nextBytes.length < MAX_SIZE ? LAST_PENDING : FULL_PENDING;
+            }
         }
 
-        byte[] next = prefetch();
-        FileChunk fileChunk = FileChunk.create( preFetchedBytes == null ? new byte[0] : preFetchedBytes, next == null );
-        preFetchedBytes = next;
-
-        return fileChunk;
+        if ( state == FULL_PENDING )
+        {
+            byte[] toSend = nextBytes;
+            nextBytes = prefetch();
+            if ( nextBytes == null )
+            {
+                state = FINISHED;
+                return FileChunk.create( toSend, true );
+            }
+            else if ( nextBytes.length < MAX_SIZE )
+            {
+                state = LAST_PENDING;
+                return FileChunk.create( toSend, false );
+            }
+            else
+            {
+                return FileChunk.create( toSend, false );
+            }
+        }
+        else if ( state == LAST_PENDING )
+        {
+            state = FINISHED;
+            return FileChunk.create( nextBytes, true );
+        }
+        else
+        {
+            throw new IllegalStateException();
+        }
     }
 
     @Override
@@ -98,7 +135,6 @@ class FileSender implements ChunkedInput<FileChunk>
             int bytesRead = channel.read( byteBuffer );
             if ( bytesRead == -1 )
             {
-                endOfInput = true;
                 break;
             }
         }
@@ -121,5 +157,13 @@ class FileSender implements ChunkedInput<FileChunk>
         buffer.get( bytes );
         buffer.clear();
         return bytes;
+    }
+
+    enum State
+    {
+        PRE_INIT,
+        FULL_PENDING,
+        LAST_PENDING,
+        FINISHED
     }
 }


### PR DESCRIPTION
This could lead to protocol errors where file chunks were
continued to be sent even though the "last" one had already
been sent.

This does not change the protocol as such even though it would
be beneficial to get rid of the dual usage of the encodedLength
field. An encodedLength of less than the maximum size is
interpreted as the last chunk on the receiving end.

This was problematic with growing files which would encode a
length less than the maximum size and yet had a possibility
to send additional chunks for files which had grown.

In particular this became a common problem because the first
chunk was prefetched during the creation of the FileSender
which could be a very long time before it actually was
sent. This could be many minutes or even hours. For the counts
store which has two files that are alternately truncated, it
would be a common case that one file was initially prefetched
while empty but no longer so when it became time to send it.

This would generally be harmless though, because the subsequent
recovery process would repair the state.

The first chunk is now no longer prefetched during the creation
of the FileSender, but rather on the first invocation of
readChunk. The end condition is also handled more cleanly now
and additional data will not be attempted to be read if the end
condition has been met and a last-chunk has been created.