### PR TITLE
Fix bug in detach delete, which could cause deadlocks

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TwoPhaseNodeForRelationshipLocking.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TwoPhaseNodeForRelationshipLocking.java
@@ -111,10 +111,7 @@ class TwoPhaseNodeForRelationshipLocking
 
     private void lockAllNodes( KernelStatement state, long[] nodeIds )
     {
-        for ( long nodeId : nodeIds )
-        {
-            state.locks().optimistic().acquireExclusive( state.lockTracer(), ResourceTypes.NODE, nodeId );
-        }
+        state.locks().optimistic().acquireExclusive( state.lockTracer(), ResourceTypes.NODE, nodeIds );
     }
 
     private void unlockAllNodes( KernelStatement state, long[] nodeIds  )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TwoPhaseNodeForRelationshipLocking.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/TwoPhaseNodeForRelationshipLocking.java
@@ -19,11 +19,14 @@
  */
 package org.neo4j.kernel.impl.api;
 
+import java.util.Arrays;
+
 import org.neo4j.collection.primitive.Primitive;
-import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.collection.primitive.PrimitiveArrays;
 import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.cursor.Cursor;
 import org.neo4j.function.ThrowingConsumer;
+import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.impl.api.operations.EntityReadOperations;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
@@ -31,18 +34,20 @@ import org.neo4j.storageengine.api.Direction;
 import org.neo4j.storageengine.api.NodeItem;
 import org.neo4j.storageengine.api.RelationshipItem;
 
