### PR TITLE
Fixes issues w/ concurrent schema changes

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -172,27 +172,27 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
     @Override
     public void init()
     {
-        IndexMap indexMap = indexMapRef.indexMapSnapshot();
-
-        Map<InternalIndexState, List<IndexLogRecord>> indexStates = new EnumMap<>( InternalIndexState.class );
-        for ( IndexRule indexRule : indexRules )
+        indexMapRef.modify( indexMap ->
         {
-            IndexProxy indexProxy;
-
-            long indexId = indexRule.getId();
-            IndexDescriptor descriptor = indexRule.getIndexDescriptor();
-            SchemaIndexProvider.Descriptor providerDescriptor = indexRule.getProviderDescriptor();
-            SchemaIndexProvider provider = providerMap.apply( providerDescriptor );
-            InternalIndexState initialState = provider.getInitialState( indexId, descriptor );
-            indexStates.computeIfAbsent( initialState, internalIndexState -> new ArrayList<>() )
-                    .add( new IndexLogRecord( indexId, descriptor ) );
-
-            log.debug( indexStateInfo( "init", indexId, initialState, descriptor ) );
-            switch ( initialState )
+            Map<InternalIndexState, List<IndexLogRecord>> indexStates = new EnumMap<>( InternalIndexState.class );
+            for ( IndexRule indexRule : indexRules )
             {
+                IndexProxy indexProxy;
+
+                long indexId = indexRule.getId();
+                IndexDescriptor descriptor = indexRule.getIndexDescriptor();
+                SchemaIndexProvider.Descriptor providerDescriptor = indexRule.getProviderDescriptor();
+                SchemaIndexProvider provider = providerMap.apply( providerDescriptor );
+                InternalIndexState initialState = provider.getInitialState( indexId, descriptor );
+                indexStates.computeIfAbsent( initialState, internalIndexState -> new ArrayList<>() )
+                .add( new IndexLogRecord( indexId, descriptor ) );
+
+                log.debug( indexStateInfo( "init", indexId, initialState, descriptor ) );
+                switch ( initialState )
+                {
                 case ONLINE:
                     indexProxy =
-                        indexProxyCreator.createOnlineIndexProxy( indexId, descriptor, providerDescriptor );
+                    indexProxyCreator.createOnlineIndexProxy( indexId, descriptor, providerDescriptor );
                     break;
                 case POPULATING:
                     // The database was shut down during population, or a crash has occurred, or some other sad thing.
@@ -205,12 +205,12 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
                     break;
                 default:
                     throw new IllegalArgumentException( "" + initialState );
+                }
+                indexMap.putIndexProxy( indexId, indexProxy );
             }
-            indexMap.putIndexProxy( indexId, indexProxy );
-        }
-        logIndexStateSummary( "init", indexStates );
-
-        indexMapRef.setIndexMap( indexMap );
+            logIndexStateSummary( "init", indexStates );
+            return indexMap;
+        } );
     }
 
     // Recovery semantics: This is to be called after init, and after the database has run recovery.
