### PR TITLE
Ignore election performance IT

### DIFF
--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/election/ElectionPerformanceIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/election/ElectionPerformanceIT.java
@@ -48,6 +48,7 @@ import static org.neo4j.helpers.collection.Iterators.asSet;
  */
 public class ElectionPerformanceIT
 {
+    @Ignore( "This belongs better in a benchmarking suite." )
     @Test
     public void electionPerformance_NormalConditions() throws Throwable
     {


### PR DESCRIPTION
Was already ignored for the rapid conditions and are now ignored
for the normal conditions as well, since running builds in parallel
has a significant effect on the outcome.

The intention is to move this to a proper benchmarking environment
eventually. The tests are left in place so that one can run them
manually until then.

The test still exists unignored on older branches where parallel
testing is not utilized.