### PR TITLE
Fix comparison bug in slotted runtime

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MiscAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MiscAcceptanceTest.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import org.neo4j.cypher.ExecutionEngineFunSuite
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
+
+class MiscAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
+
+  // This test verifies a bugfix in slotted runtime
+  test("should be able to compare integers") {
+    val query = """
+      UNWIND range(0, 1) AS i
+      UNWIND range(0, 1) AS j
+      WITH i, j
+      WHERE i <> j
+      RETURN i, j"""
+
+    val result = executeWith(Configs.All - Configs.Compiled, query)
+    result.toList should equal(List(Map("j" -> 1, "i" -> 0), Map("j" -> 0, "i" -> 1)))
+  }
+
+}

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/PipelineInformation.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/PipelineInformation.scala
@@ -127,6 +127,11 @@ object PipelineInformation {
 
     result.toString()
   }
+
+  def isLongSlot(slot: Slot) = slot match {
+    case _: LongSlot => true
+    case _ => false
+  }
 }
 
 class PipelineInformation(private var slots: Map[String, Slot],

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/SlottedRewriter.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/SlottedRewriter.scala
@@ -146,8 +146,10 @@ class SlottedRewriter(tokenContext: TokenContext) {
       case e@Equals(Variable(k1), Variable(k2)) => // TODO: Handle nullability
         val slot1 = pipelineInformation(k1)
         val slot2 = pipelineInformation(k2)
-        if (slot1.typ == slot2.typ)
+        if (slot1.typ == slot2.typ && PipelineInformation.isLongSlot(slot1)) {
+          assert(PipelineInformation.isLongSlot(slot2))
           PrimitiveEquals(IdFromSlot(slot1.offset), IdFromSlot(slot2.offset))
+        }
         else
           e
 


### PR DESCRIPTION
SlottedRewriter should apply PrimitiveEquals only on variables allocated
to LongSlots.