@@ -219,21 +219,21 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
     {
         state = State.STARTING;
 
-        IndexMap indexMap = indexMapRef.indexMapSnapshot();
-
         final Map<Long,RebuildingIndexDescriptor> rebuildingDescriptors = new HashMap<>();
-        Map<InternalIndexState, List<IndexLogRecord>> indexStates = new EnumMap<>( InternalIndexState.class );
-
-        // Find all indexes that are not already online, do not require rebuilding, and create them
-        indexMap.forEachIndexProxy( ( indexId, proxy ) ->
+        indexMapRef.modify( indexMap ->
         {
-            InternalIndexState state = proxy.getState();
-            IndexDescriptor descriptor = proxy.getDescriptor();
-            indexStates.computeIfAbsent( state, internalIndexState -> new ArrayList<>() )
-                    .add( new IndexLogRecord( indexId, descriptor ) );
-            log.debug( indexStateInfo( "start", indexId, state, descriptor ) );
-            switch ( state )
+            Map<InternalIndexState, List<IndexLogRecord>> indexStates = new EnumMap<>( InternalIndexState.class );
+
+            // Find all indexes that are not already online, do not require rebuilding, and create them
+            indexMap.forEachIndexProxy( ( indexId, proxy ) ->
             {
+                InternalIndexState state = proxy.getState();
+                IndexDescriptor descriptor = proxy.getDescriptor();
+                indexStates.computeIfAbsent( state, internalIndexState -> new ArrayList<>() )
+                .add( new IndexLogRecord( indexId, descriptor ) );
+                log.debug( indexStateInfo( "start", indexId, state, descriptor ) );
+                switch ( state )
+                {
                 case ONLINE:
                     // Don't do anything, index is ok.
                     break;
@@ -247,36 +247,36 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
                     break;
                 default:
                     throw new IllegalStateException( "Unknown state: " + state );
-            }
-        } );
-        logIndexStateSummary( "start", indexStates );
+                }
+            } );
+            logIndexStateSummary( "start", indexStates );
 
-        // Drop placeholder proxies for indexes that need to be rebuilt
-        dropRecoveringIndexes( indexMap, rebuildingDescriptors.keySet() );
+            // Drop placeholder proxies for indexes that need to be rebuilt
+            dropRecoveringIndexes( indexMap, rebuildingDescriptors.keySet() );
 
-        // Rebuild indexes by recreating and repopulating them
-        if ( !rebuildingDescriptors.isEmpty() )
-        {
-            IndexPopulationJob populationJob = newIndexPopulationJob();
-            for ( Map.Entry<Long,RebuildingIndexDescriptor> entry : rebuildingDescriptors.entrySet() )
+            // Rebuild indexes by recreating and repopulating them
+            if ( !rebuildingDescriptors.isEmpty() )
             {
-                long indexId = entry.getKey();
-                RebuildingIndexDescriptor descriptor = entry.getValue();
+                IndexPopulationJob populationJob = newIndexPopulationJob();
+                for ( Map.Entry<Long,RebuildingIndexDescriptor> entry : rebuildingDescriptors.entrySet() )
+                {
+                    long indexId = entry.getKey();
+                    RebuildingIndexDescriptor descriptor = entry.getValue();
 
-                IndexProxy proxy = indexProxyCreator.createPopulatingIndexProxy(
-                        indexId,
-                        descriptor.getIndexDescriptor(),
-                        descriptor.getProviderDescriptor(),
-                        false, // never pass through a tentative online state during recovery
-                        monitor,
-                        populationJob );
-                proxy.start();
-                indexMap.putIndexProxy( indexId, proxy );
+                    IndexProxy proxy = indexProxyCreator.createPopulatingIndexProxy(
+                            indexId,
+                            descriptor.getIndexDescriptor(),
+                            descriptor.getProviderDescriptor(),
+                            false, // never pass through a tentative online state during recovery
+                            monitor,
+                            populationJob );
+                    proxy.start();
+                    indexMap.putIndexProxy( indexId, proxy );
+                }
+                startIndexPopulation( populationJob );
             }
-            startIndexPopulation( populationJob );
-        }
-
-        indexMapRef.setIndexMap( indexMap );
+            return indexMap;
+        } );
 
         samplingController.recoverIndexSamples();
         samplingController.start();
@@ -437,57 +437,58 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
      * it is *vital* that it is stable, and handles errors very well. Failing here means that the entire db
      * will shut down.
      */
