### PR TITLE
Removes optimization to not checkpoint GBPTree on no changes

### DIFF
--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
@@ -1209,7 +1209,7 @@ public class GBPTreeTest
     }
 
     @Test
-    public void shouldNotCheckpointOnCloseIfNoChangesHappened() throws Exception
+    public void shouldNotCheckpointOnClose() throws Exception
     {
         // GIVEN
         CheckpointCounter checkpointCounter = new CheckpointCounter();
@@ -1228,6 +1228,27 @@ public class GBPTreeTest
 
         // THEN
         assertEquals( 1, checkpointCounter.count() );
+    }
+
+    @Test
+    public void shouldCheckpointEvenIfNoChanges() throws Exception
+    {
+        // GIVEN
+        CheckpointCounter checkpointCounter = new CheckpointCounter();
+
+        // WHEN
+        try ( GBPTree<MutableLong,MutableLong> index = index().with( checkpointCounter ).build() )
+        {
+            checkpointCounter.reset();
+            for ( int i = 0; i < 2; i++ )
+            {
+
+            }
+            index.checkpoint( unlimited() );
+
+            // THEN
+            assertEquals( 1, checkpointCounter.count() );
+        }
     }
 
     @Test

--- a/tools/src/main/java/org/neo4j/tools/dump/DumpGBPTree.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/DumpGBPTree.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.tools.dump;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.index.internal.gbptree.GBPTree;
+import org.neo4j.index.internal.gbptree.TreePrinter;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+
+/**
+ * For now only dumps header, could be made more useful over time.
+ */
+public class DumpGBPTree
+{
+    /**
+     * Dumps stuff about a {@link GBPTree} to console in human readable format.
+     *
+     * @param args arguments.
+     * @throws IOException on I/O error.
+     */
+    public static void main( String[] args ) throws IOException
+    {
+        if ( args.length == 0 )
+        {
+            System.err.println( "File argument expected" );
+            System.exit( 1 );
+        }
+
+        File file = new File( args[0] );
+        System.out.println( "Dumping " + file.getAbsolutePath() );
+        TreePrinter.printHeader( new DefaultFileSystemAbstraction(), file, System.out );
+    }
+}


### PR DESCRIPTION
This solves an issue which would be observed as a tree looking like non-clean
even after a clean db shutdown. The main reason for this is that skipping
the checkpoint would not await the background clean job and so closing the tree
could potentially be done before the clean job was done. This would prevent
the tree from being marked as clean on close.

Read-only tools like consistency checker asserts that no recovery is required
before starting and so would fail on a db containing such a tree.