### PR TITLE
LazyType to use array internally

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/ExceptionTranslatingQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/ExceptionTranslatingQueryContext.scala
@@ -202,10 +202,10 @@ class ExceptionTranslatingQueryContext(val inner: QueryContext) extends QueryCon
   override def getOrCreateRelTypeId(relTypeName: String) =
     translateException(inner.getOrCreateRelTypeId(relTypeName))
 
-  override def getRelationshipsForIds(node: Long, dir: SemanticDirection, types: Option[Seq[Int]]) =
+  override def getRelationshipsForIds(node: Long, dir: SemanticDirection, types: Option[Array[Int]]) =
     translateException(inner.getRelationshipsForIds(node, dir, types))
 
-  override def getRelationshipsForIdsPrimitive(node: Long, dir: SemanticDirection, types: Option[Seq[Int]]): RelationshipIterator =
+  override def getRelationshipsForIdsPrimitive(node: Long, dir: SemanticDirection, types: Option[Array[Int]]): RelationshipIterator =
     translateException(inner.getRelationshipsForIdsPrimitive(node, dir, types))
 
   override def getRelationshipFor(relationshipId: Long, typeId: Int, startNodeId: Long, endNodeId: Long): Relationship =

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/CommunityPipeBuilder.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/CommunityPipeBuilder.scala
@@ -69,7 +69,8 @@ case class CommunityPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe
         NodeCountFromCountStorePipe(ident, labels.map(l => l.map(LazyLabel.apply)))(id = id)
 
       case RelationshipCountFromCountStore(IdName(ident), startLabel, typeNames, endLabel, _) =>
-        RelationshipCountFromCountStorePipe(ident, startLabel.map(LazyLabel.apply), LazyTypes(typeNames.map(_.name)), endLabel.map(LazyLabel.apply))(id = id)
+        RelationshipCountFromCountStorePipe(ident, startLabel.map(LazyLabel.apply),
+                                            LazyTypes(typeNames.map(_.name).toArray), endLabel.map(LazyLabel.apply))(id = id)
 
       case NodeByLabelScan(IdName(ident), label, _) =>
         NodeByLabelScanPipe(ident, LazyLabel(label))(id = id)
@@ -112,7 +113,7 @@ case class CommunityPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe
         ProjectEndpointsPipe(source, rel.name,
           start.name, startInScope,
           end.name, endInScope,
-          types.map(LazyTypes.apply), directed, length.isSimple)()
+          types.map(_.toArray).map(LazyTypes.apply), directed, length.isSimple)()
 
       case EmptyResult(_) =>
         EmptyResultPipe(source)(id = id)
@@ -121,21 +122,21 @@ case class CommunityPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe
         FilterPipe(source, predicates.map(buildPredicate).reduce(_ andWith _))(id = id)
 
       case Expand(_, IdName(fromName), dir, types: Seq[RelTypeName], IdName(toName), IdName(relName), ExpandAll) =>
-        ExpandAllPipe(source, fromName, relName, toName, dir, LazyTypes(types))(id = id)
+        ExpandAllPipe(source, fromName, relName, toName, dir, LazyTypes(types.toArray))(id = id)
 
       case Expand(_, IdName(fromName), dir, types: Seq[RelTypeName], IdName(toName), IdName(relName), ExpandInto) =>
-        ExpandIntoPipe(source, fromName, relName, toName, dir, LazyTypes(types))(id = id)
+        ExpandIntoPipe(source, fromName, relName, toName, dir, LazyTypes(types.toArray))(id = id)
 
       case LockNodes(_, nodesToLock) =>
         LockNodesPipe(source, nodesToLock.map(_.name))()
 
       case OptionalExpand(_, IdName(fromName), dir, types, IdName(toName), IdName(relName), ExpandAll, predicates) =>
         val predicate: Predicate = predicates.map(buildPredicate).reduceOption(_ andWith _).getOrElse(True())
-        OptionalExpandAllPipe(source, fromName, relName, toName, dir, LazyTypes(types), predicate)(id = id)
+        OptionalExpandAllPipe(source, fromName, relName, toName, dir, LazyTypes(types.toArray), predicate)(id = id)
 
       case OptionalExpand(_, IdName(fromName), dir, types, IdName(toName), IdName(relName), ExpandInto, predicates) =>
         val predicate = predicates.map(buildPredicate).reduceOption(_ andWith _).getOrElse(True())
-        OptionalExpandIntoPipe(source, fromName, relName, toName, dir, LazyTypes(types), predicate)(id = id)
+        OptionalExpandIntoPipe(source, fromName, relName, toName, dir, LazyTypes(types.toArray), predicate)(id = id)
 
       case VarExpand(_,
                      IdName(fromName),
@@ -155,18 +156,18 @@ case class CommunityPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe
         }
 
         VarLengthExpandPipe(source, fromName, relName, toName, dir, projectedDir,
-          LazyTypes(types), min, max, nodeInScope, predicate)(id = id)
+          LazyTypes(types.toArray), min, max, nodeInScope, predicate)(id = id)
 
       case Optional(inner, protectedSymbols) =>
         OptionalPipe((inner.availableSymbols -- protectedSymbols).map(_.name), source)(id = id)
 
       case PruningVarExpand(_, IdName(from), dir, types, IdName(toName), minLength, maxLength, predicates) =>
         val predicate = varLengthPredicate(predicates)
