### PR TITLE
Bugfix that nested lists can not be used with max or min

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/aggregation/MaxFunction.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/aggregation/MaxFunction.scala
@@ -36,7 +36,7 @@ trait MinMax extends AggregationFunction {
 
   override def apply(data: ExecutionContext, state: QueryState) {
     value(data, state) match {
-      case v if v == Values.NO_VALUE =>
+      case Values.NO_VALUE =>
       case x: AnyValue => checkIfLargest(x)
     }
   }

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/functions/Max.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/functions/Max.scala
@@ -16,15 +16,15 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_3.ast.functions
 
-import org.neo4j.cypher.internal.frontend.v3_3.ast.{AggregatingFunction, ExpressionSignature, SimpleTypedFunction}
+import org.neo4j.cypher.internal.frontend.v3_3.ast
+import org.neo4j.cypher.internal.frontend.v3_3.ast.AggregatingFunction
 import org.neo4j.cypher.internal.frontend.v3_3.symbols._
 
-case object Max extends AggregatingFunction with SimpleTypedFunction {
+case object Max extends AggregatingFunction {
   override def name = "max"
 
-  override val signatures = Vector(
-    ExpressionSignature(argumentTypes = Vector(CTInteger), outputType = CTInteger),
-    ExpressionSignature(argumentTypes = Vector(CTFloat), outputType = CTFloat),
-    ExpressionSignature(argumentTypes = Vector(CTString), outputType = CTString)
-  )
+  override def semanticCheck(ctx: ast.Expression.SemanticContext, invocation: ast.FunctionInvocation) =
+    checkArgs(invocation, 1) chain
+      invocation.arguments.expectType(CTAny.covariant) chain
+      invocation.specifyType(invocation.arguments.leastUpperBoundsOfTypes)
 }

--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/functions/Min.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/functions/Min.scala
@@ -16,15 +16,16 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_3.ast.functions
 
+import org.neo4j.cypher.internal.frontend.v3_3.ast
+import org.neo4j.cypher.internal.frontend.v3_3.ast.functions.Max.checkArgs
 import org.neo4j.cypher.internal.frontend.v3_3.ast.{AggregatingFunction, ExpressionSignature, SimpleTypedFunction}
 import org.neo4j.cypher.internal.frontend.v3_3.symbols._
 
-case object Min extends AggregatingFunction with SimpleTypedFunction {
+case object Min extends AggregatingFunction {
   override def name = "min"
 
-  override val signatures = Vector(
-    ExpressionSignature(argumentTypes = Vector(CTInteger), outputType = CTInteger),
-    ExpressionSignature(argumentTypes = Vector(CTFloat), outputType = CTFloat),
-    ExpressionSignature(argumentTypes = Vector(CTString), outputType = CTString)
-  )
+  override def semanticCheck(ctx: ast.Expression.SemanticContext, invocation: ast.FunctionInvocation) =
+    checkArgs(invocation, 1) chain
+      invocation.arguments.expectType(CTAny.covariant) chain
+      invocation.specifyType(invocation.arguments.leastUpperBoundsOfTypes)
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
@@ -62,8 +62,11 @@ Negative parameter for LIMIT should not generate errors
 LIMIT 0 should stop side effects
 
 //AggregationAcceptance.feature
-Should give max of numerical values
-Should give max of numerical and text values
-Should give max of text values
-Should give max of list values
-Should give max of numerical and list values
+max() over strings
+min() over strings
+max() over mixed numeric values
+min() over mixed numeric values
+max() over mixed values
+min() over mixed values
+max() over list values
+min() over list values

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
@@ -60,3 +60,10 @@ Negative parameter for LIMIT should not generate errors
 
 // ReturnAcceptance.feature
 LIMIT 0 should stop side effects
+
+//AggregationAcceptance.feature
+Should give max of numerical values
+Should give max of numerical and text values
+Should give max of text values
+Should give max of list values
+Should give max of numerical and list values

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-31.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-31.txt
@@ -9,3 +9,8 @@ ORDER BY node problem
 
 // ReturnAcceptance.feature
 LIMIT 0 should stop side effects
+
+//AggregationAcceptance.feature
+Should give max of numerical and text values
+Should give max of list values
+Should give max of numerical and list values

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-31.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-31.txt
@@ -11,6 +11,7 @@ ORDER BY node problem
 LIMIT 0 should stop side effects
 
 //AggregationAcceptance.feature
-Should give max of numerical and text values
-Should give max of list values
-Should give max of numerical and list values
+max() over mixed values
+min() over mixed values
+max() over list values
+min() over list values

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-32.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-32.txt
@@ -1,3 +1,7 @@
 //MatchAcceptance.feature
 difficult to plan query number 1
 difficult to plan query number 2
+
+//AggregationAcceptance.feature
+Should give max of numerical and list values
+Should give max of list values

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-32.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-32.txt
@@ -3,5 +3,8 @@ difficult to plan query number 1
 difficult to plan query number 2
 
 //AggregationAcceptance.feature
-Should give max of numerical and list values
-Should give max of list values
+max() over mixed values
+min() over mixed values
+max() over list values
+min() over list values
+

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -175,14 +175,18 @@ Handles checking properties on relationships in path - using ALL() function on p
 Handles checking properties on relationships in multistep path - using ALL() function on path relationship properties
 
 //AggregationAcceptance.feature
-Should give max of integer values
-Should give max of float values
-Should give max of numerical values
-Should give max of numerical and text values
-Should give max of text values
-Should give max of list values
-Should give max of numerical and list values
-Should give max of numerical and null values
+max() over strings
+min() over strings
+max() over mixed numeric values
+min() over mixed numeric values
+max() over mixed values
+min() over mixed values
+max() over list values
+min() over list values
+max() over integers
+min() over integers
+max() over floats
+min() over floats
 
 //MatchAcceptance.feature
 difficult to plan query number 1

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -174,6 +174,16 @@ Handles checking properties on relationships in path - using ALL() function on r
 Handles checking properties on relationships in path - using ALL() function on path relationship properties
 Handles checking properties on relationships in multistep path - using ALL() function on path relationship properties
 
+//AggregationAcceptance.feature
+Should give max of integer values
+Should give max of float values
+Should give max of numerical values
+Should give max of numerical and text values
+Should give max of text values
+Should give max of list values
+Should give max of numerical and list values
+Should give max of numerical and null values
+
 //MatchAcceptance.feature
 difficult to plan query number 1
 difficult to plan query number 2

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/AggregationAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/AggregationAcceptance.feature
@@ -40,82 +40,134 @@ Feature: AggregationAcceptance
       | 1      | 1      |
     And no side effects
 
-  Scenario: Should give max of integer values
+  Scenario: max() over strings
     When executing query:
       """
-      UNWIND [1,2] AS x RETURN max(x)
+      UNWIND ['a', 'b', 'B', null, 'abc', 'abc1'] AS i
+      RETURN max(i)
+      """
+    Then the result should be:
+      | max(i) |
+      | 'b'    |
+    And no side effects
+
+  Scenario: min() over strings
+    When executing query:
+      """
+      UNWIND ['a', 'b', 'B', null, 'abc', 'abc1'] AS i
+      RETURN min(i)
+      """
+    Then the result should be:
+      | min(i) |
+      | 'B'    |
+    And no side effects
+
+  Scenario: max() over integers
+    When executing query:
+      """
+      UNWIND [1, 2, 0, null, -1] AS x
+      RETURN max(x)
       """
     Then the result should be:
       | max(x) |
       | 2      |
     And no side effects
 
-  Scenario: Should give max of float values
+  Scenario: min() over integers
     When executing query:
       """
-      UNWIND [1.0,2.0] AS x RETURN max(x)
+      UNWIND [1, 2, 0, null, -1] AS x
+      RETURN min(x)
+      """
+    Then the result should be:
+      | min(x) |
+      | -1     |
+    And no side effects
+
+  Scenario: max() over floats
+    When executing query:
+      """
+      UNWIND [1.0, 2.0, 0.5, null] AS x
+      RETURN max(x)
       """
     Then the result should be:
       | max(x) |
       | 2.0    |
     And no side effects
 
-  Scenario: Should give max of numerical values
+  Scenario: min() over floats
     When executing query:
       """
-      UNWIND [1,2.0] AS x RETURN max(x)
+      UNWIND [1.0, 2.0, 0.5, null] AS x
+      RETURN min(x)
+      """
+    Then the result should be:
+      | min(x) |
+      | 0.5    |
+    And no side effects
+
+  Scenario: max() over mixed numeric values
+    When executing query:
+      """
+      UNWIND [1, 2.0, 5, null, 3.2, 0.1] AS x
+      RETURN max(x)
       """
     Then the result should be:
       | max(x) |
-      | 2.0    |
+      | 5      |
     And no side effects
 
-  Scenario: Should give max of text values
+  Scenario: min() over mixed numeric values
     When executing query:
       """
-      UNWIND ['fu','bar'] AS x RETURN max(x)
+      UNWIND [1, 2.0, 5, null, 3.2, 0.1] AS x
+      RETURN min(x)
       """
     Then the result should be:
-      | max(x)  |
-      | 'fu'    |
+      | min(x) |
+      | 0.1    |
     And no side effects
 
-  Scenario: Should give max of numerical and text values
+  Scenario: max() over mixed values
     When executing query:
       """
-      UNWIND [1,'a'] AS x RETURN max(x)
-      """
-    Then the result should be:
-      | max(x) |
-      | 1      |
-    And no side effects
-
-  Scenario: Should give max of list values
-    When executing query:
-      """
-      UNWIND [[1],[2]] AS x RETURN max(x)
-      """
-    Then the result should be:
-      | max(x) |
-      | [2]    |
-    And no side effects
-
-  Scenario: Should give max of numerical and list values
-    When executing query:
-      """
-      UNWIND [1,[2]] AS x RETURN max(x)
+      UNWIND [1, 'a', null, [1, 2], 0.2, 'b'] AS x
+      RETURN max(x)
       """
     Then the result should be:
       | max(x) |
       | 1      |
     And no side effects
 
-  Scenario: Should give max of numerical and null values
+  Scenario: min() over mixed values
     When executing query:
       """
-      UNWIND [1,null] AS x RETURN max(x)
+      UNWIND [1, 'a', null, [1, 2], 0.2, 'b'] AS x
+      RETURN min(x)
+      """
+    Then the result should be:
+      | min(x) |
+      | [1, 2] |
+    And no side effects
+
+  Scenario: max() over list values
+    When executing query:
+      """
+      UNWIND [[1], [2], [2, 1]] AS x
+      RETURN max(x)
       """
     Then the result should be:
       | max(x) |
-      | 1      |
+      | [2, 1] |
+    And no side effects
+
+  Scenario: min() over list values
+    When executing query:
+      """
+      UNWIND [[1], [2], [2, 1]] AS x
+      RETURN min(x)
+      """
+    Then the result should be:
+      | min(x) |
+      | [1]    |
     And no side effects

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/AggregationAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/AggregationAcceptance.feature
@@ -39,3 +39,83 @@ Feature: AggregationAcceptance
       | aCount | zCount |
       | 1      | 1      |
     And no side effects
+
+  Scenario: Should give max of integer values
+    When executing query:
+      """
+      UNWIND [1,2] AS x RETURN max(x)
+      """
+    Then the result should be:
+      | max(x) |
+      | 2      |
+    And no side effects
+
+  Scenario: Should give max of float values
+    When executing query:
+      """
+      UNWIND [1.0,2.0] AS x RETURN max(x)
+      """
+    Then the result should be:
+      | max(x) |
+      | 2.0    |
+    And no side effects
+
+  Scenario: Should give max of numerical values
+    When executing query:
+      """
+      UNWIND [1,2.0] AS x RETURN max(x)
+      """
+    Then the result should be:
+      | max(x) |
+      | 2.0    |
+    And no side effects
+
+  Scenario: Should give max of text values
+    When executing query:
+      """
+      UNWIND ['fu','bar'] AS x RETURN max(x)
+      """
+    Then the result should be:
+      | max(x)  |
+      | 'fu'    |
+    And no side effects
+
+  Scenario: Should give max of numerical and text values
+    When executing query:
+      """
+      UNWIND [1,'a'] AS x RETURN max(x)
+      """
+    Then the result should be:
+      | max(x) |
+      | 1      |
+    And no side effects
+
+  Scenario: Should give max of list values
+    When executing query:
+      """
+      UNWIND [[1],[2]] AS x RETURN max(x)
+      """
+    Then the result should be:
+      | max(x) |
+      | [2]    |
+    And no side effects
+
+  Scenario: Should give max of numerical and list values
+    When executing query:
+      """
+      UNWIND [1,[2]] AS x RETURN max(x)
+      """
+    Then the result should be:
+      | max(x) |
+      | 1      |
+    And no side effects
+
+  Scenario: Should give max of numerical and null values
+    When executing query:
+      """
+      UNWIND [1,null] AS x RETURN max(x)
+      """
+    Then the result should be:
+      | max(x) |
+      | 1      |
+    And no side effects


### PR DESCRIPTION
This also adds missing acceptance tests for the max aggregation function. Now they should work according to 
https://github.com/opencypher/openCypher/blob/master/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc

changelog: Change the behaviour of min and max to not throw exceptions when aggregating values other than numbers and strings.