### PR TITLE
Fix where multiple label predicates are combined with OR

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/NormalizeComparisonsTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/ast/rewriters/NormalizeComparisonsTest.scala
@@ -19,13 +19,12 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.ast.rewriters
 
-import org.neo4j.cypher.internal.frontend.v3_2.DummyPosition
 import org.neo4j.cypher.internal.frontend.v3_2.ast.rewriters.normalizeComparisons
 import org.neo4j.cypher.internal.frontend.v3_2.ast.{Equals, Expression, InvalidNotEquals, NotEquals, Variable, _}
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 
-class NormalizeComparisonsTest extends CypherFunSuite {
-  val pos = DummyPosition(0)
+class NormalizeComparisonsTest extends CypherFunSuite with AstConstructionTestSupport {
+
   val expression: Expression = Variable("foo")(pos)
   val comparisons = List(
     Equals(expression, expression)(pos),
@@ -43,5 +42,20 @@ class NormalizeComparisonsTest extends CypherFunSuite {
 
       rewritten.lhs shouldNot be theSameInstanceAs rewritten.rhs
     }
+  }
+
+  test("extract multiple hasLabels") {
+    val original = HasLabels(varFor("a"), Seq(lblName("X"), lblName("Y")))(pos)
+
+    original.endoRewrite(normalizeComparisons) should equal(
+      Ands(Set(
+        HasLabels(varFor("a"), Seq(lblName("X")))(pos),
+        HasLabels(varFor("a"), Seq(lblName("Y")))(pos)))(pos))
+  }
+
+  test("does not extract single hasLabels") {
+    val original = HasLabels(varFor("a"), Seq(lblName("Y")))(pos)
+
+    original.endoRewrite(normalizeComparisons) should equal(original)
   }
 }

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/rewriters/normalizeComparisons.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/rewriters/normalizeComparisons.scala
@@ -41,5 +41,8 @@ case object normalizeComparisons extends Rewriter {
       GreaterThanOrEqual(lhs.endoRewrite(copyVariables), rhs.endoRewrite(copyVariables))(c.position)
     case c@InvalidNotEquals(lhs, rhs) =>
       InvalidNotEquals(lhs.endoRewrite(copyVariables), rhs.endoRewrite(copyVariables))(c.position)
+    case c@HasLabels(expr, labels) if labels.size > 1 =>
+      val hasLabels = labels.map(l => HasLabels(expr.endoRewrite(copyVariables), Seq(l))(c.position))
+      Ands(hasLabels.toSet)(c.position)
   })
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -161,3 +161,4 @@ Using a optional match after aggregation and before an aggregation
 difficult to plan query number 1
 difficult to plan query number 2
 difficult to plan query number 3
+Match on multiple labels with OR

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/MatchAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/MatchAcceptance.feature
@@ -120,7 +120,24 @@ Feature: MatchAcceptance
     Given an empty graph
     And having executed:
       """
-      CREATE (a:A:B)
+      CREATE (:A:B), (:A:C), (:B:C)
+      """
+    When executing query:
+      """
+      MATCH (a)
+      WHERE a:A:B
+      RETURN a
+      """
+    Then the result should be:
+      | a      |
+      | (:A:B) |
+    And no side effects
+
+  Scenario: Match on multiple labels with OR
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:A:B), (:A:C), (:B:C)
       """
     When executing query:
       """
@@ -131,4 +148,5 @@ Feature: MatchAcceptance
     Then the result should be:
       | a      |
       | (:A:B) |
+      | (:A:C) |
     And no side effects

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/MatchAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/MatchAcceptance.feature
@@ -116,3 +116,19 @@ Feature: MatchAcceptance
       | 'apa' |
     And no side effects
 
+  Scenario: Match on multiple labels
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (a:A:B)
+      """
+    When executing query:
+      """
+      MATCH (a)
+      WHERE (a:A:B OR a:A:C)
+      RETURN a
+      """
+    Then the result should be:
+      | a      |
+      | (:A:B) |
+    And no side effects

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -693,14 +693,63 @@ return p""")
     result.toList should equal(List(Map("size" -> 8)))
   }
 
