### PR TITLE
In-transaction assertions in CypherComparisonSupport

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
@@ -467,7 +467,7 @@ object CypherComparisonSupport {
           if (runtime.acceptedRuntimeNames.contains(reportedRuntimeName)
             && planner.acceptedPlannerNames.contains(reportedPlannerName)
             && version.acceptedVersionNames.contains(reportedVersionName)) {
-            fail(s"Unexpectedly succeeded using $name for query $query, with $reportedVersionName and $reportedRuntimeName runtime and $reportedPlannerName planner.nMatchAC")
+            fail(s"Unexpectedly succeeded using $name for query $query, with $reportedVersionName and $reportedRuntimeName runtime and $reportedPlannerName planner.")
           }
       }
     }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAggregationsBackedByCountStoreAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAggregationsBackedByCountStoreAcceptanceTest.scala
@@ -20,12 +20,14 @@
 package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.internal.InternalExecutionResult
-import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.InternalPlanDescription
-import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport, QueryStatisticsTestSupport}
-import org.scalatest.matchers.{MatchResult, Matcher}
+import org.neo4j.cypher.{ExecutionEngineFunSuite, QueryPlanTestSupport, QueryStatisticsTestSupport}
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.{ComparePlansWithAssertion, Configs, TestConfiguration}
 
 class MatchAggregationsBackedByCountStoreAcceptanceTest
