### PR TITLE
Avoid stack overflow on IBM JDK in case of panic during import

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/AbstractStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/AbstractStep.java
@@ -151,7 +151,7 @@ public abstract class AbstractStep<T> implements Step<T>
     {
         if ( isPanic() )
         {
-            throw new RuntimeException( "Panic called, so exiting", panic );
+            throw Exceptions.launderedException( panic );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProducerStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProducerStep.java
@@ -48,7 +48,7 @@ public abstract class ProducerStep extends AbstractStep<Void> implements StatsPr
     @Override
     public long receive( long ticket, Void batch )
     {
-        // It's fone to not store a reference to this thread here because either it completes and exits
+        // It's fine to not store a reference to this thread here because either it completes and exits
         // normally, notices a panic and exits via an exception.
         new Thread( name() )
         {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/StageExecution.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/StageExecution.java
@@ -22,7 +22,6 @@ package org.neo4j.unsafe.impl.batchimport.staging;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
@@ -162,7 +161,10 @@ public class StageExecution implements StageControl
         }
         else
         {
-            panic.addSuppressed( cause );
+            if ( !panic.equals( cause ) )
+            {
+                panic.addSuppressed( cause );
+            }
         }
     }
 


### PR DESCRIPTION
Since IBM JDK 8 does not check for circular references in exception
current panic mechanic in import tool can cause stack overflow
when printing exception stack trace.
Current PR change panic handling to not wrap original
source of panic into new RuntimeException and will avoid setting
panic exception being suppressed by panic exception.