### PR TITLE
Do not explicitly load the bloom procedures

### DIFF
--- a/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomKernelExtension.java
+++ b/enterprise/fulltext-addon/src/main/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomKernelExtension.java
@@ -89,7 +89,6 @@ class BloomKernelExtension extends LifecycleAdapter
 
             provider.init();
             procedures.registerComponent( FulltextProvider.class, context -> provider, true );
-            procedures.registerProcedure( BloomProcedures.class );
         }
     }
 


### PR DESCRIPTION
As this causes the DB to crash on startup when starting with the plugin
jar. The procedures are picked up separately and explicitly loading them
as well leads to a conflict. This also means that we need to load the
procedures manually in the integration test.