-        PruningVarLengthExpandPipe(source, from, toName, LazyTypes(types), dir, minLength, maxLength, predicate)()
+        PruningVarLengthExpandPipe(source, from, toName, LazyTypes(types.toArray), dir, minLength, maxLength, predicate)()
 
       case FullPruningVarExpand(_, IdName(from), dir, types, IdName(toName), minLength, maxLength, predicates) =>
         val predicate = varLengthPredicate(predicates)
-        FullPruningVarLengthExpandPipe(source, from, toName, LazyTypes(types), dir, minLength, maxLength, predicate)()
+        FullPruningVarLengthExpandPipe(source, from, toName, LazyTypes(types.toArray), dir, minLength, maxLength, predicate)()
 
       case Sort(_, sortItems) =>
         SortPipe(source, sortItems.map(translateColumnOrder))(id = id)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/CommunityPipeBuilder.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/CommunityPipeBuilder.scala
@@ -70,7 +70,7 @@ case class CommunityPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe
 
       case RelationshipCountFromCountStore(IdName(ident), startLabel, typeNames, endLabel, _) =>
         RelationshipCountFromCountStorePipe(ident, startLabel.map(LazyLabel.apply),
-                                            LazyTypes(typeNames.map(_.name).toArray), endLabel.map(LazyLabel.apply))(id = id)
+                                            new LazyTypes(typeNames.map(_.name).toArray), endLabel.map(LazyLabel.apply))(id = id)
 
       case NodeByLabelScan(IdName(ident), label, _) =>
         NodeByLabelScanPipe(ident, LazyLabel(label))(id = id)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/CachingExpandInto.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/CachingExpandInto.scala