+import static org.neo4j.kernel.api.StatementConstants.NO_SUCH_RELATIONSHIP;
+
 class TwoPhaseNodeForRelationshipLocking
 {
-    private final PrimitiveLongSet nodeIds = Primitive.longSet();
-    private final EntityReadOperations entityReadOperations;
+    private final EntityReadOperations ops;
     private final ThrowingConsumer<Long,KernelException> relIdAction;
 
     private long firstRelId;
+    private long[] sortedNodeIds;
 
     TwoPhaseNodeForRelationshipLocking( EntityReadOperations entityReadOperations,
             ThrowingConsumer<Long,KernelException> relIdAction )
     {
-        this.entityReadOperations = entityReadOperations;
+        this.ops = entityReadOperations;
         this.relIdAction = relIdAction;
     }
 
@@ -51,24 +56,18 @@ class TwoPhaseNodeForRelationshipLocking
         boolean retry;
         do
         {
-            nodeIds.add( nodeId );
             retry = false;
-            firstRelId = -1;
+            firstRelId = NO_SUCH_RELATIONSHIP;
 
             // lock all the nodes involved by following the node id ordering
-            try ( Cursor<NodeItem> node = entityReadOperations.nodeCursorById( state, nodeId ) )
-            {
-                entityReadOperations.nodeGetRelationships( state, node.get(), Direction.BOTH )
-                        .forAll( this::collectNodeId );
-            }
+            collectAndSortNodeIds( nodeId, state );
 
-            lockAllNodes( state );
+            lockAllNodes( state, sortedNodeIds );
 
             // perform the action on each relationship, we will retry if the the relationship iterator contains new relationships
-            try ( Cursor<NodeItem> node = entityReadOperations.nodeCursorById( state, nodeId ) )
+            try ( Cursor<NodeItem> node = ops.nodeCursorById( state, nodeId ) )
             {
-                try ( Cursor<RelationshipItem> relationships = entityReadOperations
-                        .nodeGetRelationships( state, node.get(), Direction.BOTH ) )
+                try ( Cursor<RelationshipItem> relationships = ops.nodeGetRelationships( state, node.get(), Direction.BOTH ) )
                 {
                     boolean first = true;
                     while ( relationships.next() && !retry )
@@ -82,24 +81,48 @@ class TwoPhaseNodeForRelationshipLocking
         while ( retry );
     }
 
-    private void lockAllNodes( KernelStatement state )
+    private void collectAndSortNodeIds( long nodeId, KernelStatement state ) throws EntityNotFoundException
     {
-        PrimitiveLongIterator nodeIdIterator = nodeIds.iterator();
-        while ( nodeIdIterator.hasNext() )
+        PrimitiveLongSet nodeIdSet = Primitive.longSet();
+        nodeIdSet.add( nodeId );
+
+        try ( Cursor<NodeItem> node = ops.nodeCursorById( state, nodeId ) )
         {
-            state.locks().optimistic()
-                    .acquireExclusive( state.lockTracer(), ResourceTypes.NODE, nodeIdIterator.next() );
+            try ( Cursor<RelationshipItem> rels = ops.nodeGetRelationships( state, node.get(), Direction.BOTH ) )
+            {
+                while ( rels.next() )
+                {
+                    RelationshipItem rel = rels.get();
+                    if ( firstRelId == NO_SUCH_RELATIONSHIP )
+                    {
+                        firstRelId = rel.id();
+                    }
+
+                    nodeIdSet.add( rel.startNode() );
+                    nodeIdSet.add( rel.endNode() );
+                }
+            }
+        }
+
+        long[] nodeIds = PrimitiveArrays.of( nodeIdSet );
+        Arrays.sort( nodeIds );
+        this.sortedNodeIds = nodeIds;
+    }
+
+    private void lockAllNodes( KernelStatement state, long[] nodeIds )
+    {
+        for ( long nodeId : nodeIds )
+        {
+            state.locks().optimistic().acquireExclusive( state.lockTracer(), ResourceTypes.NODE, nodeId );
         }
     }
 
-    private void unlockAllNodes( KernelStatement state )
+    private void unlockAllNodes( KernelStatement state, long[] nodeIds  )
     {
-        PrimitiveLongIterator iterator = nodeIds.iterator();
-        while ( iterator.hasNext() )
+        for ( long nodeId : nodeIds )
         {
-            state.locks().optimistic().releaseExclusive( ResourceTypes.NODE, iterator.next() );
+            state.locks().optimistic().releaseExclusive( ResourceTypes.NODE, nodeId );
         }
-        nodeIds.clear();
     }
 
     private boolean performAction( KernelStatement state, RelationshipItem rel, boolean first ) throws KernelException
@@ -110,23 +133,13 @@ class TwoPhaseNodeForRelationshipLocking
             {
                 // if the first relationship is not the same someone added some new rels, so we need to
                 // lock them all again
-                unlockAllNodes( state );
+                unlockAllNodes( state, sortedNodeIds );
+                sortedNodeIds = null;
                 return true;
             }
         }
 
         relIdAction.accept( rel.id() );
         return false;
-    }
-
-    private void collectNodeId( RelationshipItem rel )
-    {
-        if ( firstRelId == -1 )
-        {
-            firstRelId = rel.id();
-        }
-
-        nodeIds.add( rel.startNode() );
-        nodeIds.add( rel.endNode() );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursor.java
@@ -43,6 +43,10 @@ public class StoreNodeRelationshipCursor extends StoreAbstractRelationshipCursor
 {
     private final RelationshipGroupRecord groupRecord;
     private final Consumer<StoreNodeRelationshipCursor> instanceCache;
+    private final RecordCursors cursors;
+
+    // Reset all this state on init()
+    // --------
     private boolean isDense;
     private long relationshipId;
     private long fromNodeId;
@@ -50,7 +54,7 @@ public class StoreNodeRelationshipCursor extends StoreAbstractRelationshipCursor
     private IntPredicate allowedTypes;
     private int groupChainIndex;
     private boolean end;
-    private final RecordCursors cursors;
+    // --------
 
     public StoreNodeRelationshipCursor( RelationshipRecord relationshipRecord,
             RelationshipGroupRecord groupRecord,
@@ -75,6 +79,7 @@ public class StoreNodeRelationshipCursor extends StoreAbstractRelationshipCursor
         this.fromNodeId = fromNodeId;
         this.direction = direction;
         this.allowedTypes = allowedTypes;
+        this.groupChainIndex = 0;
         this.end = false;
 
         if ( isDense && relationshipId != Record.NO_NEXT_RELATIONSHIP.intValue() )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
@@ -516,8 +516,8 @@ public class LockingStatementOperationsTest
 
         lockingOps.nodeDetachDelete( state, nodeId );
 
-        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, relationship.startNodeId );
-        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, relationship.endNodeId );
+        order.verify( locks ).acquireExclusive(
+                LockTracer.NONE, ResourceTypes.NODE, relationship.startNodeId, relationship.endNodeId );
         order.verify( locks, times( 0 ) ).releaseExclusive( ResourceTypes.NODE, relationship.startNodeId );
         order.verify( locks, times( 0 ) ).releaseExclusive( ResourceTypes.NODE, relationship.endNodeId );
         order.verify( entityWriteOps ).nodeDetachDelete( state, nodeId );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TwoPhaseNodeForRelationshipLockingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TwoPhaseNodeForRelationshipLockingTest.java
@@ -70,10 +70,14 @@ public class TwoPhaseNodeForRelationshipLockingTest
         Collector collector = new Collector();
         TwoPhaseNodeForRelationshipLocking locking = new TwoPhaseNodeForRelationshipLocking( ops, collector );
 
-        RelationshipData relationship1 = new RelationshipData( 21L, nodeId, 43L );
-        RelationshipData relationship2 = new RelationshipData( 22L, 40L, nodeId );
-        RelationshipData relationship3 = new RelationshipData( 23L, nodeId, 41L );
-        returnRelationships( ops, state, nodeId, false, relationship1, relationship2, relationship3 );
+        returnRelationships(
+                ops, state, nodeId, false,
+                new RelationshipData( 21L, nodeId, 43L ),
+                new RelationshipData( 22L, 40L, nodeId ),
+                new RelationshipData( 23L, nodeId, 41L ),
+                new RelationshipData( 2L, nodeId, 3L ),
+                new RelationshipData( 3L, 49L, nodeId ),
+                new RelationshipData( 50L, nodeId, 41L ) );
 
         InOrder inOrder = inOrder( locks );
 
@@ -81,11 +85,13 @@ public class TwoPhaseNodeForRelationshipLockingTest
         locking.lockAllNodesAndConsumeRelationships( nodeId, state );
 
         // then
+        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 3L );
         inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 40L );
         inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 41L );
         inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, nodeId );
         inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 43L );