-  /**
-   * Append variable to keys and transform value arrays to lists
-   */
-  private def asResult(data: Map[String, Any], id: String) =
-    data.map {
-      case (k, v) => (s"$id.$k", v)
-    }.mapValues {
-      case v: Array[_] => v.toList
-      case v => v
-    }
+  test("Should handle multiple labels") {
+    val n1 = createLabeledNode("A", "B", "C")
+    val n2 = createLabeledNode("A", "B")
+    createLabeledNode("A", "C")
+    createLabeledNode("B", "C")
+    createLabeledNode("A")
+    createLabeledNode("B")
+    createLabeledNode("C")
+
+    val result = innerExecute("MATCH (a) WHERE a:A:B RETURN a")
+
+    // Then
+    result.toList should equal(List(Map("a" -> n1), Map("a" -> n2)))
+  }
+
+  test("Should handle multiple labels with OR") {
+    val n1 = createLabeledNode("A", "B", "C")
+    val n2 = createLabeledNode("A", "B")
+    val n3 = createLabeledNode("A", "C")
+    createLabeledNode("B", "C")
+    createLabeledNode("A")
+    createLabeledNode("B")
+    createLabeledNode("C")
+
+    val result = innerExecute("MATCH (a) WHERE a:A:B OR a:A:C RETURN a")
+
+    // Then
+    result.toList should equal(List(Map("a" -> n1), Map("a" -> n2), Map("a" -> n3)))
+  }
+
+  test("Should handle multiple labels with OR and AND") {
+    val n1 = createLabeledNode("A", "B", "C")
+    val n2 = createLabeledNode("A", "B")
+    val n3 = createLabeledNode("A", "C")
+    createLabeledNode("B", "C")
+    createLabeledNode("A")
+    createLabeledNode("B")
+    createLabeledNode("C")
+
+    val result = innerExecute("MATCH (a) WHERE (a:A AND a:B) OR (a:A AND a:C) RETURN a")
+
+    // Then
+    result.toList should equal(List(Map("a" -> n1), Map("a" -> n2), Map("a" -> n3)))
+  }
+
+  test("Should handle multiple labels with AND") {
+    val n = createLabeledNode("A", "B", "C")
+    createLabeledNode("A", "B")
+    createLabeledNode("A", "C")
+    createLabeledNode("B", "C")
+    createLabeledNode("A")
+    createLabeledNode("B")
+    createLabeledNode("C")
+
+    val result = innerExecute("MATCH (a) WHERE a:A:B AND a:A:C RETURN a")
+
+    // Then
+    result.toList should equal(List(Map("a" -> n)))
+  }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -702,7 +702,7 @@ return p""")
     createLabeledNode("B")
     createLabeledNode("C")
 
-    val result = innerExecute("MATCH (a) WHERE a:A:B RETURN a")
+    val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH (a) WHERE a:A:B RETURN a")
 
     // Then
     result.toList should equal(List(Map("a" -> n1), Map("a" -> n2)))
@@ -717,7 +717,7 @@ return p""")
     createLabeledNode("B")
     createLabeledNode("C")
 
-    val result = innerExecute("MATCH (a) WHERE a:A:B OR a:A:C RETURN a")
+    val result = executeWithAllPlannersAndCompatibilityMode("MATCH (a) WHERE a:A:B OR a:A:C RETURN a")
 
     // Then
     result.toList should equal(List(Map("a" -> n1), Map("a" -> n2), Map("a" -> n3)))
@@ -732,7 +732,7 @@ return p""")
     createLabeledNode("B")
     createLabeledNode("C")
 
-    val result = innerExecute("MATCH (a) WHERE (a:A AND a:B) OR (a:A AND a:C) RETURN a")
+    val result = executeWithAllPlannersAndCompatibilityMode("MATCH (a) WHERE (a:A AND a:B) OR (a:A AND a:C) RETURN a")
 
     // Then
     result.toList should equal(List(Map("a" -> n1), Map("a" -> n2), Map("a" -> n3)))
@@ -747,7 +747,7 @@ return p""")
     createLabeledNode("B")
     createLabeledNode("C")
 
-    val result = innerExecute("MATCH (a) WHERE a:A:B AND a:A:C RETURN a")
+    val result = executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH (a) WHERE a:A:B AND a:A:C RETURN a")
 
     // Then
     result.toList should equal(List(Map("a" -> n)))


### PR DESCRIPTION
A `HasLabels` containing multiple labels will be rewritten to an `Ands` with
a set of `HasLabels` containing one label each. This fixes an issue with
planning an `Or` with multiple labels on at least side.

Fixes #10100