### PR TITLE
HighLimitFormatSettings as reference of HighLimit format settings

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/DynamicRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/DynamicRecordFormat.java
@@ -37,7 +37,7 @@ public class DynamicRecordFormat extends BaseOneByteHeaderRecordFormat<DynamicRe
     public DynamicRecordFormat()
     {
         super( INT_STORE_HEADER_READER, RECORD_HEADER_SIZE, 0x10/*the inUse bit is the lsb in the second nibble*/,
-                StandardFormatSettings.DYNAMIC_RECORD_MAXIMUM_ID_BITS );
+                StandardFormatSettings.DYNAMIC_MAXIMUM_ID_BITS );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/NodeRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/NodeRecordFormat.java
@@ -35,7 +35,7 @@ public class NodeRecordFormat extends BaseOneByteHeaderRecordFormat<NodeRecord>
 
     public NodeRecordFormat()
     {
-        super( fixedRecordSize( RECORD_SIZE ), 0, IN_USE_BIT, StandardFormatSettings.NODE_RECORD_MAXIMUM_ID_BITS );
+        super( fixedRecordSize( RECORD_SIZE ), 0, IN_USE_BIT, StandardFormatSettings.NODE_MAXIMUM_ID_BITS );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/PropertyRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/PropertyRecordFormat.java
@@ -40,7 +40,7 @@ public class PropertyRecordFormat extends BaseRecordFormat<PropertyRecord>
 
     public PropertyRecordFormat()
     {
-        super( fixedRecordSize( RECORD_SIZE ), 0, StandardFormatSettings.PROPERTY_RECORD_MAXIMUM_ID_BITS );
+        super( fixedRecordSize( RECORD_SIZE ), 0, StandardFormatSettings.PROPERTY_MAXIMUM_ID_BITS );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardFormatSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/StandardFormatSettings.java
@@ -25,12 +25,12 @@ package org.neo4j.kernel.impl.store.format.standard;
 public final class StandardFormatSettings
 {
     public static final int PROPERTY_TOKEN_MAXIMUM_ID_BITS = 24;
-    static final int NODE_RECORD_MAXIMUM_ID_BITS = 35;
+    static final int NODE_MAXIMUM_ID_BITS = 35;
     static final int RELATIONSHIP_MAXIMUM_ID_BITS = 35;
-    static final int PROPERTY_RECORD_MAXIMUM_ID_BITS = 36;
-    static final int DYNAMIC_RECORD_MAXIMUM_ID_BITS = 36;
-    static final int LABEL_TOKEN_MAXIMUM_ID_BITS = 32;
-    static final int RELATIONSHIP_TYPE_TOKEN_MAXIMUM_ID_BITS = 16;
+    static final int PROPERTY_MAXIMUM_ID_BITS = 36;
+    public static final int DYNAMIC_MAXIMUM_ID_BITS = 36;
+    public static final int LABEL_TOKEN_MAXIMUM_ID_BITS = 32;
+    public static final int RELATIONSHIP_TYPE_TOKEN_MAXIMUM_ID_BITS = 16;
     static final int RELATIONSHIP_GROUP_MAXIMUM_ID_BITS = 35;
 
     private StandardFormatSettings()

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormat.java
@@ -97,9 +97,9 @@ abstract class BaseHighLimitRecordFormat<RECORD extends AbstractBaseRecord>
     static final int HEADER_BIT_FIRST_RECORD_UNIT = 0b0000_0100;
     static final int HEADER_BIT_FIXED_REFERENCE = 0b0000_0100;
 
-    protected BaseHighLimitRecordFormat( Function<StoreHeader,Integer> recordSize, int recordHeaderSize )
+    protected BaseHighLimitRecordFormat( Function<StoreHeader,Integer> recordSize, int recordHeaderSize, int maxIdBits )
     {
-        super( recordSize, recordHeaderSize, IN_USE_BIT, HighLimit.DEFAULT_MAXIMUM_BITS_PER_ID );
+        super( recordSize, recordHeaderSize, IN_USE_BIT, maxIdBits );
     }
 
     public void read( RECORD record, PageCursor primaryCursor, RecordLoad mode, int recordSize )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/DynamicRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/DynamicRecordFormat.java
@@ -51,7 +51,7 @@ public class DynamicRecordFormat extends BaseOneByteHeaderRecordFormat<DynamicRe
 
     public DynamicRecordFormat()
     {
-        super( INT_STORE_HEADER_READER, RECORD_HEADER_SIZE, IN_USE_BIT, HighLimit.DEFAULT_MAXIMUM_BITS_PER_ID );
+        super( INT_STORE_HEADER_READER, RECORD_HEADER_SIZE, IN_USE_BIT, HighLimitFormatSettings.DYNAMIC_MAXIMUM_ID_BITS );
     }
 
     @Override

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
@@ -44,11 +44,6 @@ import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
  */
 public class HighLimit extends BaseRecordFormats
 {
-    /**
-     * Default maximum number of bits that can be used to represent id
-     */
-    static final int DEFAULT_MAXIMUM_BITS_PER_ID = 50;
-
     public static final String STORE_VERSION = StoreVersion.HIGH_LIMIT_V3_2_0.versionString();
 
     public static final RecordFormats RECORD_FORMATS = new HighLimit();

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitFormatSettings.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimitFormatSettings.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store.format.highlimit;
+
+import org.neo4j.kernel.impl.store.format.standard.StandardFormatSettings;
+
+/**
+ * Reference class for high limit format settings.
+ *
+ * @see HighLimit
+ */
+public class HighLimitFormatSettings
+{
+    /**
+     * Default maximum number of bits that can be used to represent id
+     */
+    static final int DEFAULT_MAXIMUM_BITS_PER_ID = 50;
+
+    static final int PROPERTY_MAXIMUM_ID_BITS = DEFAULT_MAXIMUM_BITS_PER_ID;
+    static final int NODE_MAXIMUM_ID_BITS = DEFAULT_MAXIMUM_BITS_PER_ID;
+    static final int RELATIONSHIP_MAXIMUM_ID_BITS = DEFAULT_MAXIMUM_BITS_PER_ID;
+    static final int RELATIONSHIP_GROUP_MAXIMUM_ID_BITS = DEFAULT_MAXIMUM_BITS_PER_ID;
+    static final int DYNAMIC_MAXIMUM_ID_BITS = DEFAULT_MAXIMUM_BITS_PER_ID;
+
+    @SuppressWarnings( "unused" )
+    static final int PROPERTY_TOKEN_MAXIMUM_ID_BITS = StandardFormatSettings.PROPERTY_TOKEN_MAXIMUM_ID_BITS;
+    @SuppressWarnings( "unused" )
+    static final int LABEL_TOKEN_MAXIMUM_ID_BITS = StandardFormatSettings.LABEL_TOKEN_MAXIMUM_ID_BITS;
+    @SuppressWarnings( "unused" )
+    static final int RELATIONSHIP_TYPE_TOKEN_MAXIMUM_ID_BITS = StandardFormatSettings.RELATIONSHIP_TYPE_TOKEN_MAXIMUM_ID_BITS;
+
+    private HighLimitFormatSettings()
+    {
+    }
+}

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/NodeRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/NodeRecordFormat.java
@@ -74,7 +74,7 @@ class NodeRecordFormat extends BaseHighLimitRecordFormat<NodeRecord>
 
     NodeRecordFormat( int recordSize )
     {
-        super( fixedRecordSize( recordSize ), 0 );
+        super( fixedRecordSize( recordSize ), 0, HighLimitFormatSettings.NODE_MAXIMUM_ID_BITS );
     }
 
     @Override

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/PropertyRecordFormat.java
@@ -81,7 +81,7 @@ class PropertyRecordFormat extends BaseOneByteHeaderRecordFormat<PropertyRecord>
 
     protected PropertyRecordFormat()
     {
-        super( fixedRecordSize( RECORD_SIZE ), 0, IN_USE_BIT, HighLimit.DEFAULT_MAXIMUM_BITS_PER_ID );
+        super( fixedRecordSize( RECORD_SIZE ), 0, IN_USE_BIT, HighLimitFormatSettings.PROPERTY_MAXIMUM_ID_BITS );
     }
 
     @Override

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipGroupRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipGroupRecordFormat.java
@@ -85,7 +85,7 @@ class RelationshipGroupRecordFormat extends BaseHighLimitRecordFormat<Relationsh
 
     RelationshipGroupRecordFormat( int recordSize )
     {
-        super( fixedRecordSize( recordSize ), 0 );
+        super( fixedRecordSize( recordSize ), 0, HighLimitFormatSettings.RELATIONSHIP_GROUP_MAXIMUM_ID_BITS );
     }
 
     @Override

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormat.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipRecordFormat.java
@@ -99,7 +99,7 @@ class RelationshipRecordFormat extends BaseHighLimitRecordFormat<RelationshipRec
 
     RelationshipRecordFormat( int recordSize )
     {
-        super( fixedRecordSize( recordSize ), 0 );
+        super( fixedRecordSize( recordSize ), 0, HighLimitFormatSettings.RELATIONSHIP_MAXIMUM_ID_BITS );
     }
 
     @Override

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/BaseHighLimitRecordFormatTest.java
@@ -97,7 +97,7 @@ public class BaseHighLimitRecordFormatTest
 
         protected MyRecordFormat()
         {
-            super( header -> 4, 4 );
+            super( header -> 4, 4, HighLimitFormatSettings.DEFAULT_MAXIMUM_BITS_PER_ID );
         }
 
         @Override


### PR DESCRIPTION
Introduce HighLimitFormatSettings, move all of the max ids definition
to new settings class, update high limit format to reference new constants
instead.
Rename constants in HighLimitFormatSettings and StandardFormatSettings
to not include "record" word in all of the constant names.