### PR TITLE
Migrate mockito to latest 2.10.0

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/BoltChannelTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/BoltChannelTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import org.neo4j.bolt.logging.BoltMessageLogger;
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/logging/BoltMessageLoggerImplTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/logging/BoltMessageLoggerImplTest.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.bolt.logging;
 
-import java.net.InetSocketAddress;
-
 import io.netty.channel.Channel;
 import io.netty.channel.unix.DomainSocketAddress;
 import io.netty.util.Attribute;
@@ -28,7 +26,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.net.InetSocketAddress;
 
 import org.neo4j.bolt.v1.runtime.Neo4jError;
 import org.neo4j.kernel.DeadlockDetectedException;
@@ -37,7 +37,6 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.bolt.logging.BoltMessageLoggerImpl.CORRELATION_ATTRIBUTE_KEY;
 import static org.neo4j.helpers.ValueUtils.asMapValue;
 import static org.neo4j.helpers.collection.MapUtil.map;

--- a/community/bolt/src/test/java/org/neo4j/bolt/logging/BoltMessageLoggingTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/logging/BoltMessageLoggingTest.java
@@ -19,15 +19,15 @@
  */
 package org.neo4j.bolt.logging;
 
-import java.io.IOException;
-import java.net.InetSocketAddress;
-
 import io.netty.channel.Channel;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