-    public synchronized void createIndexes( IndexRule... rules ) throws IOException
+    public void createIndexes( IndexRule... rules ) throws IOException
     {
-        IndexMap indexMap = indexMapRef.indexMapSnapshot();
-        IndexPopulationJob populationJob = null;
-
-        for ( IndexRule rule : rules )
+        indexMapRef.modify( indexMap ->
         {
-            long ruleId = rule.getId();
-            IndexProxy index = indexMap.getIndexProxy( ruleId );
-            if ( index != null && state == State.NOT_STARTED )
+            IndexPopulationJob populationJob = null;
+
+            for ( IndexRule rule : rules )
             {
-                // During recovery we might run into this scenario:
-                // - We're starting recovery on a database, where init() is called and all indexes that
-                //   are found in the store, instantiated and put into the IndexMap. Among them is index X.
-                // - While we recover the database we bump into a transaction creating index Y, with the
-                //   same IndexDescriptor, i.e. same label/property, as X. This is possible since this took
-                //   place before the creation of X.
-                // - When Y is dropped in between this creation and the creation of X (it will have to be
-                //   otherwise X wouldn't have had an opportunity to be created) the index is removed from
-                //   the IndexMap, both by id AND descriptor.
-                //
-                // Because of the scenario above we need to put this created index into the IndexMap
-                // again, otherwise it will disappear from the IndexMap (at least for lookup by descriptor)
-                // and not be able to accept changes applied from recovery later on.
-                indexMap.putIndexProxy( ruleId, index );
-                indexMapRef.setIndexMap( indexMap );
-                continue;
-            }
-            final IndexDescriptor descriptor = rule.getIndexDescriptor();
-            SchemaIndexProvider.Descriptor providerDescriptor = rule.getProviderDescriptor();
-            boolean flipToTentative = rule.canSupportUniqueConstraint();
-            if ( state == State.RUNNING )
-            {
-                populationJob = populationJob == null ? newIndexPopulationJob() : populationJob;
-                index = indexProxyCreator.createPopulatingIndexProxy(
-                        ruleId, descriptor, providerDescriptor, flipToTentative, monitor, populationJob );
-                index.start();
-            }
-            else
-            {
-                index = indexProxyCreator.createRecoveringIndexProxy( descriptor, providerDescriptor );
+                long ruleId = rule.getId();
+                IndexProxy index = indexMap.getIndexProxy( ruleId );
+                if ( index != null && state == State.NOT_STARTED )
+                {
+                    // During recovery we might run into this scenario:
+                    // - We're starting recovery on a database, where init() is called and all indexes that
+                    //   are found in the store, instantiated and put into the IndexMap. Among them is index X.
+                    // - While we recover the database we bump into a transaction creating index Y, with the
+                    //   same IndexDescriptor, i.e. same label/property, as X. This is possible since this took
+                    //   place before the creation of X.
+                    // - When Y is dropped in between this creation and the creation of X (it will have to be
+                    //   otherwise X wouldn't have had an opportunity to be created) the index is removed from
+                    //   the IndexMap, both by id AND descriptor.
+                    //
+                    // Because of the scenario above we need to put this created index into the IndexMap
+                    // again, otherwise it will disappear from the IndexMap (at least for lookup by descriptor)
+                    // and not be able to accept changes applied from recovery later on.
+                    indexMap.putIndexProxy( ruleId, index );
+                    continue;
+                }
+                final IndexDescriptor descriptor = rule.getIndexDescriptor();
+                SchemaIndexProvider.Descriptor providerDescriptor = rule.getProviderDescriptor();
+                boolean flipToTentative = rule.canSupportUniqueConstraint();
+                if ( state == State.RUNNING )
+                {
+                    populationJob = populationJob == null ? newIndexPopulationJob() : populationJob;
+                    index = indexProxyCreator.createPopulatingIndexProxy(
+                            ruleId, descriptor, providerDescriptor, flipToTentative, monitor, populationJob );
+                    index.start();
+                }
+                else
+                {
+                    index = indexProxyCreator.createRecoveringIndexProxy( descriptor, providerDescriptor );
+                }
+
+                indexMap.putIndexProxy( rule.getId(), index );
             }
 
-            indexMap.putIndexProxy( rule.getId(), index );
-        }
-
-        if ( populationJob != null )
-        {
-            startIndexPopulation( populationJob );
-        }
-        indexMapRef.setIndexMap( indexMap );
+            if ( populationJob != null )
+            {
+                startIndexPopulation( populationJob );
+            }
+            return indexMap;
+        } );
     }
 
     private void processUpdate( IndexUpdaterMap updaterMap, IndexEntryUpdate<LabelSchemaDescriptor> indexUpdate )
