### PR TITLE
3.4 cypher util auto formatting

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,5 @@
+maxColumn = 100
+align.openParenCallSite = false
+danglingParentheses = true
+align = none
+docstrings = JavaDoc

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/ASTNode.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/ASTNode.scala
@@ -18,10 +18,7 @@ package org.neo4j.cypher.internal.util.v3_4
 
 import org.neo4j.cypher.internal.util.v3_4.Rewritable._
 
-trait ASTNode
-  extends Product
-  with Foldable
-  with Rewritable {
+trait ASTNode extends Product with Foldable with Rewritable {
 
   self =>
 

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/CypherException.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/CypherException.scala
@@ -18,7 +18,8 @@ package org.neo4j.cypher.internal.util.v3_4
 
 import org.neo4j.cypher.internal.util.v3_4.spi.MapToPublicExceptions
 
-abstract class CypherException(protected val message: String, cause: Throwable) extends RuntimeException(message, cause) {
+abstract class CypherException(protected val message: String, cause: Throwable)
+    extends RuntimeException(message, cause) {
   def this() = this(null, null)
 
   def this(message: String) = this(message, null)
@@ -29,77 +30,105 @@ abstract class CypherException(protected val message: String, cause: Throwable) 
 }
 
 class UniquePathNotUniqueException(message: String) extends CypherException {
-  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]): T = mapper.uniquePathNotUniqueException(message, this)
+  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]): T =
+    mapper.uniquePathNotUniqueException(message, this)
 }
 
 class FailedIndexException(indexName: String) extends CypherException {
-  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.failedIndexException(indexName, this)
+  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
+    mapper.failedIndexException(indexName, this)
 }
 