@@ -48,7 +48,7 @@ trait CachingExpandInto {
    * Finds all relationships connecting fromNode and toNode.
    */
   protected def findRelationships(query: QueryContext, fromNode: NodeValue, toNode: NodeValue,
-                                relCache: RelationshipsCache, dir: SemanticDirection, relTypes: => Option[Seq[Int]]): Iterator[EdgeValue] = {
+                                relCache: RelationshipsCache, dir: SemanticDirection, relTypes: => Option[Array[Int]]): Iterator[EdgeValue] = {
 
     val fromNodeIsDense = query.nodeIsDense(fromNode.id())
     val toNodeIsDense = query.nodeIsDense(toNode.id())
@@ -87,7 +87,7 @@ trait CachingExpandInto {
   }
 
   private def relIterator(query: QueryContext, fromNode: NodeValue,  toNode: NodeValue, preserveDirection: Boolean,
-                          relTypes: Option[Seq[Int]], relCache: RelationshipsCache, dir: SemanticDirection) = {
+                          relTypes: Option[Array[Int]], relCache: RelationshipsCache, dir: SemanticDirection) = {
     val (start, localDirection, end) = if(preserveDirection) (fromNode, dir, toNode) else (toNode, dir.reversed, fromNode)
     val relationships = query.getRelationshipsForIds(start.id(), localDirection, relTypes).map(ValueUtils.fromRelationshipProxy)
     new PrefetchingIterator[EdgeValue] {
@@ -109,10 +109,10 @@ trait CachingExpandInto {
     }.asScala
   }
 
-  private def getDegree(node: NodeValue, relTypes: Option[Seq[Int]], direction: SemanticDirection, query: QueryContext) = {
+  private def getDegree(node: NodeValue, relTypes: Option[Array[Int]], direction: SemanticDirection, query: QueryContext) = {
     relTypes.map {
       case rels if rels.isEmpty   => query.nodeGetDegree(node.id(), direction)
-      case rels if rels.size == 1 => query.nodeGetDegree(node.id(), direction, rels.head)
+      case rels if rels.length == 1 => query.nodeGetDegree(node.id(), direction, rels.head)
       case rels                   => rels.foldLeft(0)(
         (acc, rel)                => acc + query.nodeGetDegree(node.id(), direction, rel)
       )

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/LazyTypes.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/LazyTypes.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.frontend.v3_3.SemanticTable
 import org.neo4j.cypher.internal.frontend.v3_3.ast.RelTypeName
 import org.neo4j.cypher.internal.spi.v3_3.QueryContext
 
-case class LazyTypes(names: Array[String]) {
+final class LazyTypes(val names: Array[String]) {
 
   private var ids = Array.empty[Int]
 
@@ -33,13 +33,22 @@ case class LazyTypes(names: Array[String]) {
     }
     Some(ids)
   }
+
+  override def hashCode(): Int = scala.util.hashing.MurmurHash3.seqHash(names)
+
+  override def equals(obj: scala.Any): Boolean = {
+    obj match {
+      case lazyTypes: LazyTypes => names.sameElements(lazyTypes.names)
+      case _ => false
+    }
+  }
 }
 
 object LazyTypes {
   def apply(names: Array[RelTypeName])(implicit table:SemanticTable): LazyTypes = {
-    val types = LazyTypes(names.map(_.name))
+    val types = new LazyTypes(names.map(_.name))
     types.ids = names.flatMap(_.id).map(_.id)
     types
   }
-  val empty = LazyTypes(Array.empty[String])
+  val empty = new LazyTypes(Array.empty[String])
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/LazyTypes.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/LazyTypes.scala
@@ -23,25 +23,23 @@ import org.neo4j.cypher.internal.frontend.v3_3.SemanticTable
 import org.neo4j.cypher.internal.frontend.v3_3.ast.RelTypeName
 import org.neo4j.cypher.internal.spi.v3_3.QueryContext
 
-case class LazyTypes(names:Seq[String]) {
-  private var ids = Seq.empty[Int]
+case class LazyTypes(names: Array[String]) {
 
-  def types(context: QueryContext): Option[Seq[Int]] = names match {
-      case Seq() => None
-      case _     => {
-        if (ids.size != names.size) {
-          ids = names.flatMap(context.getOptRelTypeId)
-        }
-        Some(ids)
-      }
+  private var ids = Array.empty[Int]
+
+  def types(context: QueryContext): Option[Array[Int]] = if (names.isEmpty) None else {
+    if (ids.length != names.length) {
+      ids = names.flatMap(context.getOptRelTypeId)
     }
+    Some(ids)
+  }
 }
 
 object LazyTypes {
-  def apply(names: Seq[RelTypeName])(implicit table:SemanticTable): LazyTypes = {
+  def apply(names: Array[RelTypeName])(implicit table:SemanticTable): LazyTypes = {
     val types = LazyTypes(names.map(_.name))
     types.ids = names.flatMap(_.id).map(_.id)
     types
   }
-  val empty = LazyTypes(Seq.empty[String])
+  val empty = LazyTypes(Array.empty[String])
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/matching/PatternRelationship.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/matching/PatternRelationship.scala
@@ -39,7 +39,7 @@ class PatternRelationship(key: String,
                           val properties: Map[KeyToken, Expression] = Map.empty,
                           val dir: SemanticDirection)
   extends PatternElement(key) {
-  private val types = LazyTypes(relTypes.toArray)
+  private val types = new LazyTypes(relTypes.toArray)
 
   def variables2: Map[String, CypherType] = Map(startNode.key -> CTNode, endNode.key -> CTNode, key -> CTRelationship)
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/matching/PatternRelationship.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/matching/PatternRelationship.scala
@@ -39,7 +39,7 @@ class PatternRelationship(key: String,
                           val properties: Map[KeyToken, Expression] = Map.empty,
                           val dir: SemanticDirection)
   extends PatternElement(key) {
-  private val types = LazyTypes(relTypes)
+  private val types = LazyTypes(relTypes.toArray)
 
   def variables2: Map[String, CypherType] = Map(startNode.key -> CTNode, endNode.key -> CTNode, key -> CTRelationship)
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/DelegatingQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/DelegatingQueryContext.scala
@@ -76,10 +76,10 @@ class DelegatingQueryContext(val inner: QueryContext) extends QueryContext {
 
   override def getOrCreateLabelId(labelName: String): Int = singleDbHit(inner.getOrCreateLabelId(labelName))
 
-  override def getRelationshipsForIds(node: Long, dir: SemanticDirection, types: Option[Seq[Int]]): Iterator[Relationship] =
+  override def getRelationshipsForIds(node: Long, dir: SemanticDirection, types: Option[Array[Int]]): Iterator[Relationship] =
   manyDbHits(inner.getRelationshipsForIds(node, dir, types))
 
-  override def getRelationshipsForIdsPrimitive(node: Long, dir: SemanticDirection, types: Option[Seq[Int]]): RelationshipIterator =
+  override def getRelationshipsForIdsPrimitive(node: Long, dir: SemanticDirection, types: Option[Array[Int]]): RelationshipIterator =
   manyDbHits(inner.getRelationshipsForIdsPrimitive(node, dir, types))
 
   override def getRelationshipFor(relationshipId: Long, typeId: Int, startNodeId: Long, endNodeId: Long): Relationship =

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/QueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/QueryContext.scala
@@ -74,9 +74,9 @@ trait QueryContext extends TokenContext {
 
   def getOrCreateRelTypeId(relTypeName: String): Int
 
-  def getRelationshipsForIds(node: Long, dir: SemanticDirection, types: Option[Seq[Int]]): Iterator[Relationship]
+  def getRelationshipsForIds(node: Long, dir: SemanticDirection, types: Option[Array[Int]]): Iterator[Relationship]
 
-  def getRelationshipsForIdsPrimitive(node: Long, dir: SemanticDirection, types: Option[Seq[Int]]): RelationshipIterator
+  def getRelationshipsForIdsPrimitive(node: Long, dir: SemanticDirection, types: Option[Array[Int]]): RelationshipIterator
 
   def getRelationshipFor(relationshipId: Long, typeId: Int, startNodeId: Long, endNodeId: Long): Relationship
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundQueryContext.scala
@@ -136,22 +136,22 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
     transactionalContext.statement.tokenWriteOperations().labelGetOrCreateForName(labelName)
 
 
-  def getRelationshipsForIds(node: Long, dir: SemanticDirection, types: Option[Seq[Int]]): Iterator[Relationship] = {
+  def getRelationshipsForIds(node: Long, dir: SemanticDirection, types: Option[Array[Int]]): Iterator[Relationship] = {
     val relationships = types match {
       case None =>
         transactionalContext.statement.readOperations().nodeGetRelationships(node, toGraphDb(dir))
       case Some(typeIds) =>
-        transactionalContext.statement.readOperations().nodeGetRelationships(node, toGraphDb(dir), typeIds.toArray)
+        transactionalContext.statement.readOperations().nodeGetRelationships(node, toGraphDb(dir), typeIds)
     }
     new BeansAPIRelationshipIterator(relationships, entityAccessor)
   }
 
-  override def getRelationshipsForIdsPrimitive(node: Long, dir: SemanticDirection, types: Option[Seq[Int]]): RelationshipIterator =
+  override def getRelationshipsForIdsPrimitive(node: Long, dir: SemanticDirection, types: Option[Array[Int]]): RelationshipIterator =
     types match {
       case None =>
         transactionalContext.statement.readOperations().nodeGetRelationships(node, toGraphDb(dir))
       case Some(typeIds) =>
-        transactionalContext.statement.readOperations().nodeGetRelationships(node, toGraphDb(dir), typeIds.toArray)
+        transactionalContext.statement.readOperations().nodeGetRelationships(node, toGraphDb(dir), typeIds)
     }
 
   override def getRelationshipFor(relationshipId: Long, typeId: Int, startNodeId: Long, endNodeId: Long): RelationshipProxy = try {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/ExpandAllPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/ExpandAllPipeTest.scala
@@ -60,14 +60,18 @@ class ExpandAllPipeTest extends CypherFunSuite {
 
   test("should return no relationships for types that have not been defined yet") {
     // given
-    when(query.getRelationshipsForIds(any(), any(), Matchers.eq(Some(Array.empty)))).thenAnswer(new Answer[Iterator[Relationship]]{
-      override def answer(invocationOnMock: InvocationOnMock): Iterator[Relationship] = Iterator.empty
-    })
-    when(query.getRelationshipsForIds(any(), any(), Matchers.eq(Some(Array(1,2))))).thenAnswer(new Answer[Iterator[Relationship]]{
-      override def answer(invocationOnMock: InvocationOnMock): Iterator[Relationship] = Iterator(relationship1, relationship2)
+    when(query.getRelationshipsForIds(any(), any(), any())).thenAnswer(new Answer[Iterator[Relationship]]{
+      override def answer(invocationOnMock: InvocationOnMock): Iterator[Relationship] = {
+        val arg = invocationOnMock.getArgumentAt(2, classOf[Option[Array[Int]]])
+        arg match {
+          case None => Iterator.empty
+          case Some(array) if array.isEmpty => Iterator.empty
+          case _ => Iterator(relationship1, relationship2)
+        }
+      }
     })
 
-    val pipe = ExpandAllPipe(newMockedPipe("a", row("a"-> startNode)), "a", "r", "b", SemanticDirection.OUTGOING, LazyTypes(Array("FOO", "BAR")))()
+    val pipe = ExpandAllPipe(newMockedPipe("a", row("a"-> startNode)), "a", "r", "b", SemanticDirection.OUTGOING, new LazyTypes(Array("FOO", "BAR")))()
 
     // when
     when(query.getOptRelTypeId("FOO")).thenReturn(None)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/ExpandAllPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/ExpandAllPipeTest.scala
@@ -60,14 +60,14 @@ class ExpandAllPipeTest extends CypherFunSuite {
 
   test("should return no relationships for types that have not been defined yet") {
     // given
-    when(query.getRelationshipsForIds(any(), any(), Matchers.eq(Some(Seq.empty)))).thenAnswer(new Answer[Iterator[Relationship]]{
+    when(query.getRelationshipsForIds(any(), any(), Matchers.eq(Some(Array.empty)))).thenAnswer(new Answer[Iterator[Relationship]]{
       override def answer(invocationOnMock: InvocationOnMock): Iterator[Relationship] = Iterator.empty
     })
-    when(query.getRelationshipsForIds(any(), any(), Matchers.eq(Some(Seq(1,2))))).thenAnswer(new Answer[Iterator[Relationship]]{
+    when(query.getRelationshipsForIds(any(), any(), Matchers.eq(Some(Array(1,2))))).thenAnswer(new Answer[Iterator[Relationship]]{
       override def answer(invocationOnMock: InvocationOnMock): Iterator[Relationship] = Iterator(relationship1, relationship2)
     })
 
-    val pipe = ExpandAllPipe(newMockedPipe("a", row("a"-> startNode)), "a", "r", "b", SemanticDirection.OUTGOING, LazyTypes(Seq("FOO", "BAR")))()
+    val pipe = ExpandAllPipe(newMockedPipe("a", row("a"-> startNode)), "a", "r", "b", SemanticDirection.OUTGOING, LazyTypes(Array("FOO", "BAR")))()
 
     // when
     when(query.getOptRelTypeId("FOO")).thenReturn(None)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/ExpandIntoPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/ExpandIntoPipeTest.scala
@@ -59,17 +59,19 @@ class ExpandIntoPipeTest extends CypherFunSuite with PipeTestSupport {
 
   test("should return no relationships for types that have not been defined yet") {
     // given
-    when(query.getRelationshipsForIds(any(), any(), mockEq(Some(Array.empty)))).thenAnswer(
-      new Answer[Iterator[Relationship]] {
-        override def answer(invocationOnMock: InvocationOnMock) = Iterator.empty
-      })
-    when(query.getRelationshipsForIds(any(), any(), mockEq(Some(Array(1, 2))))).thenAnswer(
-      new Answer[Iterator[Relationship]] {
-        override def answer(invocationOnMock: InvocationOnMock) = Iterator(relationship1, relationship2)
-      })
+    when(query.getRelationshipsForIds(any(), any(), any())).thenAnswer(new Answer[Iterator[Relationship]]{
+      override def answer(invocationOnMock: InvocationOnMock): Iterator[Relationship] = {
+        val arg = invocationOnMock.getArgumentAt(2, classOf[Option[Array[Int]]])
+        arg match {
+          case None => Iterator.empty
+          case Some(array) if array.isEmpty => Iterator.empty
+          case _ => Iterator(relationship1, relationship2)
+        }
+      }
+    })
     when(query.nodeGetDegree(any(), any(), any())).thenReturn(1)
 
-    val pipe = ExpandIntoPipe(newMockedPipe("a", row("a"-> startNode, "b" -> endNode1)), "a", "r", "b", SemanticDirection.OUTGOING, LazyTypes(Array("FOO", "BAR")))()
+    val pipe = ExpandIntoPipe(newMockedPipe("a", row("a"-> startNode, "b" -> endNode1)), "a", "r", "b", SemanticDirection.OUTGOING, new LazyTypes(Array("FOO", "BAR")))()
 
     // when
     when(query.getOptRelTypeId("FOO")).thenReturn(None)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/ExpandIntoPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/ExpandIntoPipeTest.scala
@@ -59,17 +59,17 @@ class ExpandIntoPipeTest extends CypherFunSuite with PipeTestSupport {
 
   test("should return no relationships for types that have not been defined yet") {
     // given
-    when(query.getRelationshipsForIds(any(), any(), mockEq(Some(Seq.empty)))).thenAnswer(
+    when(query.getRelationshipsForIds(any(), any(), mockEq(Some(Array.empty)))).thenAnswer(
       new Answer[Iterator[Relationship]] {
         override def answer(invocationOnMock: InvocationOnMock) = Iterator.empty
       })
-    when(query.getRelationshipsForIds(any(), any(), mockEq(Some(Seq(1, 2))))).thenAnswer(
+    when(query.getRelationshipsForIds(any(), any(), mockEq(Some(Array(1, 2))))).thenAnswer(
       new Answer[Iterator[Relationship]] {
         override def answer(invocationOnMock: InvocationOnMock) = Iterator(relationship1, relationship2)
       })
     when(query.nodeGetDegree(any(), any(), any())).thenReturn(1)
 
-    val pipe = ExpandIntoPipe(newMockedPipe("a", row("a"-> startNode, "b" -> endNode1)), "a", "r", "b", SemanticDirection.OUTGOING, LazyTypes(Seq("FOO", "BAR")))()
+    val pipe = ExpandIntoPipe(newMockedPipe("a", row("a"-> startNode, "b" -> endNode1)), "a", "r", "b", SemanticDirection.OUTGOING, LazyTypes(Array("FOO", "BAR")))()
 
     // when
     when(query.getOptRelTypeId("FOO")).thenReturn(None)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/LazyTypesTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/LazyTypesTest.scala
@@ -27,7 +27,7 @@ class LazyTypesTest extends CypherFunSuite {
 
   test("should not initialize state when state is complete") {
     // given
-    val types = LazyTypes(Array("a", "b", "c"))
+    val types = new LazyTypes(Array("a", "b", "c"))
 
     val context = mock[QueryContext]
     when(context.getOptRelTypeId("a")).thenReturn(Some(1))
@@ -45,7 +45,7 @@ class LazyTypesTest extends CypherFunSuite {
 
   test("should re-initialize if not fully initialized") {
     // given
-    val types = LazyTypes(Array("a", "b", "c"))
+    val types = new LazyTypes(Array("a", "b", "c"))
 
     val context = mock[QueryContext]
     when(context.getOptRelTypeId("a")).thenReturn(Some(1))

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/LazyTypesTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/LazyTypesTest.scala
@@ -27,7 +27,7 @@ class LazyTypesTest extends CypherFunSuite {
 
   test("should not initialize state when state is complete") {
     // given
-    val types = LazyTypes(Seq("a", "b", "c"))
+    val types = LazyTypes(Array("a", "b", "c"))
 
     val context = mock[QueryContext]
     when(context.getOptRelTypeId("a")).thenReturn(Some(1))
@@ -45,7 +45,7 @@ class LazyTypesTest extends CypherFunSuite {
 
   test("should re-initialize if not fully initialized") {
     // given
-    val types = LazyTypes(Seq("a", "b", "c"))
+    val types = LazyTypes(Array("a", "b", "c"))
 
     val context = mock[QueryContext]
     when(context.getOptRelTypeId("a")).thenReturn(Some(1))

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/ProjectEndpointsPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/ProjectEndpointsPipeTest.scala
@@ -109,7 +109,7 @@ class ProjectEndpointsPipeTest extends CypherFunSuite {
 
     // when
     val result =
-      ProjectEndpointsPipe(left, "r", "a", startInScope = false, "b", endInScope = false, Some(LazyTypes(Array("A"))), directed = true, simpleLength = true)().
+      ProjectEndpointsPipe(left, "r", "a", startInScope = false, "b", endInScope = false, Some(new LazyTypes(Array("A"))), directed = true, simpleLength = true)().
         createResults(queryState).toList
 
     // then
@@ -210,7 +210,7 @@ class ProjectEndpointsPipeTest extends CypherFunSuite {
 
     // when
     val result =
-      ProjectEndpointsPipe(left, "r", "a", startInScope = false, "b", endInScope = false, Some(LazyTypes(Array("B"))), directed = false, simpleLength = true)().
+      ProjectEndpointsPipe(left, "r", "a", startInScope = false, "b", endInScope = false, Some(new LazyTypes(Array("B"))), directed = false, simpleLength = true)().
         createResults(queryState).toList
 
     // then
@@ -280,7 +280,7 @@ class ProjectEndpointsPipeTest extends CypherFunSuite {
 
     // when
     val result =
-      ProjectEndpointsPipe(left, "r", "a", startInScope = false, "b", endInScope = false, Some(LazyTypes(Array("A"))), directed = true, simpleLength = false)().
+      ProjectEndpointsPipe(left, "r", "a", startInScope = false, "b", endInScope = false, Some(new LazyTypes(Array("A"))), directed = true, simpleLength = false)().
         createResults(queryState).toList
 
     // then
@@ -303,7 +303,7 @@ class ProjectEndpointsPipeTest extends CypherFunSuite {
 
     // when
     val result =
-      ProjectEndpointsPipe(left, "r", "a", startInScope = false, "b", endInScope = false, Some(LazyTypes(Array("A"))), directed = true, simpleLength = false)().
+      ProjectEndpointsPipe(left, "r", "a", startInScope = false, "b", endInScope = false, Some(new LazyTypes(Array("A"))), directed = true, simpleLength = false)().
         createResults(queryState).toList
 
     // then

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/ProjectEndpointsPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/ProjectEndpointsPipeTest.scala
@@ -109,7 +109,7 @@ class ProjectEndpointsPipeTest extends CypherFunSuite {
 
     // when
     val result =
-      ProjectEndpointsPipe(left, "r", "a", startInScope = false, "b", endInScope = false, Some(LazyTypes(Seq("A"))), directed = true, simpleLength = true)().
+      ProjectEndpointsPipe(left, "r", "a", startInScope = false, "b", endInScope = false, Some(LazyTypes(Array("A"))), directed = true, simpleLength = true)().
         createResults(queryState).toList
 
     // then
@@ -210,7 +210,7 @@ class ProjectEndpointsPipeTest extends CypherFunSuite {
 
     // when
     val result =
-      ProjectEndpointsPipe(left, "r", "a", startInScope = false, "b", endInScope = false, Some(LazyTypes(Seq("B"))), directed = false, simpleLength = true)().
+      ProjectEndpointsPipe(left, "r", "a", startInScope = false, "b", endInScope = false, Some(LazyTypes(Array("B"))), directed = false, simpleLength = true)().
         createResults(queryState).toList
 
     // then
@@ -280,7 +280,7 @@ class ProjectEndpointsPipeTest extends CypherFunSuite {
 
     // when
     val result =
-      ProjectEndpointsPipe(left, "r", "a", startInScope = false, "b", endInScope = false, Some(LazyTypes(Seq("A"))), directed = true, simpleLength = false)().
+      ProjectEndpointsPipe(left, "r", "a", startInScope = false, "b", endInScope = false, Some(LazyTypes(Array("A"))), directed = true, simpleLength = false)().
         createResults(queryState).toList
 
     // then
@@ -303,7 +303,7 @@ class ProjectEndpointsPipeTest extends CypherFunSuite {
 
     // when
     val result =
-      ProjectEndpointsPipe(left, "r", "a", startInScope = false, "b", endInScope = false, Some(LazyTypes(Seq("A"))), directed = true, simpleLength = false)().
+      ProjectEndpointsPipe(left, "r", "a", startInScope = false, "b", endInScope = false, Some(LazyTypes(Array("A"))), directed = true, simpleLength = false)().
         createResults(queryState).toList
 
     // then

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/RelationshipCountFromCountStorePipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/RelationshipCountFromCountStorePipeTest.scala
@@ -66,7 +66,7 @@ class RelationshipCountFromCountStorePipeTest extends CypherFunSuite with AstCon
   test("should return zero if rel-type is missing") {
     implicit val table = new SemanticTable()
 
-    val pipe = RelationshipCountFromCountStorePipe("count(r)", None, LazyTypes(Array("X")), Some(LazyLabel(LabelName("A") _)))()
+    val pipe = RelationshipCountFromCountStorePipe("count(r)", None, new LazyTypes(Array("X")), Some(LazyLabel(LabelName("A") _)))()
 
     val mockedContext: QueryContext = mock[QueryContext]
     // try to guarantee that the mock won't be the reason for the exception

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/RelationshipCountFromCountStorePipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/RelationshipCountFromCountStorePipeTest.scala
@@ -42,7 +42,7 @@ class RelationshipCountFromCountStorePipeTest extends CypherFunSuite with AstCon
     implicit val table = new SemanticTable()
     table.resolvedRelTypeNames.put("X", RelTypeId(22))
 
-    val pipe = RelationshipCountFromCountStorePipe("count(r)", None, LazyTypes(Seq(RelTypeName("X")(pos))), None)()
+    val pipe = RelationshipCountFromCountStorePipe("count(r)", None, LazyTypes(Array(RelTypeName("X")(pos))), None)()
 
     val queryState = QueryStateHelper.emptyWith(
       query = when(mock[QueryContext].relationshipCountByCountStore(WILDCARD, 22, WILDCARD)).thenReturn(42L).getMock[QueryContext]
@@ -55,7 +55,7 @@ class RelationshipCountFromCountStorePipeTest extends CypherFunSuite with AstCon
     table.resolvedRelTypeNames.put("X", RelTypeId(22))
     table.resolvedLabelIds.put("A", LabelId(12))
 
-    val pipe = RelationshipCountFromCountStorePipe("count(r)", Some(LazyLabel(LabelName("A") _)), LazyTypes(Seq(RelTypeName("X")(pos))), None)()
+    val pipe = RelationshipCountFromCountStorePipe("count(r)", Some(LazyLabel(LabelName("A") _)), LazyTypes(Array(RelTypeName("X")(pos))), None)()
 
     val queryState = QueryStateHelper.emptyWith(
       query = when(mock[QueryContext].relationshipCountByCountStore(12, 22, WILDCARD)).thenReturn(42L).getMock[QueryContext]
@@ -66,7 +66,7 @@ class RelationshipCountFromCountStorePipeTest extends CypherFunSuite with AstCon
   test("should return zero if rel-type is missing") {
     implicit val table = new SemanticTable()
 
-    val pipe = RelationshipCountFromCountStorePipe("count(r)", None, LazyTypes(Seq("X")), Some(LazyLabel(LabelName("A") _)))()
+    val pipe = RelationshipCountFromCountStorePipe("count(r)", None, LazyTypes(Array("X")), Some(LazyLabel(LabelName("A") _)))()
 
     val mockedContext: QueryContext = mock[QueryContext]
     // try to guarantee that the mock won't be the reason for the exception

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/pipes/ActualCostCalculationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/pipes/ActualCostCalculationTest.scala
@@ -291,7 +291,7 @@ class ActualCostCalculationTest extends CypherFunSuite {
 
   private def hashJoin(l: Pipe, r: Pipe) = NodeHashJoinPipe(Set("x"), l, r)()
 
-  private def expand(l: Pipe, t: String) = ExpandAllPipe(l, "x", "r", "n", SemanticDirection.OUTGOING, LazyTypes(Seq(t)))()
+  private def expand(l: Pipe, t: String) = ExpandAllPipe(l, "x", "r", "n", SemanticDirection.OUTGOING, LazyTypes(Array(t)))()
 
   private def allNodes = AllNodesScanPipe("x")()
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/pipes/ActualCostCalculationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/pipes/ActualCostCalculationTest.scala
@@ -291,7 +291,7 @@ class ActualCostCalculationTest extends CypherFunSuite {
 
   private def hashJoin(l: Pipe, r: Pipe) = NodeHashJoinPipe(Set("x"), l, r)()
 
-  private def expand(l: Pipe, t: String) = ExpandAllPipe(l, "x", "r", "n", SemanticDirection.OUTGOING, LazyTypes(Array(t)))()
+  private def expand(l: Pipe, t: String) = ExpandAllPipe(l, "x", "r", "n", SemanticDirection.OUTGOING, new LazyTypes(Array(t)))()
 
   private def allNodes = AllNodesScanPipe("x")()
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/pipes/FullPruningVarLengthExpandPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/pipes/FullPruningVarLengthExpandPipeTest.scala
@@ -39,7 +39,7 @@ import scala.collection.immutable.IndexedSeq
 import scala.util.Random
 
 class FullPruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
-  val types = LazyTypes(Array.empty[String])
+  val types = new LazyTypes(Array.empty[String])
 
   test("node without any relationships produces empty result") {
     val n1 = createNode()

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/pipes/FullPruningVarLengthExpandPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/pipes/FullPruningVarLengthExpandPipeTest.scala
@@ -39,7 +39,7 @@ import scala.collection.immutable.IndexedSeq
 import scala.util.Random
 
 class FullPruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
-  val types = LazyTypes(Seq.empty[String])
+  val types = LazyTypes(Array.empty[String])
 
   test("node without any relationships produces empty result") {
     val n1 = createNode()

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/pipes/PruningVarLengthExpandPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/pipes/PruningVarLengthExpandPipeTest.scala
@@ -38,7 +38,7 @@ import scala.collection.immutable.IndexedSeq
 import scala.util.Random
 
 class PruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
-  val types = LazyTypes(Array.empty[String])
+  val types = new LazyTypes(Array.empty[String])
 
   test("node without any relationships produces empty result") {
     val n1 = createNode()

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/pipes/PruningVarLengthExpandPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/pipes/PruningVarLengthExpandPipeTest.scala
@@ -38,7 +38,7 @@ import scala.collection.immutable.IndexedSeq
 import scala.util.Random
 
 class PruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
-  val types = LazyTypes(Seq.empty[String])
+  val types = LazyTypes(Array.empty[String])
 
   test("node without any relationships produces empty result") {
     val n1 = createNode()

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_3/QueryContextAdaptation.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_3/QueryContextAdaptation.scala
@@ -87,9 +87,9 @@ trait QueryContextAdaptation {
 
   override def indexSeek(index: IndexDescriptor, value: Seq[Any]): scala.Iterator[Node] = ???
 
-  override def getRelationshipsForIds(node: Long, dir: SemanticDirection, types: Option[Seq[Int]]): scala.Iterator[Relationship] = ???
+  override def getRelationshipsForIds(node: Long, dir: SemanticDirection, types: Option[Array[Int]]): scala.Iterator[Relationship] = ???
 
-  override def getRelationshipsForIdsPrimitive(node: Long, dir: SemanticDirection, types: Option[Seq[Int]]): RelationshipIterator = ???
+  override def getRelationshipsForIdsPrimitive(node: Long, dir: SemanticDirection, types: Option[Array[Int]]): RelationshipIterator = ???
 
   override def getRelationshipFor(relationshipId: Long, typeId: Int, startNodeId: Long, endNodeId: Long): Relationship = ???
 

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/SlottedPipeBuilder.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/SlottedPipeBuilder.scala
@@ -103,20 +103,20 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
         val fromSlot = pipeline.getLongOffsetFor(from)
         val relSlot = pipeline.getLongOffsetFor(relName)
         val toSlot = pipeline.getLongOffsetFor(to)
-        ExpandAllSlottedPipe(source, fromSlot, relSlot, toSlot, dir, LazyTypes(types), pipeline)(id)
+        ExpandAllSlottedPipe(source, fromSlot, relSlot, toSlot, dir, LazyTypes(types.toArray), pipeline)(id)
 
       case Expand(_, IdName(from), dir, types, IdName(to), IdName(relName), ExpandInto) =>
         val fromOffset = pipeline.getLongOffsetFor(from)
         val relOffset = pipeline.getLongOffsetFor(relName)
         val toOffset = pipeline.getLongOffsetFor(to)
-        ExpandIntoSlottedPipe(source, fromOffset, relOffset, toOffset, dir, LazyTypes(types), pipeline)(id)
+        ExpandIntoSlottedPipe(source, fromOffset, relOffset, toOffset, dir, LazyTypes(types.toArray), pipeline)(id)
 
       case OptionalExpand(_, IdName(fromName), dir, types, IdName(toName), IdName(relName), ExpandAll, predicates) =>
         val fromOffset = pipeline.getLongOffsetFor(fromName)
         val relOffset = pipeline.getLongOffsetFor(relName)
         val toOffset = pipeline.getLongOffsetFor(toName)
         val predicate: Predicate = predicates.map(buildPredicate).reduceOption(_ andWith _).getOrElse(True())
-        OptionalExpandAllSlottedPipe(source, fromOffset, relOffset, toOffset, dir, LazyTypes(types), predicate,
+        OptionalExpandAllSlottedPipe(source, fromOffset, relOffset, toOffset, dir, LazyTypes(types.toArray), predicate,
                                       pipeline)(id)
 
       case OptionalExpand(_, IdName(fromName), dir, types, IdName(toName), IdName(relName), ExpandInto, predicates) =>
@@ -124,7 +124,7 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
         val relOffset = pipeline.getLongOffsetFor(relName)
         val toOffset = pipeline.getLongOffsetFor(toName)
         val predicate = predicates.map(buildPredicate).reduceOption(_ andWith _).getOrElse(True())
-        OptionalExpandIntoSlottedPipe(source, fromOffset, relOffset, toOffset, dir, LazyTypes(types), predicate,
+        OptionalExpandIntoSlottedPipe(source, fromOffset, relOffset, toOffset, dir, LazyTypes(types.toArray), predicate,
                                        pipeline)(id)
 
       case VarExpand(sourcePlan, IdName(fromName), dir, projectedDir, types, IdName(toName), IdName(relName),
@@ -144,7 +144,7 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
         val tempNodeOffset = incomingPipeline.getLongOffsetFor(tempNode)
         val tempEdgeOffset = incomingPipeline.getLongOffsetFor(tempEdge)
         val sizeOfTemporaryStorage = 2
-        VarLengthExpandSlottedPipe(source, fromOffset, relOffset, toOffset, dir, projectedDir, LazyTypes(types), min,
+        VarLengthExpandSlottedPipe(source, fromOffset, relOffset, toOffset, dir, projectedDir, LazyTypes(types.toArray), min,
                                     max, shouldExpandAll, pipeline,
                                     tempNodeOffset = tempNodeOffset,
                                     tempEdgeOffset = tempEdgeOffset,

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/pipes/PrimitiveCachingExpandInto.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/pipes/PrimitiveCachingExpandInto.scala
@@ -43,7 +43,7 @@ trait PrimitiveCachingExpandInto {
     * Finds all relationships connecting fromNode and toNode.
     */
   protected def findRelationships(query: QueryContext, fromNode: Long, toNode: Long,
-                                  relCache: PrimitiveRelationshipsCache, dir: SemanticDirection, relTypes: => Option[Seq[Int]]): PrimitiveLongIterator = {
+                                  relCache: PrimitiveRelationshipsCache, dir: SemanticDirection, relTypes: => Option[Array[Int]]): PrimitiveLongIterator = {
 
     val fromNodeIsDense = query.nodeIsDense(fromNode)
     val toNodeIsDense = query.nodeIsDense(toNode)
@@ -82,7 +82,7 @@ trait PrimitiveCachingExpandInto {
   }
 
   private def relIterator(query: QueryContext, fromNode: Long, toNode: Long, preserveDirection: Boolean,
-                          relTypes: Option[Seq[Int]], relCache: PrimitiveRelationshipsCache, dir: SemanticDirection): PrimitiveLongIterator = {
+                          relTypes: Option[Array[Int]], relCache: PrimitiveRelationshipsCache, dir: SemanticDirection): PrimitiveLongIterator = {
     val (start, localDirection, end) = if (preserveDirection) (fromNode, dir, toNode) else (toNode, dir.reversed, fromNode)
     val relationships: RelationshipIterator = query.getRelationshipsForIdsPrimitive(start, localDirection, relTypes)
 
@@ -130,10 +130,10 @@ trait PrimitiveCachingExpandInto {
     }
   }
 
-  private def getDegree(node: Long, relTypes: Option[Seq[Int]], direction: SemanticDirection, query: QueryContext) = {
+  private def getDegree(node: Long, relTypes: Option[Array[Int]], direction: SemanticDirection, query: QueryContext) = {
     relTypes.map {
       case rels if rels.isEmpty => query.nodeGetDegree(node, direction)
-      case rels if rels.size == 1 => query.nodeGetDegree(node, direction, rels.head)
+      case rels if rels.length == 1 => query.nodeGetDegree(node, direction, rels.head)
       case rels => rels.foldLeft(0)(
         (acc, rel) => acc + query.nodeGetDegree(node, direction, rel)
       )


### PR DESCRIPTION
In runtime we were forcing `LazyType` to do

```
if (ids.size != names.size) {
    ids = names.flatMap(context.getOptRelTypeId)
}
```

where both `ids` and `names` are scala lists meaning that the two size
operations are O(n). Furthermore when `types` are sent to the kernel we
turn the `Seq` into an array, meaning one more O(n) operation plus
allocation. Instead of doing all this extra work `LazyType` should just
maintain an internal array instead.

For most queries this is not a huge problem since the number of `types` is generally pretty small, however from recordings of actual production databases this has showed up as a hotspot. 