@@ -500,23 +501,27 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
         }
     }
 
-    public synchronized void dropIndex( IndexRule rule )
+    public void dropIndex( IndexRule rule )
     {
-        long indexId = rule.getId();
-        IndexProxy index = indexMapRef.removeIndexProxy( indexId );
-        if ( state == State.RUNNING )
+        indexMapRef.modify( indexMap ->
         {
-            assert index != null : "Index " + rule + " doesn't exists";
-            try
+            long indexId = rule.getId();
+            IndexProxy index = indexMap.removeIndexProxy( indexId );
+            if ( state == State.RUNNING )
             {
-                Future<Void> dropFuture = index.drop();
-                awaitIndexFuture( dropFuture );
+                assert index != null : "Index " + rule + " doesn't exists";
+                try
+                {
+                    Future<Void> dropFuture = index.drop();
+                    awaitIndexFuture( dropFuture );
+                }
+                catch ( Exception e )
+                {
+                    throw launderedException( e );
+                }
             }
-            catch ( Exception e )
-            {
-                throw launderedException( e );
-            }
-        }
+            return indexMap;
+        } );
     }
 
     public void triggerIndexSampling( IndexSamplingMode mode )
@@ -628,31 +633,37 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
 
     private void closeAllIndexes()
     {
-        Iterable<IndexProxy> indexesToStop = indexMapRef.clear();
-        Collection<Future<Void>> indexStopFutures = new ArrayList<>();
-        for ( IndexProxy index : indexesToStop )
+        indexMapRef.modify( indexMap ->
         {
-            try
+            Iterable<IndexProxy> indexesToStop = indexMap.getAllIndexProxies();
+            Collection<Future<Void>> indexStopFutures = new ArrayList<>();
+            for ( IndexProxy index : indexesToStop )
             {
-                indexStopFutures.add( index.close() );
+                try
+                {
+                    indexStopFutures.add( index.close() );
+                }
+                catch ( Exception e )
+                {
+                    log.error( "Unable to close index", e );
+                }
             }
-            catch ( Exception e )
-            {
-                log.error( "Unable to close index", e );
-            }
-        }
 
-        for ( Future<Void> future : indexStopFutures )
-        {
-            try
+            for ( Future<Void> future : indexStopFutures )
             {
-                awaitIndexFuture( future );
+                try
+                {
+                    awaitIndexFuture( future );
+                }
+                catch ( Exception e )
+                {
+                    log.error( "Error awaiting index to close", e );
+                }
             }
-            catch ( Exception e )
-            {
-                log.error( "Error awaiting index to close", e );
-            }
-        }
+
+            // Effectively clearing it
+            return new IndexMap();
+        } );
     }
 
     public ResourceIterator<File> snapshotStoreFiles() throws IOException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -437,7 +437,7 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
      * it is *vital* that it is stable, and handles errors very well. Failing here means that the entire db
      * will shut down.
      */
-    public void createIndexes( IndexRule... rules ) throws IOException
+    public synchronized void createIndexes( IndexRule... rules ) throws IOException
     {
         IndexMap indexMap = indexMapRef.indexMapSnapshot();
         IndexPopulationJob populationJob = null;
@@ -500,7 +500,7 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
         }
     }
 
