### PR TITLE
Revert "Merge pull request #10045 from Lojjs/3.3-cost-model"

### DIFF
--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/CardinalityCostModel.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/CardinalityCostModel.scala
@@ -28,8 +28,8 @@ object CardinalityCostModel extends CostModel {
   def VERBOSE = java.lang.Boolean.getBoolean("CardinalityCostModel.VERBOSE")
 
   private val DEFAULT_COST_PER_ROW: CostPerRow = 0.1
-  private val PROBE_BUILD_COST: CostPerRow = 19.4
-  private val PROBE_SEARCH_COST: CostPerRow = 11.5
+  private val PROBE_BUILD_COST: CostPerRow = 3.1
+  private val PROBE_SEARCH_COST: CostPerRow = 2.4
   private val EAGERNESS_MULTIPLIER: Multiplier = 2.0
 
   private def costPerRow(plan: LogicalPlan): CostPerRow = plan match {
@@ -38,9 +38,10 @@ object CardinalityCostModel extends CostModel {
      * see ActualCostCalculationTest
      */
 
-    case _: NodeByLabelScan  => 1.0
-    case _: NodeIndexScan |
-         _: ProjectEndpoints => 2.4
+    case _: NodeByLabelScan |
+         _: NodeIndexScan |
+         _: ProjectEndpoints
+    => 1.0
 
     // Filtering on labels and properties
     case Selection(predicates, _) =>
@@ -54,22 +55,22 @@ object CardinalityCostModel extends CostModel {
         DEFAULT_COST_PER_ROW
 
     case _: AllNodesScan
-    => 1.8
+    => 1.2
 
     case _: Expand |
          _: VarExpand
-    => 5.0
+    => 1.5
 
     case _: NodeUniqueIndexSeek |
          _: NodeIndexSeek |
          _: NodeIndexContainsScan |
          _: NodeIndexEndsWithScan
-    => 2.3
+    => 1.9
 
     case _: NodeByIdSeek |
          _: DirectedRelationshipByIdSeek |
          _: UndirectedRelationshipByIdSeek
-    => 25.0
+    => 6.2
 
     case _: NodeHashJoin |
          _: Aggregation |

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/CardinalityCostModelTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/CardinalityCostModelTest.scala
@@ -40,7 +40,7 @@ class CardinalityCostModelTest extends CypherFunSuite with LogicalPlanningTestSu
           )(solvedWithEstimation(10.0)), "a", SemanticDirection.OUTGOING, Seq.empty, "b", "r1")(solvedWithEstimation(100.0))
       )(solvedWithEstimation(10.0))
 
-    CardinalityCostModel(plan, QueryGraphSolverInput.empty) should equal(Cost(301))
+    CardinalityCostModel(plan, QueryGraphSolverInput.empty) should equal(Cost(231))
   }
 
   test("should introduce increase cost when estimating an eager operator and lazyness is preferred") {
@@ -57,28 +57,7 @@ class CardinalityCostModelTest extends CypherFunSuite with LogicalPlanningTestSu
     CardinalityCostModel(plan, whatever) should be < CardinalityCostModel(plan, pleaseLazy)
   }
 
