### PR TITLE
Reduce batchsize to 1 to have a deterministic way of counting reuses

### DIFF
--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/ClusterIdReuseIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/ClusterIdReuseIT.java
@@ -49,6 +49,8 @@ public class ClusterIdReuseIT
             .withNumberOfCoreMembers( 3 )
             // increased to decrease likelihood of unnecessary leadership changes
             .withSharedCoreParam( CausalClusteringSettings.leader_election_timeout, "2s" )
+            // need to be 1 in order for the reuse count to be deterministic
+            .withSharedCoreParam( GraphDatabaseSettings.record_id_batch_size, Integer.toString( 1 ) )
             .withNumberOfReadReplicas( 0 );
     private Cluster cluster;
 
@@ -67,8 +69,7 @@ public class ClusterIdReuseIT
     @Test
     public void shouldReuseIdsInCluster() throws Exception
     {
-        final int RECORD_ID_BATCH_SIZE = 1;
-        cluster = clusterRule.withSharedCoreParam( GraphDatabaseSettings.record_id_batch_size, Integer.toString( RECORD_ID_BATCH_SIZE ) ).startCluster();
+        cluster = clusterRule.startCluster();
 
         final MutableLong first = new MutableLong();
         final MutableLong second = new MutableLong();
@@ -111,8 +112,7 @@ public class ClusterIdReuseIT
     @Test
     public void newLeaderShouldNotReuseIds() throws Exception
     {
-        final int RECORD_ID_BATCH_SIZE = 20;
-        cluster = clusterRule.withSharedCoreParam( GraphDatabaseSettings.record_id_batch_size, Integer.toString( RECORD_ID_BATCH_SIZE ) ).startCluster();
+        cluster = clusterRule.startCluster();
 
         final MutableLong first = new MutableLong();
         final MutableLong second = new MutableLong();
@@ -143,7 +143,7 @@ public class ClusterIdReuseIT
         CoreClusterMember newCreationLeader = cluster.coreTx( ( db, tx ) ->
         {
             Node node = db.createNode();
-            assertEquals( idGenerator.getHighId(), node.getId() + RECORD_ID_BATCH_SIZE );
+            assertEquals( idGenerator.getHighestPossibleIdInUse(), node.getId() );
 
             tx.success();
         } );


### PR DESCRIPTION
This hopefully fixes the recent flakiness that has been observed.

What happened is that the batching of taking id:s will be given back when the WeakReference is released, which can happen at any point in time.