-  extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with NewPlannerTestSupport {
+  extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with CypherComparisonSupport with QueryPlanTestSupport {
+
+  val defaultConfig = Configs.AllExceptSlotted
+  val expectOtherPlan = Configs.AllRulePlanners + Configs.Cost2_3
 
   test("do not plan counts store lookup for loop matches") {
     val n = createNode()
@@ -35,780 +37,613 @@ class MatchAggregationsBackedByCountStoreAcceptanceTest
     // one non-loop
     relate(n, createNode())
 
-    val resultStar = executeWithAllPlannersAndCompatibilityMode("MATCH (a)-->(a) RETURN count(*)")
-    val resultVar = executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH (a)-[r]->(a) RETURN count(r)")
+    val resultStar = executeWith(Configs.Interpreted + Configs.BackwardsCompatibility, "MATCH (a)-->(a) RETURN count(*)")
+    val resultVar = executeWith(Configs.All, "MATCH (a)-[r]->(a) RETURN count(r)")
 
     resultStar.toList should equal(List(Map("count(*)" -> 2)))
     resultVar.toList should equal(List(Map("count(r)" -> 2)))
 
-    resultStar.executionPlanDescription() shouldNot includeOperation("RelationshipCountFromCountStore")
-    resultVar.executionPlanDescription() shouldNot includeOperation("RelationshipCountFromCountStore")
+    resultStar.executionPlanDescription() shouldNot useOperators("RelationshipCountFromCountStore")
+    resultVar.executionPlanDescription() shouldNot useOperators("RelationshipCountFromCountStore")
   }
 
   test("counts nodes using count store") {
     // Given
-    withModel(
+    val executeBefore = () => setupModel()
+    val query = "MATCH (n) RETURN count(n)"
 
-      // When
-      query = "MATCH (n) RETURN count(n)", f = { result =>
-
-        // Then
-        result.columnAs("count(n)").toSet[Int] should equal(Set(3))
-
-    }, allRuntimes = true)
+    // Then
+    compareCount(query, 0)
+    compareCount(query, 3, executeBefore = executeBefore)
   }
 
   test("capitalized COUNTS nodes using count store") {
     // Given
-    withModel(
+    val executeBefore = () => setupModel()
+    val query = "MATCH (n) RETURN COUNT(n)"
 
-      // When
-      query = "MATCH (n) RETURN COUNT(n)", f = { result =>
-
-        // Then
-        result.columnAs("COUNT(n)").toSet[Int] should equal(Set(3))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0)
+    compareCount(query, 3, executeBefore = executeBefore)
   }
 
   test("counts nodes using count store with count(*)") {
     // Given
-    withModel(
+    val executeBefore = () => setupModel()
+    val query = "MATCH (n) RETURN count(*)"
 
-      // When
-      query = "MATCH (n) RETURN count(*)", f = { result =>
-
-        // Then
-        result.columnAs("count(*)").toSet[Int] should equal(Set(3))
-
-    }, allRuntimes = true)
+    // Then
+    compareCount(query, 0)
+    compareCount(query, 3, executeBefore = executeBefore)
   }
 
   test("counts labeled nodes using count store") {
     // Given
-    withModel(label1 = "Admin",
+    val executeBefore = () => setupModel(label1 = "Admin")
+    val query = "MATCH (n:User) RETURN count(n)"
 
-      // When
-      query = "MATCH (n:User) RETURN count(n)", f = { result =>
-
-        // Then
-        result.columnAs("count(n)").toSet[Int] should equal(Set(1))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0)
+    compareCount(query, 1, executeBefore = executeBefore)
   }
 
   test("counts nodes using count store and projection expression") {
     // Given
-    withModel(label1 = "Admin",
+    val executeBefore = () => setupModel(label1 = "Admin")
+    val query = "MATCH (n:User) RETURN count(n) > 0"
 
-      // When
-      query = "MATCH (n:User) RETURN count(n) > 0", f = { result =>
-
-        // Then
-        result.columnAs("count(n) > 0").toSet[Boolean] should equal(Set(true))
-
-      }, expectedResultOnEmptyDatabase = Set(false))
+    // Then
+    compareCount(query, false, Configs.AllExceptSlotted - Configs.Compiled)
+    compareCount(query, true, Configs.AllExceptSlotted - Configs.Compiled, executeBefore = executeBefore)
   }
 
   test("counts nodes using count store and projection expression with variable") {
     // Given
-    withModel(
+    val executeBefore = () => setupModel()
+    val query = "MATCH (n) RETURN count(n)/2.0*5 as someNum"
 
-      // When
-      query = "MATCH (n) RETURN count(n)/2.0*5 as someNum", f = { result =>
-
-        // Then
-        result.columnAs("someNum").toSet[Int] should equal(Set(7.5))
-
-      })
+    // Then
+    compareCount(query, 0, Configs.AllExceptSlotted - Configs.Compiled)
+    compareCount(query, 7.5, Configs.AllExceptSlotted - Configs.Compiled, executeBefore = executeBefore)
   }
 
   test("counts relationships with unspecified type using count store") {
     // Given
-    withRelationshipsModel(
+    val executeBefore = () => setupModel()
+    val query = "MATCH ()-[r]->() RETURN count(r)"
 
-      // When
-      query = "MATCH ()-[r]->() RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(2))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    compareCount(query, 2, expectedLogicalPlan = "RelationshipCountFromCountStore", executeBefore = executeBefore)
   }
 
   test("counts relationships with unspecified type using count store with count(*)") {
     // Given
-    withRelationshipsModel(
+    val executeBefore = () => setupModel()
+    val query = "MATCH ()-->() RETURN count(*)"
 
-      // When
-      query = "MATCH ()-->() RETURN count(*)", f = { result =>
-
-        // Then
-        result.columnAs("count(*)").toSet[Int] should equal(Set(2))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    compareCount(query, 2, expectedLogicalPlan = "RelationshipCountFromCountStore", executeBefore = executeBefore)
   }
 
   test("counts relationships with type using count store") {
     // Given
-    withRelationshipsModel(
+    val executeBefore = () => setupModel()
+    val query = "MATCH ()-[r:KNOWS]->() RETURN count(r)"
 
-      // When
-      query = "MATCH ()-[r:KNOWS]->() RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(1))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    compareCount(query, 1, expectedLogicalPlan = "RelationshipCountFromCountStore", executeBefore = executeBefore)
   }
 
   test("counts relationships with type using count store with count(*)") {
     // Given
-    withRelationshipsModel(
+    val executeBefore = () => setupModel()
+    val query = "MATCH ()-[r:KNOWS]->() RETURN count(*)"
 
-      // When
-      query = "MATCH ()-[r:KNOWS]->() RETURN count(*)", f = { result =>
-
-        // Then
-        result.columnAs("count(*)").toSet[Int] should equal(Set(1))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    compareCount(query, 1, expectedLogicalPlan = "RelationshipCountFromCountStore", executeBefore = executeBefore)
   }
 
   test("counts relationships with unspecified type and labeled source node using count store") {
     // Given
-    withRelationshipsModel(
+    val executeBefore = () => setupModel()
+    val query = "MATCH (:User)-[r]->() RETURN count(r)"
 
-      // When
-      query = "MATCH (:User)-[r]->() RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(1))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    compareCount(query, 1, expectedLogicalPlan = "RelationshipCountFromCountStore", executeBefore = executeBefore)
   }
 
   test("counts relationships with type and labeled source node using count store") {
     // Given
-    withRelationshipsModel(
+    val executeBefore = () => setupModel()
+    val query = "MATCH ()<-[r:KNOWS]-(:User) RETURN count(r)"
 
-      // When
-      query = "MATCH ()<-[r:KNOWS]-(:User) RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(1))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    compareCount(query, 1, expectedLogicalPlan = "RelationshipCountFromCountStore", executeBefore = executeBefore)
   }
 
   test("counts relationships with unspecified type and labeled destination node using count store") {
     // Given
-    withRelationshipsModel(
+    val executeBefore = () => setupModel()
+    val query = "MATCH ()-[r]->(:User) RETURN count(r)"
 
-      // When
-      query = "MATCH ()-[r]->(:User) RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(1))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    compareCount(query, 1, expectedLogicalPlan = "RelationshipCountFromCountStore", executeBefore = executeBefore)
   }
 
   test("counts relationships with type and labeled destination node using count store") {
     // Given
-    withRelationshipsModel(
+    val executeBefore = () => setupModel()
+    val query = "MATCH ()-[r:KNOWS]->(:User) RETURN count(r)"
 
-      // When
-      query = "MATCH ()-[r:KNOWS]->(:User) RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(1))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    compareCount(query, 1, expectedLogicalPlan = "RelationshipCountFromCountStore", executeBefore = executeBefore)
   }
 
   test("counts relationships with type and labeled source and destination without using count store") {
     // Given
-    withRelationshipsModel(expectedLogicalPlan = "NodeByLabelScan",
+    val executeBefore = () => setupModel()
+    val query = "MATCH (:User)-[r:KNOWS]->(:User) RETURN count(r)"
 
-      // When
-      query = "MATCH (:User)-[r:KNOWS]->(:User) RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(1))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, Configs.All, expectedLogicalPlan = "NodeByLabelScan", expectOtherPlanIn = Configs.AllRulePlanners)
+    compareCount(query, 1, Configs.All, expectedLogicalPlan = "NodeByLabelScan", expectOtherPlanIn = Configs.AllRulePlanners, executeBefore = executeBefore)
   }
 
   test("counts relationships with unspecified type and labeled source and destination without using count store") {
     // Given
-    withRelationshipsModel(expectedLogicalPlan = "NodeByLabelScan",
+    val executeBefore = () => setupModel()
+    val query = "MATCH (:User)-[r]->(:User) RETURN count(r)"
 
-      // When
-      query = "MATCH (:User)-[r]->(:User) RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(1))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, Configs.All, expectedLogicalPlan = "NodeByLabelScan", expectOtherPlanIn = Configs.AllRulePlanners)
+    compareCount(query, 1, Configs.All, expectedLogicalPlan = "NodeByLabelScan", expectOtherPlanIn = Configs.AllRulePlanners, executeBefore = executeBefore)
   }
 
   test("counts relationships with type, reverse direction and labeled source node using count store") {
     // Given
-    withRelationshipsModel(
+    val executeBefore = () => setupModel()
+    val query = "MATCH (:User)<-[r:KNOWS]-() RETURN count(r)"
 
-      // When
-      query = "MATCH (:User)<-[r:KNOWS]-() RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(1))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    compareCount(query, 1, expectedLogicalPlan = "RelationshipCountFromCountStore", executeBefore = executeBefore)
   }
 
   test("counts relationships with type, reverse direction and labeled destination node using count store") {
     // Given
-    withRelationshipsModel(
+    val executeBefore = () => setupModel()
+    val query = "MATCH ()<-[r:KNOWS]-(:User) RETURN count(r)"
 
-      // When
-      query = "MATCH ()<-[r:KNOWS]-(:User) RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(1))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    compareCount(query, 1, expectedLogicalPlan = "RelationshipCountFromCountStore", executeBefore = executeBefore)
   }
 
   test("counts relationships with type, any direction and labeled source node without using count store") {
     // Given
-    withRelationshipsModel(expectedLogicalPlan = "NodeByLabelScan",
+    val executeBefore = () => setupModel()
+    val query = "MATCH (:User)-[r:KNOWS]-() RETURN count(r)"
 
-      // When
-      query = "MATCH (:User)-[r:KNOWS]-() RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(2))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, Configs.All, expectedLogicalPlan = "NodeByLabelScan")
+    compareCount(query, 2, Configs.All, expectedLogicalPlan = "NodeByLabelScan", executeBefore = executeBefore)
   }
 
   test("counts relationships with type, any direction and labeled destination node without using count store") {
     // Given
-    withRelationshipsModel(expectedLogicalPlan = "NodeByLabelScan",
+    val executeBefore = () => setupModel()
+    val query = "MATCH ()-[r:KNOWS]-(:User) RETURN count(r)"
 
-      // When
-      query = "MATCH ()-[r:KNOWS]-(:User) RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(2))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, Configs.All, expectedLogicalPlan = "NodeByLabelScan", expectOtherPlanIn = Configs.AllRulePlanners)
+    compareCount(query, 2, Configs.All, expectedLogicalPlan = "NodeByLabelScan", expectOtherPlanIn = Configs.AllRulePlanners, executeBefore = executeBefore)
   }
 
   test("counts relationships with type, any direction and no labeled nodes without using count store") {
     // Given
-    withRelationshipsModel(expectedLogicalPlan = "AllNodesScan",
+    val executeBefore = () => setupModel()
+    val query = "MATCH ()-[r:KNOWS]-() RETURN count(r)"
 
-      // When
-      query = "MATCH ()-[r:KNOWS]-() RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(2))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, Configs.All, expectedLogicalPlan = "AllNodesScan", expectOtherPlanIn = Configs.AllRulePlanners)
+    compareCount(query, 2, Configs.All, expectedLogicalPlan = "AllNodesScan", expectOtherPlanIn = Configs.AllRulePlanners, executeBefore = executeBefore)
   }
 
   test("counts nodes using count store considering transaction state") {
     // Given
-    withModelAndTransaction(
+    val executeBefore = () => inTXModification()
+    val query = "MATCH (n:User) RETURN count(n)"
 
-      // When
-      query = "MATCH (n:User) RETURN count(n)", f = { result =>
-
-        // Then
-        result.columnAs("count(n)").toSet[Int] should equal(Set(3))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0)
+    setupBigModel()
+    compareCount(query, 3, assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts labeled nodes using count store considering transaction state (test1)") {
     // Given
-    withModelAndTransaction(label1 = "Admin", label2 = "User",
+    val executeBefore = () => inTXModification(label1 = "Admin", label2 = "User")
+    val query = "MATCH (n:User) RETURN count(n)"
 
-      // When
-      query = "MATCH (n:User) RETURN count(n)", f = { result =>
-
-        // Then
-        result.columnAs("count(n)").toSet[Int] should equal(Set(2))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0)
+    setupBigModel(label1 = "Admin", label2 = "User")
+    compareCount(query, 2, assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts labeled nodes using count store considering transaction state (test2)") {
     // Given
-    withModelAndTransaction(label1 = "Admin", label2 = "User",
+    val executeBefore = () => inTXModification(label1 = "Admin", label2 = "User")
+    val query = "MATCH (n:Admin) RETURN count(n)"
 
-      // When
-      query = "MATCH (n:Admin) RETURN count(n)", f = { result =>
-
-        // Then
-        result.columnAs("count(n)").toSet[Int] should equal(Set(1))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0)
+    setupBigModel(label1 = "Admin", label2 = "User")
+    compareCount(query, 1, assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts labeled nodes using count store considering transaction state containing newly created label (test1)") {
     // Given
-    withModelAndTransaction(label3 = "Admin",
+    val executeBefore = () => inTXModification(label3 = "Admin")
+    val query = "MATCH (n:Admin) RETURN count(n)"
 
-      // When
-      query = "MATCH (n:Admin) RETURN count(n)", f = { result =>
-
-        // Then
-        result.columnAs("count(n)").toSet[Int] should equal(Set(1))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0)
+    setupBigModel()
+    compareCount(query, 1, assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
 
   test("counts labeled nodes using count store considering transaction state containing newly created label (test2)") {
     // Given
-    withModelAndTransaction(label3 = "Admin",
+    val executeBefore = () => inTXModification(label3 = "Admin")
+    val query = "MATCH (n:User) RETURN count(n)"
 
-      // When
-      query = "MATCH (n:User) RETURN count(n)", f = { result =>
-
-        // Then
-        result.columnAs("count(n)").toSet[Int] should equal(Set(2))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0)
+    setupBigModel()
+    compareCount(query, 2, assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts nodes using count store and projection expression considering transaction state") {
     // Given
-    withModelAndTransaction(label1 = "Admin",
+    val executeBefore = () => inTXModification(label1 = "Admin")
+    val query = "MATCH (n:User) RETURN count(n) > 1"
 
-      // When
-      query = "MATCH (n:User) RETURN count(n) > 1", f = { result =>
-
-        // Then
-        result.columnAs("count(n) > 1").toSet[Boolean] should equal(Set(true))
-
-      },
-      expectedResultOnEmptyDatabase = Set(false))
+    // Then
+    compareCount(query, false, Configs.AllExceptSlotted - Configs.Compiled)
+    setupBigModel(label1 = "Admin")
+    compareCount(query, true, Configs.AllExceptSlotted - Configs.Compiled, assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts nodes using count store and projection expression with variable considering transaction state") {
     // Given
-    withModelAndTransaction(
+    val executeBefore = () => inTXModification()
+    val query = "MATCH (n) RETURN count(n)/3*5 as someNum"
 
-      // When
-      query = "MATCH (n) RETURN count(n)/3*5 as someNum", f = { result =>
-
-        // Then
-        result.columnAs("someNum").toSet[Int] should equal(Set(5))
-
-      })
+    // Then
+    compareCount(query, 0, Configs.AllExceptSlotted - Configs.Compiled)
+    setupBigModel()
+    compareCount(query, 5, Configs.AllExceptSlotted - Configs.Compiled, assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts relationships using count store considering transaction state") {
     // Given
-    withRelationshipsModelAndTransaction(
+    val executeBefore = () => inTXModification()
+    val query = "MATCH ()-[r]->() RETURN count(r)"
 
-      // When
-      query = "MATCH ()-[r]->() RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(3))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    setupBigModel()
+    compareCount(query, 3, expectedLogicalPlan = "RelationshipCountFromCountStore", assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts relationships with type using count store considering transaction state") {
     // Given
-    withRelationshipsModelAndTransaction(
+    val executeBefore = () => inTXModification()
+    val query = "MATCH ()-[r:KNOWS]->() RETURN count(r)"
 
-      // When
-      query = "MATCH ()-[r:KNOWS]->() RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(3))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    setupBigModel()
+    compareCount(query, 3, expectedLogicalPlan = "RelationshipCountFromCountStore", assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts relationships with multiple types using count store considering transaction state") {
     // Given
-    withRelationshipsModelAndTransaction(type1 = "KNOWS", type2 = "FOLLOWS", type3 = "FRIEND_OF",
+    val executeBefore = () => inTXModification(type2 = "FOLLOWS", type3 = "FRIEND_OF")
+    val query = "MATCH ()-[r:KNOWS|FOLLOWS]->() RETURN count(r)"
 
-      // When
-      query = "MATCH ()-[r:KNOWS|FOLLOWS]->() RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(2))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    setupBigModel()
+    compareCount(query, 2, expectedLogicalPlan = "RelationshipCountFromCountStore", assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts relationships using count store and projection with expression considering transaction state") {
     // Given
-    withRelationshipsModelAndTransaction(
+    val executeBefore = () => inTXModification()
+    val query = "MATCH ()-[r]->() RETURN count(r) > 2"
 
-      // When
-      query = "MATCH ()-[r]->() RETURN count(r) > 2", f = { result =>
-
-        // Then
-        result.columnAs("count(r) > 2").toSet[Boolean] should equal(Set(true))
-
-      },
-      expectedResultOnEmptyDatabase = Set(false))
+    // Then
+    compareCount(query, false, Configs.AllExceptSlotted - Configs.Compiled, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    setupBigModel()
+    compareCount(query, true, Configs.AllExceptSlotted - Configs.Compiled, expectedLogicalPlan = "RelationshipCountFromCountStore", assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts relationships using count store and projection with expression and variable considering transaction state") {
     // Given
-    withRelationshipsModelAndTransaction(
+    val executeBefore = () => inTXModification()
+    val query = "MATCH ()-[r]->() RETURN count(r)/3*5 as someNum"
 
-      // When
-      query = "MATCH ()-[r]->() RETURN count(r)/3*5 as someNum", f = { result =>
-
-        // Then
-        result.columnAs("someNum").toSet[Int] should equal(Set(5))
-
-      })
+    // Then
+    compareCount(query, 0, Configs.AllExceptSlotted - Configs.Compiled, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    setupBigModel()
+    compareCount(query, 5, Configs.AllExceptSlotted - Configs.Compiled, expectedLogicalPlan = "RelationshipCountFromCountStore", assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts relationships using count store and horizon with further query") {
     // Given
-    withRelationshipsModelAndTransaction(label1 = "User", label2 = "Admin", label3 = "Person",
+    val executeBefore = () => inTXModification(label2 = "Admin", label3 = "Person")
+    val query = """
+                  |MATCH (:User)-[r:KNOWS]->() WITH count(r) as userKnows
+                  |MATCH (n)-[r:KNOWS]->() WITH count(r) as otherKnows, n, userKnows WHERE otherKnows <> userKnows
+                  |RETURN userKnows, otherKnows
+                """.stripMargin
+    val expectSucceed = Configs.AllExceptSlotted - Configs.Compiled
 
-      // When
-      query =
-        """
-          |MATCH (:User)-[r:KNOWS]->() WITH count(r) as userKnows
-          |MATCH (n)-[r:KNOWS]->() WITH count(r) as otherKnows, n, userKnows WHERE otherKnows <> userKnows
-          |RETURN userKnows, otherKnows
-        """.stripMargin, f = { result =>
+    // Then
+    val resultOnEmpty = executeWith(
+      expectSucceed,
+      query,
+      executeBefore = executeBefore,
+      planComparisonStrategy = ComparePlansWithAssertion(plan => {
+        plan should useOperators("RelationshipCountFromCountStore")
+      }, expectOtherPlan))
+    resultOnEmpty.toList should equal(List())
 
-        // Then
-        result.toList should equal(List(Map("userKnows" -> 2, "otherKnows" -> 1)))
+    setupBigModel(label2 = "Admin")
 
-      },
-      expectedResultOnEmptyDatabase = Set.empty)
+    val resultAssertionInTx = Some({ result: InternalExecutionResult => result.toList should equal(List(Map("userKnows" -> 2, "otherKnows" -> 1))) })
+    val result = executeWith(
+      expectSucceed,
+      query,
+      executeBefore = executeBefore,
+      planComparisonStrategy = ComparePlansWithAssertion(plan => {
+        plan should useOperators("RelationshipCountFromCountStore")
+      }, expectOtherPlan),
+      resultAssertionInTx = resultAssertionInTx)
   }
 
 //  MATCH (n:X)-[r:Y]->() WITH count(r) as rcount MATCH (n)-[r:Y]->() WHERE count(r) = rcount RETURN rcount, labels(n)
   test("counts relationships with type using count store considering transaction state and multiple types in model") {
     // Given
-    withRelationshipsModelAndTransaction(type1 = "KNOWS", type2 = "FOLLOWS", type3 = "KNOWS",
+    val executeBefore = () => inTXModification(type2 = "FOLLOWS")
+    val query = "MATCH ()-[r:KNOWS]->() RETURN count(r)"
 
-      // When
-      query = "MATCH ()-[r:KNOWS]->() RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(2))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    setupBigModel()
+    compareCount(query, 2, expectedLogicalPlan = "RelationshipCountFromCountStore", assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts relationships with type and labeled source using count store considering transaction state") {
     // Given
-    withRelationshipsModelAndTransaction(
+    val executeBefore = () => inTXModification()
+    val query = "MATCH (:User)-[r:KNOWS]->() RETURN count(r)"
 
-      // When
-      query = "MATCH (:User)-[r:KNOWS]->() RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(3))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    setupBigModel()
+    compareCount(query, 3, expectedLogicalPlan = "RelationshipCountFromCountStore", assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts relationships with type, reverse direction and labeled source using count store considering transaction state") {
     // Given
-    withRelationshipsModelAndTransaction(
+    val executeBefore = () => inTXModification()
+    val query = "MATCH (:User)<-[r:KNOWS]-() RETURN count(r)"
 
-      // When
-      query = "MATCH (:User)<-[r:KNOWS]-() RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(3))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    setupBigModel()
+    compareCount(query, 3, expectedLogicalPlan = "RelationshipCountFromCountStore", assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts relationships with unspecified type and labeled source using count store considering transaction state") {
     // Given
-    withRelationshipsModelAndTransaction(
+    val executeBefore = () => inTXModification()
+    val query = "MATCH (:User)-[r]->() RETURN count(r)"
 
-      // When
-      query = "MATCH (:User)-[r]->() RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(3))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    setupBigModel()
+    compareCount(query, 3, expectedLogicalPlan = "RelationshipCountFromCountStore", assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts relationships with type and labeled destination using count store considering transaction state") {
     // Given
-    withRelationshipsModelAndTransaction(
+    val executeBefore = () => inTXModification()
+    val query = "MATCH ()-[r:KNOWS]->(:User) RETURN count(r)"
 
-      // When
-      query = "MATCH ()-[r:KNOWS]->(:User) RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(3))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    setupBigModel()
+    compareCount(query, 3, expectedLogicalPlan = "RelationshipCountFromCountStore", assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts relationships with type, reverse direction and labeled destination using count store considering transaction state") {
     // Given
-    withRelationshipsModelAndTransaction(
+    val executeBefore = () => inTXModification()
+    val query = "MATCH ()<-[r:KNOWS]-(:User) RETURN count(r)"
 
-      // When
-      query = "MATCH ()<-[r:KNOWS]-(:User) RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(3))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    setupBigModel()
+    compareCount(query, 3, expectedLogicalPlan = "RelationshipCountFromCountStore", assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts relationships with unspecified type and labeled destination using count store considering transaction state") {
     // Given
-    withRelationshipsModelAndTransaction(
+    val executeBefore = () => inTXModification()
+    val query = "MATCH ()-[r]->(:User) RETURN count(r)"
 
-      // When
-      query = "MATCH ()-[r]->(:User) RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(3))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    setupBigModel()
+    compareCount(query, 3, expectedLogicalPlan = "RelationshipCountFromCountStore", assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts relationships with type and labeled source and destination without using count store considering transaction state") {
     // Given
-    withRelationshipsModelAndTransaction(expectedLogicalPlan = "NodeByLabelScan",
+    val executeBefore = () => inTXModification()
+    val query = "MATCH (:User)-[r:KNOWS]->(:User) RETURN count(r)"
 
-      // When
-      query = "MATCH (:User)-[r:KNOWS]->(:User) RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(3))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, Configs.All, expectedLogicalPlan = "NodeByLabelScan", expectOtherPlanIn = Configs.AllRulePlanners)
+    setupBigModel()
+    compareCount(query, 3, Configs.All, expectedLogicalPlan = "NodeByLabelScan", expectOtherPlanIn = Configs.AllRulePlanners, assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts relationships with unspecified type and labeled source and destination without using count store considering transaction state") {
     // Given
-    withRelationshipsModelAndTransaction(expectedLogicalPlan = "NodeByLabelScan",
+    val executeBefore = () => inTXModification()
+    val query = "MATCH (:User)-[r]->(:User) RETURN count(r)"
 
-      // When
-      query = "MATCH (:User)-[r]->(:User) RETURN count(r)", f = { result =>
-
-        // Then
-        result.columnAs("count(r)").toSet[Int] should equal(Set(3))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, Configs.All, expectedLogicalPlan = "NodeByLabelScan", expectOtherPlanIn = Configs.AllRulePlanners)
+    setupBigModel()
+    compareCount(query, 3, Configs.All, expectedLogicalPlan = "NodeByLabelScan", expectOtherPlanIn = Configs.AllRulePlanners, assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("should work even when the tokens are already known") {
-    innerExecute(
+    graph.execute(
       s"""
          |CREATE (p:User {name: 'Petra'})
          |CREATE (s:User {name: 'Steve'})
          |CREATE (p)-[:KNOWS]->(s)
       """.stripMargin)
 
-    val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH (:User)-[r:KNOWS]->() RETURN count(r)")
-
-    result.columnAs("count(r)").toSet[Int] should equal(Set(1))
+    compareCount("MATCH (:User)-[r:KNOWS]->() RETURN count(r)", 1, expectedLogicalPlan = "RelationshipCountFromCountStore")
   }
 
   test("runtime checking of tokens - nodes - not existing when planning nor when running") {
     createLabeledNode("NotRelated")
-    val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH (n:Nonexistent) RETURN count(n)")
-    result.toList should equal(List(Map("count(n)" -> 0)))
+    compareCount("MATCH (n:Nonexistent) RETURN count(n)", 0)
   }
 
   test("runtime checking of tokens - nodes - not existing when planning but exists when running") {
     createLabeledNode("NotRelated")
-    val result1 = executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH (n:justCreated) RETURN count(n)")
-    result1.toList should equal(List(Map("count(n)" -> 0)))
+    compareCount("MATCH (n:justCreated) RETURN count(n)", 0)
     createLabeledNode("justCreated")
-    val result2 = executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH (n:justCreated) RETURN count(n)")
-    result2.toList should equal(List(Map("count(n)" -> 1)))
+    compareCount("MATCH (n:justCreated) RETURN count(n)", 1)
   }
 
   test("runtime checking of tokens - relationships - not existing when planning nor when running") {
     relate(createNode(), createNode(), "UNRELATED")
-    val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH ()-[r:Nonexistent]->() RETURN count(r)")
-    result.toList should equal(List(Map("count(r)" -> 0)))
+    compareCount("MATCH ()-[r:Nonexistent]->() RETURN count(r)", 0, expectedLogicalPlan = "RelationshipCountFromCountStore")
   }
 
   test("runtime checking of tokens - relationships - not existing when planning but exists when running") {
     relate(createNode(), createNode(), "UNRELATED")
-    val result1 = executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH ()-[r:justCreated]->() RETURN count(r)")
-    result1.toList should equal(List(Map("count(r)" -> 0)))
+    compareCount("MATCH ()-[r:justCreated]->() RETURN count(r)", 0, expectedLogicalPlan = "RelationshipCountFromCountStore")
     relate(createNode(), createNode(), "justCreated")
-    val result2 = executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH ()-[r:justCreated]->() RETURN count(r)")
-    result2.toList should equal(List(Map("count(r)" -> 1)))
+    compareCount("MATCH ()-[r:justCreated]->() RETURN count(r)", 1, expectedLogicalPlan = "RelationshipCountFromCountStore")
   }
 
   test("count store on two unlabeled nodes") {
     // Given
-    withModel(
+    val executeBefore = () => setupModel()
+    val query = "MATCH (n), (m) RETURN count(n)"
 
-      // When
-      query = "MATCH (n), (m) RETURN count(n)", f = { result =>
-
-        // Then
-        result.columnAs("count(n)").toSet[Int] should equal(Set(9))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectOtherPlanIn = expectOtherPlan + Configs.Cost3_1 + Configs.Cost3_2)
+    compareCount(query, 9, expectOtherPlanIn = expectOtherPlan + Configs.Cost3_1 + Configs.Cost3_2, executeBefore = executeBefore)
   }
 
   test("count store on two unlabeled nodes and count(*)") {
     // Given
-    withModel(
+    val executeBefore = () => setupModel()
+    val query = "MATCH (n), (m) RETURN count(*)"
 
-      // When
-      query = "MATCH (n), (m) RETURN count(*)", f = { result =>
-
-        // Then
-        result.columnAs("count(*)").toSet[Int] should equal(Set(9))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectOtherPlanIn = expectOtherPlan + Configs.Cost3_1 + Configs.Cost3_2)
+    compareCount(query, 9, expectOtherPlanIn = expectOtherPlan + Configs.Cost3_1 + Configs.Cost3_2, executeBefore = executeBefore)
   }
 
   test("count store on one labeled node and one unlabeled") {
     // Given
-    withModel(
+    val executeBefore = () => setupModel()
+    val query = "MATCH (n:User),(m) RETURN count(n)"
 
-      // When
-      query = "MATCH (n:User),(m) RETURN count(n)", f = { result =>
-
-        // Then
-        result.columnAs("count(n)").toSet[Int] should equal(Set(6))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectOtherPlanIn = expectOtherPlan + Configs.Cost3_1 + Configs.Cost3_2)
+    compareCount(query, 6, expectOtherPlanIn = expectOtherPlan + Configs.Cost3_1 + Configs.Cost3_2, executeBefore = executeBefore)
   }
 
   test("count store on one labeled node and one unlabeled and count(*)") {
     // Given
-    withModel(
+    val executeBefore = () => setupModel()
+    val query = "MATCH (n:User),(m) RETURN count(*)"
 
-      // When
-      query = "MATCH (n:User),(m) RETURN count(*)", f = { result =>
-
-        // Then
-        result.columnAs("count(*)").toSet[Int] should equal(Set(6))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectOtherPlanIn = expectOtherPlan + Configs.Cost3_1 + Configs.Cost3_2)
+    compareCount(query, 6, expectOtherPlanIn = expectOtherPlan + Configs.Cost3_1 + Configs.Cost3_2, executeBefore = executeBefore)
   }
 
   test("count store on two labeled nodes") {
     // Given
-    withModel(
+    val executeBefore = () => setupModel()
+    val query = "MATCH (n:User),(m:User) RETURN count(n)"
 
-      // When
-      query = "MATCH (n:User),(m:User) RETURN count(n)", f = { result =>
-
-        // Then
-        result.columnAs("count(n)").toSet[Int] should equal(Set(4))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectOtherPlanIn = expectOtherPlan + Configs.Cost3_1 + Configs.Cost3_2)
+    compareCount(query, 4, expectOtherPlanIn = expectOtherPlan + Configs.Cost3_1 + Configs.Cost3_2, executeBefore = executeBefore)
   }
 
   test("count store with many nodes") {
     // Given
-    withModel(
+    val executeBefore = () => setupModel()
+    val query = "MATCH (n:User),(m),(o:User),(p) RETURN count(*)"
 
-      // When
-      query = "MATCH (n:User),(m),(o:User),(p) RETURN count(*)", f = { result =>
-
-        // Then
-        result.columnAs("count(*)").toSet[Int] should equal(Set(36))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectOtherPlanIn = expectOtherPlan + Configs.Cost3_1 + Configs.Cost3_2)
+    compareCount(query, 36, expectOtherPlanIn = expectOtherPlan + Configs.Cost3_1 + Configs.Cost3_2, executeBefore = executeBefore)
   }
 
   test("count store with many but odd number of nodes") {
     // Given
-    withModel(
+    val executeBefore = () => setupModel()
+    val query = "MATCH (n:User),(m),(o:User),(p), (q) RETURN count(*)"
 
-      // When
-      query = "MATCH (n:User),(m),(o:User),(p), (q) RETURN count(*)", f = { result =>
-
-        // Then
-        result.columnAs("count(*)").toSet[Int] should equal(Set(108))
-
-      }, allRuntimes = true)
+    // Then
+    compareCount(query, 0, expectOtherPlanIn = expectOtherPlan + Configs.Cost3_1 + Configs.Cost3_2)
+    compareCount(query, 108, expectOtherPlanIn = expectOtherPlan + Configs.Cost3_1 + Configs.Cost3_2, executeBefore = executeBefore)
   }
 
-  def withModel(label1: String = "User",
-                label2: String = "User",
-                type1: String = "KNOWS",
-                expectedLogicalPlan: String = "NodeCountFromCountStore",
-                query: String, f: InternalExecutionResult => Unit,
-                expectedResultOnEmptyDatabase: Set[Any] = Set(0),
-                allRuntimes: Boolean = false): Unit = {
-    verifyOnEmptyDatabase(expectedLogicalPlan, query, expectedResultOnEmptyDatabase, allRuntimes)
-
-    innerExecute(
+  private def setupModel(label1: String = "User",
+                 label2: String = "User",
+                 type1: String = "KNOWS"): Unit = {
+    graph.execute(
       s"""
          |CREATE (p:$label1 {name: 'Petra'})
          |CREATE (s:$label2 {name: 'Steve'})
          |CREATE (p)-[:$type1]->(s)
          |CREATE (a)-[:LOOP]->(a)
       """.stripMargin)
-
-    val result: InternalExecutionResult =
-      if (allRuntimes) executeWithAllPlannersAndRuntimesAndCompatibilityMode(query)
-      else executeWithAllPlannersAndCompatibilityMode(query)
-    result.executionPlanDescription() should includeOperation(expectedLogicalPlan)
-    f(result)
-
-    deleteAllEntities()
-
-    verifyOnEmptyDatabase(expectedLogicalPlan, query, expectedResultOnEmptyDatabase, allRuntimes)
   }
 
-  private def verifyOnEmptyDatabase(expectedLogicalPlan: String, query: String,
-                                   expectedResult: Set[Any], allRuntimes: Boolean): Unit = {
-    val resultOnEmptyDb: InternalExecutionResult =
-      if (allRuntimes) executeWithAllPlannersAndRuntimesAndCompatibilityMode(query)
-      else  executeWithAllPlannersAndCompatibilityMode(query)
-    resultOnEmptyDb.executionPlanDescription() should includeOperation(expectedLogicalPlan)
-    withClue("should return a count of 0 on an empty database") {
-      resultOnEmptyDb.columnAs(resultOnEmptyDb.columns.head).toSet[Int] should equal(expectedResult)
-    }
-  }
-
-  def withRelationshipsModel(label1: String = "User",
-                             label2: String = "User",
-                             type1: String = "KNOWS",
-                             expectedLogicalPlan: String = "RelationshipCountFromCountStore",
-                             query: String, f: InternalExecutionResult => Unit,
-                             allRuntimes: Boolean = false): Unit = {
-    withModel(label1, label2, type1, expectedLogicalPlan, query, f, allRuntimes = allRuntimes)
-  }
-
-  def withModelAndTransaction(label1: String = "User",
-                label2: String = "User",
-                label3: String = "User",
-                type1: String = "KNOWS",
-                type2: String = "KNOWS",
-                type3: String = "KNOWS",
-                expectedLogicalPlan: String = "NodeCountFromCountStore",
-                query: String, f: InternalExecutionResult => Unit,
-                expectedResultOnEmptyDatabase: Set[Any] = Set(0),
-                allRuntimes: Boolean = false): Unit = {
-    verifyOnEmptyDatabase(expectedLogicalPlan, query, expectedResultOnEmptyDatabase, allRuntimes)
-
-    innerExecute(
+  private def setupBigModel(label1: String = "User",
+                    label2: String = "User",
+                    type1: String = "KNOWS"): Unit = {
+    graph.execute(
       s"""
          |CREATE (m:X {name: 'Mats'})
          |CREATE (p:$label1 {name: 'Petra'})
@@ -816,53 +651,48 @@ class MatchAggregationsBackedByCountStoreAcceptanceTest
          |CREATE (p)-[:$type1]->(s)
          |CREATE (m)-[:$type1]->(s)
       """.stripMargin)
+  }
 
-    graph.inTx {
-      executeWithCostPlannerAndInterpretedRuntimeOnly("MATCH (m:X)-[r]->() DELETE m, r")
-      executeWithCostPlannerAndInterpretedRuntimeOnly(
-        s"""
-           |MATCH (p:$label1 {name: 'Petra'})
-           |MATCH (s:$label2 {name: 'Steve'})
-           |CREATE (c:$label3 {name: 'Craig'})
-           |CREATE (p)-[:$type2]->(c)
-           |CREATE (c)-[:$type3]->(s)
+  private def inTXModification(label1: String = "User",
+                       label2: String = "User",
+                       label3: String = "User",
+                       type2: String = "KNOWS",
+                       type3: String = "KNOWS"): Unit = {
+    graph.execute("MATCH (m:X)-[r]->() DELETE m, r")
+    graph.execute(
+      s"""
+         |MATCH (p:$label1 {name: 'Petra'})
+         |MATCH (s:$label2 {name: 'Steve'})
+         |CREATE (c:$label3 {name: 'Craig'})
+         |CREATE (p)-[:$type2]->(c)
+         |CREATE (c)-[:$type3]->(s)
         """.stripMargin)
-      val result: InternalExecutionResult =
-        if (allRuntimes) executeWithAllPlannersAndRuntimesAndCompatibilityMode(query)
-        else executeWithCostPlannerAndInterpretedRuntimeOnly(query)
-      result.executionPlanDescription() should includeOperation(expectedLogicalPlan)
-      f(result)
-    }
-
-    deleteAllEntities()
-    verifyOnEmptyDatabase(expectedLogicalPlan, query, expectedResultOnEmptyDatabase, allRuntimes = allRuntimes)
   }
 
-  def withRelationshipsModelAndTransaction(label1: String = "User",
-                        label2: String = "User",
-                        label3: String = "User",
-                        type1: String = "KNOWS",
-                        type2: String = "KNOWS",
-                        type3: String = "KNOWS",
-                        expectedLogicalPlan: String = "RelationshipCountFromCountStore",
-                        query: String, f: InternalExecutionResult => Unit,
-                        expectedResultOnEmptyDatabase: Set[Any] = Set(0),
-                        allRuntimes: Boolean = false): Unit = {
-    withModelAndTransaction(label1, label2, label3, type1, type2, type3,
-                            expectedLogicalPlan, query, f, expectedResultOnEmptyDatabase, allRuntimes)
-  }
+  private def compareCount(query: String,
+                   expectedCount: Any,
+                   expectSucceed: TestConfiguration = defaultConfig,
+                   expectedLogicalPlan: String = "NodeCountFromCountStore",
+                   expectOtherPlanIn: TestConfiguration = expectOtherPlan,
+                   assertCountInTransaction: Boolean = false,
+                   executeBefore: () => Unit = () => {}) = {
 
-  case class includeOperation(operationName: String) extends Matcher[InternalPlanDescription] {
-
-    override def apply(result: InternalPlanDescription): MatchResult = {
-      val operationExists = result.flatten.exists { description =>
-        description.name == operationName
+    val resultAssertionInTx =
+      if (assertCountInTransaction) {
+        Some({ result: InternalExecutionResult => result.columnAs(result.columns.head).toSet[Any] should equal(Set(expectedCount)) })
+      } else {
+        None
       }
 
-      MatchResult(operationExists, matchResultMsg(negated = false, result), matchResultMsg(negated = true, result))
-    }
-
-    private def matchResultMsg(negated: Boolean, result: InternalPlanDescription) =
-      s"$operationName ${if (negated) "" else "not"} found in plan description\n $result"
+    val result = executeWith(
+      expectSucceed,
+      query,
+      executeBefore = executeBefore,
+      planComparisonStrategy = ComparePlansWithAssertion(plan => {
+        plan should useOperators(expectedLogicalPlan)
+      }, expectOtherPlanIn),
+      resultAssertionInTx = resultAssertionInTx)
+    result.columnAs(result.columns.head).toSet[Any] should equal(Set(expectedCount))
   }
+
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathComplexQueryAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathComplexQueryAcceptanceTest.scala
@@ -65,7 +65,7 @@ class ShortestPathComplexQueryAcceptanceTest extends ExecutionEngineFunSuite wit
   }
 
   private def setupModel(): Unit = {
-    executeWith(Configs.CommunityInterpreted - Configs.Cost2_3,
+    graph.execute(
       """
         |MERGE (p1:Pixie {fname:'Charles'})
         |MERGE (p2:Pixie {fname:'Kim'})
@@ -74,6 +74,6 @@ class ShortestPathComplexQueryAcceptanceTest extends ExecutionEngineFunSuite wit
         |MERGE (p5:Pixie {fname:'Paz'})
         |MERGE (p1)-[:KNOWS]->(p2)-[:KNOWS]->(p3)-[:KNOWS]->(p4)-[:KNOWS]->(p5)-[:KNOWS]->(p1)
         |RETURN p1,p2,p3,p4,p5
-      """.stripMargin, rollback = false)
+      """.stripMargin)
   }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathLongerAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathLongerAcceptanceTest.scala
@@ -31,7 +31,7 @@ import org.neo4j.graphalgo.impl.path.ShortestPath
 import org.neo4j.graphalgo.impl.path.ShortestPath.DataMonitor
 import org.neo4j.graphdb.factory.GraphDatabaseSettings
 import org.neo4j.graphdb.{Node, Path}
-import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.{ComparePlansWithAssertion, CompareResults, Configs}
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.{ComparePlansWithAssertion, Configs}
 import org.neo4j.kernel.monitoring.Monitors
 import org.scalatest.matchers.{MatchResult, Matcher}
 
@@ -612,12 +612,10 @@ class ShortestPathLongerAcceptanceTest extends ExecutionEngineFunSuite with Cyph
                   |WHERE ALL(id IN wps WHERE id IN EXTRACT(n IN nodes(p) | n.id))
                   |WITH p, size(nodes(p)) as length order by length DESC limit 1
                   |RETURN EXTRACT(n IN nodes(p) | n.id) as nodes""".stripMargin
-    executeWith(Configs.CommunityInterpreted, query,
-      planComparisonStrategy = CompareResults(
-        _.toList should equal(List(Map("nodes" -> List(3, 2, 1, 11, 12, 13, 26, 27, 14)))),
-        expectPlansToFail = Configs.AllRulePlanners + Configs.Cost2_3
-      ),
+    val result = executeWith(Configs.CommunityInterpreted, query,
       expectedDifferentResults = Configs.AllRulePlanners + Configs.Cost2_3)
+
+    result.toList should equal(List(Map("nodes" -> List(3, 2, 1, 11, 12, 13, 26, 27, 14))))
   }
 
   test("don't forget to turn off verbose!") {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartsWithImplementationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartsWithImplementationAcceptanceTest.scala
@@ -20,10 +20,11 @@
 package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes.IndexSeekByRange
-import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport, QueryStatisticsTestSupport}
+import org.neo4j.cypher.{ExecutionEngineFunSuite, QueryStatisticsTestSupport}
 import org.neo4j.graphdb.{Node, ResourceIterator}
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
 
-class StartsWithImplementationAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with NewPlannerTestSupport {
+class StartsWithImplementationAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with CypherComparisonSupport {
 
   var aNode: Node = null
   var bNode: Node = null
@@ -51,7 +52,7 @@ class StartsWithImplementationAcceptanceTest extends ExecutionEngineFunSuite wit
     createLabeledNode(Map("prop" -> "www123"), "Address")
     createLabeledNode(Map("prop" -> "www"), "Address")
 
-    val result = executeWithAllPlannersAndCompatibilityMode("MATCH (a:Address) WHERE a.prop STARTS WITH 'www' RETURN a")
+    val result = executeWith(Configs.Interpreted, "MATCH (a:Address) WHERE a.prop STARTS WITH 'www' RETURN a")
 
     result should not(use(IndexSeekByRange.name))
   }
@@ -64,15 +65,16 @@ class StartsWithImplementationAcceptanceTest extends ExecutionEngineFunSuite wit
       createLabeledNode(Map("name" -> "Stefanie"), "User")
       createLabeledNode(Map("name" -> "Craig"), "User")
     }
-    graph.inTx {
-      drain(graph.execute("MATCH (u:User {name: 'Craig'}) SET u.name = 'Steven'"))
-      drain(graph.execute("MATCH (u:User {name: 'Stephan'}) DELETE u"))
-      drain(graph.execute("MATCH (u:User {name: 'Stefanie'}) SET u.name = 'steffi'"))
+      val executeBefore = () => {
+        drain(graph.execute("MATCH (u:User {name: 'Craig'}) SET u.name = 'Steven'"))
+        drain(graph.execute("MATCH (u:User {name: 'Stephan'}) DELETE u"))
+        drain(graph.execute("MATCH (u:User {name: 'Stefanie'}) SET u.name = 'steffi'"))
+      }
 
-      val result = executeWithAllPlannersAndCompatibilityMode("MATCH (u:User) WHERE u.name STARTS WITH 'Ste' RETURN u.name as name").columnAs("name").toList.toSet
-
-      result should equal(Set[String]("Stefan", "Steven"))
-    }
+      executeWith(Configs.Interpreted, "MATCH (u:User) WHERE u.name STARTS WITH 'Ste' RETURN u.name as name", executeBefore = executeBefore,
+        resultAssertionInTx = Some(result => {
+          result.toSet should equal(Set(Map("name" -> "Stefan"),Map("name" -> "Steven")))
+        }))
   }
 
   private def drain(iter: ResourceIterator[_]): Unit = {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/VarLengthExpandQueryPlanAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/VarLengthExpandQueryPlanAcceptanceTest.scala
@@ -33,9 +33,9 @@ class VarLengthExpandQueryPlanAcceptanceTest extends ExecutionEngineFunSuite wit
 
     val ignoreConfiguration = Configs.AllRulePlanners + Configs.Cost2_3
     executeWith(expectedToSucceed, query, planComparisonStrategy =
-      CompareResults(result => {
-        result.executionPlanDescription() should useOperatorWithText("VarLengthExpand(All)", "(e)<-[:*..4]-(a)")
-        result.executionPlanDescription() should useOperatorWithText("NodeByLabelScan", ":To")
+      ComparePlansWithAssertion(plan => {
+        plan should useOperatorWithText("VarLengthExpand(All)", "(e)<-[:*..4]-(a)")
+        plan should useOperatorWithText("NodeByLabelScan", ":To")
       }, expectPlansToFail = ignoreConfiguration))
   }
 
@@ -44,41 +44,41 @@ class VarLengthExpandQueryPlanAcceptanceTest extends ExecutionEngineFunSuite wit
     val query = "PROFILE MATCH (a:From {name:'Keanu Reeves'})-[*..4]->(e:To {name:'Andres'}) RETURN *"
     val ignoreConfiguration = Configs.AllRulePlanners + Configs.Cost2_3
     executeWith(expectedToSucceed, query, planComparisonStrategy =
-      CompareResults(result => {
-        result.executionPlanDescription() should useOperatorWithText("VarLengthExpand(All)", "(a)-[:*..4]->(e)")
-        result.executionPlanDescription() should useOperatorWithText("NodeByLabelScan", ":From")
+      ComparePlansWithAssertion( plan => {
+        plan should useOperatorWithText("VarLengthExpand(All)", "(a)-[:*..4]->(e)")
+        plan should useOperatorWithText("NodeByLabelScan", ":From")
       }, expectPlansToFail = ignoreConfiguration))
   }
 
   test("Plan pruning var expand on distinct var-length match") {
     val query = "MATCH (a)-[*1..2]->(c) RETURN DISTINCT c"
     executeWith(expectedToSucceed - Configs.SlottedInterpreted, query, planComparisonStrategy =
-      CompareResults(result => {
-        result.executionPlanDescription() should useOperators("VarLengthExpand(Pruning)")
+      ComparePlansWithAssertion( plan => {
+        plan should useOperators("VarLengthExpand(Pruning)")
       }, expectPlansToFail = ignoreConfiguration))
   }
 
   test("Plan pruning var expand on distinct var-length match with projection and aggregation") {
     val query = "MATCH (a)-[*1..2]->(c) WITH DISTINCT c RETURN count(*)"
     executeWith(expectedToSucceed - Configs.SlottedInterpreted, query, planComparisonStrategy =
-      CompareResults(result => {
-        result.executionPlanDescription() should useOperators("VarLengthExpand(Pruning)")
+      ComparePlansWithAssertion( plan => {
+        plan should useOperators("VarLengthExpand(Pruning)")
       }, expectPlansToFail = ignoreConfiguration))
   }
 
   test("query with distinct aggregation") {
     val query = "MATCH (from)-[*1..3]->(to) RETURN count(DISTINCT to)"
     executeWith(expectedToSucceed - Configs.SlottedInterpreted, query, planComparisonStrategy =
-      CompareResults(result => {
-        result.executionPlanDescription() should useOperators("VarLengthExpand(Pruning)")
+      ComparePlansWithAssertion( plan => {
+        plan should useOperators("VarLengthExpand(Pruning)")
       }, expectPlansToFail = ignoreConfiguration))
   }
 
   test("Simple query that filters between expand and distinct") {
     val query = "MATCH (a)-[*1..3]->(b:X) RETURN DISTINCT b"
     executeWith(expectedToSucceed - Configs.SlottedInterpreted, query, planComparisonStrategy =
-      CompareResults(result => {
-        result.executionPlanDescription() should useOperators("VarLengthExpand(Pruning)")
+      ComparePlansWithAssertion( plan => {
+        plan should useOperators("VarLengthExpand(Pruning)")
       }, expectPlansToFail = ignoreConfiguration))
   }
 
@@ -86,32 +86,32 @@ class VarLengthExpandQueryPlanAcceptanceTest extends ExecutionEngineFunSuite wit
     val query = "MATCH (a)-[:R*1..3]->(b) WITH count(*) AS count RETURN DISTINCT count"
     val ignoreConfiguration = Configs.AllRulePlanners
     executeWith(expectedToSucceed, query, planComparisonStrategy =
-      CompareResults(result => {
-        result.executionPlanDescription() should useOperators("VarLengthExpand(All)")
+      ComparePlansWithAssertion( plan => {
+        plan should useOperators("VarLengthExpand(All)")
       }, expectPlansToFail = ignoreConfiguration))
   }
 
   test("Double var expand with distinct result") {
     val query = "MATCH (a)-[:R*1..3]->(b)-[:T*1..3]->(c) RETURN DISTINCT c"
     executeWith(expectedToSucceed - Configs.SlottedInterpreted, query, planComparisonStrategy =
-      CompareResults(result => {
-        result.executionPlanDescription() should useOperators("VarLengthExpand(Pruning)")
+      ComparePlansWithAssertion( plan => {
+        plan should useOperators("VarLengthExpand(Pruning)")
       }, expectPlansToFail = ignoreConfiguration))
   }
 
   test("var expand followed by normal expand") {
     val query = "MATCH (a)-[:R*1..3]->(b)-[:T]->(c) RETURN DISTINCT c"
     executeWith(expectedToSucceed - Configs.SlottedInterpreted, query, planComparisonStrategy =
-      CompareResults(result => {
-        result.executionPlanDescription() should useOperators("VarLengthExpand(Pruning)")
+      ComparePlansWithAssertion( plan => {
+        plan should useOperators("VarLengthExpand(Pruning)")
       }, expectPlansToFail = ignoreConfiguration))
   }
 
   test("optional match can be solved with PruningVarExpand") {
     val query = "MATCH (a) OPTIONAL MATCH (a)-[:R*1..3]->(b)-[:T]->(c) RETURN DISTINCT c"
     executeWith(expectedToSucceed - Configs.SlottedInterpreted, query, planComparisonStrategy =
-      CompareResults(result => {
-        result.executionPlanDescription() should useOperators("VarLengthExpand(Pruning)")
+      ComparePlansWithAssertion( plan => {
+        plan should useOperators("VarLengthExpand(Pruning)")
       }, expectPlansToFail = ignoreConfiguration))
   }
 
@@ -119,16 +119,16 @@ class VarLengthExpandQueryPlanAcceptanceTest extends ExecutionEngineFunSuite wit
     val query = "MATCH (a)-[*1..3]->(b) RETURN b, count(*)"
     val ignoreConfiguration = Configs.AllRulePlanners
     executeWith(Configs.Interpreted + Configs.Cost2_3, query, planComparisonStrategy =
-      CompareResults(result => {
-        result.executionPlanDescription() should useOperators("VarLengthExpand(All)")
+      ComparePlansWithAssertion( plan => {
+        plan should useOperators("VarLengthExpand(All)")
       }, expectPlansToFail = ignoreConfiguration))
   }
 
   test("on longer var-lengths, we use FullPruningVarExpand") {
     val query = "MATCH (a)-[*4..5]->(b) RETURN DISTINCT b"
     executeWith(expectedToSucceed - Configs.SlottedInterpreted, query, planComparisonStrategy =
-      CompareResults(result => {
-        result.executionPlanDescription() should useOperators("VarLengthExpand(FullPruning)")
+      ComparePlansWithAssertion( plan => {
+        plan should useOperators("VarLengthExpand(FullPruning)")
       }, expectPlansToFail = ignoreConfiguration))
   }
 
@@ -136,8 +136,8 @@ class VarLengthExpandQueryPlanAcceptanceTest extends ExecutionEngineFunSuite wit
     val query = "MATCH (a)-[*1..1]->(b) RETURN DISTINCT b"
     val ignoreConfiguration = Configs.AllRulePlanners
     executeWith(expectedToSucceed, query, planComparisonStrategy =
-      CompareResults(result => {
-        result.executionPlanDescription() should useOperators("VarLengthExpand(All)")
+      ComparePlansWithAssertion( plan => {
+        plan should useOperators("VarLengthExpand(All)")
       }, expectPlansToFail = ignoreConfiguration))
   }
 


### PR DESCRIPTION
Ability to write assertions on the result that are executed inside of the transaction.
Porting of two test classes that required the above feature.