-    public void dropIndex( IndexRule rule )
+    public synchronized void dropIndex( IndexRule rule )
     {
         long indexId = rule.getId();
         IndexProxy index = indexMapRef.removeIndexProxy( indexId );

--- a/community/kernel/src/test/java/org/neo4j/graphdb/schema/ConcurrentCreateDropIndexIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/schema/ConcurrentCreateDropIndexIT.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb.schema;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.List;
+
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.Race;
+import org.neo4j.test.rule.DatabaseRule;
+import org.neo4j.test.rule.ImpermanentDatabaseRule;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.helpers.collection.Iterables.asList;
+
+public class ConcurrentCreateDropIndexIT
+{
+    private static final String KEY = "key";
+
+    @Rule
+    public final DatabaseRule db = new ImpermanentDatabaseRule();
+
+    @Test
+    public void shouldTest() throws Throwable
+    {
+        // GIVEN all the required labels created, to not disturb timings in racing threads later
+        int threads = Runtime.getRuntime().availableProcessors();
+        try ( Transaction tx = db.beginTx() )
+        {
+            for ( int i = 0; i < threads; i++ )
+            {
+                db.createNode( label( i ) );
+            }
+            tx.success();
+        }
+
+        // WHEN concurrently creating indexes for different labels
+        Race race = new Race();
+        for ( int i = 0; i < threads; i++ )
+        {
+            int yo = i;
+            race.addContestant( () ->
+            {
+                try ( Transaction tx = db.beginTx() )
+                {
+                    db.schema().indexFor( label( yo ) ).on( KEY ).create();
+                    tx.success();
+                }
+            }, 1 );
+        }
+        race.go();
+
+        // THEN they should all be observed as existing in the end
+        List<IndexDefinition> indexes;
+        try ( Transaction tx = db.beginTx() )
+        {
+            indexes = asList( db.schema().getIndexes() );
+            tx.success();
+        }
+        assertEquals( threads, indexes.size() );
+
+        // and WHEN dropping them
+        race = new Race();
+        for ( IndexDefinition index : indexes )
+        {
+            race.addContestant( () ->
+            {
+                try ( Transaction tx = db.beginTx() )
+                {
+                    index.drop();
+                    tx.success();
+                }
+            }, 1 );
+        }
+        race.go();
+
+        // THEN they should all be observed as dropped in the end
+        try ( Transaction tx = db.beginTx() )
+        {
+            assertEquals( 0, asList( db.schema().getIndexes() ).size() );
+            tx.success();
+        }
+    }
+
+    private static Label label( int i )
+    {
+        return Label.label( "L" + i );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexMapReferenceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexMapReferenceTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.index;
+
+import org.junit.Test;
+
+import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
+import org.neo4j.test.Race;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class IndexMapReferenceTest
+{
+    @Test
+    public void shouldSynchronizeModifications() throws Throwable
+    {
+        // given
+        IndexMapReference ref = new IndexMapReference();
+        IndexProxy[] existing = mockedIndexProxies( 5, 0 );
+        ref.modify( indexMap ->
+        {
+            for ( int i = 0; i < existing.length; i++ )
+            {
+                indexMap.putIndexProxy( i, existing[i] );
+            }
+            return indexMap;
+        } );
+
+        // when
+        Race race = new Race();
+        for ( int i = 0; i < existing.length; i++ )
+        {
+            race.addContestant( removeIndexProxy( ref, i ), 1 );
+        }
+        IndexProxy[] created = mockedIndexProxies( 3, existing.length );
+        for ( int i = 0; i < existing.length; i++ )
+        {
+            race.addContestant( putIndexProxy( ref, existing.length + i, created[i] ), 1 );
+        }
+        race.go();
+
+        // then
+        for ( int i = 0; i < existing.length; i++ )
+        {
+            assertNull( ref.getIndexProxy( i ) );
+        }
+        for ( int i = 0; i < created.length; i++ )
+        {
+            assertSame( created[i], ref.getIndexProxy( existing.length + i ) );
+        }
+    }
+
+    private Runnable putIndexProxy( IndexMapReference ref, long indexId, IndexProxy proxy )
+    {
+        return () -> ref.modify( indexMap ->
+        {
+            indexMap.putIndexProxy( indexId, proxy );
+            return indexMap;
+        } );
+    }
+
+    private Runnable removeIndexProxy( IndexMapReference ref, long indexId )
+    {
+        return () -> ref.modify( indexMap ->
+        {
+            indexMap.removeIndexProxy( indexId );
+            return indexMap;
+        } );
+    }
+
+    private IndexProxy[] mockedIndexProxies( int base, int count )
+    {
+        IndexProxy[] existing = new IndexProxy[count];
+        for ( int i = 0; i < count; i++ )
+        {
+            existing[i] = mock( IndexProxy.class );
+            when( existing[i].getDescriptor() ).thenReturn( IndexDescriptorFactory.forLabel( base + i, 1 ) );
+        }
+        return existing;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
@@ -984,21 +984,25 @@ public class IndexingServiceTest
     public void flushAllIndexesWhileSomeOfThemDropped() throws IOException
     {
         IndexMapReference indexMapReference = new IndexMapReference();
-        IndexMap indexMap = indexMapReference.indexMapSnapshot();
-
         IndexProxy validIndex = createIndexProxyMock();
-        indexMap.putIndexProxy( 1, validIndex );
-        indexMap.putIndexProxy( 2, validIndex );
         IndexProxy deletedIndexProxy = createIndexProxyMock();
-        indexMap.putIndexProxy( 3, deletedIndexProxy );
-        indexMap.putIndexProxy( 4, validIndex );
-        indexMap.putIndexProxy( 5, validIndex );
-
-        indexMapReference.setIndexMap( indexMap );
+        indexMapReference.modify( indexMap ->
+        {
+            indexMap.putIndexProxy( 1, validIndex );
+            indexMap.putIndexProxy( 2, validIndex );
+            indexMap.putIndexProxy( 3, deletedIndexProxy );
+            indexMap.putIndexProxy( 4, validIndex );
+            indexMap.putIndexProxy( 5, validIndex );
+            return indexMap;
+        } );
 
         doAnswer( invocation ->
         {
-            indexMap.removeIndexProxy( 3 );
+            indexMapReference.modify( indexMap ->
+            {
+                indexMap.removeIndexProxy( 3 );
+                return indexMap;
+            } );
             throw new RuntimeException( "Index deleted." );
         } ).when( deletedIndexProxy ).force();
 
@@ -1012,19 +1016,18 @@ public class IndexingServiceTest
     public void failForceAllWhenOneOfTheIndexesFailToForce() throws IOException
     {
         IndexMapReference indexMapReference = new IndexMapReference();
-        IndexMap indexMap = indexMapReference.indexMapSnapshot();
-
-        IndexProxy validIndex = createIndexProxyMock();
-
-        indexMap.putIndexProxy( 1, validIndex );
-        indexMap.putIndexProxy( 2, validIndex );
-        IndexProxy strangeIndexProxy = createIndexProxyMock();
-        indexMap.putIndexProxy( 3, strangeIndexProxy );
-        indexMap.putIndexProxy( 4, validIndex );
-        indexMap.putIndexProxy( 5, validIndex );
-        doThrow( new UncheckedIOException( new IOException( "Can't force" ) ) ).when( strangeIndexProxy ).force();
-
-        indexMapReference.setIndexMap( indexMap );
+        indexMapReference.modify( indexMap ->
+        {
+            IndexProxy validIndex = createIndexProxyMock();
+            indexMap.putIndexProxy( 1, validIndex );
+            indexMap.putIndexProxy( 2, validIndex );
+            IndexProxy strangeIndexProxy = createIndexProxyMock();
+            indexMap.putIndexProxy( 3, strangeIndexProxy );
+            indexMap.putIndexProxy( 4, validIndex );
+            indexMap.putIndexProxy( 5, validIndex );
+            doThrow( new UncheckedIOException( new IOException( "Can't force" ) ) ).when( strangeIndexProxy ).force();
+            return indexMap;
+        } );
 
         IndexingService indexingService = createIndexServiceWithCustomIndexMap( indexMapReference );
 


### PR DESCRIPTION
Individual commits tells the story, but generally this is about various issues with concurrent schema changes, such that the loaded representation of the schema may end up in state of permanently missing some updates, and also temporary reading temporarily broken schema.

Some of these issues has existed since the introduction of schema, but the more severe ones was introduced with the global schema lock split.

The `ConcurrentCreateDropIndexIT` test could previously run into all these issues in one or two runs, consistently, so could reproduce very reliably. For that reason I opted for adding only that test for this.