### PR TITLE
Increase election timeout for id reuse IT

### DIFF
--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/ClusterIdReuseIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/ClusterIdReuseIT.java
@@ -47,6 +47,8 @@ public class ClusterIdReuseIT
     @Rule
     public final ClusterRule clusterRule = new ClusterRule( getClass() )
             .withNumberOfCoreMembers( 3 )
+            // increased to decrease likelihood of unnecessary leadership changes
+            .withSharedCoreParam( CausalClusteringSettings.leader_election_timeout, "2s" )
             .withNumberOfReadReplicas( 0 );
     private Cluster cluster;
 
@@ -118,6 +120,7 @@ public class ClusterIdReuseIT
         CoreClusterMember creationLeader = createThreeNodes( cluster, first, second );
         CoreClusterMember deletionLeader = removeTwoNodes( cluster, first, second );
 
+        // the following assumption is not sufficient for the subsequent assertions, since leadership is a volatile state
         assumeTrue( creationLeader != null && creationLeader.equals( deletionLeader ) );
 
         idMaintenanceOnLeader( creationLeader );


### PR DESCRIPTION
This is not a perfect solution. The test probably needs to be
rewritten and deep reacher into the stack for some assumptions
on when the assertion can be trusted.