### PR TITLE
Report recovery progress

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/recovery/RecoveryRequiredChecker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/recovery/RecoveryRequiredChecker.java
@@ -25,16 +25,15 @@ import java.io.IOException;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.impl.store.NeoStores;
-import org.neo4j.kernel.impl.transaction.log.LogPosition;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
 import org.neo4j.kernel.impl.transaction.log.ReadableClosablePositionAwareChannel;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
 import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.kernel.recovery.LogTailScanner;
-import org.neo4j.kernel.recovery.PositionToRecoverFrom;
+import org.neo4j.kernel.recovery.RecoveryStartInformationProvider;
 
-import static org.neo4j.kernel.recovery.PositionToRecoverFrom.NO_MONITOR;
+import static org.neo4j.kernel.recovery.RecoveryStartInformationProvider.NO_MONITOR;
 
 /**
  * An external tool that can determine if a given store will need recovery.
@@ -64,6 +63,6 @@ public class RecoveryRequiredChecker
         PhysicalLogFiles logFiles = new PhysicalLogFiles( dataDir, fs );
         LogEntryReader<ReadableClosablePositionAwareChannel> reader = new VersionAwareLogEntryReader<>();
         LogTailScanner tailScanner = new LogTailScanner( logFiles, fs, reader, monitors );
-        return new PositionToRecoverFrom( tailScanner, NO_MONITOR ).get() != LogPosition.UNSPECIFIED;
+        return new RecoveryStartInformationProvider( tailScanner, NO_MONITOR ).get().isRecoveryRequired();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CountsComputer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CountsComputer.java
@@ -23,8 +23,8 @@ import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.impl.api.CountsAccessor;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
 import org.neo4j.kernel.impl.store.kvstore.DataInitializer;
-import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
-import org.neo4j.kernel.impl.storemigration.monitoring.SilentMigrationProgressMonitor;
+import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
+import org.neo4j.kernel.impl.util.monitoring.SilentProgressReporter;
 import org.neo4j.unsafe.impl.batchimport.Configuration;
 import org.neo4j.unsafe.impl.batchimport.NodeCountsStage;
 import org.neo4j.unsafe.impl.batchimport.RelationshipCountsStage;
@@ -53,7 +53,7 @@ public class CountsComputer implements DataInitializer<CountsAccessor.Updater>
     private final int highLabelId;
     private final int highRelationshipTypeId;
     private final long lastCommittedTransactionId;
-    private final MigrationProgressMonitor.Section progressMonitor;
+    private final ProgressReporter progressMonitor;
 
     public CountsComputer( NeoStores stores, PageCache pageCache )
     {
@@ -68,11 +68,11 @@ public class CountsComputer implements DataInitializer<CountsAccessor.Updater>
             int highLabelId, int highRelationshipTypeId, NumberArrayFactory numberArrayFactory )
     {
         this( lastCommittedTransactionId, nodes, relationships, highLabelId, highRelationshipTypeId,
-                numberArrayFactory, SilentMigrationProgressMonitor.NO_OP_SECTION );
+                numberArrayFactory, SilentProgressReporter.INSTANCE );
     }
 
     public CountsComputer( long lastCommittedTransactionId, NodeStore nodes, RelationshipStore relationships,
-            int highLabelId, int highRelationshipTypeId, NumberArrayFactory numberArrayFactory, MigrationProgressMonitor.Section progressMonitor )
+            int highLabelId, int highRelationshipTypeId, NumberArrayFactory numberArrayFactory, ProgressReporter progressMonitor )
     {
         this.lastCommittedTransactionId = lastCommittedTransactionId;
         this.nodes = nodes;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/DirectRecordStoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/DirectRecordStoreMigrator.java
@@ -35,7 +35,7 @@ import org.neo4j.kernel.impl.store.StoreType;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
-import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
+import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
 import org.neo4j.logging.NullLogProvider;
 
 import static org.neo4j.helpers.ArrayUtil.contains;
@@ -58,10 +58,10 @@ public class DirectRecordStoreMigrator
     }
 
     public void migrate( File fromStoreDir, RecordFormats fromFormat, File toStoreDir, RecordFormats toFormat,
-            MigrationProgressMonitor.Section progressMonitor, StoreType[] types, StoreType... additionalTypesToOpen )
+            ProgressReporter progressReporter, StoreType[] types, StoreType... additionalTypesToOpen )
     {
         StoreType[] storesToOpen = ArrayUtil.concat( types, additionalTypesToOpen );
-        progressMonitor.start( storesToOpen.length );
+        progressReporter.start( storesToOpen.length );
 
         try (
                 NeoStores fromStores = new StoreFactory( fromStoreDir, config, new DefaultIdGeneratorFactory( fs ),
@@ -77,7 +77,7 @@ public class DirectRecordStoreMigrator
                 if ( type.isRecordStore() )
                 {
                     migrate( fromStores.getRecordStore( type ), toStores.getRecordStore( type ) );
-                    progressMonitor.progress( 1 );
+                    progressReporter.progress( 1 );
                 }
             }
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrationParticipant.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreMigrationParticipant.java
@@ -22,9 +22,9 @@ package org.neo4j.kernel.impl.storemigration;
 import java.io.File;
 import java.io.IOException;
 
-import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
 import org.neo4j.kernel.impl.storemigration.participant.AbstractStoreMigrationParticipant;
 import org.neo4j.kernel.impl.util.UnsatisfiedDependencyException;
+import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
 
 public interface StoreMigrationParticipant
 {
@@ -48,14 +48,14 @@ public interface StoreMigrationParticipant
      * @throws IOException if there was an error migrating.
      * @throws UnsatisfiedDependencyException if one or more dependencies were unsatisfied.
      */