-        assertEquals( set( 21L, 22L, 23L ), collector.set );
+        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 49L );
+        assertEquals( set( 21L, 22L, 23L, 2L, 3L, 50L ), collector.set );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TwoPhaseNodeForRelationshipLockingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TwoPhaseNodeForRelationshipLockingTest.java
@@ -85,12 +85,7 @@ public class TwoPhaseNodeForRelationshipLockingTest
         locking.lockAllNodesAndConsumeRelationships( nodeId, state );
 
         // then
-        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 3L );
-        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 40L );
-        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 41L );
-        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, nodeId );
-        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 43L );
-        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 49L );
+        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 3L, 40L, 41L, nodeId, 43L, 49L );
         assertEquals( set( 21L, 22L, 23L, 2L, 3L, 50L ), collector.set );
     }
 
@@ -113,18 +108,13 @@ public class TwoPhaseNodeForRelationshipLockingTest
         locking.lockAllNodesAndConsumeRelationships( nodeId, state );
 
         // then
-        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 40L );
-        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 41L );
-        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, nodeId );
+        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 40L, 41L, nodeId );
 
         inOrder.verify( locks ).releaseExclusive( ResourceTypes.NODE, 40L );
         inOrder.verify( locks ).releaseExclusive( ResourceTypes.NODE, 41L );
         inOrder.verify( locks ).releaseExclusive( ResourceTypes.NODE, nodeId );
 
-        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 40L );
-        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 41L );
-        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, nodeId );
-        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 43L );
+        inOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 40L, 41L, nodeId, 43L );
         assertEquals( set( 21L, 22L, 23L ), collector.set );
     }
 

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveArrays.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveArrays.java
@@ -224,6 +224,23 @@ public class PrimitiveArrays
     }
 
     /**
+     * Copy PrimitiveLongCollection into new long array
+     * @param collection the collection to copy
+     * @return the new long array
+     */
+    public static long[] of( PrimitiveLongCollection collection )
+    {
+        int i = 0;
+        long[] result = new long[collection.size()];
+        PrimitiveLongIterator iterator = collection.iterator();
+        while ( iterator.hasNext() )
+        {
+            result[i++] = iterator.next();
+        }
+        return result;
+    }
+
+    /**
      * Compute the number of unique values in two sorted long array sets
      * @param left a sorted array set
      * @param right another sorted array set


### PR DESCRIPTION
This bug was caused by TwoPhaseNodeForRelationshipLocking not
guaranteeing to acquire locks in ascending node id order. This was
tested, but the 3 tested nodes coincidentally were provided in the
correct order by that iterator, causing the test to pass.