@@ -42,7 +42,6 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.startsWith;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.bolt_logging_enabled;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 
@@ -64,7 +63,6 @@ public class BoltMessageLoggingTest
     {
         Config config = newConfig( false );
 
-        when( channel.remoteAddress() ).thenReturn( inetSocketAddress );
         BoltMessageLogging logging = BoltMessageLogging.create( fs, jobScheduler, config, log );
         BoltMessageLogger logger = logging.newLogger( channel );
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/ChunkedOutputTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/ChunkedOutputTest.java
@@ -22,7 +22,6 @@ package org.neo4j.bolt.v1.transport.socket;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelPromise;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,6 +42,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -193,10 +193,10 @@ public class ChunkedOutputTest
         final CountDownLatch finishLatch = new CountDownLatch( 1 );
         final AtomicBoolean parallelException = new AtomicBoolean( false );
 
-        when( ch.writeAndFlush( any(), any( ChannelPromise.class ) ) ).thenAnswer( invocation ->
+        when( ch.writeAndFlush( any(), isNull() ) ).thenAnswer( invocation ->
         {
             startLatch.countDown();
-            ByteBuf byteBuf = (ByteBuf) invocation.getArguments()[0];
+            ByteBuf byteBuf = invocation.getArgument( 0 );
             writtenData.limit( writtenData.position() + byteBuf.readableBytes() );
             byteBuf.readBytes( writtenData );
             return null;
@@ -275,9 +275,9 @@ public class ChunkedOutputTest
 
     private void setupWriteAndFlush()
     {
-        when( ch.writeAndFlush( any(), any( ChannelPromise.class ) ) ).thenAnswer( invocation ->
+        when( ch.writeAndFlush( any(), isNull() ) ).thenAnswer( invocation ->
         {
-            ByteBuf byteBuf = (ByteBuf) invocation.getArguments()[0];
+            ByteBuf byteBuf = invocation.getArgument( 0 );
             writtenData.limit( writtenData.position() + byteBuf.readableBytes() );
             byteBuf.readBytes( writtenData );
             return null;

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/Chunker.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/Chunker.java
@@ -22,15 +22,13 @@ package org.neo4j.bolt.v1.transport.socket;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelPromise;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import org.neo4j.bolt.v1.transport.ChunkedOutput;
 
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -48,9 +46,9 @@ public class Chunker
 
         Channel ch = mock( Channel.class );
         when( ch.alloc() ).thenReturn( UnpooledByteBufAllocator.DEFAULT );
-        when( ch.writeAndFlush( any(), any( ChannelPromise.class ) ) ).then( inv ->
+        when( ch.writeAndFlush( any(), isNull() ) ).then( inv ->
         {
-            ByteBuf buf = (ByteBuf) inv.getArguments()[0];
+            ByteBuf buf = inv.getArgument( 0 );
             outputBuffer.limit( outputBuffer.position() + buf.readableBytes() );
             buf.readBytes( outputBuffer );
             buf.release();

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/FragmentedMessageDeliveryTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/FragmentedMessageDeliveryTest.java
@@ -113,10 +113,10 @@ public class FragmentedMessageDeliveryTest
         BoltStateMachine machine = mock( BoltStateMachine.class );
 
         Channel ch = mock( Channel.class );
-        when(ch.alloc()).thenReturn( UnpooledByteBufAllocator.DEFAULT );
+        when( ch.alloc() ).thenReturn( UnpooledByteBufAllocator.DEFAULT );
 
         ChannelHandlerContext ctx = mock( ChannelHandlerContext.class );
-        when(ctx.channel()).thenReturn( ch );
+        when( ctx.channel() ).thenReturn( ch );
 
         BoltChannel boltChannel = mock( BoltChannel.class );
         when( boltChannel.channelHandlerContext() ).thenReturn( ctx );

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/CheckConsistencyCommandTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/CheckConsistencyCommandTest.java
@@ -51,7 +51,6 @@ import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.stub;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -158,9 +157,9 @@ public class CheckConsistencyCommandTest
                 new CheckConsistencyCommand( homeDir, testDir.directory( "conf" ).toPath(), outsideWorld,
                         consistencyCheckService );
 
-        stub( consistencyCheckService.runFullConsistencyCheck( anyObject(), anyObject(), anyObject(), anyObject(),
+        when( consistencyCheckService.runFullConsistencyCheck( anyObject(), anyObject(), anyObject(), anyObject(),
                 anyObject(), anyBoolean(), anyObject(), any( CheckConsistencyConfig.class ) ) )
-                .toReturn( ConsistencyCheckService.Result.success( null ) );
+                .thenReturn( ConsistencyCheckService.Result.success( null ) );
 
         checkConsistencyCommand.execute( new String[]{"--database=mydb"} );
 
@@ -182,9 +181,9 @@ public class CheckConsistencyCommandTest
                 new CheckConsistencyCommand( homeDir, testDir.directory( "conf" ).toPath(), outsideWorld,
                         consistencyCheckService );
 
-        stub( consistencyCheckService.runFullConsistencyCheck( anyObject(), anyObject(), anyObject(), anyObject(),
+        when( consistencyCheckService.runFullConsistencyCheck( anyObject(), anyObject(), anyObject(), anyObject(),
                 anyObject(), anyBoolean(), anyObject(), any( CheckConsistencyConfig.class ) ) )
-                .toReturn( ConsistencyCheckService.Result.success( null ) );
+                .thenReturn( ConsistencyCheckService.Result.success( null ) );
 
         checkConsistencyCommand.execute( new String[]{"--database=mydb", "--report-dir=some-dir-or-other"} );
 
@@ -207,9 +206,9 @@ public class CheckConsistencyCommandTest
                 new CheckConsistencyCommand( homeDir, testDir.directory( "conf" ).toPath(), outsideWorld,
                         consistencyCheckService );
 
-        stub( consistencyCheckService.runFullConsistencyCheck( anyObject(), anyObject(), anyObject(), anyObject(),
+        when( consistencyCheckService.runFullConsistencyCheck( anyObject(), anyObject(), anyObject(), anyObject(),
                 anyObject(), anyBoolean(), anyObject(), any( CheckConsistencyConfig.class ) ) )
-                .toReturn( ConsistencyCheckService.Result.success( null ) );
+                .thenReturn( ConsistencyCheckService.Result.success( null ) );
 
         checkConsistencyCommand.execute( new String[]{"--database=mydb", "--report-dir=" + Paths.get( "..", "bar" )} );
 
@@ -231,9 +230,9 @@ public class CheckConsistencyCommandTest
                 new CheckConsistencyCommand( homeDir, testDir.directory( "conf" ).toPath(), outsideWorld,
                         consistencyCheckService );
 
-        stub( consistencyCheckService.runFullConsistencyCheck( anyObject(), anyObject(), anyObject(), anyObject(),
+        when( consistencyCheckService.runFullConsistencyCheck( anyObject(), anyObject(), anyObject(), anyObject(),
                 anyObject(), anyBoolean(), anyObject(), any( CheckConsistencyConfig.class ) ) )
-                .toReturn( ConsistencyCheckService.Result.success( null ) );
+                .thenReturn( ConsistencyCheckService.Result.success( null ) );
 
         checkConsistencyCommand.execute( new String[]{"--database=mydb", "--check-graph=false",
                 "--check-indexes=false", "--check-label-scan-store=false", "--check-property-owners=true"} );
@@ -254,9 +253,9 @@ public class CheckConsistencyCommandTest
                 new CheckConsistencyCommand( homeDir, testDir.directory( "conf" ).toPath(), outsideWorld,
                         consistencyCheckService );
 
-        stub( consistencyCheckService.runFullConsistencyCheck( anyObject(), anyObject(), anyObject(), anyObject(),
+        when( consistencyCheckService.runFullConsistencyCheck( anyObject(), anyObject(), anyObject(), anyObject(),
                 anyObject(), anyBoolean(), any( CheckConsistencyConfig.class ) ) )
-                .toReturn( ConsistencyCheckService.Result.success( null ) );
+                .thenReturn( ConsistencyCheckService.Result.success( null ) );
 
         expect.expect( IncorrectUsage.class );
         expect.expectMessage( "Only one of '--database' and '--backup' can be specified." );

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/report/ConsistencyReporterTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/report/ConsistencyReporterTest.java
@@ -31,6 +31,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Suite;
 import org.junit.runners.model.Statement;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -52,8 +53,8 @@ import org.neo4j.consistency.store.synthetic.CountsEntry;
 import org.neo4j.consistency.store.synthetic.IndexEntry;
 import org.neo4j.consistency.store.synthetic.LabelScanDocument;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
-import org.neo4j.kernel.api.schema.SchemaDescriptor;
 import org.neo4j.kernel.api.labelscan.NodeLabelRange;
+import org.neo4j.kernel.api.schema.SchemaDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
@@ -75,13 +76,13 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static org.neo4j.consistency.report.ConsistencyReporter.NO_MONITOR;
 import static org.neo4j.kernel.impl.store.counts.keys.CountsKeyFactory.nodeKey;
 
@@ -230,8 +231,7 @@ public class ConsistencyReporterTest
                 else
                 {
                     verify( report ).error( any( RecordType.class ),
-                                            any( AbstractBaseRecord.class ),
-                                            argThat( hasExpectedFormat() ), any( Object[].class ) );
+                                            any( AbstractBaseRecord.class ), argThat( hasExpectedFormat() ), nullSafeAny() );
                 }
             }
             else
@@ -246,7 +246,7 @@ public class ConsistencyReporterTest
                 {
                     verify( report ).warning( any( RecordType.class ),
                                               any( AbstractBaseRecord.class ),
-                                              argThat( hasExpectedFormat() ), any( Object[].class ) );
+                                              argThat( hasExpectedFormat() ), nullSafeAny() );
                 }
             }
         }
@@ -455,6 +455,11 @@ public class ConsistencyReporterTest
                         ex );
             }
         }
+    }
+
+    private static <T> T[] nullSafeAny()
+    {
+        return ArgumentMatchers.argThat( argument -> true );
     }
 
     private static Matcher<String> hasExpectedFormat()

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/store/RecordAccessStub.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/store/RecordAccessStub.java
@@ -56,6 +56,7 @@ import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 
 import static java.util.Collections.singletonMap;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -114,6 +115,7 @@ public class RecordAccessStub implements RecordAccess
             {
                 PendingReferenceCheck mock = mock( PendingReferenceCheck.class );
                 DeferredReferenceCheck check = new DeferredReferenceCheck( Engine.this, checker );
+                doAnswer( check ).when( mock ).checkReference( isNull(), isNull() );
                 doAnswer( check ).when( mock ).checkReference( any( AbstractBaseRecord.class ),
                                                                any( RecordAccess.class ) );
                 doAnswer( check ).when( mock ).checkDiffReference( any( AbstractBaseRecord.class ),

--- a/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/CNFNormalizerTest.scala
+++ b/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/CNFNormalizerTest.scala
@@ -19,13 +19,13 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.ast.rewriters
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_4.test_helpers.ContextHelper
-import org.neo4j.cypher.internal.frontend.v3_4.{AstRewritingMonitor, Rewriter}
 import org.neo4j.cypher.internal.frontend.v3_4.ast.rewriters.CNFNormalizer
 import org.neo4j.cypher.internal.frontend.v3_4.phases.Monitors
 import org.neo4j.cypher.internal.frontend.v3_4.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.frontend.v3_4.{AstRewritingMonitor, Rewriter}
 
 class CNFNormalizerTest extends CypherFunSuite with PredicateTestSupport {
 

--- a/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/CachedFunctionTest.scala
+++ b/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/helpers/CachedFunctionTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.helpers
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.frontend.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.ir.v3_4.{IdName, QueryGraph}

--- a/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/LogicalPlanningTestSupport.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_4._
 import org.neo4j.cypher.internal.compiler.v3_4.ast.rewriters.namePatternPredicatePatternElements
@@ -94,7 +94,7 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
 
   def newMockedStrategy(plan: LogicalPlan) = {
     val strategy = mock[QueryGraphSolver]
-    doReturn(plan).when(strategy).plan(any())(any())
+    doReturn(plan, Nil: _*).when(strategy).plan(any())(any())
     strategy
   }
 
@@ -120,7 +120,7 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
 
   def newMockedPlanContext(implicit statistics: GraphStatistics = newMockedStatistics) = {
     val context = mock[PlanContext]
-    doReturn(statistics).when(context).statistics
+    doReturn(statistics, Nil: _*).when(context).statistics
     context
   }
 

--- a/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/DefaultQueryPlannerTest.scala
+++ b/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/DefaultQueryPlannerTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical
 
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify, when}
 import org.neo4j.cypher.internal.compiler.v3_4.planner._
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.Metrics.QueryGraphSolverInput

--- a/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PriorityLeafPlannerListTest.scala
+++ b/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PriorityLeafPlannerListTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical
 
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, verifyZeroInteractions, when}
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport2
 import org.neo4j.cypher.internal.frontend.v3_4.test_helpers.CypherFunSuite

--- a/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/assumeIndependence/PatternSelectivityCalculatorTest.scala
+++ b/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/cardinality/assumeIndependence/PatternSelectivityCalculatorTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical.cardinality.assumeIndependence
 
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
@@ -90,7 +90,7 @@ class PatternSelectivityCalculatorTest extends CypherFunSuite with LogicalPlanCo
     val stats: GraphStatistics = mock[GraphStatistics]
     when(stats.nodesWithLabelCardinality(any())).thenAnswer(new Answer[Cardinality] {
       override def answer(invocationOnMock: InvocationOnMock): Cardinality = {
-        val arg = invocationOnMock.getArguments()(0).asInstanceOf[Option[LabelId]]
+        val arg:Option[LabelId] = invocationOnMock.getArgument(0)
         arg match {
           case None => Cardinality(10)
           case Some(_) => Cardinality(1)

--- a/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/patternExpressionRewriterTest.scala
+++ b/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/patternExpressionRewriterTest.scala
@@ -33,7 +33,7 @@ import org.neo4j.cypher.internal.v3_4.logical.plans.{AllNodesScan, LogicalPlan, 
 
 class patternExpressionRewriterTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
-  import org.mockito.Matchers._
+  import org.mockito.ArgumentMatchers._
 
   test("Rewrites pattern expressions") {
     // given
@@ -104,7 +104,7 @@ class patternExpressionRewriterTest extends CypherFunSuite with LogicalPlanningT
     when(strategy.planPatternExpression(any[Set[IdName]], any[PatternExpression])(any[LogicalPlanningContext])).thenAnswer(
       new Answer[(LogicalPlan, PatternExpression)] {
         override def answer(invocation: InvocationOnMock): (LogicalPlan, PatternExpression) = {
-          val expr = invocation.getArguments()(1).asInstanceOf[PatternExpression]
+          val expr:PatternExpression = invocation.getArgument(1)
           val (namedExpr, _) = PatternExpressionPatternElementNamer(expr)
           (dummyPlan, namedExpr)
         }

--- a/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/ExtractBestPlanTest.scala
+++ b/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/ExtractBestPlanTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_4.IndexDescriptor
 import org.neo4j.cypher.internal.compiler.v3_4.planner._

--- a/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/OrLeafPlannerTest.scala
+++ b/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/OrLeafPlannerTest.scala
@@ -19,8 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps
 
-import org.mockito.Matchers
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.{LeafPlanFromExpressions, LeafPlansForVariable, LogicalPlanningContext}
@@ -40,8 +40,9 @@ class OrLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSupport {
     val e1 = Variable("e1")(pos)
     val e2 = Variable("e2")(pos)
     val ors = Ors(Set(e1, e2))(pos)
-    when(inner1.producePlanFor(Matchers.eq(Set(e1)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("x"), Set(p1))))
-    when(inner1.producePlanFor(Matchers.eq(Set(e2)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("x"), Set(p2))))
+    when(inner1.producePlanFor(ArgumentMatchers.eq(Set(e1)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("x"), Set
+    (p1))))
+    when(inner1.producePlanFor(ArgumentMatchers.eq(Set(e2)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("x"), Set(p2))))
     val orPlanner = OrLeafPlanner(Seq(inner1))
 
     val expected = Distinct(
@@ -60,8 +61,8 @@ class OrLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSupport {
     val e1 = Variable("e1")(pos)
     val e2 = Variable("e2")(pos)
     val ors = Ors(Set(e1, e2))(pos)
-    when(inner1.producePlanFor(Matchers.eq(Set(e1)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("e1"), Set(p1))))
-    when(inner1.producePlanFor(Matchers.eq(Set(e2)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("e2"), Set(p2))))
+    when(inner1.producePlanFor(ArgumentMatchers.eq(Set(e1)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("e1"), Set(p1))))
+    when(inner1.producePlanFor(ArgumentMatchers.eq(Set(e2)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("e2"), Set(p2))))
     val orPlanner = OrLeafPlanner(Seq(inner1))
 
     val queryGraph = QueryGraph.empty.withSelections(Selections.from(ors))
@@ -75,8 +76,8 @@ class OrLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSupport {
     val e1 = Variable("e1")(pos)
     val e2 = Variable("e2")(pos)
     val ors = Ors(Set(e1, e2))(pos)
-    when(inner1.producePlanFor(Matchers.eq(Set(e1)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("e1"), Set(p1))))
-    when(inner1.producePlanFor(Matchers.eq(Set(e2)), any())(any())).thenReturn(Set.empty[LeafPlansForVariable])
+    when(inner1.producePlanFor(ArgumentMatchers.eq(Set(e1)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("e1"), Set(p1))))
+    when(inner1.producePlanFor(ArgumentMatchers.eq(Set(e2)), any())(any())).thenReturn(Set.empty[LeafPlansForVariable])
     val orPlanner = OrLeafPlanner(Seq(inner1))
 
     val queryGraph = QueryGraph.empty.withSelections(Selections.from(ors))
@@ -95,10 +96,10 @@ class OrLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSupport {
     val e1 = Variable("e1")(pos)
     val e2 = Variable("e2")(pos)
     val ors = Ors(Set(e1, e2))(pos)
-    when(inner1.producePlanFor(Matchers.eq(Set(e1)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("x"), Set(p1))))
-    when(inner1.producePlanFor(Matchers.eq(Set(e2)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("x"), Set(p2))))
-    when(inner2.producePlanFor(Matchers.eq(Set(e1)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("x"), Set(p3))))
-    when(inner2.producePlanFor(Matchers.eq(Set(e2)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("x"), Set(p4))))
+    when(inner1.producePlanFor(ArgumentMatchers.eq(Set(e1)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("x"), Set(p1))))
+    when(inner1.producePlanFor(ArgumentMatchers.eq(Set(e2)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("x"), Set(p2))))
+    when(inner2.producePlanFor(ArgumentMatchers.eq(Set(e1)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("x"), Set(p3))))
+    when(inner2.producePlanFor(ArgumentMatchers.eq(Set(e2)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("x"), Set(p4))))
     val orPlanner = OrLeafPlanner(Seq(inner1, inner2))
 
     val queryGraph = QueryGraph.empty.withSelections(Selections.from(ors))
@@ -130,10 +131,10 @@ class OrLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSupport {
     val e1 = Variable("e1")(pos)
     val e2 = Variable("e2")(pos)
     val ors = Ors(Set(e1, e2))(pos)
-    when(inner1.producePlanFor(Matchers.eq(Set(e1)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("x"), Set(p1))))
-    when(inner1.producePlanFor(Matchers.eq(Set(e2)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("x"), Set(p2))))
-    when(inner2.producePlanFor(Matchers.eq(Set(e1)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("x"), Set(p3))))
-    when(inner2.producePlanFor(Matchers.eq(Set(e2)), any())(any())).thenReturn(Set.empty[LeafPlansForVariable])
+    when(inner1.producePlanFor(ArgumentMatchers.eq(Set(e1)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("x"), Set(p1))))
+    when(inner1.producePlanFor(ArgumentMatchers.eq(Set(e2)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("x"), Set(p2))))
+    when(inner2.producePlanFor(ArgumentMatchers.eq(Set(e1)), any())(any())).thenReturn(Set(LeafPlansForVariable(IdName("x"), Set(p3))))
+    when(inner2.producePlanFor(ArgumentMatchers.eq(Set(e2)), any())(any())).thenReturn(Set.empty[LeafPlansForVariable])
     val orPlanner = OrLeafPlanner(Seq(inner1, inner2))
 
     val queryGraph = QueryGraph.empty.withSelections(Selections.from(ors))

--- a/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/PatternExpressionSolverTest.scala
+++ b/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/PatternExpressionSolverTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.{LogicalPlanningContext, QueryGraphSolver}

--- a/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/SelectPatternPredicatesTest.scala
+++ b/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/SelectPatternPredicatesTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_4.planner._
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.Metrics.QueryGraphSolverInput

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/QueryExecutionMonitorTest.scala
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/QueryExecutionMonitorTest.scala
@@ -19,12 +19,12 @@
  */
 package org.neo4j.cypher
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.neo4j.cypher.ExecutionEngineHelper.createEngine
+import org.neo4j.cypher.internal.ExecutionEngine
 import org.neo4j.cypher.internal.frontend.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.helpers.GraphIcing
-import org.neo4j.cypher.internal.{ExecutionEngine}
 import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService
 import org.neo4j.graphdb.Result
 import org.neo4j.graphdb.Result.{ResultRow, ResultVisitor}
@@ -32,8 +32,8 @@ import org.neo4j.kernel.GraphDatabaseQueryService
 import org.neo4j.kernel.api.query.ExecutingQuery
 import org.neo4j.kernel.impl.query.{QueryExecutionMonitor, TransactionalContext}
 import org.neo4j.test.TestGraphDatabaseFactory
-import scala.collection.JavaConverters._
 
+import scala.collection.JavaConverters._
 import scala.collection.immutable.Map
 import scala.language.implicitConversions
 

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/ParameterConverterTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/codegen/ParameterConverterTest.java
@@ -77,14 +77,14 @@ public class ParameterConverterTest
         NodeManager manager = mock( NodeManager.class );
         when( manager.newNodeProxyById( anyLong() ) ).thenAnswer( invocationOnMock ->
         {
-            long id = invocationOnMock.getArgumentAt( 0, long.class );
+            long id = invocationOnMock.getArgument( 0 );
             NodeProxy mock = mock( NodeProxy.class );
             when( mock.getId() ).thenReturn( id );
             return mock;
         } );
         when( manager.newRelationshipProxyById( anyLong() ) ).thenAnswer( invocationOnMock ->
         {
-            long id = invocationOnMock.getArgumentAt( 0, long.class );
+            long id = invocationOnMock.getArgument( 0 );
             RelationshipProxy mock = mock( RelationshipProxy.class );
             when( mock.getId() ).thenReturn( id );
             return mock;

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ClosingIteratorTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ClosingIteratorTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime
 
-import org.mockito.Matchers.anyBoolean
+import org.mockito.ArgumentMatchers.anyBoolean
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.frontend.v3_4.CypherException
 import org.neo4j.cypher.internal.frontend.v3_4.test_helpers.CypherFunSuite

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/commands/AndsTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/commands/AndsTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.commands
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.ExecutionContext
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.commands.predicates.{Ands, Not, Predicate, True}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/commands/OrsTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/commands/OrsTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.commands
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.ExecutionContext
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.commands.predicates.{Not, Ors, Predicate, True}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/commands/expressions/RelationshipTypeFunctionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/commands/expressions/RelationshipTypeFunctionTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.commands.expressions
 
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.ImplicitValueConversion._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.pipes.QueryStateHelper
@@ -33,28 +33,30 @@ class RelationshipTypeFunctionTest extends CypherFunSuite with FakeEntityTestSup
 
   private val mockedContext = mock[QueryContext]
   private val operations = mock[Operations[Relationship]]
-  doReturn(operations).when(mockedContext).relationshipOps
+  result(operations).when(mockedContext).relationshipOps
 
   private val state = QueryStateHelper.emptyWith(query = mockedContext)
   private val function = RelationshipTypeFunction(Variable("r"))
 
   test("should give the type of a relationship") {
-    doReturn(false).when(operations).isDeletedInThisTx(any())
+    result(false).when(operations).isDeletedInThisTx(any())
 
     val rel = new FakeRel(null, null, RelationshipType.withName("T"))
     function.compute(rel, null, state) should equal(stringValue("T"))
   }
 
   test("should handle deleted relationships since types are inlined") {
-    doReturn(true).when(operations).isDeletedInThisTx(any())
+    result(true).when(operations).isDeletedInThisTx(any())
 
     val rel = new FakeRel(null, null, RelationshipType.withName("T"))
     function.compute(rel, null, state) should equal(stringValue("T"))
   }
 
   test("should throw if encountering anything other than a relationship") {
-    doReturn(false).when(operations).isDeletedInThisTx(any())
+    result(false).when(operations).isDeletedInThisTx(any())
 
     a [ParameterWrongTypeException] should be thrownBy function.compute(1337L, null, state)
   }
+
+  private def result(value: Any) = doReturn(value, Nil: _*)
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/CheckForLoadCsvAndMatchOnLargeLabelTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/CheckForLoadCsvAndMatchOnLargeLabelTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
@@ -40,7 +40,7 @@ class CheckForLoadCsvAndMatchOnLargeLabelTest extends CypherFunSuite {
   private val planContext = mock[PlanContext]
   when(planContext.getOptLabelId(anyString)).thenAnswer(new Answer[Option[Int]] {
     override def answer(invocationOnMock: InvocationOnMock): Option[Int] = {
-     val label = invocationOnMock.getArguments()(0).asInstanceOf[String]
+      val label: String = invocationOnMock.getArgument(0)
       indexFor.get(label)
     }
   })

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/ExecutionWorkflowBuilderTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/ExecutionWorkflowBuilderTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.pipes.Pipe
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.{EagerResultIterator, _}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/LoadCsvPeriodicCommitObserverTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/LoadCsvPeriodicCommitObserverTest.scala
@@ -21,8 +21,8 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan
 
 import java.net.URL
 
-import org.mockito.Matchers
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.pipes.ExternalCSVResource
 import org.neo4j.cypher.internal.frontend.v3_4.test_helpers.CypherFunSuite
@@ -37,7 +37,7 @@ class LoadCsvPeriodicCommitObserverTest extends CypherFunSuite {
 
   test("writing should not trigger tx restart until next csv line is fetched") {
     // Given
-    when(resource.getCsvIterator(Matchers.eq(url), any(), any())).thenReturn(Iterator(Array("yo")))
+    when(resource.getCsvIterator(ArgumentMatchers.eq(url), any(), any())).thenReturn(Iterator(Array("yo")))
 
     // When
     val iterator = resourceUnderTest.getCsvIterator(url, None, false)
@@ -50,7 +50,7 @@ class LoadCsvPeriodicCommitObserverTest extends CypherFunSuite {
 
   test("multiple iterators are still handled correctly only commit when the first iterator advances") {
     // Given
-    when(resource.getCsvIterator(Matchers.eq(url), any(), any())).
+    when(resource.getCsvIterator(ArgumentMatchers.eq(url), any(), any())).
       thenReturn(Iterator(Array("yo"))).
       thenReturn(Iterator(Array("yo")))
     val iterator1 = resourceUnderTest.getCsvIterator(url, None, false)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/procs/ProcedureCallExecutionPlanTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/procs/ProcedureCallExecutionPlanTest.scala
@@ -19,16 +19,16 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan.procs
 
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.NormalMode
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.commands.convert.{CommunityExpressionConverter, ExpressionConverters}
 import org.neo4j.cypher.internal.frontend.v3_4.ast._
-import org.neo4j.cypher.internal.frontend.v3_4.{DummyPosition, symbols}
 import org.neo4j.cypher.internal.frontend.v3_4.symbols._
 import org.neo4j.cypher.internal.frontend.v3_4.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.frontend.v3_4.{DummyPosition, symbols}
 import org.neo4j.cypher.internal.spi.v3_4.{QueryContext, QueryTransactionalContext}
 import org.neo4j.cypher.internal.v3_4.logical.plans._
 import org.neo4j.values.storable.LongValue
@@ -106,7 +106,7 @@ class ProcedureCallExecutionPlanTest extends CypherFunSuite {
 
   val procedureResult = new Answer[Iterator[Array[AnyRef]]] {
     override def answer(invocationOnMock: InvocationOnMock) = {
-      val input = invocationOnMock.getArguments()(1).asInstanceOf[Seq[AnyRef]]
+      val input: Seq[AnyRef] = invocationOnMock.getArgument(1)
       new Iterator[Array[AnyRef]] {
         override def hasNext = !iteratorExhausted
 
@@ -122,6 +122,6 @@ class ProcedureCallExecutionPlanTest extends CypherFunSuite {
   when(ctx.callReadOnlyProcedure(any[QualifiedName], any[Seq[Any]], any[Array[String]])).thenAnswer(procedureResult)
   when(ctx.callReadWriteProcedure(any[QualifiedName], any[Seq[Any]], any[Array[String]])).thenAnswer(procedureResult)
   when(ctx.asObject(any[LongValue])).thenAnswer(new Answer[Long]() {
-    override def answer(invocationOnMock: InvocationOnMock): Long = invocationOnMock.getArguments()(0).asInstanceOf[LongValue].value()
+    override def answer(invocationOnMock: InvocationOnMock): Long = invocationOnMock.getArgument(0).asInstanceOf[LongValue].value()
   })
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/ExpandAllPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/ExpandAllPipeTest.scala
@@ -19,8 +19,8 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.pipes
 
-import org.mockito.Matchers
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
@@ -60,10 +60,12 @@ class ExpandAllPipeTest extends CypherFunSuite {
 
   test("should return no relationships for types that have not been defined yet") {
     // given
-    when(query.getRelationshipsForIds(any(), any(), Matchers.eq(Some(Seq.empty)))).thenAnswer(new Answer[Iterator[Relationship]]{
+    when(query.getRelationshipsForIds(any(), any(), ArgumentMatchers.eq(Some(Seq.empty)))).thenAnswer(new
+        Answer[Iterator[Relationship]]{
       override def answer(invocationOnMock: InvocationOnMock): Iterator[Relationship] = Iterator.empty
     })
-    when(query.getRelationshipsForIds(any(), any(), Matchers.eq(Some(Seq(1,2))))).thenAnswer(new Answer[Iterator[Relationship]]{
+    when(query.getRelationshipsForIds(any(), any(), ArgumentMatchers.eq(Some(Seq(1,2))))).thenAnswer(new
+        Answer[Iterator[Relationship]]{
       override def answer(invocationOnMock: InvocationOnMock): Iterator[Relationship] = Iterator(relationship1, relationship2)
     })
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/ExpandAllPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/ExpandAllPipeTest.scala
@@ -64,8 +64,8 @@ class ExpandAllPipeTest extends CypherFunSuite {
         Answer[Iterator[Relationship]]{
       override def answer(invocationOnMock: InvocationOnMock): Iterator[Relationship] = Iterator.empty
     })
-    when(query.getRelationshipsForIds(any(), any(), ArgumentMatchers.eq(Some(Seq(1,2))))).thenAnswer(new
-        Answer[Iterator[Relationship]]{
+    when(query.getRelationshipsForIds(any(), any(), ArgumentMatchers.eq(Some(Seq(1,2)))))
+      .thenAnswer(new Answer[Iterator[Relationship]]{
       override def answer(invocationOnMock: InvocationOnMock): Iterator[Relationship] = Iterator(relationship1, relationship2)
     })
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/ExpandIntoPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/ExpandIntoPipeTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.pipes
 
-import org.mockito.Matchers.{eq => mockEq, _}
+import org.mockito.ArgumentMatchers.{eq => mockEq, _}
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/NodeHashJoinPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/NodeHashJoinPipeTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.pipes
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.ExecutionContext

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/NodeIndexScanPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/NodeIndexScanPipeTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.pipes
 
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_4.IndexDescriptor
 import org.neo4j.cypher.internal.frontend.v3_4.ast.{LabelToken, PropertyKeyToken, _}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/NodeIndexSeekPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/NodeIndexSeekPipeTest.scala
@@ -19,8 +19,8 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.pipes
 
-import org.mockito.Matchers
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.ExecutionContext
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.commands.expressions.{ListLiteral, Literal, Variable}
@@ -256,7 +256,7 @@ class NodeIndexSeekPipeTest extends CypherFunSuite with AstConstructionTestSuppo
     when(query.indexSeek(any(), any())).thenReturn(Iterator.empty)
 
     values.foreach {
-      case (searchTerm, result) => when(query.indexSeek(any(), Matchers.eq(searchTerm))).thenReturn(result)
+      case (searchTerm, result) => when(query.indexSeek(any(), ArgumentMatchers.eq(searchTerm))).thenReturn(result)
     }
 
     query

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/NodeOuterHashJoinPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/NodeOuterHashJoinPipeTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.pipes
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.ExecutionContext
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.ImplicitValueConversion._

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/OptionalExpandAllPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/OptionalExpandAllPipeTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.pipes
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/OptionalExpandIntoPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/OptionalExpandIntoPipeTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.pipes
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/PipeTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/PipeTestSupport.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.pipes
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/ProjectEndpointsPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/ProjectEndpointsPipeTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.pipes
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/QueryStateHelper.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/QueryStateHelper.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime.pipes
 
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.mockito.{Matchers, Mockito}
+import org.mockito.{ArgumentMatchers, Mockito}
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.ExecutionContext
 import org.neo4j.cypher.internal.spi.v3_4.QueryContext
 import org.neo4j.graphdb.spatial.Point
@@ -45,8 +45,8 @@ object QueryStateHelper {
   def emptyWithValueSerialization: QueryState = emptyWith(query = context)
 
   private val context = Mockito.mock(classOf[QueryContext])
-  Mockito.when(context.asObject(Matchers.any())).thenAnswer(new Answer[Any] {
-    override def answer(invocationOnMock: InvocationOnMock): AnyRef = toObject(invocationOnMock.getArgumentAt(0, classOf[AnyValue]))
+  Mockito.when(context.asObject(ArgumentMatchers.any())).thenAnswer(new Answer[Any] {
+    override def answer(invocationOnMock: InvocationOnMock): AnyRef = toObject(invocationOnMock.getArgument(0))
   })
 
   private def toObject(any: AnyValue) = {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/RollUpApplyPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/RollUpApplyPipeTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.pipes
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
@@ -80,7 +80,7 @@ class RollUpApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     val rhs = mock[Pipe]
     when(rhs.createResults(any())).then(new Answer[Iterator[ExecutionContext]] {
       override def answer(invocation: InvocationOnMock) = {
-        val state = invocation.getArguments.apply(0).asInstanceOf[QueryState]
+        val state:QueryState = invocation.getArgument(0)
         state.initialContext should not be empty
         Iterator.empty
       }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/SetPropertyPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/SetPropertyPipeTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.pipes
 
-import org.mockito.Matchers.{anyInt, anyLong}
+import org.mockito.ArgumentMatchers.{anyInt, anyLong}
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.commands.expressions._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.commands.values.{KeyToken, TokenType}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/ValueHashJoinPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/ValueHashJoinPipeTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.pipes
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.neo4j.cypher.ValueComparisonHelper.beEquivalentTo
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.ExecutionContext
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.ImplicitValueConversion._

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/VarLengthExpandPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/VarLengthExpandPipeTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.pipes
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/profiler/ProfilerTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/profiler/ProfilerTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.profiler
 
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.ExecutionContext
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.commands.expressions.{NestedPipeExpression, ProjectedPath}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_4/CSVResourcesTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_4/CSVResourcesTest.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.spi.v3_4
 import java.net.URL
 
 import org.apache.commons.lang3.SystemUtils
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.TaskCloser
 import org.neo4j.cypher.internal.compiler.v3_4.test_helpers.CreateTempFileTestSupport

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_4/UpdateCountingQueryContextTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_4/UpdateCountingQueryContextTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.spi.v3_4
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito.when
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
@@ -47,23 +47,23 @@ class UpdateCountingQueryContextTest extends CypherFunSuite {
   // We need to have the inner mock return the right counts for added/removed labels.
   when( inner.setLabelsOnNode(anyLong(), any()) ).thenAnswer( new Answer[Int]() {
     def answer(invocation: InvocationOnMock):Int = {
-      invocation.getArguments()(1).asInstanceOf[Iterator[String]].size
+      invocation.getArgument(1).asInstanceOf[Iterator[String]].size
     }
   } )
 
   when( inner.removeLabelsFromNode(anyLong(), any()) ).thenAnswer( new Answer[Int]() {
     def answer(invocation: InvocationOnMock):Int = {
-      invocation.getArguments()(1).asInstanceOf[Iterator[String]].size
+      invocation.getArgument(1).asInstanceOf[Iterator[String]].size
     }
   } )
 
-  when(inner.createUniqueConstraint(anyObject())).thenReturn(true)
+  when(inner.createUniqueConstraint(any())).thenReturn(true)
 
   when( inner.createNodePropertyExistenceConstraint(anyInt(), anyInt()) ).thenReturn(true)
 
   when( inner.createRelationshipPropertyExistenceConstraint(anyInt(), anyInt()) ).thenReturn(true)
 
-  when(inner.addIndexRule(anyObject()))
+  when(inner.addIndexRule(any()))
     .thenReturn(IdempotentResult(mock[IndexDescriptor]))
 
   var context: UpdateCountingQueryContext = null

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DumpCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DumpCommandTest.java
@@ -249,7 +249,7 @@ public class DumpCommandTest
         doAnswer( invocation ->
         {
             //noinspection unchecked
-            Predicate<Path> exclude = (Predicate<Path>) invocation.getArgumentAt( 2, Predicate.class );
+            Predicate<Path> exclude = invocation.getArgument( 2 );
             assertThat( exclude.test( Paths.get( StoreLocker.STORE_LOCK_FILENAME ) ), is( true ) );
             assertThat( exclude.test( Paths.get( "some-other-file" ) ), is( false ) );
             return null;

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/util/PathImplTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/impl/util/PathImplTest.java
@@ -173,7 +173,7 @@ public class PathImplTest
         @Override
         public NodeProxy answer( InvocationOnMock invocation ) throws Throwable
         {
-            return createNodeProxy( ((Number) invocation.getArguments()[0]).intValue() );
+            return createNodeProxy( ((Number) invocation.getArgument( 0 )).intValue() );
         }
     }
 }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/FreeListIdProviderTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/FreeListIdProviderTest.java
@@ -41,7 +41,6 @@ import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.index.internal.gbptree.FreeListIdProvider.NO_MONITOR;
 
 public class FreeListIdProviderTest
@@ -65,7 +64,7 @@ public class FreeListIdProviderTest
     public void setUpPagedFile() throws IOException
     {
         when( pagedFile.io( anyLong(), anyInt() ) ).thenAnswer(
-                invocation -> cursor.duplicate( invocation.getArgumentAt( 0, Long.class ).longValue() ) );
+                invocation -> cursor.duplicate( invocation.getArgument( 0 ) ) );
         freelist.initialize( BASE_ID + 1, BASE_ID + 1, BASE_ID + 1, 0, 0 );
     }
 

--- a/community/io/src/test/java/org/neo4j/io/IOUtilsTest.java
+++ b/community/io/src/test/java/org/neo4j/io/IOUtilsTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 

--- a/community/io/src/test/java/org/neo4j/io/fs/FileVisitorsDecoratorsTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/FileVisitorsDecoratorsTest.java
@@ -41,7 +41,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.stub;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.function.ThrowingConsumer.noop;
@@ -119,7 +118,7 @@ public class FileVisitorsDecoratorsTest
     @Test
     public void shouldPropagateExceptionsFromPreVisitDirectory() throws IOException
     {
-        stub( wrapped.preVisitDirectory( any(), any() ) ).toThrow( new IOException() );
+        when( wrapped.preVisitDirectory( any(), any() ) ).thenThrow( new IOException() );
 
         try
         {
@@ -153,7 +152,7 @@ public class FileVisitorsDecoratorsTest
     @Test
     public void shouldPropagateExceptionsFromPostVisitDirectory() throws IOException
     {
-        stub( wrapped.postVisitDirectory( any(), any() ) ).toThrow( new IOException() );
+        when( wrapped.postVisitDirectory( any(), any() ) ).thenThrow( new IOException() );
 
         try
         {
@@ -187,7 +186,7 @@ public class FileVisitorsDecoratorsTest
     @Test
     public void shouldPropagateExceptionsFromVisitFile() throws IOException
     {
-        stub( wrapped.visitFile( any(), any() ) ).toThrow( new IOException() );
+        when( wrapped.visitFile( any(), any() ) ).thenThrow( new IOException() );
 
         try
         {
@@ -221,7 +220,7 @@ public class FileVisitorsDecoratorsTest
     @Test
     public void shouldPropagateExceptionsFromVisitFileFailed() throws IOException
     {
-        stub( wrapped.visitFileFailed( any(), any() ) ).toThrow( new IOException() );
+        when( wrapped.visitFileFailed( any(), any() ) ).thenThrow( new IOException() );
 
         try
         {

--- a/community/io/src/test/java/org/neo4j/io/fs/OnDirectoryTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/OnDirectoryTest.java
@@ -19,21 +19,20 @@
  */
 package org.neo4j.io.fs;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
 import java.io.IOException;
 import java.nio.file.FileVisitor;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-
 import org.neo4j.function.ThrowingConsumer;
 
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-
 import static org.neo4j.io.fs.FileVisitors.onDirectory;
 
 @RunWith( MockitoJUnitRunner.class )

--- a/community/io/src/test/java/org/neo4j/io/fs/OnFileTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/OnFileTest.java
@@ -19,21 +19,20 @@
  */
 package org.neo4j.io.fs;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
 import java.io.IOException;
 import java.nio.file.FileVisitor;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-
 import org.neo4j.function.ThrowingConsumer;
 
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-
 import static org.neo4j.io.fs.FileVisitors.onFile;
 
 @RunWith( MockitoJUnitRunner.class )

--- a/community/io/src/test/java/org/neo4j/io/fs/OnlyMatchingFileVisitorTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/OnlyMatchingFileVisitorTest.java
@@ -19,22 +19,21 @@
  */
 package org.neo4j.io.fs;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.FileVisitor;
 import java.nio.file.Path;
-
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-
 import static org.neo4j.function.Predicates.alwaysFalse;
 import static org.neo4j.io.fs.FileVisitors.onlyMatching;
 

--- a/community/io/src/test/java/org/neo4j/io/fs/ThrowExceptionsFileVisitorTest.java
+++ b/community/io/src/test/java/org/neo4j/io/fs/ThrowExceptionsFileVisitorTest.java
@@ -19,21 +19,18 @@
  */
 package org.neo4j.io.fs;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
 import java.io.IOException;
 import java.nio.file.FileVisitor;
 import java.nio.file.Path;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.stub;
-
 import static org.neo4j.io.fs.FileVisitors.throwExceptions;
 
 @RunWith( MockitoJUnitRunner.class )
@@ -46,7 +43,6 @@ public class ThrowExceptionsFileVisitorTest
     public void shouldThrowExceptionFromVisitFileFailed() throws IOException
     {
         IOException exception = new IOException();
-        stub( wrapped.visitFileFailed( any(), any() ) ).toThrow( exception );
         try
         {
             throwExceptions( wrapped ).visitFileFailed( null, exception );
@@ -62,7 +58,6 @@ public class ThrowExceptionsFileVisitorTest
     public void shouldThrowExceptionFromPostVisitDirectory() throws IOException
     {
         IOException exception = new IOException();
-        stub( wrapped.postVisitDirectory( any(), any() ) ).toThrow( exception );
         try
         {
             throwExceptions( wrapped ).postVisitDirectory( null, exception );

--- a/community/kernel/src/test/java/org/neo4j/helpers/progress/ProgressMonitorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/progress/ProgressMonitorTest.java
@@ -27,6 +27,7 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
+
 import java.io.ByteArrayOutputStream;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
@@ -621,7 +622,7 @@ public class ProgressMonitorTest
             ProgressMonitorFactory factory = Mockito.mock( ProgressMonitorFactory.class );
             when( factory.newOpenEndedIndicator( any( String.class ), anyInt() ) ).thenAnswer( invocation ->
             {
-                when( indicatorMock.reportResolution() ).thenReturn( (Integer) invocation.getArguments()[1] );
+                when( indicatorMock.reportResolution() ).thenReturn( invocation.getArgument(1) );
                 return indicatorMock;
             } );
             factoryMocks.put( factory, true );

--- a/community/kernel/src/test/java/org/neo4j/kernel/GraphDatabaseFacadeFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/GraphDatabaseFacadeFactoryTest.java
@@ -126,7 +126,7 @@ public class GraphDatabaseFacadeFactoryTest
             {
                 final LifeSupport lifeMock = mock( LifeSupport.class );
                 doThrow( startupError ).when( lifeMock ).start();
-                doAnswer( invocation -> invocation.getArguments()[0] ).when( lifeMock ).add( any( Lifecycle.class ) );
+                doAnswer( invocation -> invocation.getArgument( 0 ) ).when( lifeMock ).add( any( Lifecycle.class ) );
 
                 return new PlatformModule( storeDir, config, databaseInfo, dependencies, graphDatabaseFacade )
                 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -477,11 +477,10 @@ public class BuiltInProceduresTest
         when( read.proceduresGetAll() ).thenReturn( procs.getAllProcedures() );
 
         when( read.propertyKeyGetName( anyInt() ) )
-                .thenAnswer( invocation -> propKeys.get( invocation.getArguments()[0] ) );
-        when( read.labelGetName( anyInt() ) )
-                .thenAnswer( invocation -> labels.get( invocation.getArguments()[0] ) );
+                .thenAnswer( invocation -> propKeys.get( invocation.getArgument( 0 ) ) );
+        when( read.labelGetName( anyInt() ) ).thenAnswer( invocation -> labels.get( invocation.getArgument( 0 ) ) );
         when( read.relationshipTypeGetName( anyInt() ) )
-                .thenAnswer( invocation -> relTypes.get( invocation.getArguments()[0] ) );
+                .thenAnswer( invocation -> relTypes.get( invocation.getArgument( 0 ) ) );
 
         // Make it appear that labels are in use
         // TODO: We really should just have `labelsInUse()` on the Kernel API directly,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationTest.java
@@ -368,7 +368,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
         doAnswer( invocation ->
         {
             @SuppressWarnings( "unchecked" )
-            Collection<StorageCommand> commands = invocation.getArgumentAt( 0, Collection.class );
+            Collection<StorageCommand> commands = invocation.getArgument( 0 );
             commands.add( mock( Command.class ) );
             return null;
         } ).when( storageEngine ).createCommands(
@@ -383,6 +383,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
             SimpleStatementLocks statementLocks = new SimpleStatementLocks( mock( Locks.Client.class ) );
             transaction.initialize( 5L, BASE_TX_COMMIT_TIMESTAMP, statementLocks, KernelTransaction.Type.implicit,
                     AUTH_DISABLED, 0L );
+            transaction.txState();
             try ( KernelStatement statement = transaction.acquireStatement() )
             {
                 statement.explicitIndexTxState(); // which will pull it from the supplier and the mocking above

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTestBase.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTestBase.java
@@ -44,6 +44,7 @@ import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
 import org.neo4j.kernel.impl.transaction.TransactionMonitor;
 import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
+import org.neo4j.kernel.impl.transaction.command.Command;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.transaction.tracing.CommitEvent;
 import org.neo4j.kernel.impl.transaction.tracing.TransactionTracer;
@@ -57,8 +58,8 @@ import org.neo4j.storageengine.api.txstate.ReadableTransactionState;
 import org.neo4j.time.Clocks;
 import org.neo4j.time.FakeClock;
 
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyCollectionOf;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -94,9 +95,10 @@ public class KernelTransactionTestBase
         when( readLayer.newStatement() ).thenReturn( mock( StoreStatement.class ) );
         when( neoStores.getMetaDataStore() ).thenReturn( metaDataStore );
         when( storageEngine.storeReadLayer() ).thenReturn( readLayer );
-        doAnswer( invocation -> ((Collection<StorageCommand>) invocation.getArguments()[0]).add( null ) )
+        doAnswer( invocation -> ((Collection<StorageCommand>) invocation.getArgument(0) ).add( new Command
+                .RelationshipCountsCommand( 1, 2,3, 4L ) ) )
             .when( storageEngine ).createCommands(
-                    anyCollectionOf( StorageCommand.class ),
+                    anyCollection(),
                     any( ReadableTransactionState.class ),
                     any( StorageStatement.class ), any( ResourceLocker.class ),
                     anyLong() );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
@@ -508,7 +508,8 @@ public class KernelTransactionsTest
         when( storageEngine.storeReadLayer() ).thenReturn( readLayer );
         doAnswer( invocation ->
         {
-            invocation.getArgumentAt( 0, Collection.class ).add( mock( StorageCommand.class ) );
+            Collection<StorageCommand> argument = invocation.getArgument( 0 );
+            argument.add( mock( StorageCommand.class ) );
             return null;
         } ).when( storageEngine ).createCommands(
                 anyCollection(),
@@ -582,7 +583,7 @@ public class KernelTransactionsTest
                 any( TransactionApplicationMode.class ) ) )
                 .then( invocation ->
                 {
-                    slot[0] = ((TransactionToApply) invocation.getArguments()[0]).transactionRepresentation();
+                    slot[0] = ((TransactionToApply) invocation.getArgument( 0 )).transactionRepresentation();
                     return 1L;
                 } );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
@@ -390,8 +390,7 @@ public class LockingStatementOperationsTest
             // and GIVEN
             doAnswer( invocation ->
             {
-                RelationshipVisitor<RuntimeException> visitor =
-                        (RelationshipVisitor<RuntimeException>) invocation.getArguments()[2];
+                RelationshipVisitor<RuntimeException> visitor = invocation.getArgument( 2 );
                 visitor.visit( relationshipId, 0, lowId, highId );
                 return null;
             } ).when( entityReadOps ).relationshipVisit( any( KernelStatement.class ), anyLong(),
@@ -413,8 +412,7 @@ public class LockingStatementOperationsTest
             // and GIVEN
             doAnswer( invocation ->
             {
-                RelationshipVisitor<RuntimeException> visitor =
-                        (RelationshipVisitor<RuntimeException>) invocation.getArguments()[2];
+                RelationshipVisitor<RuntimeException> visitor = invocation.getArgument( 2 );
                 visitor.visit( relationshipId, 0, highId, lowId );
                 return null;
             } ).when( entityReadOps ).relationshipVisit( any( KernelStatement.class ), anyLong(),

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/OperationsFacadeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/OperationsFacadeTest.java
@@ -26,7 +26,7 @@ import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import org.neo4j.kernel.api.TokenNameLookup;
 import org.neo4j.kernel.api.exceptions.schema.SchemaRuleNotFoundException;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementOperationsTestHelper.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementOperationsTestHelper.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.api;
 
-import org.mockito.Matchers;
-
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.exceptions.index.IndexNotApplicableKernelException;
@@ -44,6 +42,8 @@ import org.neo4j.kernel.impl.locking.SimpleStatementLocks;
 import org.neo4j.storageengine.api.StorageStatement;
 import org.neo4j.storageengine.api.schema.IndexReader;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -78,10 +78,10 @@ public abstract class StatementOperationsTestHelper
         try
         {
             IndexReader indexReader = mock( IndexReader.class );
-            when( indexReader.query( Matchers.isA( IndexQuery.ExactPredicate.class ) ) )
+            when( indexReader.query( isA( IndexQuery.ExactPredicate.class ) ) )
                     .thenReturn( PrimitiveLongCollections.emptyIterator() );
             StorageStatement storageStatement = mock( StorageStatement.class );
-            when( storageStatement.getIndexReader( Matchers.any() ) ).thenReturn( indexReader );
+            when( storageStatement.getIndexReader( any() ) ).thenReturn( indexReader );
             when( state.getStoreStatement() ).thenReturn( storageStatement );
         }
         catch ( IndexNotFoundKernelException | IndexNotApplicableKernelException e )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/BatchingMultipleIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/BatchingMultipleIndexPopulatorTest.java
@@ -361,10 +361,8 @@ public class BatchingMultipleIndexPopulatorTest
         IndexStoreView storeView = mock( IndexStoreView.class );
         when( storeView.visitNodes( any(), any(), any(), any(), anyBoolean() ) ).thenAnswer( invocation ->
         {
-            Object visitorArg = invocation.getArguments()[2];
-            Visitor<NodeUpdates,IndexPopulationFailedKernelException> visitor =
-                    (Visitor<NodeUpdates,IndexPopulationFailedKernelException>) visitorArg;
-            return new IndexEntryUpdateScan( updates, visitor );
+            Visitor<NodeUpdates,IndexPopulationFailedKernelException> visitorArg = invocation.getArgument( 2 );
+            return new IndexEntryUpdateScan( updates, visitorArg );
         } );
         return storeView;
     }
@@ -375,7 +373,7 @@ public class BatchingMultipleIndexPopulatorTest
         when( executor.awaitTermination( anyLong(), any() ) ).thenReturn( true );
         doAnswer( invocation ->
         {
-            ((Runnable) invocation.getArguments()[0]).run();
+            ((Runnable) invocation.getArgument( 0 )).run();
             return null;
         } ).when( executor ).execute( any() );
         return executor;
@@ -396,7 +394,7 @@ public class BatchingMultipleIndexPopulatorTest
         ExecutorService result = mock( ExecutorService.class );
         doAnswer( invocation ->
         {
-            invocation.getArgumentAt( 0, Runnable.class ).run();
+            invocation.<Runnable>getArgument( 0 ).run();
             return null;
         } ).when( result ).execute( any( Runnable.class ) );
         return result;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
@@ -23,7 +23,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -82,6 +82,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.doThrow;
@@ -207,7 +209,7 @@ public class IndexPopulationJobTest
         verify( populator ).create();
         verify( populator ).includeSample( update1 );
         verify( populator ).includeSample( update2 );
-        verify( populator, times( 2 ) ).add( Matchers.anyCollection() );
+        verify( populator, times( 2 ) ).add( anyCollection() );
         verify( populator ).sampleResult();
         verify( populator ).close( true );
 
@@ -299,8 +301,8 @@ public class IndexPopulationJobTest
         IndexStoreView storeView = mock( IndexStoreView.class );
         ControlledStoreScan storeScan = new ControlledStoreScan();
         when( storeView.visitNodes( any(int[].class), any( IntPredicate.class ),
-                Matchers.<Visitor<NodeUpdates,RuntimeException>>any(),
-                Matchers.<Visitor<NodeLabelUpdate,RuntimeException>>any(), anyBoolean() ) )
+                ArgumentMatchers.<Visitor<NodeUpdates,RuntimeException>>any(),
+                ArgumentMatchers.<Visitor<NodeLabelUpdate,RuntimeException>>any(), anyBoolean() ) )
                 .thenReturn(storeScan );
 
         final IndexPopulationJob job = newIndexPopulationJob( populator, index, storeView,
@@ -324,7 +326,7 @@ public class IndexPopulationJobTest
 
         // THEN
         verify( populator, times( 1 ) ).close( false );
-        verify( index, times( 0 ) ).flip( Matchers.any(), Matchers.any() );
+        verify( index, times( 0 ) ).flip( any(), any() );
     }
 
     @Test
@@ -408,7 +410,7 @@ public class IndexPopulationJobTest
         job.run();
 
         // Then
-        verify( populator ).markAsFailed( Matchers.contains( failureMessage ) );
+        verify( populator ).markAsFailed( contains( failureMessage ) );
     }
 
     private static class ControlledStoreScan implements StoreScan<RuntimeException>

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
@@ -104,6 +104,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
@@ -162,7 +163,7 @@ public class IndexingServiceTest
     {
         when( populator.sampleResult() ).thenReturn( new IndexSample() );
         when( storeView.indexSample( anyLong(), any( DoubleLongRegister.class ) ) )
-                .thenAnswer( invocation -> invocation.getArguments()[1] );
+                .thenAnswer( invocation -> invocation.getArgument( 1 ) );
     }
 
     @Test
@@ -1201,14 +1202,14 @@ public class IndexingServiceTest
         void getsProcessedByStoreScanFrom( IndexStoreView mock )
         {
             when( mock.visitNodes( any(int[].class), any( IntPredicate.class ),
-                    any( Visitor.class ), any( Visitor.class ), anyBoolean() ) ).thenAnswer( this );
+                    any( Visitor.class ), isNull(), anyBoolean() ) ).thenAnswer( this );
         }
 
         @Override
         public StoreScan<IndexPopulationFailedKernelException> answer( InvocationOnMock invocation ) throws Throwable
         {
             final Visitor<NodeUpdates,IndexPopulationFailedKernelException> visitor =
-                    visitor( invocation.getArguments()[2] );
+                    visitor( invocation.getArgument( 2 ) );
             return new StoreScan<IndexPopulationFailedKernelException>()
             {
                 @Override
@@ -1268,7 +1269,7 @@ public class IndexingServiceTest
         @Override
         public String answer( InvocationOnMock invocation ) throws Throwable
         {
-            int id = (Integer) invocation.getArguments()[0];
+            int id = invocation.getArgument( 0 );
             return kind + "[" + id + "]";
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/MultipleIndexPopulatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/MultipleIndexPopulatorTest.java
@@ -19,13 +19,12 @@
  */
 package org.neo4j.kernel.impl.api.index;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.util.concurrent.Callable;
@@ -48,6 +47,7 @@ import org.neo4j.storageengine.api.schema.IndexSample;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyLong;
@@ -76,13 +76,6 @@ public class MultipleIndexPopulatorTest
     private MultipleIndexPopulator multipleIndexPopulator;
 
     private final LabelSchemaDescriptor index1 = SchemaDescriptorFactory.forLabel( 1, 1 );
-
-    @Before
-    public void setUp()
-    {
-        when( indexStoreView.visitNodes( any( int[].class ), any( IntPredicate.class ), any(Visitor.class),
-                any(Visitor.class), anyBoolean() ) ).thenReturn( storeScan );
-    }
 
     @Test
     public void testMultiplePopulatorsCreation() throws Exception
@@ -143,7 +136,7 @@ public class MultipleIndexPopulatorTest
         multipleIndexPopulator.indexAllNodes();
 
         verify( indexStoreView ).visitNodes( any(int[].class), any( IntPredicate.class ), any( Visitor.class ),
-                any( Visitor.class ), anyBoolean() );
+                isNull(), anyBoolean() );
     }
 
     @Test
@@ -197,8 +190,6 @@ public class MultipleIndexPopulatorTest
     public void testFailByNonExistingPopulation() throws IOException
     {
         IndexPopulation nonExistingPopulation = mock( IndexPopulation.class );
-        when( nonExistingPopulation.schema() ).thenReturn( SchemaDescriptorFactory.forLabel( 1, 1 ) );
-
         IndexPopulator populator = createIndexPopulator();
 
         addPopulator( populator, 1 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexTxStateUpdaterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/IndexTxStateUpdaterTest.java
@@ -42,6 +42,8 @@ import org.neo4j.storageengine.api.StoreReadLayer;
 import org.neo4j.values.storable.ValueTuple;
 import org.neo4j.values.storable.Values;
 
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
@@ -89,12 +91,10 @@ public class IndexTxStateUpdaterTest
         StoreReadLayer storeReadLayer = mock( StoreReadLayer.class );
         when( storeReadLayer.indexesGetAll() ).thenAnswer( x -> indexes.iterator() );
         when( storeReadLayer.indexesGetForLabel(anyInt() ) )
-                .thenAnswer(
-                    x -> filter( hasLabel( (Integer)x.getArguments()[0] ), indexes.iterator() ) );
+                .thenAnswer( x -> filter( hasLabel( x.getArgument( 0 ) ), indexes.iterator() ) );
 
         when( storeReadLayer.indexesGetRelatedToProperty( anyInt() ) )
-                .thenAnswer(
-                    x -> filter( hasProperty( (Integer)x.getArguments()[0] ), indexes.iterator() ) );
+                .thenAnswer( x -> filter( hasProperty( x.getArgument( 0 ) ), indexes.iterator() ) );
 
         PrimitiveIntSet labels = Primitive.intSet();
         labels.add( labelId1 );
@@ -141,7 +141,7 @@ public class IndexTxStateUpdaterTest
         // THEN
         verifyIndexUpdate( indexOn1_1.schema(), node.id(), null, values( "hi1" ) );
         verifyIndexUpdate( uniqueOn1_2.schema(), node.id(), null, values( "hi2" ) );
-        verify( txState, times( 2 ) ).indexDoUpdateEntry( any(), anyInt(), any(), any() );
+        verify( txState, times( 2 ) ).indexDoUpdateEntry( any(), anyLong(), isNull(), any() );
     }
 
     @Test
@@ -152,7 +152,7 @@ public class IndexTxStateUpdaterTest
 
         // THEN
         verifyIndexUpdate( uniqueOn2_2_3.schema(), node.id(), values( "hi2", "hi3" ), null );
-        verify( txState, times( 1 ) ).indexDoUpdateEntry( any(), anyInt(), any(), any() );
+        verify( txState, times( 1 ) ).indexDoUpdateEntry( any(), anyLong(), any(), isNull() );
     }
 
     // PROPERTIES
@@ -178,7 +178,7 @@ public class IndexTxStateUpdaterTest
         // THEN
         verifyIndexUpdate( indexOn2_new.schema(), node.id(), null, values( "newHi" ) );
         verifyIndexUpdate( indexOn1_1_new.schema(), node.id(), null, values( "hi1", "newHi" ) );
-        verify( txState, times( 2 ) ).indexDoUpdateEntry( any(), anyInt(), any(), any() );
+        verify( txState, times( 2 ) ).indexDoUpdateEntry( any(), anyLong(), isNull(), any() );
     }
 
     @Test
@@ -190,7 +190,7 @@ public class IndexTxStateUpdaterTest
         // THEN
         verifyIndexUpdate( uniqueOn1_2.schema(), node.id(), values( "hi2" ), null );
         verifyIndexUpdate( uniqueOn2_2_3.schema(), node.id(), values( "hi2", "hi3" ), null );
-        verify( txState, times( 2 ) ).indexDoUpdateEntry( any(), anyInt(), any(), any() );
+        verify( txState, times( 2 ) ).indexDoUpdateEntry( any(), anyLong(), any(), isNull() );
     }
 
     @Test
@@ -202,7 +202,7 @@ public class IndexTxStateUpdaterTest
         // THEN
         verifyIndexUpdate( uniqueOn1_2.schema(), node.id(), values( "hi2" ), values( "new2" ) );
         verifyIndexUpdate( uniqueOn2_2_3.schema(), node.id(), values( "hi2", "hi3" ), values( "new2", "hi3" ) );
-        verify( txState, times( 2 ) ).indexDoUpdateEntry( any(), anyInt(), any(), any() );
+        verify( txState, times( 2 ) ).indexDoUpdateEntry( any(), anyLong(), any(), any() );
     }
 
     private ValueTuple values( Object... values )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyPayloadCursorTest.java
@@ -472,7 +472,8 @@ public class StorePropertyPayloadCursorTest
             DynamicArrayStore dynamicArrayStore, Object... values )
     {
         StorePropertyPayloadCursor cursor = new StorePropertyPayloadCursor(
-                dynamicStringStore.newRecordCursor( null ), dynamicArrayStore.newRecordCursor( null ) );
+                dynamicStringStore.newRecordCursor( new DynamicRecord( -1 ) ),
+                dynamicArrayStore.newRecordCursor( new DynamicRecord( -1 ) ) );
 
         long[] blocks = asBlocks( values );
         cursor.init( blocks, blocks.length );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeProxySingleRelationshipTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeProxySingleRelationshipTest.java
@@ -20,8 +20,6 @@
 package org.neo4j.kernel.impl.core;
 
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import org.neo4j.graphdb.Direction;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -107,10 +105,10 @@ public class NodeProxySingleRelationshipTest
         final RelationshipProxy.RelationshipActions relActions = mock( RelationshipProxy.RelationshipActions.class );
         when( nodeActions.newRelationshipProxy( anyLong(), anyLong(), anyInt(), anyLong() ) ).then( invocation ->
         {
-            Long id = (Long) invocation.getArguments()[0];
-            Long startNode = (Long) invocation.getArguments()[1];
-            Integer type = (Integer) invocation.getArguments()[2];
-            Long endNode = (Long) invocation.getArguments()[3];
+            Long id = invocation.getArgument(0);
+            Long startNode = invocation.getArgument( 1 );
+            Integer type = invocation.getArgument( 2 );
+            Long endNode = invocation.getArgument( 3 );
             return new RelationshipProxy( relActions, id, startNode, type, endNode );
         } );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipProxyTest.java
@@ -61,9 +61,9 @@ public class RelationshipProxyTest extends PropertyContainerProxyTest
         // GIVEN
         RelationshipActions actions = mock( RelationshipActions.class );
         when( actions.newNodeProxy( anyLong() ) ).then(
-                invocation -> nodeWithId( (Long) invocation.getArguments()[0] ) );
+                invocation -> nodeWithId( invocation.getArgument( 0 ) ) );
         when( actions.getRelationshipTypeById( anyInt() ) ).then(
-                invocation -> new RelationshipTypeToken( "whatever", (Integer) invocation.getArguments()[0] ) );
+                invocation -> new RelationshipTypeToken( "whatever", invocation.getArgument( 0 ) ) );
 
         long[] ids = new long[]{
                 1437589437,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ResourceInjectionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ResourceInjectionTest.java
@@ -50,9 +50,9 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.allOf;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
 @SuppressWarnings( "WeakerAccess" )
 public class ResourceInjectionTest

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreTest.java
@@ -19,12 +19,6 @@
  */
 package org.neo4j.kernel.impl.store;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.OpenOption;
-import java.util.Arrays;
-import java.util.function.Supplier;
-
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -32,6 +26,12 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.RuleChain;
 import org.mockito.InOrder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.OpenOption;
+import java.util.Arrays;
+import java.util.function.Supplier;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -122,7 +122,7 @@ public class CommonAbstractStoreTest
     @Before
     public void setUpMocks() throws IOException
     {
-        when( idGeneratorFactory.open( any( File.class ), eq( idType ), any( Supplier.class ), anyInt() ) )
+        when( idGeneratorFactory.open( any( File.class ), eq( idType ), any( Supplier.class ), anyLong() ) )
                 .thenReturn( idGenerator );
 
         when( pageFile.pageSize() ).thenReturn( PAGE_SIZE );
@@ -153,7 +153,7 @@ public class CommonAbstractStoreTest
         long pageIdForRecord = store.pageIdForRecord( recordId );
 
         when( pageCursor.getCurrentPageId() ).thenReturn( pageIdForRecord );
-        when( pageCursor.next( anyInt() ) ).thenReturn( true );
+        when( pageCursor.next( anyLong() ) ).thenReturn( true );
 
         RecordCursor<TheRecord> cursor = store.newRecordCursor( newRecord( -1 ) );
         cursor.acquire( recordId, RecordLoad.FORCE );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RecordStoreUtil.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RecordStoreUtil.java
@@ -42,14 +42,15 @@ public class RecordStoreUtil
         @Override
         public NodeRecord answer( InvocationOnMock invocation ) throws Throwable
         {
-            if ( ((Number)invocation.getArguments()[0]).longValue() == 0L && invocation.getArguments()[1] == null &&
-                    invocation.getArguments()[2] == null )
+            if ( ((Number) invocation.getArgument( 0 )).longValue() == 0L &&
+                    invocation.getArgument( 1 ) == null &&
+                    invocation.getArgument( 2 ) == null )
             {
                 return null;
             }
 
-            NodeRecord record = (NodeRecord) invocation.getArguments()[1];
-            record.setId( ((Number)invocation.getArguments()[0]).longValue() );
+            NodeRecord record = invocation.getArgument( 1 );
+            record.setId( ((Number) invocation.getArgument( 0 )).longValue() );
             record.setInUse( true );
             record.setDense( dense );
             record.setNextRel( nextRel );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/ReaderLogVersionBridgeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/ReaderLogVersionBridgeTest.java
@@ -20,7 +20,7 @@
 package org.neo4j.kernel.impl.transaction;
 
 import org.junit.Test;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -66,9 +66,9 @@ public class ReaderLogVersionBridgeTest
         when( logFiles.getLogFileForVersion( version + 1 ) ).thenReturn( file );
         when( fs.fileExists( file ) ).thenReturn( true );
         when( fs.open( file, "r" ) ).thenReturn( newStoreChannel );
-        when( newStoreChannel.read( Matchers.<ByteBuffer>any() ) ).then( invocationOnMock ->
+        when( newStoreChannel.read( ArgumentMatchers.<ByteBuffer>any() ) ).then( invocationOnMock ->
         {
-            ByteBuffer buffer = (ByteBuffer) invocationOnMock.getArguments()[0];
+            ByteBuffer buffer = invocationOnMock.getArgument( 0 );
             buffer.putLong( encodeLogVersion( version + 1 ) );
             buffer.putLong( 42 );
             return LOG_HEADER_SIZE;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoStoreTransactionApplierTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/NeoStoreTransactionApplierTest.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.impl.transaction.command;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Matchers;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -78,6 +77,7 @@ import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -129,9 +129,9 @@ public class NeoStoreTransactionApplierTest
         when( neoStores.getPropertyKeyTokenStore() ).thenReturn( propertyKeyTokenStore );
         when( neoStores.getSchemaStore() ).thenReturn( schemaStore );
         when( nodeStore.getDynamicLabelStore() ).thenReturn( dynamicLabelStore );
-        when( lockService.acquireNodeLock( anyLong(), Matchers.any() ) )
+        when( lockService.acquireNodeLock( anyLong(), any() ) )
                 .thenReturn( LockService.NO_LOCK );
-        when( lockService.acquireRelationshipLock( anyLong(), Matchers.any() ) )
+        when( lockService.acquireRelationshipLock( anyLong(), any() ) )
                 .thenReturn( LockService.NO_LOCK );
         when( transactionToApply.transactionId() ).thenReturn( transactionId );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/ReversedMultiFileTransactionCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/ReversedMultiFileTransactionCursorTest.java
@@ -29,14 +29,12 @@ import org.neo4j.helpers.ArrayUtil;
 import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryCommit;
 
+import static java.lang.Math.toIntExact;
+import static java.util.Arrays.copyOfRange;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
-import static java.lang.Math.toIntExact;
-import static java.util.Arrays.copyOfRange;
-
 import static org.neo4j.kernel.impl.transaction.log.GivenTransactionCursor.exhaust;
 import static org.neo4j.kernel.impl.transaction.log.GivenTransactionCursor.given;
 import static org.neo4j.kernel.impl.transaction.log.LogPosition.start;
@@ -135,7 +133,7 @@ public class ReversedMultiFileTransactionCursorTest
 
         when( result.apply( any( LogPosition.class ) ) ).thenAnswer( invocation ->
         {
-            LogPosition position = invocation.getArgumentAt( 0, LogPosition.class );
+            LogPosition position = invocation.getArgument( 0 );
             if ( position == null )
             {
                 // A mockito issue when calling the "when" methods, I believe

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/ThresholdBasedPruneStrategyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/ThresholdBasedPruneStrategyTest.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.impl.transaction.log.pruning;
 
 import org.junit.Test;
-import org.mockito.Matchers;
 
 import java.io.File;
 
@@ -28,6 +27,8 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.transaction.log.LogFileInformation;
 import org.neo4j.kernel.impl.transaction.log.PhysicalLogFiles;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -67,9 +68,9 @@ public class ThresholdBasedPruneStrategyTest
         when( fileSystem.fileExists( fileName2 ) ).thenReturn( true );
         when( fileSystem.fileExists( fileName1 ) ).thenReturn( true );
 
-        when( fileSystem.getFileSize( Matchers.any() ) ).thenReturn( LOG_HEADER_SIZE + 1L );
+        when( fileSystem.getFileSize( any() ) ).thenReturn( LOG_HEADER_SIZE + 1L );
 
-        when( threshold.reached( Matchers.any(), anyLong(), Matchers.any() ) ).thenReturn( false );
+        when( threshold.reached( any(), anyLong(), any() ) ).thenReturn( false );
 
         final ThresholdBasedPruneStrategy strategy = new ThresholdBasedPruneStrategy( fileSystem, logFileInfo, files, threshold );
 
@@ -78,20 +79,20 @@ public class ThresholdBasedPruneStrategyTest
 
         // Then
         verify( threshold, times( 1 ) ).init();
-        verify( fileSystem, times( 0 ) ).deleteFile( Matchers.any() );
+        verify( fileSystem, times( 0 ) ).deleteFile( any() );
     }
 
     @Test
     public void shouldDeleteJustWhatTheThresholdSays() throws Exception
     {
         // Given
-        when( threshold.reached( Matchers.any(), Matchers.eq( 6L ), Matchers.any() ) )
+        when( threshold.reached( any(), eq( 6L ), any() ) )
                 .thenReturn( false );
-        when( threshold.reached( Matchers.any(), Matchers.eq( 5L ), Matchers.any() ) )
+        when( threshold.reached( any(), eq( 5L ), any() ) )
                 .thenReturn( false );
-        when( threshold.reached( Matchers.any(), Matchers.eq( 4L ), Matchers.any() ) )
+        when( threshold.reached( any(), eq( 4L ), any() ) )
                 .thenReturn( false );
-        when( threshold.reached( Matchers.any(), Matchers.eq( 3L ), Matchers.any() ) )
+        when( threshold.reached( any(), eq( 3L ), any() ) )
                 .thenReturn( true );
 
         File fileName1 = new File( "logical.log.v1" );
@@ -115,7 +116,7 @@ public class ThresholdBasedPruneStrategyTest
         when( fileSystem.fileExists( fileName2 ) ).thenReturn( true );
         when( fileSystem.fileExists( fileName1 ) ).thenReturn( true );
 
-        when( fileSystem.getFileSize( Matchers.any() ) ).thenReturn( LOG_HEADER_SIZE + 1L );
+        when( fileSystem.getFileSize( any() ) ).thenReturn( LOG_HEADER_SIZE + 1L );
 
         final ThresholdBasedPruneStrategy strategy = new ThresholdBasedPruneStrategy(
                 fileSystem, logFileInfo, files, threshold

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NodeStoreScanTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NodeStoreScanTest.java
@@ -50,17 +50,19 @@ public class NodeStoreScanTest
     public void shouldGiveBackCompletionPercentage() throws Throwable
     {
         // given
-        final int total = 10;
-        when( nodeStore.getHighId() ).thenReturn( (long) total );
+        long total = 10;
+        when( nodeStore.getHighId() ).thenReturn( total );
+        NodeRecord emptyRecord = new NodeRecord( 0 );
         NodeRecord inUseRecord = new NodeRecord( 42 );
         inUseRecord.setInUse( true );
+        when( nodeStore.newRecord() ).thenReturn( emptyRecord );
         when( nodeStore.getRecord( anyLong(), any( NodeRecord.class ), any( RecordLoad.class ) ) ).thenReturn(
                 inUseRecord, inUseRecord, inUseRecord, inUseRecord,
                 inUseRecord, inUseRecord, inUseRecord, inUseRecord, inUseRecord, inUseRecord );
 
         final PercentageSupplier percentageSupplier = new PercentageSupplier();
 
-        final NodeStoreScan<RuntimeException> scan = new NodeStoreScan<RuntimeException>( nodeStore, locks,  total )
+        final NodeStoreScan<RuntimeException> scan = new NodeStoreScan<RuntimeException>( nodeStore, locks, total )
         {
             private int read;
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PropertyLoaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/PropertyLoaderTest.java
@@ -171,8 +171,8 @@ public class PropertyLoaderTest
     {
         when( store.getRecord( eq( id ), any( recordClass ), any( RecordLoad.class ) ) ).thenAnswer( invocation ->
         {
-            R record = (R) invocation.getArguments()[1];
-            record.setId( ((Number)invocation.getArguments()[0]).longValue() );
+            R record = invocation.getArgument( 1 );
+            record.setId( ((Number) invocation.getArgument( 0 )).longValue() );
             record.setNextProp( 1 );
             return record;
         } );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/storeview/NeoStoreIndexStoreViewTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/storeview/NeoStoreIndexStoreViewTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.InOrder;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -68,7 +69,6 @@ import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.helpers.collection.Iterators.asSet;
 
 public class NeoStoreIndexStoreViewTest
@@ -104,7 +104,7 @@ public class NeoStoreIndexStoreViewTest
         when( locks.acquireNodeLock( anyLong(), any() ) ).thenAnswer(
                 invocation ->
                 {
-                    Long nodeId = (Long) invocation.getArguments()[0];
+                    Long nodeId = invocation.getArgument( 0 );
                     return lockMocks.computeIfAbsent( nodeId, k -> mock( Lock.class ) );
                 } );
         storeView = new NeoStoreIndexStoreView( locks, neoStores );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TraversalBranchImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TraversalBranchImplTest.java
@@ -29,6 +29,7 @@ import org.neo4j.graphdb.traversal.TraversalBranch;
 import org.neo4j.graphdb.traversal.TraversalContext;
 import org.neo4j.helpers.collection.Iterables;
 
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -52,7 +53,7 @@ public class TraversalBranchImplTest
         when( expander.expand( eq( branch ), any( BranchState.class ) ) )
                 .thenReturn( Iterables.emptyResourceIterable() );
         TraversalContext context = mock( TraversalContext.class );
-        when( context.evaluate( eq( branch ), any( BranchState.class ) ) ).thenReturn( INCLUDE_AND_CONTINUE );
+        when( context.evaluate( eq( branch ), isNull() ) ).thenReturn( INCLUDE_AND_CONTINUE );
 
         // WHEN initializing
         branch.initialize( expander, context );

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
@@ -114,11 +114,11 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static org.neo4j.graphdb.GraphDatabaseInternalLogIT.INTERNAL_LOG_FILE;
 import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.helpers.collection.Iterables.map;
@@ -930,7 +930,8 @@ public class BatchInsertTest
         verify( provider ).start();
         verify( provider ).getPopulator( anyLong(), any( IndexDescriptor.class ), any( IndexSamplingConfig.class ) );
         verify( populator ).create();
-        verify( populator ).add( argThat( matchesCollection( add( nodeId, internalIndex.schema(), Values.of( "Jakewins" ) ) ) ) );
+        verify( populator ).add( argThat( matchesCollection( add( nodeId, internalIndex.schema(),
+                Values.of( "Jakewins" ) ) ) ) );
         verify( populator ).verifyDeferredConstraints( any( PropertyAccessor.class ) );
         verify( populator ).close( true );
         verify( provider ).stop();

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/EncodeGroupsStepTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/EncodeGroupsStepTest.java
@@ -55,7 +55,7 @@ public class EncodeGroupsStepTest
         doAnswer( invocation ->
         {
             // our own way of marking that this has record been prepared (firstOut=1)
-            invocation.getArgumentAt( 0, RelationshipGroupRecord.class ).setFirstOut( 1 );
+            invocation.<RelationshipGroupRecord>getArgument( 0 ).setFirstOut( 1 );
             return null;
         } ).when( store ).prepareForCommit( any( RelationshipGroupRecord.class ) );
         Configuration config = Configuration.withBatchSize( DEFAULT, 10 );

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsProcessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/RelationshipCountsProcessorTest.java
@@ -108,11 +108,11 @@ public class RelationshipCountsProcessorTest
         verify( countsUpdater ).incrementRelationshipCount( ANY, 0, 2, 1L );
     }
 
-    private class IsNonNegativeLong extends ArgumentMatcher<Long>
+    private class IsNonNegativeLong implements ArgumentMatcher<Long>
     {
-        public boolean matches( Object argument )
+        public boolean matches( Long argument )
         {
-            return argument != null && ((Long) argument) >= 0;
+            return argument != null && argument >= 0;
         }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/StoreWithReservedId.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/StoreWithReservedId.java
@@ -28,6 +28,7 @@ import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.mock;
@@ -84,12 +85,12 @@ public final class StoreWithReservedId
         RecordCursor<R> cursor = mock( RecordCursor.class );
         when( cursor.next( anyInt() ) ).thenAnswer( invocation ->
         {
-            long id = (long) invocation.getArguments()[0];
+            long id = invocation.getArgument( 0 );
             long realId = (id == highId - 1) ? IdGeneratorImpl.INTEGER_MINUS_ONE : id;
             record.setId( realId );
             return true;
         } );
-        when( cursor.acquire( anyInt(), any() ) ).thenReturn( cursor );
+        when( cursor.acquire( anyLong(), any() ) ).thenReturn( cursor );
         return cursor;
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactoryTest.java
@@ -112,7 +112,7 @@ public class NumberArrayFactoryTest
     {
         // GIVEN
         NumberArrayFactory lowMemoryFactory = mock( NumberArrayFactory.class );
-        doThrow( OutOfMemoryError.class ).when( lowMemoryFactory ).newIntArray( anyLong(), anyInt(), anyInt() );
+        doThrow( OutOfMemoryError.class ).when( lowMemoryFactory ).newIntArray( anyLong(), anyInt(), anyLong() );
         NumberArrayFactory factory = new NumberArrayFactory.Auto( lowMemoryFactory, NumberArrayFactory.HEAP );
 
         // WHEN
@@ -131,7 +131,7 @@ public class NumberArrayFactoryTest
         // GIVEN
         NumberArrayFactory throwingMemoryFactory = mock( NumberArrayFactory.class );
         doThrow( ArithmeticException.class ).when( throwingMemoryFactory )
-                .newByteArray( anyLong(), any( byte[].class ), anyInt() );
+                .newByteArray( anyLong(), any( byte[].class ), anyLong() );
         NumberArrayFactory factory = new NumberArrayFactory.Auto( throwingMemoryFactory, NumberArrayFactory.HEAP );
 
         // WHEN

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/verification/PartitionedUniquenessVerifierTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/verification/PartitionedUniquenessVerifierTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Answers;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueDatabaseIndexPopulatingUpdaterTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueDatabaseIndexPopulatingUpdaterTest.java
@@ -33,10 +33,10 @@ import org.neo4j.storageengine.api.schema.IndexSample;
 
 import static org.hamcrest.Matchers.hasToString;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static org.neo4j.kernel.api.impl.LuceneTestUtil.documentRepresentingProperties;
 import static org.neo4j.kernel.api.impl.schema.LuceneDocumentStructure.newTermForChangeOrRemove;
 import static org.neo4j.kernel.api.index.IndexQueryHelper.add;

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/reader/PartitionedIndexReaderTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/reader/PartitionedIndexReaderTest.java
@@ -22,7 +22,7 @@ package org.neo4j.kernel.api.impl.schema.reader;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.util.Arrays;

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/reader/SimpleIndexReaderTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/reader/SimpleIndexReaderTest.java
@@ -22,9 +22,10 @@ package org.neo4j.kernel.api.impl.schema.reader;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
+import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.NumericRangeQuery;
-import org.apache.lucene.search.PrefixQuery;
-import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.TermRangeQuery;
+import org.apache.lucene.search.TotalHitCountCollector;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -81,7 +82,7 @@ public class SimpleIndexReaderTest
 
         simpleIndexReader.query( IndexQuery.exact( 1, "test" ) );
 
-        verify( indexSearcher ).search( any( TermQuery.class ), any( DocValuesCollector.class ) );
+        verify( indexSearcher ).search( any( BooleanQuery.class ), any( DocValuesCollector.class ) );
     }
 
     @Test
@@ -101,7 +102,7 @@ public class SimpleIndexReaderTest
 
         simpleIndexReader.query( range( 1, "a", false, "b", true ) );
 
-        verify( indexSearcher ).search( any( TermQuery.class ), any( DocValuesCollector.class ) );
+        verify( indexSearcher ).search( any( TermRangeQuery.class ), any( DocValuesCollector.class ) );
     }
 
     @Test
@@ -111,7 +112,7 @@ public class SimpleIndexReaderTest
 
         simpleIndexReader.query( IndexQuery.stringPrefix( 1, "bb" ) );
 
-        verify( indexSearcher ).search( any( PrefixQuery.class ), any( DocValuesCollector.class ) );
+        verify( indexSearcher ).search( any( MultiTermQuery.class ), any( DocValuesCollector.class ) );
     }
 
     @Test
@@ -131,7 +132,7 @@ public class SimpleIndexReaderTest
 
         simpleIndexReader.countIndexedNodes( 2, Values.of( "testValue" ) );
 
-        verify( indexSearcher ).search( any( BooleanQuery.class ), any( DocValuesCollector.class ) );
+        verify( indexSearcher ).search( any( BooleanQuery.class ), any( TotalHitCountCollector.class ) );
     }
 
     @Test

--- a/community/server/src/test/java/org/neo4j/server/modules/DBMSModuleTest.java
+++ b/community/server/src/test/java/org/neo4j/server/modules/DBMSModuleTest.java
@@ -19,11 +19,9 @@
  */
 package org.neo4j.server.modules;
 
-import org.hamcrest.Description;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentMatcher;
-import org.mockito.Matchers;
 
 import java.net.URI;
 import java.util.List;
@@ -35,6 +33,8 @@ import org.neo4j.server.rest.dbms.UserService;
 import org.neo4j.server.web.WebServer;
 import org.neo4j.test.rule.SuppressOutput;
 
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Matchers.anyCollection;
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Matchers.anyString;
@@ -65,7 +65,7 @@ public class DBMSModuleTest
 
         module.start();
 
-        verify( webServer ).addJAXRSClasses( anyList(), anyString(), anyCollection() );
+        verify( webServer ).addJAXRSClasses( anyList(), anyString(), isNull() );
     }
 
     @SuppressWarnings( "unchecked" )
@@ -84,20 +84,18 @@ public class DBMSModuleTest
 
         module.start();
 
-        verify( webServer ).addJAXRSClasses( anyList(), anyString(), anyCollection() );
-        verify( webServer, never() ).addJAXRSClasses( Matchers.argThat( new ArgumentMatcher<List<String>>()
+        verify( webServer ).addJAXRSClasses( anyList(), anyString(), isNull() );
+        verify( webServer, never() ).addJAXRSClasses( argThat( new ArgumentMatcher<List<String>>()
         {
             @Override
-            public boolean matches( Object argument )
+            public boolean matches( List<String> argument )
             {
-                List<String> argumentList = (List<String>) argument;
-                return argumentList.contains( UserService.class.getName() );
+                return argument.contains( UserService.class.getName() );
             }
 
-            @Override
-            public void describeTo( Description description )
+            public String toString()
             {
-                description.appendText( "<List containing " + UserService.class.getName() + ">" );
+                return "<List containing " + UserService.class.getName() + ">";
             }
         } ), anyString(), anyCollection() );
     }

--- a/community/server/src/test/java/org/neo4j/server/rest/repr/RepresentationFormatRepositoryTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/repr/RepresentationFormatRepositoryTest.java
@@ -20,10 +20,8 @@
 package org.neo4j.server.rest.repr;
 
 import org.junit.Test;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.io.ByteArrayOutputStream;
 import java.net.URI;
@@ -38,7 +36,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -82,9 +80,9 @@ public class RepresentationFormatRepositoryTest
     {
         final Response.ResponseBuilder responseBuilder = mock( Response.ResponseBuilder.class );
         // no streaming
-        when( responseBuilder.entity( anyString() ) ).thenReturn( responseBuilder );
+        when( responseBuilder.entity( any(byte[].class) ) ).thenReturn( responseBuilder );
         Mockito.verify( responseBuilder, never() ).entity( isA( StreamingOutput.class ) );
-        when( responseBuilder.type( Matchers.<MediaType>any() ) ).thenReturn( responseBuilder );
+        when( responseBuilder.type( ArgumentMatchers.<MediaType>any() ) ).thenReturn( responseBuilder );
         when( responseBuilder.build() ).thenReturn( null );
         OutputFormat format = repository.outputFormat( asList( MediaType.TEXT_HTML_TYPE ),
                 new URI( "http://some.host" ), streamingHeader() );
@@ -112,13 +110,13 @@ public class RepresentationFormatRepositoryTest
     private Response.ResponseBuilder mockResponsBuilder( Response response, final AtomicReference<StreamingOutput> ref )
     {
         final Response.ResponseBuilder responseBuilder = mock( Response.ResponseBuilder.class );
-        when( responseBuilder.entity( Matchers.isA( StreamingOutput.class ) ) ).thenAnswer(
+        when( responseBuilder.entity( ArgumentMatchers.isA( StreamingOutput.class ) ) ).thenAnswer(
                 invocationOnMock ->
                 {
-                    ref.set( (StreamingOutput) invocationOnMock.getArguments()[0] );
+                    ref.set( invocationOnMock.getArgument( 0 ) );
                     return responseBuilder;
                 } );
-        when( responseBuilder.type( Matchers.<MediaType>any() ) ).thenReturn( responseBuilder );
+        when( responseBuilder.type( ArgumentMatchers.<MediaType>any() ) ).thenReturn( responseBuilder );
         when( responseBuilder.build() ).thenReturn( response );
         return responseBuilder;
     }

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/ExecutionResultSerializerTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/ExecutionResultSerializerTest.java
@@ -22,8 +22,6 @@ package org.neo4j.server.rest.transactional;
 import org.codehaus.jackson.JsonNode;
 import org.junit.Test;
 import org.mockito.internal.stubbing.answers.ThrowsException;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -992,7 +990,7 @@ public class ExecutionResultSerializerTest extends TxStateCheckerTestSupport
         doAnswer( invocation ->
         {
             Result result = (Result) invocation.getMock();
-            Result.ResultVisitor visitor = (Result.ResultVisitor) invocation.getArguments()[0];
+            Result.ResultVisitor visitor = invocation.getArgument( 0 );
             while ( result.hasNext() )
             {
                 visitor.visit( new MapRow( result.next() ) );

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleTest.java
@@ -24,7 +24,6 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Test;
 import org.mockito.InOrder;
-import org.mockito.hamcrest.MockitoHamcrest;
 
 import java.net.URI;
 import java.util.HashSet;
@@ -67,6 +66,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static org.neo4j.helpers.collection.MapUtil.map;
 import static org.neo4j.kernel.api.KernelTransaction.Type.explicit;
 import static org.neo4j.kernel.api.security.SecurityContext.AUTH_DISABLED;
@@ -101,7 +101,7 @@ public class TransactionHandleTest
         outputOrder.verify( output ).statementResult( executionResult, false, (ResultDataContent[])null );
         outputOrder.verify( output ).notifications( anyCollection() );
         outputOrder.verify( output ).transactionStatus( anyLong() );
-        outputOrder.verify( output ).errors( MockitoHamcrest.argThat( hasNoErrors() ) );
+        outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
     }
@@ -135,9 +135,9 @@ public class TransactionHandleTest
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).transactionCommitUri( uriScheme.txCommitUri( 1337 ) );
         outputOrder.verify( output ).statementResult( executionResult, false, (ResultDataContent[])null );
-        outputOrder.verify( output ).notifications( anyCollectionOf( Notification.class ) );
+        outputOrder.verify( output ).notifications( anyCollection() );
         outputOrder.verify( output ).transactionStatus( anyLong() );
-        outputOrder.verify( output ).errors( MockitoHamcrest.argThat( hasNoErrors() ) );
+        outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
     }
@@ -179,7 +179,7 @@ public class TransactionHandleTest
         outputOrder.verify( output ).statementResult( executionResult, false, (ResultDataContent[]) null );
         outputOrder.verify( output ).notifications( anyCollectionOf( Notification.class ) );
         outputOrder.verify( output ).transactionStatus( anyLong() );
-        outputOrder.verify( output ).errors( MockitoHamcrest.argThat( hasNoErrors() ) );
+        outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
     }
@@ -213,7 +213,7 @@ public class TransactionHandleTest
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).statementResult( executionResult, false, (ResultDataContent[]) null );
         outputOrder.verify( output ).notifications( anyCollectionOf( Notification.class ) );
-        outputOrder.verify( output ).errors( MockitoHamcrest.argThat( hasNoErrors() ) );
+        outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
     }
@@ -251,7 +251,7 @@ public class TransactionHandleTest
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).statementResult( result, false, (ResultDataContent[])null );
         outputOrder.verify( output ).notifications( anyCollectionOf( Notification.class ) );
-        outputOrder.verify( output ).errors( MockitoHamcrest.argThat( hasNoErrors() ) );
+        outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
     }
@@ -279,7 +279,7 @@ public class TransactionHandleTest
         transactionOrder.verify( registry ).forget( 1337L );
 
         InOrder outputOrder = inOrder( output );
-        outputOrder.verify( output ).errors( MockitoHamcrest.argThat( hasNoErrors() ) );
+        outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
     }
@@ -318,7 +318,7 @@ public class TransactionHandleTest
         outputOrder.verify( output ).statementResult( executionResult, false, (ResultDataContent[])null );
         outputOrder.verify( output ).notifications( anyCollectionOf( Notification.class ) );
         outputOrder.verify( output ).transactionStatus( anyLong() );
-        outputOrder.verify( output ).errors( MockitoHamcrest.argThat( hasNoErrors() ) );
+        outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
     }
@@ -350,7 +350,7 @@ public class TransactionHandleTest
 
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).transactionCommitUri( uriScheme.txCommitUri( 1337 ) );
-        outputOrder.verify( output ).errors( MockitoHamcrest.argThat( hasErrors( Status.Statement.ExecutionFailed ) ) );
+        outputOrder.verify( output ).errors( argThat( hasErrors( Status.Statement.ExecutionFailed ) ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
     }
@@ -390,7 +390,7 @@ public class TransactionHandleTest
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).statementResult( executionResult, false, (ResultDataContent[])null );
         outputOrder.verify( output ).notifications( anyCollectionOf( Notification.class ) );
-        outputOrder.verify( output ).errors( MockitoHamcrest.argThat( hasErrors( Status.Transaction
+        outputOrder.verify( output ).errors( argThat( hasErrors( Status.Transaction
                 .TransactionCommitFailed ) ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
@@ -422,7 +422,7 @@ public class TransactionHandleTest
         verify( registry ).forget( 1337L );
 
         InOrder outputOrder = inOrder( output );
-        outputOrder.verify( output ).errors( MockitoHamcrest.argThat( hasErrors( Status.Statement.SyntaxError ) ) );
+        outputOrder.verify( output ).errors( argThat( hasErrors( Status.Statement.SyntaxError ) ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
     }
@@ -454,7 +454,7 @@ public class TransactionHandleTest
 
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).statementResult( isNull(), eq( false ), isNull() );
-        outputOrder.verify( output ).errors( MockitoHamcrest.argThat( hasErrors( Status.Statement.ExecutionFailed ) ) );
+        outputOrder.verify( output ).errors( argThat( hasErrors( Status.Statement.ExecutionFailed ) ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
     }
@@ -503,7 +503,7 @@ public class TransactionHandleTest
                 mock( HttpServletRequest.class ) );
 
         // then
-        verify( output ).errors( MockitoHamcrest.argThat( hasErrors( Status.Transaction.DeadlockDetected ) ) );
+        verify( output ).errors( argThat( hasErrors( Status.Transaction.DeadlockDetected ) ) );
     }
 
     @Test

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleTest.java
@@ -24,6 +24,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Test;
 import org.mockito.InOrder;
+import org.mockito.hamcrest.MockitoHamcrest;
 
 import java.net.URI;
 import java.util.HashSet;
@@ -49,12 +50,13 @@ import org.neo4j.server.rest.transactional.error.Neo4jError;
 import org.neo4j.server.rest.web.TransactionUriScheme;
 
 import static java.util.Arrays.asList;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Matchers.anyCollectionOf;
 import static org.mockito.Matchers.anyMap;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
-import static org.mockito.Mockito.argThat;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.inOrder;
@@ -97,9 +99,9 @@ public class TransactionHandleTest
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).transactionCommitUri( uriScheme.txCommitUri( 1337 ) );
         outputOrder.verify( output ).statementResult( executionResult, false, (ResultDataContent[])null );
-        outputOrder.verify( output ).notifications( anyCollectionOf( Notification.class ) );
+        outputOrder.verify( output ).notifications( anyCollection() );
         outputOrder.verify( output ).transactionStatus( anyLong() );
-        outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
+        outputOrder.verify( output ).errors( MockitoHamcrest.argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
     }
@@ -135,7 +137,7 @@ public class TransactionHandleTest
         outputOrder.verify( output ).statementResult( executionResult, false, (ResultDataContent[])null );
         outputOrder.verify( output ).notifications( anyCollectionOf( Notification.class ) );
         outputOrder.verify( output ).transactionStatus( anyLong() );
-        outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
+        outputOrder.verify( output ).errors( MockitoHamcrest.argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
     }
@@ -177,7 +179,7 @@ public class TransactionHandleTest
         outputOrder.verify( output ).statementResult( executionResult, false, (ResultDataContent[]) null );
         outputOrder.verify( output ).notifications( anyCollectionOf( Notification.class ) );
         outputOrder.verify( output ).transactionStatus( anyLong() );
-        outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
+        outputOrder.verify( output ).errors( MockitoHamcrest.argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
     }
@@ -211,7 +213,7 @@ public class TransactionHandleTest
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).statementResult( executionResult, false, (ResultDataContent[]) null );
         outputOrder.verify( output ).notifications( anyCollectionOf( Notification.class ) );
-        outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
+        outputOrder.verify( output ).errors( MockitoHamcrest.argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
     }
@@ -249,7 +251,7 @@ public class TransactionHandleTest
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).statementResult( result, false, (ResultDataContent[])null );
         outputOrder.verify( output ).notifications( anyCollectionOf( Notification.class ) );
-        outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
+        outputOrder.verify( output ).errors( MockitoHamcrest.argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
     }
@@ -277,7 +279,7 @@ public class TransactionHandleTest
         transactionOrder.verify( registry ).forget( 1337L );
 
         InOrder outputOrder = inOrder( output );
-        outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
+        outputOrder.verify( output ).errors( MockitoHamcrest.argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
     }
@@ -316,7 +318,7 @@ public class TransactionHandleTest
         outputOrder.verify( output ).statementResult( executionResult, false, (ResultDataContent[])null );
         outputOrder.verify( output ).notifications( anyCollectionOf( Notification.class ) );
         outputOrder.verify( output ).transactionStatus( anyLong() );
-        outputOrder.verify( output ).errors( argThat( hasNoErrors() ) );
+        outputOrder.verify( output ).errors( MockitoHamcrest.argThat( hasNoErrors() ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
     }
@@ -348,7 +350,7 @@ public class TransactionHandleTest
 
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).transactionCommitUri( uriScheme.txCommitUri( 1337 ) );
-        outputOrder.verify( output ).errors( argThat( hasErrors( Status.Statement.ExecutionFailed ) ) );
+        outputOrder.verify( output ).errors( MockitoHamcrest.argThat( hasErrors( Status.Statement.ExecutionFailed ) ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
     }
@@ -388,7 +390,8 @@ public class TransactionHandleTest
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).statementResult( executionResult, false, (ResultDataContent[])null );
         outputOrder.verify( output ).notifications( anyCollectionOf( Notification.class ) );
-        outputOrder.verify( output ).errors( argThat( hasErrors( Status.Transaction.TransactionCommitFailed ) ) );
+        outputOrder.verify( output ).errors( MockitoHamcrest.argThat( hasErrors( Status.Transaction
+                .TransactionCommitFailed ) ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
     }
@@ -419,7 +422,7 @@ public class TransactionHandleTest
         verify( registry ).forget( 1337L );
 
         InOrder outputOrder = inOrder( output );
-        outputOrder.verify( output ).errors( argThat( hasErrors( Status.Statement.SyntaxError ) ) );
+        outputOrder.verify( output ).errors( MockitoHamcrest.argThat( hasErrors( Status.Statement.SyntaxError ) ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
     }
@@ -450,7 +453,8 @@ public class TransactionHandleTest
         verify( registry ).forget( 1337L );
 
         InOrder outputOrder = inOrder( output );
-        outputOrder.verify( output ).errors( argThat( hasErrors( Status.Statement.ExecutionFailed ) ) );
+        outputOrder.verify( output ).statementResult( isNull(), eq( false ), isNull() );
+        outputOrder.verify( output ).errors( MockitoHamcrest.argThat( hasErrors( Status.Statement.ExecutionFailed ) ) );
         outputOrder.verify( output ).finish();
         verifyNoMoreInteractions( output );
     }
@@ -484,7 +488,7 @@ public class TransactionHandleTest
     {
         // given
         QueryExecutionEngine executionEngine = mock( QueryExecutionEngine.class );
-        when( executionEngine.executeQuery( anyString(), anyMap(), any( TransactionalContext.class ) ) )
+        when( executionEngine.executeQuery( anyString(), anyMap(), isNull() ) )
                 .thenThrow( new DeadlockDetectedException( "deadlock" ) );
 
         GraphDatabaseQueryService queryService = mock( GraphDatabaseQueryService.class );
@@ -499,7 +503,7 @@ public class TransactionHandleTest
                 mock( HttpServletRequest.class ) );
 
         // then
-        verify( output ).errors( argThat( hasErrors( Status.Transaction.DeadlockDetected ) ) );
+        verify( output ).errors( MockitoHamcrest.argThat( hasErrors( Status.Transaction.DeadlockDetected ) ) );
     }
 
     @Test

--- a/community/server/src/test/java/org/neo4j/server/rest/web/CollectUserAgentFilterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/web/CollectUserAgentFilterTest.java
@@ -37,7 +37,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.stub;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.test.rule.SuppressOutput.suppressAll;
@@ -92,7 +91,7 @@ public class CollectUserAgentFilterTest
     public void shouldSwallowAnyExceptionsThrownByTheRequest() throws IOException, ServletException
     {
         HttpServletRequest request = mock( HttpServletRequest.class );
-        stub(request.getHeader( anyString() )).toThrow( new RuntimeException() );
+        when(request.getHeader( anyString() )).thenThrow( new RuntimeException() );
         filter.doFilter( request, null, filterChain );
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/RaftMachineLogTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/RaftMachineLogTest.java
@@ -23,7 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import org.neo4j.causalclustering.core.consensus.RaftMachine;
 import org.neo4j.causalclustering.core.consensus.RaftMachineBuilder;

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/PruningStrategyTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/segmented/PruningStrategyTest.java
@@ -55,7 +55,7 @@ abstract class PruningStrategyTest
     {
         doAnswer( invocation ->
         {
-            Visitor<SegmentFile,RuntimeException> visitor = (Visitor) invocation.getArguments()[0];
+            Visitor<SegmentFile,RuntimeException> visitor = invocation.getArgument( 0 );
             ListIterator<SegmentFile> itr = files.listIterator( files.size() );
             boolean terminate = false;
             while ( itr.hasPrevious() && !terminate )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/membership/RaftGroupMembershipTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/membership/RaftGroupMembershipTest.java
@@ -25,7 +25,7 @@ import org.hamcrest.TypeSafeMatcher;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import org.neo4j.causalclustering.core.consensus.DirectNetworking;
 import org.neo4j.causalclustering.core.consensus.RaftTestFixture;

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/AppendEntriesMessageFlowTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/AppendEntriesMessageFlowTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/AppendingTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/AppendingTest.java
@@ -27,8 +27,8 @@ import org.neo4j.causalclustering.core.consensus.RaftMessages;
 import org.neo4j.causalclustering.core.consensus.ReplicatedInteger;
 import org.neo4j.causalclustering.core.consensus.log.RaftLogEntry;
 import org.neo4j.causalclustering.core.consensus.log.ReadableRaftLog;
-import org.neo4j.causalclustering.core.consensus.outcome.RaftLogCommand;
 import org.neo4j.causalclustering.core.consensus.outcome.Outcome;
+import org.neo4j.causalclustering.core.consensus.outcome.RaftLogCommand;
 import org.neo4j.causalclustering.core.consensus.outcome.TruncateLogCommand;
 import org.neo4j.causalclustering.core.consensus.state.ReadableRaftState;
 import org.neo4j.causalclustering.identity.MemberId;
@@ -37,11 +37,11 @@ import org.neo4j.logging.NullLog;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static org.neo4j.causalclustering.identity.RaftTestMember.member;
 
 public class AppendingTest

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/CandidateTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/CandidateTest.java
@@ -21,7 +21,7 @@ package org.neo4j.causalclustering.core.consensus.roles;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/ElectionTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/ElectionTest.java
@@ -22,7 +22,7 @@ package org.neo4j.causalclustering.core.consensus.roles;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import org.neo4j.causalclustering.core.consensus.RaftMachine;
 import org.neo4j.causalclustering.core.consensus.RaftMachineBuilder;

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/FollowerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/FollowerTest.java
@@ -22,7 +22,7 @@ package org.neo4j.causalclustering.core.consensus.roles;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.util.Collection;

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/LeaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/LeaderTest.java
@@ -21,7 +21,7 @@ package org.neo4j.causalclustering.core.consensus.roles;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import org.neo4j.causalclustering.core.consensus.RaftMessages;
 import org.neo4j.causalclustering.core.consensus.RaftMessages.AppendEntries;

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/vote/VotingTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/vote/VotingTest.java
@@ -21,7 +21,7 @@ package org.neo4j.causalclustering.core.consensus.vote;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.UUID;
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedTokenHolderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/token/ReplicatedTokenHolderTest.java
@@ -122,8 +122,8 @@ public class ReplicatedTokenHolderTest
         StorageEngine storageEngine = mock( StorageEngine.class );
         doAnswer( invocation ->
         {
-            Collection<StorageCommand> target = invocation.getArgumentAt( 0, Collection.class );
-            ReadableTransactionState txState = invocation.getArgumentAt( 1, ReadableTransactionState.class );
+            Collection<StorageCommand> target = invocation.getArgument( 0 );
+            ReadableTransactionState txState = invocation.getArgument( 1 );
             txState.accept( new TxStateVisitor.Adapter()
             {
                 @Override

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransactionStateMachineTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransactionStateMachineTest.java
@@ -163,7 +163,7 @@ public class ReplicatedTransactionStateMachineTest
                 any( TransactionToApply.class), any( CommitEvent.class ), any( TransactionApplicationMode.class ) )
         ).thenAnswer( invocation ->
         {
-            TransactionToApply txToApply = (TransactionToApply) invocation.getArguments()[0];
+            TransactionToApply txToApply = invocation.getArgument( 0 );
             txToApply.commitment( new FakeCommitment( txId, mock( TransactionIdStore.class ) ), txId );
             txToApply.commitment().publishAsCommitted();
             txToApply.commitment().publishAsClosed();

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/RaftMessageProcessingTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/RaftMessageProcessingTest.java
@@ -23,7 +23,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.util.UUID;

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/StateMachinesTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/StateMachinesTest.java
@@ -20,16 +20,13 @@
 package org.neo4j.cluster;
 
 import org.junit.Test;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.Executor;
 
 import org.neo4j.cluster.com.message.Message;
 import org.neo4j.cluster.com.message.MessageHolder;
@@ -92,13 +89,13 @@ public class StateMachinesTest
         // The sender, which adds messages outgoing to the list above.
         doAnswer( invocation ->
         {
-            sentOut.addAll( (Collection<? extends Message>) invocation.getArguments()[0] );
+            sentOut.addAll( invocation.getArgument( 0 ) );
             return null;
-        } ).when( sender ).process( Matchers.<List<Message<? extends MessageType>>>any() );
+        } ).when( sender ).process( ArgumentMatchers.<List<Message<? extends MessageType>>>any() );
 
         StateMachines stateMachines = new StateMachines( NullLogProvider.getInstance(), mock( StateMachines.Monitor.class ),
                 mock( MessageSource.class ), sender,
-                mock( Timeouts.class ), mock( DelayedDirectExecutor.class ), command -> command.run(), me
+                mock( Timeouts.class ), mock( DelayedDirectExecutor.class ), Runnable::run, me
         );
 
         // The state machine, which has a TestMessage message type and simply adds a TO header to the messages it
@@ -107,8 +104,8 @@ public class StateMachinesTest
         when( machine.getMessageType() ).then( (Answer<Object>) invocation -> TestMessage.class );
         doAnswer( invocation ->
         {
-            Message message = (Message) invocation.getArguments()[0];
-            MessageHolder holder = (MessageHolder) invocation.getArguments()[1];
+            Message message = invocation.getArgument( 0 );
+            MessageHolder holder = invocation.getArgument( 1 );
             message.setHeader( Message.TO, "to://neverland" );
             holder.offer( message );
             return null;

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/com/message/NetworkSenderReceiverTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/com/message/NetworkSenderReceiverTest.java
@@ -20,7 +20,7 @@
 package org.neo4j.cluster.com.message;
 
 import org.junit.Test;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 
 import java.net.URI;
 import java.util.Map;
@@ -116,7 +116,7 @@ public class NetworkSenderReceiverTest
         {
             LogProvider logProviderMock = mock( LogProvider.class );
             Log logMock = mock( Log.class );
-            when( logProviderMock.getLog( Matchers.<Class>any() ) ).thenReturn( logMock );
+            when( logProviderMock.getLog( ArgumentMatchers.<Class>any() ) ).thenReturn( logMock );
 
             final Semaphore sem = new Semaphore( 0 );
 

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/MessageArgumentMatcher.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/MessageArgumentMatcher.java
@@ -81,13 +81,13 @@ public class MessageArgumentMatcher<T extends MessageType> implements ArgumentMa
             return false;
         }
         boolean toMatches = to == null || to.toString().equals( message.getHeader( Message.TO ) );
-        boolean fromMatches = from == null || from.toString().equals( ((Message) message).getHeader( Message.FROM ) );
+        boolean fromMatches = from == null || from.toString().equals( message.getHeader( Message.FROM ) );
         boolean typeMatches = theMessageType == null || theMessageType == ((Message) message).getMessageType();
-        boolean payloadMatches = payload == null || payload.equals( ((Message) message).getPayload() );
+        boolean payloadMatches = payload == null || payload.equals( message.getPayload() );
         boolean headersMatch = true;
         for ( String header : headers )
         {
-            headersMatch = headersMatch && matchHeaderAndValue( header, ((Message) message).getHeader( header ) );
+            headersMatch = headersMatch && matchHeaderAndValue( header, message.getHeader( header ) );
         }
         return fromMatches && toMatches && typeMatches && payloadMatches && headersMatch;
     }

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/MessageArgumentMatcher.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/MessageArgumentMatcher.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.cluster.protocol;
 
-import org.hamcrest.Description;
 import org.mockito.ArgumentMatcher;
 
 import java.io.Serializable;
@@ -30,7 +29,7 @@ import java.util.List;
 import org.neo4j.cluster.com.message.Message;
 import org.neo4j.cluster.com.message.MessageType;
 
-public class MessageArgumentMatcher<T extends MessageType> extends ArgumentMatcher<Message<T>>
+public class MessageArgumentMatcher<T extends MessageType> implements ArgumentMatcher<Message<T>>
 {
     private URI from;
     private URI to;
@@ -75,25 +74,20 @@ public class MessageArgumentMatcher<T extends MessageType> extends ArgumentMatch
     }
 
     @Override
-    public boolean matches( Object message )
+    public boolean matches( Message<T> message )
     {
-        if ( message == null || !( message instanceof Message ) )
+        if ( message == null )
         {
             return false;
         }
-        if ( message == this )
-        {
-            return true;
-        }
-        Message toMatchAgainst = (Message) message;
-        boolean toMatches = to == null || to.toString().equals( toMatchAgainst.getHeader( Message.TO ) );
-        boolean fromMatches = from == null || from.toString().equals( toMatchAgainst.getHeader( Message.FROM ) );
-        boolean typeMatches = theMessageType == null || theMessageType == toMatchAgainst.getMessageType();
-        boolean payloadMatches = payload == null || payload.equals( toMatchAgainst.getPayload() );
+        boolean toMatches = to == null || to.toString().equals( message.getHeader( Message.TO ) );
+        boolean fromMatches = from == null || from.toString().equals( ((Message) message).getHeader( Message.FROM ) );
+        boolean typeMatches = theMessageType == null || theMessageType == ((Message) message).getMessageType();
+        boolean payloadMatches = payload == null || payload.equals( ((Message) message).getPayload() );
         boolean headersMatch = true;
         for ( String header : headers )
         {
-            headersMatch = headersMatch && matchHeaderAndValue( header, toMatchAgainst.getHeader( header ) );
+            headersMatch = headersMatch && matchHeaderAndValue( header, ((Message) message).getHeader( header ) );
         }
         return fromMatches && toMatches && typeMatches && payloadMatches && headersMatch;
     }
@@ -115,10 +109,9 @@ public class MessageArgumentMatcher<T extends MessageType> extends ArgumentMatch
     }
 
     @Override
-    public void describeTo( Description description )
+    public String toString()
     {
-        description.appendText(
-                (theMessageType != null ? theMessageType.name() : "<no particular message type>") +
-                "{from=" + from + ", to=" + to + ", payload=" + payload + "}" );
+        return (theMessageType != null ? theMessageType.name() : "<no particular message type>") + "{from=" + from +
+                ", to=" + to + ", payload=" + payload + "}";
     }
 }

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/LearnerStateTest.java
@@ -20,7 +20,7 @@
 package org.neo4j.cluster.protocol.atomicbroadcast.multipaxos;
 
 import org.junit.Test;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -105,7 +105,7 @@ public class LearnerStateTest
         verify( ctx, times( 0 ) ).notifyLearnMiss( paxosInstanceIdIDontHave );
         // but the learn failed went out anyway
         verify( outgoing, times( 1 ) ).offer(
-                Matchers.<Message<? extends MessageType>>argThat( new MessageArgumentMatcher()
+                ArgumentMatchers.<Message<? extends MessageType>>argThat( new MessageArgumentMatcher()
                         .onMessageType( LearnerMessage.learnFailed ).to( URI.create( "c:/2" ) ) )
         );
     }
@@ -175,11 +175,11 @@ public class LearnerStateTest
 
         // Then
         verify( outgoing, times( 1 ) ).offer(
-                Matchers.<Message<? extends MessageType>>argThat( new MessageArgumentMatcher()
+                ArgumentMatchers.<Message<? extends MessageType>>argThat( new MessageArgumentMatcher()
                         .onMessageType( LearnerMessage.learnRequest ).to( instance2 ) )
         );
         verify( outgoing, times( 1 ) ).offer(
-                Matchers.<Message<? extends MessageType>>argThat( new MessageArgumentMatcher()
+                ArgumentMatchers.<Message<? extends MessageType>>argThat( new MessageArgumentMatcher()
                         .onMessageType( LearnerMessage.learnRequest ).to( instance4 ) )
         );
         verifyNoMoreInteractions( outgoing );

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/ProposerStateTest.java
@@ -20,11 +20,10 @@
 package org.neo4j.cluster.protocol.atomicbroadcast.multipaxos;
 
 import org.junit.Test;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import java.io.Serializable;
-import java.net.URI;
 
 import org.neo4j.cluster.com.message.Message;
 import org.neo4j.cluster.com.message.MessageHolder;
@@ -84,7 +83,7 @@ public class ProposerStateTest
 
         // Verify it was resent as a propose with the same value
         verify( mockHolder, times(1) ).offer(
-                Matchers.<Message<? extends MessageType>>argThat(
+                ArgumentMatchers.<Message<? extends MessageType>>argThat(
                         new MessageArgumentMatcher().onMessageType( ProposerMessage.propose ).withPayload( theTimedoutPayload )
                 ) );
         verify( context, times(1) ).unbookInstance( instanceId );

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterStateTest.java
@@ -281,7 +281,7 @@ public class ClusterStateTest
         return new InstanceId( i );
     }
 
-    private static class ConfigurationResponseStateMatcher extends ArgumentMatcher<ConfigurationResponseState>
+    private static class ConfigurationResponseStateMatcher implements ArgumentMatcher<ConfigurationResponseState>
     {
         private Map<InstanceId, URI> members;
 
@@ -292,10 +292,9 @@ public class ClusterStateTest
         }
 
         @Override
-        public boolean matches( Object argument )
+        public boolean matches( ConfigurationResponseState argument )
         {
-            ConfigurationResponseState arg = (ConfigurationResponseState) argument;
-            return arg.getMembers().equals( this.members );
+            return argument.getMembers().equals( this.members );
         }
     }
 }

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/election/ElectionStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/election/ElectionStateTest.java
@@ -20,7 +20,7 @@
 package org.neo4j.cluster.protocol.election;
 
 import org.junit.Test;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import java.net.URI;
@@ -33,11 +33,10 @@ import java.util.Map;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.com.message.Message;
 import org.neo4j.cluster.com.message.MessageHolder;
-import org.neo4j.cluster.com.message.MessageType;
+import org.neo4j.cluster.protocol.MessageArgumentMatcher;
 import org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.AtomicBroadcastMessage;
 import org.neo4j.cluster.protocol.cluster.ClusterContext;
 import org.neo4j.cluster.protocol.cluster.ClusterMessage;
-import org.neo4j.cluster.protocol.MessageArgumentMatcher;
 import org.neo4j.logging.NullLog;
 
 import static org.junit.Assert.assertEquals;
@@ -63,10 +62,10 @@ public class ElectionStateTest
     {
         ElectionContext context = mock( ElectionContext.class );
         ClusterContext clusterContextMock = mock( ClusterContext.class );
-        when( context.getLog( Matchers.<Class>any() ) ).thenReturn( NullLog.getInstance() );
+        when( context.getLog( ArgumentMatchers.<Class>any() ) ).thenReturn( NullLog.getInstance() );
 
         when( context.electionOk() ).thenReturn( false );
-        when( clusterContextMock.getLog( Matchers.<Class>any() ) ).thenReturn( NullLog.getInstance() );
+        when( clusterContextMock.getLog( ArgumentMatchers.<Class>any() ) ).thenReturn( NullLog.getInstance() );
 
         MessageHolder holder = mock( MessageHolder.class );
 
@@ -83,8 +82,8 @@ public class ElectionStateTest
         ClusterContext clusterContextMock = mock( ClusterContext.class );
 
         when( context.electionOk() ).thenReturn( false );
-        when( clusterContextMock.getLog( Matchers.<Class>any() ) ).thenReturn( NullLog.getInstance() );
-        when( context.getLog( Matchers.<Class>any() ) ).thenReturn( NullLog.getInstance() );
+        when( clusterContextMock.getLog( ArgumentMatchers.<Class>any() ) ).thenReturn( NullLog.getInstance() );
+        when( context.getLog( ArgumentMatchers.<Class>any() ) ).thenReturn( NullLog.getInstance() );
 
         MessageHolder holder = mock( MessageHolder.class );
 
@@ -106,7 +105,7 @@ public class ElectionStateTest
         ElectionContext context = mock( ElectionContext.class );
         ClusterContext clusterContextMock = mock( ClusterContext.class );
 
-        when( clusterContextMock.getLog( Matchers.<Class>any() ) ).thenReturn( NullLog.getInstance() );
+        when( clusterContextMock.getLog( ArgumentMatchers.<Class>any() ) ).thenReturn( NullLog.getInstance() );
         MessageHolder holder = mock( MessageHolder.class );
 
           // These mean the election can proceed normally, by us
@@ -137,9 +136,9 @@ public class ElectionStateTest
 
         // Then
           // Make sure that we asked ourselves to vote for that role and that no timer was set
-        verify( holder, times(1) ).offer( Matchers.argThat( new MessageArgumentMatcher<ElectionMessage>()
+        verify( holder, times(1) ).offer( ArgumentMatchers.argThat( new MessageArgumentMatcher<ElectionMessage>()
                 .onMessageType( ElectionMessage.vote ).withPayload( voteRequest ) ) );
-        verify( context, times( 0 ) ).setTimeout( Matchers.<String>any(), Matchers.<Message>any() );
+        verify( context, times( 0 ) ).setTimeout( ArgumentMatchers.<String>any(), ArgumentMatchers.<Message>any() );
     }
 
     @Test
@@ -164,7 +163,7 @@ public class ElectionStateTest
         // When
         election.handle( context, vote, holder );
 
-        verify( context ).getLog( Matchers.<Class>any() );
+        verify( context ).getLog( ArgumentMatchers.<Class>any() );
         verify( context ).voted( role, voter, voteCredentialComparable, 4 );
 
         // Then

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatIAmAliveProcessorTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatIAmAliveProcessorTest.java
@@ -19,27 +19,26 @@
  */
 package org.neo4j.cluster.protocol.heartbeat;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 
 import java.net.URI;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.junit.Test;
-import org.mockito.Matchers;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.com.message.Message;
 import org.neo4j.cluster.com.message.MessageHolder;
 import org.neo4j.cluster.com.message.MessageType;
 import org.neo4j.cluster.protocol.cluster.ClusterConfiguration;
 import org.neo4j.cluster.protocol.cluster.ClusterContext;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
 
 public class HeartbeatIAmAliveProcessorTest
 {
@@ -171,9 +170,9 @@ public class HeartbeatIAmAliveProcessorTest
         // The sender, which adds messages outgoing to the list above.
         doAnswer( invocation ->
         {
-            sentOut.add( (Message) invocation.getArguments()[0] );
+            sentOut.add( invocation.getArgument( 0 ) );
             return null;
-        } ).when( holder ).offer( Matchers.<Message<MessageType>>any() );
+        } ).when( holder ).offer( ArgumentMatchers.<Message<MessageType>>any() );
 
         ClusterContext mockContext = mock( ClusterContext.class );
         ClusterConfiguration mockConfiguration = mock( ClusterConfiguration.class );
@@ -215,9 +214,9 @@ public class HeartbeatIAmAliveProcessorTest
         // The sender, which adds messages outgoing to the list above.
         doAnswer( invocation ->
         {
-            sentOut.add( (Message) invocation.getArguments()[0] );
+            sentOut.add( invocation.getArgument( 0 ) );
             return null;
-        } ).when( holder ).offer( Matchers.<Message<MessageType>>any() );
+        } ).when( holder ).offer( ArgumentMatchers.<Message<MessageType>>any() );
 
         ClusterContext mockContext = mock( ClusterContext.class );
         ClusterConfiguration mockConfiguration = mock( ClusterConfiguration.class );

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatStateTest.java
@@ -20,7 +20,7 @@
 package org.neo4j.cluster.protocol.heartbeat;
 
 import org.junit.Test;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 import java.net.URI;
@@ -176,7 +176,7 @@ public class HeartbeatStateTest
         heartbeat.handle( heartbeatContext, received, holder );
 
         // Then
-        verify( holder, times( 1 ) ).offer( Matchers.argThat( new MessageArgumentMatcher<LearnerMessage>()
+        verify( holder, times( 1 ) ).offer( ArgumentMatchers.argThat( new MessageArgumentMatcher<LearnerMessage>()
                 .onMessageType( LearnerMessage.catchUp ).withHeader( Message.INSTANCE_ID, "2" ) ) );
     }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CartesianProductNotificationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CartesianProductNotificationAcceptanceTest.scala
@@ -21,7 +21,7 @@ package org.neo4j.internal.cypher.acceptance
 
 import java.time.Clock
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito.{verify, _}
 import org.neo4j.cypher.GraphDatabaseTestSupport
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.helpers.simpleExpressionEvaluator

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/CodeGeneratorTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/CodeGeneratorTest.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiled_runtime.v3_4.codegen
 import java.util
 import java.util.function.BiConsumer
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/CompiledExecutionResultTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/CompiledExecutionResultTest.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiled_runtime.v3_4.codegen
 import java.util
 import java.util.function.BiConsumer
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/ir/BuildProbeTableInstructionsTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/ir/BuildProbeTableInstructionsTest.scala
@@ -23,7 +23,7 @@ import java.util
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.function.BiConsumer
 
-import org.mockito.Matchers.any
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/ir/CodeGenSugar.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/ir/CodeGenSugar.scala
@@ -59,7 +59,7 @@ trait CodeGenSugar extends MockitoSugar {
   def compile(plan: LogicalPlan): CompiledPlan = {
     val statistics: GraphStatistics = mock[GraphStatistics]
     val context = mock[PlanContext]
-    doReturn(statistics).when(context).statistics
+    doReturn(statistics, Nil: _*).when(context).statistics
     new CodeGenerator(GeneratedQueryStructure, Clocks.systemClock())
       .generate(plan, context, semanticTable, CostBasedPlannerName.default)
   }

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/ir/CompiledProfilingTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/ir/CompiledProfilingTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compiled_runtime.v3_4.codegen.ir
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.neo4j.collection.primitive.PrimitiveLongIterator
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.ProfileMode

--- a/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/feature/parser/ParsingTestSupport.scala
+++ b/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/feature/parser/ParsingTestSupport.scala
@@ -112,9 +112,9 @@ abstract class ParsingTestSupport extends FunSuite with Matchers with DecorateAs
 
     when(result.columns()).thenReturn(cols.toList.asJava)
 
-    when(result.accept(org.mockito.Matchers.any())).thenAnswer(new Answer[Unit] {
+    when(result.accept(org.mockito.ArgumentMatchers.any())).thenAnswer(new Answer[Unit] {
       override def answer(invocationOnMock: InvocationOnMock): Unit = {
-        val visitor = invocationOnMock.getArgumentAt(0, classOf[ResultVisitor[_]])
+        val visitor:ResultVisitor[_] = invocationOnMock.getArgument( 0 )
         var continue = true
         while (continue && itr.hasNext) {
           val row = new MapRow(itr.next())

--- a/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/MasterClientTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/MasterClientTest.java
@@ -22,7 +22,7 @@ package org.neo4j.ha.upgrade;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 
 import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.com.RequestContext;
@@ -151,7 +151,7 @@ public class MasterClientTest
 
         ResponseUnpacker responseUnpacker = mock( ResponseUnpacker.class );
         MasterImpl.SPI masterImplSPI = MasterImplTest.mockedSpi( storeId );
-        when( masterImplSPI.packTransactionObligationResponse( any( RequestContext.class ), Matchers.anyObject() ) )
+        when( masterImplSPI.packTransactionObligationResponse( any( RequestContext.class ), ArgumentMatchers.any() ) )
                 .thenReturn( Response.empty() );
         when( masterImplSPI.getTransactionChecksum( anyLong() ) ).thenReturn( txChecksum );
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/SlaveUpdatePullerTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/SlaveUpdatePullerTest.java
@@ -23,9 +23,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.Matchers;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
+import org.mockito.ArgumentMatchers;
 import org.mockito.stubbing.OngoingStubbing;
 
 import java.time.Duration;
@@ -44,9 +42,9 @@ import org.neo4j.kernel.ha.com.master.InvalidEpochException;
 import org.neo4j.kernel.ha.com.master.Master;
 import org.neo4j.kernel.ha.com.slave.InvalidEpochExceptionHandler;
 import org.neo4j.kernel.impl.util.CountingJobScheduler;
-import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
 import org.neo4j.logging.AssertableLogProvider;
+import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.test.rule.CleanupRule;
 
 import static org.hamcrest.Matchers.is;
@@ -123,7 +121,7 @@ public class SlaveUpdatePullerTest
         // THEN
         verify( lastUpdateTime, times( 1 ) ).setLastUpdateTime( anyLong() );
         verify( availabilityGuard, times( 1 ) ).isAvailable( anyLong() );
-        verify( master, times( 1 ) ).pullUpdates( Matchers.any() );
+        verify( master, times( 1 ) ).pullUpdates( ArgumentMatchers.any() );
         verify( monitor, times( 1 ) ).pulledUpdates( anyLong() );
 
         // WHEN
@@ -143,7 +141,7 @@ public class SlaveUpdatePullerTest
         // THEN
         verify( lastUpdateTime, times( 1 ) ).setLastUpdateTime( anyLong() );
         verify( availabilityGuard, times( 1 ) ).isAvailable( anyLong() );
-        verify( master, times( 1 ) ).pullUpdates( Matchers.any() );
+        verify( master, times( 1 ) ).pullUpdates( ArgumentMatchers.any() );
         verify( monitor, times( 1 ) ).pulledUpdates( anyLong() );
 
         // WHEN
@@ -152,7 +150,7 @@ public class SlaveUpdatePullerTest
         // THEN
         verify( lastUpdateTime, times( 2 ) ).setLastUpdateTime( anyLong() );
         verify( availabilityGuard, times( 2 ) ).isAvailable( anyLong() );
-        verify( master, times( 2 ) ).pullUpdates( Matchers.any() );
+        verify( master, times( 2 ) ).pullUpdates( ArgumentMatchers.any() );
         verify( monitor, times( 2 ) ).pulledUpdates( anyLong() );
     }
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/UpdatePullingTransactionObligationFulfillerTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/UpdatePullingTransactionObligationFulfillerTest.java
@@ -48,7 +48,7 @@ public class UpdatePullingTransactionObligationFulfillerTest
     @Before
     public void setup() throws Throwable
     {
-        doAnswer( invocation -> ((UpdatePuller.Condition) invocation.getArguments()[0]).evaluate( 33, 34 )
+        doAnswer( invocation -> ((UpdatePuller.Condition) invocation.getArgument( 0 )).evaluate( 33, 34 )
         ).when( updatePuller ).pullUpdates( any( UpdatePuller.Condition.class ), anyBoolean() );
     }
 
@@ -79,7 +79,7 @@ public class UpdatePullingTransactionObligationFulfillerTest
 
         doAnswer( invocation ->
         {
-            ((HighAvailabilityMemberListener) invocation.getArguments()[0]).slaveIsAvailable(
+            ((HighAvailabilityMemberListener) invocation.getArgument( 0 )).slaveIsAvailable(
                     new HighAvailabilityMemberChangeEvent( null, null, serverId, null )
             );
             return null;
@@ -87,7 +87,7 @@ public class UpdatePullingTransactionObligationFulfillerTest
 
         doAnswer( invocation ->
         {
-            ((HighAvailabilityMemberListener) invocation.getArguments()[0]).instanceStops(
+            ((HighAvailabilityMemberListener) invocation.getArgument( 0 )).instanceStops(
                     new HighAvailabilityMemberChangeEvent( null, null, serverId, null )
             );
             return null;

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/DefaultConversationSPITest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/DefaultConversationSPITest.java
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.concurrent.TimeUnit;
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/HighAvailabilityMemberStateMachineTest.java
@@ -20,7 +20,7 @@
 package org.neo4j.kernel.ha.cluster;
 
 import org.junit.Test;
-import org.mockito.Matchers;
+import org.mockito.ArgumentMatchers;
 
 import java.io.File;
 import java.io.IOException;
@@ -671,9 +671,9 @@ public class HighAvailabilityMemberStateMachineTest
         final ClusterMemberListenerContainer listenerContainer = new ClusterMemberListenerContainer();
         doAnswer( invocation ->
         {
-            listenerContainer.set( (ClusterMemberListener) invocation.getArguments()[0] );
+            listenerContainer.set( invocation.getArgument( 0 ) );
             return null;
-        } ).when( events ).addClusterMemberListener( Matchers.any() );
+        } ).when( events ).addClusterMemberListener( ArgumentMatchers.any() );
         return listenerContainer;
     }
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveBranchThenCopyTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveBranchThenCopyTest.java
@@ -82,6 +82,7 @@ import org.neo4j.scheduler.JobScheduler;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
@@ -325,7 +326,7 @@ public class SwitchToSlaveBranchThenCopyTest
 
         MasterClientResolver masterClientResolver = mock( MasterClientResolver.class );
         when( masterClientResolver.instantiate( anyString(), anyInt(), anyString(), any( Monitors.class ),
-                any( StoreId.class ), any( LifeSupport.class ) ) ).thenReturn( masterClient );
+                argThat( storeId -> true ), any( LifeSupport.class ) ) ).thenReturn( masterClient );
 
         return spy( new SwitchToSlaveBranchThenCopy( new File( "" ), NullLogService.getInstance(),
                 configMock(), resolver,

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveCopyThenBranchTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveCopyThenBranchTest.java
@@ -84,6 +84,7 @@ import org.neo4j.scheduler.JobScheduler;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
@@ -229,7 +230,7 @@ public class SwitchToSlaveCopyThenBranchTest
         StoreCopyClient storeCopyClient = mock( StoreCopyClient.class );
         doAnswer( invocation ->
         {
-            MoveAfterCopy moveAfterCopy = invocation.getArgumentAt( 2, MoveAfterCopy.class );
+            MoveAfterCopy moveAfterCopy = invocation.getArgument( 2 );
             moveAfterCopy.move( Stream.empty(), new File( "" ), new File( "" ) );
             return null;
         } ).when( storeCopyClient ).copyStore(
@@ -375,7 +376,7 @@ public class SwitchToSlaveCopyThenBranchTest
 
         MasterClientResolver masterClientResolver = mock( MasterClientResolver.class );
         when( masterClientResolver.instantiate( anyString(), anyInt(), anyString(), any( Monitors.class ),
-                any( StoreId.class ), any( LifeSupport.class ) ) ).thenReturn( masterClient );
+                argThat( storeId -> true ), any( LifeSupport.class ) ) ).thenReturn( masterClient );
 
         return spy( new SwitchToSlaveCopyThenBranch( new File( "" ), NullLogService.getInstance(),
                 configMock(), resolver,

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/member/HighAvailabilitySlavesTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/member/HighAvailabilitySlavesTest.java
@@ -145,7 +145,7 @@ public class HighAvailabilitySlavesTest
                 any( Integer.class ) ) ).thenReturn( mock( Slave.class ), mock( Slave.class ) );
 
         HighAvailabilitySlaves slaves = new HighAvailabilitySlaves( clusterMembers, cluster, slaveFactory, new
-                HostnamePort( null, 0 ) );
+                HostnamePort( "localhost", 0 ) );
         slaves.init();
 
         ArgumentCaptor<ClusterListener> listener = ArgumentCaptor.forClass( ClusterListener.class );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/modeswitch/HighAvailabilityModeSwitcherTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/modeswitch/HighAvailabilityModeSwitcherTest.java
@@ -55,6 +55,7 @@ import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.logging.NullLogProvider;
 
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
@@ -169,7 +170,7 @@ public class HighAvailabilityModeSwitcherTest
                 .thenAnswer( invocationOnMock ->
                 {
                     switching.countDown();
-                    CancellationRequest cancel = (CancellationRequest) invocationOnMock.getArguments()[3];
+                    CancellationRequest cancel = invocationOnMock.getArgument( 3 );
                     if ( firstSwitch.get() )
                     {
                         while ( !cancel.cancellationRequested() )
@@ -236,8 +237,7 @@ public class HighAvailabilityModeSwitcherTest
 
                 when( executor.submit( any( Runnable.class ) ) ).thenAnswer(
                         (Answer<Future<?>>) invocation ->
-                                realExecutor.submit( () ->
-                                        ((Runnable) invocation.getArguments()[0]).run() ) );
+                                realExecutor.submit( () -> ((Runnable) invocation.getArgument( 0 )).run() ) );
 
                 when( executor.schedule( any( Runnable.class ), anyLong(), any( TimeUnit.class ) ) ).thenAnswer(
                         (Answer<Future<?>>) invocation ->
@@ -249,7 +249,7 @@ public class HighAvailabilityModeSwitcherTest
                                 // wait until the second masterIsAvailable comes and then call switchToSlave
                                 // method
                                 secondMasterAvailableComes.await();
-                                ((Runnable) invocation.getArguments()[0]).run();
+                                ((Runnable) invocation.getArgument( 0 )).run();
                                 secondMasterAvailableHandled.countDown();
                                 return null;
                             } );
@@ -440,7 +440,7 @@ public class HighAvailabilityModeSwitcherTest
     {
         // Given
         SwitchToSlaveCopyThenBranch switchToSlave = mock( SwitchToSlaveCopyThenBranch.class );
-        when( switchToSlave.switchToSlave( any( LifeSupport.class ), any( URI.class ), any( URI.class ),
+        when( switchToSlave.switchToSlave( any( LifeSupport.class ), isNull(), any( URI.class ),
                 any( CancellationRequest.class ) ) ).thenReturn( URI.create( "http://localhost" ) );
         ClusterMemberAvailability memberAvailability = mock( ClusterMemberAvailability.class );
         Election election = mock( Election.class );
@@ -459,7 +459,7 @@ public class HighAvailabilityModeSwitcherTest
 
                 doAnswer( invocation ->
                 {
-                    ((Runnable) invocation.getArguments()[0]).run();
+                    ((Runnable) invocation.getArgument( 0 )).run();
                     modeSwitchHappened.countDown();
                     return mock( Future.class );
                 } ).when( executor ).submit( any( Runnable.class ) );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/ConversationManagerTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/ConversationManagerTest.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.time.Duration;
 
@@ -31,8 +31,8 @@ import org.neo4j.com.RequestContext;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.ha.HaSettings;
 import org.neo4j.kernel.ha.cluster.ConversationSPI;
-import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.kernel.impl.util.collection.TimedRepository;
+import org.neo4j.scheduler.JobScheduler;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -87,10 +87,6 @@ public class ConversationManagerTest
     @Test
     public void testConversationWorkflow() throws Exception
     {
-        JobScheduler.JobHandle reaperJobHandle = mock( JobScheduler.JobHandle.class );
-        when( config.get( HaSettings.lock_read_timeout ) ).thenReturn( Duration.ofMillis( 1 ) );
-        when( conversationSPI.scheduleRecurringJob( any( JobScheduler.Group.class ), any( Long.class ),
-                any( Runnable.class ) ) ).thenReturn( reaperJobHandle );
         RequestContext requestContext = getRequestContext();
         conversationManager = getConversationManager();
         TimedRepository conversationStorage = mock( TimedRepository.class );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/ConversationTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/ConversationTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterImplTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/com/master/MasterImplTest.java
@@ -23,6 +23,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
+import org.mockito.hamcrest.MockitoHamcrest;
 
 import java.util.Collection;
 import java.util.Map;
@@ -63,7 +64,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
-import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -165,7 +165,7 @@ public class MasterImplTest
     private void mockEmptyResponse( SPI spi )
     {
         when( spi.packEmptyResponse( any() ) ).thenAnswer(
-                invocation -> new TransactionObligationResponse<>( invocation.getArguments()[0], StoreId.DEFAULT,
+                invocation -> new TransactionObligationResponse<>( invocation.getArgument( 0 ), StoreId.DEFAULT,
                         TransactionIdStore.BASE_TX_ID, ResourceReleaser.NO_OP ) );
     }
 
@@ -387,7 +387,7 @@ public class MasterImplTest
         master.acquireExclusiveLock( context, ResourceTypes.NODE, 1 );
 
         ArgumentCaptor<LockResult> captor = ArgumentCaptor.forClass( LockResult.class );
-        verify( spi ).packTransactionObligationResponse( argThat( is( context ) ), captor.capture() );
+        verify( spi ).packTransactionObligationResponse( MockitoHamcrest.argThat( is( context ) ), captor.capture() );
         assertThat( captor.getValue().getMessage(), is( not( nullValue() ) ) );
     }
 
@@ -404,7 +404,7 @@ public class MasterImplTest
         master.acquireSharedLock( context, ResourceTypes.NODE, 1 );
 
         ArgumentCaptor<LockResult> captor = ArgumentCaptor.forClass( LockResult.class );
-        verify( spi ).packTransactionObligationResponse( argThat( is( context ) ), captor.capture() );
+        verify( spi ).packTransactionObligationResponse( MockitoHamcrest.argThat( is( context ) ), captor.capture() );
         assertThat( captor.getValue().getMessage(), is( not( nullValue() ) ) );
     }
 
@@ -426,7 +426,7 @@ public class MasterImplTest
         master.acquireExclusiveLock( context, type, 1 );
 
         ArgumentCaptor<LockResult> captor = ArgumentCaptor.forClass( LockResult.class );
-        verify( spi ).packTransactionObligationResponse( argThat( is( context ) ), captor.capture() );
+        verify( spi ).packTransactionObligationResponse( MockitoHamcrest.argThat( is( context ) ), captor.capture() );
         assertThat( captor.getValue().getMessage(), is( not( nullValue() ) ) );
     }
 
@@ -448,7 +448,7 @@ public class MasterImplTest
         master.acquireSharedLock( context, type, 1 );
 
         ArgumentCaptor<LockResult> captor = ArgumentCaptor.forClass( LockResult.class );
-        verify( spi ).packTransactionObligationResponse( argThat( is( context ) ), captor.capture() );
+        verify( spi ).packTransactionObligationResponse( MockitoHamcrest.argThat( is( context ) ), captor.capture() );
         assertThat( captor.getValue().getMessage(), is( not( nullValue() ) ) );
     }
 
@@ -470,7 +470,7 @@ public class MasterImplTest
         master.acquireExclusiveLock( context, type, 1 );
 
         ArgumentCaptor<LockResult> captor = ArgumentCaptor.forClass( LockResult.class );
-        verify( spi ).packTransactionObligationResponse( argThat( is( context ) ), captor.capture() );
+        verify( spi ).packTransactionObligationResponse( MockitoHamcrest.argThat( is( context ) ), captor.capture() );
         assertThat( captor.getValue().getMessage(), is( not( nullValue() ) ) );
     }
 
@@ -492,7 +492,7 @@ public class MasterImplTest
         master.acquireSharedLock( context, type, 1 );
 
         ArgumentCaptor<LockResult> captor = ArgumentCaptor.forClass( LockResult.class );
-        verify( spi ).packTransactionObligationResponse( argThat( is( context ) ), captor.capture() );
+        verify( spi ).packTransactionObligationResponse( MockitoHamcrest.argThat( is( context ) ), captor.capture() );
         assertThat( captor.getValue().getMessage(), is( not( nullValue() ) ) );
     }
 
@@ -521,7 +521,7 @@ public class MasterImplTest
         MasterImpl.SPI mock = mock( MasterImpl.SPI.class );
         when( mock.storeId() ).thenReturn( storeId );
         when( mock.packEmptyResponse( any() ) ).thenAnswer(
-                invocation -> new TransactionObligationResponse<>( invocation.getArguments()[0], storeId,
+                invocation -> new TransactionObligationResponse<>( invocation.getArgument( 0 ), storeId,
                         TransactionIdStore.BASE_TX_ID, ResourceReleaser.NO_OP ) );
         return mock;
     }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/id/HaIdGeneratorFactoryTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/id/HaIdGeneratorFactoryTest.java
@@ -19,14 +19,13 @@
  */
 package org.neo4j.kernel.ha.id;
 
-import java.io.File;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.io.File;
+
 import org.neo4j.com.ComException;
-import org.neo4j.com.RequestContext;
 import org.neo4j.com.Response;
 import org.neo4j.graphdb.TransientTransactionFailureException;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
@@ -47,6 +46,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -81,7 +81,7 @@ public class HaIdGeneratorFactoryTest
         // GIVEN
         IdAllocation firstResult = new IdAllocation( new IdRange( new long[]{}, 42, 123 ), 123, 0 );
         Response<IdAllocation> response = response( firstResult );
-        when( master.allocateIds( any( RequestContext.class ), any( IdType.class ) ) ).thenReturn( response );
+        when( master.allocateIds( isNull(), any( IdType.class ) ) ).thenReturn( response );
 
         // WHEN
         IdGenerator gen = switchToSlave();
@@ -91,7 +91,7 @@ public class HaIdGeneratorFactoryTest
         {
             assertEquals(i, gen.nextId());
         }
-        verify( master, times( 1 ) ).allocateIds( any( RequestContext.class ), eq( IdType.NODE ) );
+        verify( master, times( 1 ) ).allocateIds( isNull(), eq( IdType.NODE ) );
     }
 
     @Test
@@ -101,7 +101,7 @@ public class HaIdGeneratorFactoryTest
         IdAllocation firstResult = new IdAllocation( new IdRange( new long[]{}, 42, 123 ), 42 + 123, 0 );
         IdAllocation secondResult = new IdAllocation( new IdRange( new long[]{}, 1042, 223 ), 1042 + 223, 0 );
         Response<IdAllocation> response = response( firstResult, secondResult );
-        when( master.allocateIds( any( RequestContext.class ), any( IdType.class ) ) ).thenReturn( response );
+        when( master.allocateIds( isNull(), any( IdType.class ) ) ).thenReturn( response );
 
         // WHEN
         IdGenerator gen = switchToSlave();
@@ -113,7 +113,7 @@ public class HaIdGeneratorFactoryTest
         {
             assertEquals( i, gen.nextId() );
         }
-        verify( master, times( 1 ) ).allocateIds( any( RequestContext.class ), eq( IdType.NODE ) );
+        verify( master, times( 1 ) ).allocateIds( isNull(), eq( IdType.NODE ) );
 
         startAt = secondResult.getIdRange().getRangeStart();
         forThatMany = secondResult.getIdRange().getRangeLength();
@@ -122,7 +122,7 @@ public class HaIdGeneratorFactoryTest
             assertEquals( i, gen.nextId() );
         }
 
-        verify( master, times( 2 ) ).allocateIds( any( RequestContext.class ), eq( IdType.NODE ) );
+        verify( master, times( 2 ) ).allocateIds( isNull(), eq( IdType.NODE ) );
     }
 
     @Test
@@ -132,7 +132,7 @@ public class HaIdGeneratorFactoryTest
         long[] defragIds = {42, 27172828, 314159};
         IdAllocation firstResult = new IdAllocation( new IdRange( defragIds, 0, 0 ), 0, defragIds.length );
         Response<IdAllocation> response = response( firstResult );
-        when( master.allocateIds( any( RequestContext.class ), any( IdType.class ) ) ).thenReturn( response );
+        when( master.allocateIds( isNull(), any( IdType.class ) ) ).thenReturn( response );
 
         // WHEN
         IdGenerator gen = switchToSlave();
@@ -151,7 +151,7 @@ public class HaIdGeneratorFactoryTest
         long[] defragIds = {42, 27172828, 314159};
         IdAllocation firstResult = new IdAllocation( new IdRange( defragIds, 0, 10 ), 100, defragIds.length );
         Response<IdAllocation> response = response( firstResult );
-        when( master.allocateIds( any( RequestContext.class ), any( IdType.class ) ) ).thenReturn( response );
+        when( master.allocateIds( isNull(), any( IdType.class ) ) ).thenReturn( response );
 
         // WHEN
         IdGenerator gen = switchToSlave();
@@ -171,7 +171,7 @@ public class HaIdGeneratorFactoryTest
         IdAllocation firstResult = new IdAllocation( new IdRange( new long[] {}, 42, highIdFromAllocation ),
                 highIdFromAllocation, 0 );
         Response<IdAllocation> response = response( firstResult );
-        when( master.allocateIds( any( RequestContext.class ), any( IdType.class ) ) ).thenReturn( response );
+        when( master.allocateIds( isNull(), any( IdType.class ) ) ).thenReturn( response );
 
         // WHEN
         IdGenerator gen = switchToSlave();
@@ -221,7 +221,7 @@ public class HaIdGeneratorFactoryTest
     @Test( expected = TransientTransactionFailureException.class )
     public void shouldTranslateComExceptionsIntoTransientTransactionFailures() throws Exception
     {
-        when( master.allocateIds( any( RequestContext.class ), any( IdType.class ) ) ).thenThrow( new ComException() );
+        when( master.allocateIds( isNull(), any( IdType.class ) ) ).thenThrow( new ComException() );
         IdGenerator generator = switchToSlave();
         generator.nextId();
     }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/PropertyExistenceEnforcerTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/PropertyExistenceEnforcerTest.java
@@ -71,7 +71,7 @@ public class PropertyExistenceEnforcerTest
         when( storeReadLayer.getOrCreateSchemaDependantState( eq( PropertyExistenceEnforcer.class ),
                 any( Function.class) ) ).thenAnswer( invocation ->
         {
-            Function<StoreReadLayer, PropertyExistenceEnforcer> function = invocation.getArgumentAt( 1, Function.class );
+            Function<StoreReadLayer,PropertyExistenceEnforcer> function = invocation.getArgument( 1 );
             return function.apply( storeReadLayer );
         } );
         return storeReadLayer;

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/PluginAuthenticationInfoTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/PluginAuthenticationInfoTest.java
@@ -21,7 +21,6 @@ package org.neo4j.server.security.enterprise.auth.plugin;
 
 import org.apache.shiro.crypto.hash.SimpleHash;
 import org.junit.Test;
-import org.mockito.Matchers;
 
 import java.util.List;
 
@@ -32,6 +31,7 @@ import org.neo4j.server.security.enterprise.auth.plugin.spi.CustomCacheableAuthe
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -50,7 +50,7 @@ public class PluginAuthenticationInfoTest
     public void shouldCreateCorrectAuthenticationInfoFromCacheable()
     {
         SecureHasher hasher = mock( SecureHasher.class );
-        when( hasher.hash( Matchers.any() ) ).thenReturn( new SimpleHash( "some-hash" ) );
+        when( hasher.hash( any() ) ).thenReturn( new SimpleHash( "some-hash" ) );
 
         PluginAuthenticationInfo internalAuthInfo =
                 PluginAuthenticationInfo.createCacheable(
@@ -66,7 +66,7 @@ public class PluginAuthenticationInfoTest
     public void shouldCreateCorrectAuthenticationInfoFromCustomCacheable()
     {
         SecureHasher hasher = mock( SecureHasher.class );
-        when( hasher.hash( Matchers.any() ) ).thenReturn( new SimpleHash( "some-hash" ) );
+        when( hasher.hash( any() ) ).thenReturn( new SimpleHash( "some-hash" ) );
 
         PluginAuthenticationInfo internalAuthInfo =
                 PluginAuthenticationInfo.createCacheable(

--- a/pom.xml
+++ b/pom.xml
@@ -749,14 +749,8 @@
 
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
-        <version>1.10.19</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>1.10.19</version>
+        <version>2.10.0</version>
         <scope>test</scope>
       </dependency>
 


### PR DESCRIPTION
Upgrade from mockito to latest version that among other nice features has
support of Java 9, report for unnecessary mocking, possibility to mock
final classes.
Full release notes can be found at: https://github.com/mockito/mockito/blob/release/2.x/doc/release-notes/official.md#2100-2017-09-08-published-to-jcentermaven-central