-class EntityNotFoundException(message: String, cause: Throwable = null) extends CypherException(cause) {
-  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.entityNotFoundException(message, this)
+class EntityNotFoundException(message: String, cause: Throwable = null)
+    extends CypherException(cause) {
+  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
+    mapper.entityNotFoundException(message, this)
 }
 
-class CypherTypeException(message: String, cause: Throwable = null) extends CypherException(message, cause) {
-  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.cypherTypeException(message, this)
+class CypherTypeException(message: String, cause: Throwable = null)
+    extends CypherException(message, cause) {
+  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
+    mapper.cypherTypeException(message, this)
 }
 
 class ParameterNotFoundException(message: String, cause: Throwable) extends CypherException(cause) {
   def this(message: String) = this(message, null)
 
-  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.parameterNotFoundException(message, this)
+  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
+    mapper.parameterNotFoundException(message, this)
 }
 
-class ParameterWrongTypeException(message: String, cause: Throwable = null) extends CypherException(message, cause) {
-  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.parameterWrongTypeException(message, this)
+class ParameterWrongTypeException(message: String, cause: Throwable = null)
+    extends CypherException(message, cause) {
+  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
+    mapper.parameterWrongTypeException(message, this)
 }
 
-class InvalidArgumentException(message: String, cause: Throwable = null) extends CypherException(message, cause) {
-  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.invalidArgumentException(message, this)
+class InvalidArgumentException(message: String, cause: Throwable = null)
+    extends CypherException(message, cause) {
+  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
+    mapper.invalidArgumentException(message, this)
 }
 
 class PatternException(message: String) extends CypherException(message) {
-  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.patternException(message, this)
+  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
+    mapper.patternException(message, this)
 }
 
-class InternalException(message: String, inner: Exception = null) extends CypherException(message, inner) {
-  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.internalException(message, this)
+class InternalException(message: String, inner: Exception = null)
+    extends CypherException(message, inner) {
+  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
+    mapper.internalException(message, this)
 }
 
-class NodeStillHasRelationshipsException(val nodeId: Long, cause: Throwable) extends CypherException(cause) {
-  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.nodeStillHasRelationshipsException(nodeId, this)
+class NodeStillHasRelationshipsException(val nodeId: Long, cause: Throwable)
+    extends CypherException(cause) {
+  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
+    mapper.nodeStillHasRelationshipsException(nodeId, this)
 }
 
 class ProfilerStatisticsNotReadyException extends CypherException {
-  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.profilerStatisticsNotReadyException(this)
+  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
+    mapper.profilerStatisticsNotReadyException(this)
 }
 
-class IndexHintException(variable: String, label: String, properties: Seq[String], message: String) extends CypherException {
-  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.indexHintException(variable, label, properties, message, this)
+class IndexHintException(variable: String, label: String, properties: Seq[String], message: String)
+    extends CypherException {
+  def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
+    mapper.indexHintException(variable, label, properties, message, this)
 }
 
 class JoinHintException(variable: String, message: String) extends CypherException {
-  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.joinHintException(variable, message, this)
+  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
+    mapper.joinHintException(variable, message, this)
 }
 
-class HintException(message: String, cause: Throwable = null) extends CypherException(message, cause) {
-  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]): T = mapper.hintException(message, cause)
+class HintException(message: String, cause: Throwable = null)
+    extends CypherException(message, cause) {
+  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]): T =
+    mapper.hintException(message, cause)
 }
 
 class InvalidSemanticsException(message: String) extends CypherException {
-  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.invalidSemanticException(message, this)
+  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
+    mapper.invalidSemanticException(message, this)
 }
 
-class MergeConstraintConflictException(message: String, cause: Throwable = null) extends CypherException(message, cause) {
-  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.mergeConstraintConflictException(message, this)
+class MergeConstraintConflictException(message: String, cause: Throwable = null)
+    extends CypherException(message, cause) {
+  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
+    mapper.mergeConstraintConflictException(message, this)
 }
 
 class ArithmeticException(message: String, cause: Throwable = null) extends CypherException(cause) {
-  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.arithmeticException(message, this)
+  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
+    mapper.arithmeticException(message, this)
 }
 
-class IncomparableValuesException(details: Option[String], lhs: String, rhs: String) extends CypherException {
-  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.incomparableValuesException(details, lhs, rhs, this)
+class IncomparableValuesException(details: Option[String], lhs: String, rhs: String)
+    extends CypherException {
+  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
+    mapper.incomparableValuesException(details, lhs, rhs, this)
   def this(operator: String, lhs: String, rhs: String) = this(Some(operator), lhs, rhs)
   def this(lhs: String, rhs: String) = this(None, lhs, rhs)
 }
@@ -110,21 +139,27 @@ class UnorderableValueException(value: String) extends CypherException {
 }
 
 class PeriodicCommitInOpenTransactionException extends CypherException {
-  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.periodicCommitInOpenTransactionException(this)
+  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
+    mapper.periodicCommitInOpenTransactionException(this)
 }
 
-class LoadExternalResourceException(message: String, cause: Throwable = null) extends CypherException(cause) {
-  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) = mapper.loadExternalResourceException(message, this)
+class LoadExternalResourceException(message: String, cause: Throwable = null)
+    extends CypherException(cause) {
+  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
+    mapper.loadExternalResourceException(message, this)
 }
 
-class LoadCsvStatusWrapCypherException(extraInfo: String, cause: CypherException) extends CypherException(cause) {
+class LoadCsvStatusWrapCypherException(extraInfo: String, cause: CypherException)
+    extends CypherException(cause) {
   override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
     // the mapper will map the cause here, so we cannot pass 'this' in as the cause...
     mapper.loadCsvStatusWrapCypherException(extraInfo, cause)
 }
 
-class SyntaxException(message: String, val query: String, val pos: Option[InputPosition]) extends CypherException(message) {
-  def this(message: String, query: String, offset: InputPosition) = this(message, query, Some(offset))
+class SyntaxException(message: String, val query: String, val pos: Option[InputPosition])
+    extends CypherException(message) {
+  def this(message: String, query: String, offset: InputPosition) =
+    this(message, query, Some(offset))
 
   def this(message: String) = this(message, "", None)
 
@@ -132,8 +167,10 @@ class SyntaxException(message: String, val query: String, val pos: Option[InputP
     mapper.syntaxException(message, query, pos.map(_.offset), this)
 }
 
-class CypherExecutionException(message: String, cause: Throwable) extends CypherException(message, cause) {
-  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]): T = mapper.cypherExecutionException(message, this)
+class CypherExecutionException(message: String, cause: Throwable)
+    extends CypherException(message, cause) {
+  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]): T =
+    mapper.cypherExecutionException(message, this)
 }
 
 object ExhaustiveShortestPathForbiddenException {
@@ -149,10 +186,10 @@ object ExhaustiveShortestPathForbiddenException {
        |start filtering.""".stripMargin
 }
 
-class ExhaustiveShortestPathForbiddenException extends CypherExecutionException(
-  ExhaustiveShortestPathForbiddenException.ERROR_MSG, null) {
-override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]): T =
-mapper.shortestPathFallbackDisableRuntimeException(message, this)
+class ExhaustiveShortestPathForbiddenException
+    extends CypherExecutionException(ExhaustiveShortestPathForbiddenException.ERROR_MSG, null) {
+  override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]): T =
+    mapper.shortestPathFallbackDisableRuntimeException(message, this)
 }
 
 object ShortestPathCommonEndNodesForbiddenException {
@@ -166,8 +203,8 @@ object ShortestPathCommonEndNodesForbiddenException {
        |expression followed by ordering by path length and limiting to one result.""".stripMargin
 }
 
-class ShortestPathCommonEndNodesForbiddenException extends CypherExecutionException(
-  ShortestPathCommonEndNodesForbiddenException.ERROR_MSG, null) {
+class ShortestPathCommonEndNodesForbiddenException
+    extends CypherExecutionException(ShortestPathCommonEndNodesForbiddenException.ERROR_MSG, null) {
   override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]): T =
     mapper.shortestPathCommonEndNodesForbiddenException(message, this)
 }

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/InputPosition.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/InputPosition.scala
@@ -46,7 +46,9 @@ case class InputPosition(offset: Int, line: Int, column: Int) {
 
 object InputPosition {
   implicit val byOffset =
-    Ordering.by { (pos: InputPosition) => pos.offset }
+    Ordering.by { (pos: InputPosition) =>
+      pos.offset
+    }
 
   val NONE = InputPosition(0, 0, 0)
 }

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/Ref.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/Ref.scala
@@ -32,6 +32,6 @@ final class Ref[+T <: AnyRef](val value: T) {
 
   override def equals(that: Any) = that match {
     case other: Ref[_] => value eq other.value
-    case _             => false
+    case _ => false
   }
 }

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/spi/MapToPublicExceptions.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/spi/MapToPublicExceptions.scala
@@ -31,7 +31,12 @@ trait MapToPublicExceptions[T <: Throwable] {
 
   def unorderableValueException(value: String): T
 
-  def incomparableValuesException(operator: Option[String], lhs: String, rhs: String, cause: Throwable): T
+  def incomparableValuesException(
+      operator: Option[String],
+      lhs: String,
+      rhs: String,
+      cause: Throwable
+  ): T
 
   def arithmeticException(message: String, cause: Throwable): T
 
@@ -39,7 +44,13 @@ trait MapToPublicExceptions[T <: Throwable] {
 
   def invalidSemanticException(message: String, cause: Throwable): T
 
-  def indexHintException(variable: String, label: String, properties: Seq[String], message: String, cause: Throwable): T
+  def indexHintException(
+      variable: String,
+      label: String,
+      properties: Seq[String],
+      message: String,
+      cause: Throwable
+  ): T
 
   def hintException(message: String, cause: Throwable): T
 

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/AnyType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/AnyType.scala
@@ -25,7 +25,6 @@ object AnyType {
 
     override val toString = "Any"
     override val toNeoTypeString = "ANY?"
-
   }
 }
 

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/BooleanType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/BooleanType.scala
@@ -21,7 +21,6 @@ object BooleanType {
     val parentType = CTAny
     override val toString = "Boolean"
     override val toNeoTypeString = "BOOLEAN?"
-
   }
 }
 

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/FloatType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/FloatType.scala
@@ -21,7 +21,6 @@ object FloatType {
     val parentType = CTNumber
     override val toString = "Float"
     override val toNeoTypeString = "FLOAT?"
-
   }
 }
 

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/IntegerType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/IntegerType.scala
@@ -22,7 +22,6 @@ object IntegerType {
     override lazy val coercibleTo: Set[CypherType] = Set(CTFloat)
     override val toString = "Integer"
     override val toNeoTypeString = "INTEGER?"
-
   }
 }
 

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/ListType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/ListType.scala
@@ -19,7 +19,8 @@ package org.neo4j.cypher.internal.util.v3_4.symbols
 object ListType {
   private val anyCollectionTypeInstance = new ListTypeImpl(CTAny)
 
-  def apply(iteratedType: CypherType) = if (iteratedType == CTAny) anyCollectionTypeInstance else new ListTypeImpl(iteratedType)
+  def apply(iteratedType: CypherType) =
+    if (iteratedType == CTAny) anyCollectionTypeInstance else new ListTypeImpl(iteratedType)
 
   final case class ListTypeImpl(innerType: CypherType) extends ListType {
     val parentType = CTAny
@@ -31,7 +32,6 @@ object ListType {
 
     override val toString = s"List<$innerType>"
     override val toNeoTypeString = s"LIST? OF ${innerType.toNeoTypeString}"
-
 
     override def isAssignableFrom(other: CypherType): Boolean = other match {
       case otherCollection: ListType =>
@@ -62,7 +62,6 @@ object ListType {
     case _ => None
   }
 }
-
 
 sealed abstract class ListType extends CypherType {
   def innerType: CypherType

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/MapType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/MapType.scala
@@ -21,7 +21,6 @@ object MapType {
     val parentType = CTAny
     override val toString = "Map"
     override val toNeoTypeString = "MAP?"
-
   }
 }
 

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/NodeType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/NodeType.scala
@@ -21,7 +21,6 @@ object NodeType {
     val parentType = CTMap
     override val toString = "Node"
     override val toNeoTypeString = "NODE?"
-
   }
 }
 

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/PathType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/PathType.scala
@@ -21,7 +21,6 @@ object PathType {
     val parentType = CTAny
     override val toString = "Path"
     override val toNeoTypeString = "PATH?"
-
   }
 }
 

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/RelationshipType.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/RelationshipType.scala
@@ -21,7 +21,6 @@ object RelationshipType {
     val parentType = CTMap
     override val toString = "Relationship"
     override val toNeoTypeString = "RELATIONSHIP?"
-
   }
 }
 

--- a/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/RewritableTest.scala
+++ b/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/RewritableTest.scala
@@ -22,23 +22,23 @@ object RewritableTest {
   trait Exp extends Product with Rewritable
   case class Val(int: Int) extends Exp {
     def dup(children: Seq[AnyRef]): this.type =
-      Val(children(0).asInstanceOf[Int]).asInstanceOf[this.type]
+      Val(children.head.asInstanceOf[Int]).asInstanceOf[this.type]
   }
   case class Add(lhs: Exp, rhs: Exp) extends Exp {
     def dup(children: Seq[AnyRef]): this.type =
-      Add(children(0).asInstanceOf[Exp], children(1).asInstanceOf[Exp]).asInstanceOf[this.type]
+      Add(children.head.asInstanceOf[Exp], children(1).asInstanceOf[Exp]).asInstanceOf[this.type]
   }
   case class Sum(args: Seq[Exp]) extends Exp {
     def dup(children: Seq[AnyRef]): this.type =
-      Sum(children(0).asInstanceOf[Seq[Exp]]).asInstanceOf[this.type]
+      Sum(children.head.asInstanceOf[Seq[Exp]]).asInstanceOf[this.type]
   }
   case class Pos(latlng: (Exp, Exp)) extends Exp {
     def dup(children: Seq[AnyRef]): this.type =
-      Pos(children(0).asInstanceOf[(Exp, Exp)]).asInstanceOf[this.type]
+      Pos(children.head.asInstanceOf[(Exp, Exp)]).asInstanceOf[this.type]
   }
   case class Options(args: Seq[(Exp, Exp)]) extends Exp {
     def dup(children: Seq[AnyRef]): this.type =
-      Options(children(0).asInstanceOf[Seq[(Exp, Exp)]]).asInstanceOf[this.type]
+      Options(children.head.asInstanceOf[Seq[(Exp, Exp)]]).asInstanceOf[this.type]
   }
 }
 

--- a/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/test_helpers/CypherFunSuite.scala
+++ b/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/test_helpers/CypherFunSuite.scala
@@ -26,13 +26,13 @@ import scala.reflect.Manifest
 
 @RunWith(classOf[JUnitRunner])
 abstract class CypherFunSuite
-  extends Suite
-  with Assertions
-  with CypherTestSupport
-  with MockitoSugar
-  with FunSuiteLike
-  with Matchers
-  with BeforeAndAfterEach {
+    extends Suite
+    with Assertions
+    with CypherTestSupport
+    with MockitoSugar
+    with FunSuiteLike
+    with Matchers
+    with BeforeAndAfterEach {
 
   override protected def beforeEach() {
     initTest()

--- a/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/test_helpers/CypherTestSupport.scala
+++ b/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/test_helpers/CypherTestSupport.scala
@@ -17,8 +17,7 @@
 package org.neo4j.cypher.internal.util.v3_4.test_helpers
 
 // Inherited by test mixin classes that need to manage resources
-trait CypherTestSupport  {
+trait CypherTestSupport {
   protected def initTest() {}
   protected def stopTest() {}
 }
-

--- a/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/test_helpers/IgnoreAllTests.scala
+++ b/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/test_helpers/IgnoreAllTests.scala
@@ -23,7 +23,8 @@ trait IgnoreAllTests extends CypherFunSuite {
   def ignoranceRationale = ""
 
   abstract override protected def test(testName: String, testTags: Tag*)(testFun: => Unit) {
-    val ignoredTestName = if (ignoranceRationale.isEmpty) testName else s"testName [$ignoranceRationale]"
+    val ignoredTestName =
+      if (ignoranceRationale.isEmpty) testName else s"testName [$ignoranceRationale]"
     ignore(ignoredTestName, testTags: _*)(testFun)
   }
 


### PR DESCRIPTION
We have devised a strategy for slowly adding formatting rules to scala code. It was decided that applying them on the whole code base at once was bad because it would make investigating the git history much harder. Instead we can initially add it to new modules as we are creating them, and add CI checks on one module at a time.

This PR adds some auto-formatting rules for [scalafmt](http://scalameta.org/scalafmt/), and applies them on the cypher utils module. What is left to do is to add style-checking for this module in maven. 