### PR TITLE
Clean up arguments in StandardInternalExecutionResult for testing

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/StandardInternalExecutionResult.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/executionplan/StandardInternalExecutionResult.scala
@@ -109,7 +109,7 @@ abstract class StandardInternalExecutionResult(context: QueryContext, runtime: R
      * NOTE: This should ony be used for testing, it creates an InternalExecutionResult
      * where you can call both toList and dumpToString
      */
-  def toEagerResultForTestingOnly(planner: PlannerName): InternalExecutionResult = {
+  def toEagerResultForTestingOnly(): InternalExecutionResult = {
     val dumpToStringBuilder = Seq.newBuilder[Map[String, String]]
     val result = new util.ArrayList[util.Map[String, Any]]()
     if (isOpen)
@@ -122,12 +122,16 @@ abstract class StandardInternalExecutionResult(context: QueryContext, runtime: R
 
       override protected def createInner: util.Iterator[util.Map[String, Any]] = result.iterator()
 
-      override def executionPlanDescription(): InternalPlanDescription =
-        self.executionPlanDescription()
-          .addArgument(Planner(planner.toTextOutput))
-          .addArgument(PlannerImpl(planner.name))
-          .addArgument(Runtime(runtime.toTextOutput))
-          .addArgument(RuntimeImpl(runtime.name))
+      override def executionPlanDescription(): InternalPlanDescription = {
+        val description = self.executionPlanDescription()
+        if (!description.arguments.exists(_.isInstanceOf[Runtime])) {
+          description.addArgument(Runtime(runtime.toTextOutput))
+        }
+        if (!description.arguments.exists(_.isInstanceOf[RuntimeImpl])) {
+          description.addArgument(RuntimeImpl(runtime.name))
+        }
+        description
+      }
 
       override def toList: List[Predef.Map[String, Any]] = result.asScala
         .map(m => Eagerly.immutableMapValues(m.asScala, scalaValues.asDeepScalaValue)).toList

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/RewindableExecutionResult.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/RewindableExecutionResult.scala
@@ -55,7 +55,7 @@ object RewindableExecutionResult {
         }
       case other: StandardInternalExecutionResult =>
         exceptionHandler.runSafely {
-          other.toEagerResultForTestingOnly(CostBasedPlannerName.default)
+          other.toEagerResultForTestingOnly()
         }
 
       case _ =>


### PR DESCRIPTION
The method toEagerResultForTestingOnly used to add runtimes and
planner arguments always, even when they already existed. This PR
changes that to only add runtime, if it is not defined yet. The value
for planner was hardcoded to COST, this was entirely removed.

Even though this PR touches a file in main, it should influence test only.