-  test("eager plan should be penalized when estimating cost when lazyness is preferred") {
-    // MATCH (a1: A)-[r1]->(b)<-[r2]-(a2: A) RETURN b
-    val eagerPlan = Projection(
-      NodeHashJoin(Set("b"),
-                   Expand(
-                     NodeByLabelScan("a1", lblName("A"), Set.empty)(solvedWithEstimation(10.0)),
-                     "a1", SemanticDirection.OUTGOING, Seq.empty, "b", "r1", ExpandAll
-                   )(solvedWithEstimation(50.0)),
-                   Expand(
-                     NodeByLabelScan("a2", lblName("A"), Set.empty)(solvedWithEstimation(10.0)),
-                     "a2", SemanticDirection.OUTGOING, Seq.empty, "b", "r2", ExpandAll
-                   )(solvedWithEstimation(50.0))
-      )(solvedWithEstimation(250.0)), Map("b" -> varFor("b"))
-    )(solvedWithEstimation(250.0))
-
-    val whateverCost = CardinalityCostModel(eagerPlan, QueryGraphSolverInput.empty)
-    val preferLazyCost = CardinalityCostModel(eagerPlan, QueryGraphSolverInput.empty.withPreferredStrictness(LazyMode))
-
-    whateverCost should be < preferLazyCost
-  }
-
-  test("lazy plan should not be penalized when estimating cost wrt a lazy one when lazyness is preferred") {
+  test("non-lazy plan should be penalized when estimating cost wrt a lazy one when lazyness is preferred") {
     // MATCH (a1: A)-[r1]->(b)<-[r2]-(a2: A) RETURN b
 
     val lazyPlan = Projection(
@@ -94,10 +73,24 @@ class CardinalityCostModelTest extends CypherFunSuite with LogicalPlanningTestSu
       )(solvedWithEstimation(250.0)), Map("b" -> varFor("b"))
     )(solvedWithEstimation(250.0))
 
-    val whateverCost = CardinalityCostModel(lazyPlan, QueryGraphSolverInput.empty)
-    val preferLazyCost = CardinalityCostModel(lazyPlan, QueryGraphSolverInput.empty.withPreferredStrictness(LazyMode))
+    val eagerPlan = Projection(
+      NodeHashJoin(Set("b"),
+        Expand(
+          NodeByLabelScan("a1", lblName("A"), Set.empty)(solvedWithEstimation(10.0)),
+          "a1", SemanticDirection.OUTGOING, Seq.empty, "b", "r1", ExpandAll
+        )(solvedWithEstimation(50.0)),
+        Expand(
+          NodeByLabelScan("a2", lblName("A"), Set.empty)(solvedWithEstimation(10.0)),
+          "a2", SemanticDirection.OUTGOING, Seq.empty, "b", "r2", ExpandAll
+        )(solvedWithEstimation(50.0))
+      )(solvedWithEstimation(250.0)), Map("b" -> varFor("b"))
+    )(solvedWithEstimation(250.0))
 
-    whateverCost should equal(preferLazyCost)
+    val whatever = QueryGraphSolverInput.empty
+    CardinalityCostModel(lazyPlan, whatever) should be > CardinalityCostModel(eagerPlan, whatever)
+
+    val pleaseLazy = QueryGraphSolverInput.empty.withPreferredStrictness(LazyMode)
+    CardinalityCostModel(lazyPlan, pleaseLazy) should be < CardinalityCostModel(eagerPlan, pleaseLazy)
   }
 
   test("multiple property expressions are counted for in cost") {

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/OptionalMatchPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/OptionalMatchPlanningIntegrationTest.scala
@@ -134,11 +134,7 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
   }
 
   test("should solve optional matches with arguments and predicates") {
-    val plan =  new given {
-      cost = {
-        case (_: Expand, _) => 1000.0
-      }
-    }.getLogicalPlanFor (
+    val plan = planFor(
       """MATCH (n:X)
         |OPTIONAL MATCH (n)-[r]-(m:Y)
         |WHERE m.prop = 42

--- a/community/neo4j/src/test/java/org/neo4j/locking/QueryExecutionLocksIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/locking/QueryExecutionLocksIT.java
@@ -130,11 +130,8 @@ public class QueryExecutionLocksIT
 
         try ( Transaction transaction = databaseRule.beginTx() )
         {
-            for ( int i = 0; i < 10; i++ )
-            {
-                Node node = databaseRule.createNode( human );
-                node.setProperty( propertyKey, RandomStringUtils.randomAscii( 10 ) );
-            }
+            Node node = databaseRule.createNode( human );
+            node.setProperty( propertyKey, RandomStringUtils.randomAscii( 10 ) );
             transaction.success();
         }
 
@@ -160,11 +157,8 @@ public class QueryExecutionLocksIT
 
         try ( Transaction transaction = databaseRule.beginTx() )
         {
-            for ( int i = 0; i < 10; i++ )
-            {
-                Node node = databaseRule.createNode( robot );
-                node.setProperty( propertyKey, RandomStringUtils.randomAscii( 10 ) );
-            }
+            Node node = databaseRule.createNode( robot );
+            node.setProperty( propertyKey, RandomStringUtils.randomAscii( 10 ) );
             transaction.success();
         }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
@@ -1350,11 +1350,11 @@ class EagerizationAcceptanceTest
     createLabeledNode("Two")
     createLabeledNode("Two")
     createNode()
-    val query = "MATCH (a), (b:Two) MERGE (q:Two {p: 1}) RETURN count(*) AS c"
+    val query = "MATCH (a:Two), (b) MERGE (q {p: 1}) RETURN count(*) AS c"
 
     val result: InternalExecutionResult = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
-    assertStats(result, nodesCreated = 1, propertiesWritten = 1, labelsAdded = 1)
+    assertStats(result, nodesCreated = 1, propertiesWritten = 1)
     result.toList should equal(List(Map("c" -> 6)))
   }
 
@@ -1815,7 +1815,6 @@ class EagerizationAcceptanceTest
 
     val result: InternalExecutionResult = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
-
     assertStats(result, labelsAdded = 1)
     result.toList should equal(List(Map("c" -> 12)))
   }
@@ -1926,7 +1925,7 @@ class EagerizationAcceptanceTest
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
-
+    //    expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     result.columnAs[Long]("count(*)").next shouldBe 1
   }
 
@@ -1938,7 +1937,7 @@ class EagerizationAcceptanceTest
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
-
+    //    expectedDifferentPlans = Configs.AllRulePlanners + Configs.Cost3_1)
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
   }
@@ -2231,7 +2230,6 @@ class EagerizationAcceptanceTest
 
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
-
     assertStats(result, labelsRemoved = 2)
     result.toList should equal(List(Map("c" -> 12)))
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchLongPatternAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchLongPatternAcceptanceTest.scala
@@ -87,7 +87,7 @@ class MatchLongPatternAcceptanceTest extends ExecutionEngineFunSuite with QueryS
 
   test("should plan a very long relationship pattern without combinatorial explosion") {
     // GIVEN
-    makeLargeMatrixDataset(150)
+    makeLargeMatrixDataset(100)
 
     // WHEN
     val numberOfPatternRelationships = 20
@@ -206,7 +206,10 @@ class MatchLongPatternAcceptanceTest extends ExecutionEngineFunSuite with QueryS
           val monitor = TestIDPSolverMonitor()
           val monitors: monitoring.Monitors = graph.getDependencyResolver.resolveDependency(classOf[monitoring.Monitors])
           monitors.addMonitorListener(monitor)
-          innerExecute(s"EXPLAIN CYPHER planner=IDP $query")
+          val result = innerExecute(s"EXPLAIN CYPHER planner=IDP $query")
+          val counts = countExpandsAndJoins(result.executionPlanDescription())
+          counts("joins") should be > 1
+          counts("joins") should be < numberOfPatternRelationships / 2
           acc(configValue) = monitor.maxStartIteration
       }
       acc

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekAcceptanceTest.scala
@@ -278,7 +278,7 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with NewPlanne
     val root1 = createLabeledNode(Map("uuid" -> "b"), "Company")
     val root2 = createLabeledNode(Map("uuid" -> "a"), "Company")
     val root3 = createLabeledNode(Map("uuid" -> "c"), "Company")
-    for(_ <- 1 to 10) createLabeledNode(Map("uuid" -> "z"), "Company")
+    createLabeledNode(Map("uuid" -> "z"), "Company")
 
     // When
     val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode(
@@ -296,7 +296,7 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with NewPlanne
     val root1 = createLabeledNode(Map("uuid" -> 1), "Company")
     val root2 = createLabeledNode(Map("uuid" -> 2), "Company")
     val root3 = createLabeledNode(Map("uuid" -> 3), "Company")
-    for(_ <- 1 to 10) createLabeledNode(Map("uuid" -> 6), "Company")
+    createLabeledNode(Map("uuid" -> 6), "Company")
 
     // When
     val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode(

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartPointFindingAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartPointFindingAcceptanceTest.scala
@@ -97,7 +97,7 @@ class StartPointFindingAcceptanceTest extends ExecutionEngineFunSuite with NewPl
     val b = createNode("x")
     val r = relate(a, b)
 
-    val result = executeWithAllPlannersAndRuntimes(s"match (a)-[r]-(b) where id(r) = ${r.getId} return a,r,b")
+    val result = executeWithAllPlanners(s"match (a)-[r]-(b) where id(r) = ${r.getId} return a,r,b")
     result.toSet should equal(Set(
       Map("r" -> r, "a" -> a, "b" -> b),
       Map("r" -> r, "a" -> b, "b" -> a)))

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueIndexAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueIndexAcceptanceTest.scala
@@ -19,9 +19,9 @@
  */
 package org.neo4j.internal.cypher.acceptance
 
-import org.neo4j.cypher.ExecutionEngineFunSuite
 import org.neo4j.cypher.internal.helpers.{NodeKeyConstraintCreator, UniquenessConstraintCreator}
 import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService
+import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport}
 import org.neo4j.graphdb.config.Setting
 import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.{ComparePlansWithAssertion, Configs}
 import org.neo4j.test.TestEnterpriseGraphDatabaseFactory
@@ -147,8 +147,6 @@ class UniqueIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
     test(s"$constraintCreator: should use locking unique index for merge relationship queries") {
       //GIVEN
       createLabeledNode(Map("name" -> "Andres"), "Person")
-      for(i <- 1 to 10) createLabeledNode(Map("name" -> s"Name$i"), "Person")
-
       constraintCreator.createConstraint(graph, "Person", "name")
       graph should not(haveConstraints(s"${constraintCreator.other.typeName}:Person(name)"))
       graph should haveConstraints(s"${constraintCreator.typeName}:Person(name)")
@@ -161,7 +159,7 @@ class UniqueIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
           plan shouldNot useOperators("NodeIndexSeek")
           plan shouldNot useOperators("NodeByLabelScan")
           plan should useOperators("NodeUniqueIndexSeek(Locking)")
-        }, Configs.AllRulePlanners))
+        }, Configs.AllRulePlanners + Configs.Cost3_1))
     }
 
     test(s"$constraintCreator: should use locking unique index for mixed read write queries") {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueIndexUsageAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueIndexUsageAcceptanceTest.scala
@@ -118,7 +118,7 @@ class UniqueIndexUsageAcceptanceTest extends ExecutionEngineFunSuite with NewPla
         |RETURN m""".stripMargin
 
     // When
-    val result = executeWithAllPlannersAndRuntimes(query)
+    val result = executeWithAllPlanners(query)
 
     // Then
     result.toList should equal(List(


### PR DESCRIPTION
This reverts a cost model update, because it introduced a regression in LDBC Query 12. The regression was caused by less optimal planning, due to the changed relative costs of some operators. 