-    void migrate( File storeDir, File migrationDir, MigrationProgressMonitor.Section progress,
+    void migrate( File storeDir, File migrationDir, ProgressReporter progress,
             String versionToMigrateFrom, String versionToMigrateTo ) throws IOException;
 
     /**
      * After a successful migration, move all affected files from {@code upgradeDirectory} over to
      * the {@code workingDirectory}, effectively activating the migration changes.
      * @param migrationDir directory where the
-     * {@link #migrate(File, File, MigrationProgressMonitor.Section, String, String) migration} put its files.
+     * {@link #migrate(File, File, ProgressReporter, String, String) migration} put its files.
      * @param storeDir directory the store directory of the to move the migrated files to.
      * @param versionToMigrateFrom the version we have migrated from
      * @param versionToMigrateTo the version we want to migrate to

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
@@ -34,7 +34,7 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
-import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor.Section;
+import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
 import org.neo4j.kernel.internal.Version;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
@@ -203,10 +203,10 @@ public class StoreUpgrader
         {
             for ( StoreMigrationParticipant participant : participants )
             {
-                Section section = progressMonitor.startSection( participant.getName() );
-                participant.migrate( storeDir, migrationDirectory, section, versionToMigrateFrom,
+                ProgressReporter progressReporter = progressMonitor.startSection( participant.getName() );
+                participant.migrate( storeDir, migrationDirectory, progressReporter, versionToMigrateFrom,
                         upgradableDatabase.currentVersion() );
-                section.completed();
+                progressReporter.completed();
             }
         }
         catch ( IOException | UncheckedIOException e )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/AbstractStoreMigrationParticipant.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/AbstractStoreMigrationParticipant.java
@@ -23,7 +23,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.neo4j.kernel.impl.storemigration.StoreMigrationParticipant;
-import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
+import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
 
 /**
  * Default empty implementation of StoreMigrationParticipant.
@@ -41,7 +41,7 @@ public class AbstractStoreMigrationParticipant implements StoreMigrationParticip
     }
 
     @Override
-    public void migrate( File storeDir, File migrationDir, MigrationProgressMonitor.Section progressMonitor,
+    public void migrate( File storeDir, File migrationDir, ProgressReporter progressMonitor,
             String versionToMigrateFrom, String versionToMigrateTo ) throws IOException
     {
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/CountsMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/CountsMigrator.java
@@ -44,7 +44,7 @@ import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.storemigration.ExistingTargetStrategy;
 import org.neo4j.kernel.impl.storemigration.StoreFileType;
 import org.neo4j.kernel.impl.storemigration.StoreUpgrader;
-import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
+import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
 import org.neo4j.kernel.lifecycle.Lifespan;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
@@ -84,7 +84,7 @@ public class CountsMigrator extends AbstractStoreMigrationParticipant
     }
 
     @Override
-    public void migrate( File storeDir, File migrationDir, MigrationProgressMonitor.Section progressMonitor,
+    public void migrate( File storeDir, File migrationDir, ProgressReporter progressMonitor,
             String versionToMigrateFrom, String versionToMigrateTo ) throws IOException
     {
         if ( countStoreRebuildRequired( versionToMigrateFrom ) )
@@ -147,7 +147,7 @@ public class CountsMigrator extends AbstractStoreMigrationParticipant
     }
 
     private void rebuildCountsFromScratch( File storeDirToReadFrom, File migrationDir, long lastTxId,
-            MigrationProgressMonitor.Section progressMonitor, String expectedStoreVersion, PageCache pageCache,
+            ProgressReporter progressMonitor, String expectedStoreVersion, PageCache pageCache,
             LogProvider logProvider )
     {
         final File storeFileBase = new File( migrationDir,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/ExplicitIndexMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/ExplicitIndexMigrator.java
@@ -28,7 +28,7 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.store.format.CapabilityType;
 import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
-import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
+import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
 import org.neo4j.kernel.spi.explicitindex.IndexImplementation;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
@@ -60,7 +60,7 @@ public class ExplicitIndexMigrator extends AbstractStoreMigrationParticipant
     }
 
     @Override
-    public void migrate( File storeDir, File migrationDir, MigrationProgressMonitor.Section progressMonitor,
+    public void migrate( File storeDir, File migrationDir, ProgressReporter progressMonitor,
             String versionToMigrateFrom, String versionToMigrateTo ) throws IOException
     {
         IndexImplementation indexImplementation = indexProviders.get( LUCENE_EXPLICIT_INDEX_PROVIDER_NAME );
@@ -111,7 +111,7 @@ public class ExplicitIndexMigrator extends AbstractStoreMigrationParticipant
         return migrationExplicitIndexesRoot != null && fileSystem.fileExists( migrationExplicitIndexesRoot );
     }
 
-    private void migrateExplicitIndexes( MigrationProgressMonitor.Section progressMonitor ) throws IOException
+    private void migrateExplicitIndexes( ProgressReporter progressMonitor ) throws IOException
     {
         try
         {
@@ -139,12 +139,12 @@ public class ExplicitIndexMigrator extends AbstractStoreMigrationParticipant
     }
 
     LuceneExplicitIndexUpgrader createLuceneExplicitIndexUpgrader( Path indexRootPath,
-            MigrationProgressMonitor.Section progressMonitor )
+            ProgressReporter progressMonitor )
     {
         return new LuceneExplicitIndexUpgrader( indexRootPath, progressMonitor( progressMonitor ) );
     }
 
-    private Monitor progressMonitor( MigrationProgressMonitor.Section progressMonitor )
+    private Monitor progressMonitor( ProgressReporter progressMonitor )
     {
         return new Monitor()
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/SchemaIndexMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/SchemaIndexMigrator.java
@@ -27,7 +27,7 @@ import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.impl.store.format.CapabilityType;
 import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
-import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
+import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
 
 /**
  * Migrates schema and label indexes between different neo4j versions.
@@ -50,7 +50,7 @@ public class SchemaIndexMigrator extends AbstractStoreMigrationParticipant
     }
 
     @Override
-    public void migrate( File storeDir, File migrationDir, MigrationProgressMonitor.Section progressMonitor,
+    public void migrate( File storeDir, File migrationDir, ProgressReporter progressReporter,
             String versionToMigrateFrom, String versionToMigrateTo ) throws IOException
     {
         RecordFormats from = RecordFormatSelector.selectForVersion( versionToMigrateFrom );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LoggingLogFileMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LoggingLogFileMonitor.java
@@ -23,8 +23,8 @@ import java.io.File;
 
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryCommit;
 import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
-import org.neo4j.kernel.recovery.PositionToRecoverFrom;
 import org.neo4j.kernel.recovery.RecoveryMonitor;
+import org.neo4j.kernel.recovery.RecoveryStartInformationProvider;
 import org.neo4j.logging.Log;
 
 import static java.lang.String.format;
@@ -32,7 +32,7 @@ import static java.lang.String.format;
 public class LoggingLogFileMonitor implements
         PhysicalLogFile.Monitor,
         LogRotation.Monitor, RecoveryMonitor,
-        PositionToRecoverFrom.Monitor
+        RecoveryStartInformationProvider.Monitor
 {
     private long firstTransactionRecovered = -1;
     private long lastTransactionRecovered;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/monitoring/LogProgressReporter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/monitoring/LogProgressReporter.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util.monitoring;
+
+import org.neo4j.logging.Log;
+
+import static java.lang.String.format;
+
+/**
+ * Progress reporter that reports its progress into provided log.
+ * Progress measured in percents (from 0 till 100) where just started reporter is at 0 percents and
+ * completed is at 100. Progress reporter each 10 percents.
+ */
+public class LogProgressReporter implements ProgressReporter
+{
+    private static final int STRIDE = 10;
+    private static final int HUNDRED = 100;
+
+    private final Log log;
+
+    private long current;
+    private int currentPercent;
+    private long max;
+
+    public LogProgressReporter( Log log )
+    {
+        this.log = log;
+    }
+
+    @Override
+    public void progress( long add )
+    {
+        current += add;
+        int percent = max == 0 ? HUNDRED : Math.min( HUNDRED, (int) ((current * HUNDRED) / max) );
+        ensurePercentReported( percent );
+    }
+
+    private void ensurePercentReported( int percent )
+    {
+        while ( currentPercent < percent )
+        {
+            reportPercent( ++currentPercent );
+        }
+    }
+
+    private void reportPercent( int percent )
+    {
+        if ( percent % STRIDE == 0 )
+        {
+            log.info( format( "  %d%% completed", percent ) );
+        }
+    }
+
+    @Override
+    public void start( long max )
+    {
+        this.max = max;
+    }
+
+    @Override
+    public void completed()
+    {
+        ensurePercentReported( HUNDRED );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/monitoring/ProgressReporter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/monitoring/ProgressReporter.java
@@ -17,29 +17,31 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.storemigration.monitoring;
+package org.neo4j.kernel.impl.util.monitoring;
 
-import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
-
-public interface MigrationProgressMonitor
+/**
+ * Progress indicator to track progress of long running processes.
+ * Reporter should be configured with maximum number of progress steps, by starting it.
+ * Each small step of long running task then responsible to call {@link #progress(long)} to inform about ongoing
+ * progress.
+ * In the end {@link #completed()} should be invoked to signal about execution completion.
+ */
+public interface ProgressReporter
 {
     /**
-     * Signals that the migration process has started.
-     * @param numStages The number of migration stages is the migration process that we are monitoring.
+     * @param max max progress, which {@link #progress(long)} moves towards.
      */
-    void started( int numStages );
+    void start( long max );
 
     /**
-     * Signals that migration goes into section with given {@code name}.
+     * Percentage completeness for the current section.
      *
-     * @param name descriptive name of the section to migration.
-     * @return {@link ProgressReporter} which should be notified about progress in the given section.
+     * @param add progress to add towards a maximum.
      */
-    ProgressReporter startSection( String name );
+    void progress( long add );
 
     /**
-     * The migration process has completed successfully.
+     * Called if this section was completed successfully.
      */
     void completed();
-
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/monitoring/SilentProgressReporter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/monitoring/SilentProgressReporter.java
@@ -17,28 +17,31 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.storemigration.monitoring;
+package org.neo4j.kernel.impl.util.monitoring;
 
-import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
-import org.neo4j.kernel.impl.util.monitoring.SilentProgressReporter;
-
-public class SilentMigrationProgressMonitor implements MigrationProgressMonitor
+/**
+ * Progress reporter version that does not report any progress
+ */
+public class SilentProgressReporter implements ProgressReporter
 {
+    public static final SilentProgressReporter INSTANCE = new SilentProgressReporter();
 
-    @Override
-    public void started( int numStages )
+    private SilentProgressReporter()
     {
     }
 
     @Override
-    public ProgressReporter startSection( String name )
+    public void progress( long add )
     {
-        return SilentProgressReporter.INSTANCE;
+    }
+
+    @Override
+    public void start( long max )
+    {
     }
 
     @Override
     public void completed()
     {
     }
-
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/DefaultRecoveryService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/DefaultRecoveryService.java
@@ -39,7 +39,7 @@ import static org.neo4j.kernel.impl.transaction.log.Commitment.NO_COMMITMENT;
 
 public class DefaultRecoveryService implements RecoveryService
 {
-    private final PositionToRecoverFrom positionToRecoverFrom;
+    private final RecoveryStartInformationProvider recoveryStartInformationProvider;
     private final StorageEngine storageEngine;
     private final TransactionIdStore transactionIdStore;
     private final LogicalTransactionStore logicalTransactionStore;
@@ -47,19 +47,19 @@ public class DefaultRecoveryService implements RecoveryService
 
     public DefaultRecoveryService( StorageEngine storageEngine, LogTailScanner logTailScanner,
             TransactionIdStore transactionIdStore, LogicalTransactionStore logicalTransactionStore,
-            LogVersionRepository logVersionRepository, PositionToRecoverFrom.Monitor monitor )
+            LogVersionRepository logVersionRepository, RecoveryStartInformationProvider.Monitor monitor )
     {
         this.storageEngine = storageEngine;
         this.transactionIdStore = transactionIdStore;
         this.logicalTransactionStore = logicalTransactionStore;
         this.logVersionRepository = logVersionRepository;
-        this.positionToRecoverFrom = new PositionToRecoverFrom( logTailScanner, monitor );
+        this.recoveryStartInformationProvider = new RecoveryStartInformationProvider( logTailScanner, monitor );
     }
 
     @Override
-    public LogPosition getPositionToRecoverFrom() throws IOException
+    public RecoveryStartInformation getRecoveryStartInformation() throws IOException
     {
-        return positionToRecoverFrom.get();
+        return recoveryStartInformationProvider.get();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/Recovery.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/Recovery.java
@@ -143,7 +143,9 @@ public class Recovery extends LifecycleAdapter
     {
         long numberOfTransactionToRecover =
                 getNumberOfTransactionToRecover( recoveryStartInformation, lastReversedTransaction );
-        progressReporter.start( numberOfTransactionToRecover << 1 );
+        // since we will process each transaction twice (doing reverse and direct detour) we need to
+        // multiply number of transactions that we want to recover by 2 to be able to report correct progress
+        progressReporter.start( numberOfTransactionToRecover * 2 );
     }
 
     private void reportProgress()

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/RecoveryService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/RecoveryService.java
@@ -34,7 +34,7 @@ public interface RecoveryService
 
     TransactionCursor getTransactionsInReverseOrder( LogPosition recoveryFromPosition ) throws IOException;
 
-    LogPosition getPositionToRecoverFrom() throws IOException;
+    RecoveryStartInformation getRecoveryStartInformation() throws IOException;
 
     RecoveryApplier getRecoveryApplier( TransactionApplicationMode mode ) throws Exception;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/RecoveryStartInformation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/RecoveryStartInformation.java
@@ -17,28 +17,33 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.storemigration.monitoring;
+package org.neo4j.kernel.recovery;
 
-import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
-import org.neo4j.kernel.impl.util.monitoring.SilentProgressReporter;
+import org.neo4j.kernel.impl.transaction.log.LogPosition;
 
-public class SilentMigrationProgressMonitor implements MigrationProgressMonitor
+public class RecoveryStartInformation
 {
+    private final long firstTxIdAfterLastCheckPoint;
+    private final LogPosition recoveryPosition;
 
-    @Override
-    public void started( int numStages )
+    public RecoveryStartInformation( LogPosition recoveryPosition, long firstTxIdAfterLastCheckPoint )
     {
+        this.firstTxIdAfterLastCheckPoint = firstTxIdAfterLastCheckPoint;
+        this.recoveryPosition = recoveryPosition;
     }
 
-    @Override
-    public ProgressReporter startSection( String name )
+    public boolean isRecoveryRequired()
     {
-        return SilentProgressReporter.INSTANCE;
+        return recoveryPosition != LogPosition.UNSPECIFIED;
     }
 
-    @Override
-    public void completed()
+    public long getFirstTxIdAfterLastCheckPoint()
     {
+        return firstTxIdAfterLastCheckPoint;
     }
 
+    public LogPosition getRecoveryPosition()
+    {
+        return recoveryPosition;
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeCountsProcessor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeCountsProcessor.java
@@ -24,7 +24,7 @@ import org.neo4j.kernel.impl.api.CountsAccessor;
 import org.neo4j.kernel.impl.store.NodeLabelsField;
 import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
-import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
+import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeLabelsCache;
 
 /**
@@ -35,13 +35,13 @@ public class NodeCountsProcessor implements RecordProcessor<NodeRecord>
 {
     private final NodeStore nodeStore;
     private final long[] labelCounts;
-    private MigrationProgressMonitor.Section progressMonitor;
+    private ProgressReporter progressReporter;
     private final NodeLabelsCache cache;
     private final CountsAccessor.Updater counts;
     private final int anyLabel;
 
     NodeCountsProcessor( NodeStore nodeStore, NodeLabelsCache cache, int highLabelId,
-            CountsAccessor.Updater counts, MigrationProgressMonitor.Section progressMonitor )
+            CountsAccessor.Updater counts, ProgressReporter progressReporter )
     {
         this.nodeStore = nodeStore;
         this.cache = cache;
@@ -49,7 +49,7 @@ public class NodeCountsProcessor implements RecordProcessor<NodeRecord>
         this.counts = counts;
         // Instantiate with high id + 1 since we need that extra slot for the ANY count
         this.labelCounts = new long[highLabelId + 1];
-        this.progressMonitor = progressMonitor;
+        this.progressReporter = progressReporter;
     }
 
     @Override
@@ -65,7 +65,7 @@ public class NodeCountsProcessor implements RecordProcessor<NodeRecord>
             cache.put( node.getId(), labels );
         }
         labelCounts[anyLabel]++;
-        progressMonitor.progress( 1 );
+        progressReporter.progress( 1 );
 
         // No need to update the store, we're just reading things here
         return false;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeCountsStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeCountsStage.java
@@ -21,7 +21,7 @@ package org.neo4j.unsafe.impl.batchimport;
 
 import org.neo4j.kernel.impl.api.CountsAccessor;
 import org.neo4j.kernel.impl.store.NodeStore;
-import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
+import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeLabelsCache;
 import org.neo4j.unsafe.impl.batchimport.staging.BatchFeedStep;
 import org.neo4j.unsafe.impl.batchimport.staging.ReadRecordsStep;
@@ -37,14 +37,14 @@ import static org.neo4j.unsafe.impl.batchimport.RecordIdIterator.allIn;
 public class NodeCountsStage extends Stage
 {
     public NodeCountsStage( Configuration config, NodeLabelsCache cache, NodeStore nodeStore, int highLabelId,
-            CountsAccessor.Updater countsUpdater, MigrationProgressMonitor.Section progressMonitor,
+            CountsAccessor.Updater countsUpdater, ProgressReporter progressReporter,
             StatsProvider... additionalStatsProviders )
     {
         super( "Node counts", config );
         add( new BatchFeedStep( control(), config, allIn( nodeStore, config ), nodeStore.getRecordSize() ) );
         add( new ReadRecordsStep<>( control(), config, false, nodeStore, null ) );
         add( new RecordProcessorStep<>( control(), "COUNT", config,
-                new NodeCountsProcessor( nodeStore, cache, highLabelId, countsUpdater, progressMonitor ), true,
+                new NodeCountsProcessor( nodeStore, cache, highLabelId, countsUpdater, progressReporter ), true,
                 additionalStatsProviders ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ProcessRelationshipCountsDataStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ProcessRelationshipCountsDataStep.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.neo4j.kernel.impl.api.CountsAccessor;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
-import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
+import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeLabelsCache;
 import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 import org.neo4j.unsafe.impl.batchimport.staging.BatchSender;
@@ -43,12 +43,12 @@ public class ProcessRelationshipCountsDataStep extends ProcessorStep<Relationshi
     private final int highRelationshipTypeId;
     private final CountsAccessor.Updater countsUpdater;
     private final NumberArrayFactory cacheFactory;
-    private final MigrationProgressMonitor.Section progressMonitor;
+    private final ProgressReporter progressMonitor;
 
     public ProcessRelationshipCountsDataStep( StageControl control, NodeLabelsCache cache, Configuration config, int
             highLabelId, int highRelationshipTypeId,
             CountsAccessor.Updater countsUpdater, NumberArrayFactory cacheFactory,
-            MigrationProgressMonitor.Section progressMonitor )
+            ProgressReporter progressReporter )
     {
         super( control, "COUNT", config, 0 );
         this.cache = cache;
@@ -56,7 +56,7 @@ public class ProcessRelationshipCountsDataStep extends ProcessorStep<Relationshi
         this.highRelationshipTypeId = highRelationshipTypeId;
         this.countsUpdater = countsUpdater;
         this.cacheFactory = cacheFactory;
-        this.progressMonitor = progressMonitor;
+        this.progressMonitor = progressReporter;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsStage.java
@@ -21,7 +21,7 @@ package org.neo4j.unsafe.impl.batchimport;
 
 import org.neo4j.kernel.impl.api.CountsAccessor;
 import org.neo4j.kernel.impl.store.RelationshipStore;
-import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
+import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
 import org.neo4j.unsafe.impl.batchimport.cache.NodeLabelsCache;
 import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 import org.neo4j.unsafe.impl.batchimport.staging.BatchFeedStep;
@@ -38,13 +38,13 @@ public class RelationshipCountsStage extends Stage
 {
     public RelationshipCountsStage( Configuration config, NodeLabelsCache cache, RelationshipStore relationshipStore,
             int highLabelId, int highRelationshipTypeId, CountsAccessor.Updater countsUpdater,
-            NumberArrayFactory cacheFactory, MigrationProgressMonitor.Section progressMonitor )
+            NumberArrayFactory cacheFactory, ProgressReporter progressReporter )
     {
         super( "Relationship counts", config );
         add( new BatchFeedStep( control(), config, allIn( relationshipStore, config ),
                 relationshipStore.getRecordSize() ) );
         add( new ReadRecordsStep<>( control(), config, false, relationshipStore, null ) );
         add( new ProcessRelationshipCountsDataStep( control(), cache, config,
-                highLabelId, highRelationshipTypeId, countsUpdater, cacheFactory, progressMonitor ) );
+                highLabelId, highRelationshipTypeId, countsUpdater, cacheFactory, progressReporter ) );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/RecoveryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/RecoveryTest.java
@@ -56,6 +56,7 @@ import org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryWriter;
 import org.neo4j.kernel.impl.transaction.log.entry.OnePhaseCommit;
 import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
+import org.neo4j.kernel.impl.util.monitoring.SilentProgressReporter;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.kernel.recovery.CorruptedLogsTruncator;
@@ -64,7 +65,6 @@ import org.neo4j.kernel.recovery.LogTailScanner;
 import org.neo4j.kernel.recovery.Recovery;
 import org.neo4j.kernel.recovery.RecoveryApplier;
 import org.neo4j.kernel.recovery.RecoveryMonitor;
-import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.storageengine.api.StorageEngine;
 import org.neo4j.storageengine.api.TransactionApplicationMode;
 import org.neo4j.test.rule.TestDirectory;
@@ -81,7 +81,7 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_COMMIT_TIMESTAMP;
 import static org.neo4j.kernel.impl.transaction.log.entry.LogHeaderWriter.writeLogHeader;
 import static org.neo4j.kernel.impl.transaction.log.entry.LogVersions.CURRENT_LOG_VERSION;
-import static org.neo4j.kernel.recovery.PositionToRecoverFrom.NO_MONITOR;
+import static org.neo4j.kernel.recovery.RecoveryStartInformationProvider.NO_MONITOR;
 
 public class RecoveryTest
 {
@@ -93,7 +93,6 @@ public class RecoveryTest
     private final LogVersionRepository logVersionRepository = new DeadSimpleLogVersionRepository( 1L );
     private final TransactionIdStore transactionIdStore = new DeadSimpleTransactionIdStore( 5L, 0,
             BASE_TX_COMMIT_TIMESTAMP, 0, 0 );
-    private final AssertableLogProvider logProvider = new AssertableLogProvider( true );
     private final int logVersion = 0;
 
     private LogEntry lastCommittedTxStartEntry;
@@ -207,7 +206,7 @@ public class RecoveryTest
                         }
                     };
                 }
-            }, new StartupStatisticsProvider(), logPruner, monitor, false ) );
+            }, new StartupStatisticsProvider(), logPruner, monitor, SilentProgressReporter.INSTANCE, false ) );
 
             life.start();
 
@@ -271,7 +270,7 @@ public class RecoveryTest
                 {
                     fail( "Recovery should not be required" );
                 }
-            }, new StartupStatisticsProvider(), logPruner, monitor, false ));
+            }, new StartupStatisticsProvider(), logPruner, monitor, SilentProgressReporter.INSTANCE, false ) );
 
             life.start();
 
@@ -413,7 +412,7 @@ public class RecoveryTest
                 {
                     recoveryRequired.set( true );
                 }
-            }, new StartupStatisticsProvider(), logPruner, monitor, false ) );
+            }, new StartupStatisticsProvider(), logPruner, monitor, SilentProgressReporter.INSTANCE, false ) );
 
             life.start();
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/monitoring/VisibleMigrationProgressMonitorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/monitoring/VisibleMigrationProgressMonitorTest.java
@@ -21,7 +21,7 @@ package org.neo4j.kernel.impl.storemigration.monitoring;
 
 import org.junit.Test;
 
-import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor.Section;
+import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.logging.Log;
 
@@ -73,12 +73,12 @@ public class VisibleMigrationProgressMonitorTest
 
     private void monitorSection( VisibleMigrationProgressMonitor monitor, String name, int max, int... steps )
     {
-        Section section = monitor.startSection( name );
-        section.start( max );
+        ProgressReporter progressReporter = monitor.startSection( name );
+        progressReporter.start( max );
         for ( int step : steps )
         {
-            section.progress( step );
+            progressReporter.progress( step );
         }
-        section.completed();
+        progressReporter.completed();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/ExplicitIndexMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/ExplicitIndexMigratorTest.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.store.format.standard.StandardV2_3;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
-import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
+import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
 import org.neo4j.kernel.spi.explicitindex.IndexImplementation;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
@@ -51,7 +51,7 @@ public class ExplicitIndexMigratorTest
 {
     private final FileSystemAbstraction fs = mock( FileSystemAbstraction.class );
     private final LogProvider logProvider = mock( LogProvider.class );
-    private final MigrationProgressMonitor.Section progressMonitor = mock( MigrationProgressMonitor.Section.class );
+    private final ProgressReporter progressMonitor = mock( ProgressReporter.class );
     private final File storeDir = mock( File.class );
     private final File migrationDir = mock( File.class );
     private final File originalIndexStore = mock( File.class );
@@ -172,7 +172,7 @@ public class ExplicitIndexMigratorTest
 
         @Override
         LuceneExplicitIndexUpgrader createLuceneExplicitIndexUpgrader( Path indexRootPath,
-                MigrationProgressMonitor.Section progressMonitor )
+                ProgressReporter progressReporter )
         {
             return new HumbleExplicitIndexUpgrader( indexRootPath, successfullMigration );
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/SchemaIndexMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/SchemaIndexMigratorTest.java
@@ -29,7 +29,7 @@ import org.neo4j.kernel.api.index.IndexDirectoryStructure;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.impl.store.format.standard.StandardV2_3;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
-import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
+import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.when;
 public class SchemaIndexMigratorTest
 {
     private final FileSystemAbstraction fs = mock( FileSystemAbstraction.class );
-    private final MigrationProgressMonitor.Section progressMonitor = mock( MigrationProgressMonitor.Section.class );
+    private final ProgressReporter progressReporter = mock( ProgressReporter.class );
     private final SchemaIndexProvider schemaIndexProvider = mock( SchemaIndexProvider.class );
     private final File storeDir = new File( "store" );
     private final File migrationDir = new File( "migrationDir" );
@@ -55,7 +55,7 @@ public class SchemaIndexMigratorTest
         when( schemaIndexProvider.getProviderDescriptor() )
                 .thenReturn( new SchemaIndexProvider.Descriptor( "key", "version" ) );
 
-        migrator.migrate( storeDir, migrationDir, progressMonitor, StandardV2_3.STORE_VERSION,
+        migrator.migrate( storeDir, migrationDir, progressReporter, StandardV2_3.STORE_VERSION,
                 StandardV3_0.STORE_VERSION );
 
         migrator.moveMigratedFiles( migrationDir, storeDir, StandardV2_3.STORE_VERSION, StandardV3_0.STORE_VERSION );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorTest.java
@@ -37,9 +37,9 @@ import org.neo4j.kernel.impl.logging.SimpleLogService;
 import org.neo4j.kernel.impl.store.TransactionId;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_2;
-import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
 import org.neo4j.kernel.impl.transaction.log.LogPosition;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.rule.PageCacheRule;
 import org.neo4j.test.rule.RandomRule;
@@ -199,13 +199,13 @@ public class StoreMigratorTest
         neoStore.createNewFile();
 
         // Monitor what happens
-        MySection progressMonitor = new MySection();
+        MyProgressReporter progressReporter = new MyProgressReporter();
         // Migrate with two storeversions that have the same FORMAT capabilities
-        migrator.migrate( graphDbDir, directory.directory( "migrationDir" ), progressMonitor,
+        migrator.migrate( graphDbDir, directory.directory( "migrationDir" ), progressReporter,
                 StandardV3_0.STORE_VERSION, StandardV3_2.STORE_VERSION );
 
         // Should not have started any migration
-        assertFalse( progressMonitor.started );
+        assertFalse( progressReporter.started );
     }
 
     private StoreMigrator newStoreMigrator()
@@ -214,7 +214,7 @@ public class StoreMigratorTest
                 Config.defaults(), NullLogService.getInstance() );
     }
 
-    private static class MySection implements MigrationProgressMonitor.Section
+    private static class MyProgressReporter implements ProgressReporter
     {
         public boolean started;
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogicalTransactionStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogicalTransactionStoreTest.java
@@ -40,6 +40,7 @@ import org.neo4j.kernel.impl.transaction.command.Command;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFile.Monitor;
 import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
 import org.neo4j.kernel.impl.transaction.tracing.LogAppendEvent;
+import org.neo4j.kernel.impl.util.monitoring.SilentProgressReporter;
 import org.neo4j.kernel.internal.DatabaseHealth;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.monitoring.Monitors;
@@ -48,6 +49,7 @@ import org.neo4j.kernel.recovery.Recovery;
 import org.neo4j.kernel.recovery.RecoveryApplier;
 import org.neo4j.kernel.recovery.RecoveryMonitor;
 import org.neo4j.kernel.recovery.RecoveryService;
+import org.neo4j.kernel.recovery.RecoveryStartInformation;
 import org.neo4j.storageengine.api.StorageCommand;
 import org.neo4j.storageengine.api.TransactionApplicationMode;
 import org.neo4j.test.rule.TestDirectory;
@@ -214,9 +216,9 @@ public class PhysicalLogicalTransactionStoreTest
             }
 
             @Override
-            public LogPosition getPositionToRecoverFrom() throws IOException
+            public RecoveryStartInformation getRecoveryStartInformation() throws IOException
             {
-                return LogPosition.start( 0 );
+                return new RecoveryStartInformation( LogPosition.start( 0 ), 1 );
             }
 
             @Override
@@ -235,7 +237,8 @@ public class PhysicalLogicalTransactionStoreTest
                     LogPosition positionAfterLastRecoveredTransaction )
             {
             }
-        }, new StartupStatisticsProvider(), logPruner, mock( RecoveryMonitor.class ), false ) );
+        }, new StartupStatisticsProvider(), logPruner, mock( RecoveryMonitor.class ), SilentProgressReporter.INSTANCE,
+                false ) );
 
         // WHEN
         try

--- a/community/kernel/src/test/java/org/neo4j/kernel/recovery/RecoveryProgressIndicatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/recovery/RecoveryProgressIndicatorTest.java
@@ -42,9 +42,9 @@ public class RecoveryProgressIndicatorTest
     @Test
     public void reportProgressOnRecovery() throws Throwable
     {
-        RecoveryService recoveryService = mock( RecoveryService.class, Answers.RETURNS_MOCKS.get() );
+        RecoveryService recoveryService = mock( RecoveryService.class, Answers.RETURNS_MOCKS );
         StartupStatisticsProvider statisticsProvider = mock( StartupStatisticsProvider.class );
-        TransactionLogPruner logPruner = mock( TransactionLogPruner.class );
+        CorruptedLogsTruncator logsTruncator = mock( CorruptedLogsTruncator.class );
         RecoveryMonitor recoveryMonitor = mock( RecoveryMonitor.class );
         TransactionCursor reverseTransactionCursor = mock( TransactionCursor.class );
         TransactionCursor transactionCursor = mock( TransactionCursor.class );
@@ -68,7 +68,7 @@ public class RecoveryProgressIndicatorTest
         when( recoveryService.getTransactions( recoveryStartPosition ) ).thenReturn( transactionCursor );
 
         AssertableProgressReporter progressReporter = new AssertableProgressReporter( expectedMax );
-        Recovery recovery = new Recovery( recoveryService, statisticsProvider, logPruner, recoveryMonitor,
+        Recovery recovery = new Recovery( recoveryService, statisticsProvider, logsTruncator, recoveryMonitor,
                 progressReporter, true );
         recovery.init();
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/recovery/RecoveryProgressIndicatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/recovery/RecoveryProgressIndicatorTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.recovery;
+
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import org.neo4j.kernel.impl.core.StartupStatisticsProvider;
+import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.log.LogPosition;
+import org.neo4j.kernel.impl.transaction.log.TransactionCursor;
+import org.neo4j.kernel.impl.transaction.log.entry.OnePhaseCommit;
+import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class RecoveryProgressIndicatorTest
+{
+
+    @Test
+    public void reportProgressOnRecovery() throws Throwable
+    {
+        RecoveryService recoveryService = mock( RecoveryService.class, Answers.RETURNS_MOCKS.get() );
+        StartupStatisticsProvider statisticsProvider = mock( StartupStatisticsProvider.class );
+        TransactionLogPruner logPruner = mock( TransactionLogPruner.class );
+        RecoveryMonitor recoveryMonitor = mock( RecoveryMonitor.class );
+        TransactionCursor reverseTransactionCursor = mock( TransactionCursor.class );
+        TransactionCursor transactionCursor = mock( TransactionCursor.class );
+        CommittedTransactionRepresentation transactionRepresentation = mock( CommittedTransactionRepresentation.class );
+
+        int transactionsToRecover = 5;
+        int expectedMax = transactionsToRecover * 2;
+        int lastCommittedTransactionId = 14;
+        LogPosition recoveryStartPosition = LogPosition.start( 0 );
+        int firstTxIdAfterLastCheckPoint = 10;
+        RecoveryStartInformation startInformation = new RecoveryStartInformation( recoveryStartPosition, firstTxIdAfterLastCheckPoint );
+
+        when( reverseTransactionCursor.next() ).thenAnswer( new NextTransactionAnswer( transactionsToRecover ) );
+        when( transactionCursor.next() ).thenAnswer( new NextTransactionAnswer( transactionsToRecover ) );
+        when( reverseTransactionCursor.get() ).thenReturn( transactionRepresentation );
+        when( transactionCursor.get() ).thenReturn( transactionRepresentation );
+        when( transactionRepresentation.getCommitEntry() ).thenReturn( new OnePhaseCommit( lastCommittedTransactionId, 1L ) );
+
+        when( recoveryService.getRecoveryStartInformation() ).thenReturn( startInformation );
+        when( recoveryService.getTransactionsInReverseOrder( recoveryStartPosition ) ).thenReturn( reverseTransactionCursor );
+        when( recoveryService.getTransactions( recoveryStartPosition ) ).thenReturn( transactionCursor );
+
+        AssertableProgressReporter progressReporter = new AssertableProgressReporter( expectedMax );
+        Recovery recovery = new Recovery( recoveryService, statisticsProvider, logPruner, recoveryMonitor,
+                progressReporter, true );
+        recovery.init();
+
+        progressReporter.verify();
+    }
+
+    private static class AssertableProgressReporter implements ProgressReporter
+    {
+        private final int expectedMax;
+        private int recoveredTransactions;
+        private long max;
+        private boolean completed;
+
+        AssertableProgressReporter( int expectedMax )
+        {
+            this.expectedMax = expectedMax;
+        }
+
+        @Override
+        public void start( long max )
+        {
+            this.max = max;
+        }
+
+        @Override
+        public void progress( long add )
+        {
+            recoveredTransactions += add;
+        }
+
+        @Override
+        public void completed()
+        {
+            completed = true;
+        }
+
+        public void verify()
+        {
+            assertTrue( "Progress reporting was not completed.", completed );
+            assertEquals( "Number of max recovered transactions is different.", expectedMax, max );
+            assertEquals( "Number of recovered transactions is different.", expectedMax, recoveredTransactions );
+        }
+    }
+
+    private static class NextTransactionAnswer implements Answer<Boolean>
+    {
+        private final int expectedTransactionsToRecover;
+        private int invocations;
+
+        NextTransactionAnswer( int expectedTransactionsToRecover )
+        {
+            this.expectedTransactionsToRecover = expectedTransactionsToRecover;
+        }
+
+        @Override
+        public Boolean answer( InvocationOnMock invocationOnMock ) throws Throwable
+        {
+            invocations++;
+            return invocations <= expectedTransactionsToRecover;
+        }
+    }
+}

--- a/community/neo4j/src/test/java/upgrade/StoreUpgraderInterruptionTestIT.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgraderInterruptionTestIT.java
@@ -55,6 +55,7 @@ import org.neo4j.kernel.impl.storemigration.participant.SchemaIndexMigrator;
 import org.neo4j.kernel.impl.storemigration.participant.StoreMigrator;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
 import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
+import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.kernel.recovery.LogTailScanner;
 import org.neo4j.logging.AssertableLogProvider;
@@ -121,10 +122,10 @@ public class StoreUpgraderInterruptionTestIT
         {
             @Override
             public void migrate( File sourceStoreDir, File targetStoreDir,
-                    MigrationProgressMonitor.Section progressMonitor,
+                    ProgressReporter progressReporter,
                     String versionToMigrateFrom, String versionToMigrateTo ) throws IOException
             {
-                super.migrate( sourceStoreDir, targetStoreDir, progressMonitor, versionToMigrateFrom,
+                super.migrate( sourceStoreDir, targetStoreDir, progressReporter, versionToMigrateFrom,
                         versionToMigrateTo );
                 throw new RuntimeException( "This upgrade is failing" );
             }

--- a/community/neo4j/src/test/java/upgrade/StoreUpgraderTest.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgraderTest.java
@@ -65,6 +65,7 @@ import org.neo4j.kernel.impl.storemigration.participant.SchemaIndexMigrator;
 import org.neo4j.kernel.impl.storemigration.participant.StoreMigrator;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
 import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
+import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.kernel.recovery.LogTailScanner;
 import org.neo4j.logging.AssertableLogProvider;
@@ -240,7 +241,7 @@ public class StoreUpgraderTest
 
             // THEN
             verify( observingParticipant, Mockito.times( 0 ) ).migrate( any( File.class ), any( File.class ),
-                    any( MigrationProgressMonitor.Section.class ), eq( versionToMigrateFrom ), eq( versionToMigrateTo ) );
+                    any( ProgressReporter.class ), eq( versionToMigrateFrom ), eq( versionToMigrateTo ) );
             verify( observingParticipant, Mockito.times( 1 ) ).
                     moveMigratedFiles( any( File.class ), any( File.class ), eq( versionToMigrateFrom ),
                             eq( versionToMigrateTo ) );

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitStoreMigrationTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitStoreMigrationTest.java
@@ -35,8 +35,8 @@ import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.StoreType;
 import org.neo4j.kernel.impl.store.format.CapabilityType;
 import org.neo4j.kernel.impl.store.format.highlimit.v300.HighLimitV3_0_0;
-import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
 import org.neo4j.kernel.impl.storemigration.participant.StoreMigrator;
+import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
 import org.neo4j.test.rule.PageCacheRule;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
@@ -77,7 +77,7 @@ public class HighLimitStoreMigrationTest
 
         prepareNeoStoreFile( fileSystem, storeDir, HighLimitV3_0_0.STORE_VERSION, pageCache );
 
-        MigrationProgressMonitor.Section progressMonitor = mock( MigrationProgressMonitor.Section.class );
+        ProgressReporter progressMonitor = mock( ProgressReporter.class );
 
         migrator.migrate( storeDir, migrationDir, progressMonitor, HighLimitV3_0_0.STORE_VERSION, HighLimit.STORE_VERSION );
 

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorTest.java
@@ -41,7 +41,7 @@ import org.neo4j.kernel.impl.store.format.StoreVersion;
 import org.neo4j.kernel.impl.store.format.highlimit.v300.HighLimitV3_0_0;
 import org.neo4j.kernel.impl.storemigration.StoreVersionCheck;
 import org.neo4j.kernel.impl.storemigration.StoreVersionCheck.Result;
-import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
+import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
 import org.neo4j.logging.NullLog;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.rule.TestDirectory;
@@ -87,7 +87,7 @@ public class StoreMigratorTest
             // WHEN
             StoreMigrator migrator = new StoreMigrator( fs, pageCache, config, NullLogService.getInstance()
             );
-            MigrationProgressMonitor.Section monitor = mock( MigrationProgressMonitor.Section.class );
+            ProgressReporter monitor = mock( ProgressReporter.class );
             File migrationDir = new File( storeDir, "migration" );
             fs.mkdirs( migrationDir );
             migrator.migrate( storeDir, migrationDir, monitor, fromStoreVersion,


### PR DESCRIPTION
Allow recovery to report ongoing progress, so users can have indication
of how much work is already done and how much left for recovery to restore
database and make it available for new transactions again.