### PR TITLE
Fix online backup of read-only instances with schema and legacy indexes.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/LegacyIndex.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/LegacyIndex.java
@@ -19,19 +19,21 @@
  */
 package org.neo4j.kernel.api;
 
+import org.neo4j.kernel.api.exceptions.legacyindex.LegacyIndexNotFoundKernelException;
+
 /**
  * The main way to access a legacy index. Even pure reads will need to get a hold of an object of this class
  * and to a query on. Blending of transaction state must also be handled within this object.
  */
 public interface LegacyIndex
 {
-    LegacyIndexHits get( String key, Object value );
+    LegacyIndexHits get( String key, Object value ) throws LegacyIndexNotFoundKernelException;
 
-    LegacyIndexHits query( String key, Object queryOrQueryObject );
+    LegacyIndexHits query( String key, Object queryOrQueryObject ) throws LegacyIndexNotFoundKernelException;
 
-    LegacyIndexHits query( Object queryOrQueryObject );
+    LegacyIndexHits query( Object queryOrQueryObject ) throws LegacyIndexNotFoundKernelException;
 
-    void addNode( long entity, String key, Object value );
+    void addNode( long entity, String key, Object value ) throws LegacyIndexNotFoundKernelException;
 
     void remove( long entity, String key, Object value );
 
@@ -42,13 +44,17 @@ public interface LegacyIndex
     void drop();
 
     // Relationship-index-specific accessors
-    LegacyIndexHits get( String key, Object value, long startNode, long endNode );
+    LegacyIndexHits get( String key, Object value, long startNode, long endNode )
+            throws LegacyIndexNotFoundKernelException;
 
-    LegacyIndexHits query( String key, Object queryOrQueryObject, long startNode, long endNode );
+    LegacyIndexHits query( String key, Object queryOrQueryObject, long startNode, long endNode )
+            throws LegacyIndexNotFoundKernelException;
 
-    LegacyIndexHits query( Object queryOrQueryObject, long startNode, long endNode );
+    LegacyIndexHits query( Object queryOrQueryObject, long startNode, long endNode )
+            throws LegacyIndexNotFoundKernelException;
 
-    void addRelationship( long entity, String key, Object value, long startNode, long endNode );
+    void addRelationship( long entity, String key, Object value, long startNode, long endNode )
+            throws LegacyIndexNotFoundKernelException;
 
     void removeRelationship( long entity, String key, Object value, long startNode, long endNode );
 

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/CommitContext.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/CommitContext.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.neo4j.kernel.api.exceptions.legacyindex.LegacyIndexNotFoundKernelException;
+
 /**
  * This presents a context for each {@link LuceneCommand} when they are
  * committing its data.
@@ -50,7 +52,7 @@ class CommitContext implements Closeable
         this.recovery = isRecovery;
     }
 
-    void ensureWriterInstantiated()
+    void ensureWriterInstantiated() throws LegacyIndexNotFoundKernelException
     {
         if ( searcher == null )
         {

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/IndexReferenceFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/IndexReferenceFactory.java
@@ -19,12 +19,16 @@
  */
 package org.neo4j.index.impl.lucene.legacy;
 
+import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.store.Directory;
 
 import java.io.File;
 import java.io.IOException;
+
+import org.neo4j.kernel.api.exceptions.legacyindex.LegacyIndexNotFoundKernelException;
 
 /**
  * Factory that build appropriate (read only or writable) {@link IndexReference} for provided {@link IndexIdentifier}
@@ -50,15 +54,26 @@ abstract class IndexReferenceFactory
      * @return newly create {@link IndexReference}
      *
      * @throws IOException in case of exception during accessing lucene reader/writer.
+     * @throws LegacyIndexNotFoundKernelException if the index is dropped prior to, or concurrently with, this
+     * operation.
      */
-    abstract IndexReference createIndexReference( IndexIdentifier indexIdentifier ) throws IOException;
+    abstract IndexReference createIndexReference( IndexIdentifier indexIdentifier )
+            throws IOException, LegacyIndexNotFoundKernelException;
 
     /**
-     * Refresh previously constructed indexReference.
-     * @param indexReference index reference to refresh
-     * @return refreshed index reference
+     * If nothing has changed underneath (since the searcher was last created or refreshed) {@code searcher} is
+     * returned. But if something has changed a refreshed searcher is returned. It makes use if the
+     * {@link DirectoryReader#openIfChanged(DirectoryReader, IndexWriter, boolean)} which faster than opening an index
+     * from scratch.
+     *
+     * @param indexReference the {@link IndexReference} to refresh.
+     * @return a refreshed version of the searcher or, if nothing has changed,
+     *         {@code null}.
+     * @throws RuntimeException if there's a problem with the index.
+     * @throws LegacyIndexNotFoundKernelException if the index is dropped prior to, or concurrently with, this
+     * operation.
      */
-    abstract IndexReference refresh( IndexReference indexReference );
+    abstract IndexReference refresh( IndexReference indexReference ) throws LegacyIndexNotFoundKernelException;
 
     Directory getIndexDirectory( IndexIdentifier identifier ) throws IOException
     {
@@ -66,6 +81,7 @@ abstract class IndexReferenceFactory
     }
 
     IndexSearcher newIndexSearcher( IndexIdentifier identifier, IndexReader reader )
+            throws LegacyIndexNotFoundKernelException
     {
         IndexSearcher searcher = new IndexSearcher( reader );
         IndexType type = getType( identifier );
@@ -76,7 +92,7 @@ abstract class IndexReferenceFactory
         return searcher;
     }
 
-    IndexType getType( IndexIdentifier identifier )
+    IndexType getType( IndexIdentifier identifier ) throws LegacyIndexNotFoundKernelException
     {
         return typeCache.getIndexType( identifier, false );
     }

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSource.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSource.java
@@ -509,7 +509,7 @@ public class LuceneDataSource extends LifecycleAdapter
                     {
                         if ( exception == null )
                         {
-                            exception = e instanceof IOException?
+                            exception = e instanceof IOException ?
                                         new UncheckedIOException( (IOException) e ) :
                                         (RuntimeException) e;
                         }

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/ReadOnlyIndexReferenceFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/ReadOnlyIndexReferenceFactory.java
@@ -26,6 +26,8 @@ import org.apache.lucene.search.IndexSearcher;
 import java.io.File;
 import java.io.IOException;
 
+import org.neo4j.kernel.api.exceptions.legacyindex.LegacyIndexNotFoundKernelException;
+
 public class ReadOnlyIndexReferenceFactory extends IndexReferenceFactory
 {
     public ReadOnlyIndexReferenceFactory( LuceneDataSource.LuceneFilesystemFacade filesystemFacade, File baseStorePath,
@@ -35,7 +37,8 @@ public class ReadOnlyIndexReferenceFactory extends IndexReferenceFactory
     }
 
     @Override
-    IndexReference createIndexReference( IndexIdentifier identifier ) throws IOException
+    IndexReference createIndexReference( IndexIdentifier identifier )
+            throws IOException, LegacyIndexNotFoundKernelException
     {
         IndexReader reader = DirectoryReader.open( getIndexDirectory( identifier ) );
         IndexSearcher indexSearcher = newIndexSearcher( identifier, reader );

--- a/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneKernelExtension.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneKernelExtension.java
@@ -40,6 +40,11 @@ public class LuceneKernelExtension extends LifecycleAdapter
     private final OperationalMode operationalMode;
 
     public LuceneKernelExtension( File storeDir, Config config, Supplier<IndexConfigStore> indexStore,
+            FileSystemAbstraction fileSystemAbstraction, IndexProviders indexProviders )
+    {
+        this( storeDir, config, indexStore, fileSystemAbstraction, indexProviders, OperationalMode.single );
+    }
+    public LuceneKernelExtension( File storeDir, Config config, Supplier<IndexConfigStore> indexStore,
             FileSystemAbstraction fileSystemAbstraction, IndexProviders indexProviders, OperationalMode operationalMode )
     {
         this.storeDir = storeDir;

--- a/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneKernelExtension.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/lucene/LuceneKernelExtension.java
@@ -40,12 +40,6 @@ public class LuceneKernelExtension extends LifecycleAdapter
     private final OperationalMode operationalMode;
 
     public LuceneKernelExtension( File storeDir, Config config, Supplier<IndexConfigStore> indexStore,
-            FileSystemAbstraction fileSystemAbstraction, IndexProviders indexProviders )
-    {
-        this( storeDir, config, indexStore, fileSystemAbstraction, indexProviders, OperationalMode.single );
-    }
-
-    public LuceneKernelExtension( File storeDir, Config config, Supplier<IndexConfigStore> indexStore,
             FileSystemAbstraction fileSystemAbstraction, IndexProviders indexProviders, OperationalMode operationalMode )
     {
         this.storeDir = storeDir;
@@ -59,7 +53,6 @@ public class LuceneKernelExtension extends LifecycleAdapter
     @Override
     public void init()
     {
-
         LuceneIndexImplementation indexImplementation =
                 new LuceneIndexImplementation( storeDir, config, indexStore, fileSystemAbstraction, operationalMode );
         indexProviders.registerIndexProvider( LuceneIndexImplementation.SERVICE_NAME, indexImplementation );

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexAccessor.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexAccessor.java
@@ -54,7 +54,7 @@ public class LuceneIndexAccessor implements IndexAccessor
     {
         if ( luceneIndex.isReadOnly() )
         {
-            throw new UnsupportedOperationException( "Can't create updated for read only index." );
+            throw new UnsupportedOperationException( "Can't create updater for read only index." );
         }
         switch ( mode )
         {
@@ -78,7 +78,11 @@ public class LuceneIndexAccessor implements IndexAccessor
     @Override
     public void force() throws IOException
     {
-        luceneIndex.markAsOnline();
+        // We never change status of read-only indexes.
+        if ( !luceneIndex.isReadOnly() )
+        {
+            luceneIndex.markAsOnline();
+        }
         luceneIndex.maybeRefreshBlocking();
     }
 

--- a/community/lucene-index/src/test/java/org/neo4j/concurrencytest/LegacyIndexAddDropConcurrentlyTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/concurrencytest/LegacyIndexAddDropConcurrentlyTest.java
@@ -36,7 +36,7 @@ import org.neo4j.graphdb.NotFoundException;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.test.rule.ImpermanentDatabaseRule;
 
-public class LegacyIndexAddDropConcurrently
+public class LegacyIndexAddDropConcurrentlyTest
 {
     @Rule
     public ImpermanentDatabaseRule dbRule = new ImpermanentDatabaseRule();

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSourceTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSourceTest.java
@@ -70,7 +70,7 @@ public class LuceneDataSourceTest
     }
 
     @Test
-    public void doNotTryToCommitWritersOnForceInReadOnlyMode() throws IOException
+    public void doNotTryToCommitWritersOnForceInReadOnlyMode() throws Exception
     {
         IndexIdentifier indexIdentifier = identifier( "foo" );
         prepareIndexesByIdentifiers( indexIdentifier );
@@ -84,7 +84,7 @@ public class LuceneDataSourceTest
     }
 
     @Test
-    public void notAllowIndexDeletionInReadOnlyMode() throws IOException
+    public void notAllowIndexDeletionInReadOnlyMode() throws Exception
     {
         IndexIdentifier indexIdentifier = identifier( "foo" );
         prepareIndexesByIdentifiers( indexIdentifier );
@@ -98,7 +98,7 @@ public class LuceneDataSourceTest
     }
 
     @Test
-    public void useReadOnlyIndexSearcherInReadOnlyModeForSingleInstance() throws IOException
+    public void useReadOnlyIndexSearcherInReadOnlyModeForSingleInstance() throws Exception
     {
         IndexIdentifier indexIdentifier = identifier( "foo" );
         prepareIndexesByIdentifiers( indexIdentifier );
@@ -113,7 +113,7 @@ public class LuceneDataSourceTest
     }
 
     @Test
-    public void useWritableIndexSearcherInReadOnlyModeForNonSingleInstance() throws IOException
+    public void useWritableIndexSearcherInReadOnlyModeForNonSingleInstance() throws Exception
     {
         IndexIdentifier indexIdentifier = identifier( "foo" );
         prepareIndexesByIdentifiers( indexIdentifier );
@@ -128,7 +128,7 @@ public class LuceneDataSourceTest
     }
 
     @Test
-    public void refreshReadOnlyIndexSearcherInReadOnlyMode() throws IOException
+    public void refreshReadOnlyIndexSearcherInReadOnlyMode() throws Exception
     {
         IndexIdentifier indexIdentifier = identifier( "foo" );
         prepareIndexesByIdentifiers( indexIdentifier );
@@ -253,7 +253,7 @@ public class LuceneDataSourceTest
         return stringMap();
     }
 
-    private void prepareIndexesByIdentifiers( IndexIdentifier indexIdentifier )
+    private void prepareIndexesByIdentifiers( IndexIdentifier indexIdentifier ) throws Exception
     {
         Config config = Config.embeddedDefaults();
         dataSource = life.add( getLuceneDataSource( config ) );

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/ReadOnlyIndexReferenceFactoryTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/ReadOnlyIndexReferenceFactoryTest.java
@@ -26,7 +26,6 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.RuleChain;
 
 import java.io.File;
-import java.io.IOException;
 
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.index.IndexManager;
@@ -58,7 +57,7 @@ public class ReadOnlyIndexReferenceFactoryTest
     private IndexConfigStore indexStore;
 
     @Before
-    public void setUp() throws IOException
+    public void setUp() throws Exception
     {
         setupIndexInfrastructure();
     }
@@ -75,7 +74,7 @@ public class ReadOnlyIndexReferenceFactoryTest
     }
 
     @Test
-    public void refreshReadOnlyIndexReference() throws IOException
+    public void refreshReadOnlyIndexReference() throws Exception
     {
         ReadOnlyIndexReferenceFactory indexReferenceFactory = getReadOnlyIndexReferenceFactory();
         IndexReference indexReference = indexReferenceFactory.createIndexReference( indexIdentifier );
@@ -85,7 +84,7 @@ public class ReadOnlyIndexReferenceFactoryTest
         assertSame("Refreshed instance should be the same.", indexReference, refreshedIndex);
     }
 
-    private void setupIndexInfrastructure() throws IOException
+    private void setupIndexInfrastructure() throws Exception
     {
         File storeDir = getStoreDir();
         indexStore = new IndexConfigStore( storeDir, fileSystemRule.get() );

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/TestIndexDeletion.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/TestIndexDeletion.java
@@ -37,7 +37,7 @@ import org.neo4j.graphdb.index.Index;
 import org.neo4j.graphdb.index.IndexHits;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
-import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
@@ -237,8 +237,8 @@ public class TestIndexDeletion
         }
         catch ( ExecutionException e )
         {
-            assertThat( e.getCause(), instanceOf( IllegalStateException.class ) );
-            assertThat( e.getCause().getMessage(), containsString( "Unknown index" ) );
+            assertThat( e.getCause(), instanceOf( NotFoundException.class ) );
+            assertThat( e.getCause().getMessage().toLowerCase(), containsString( "index 'index' doesn't exist" ) );
         }
 
         secondTx.rollback();

--- a/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/WritableIndexReferenceFactoryTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/impl/lucene/legacy/WritableIndexReferenceFactoryTest.java
@@ -106,7 +106,7 @@ public class WritableIndexReferenceFactoryTest
         writer.commit();
     }
 
-    private IndexReference createIndexReference( WritableIndexReferenceFactory indexReferenceFactory ) throws IOException
+    private IndexReference createIndexReference( WritableIndexReferenceFactory indexReferenceFactory ) throws Exception
     {
         IndexReference indexReference = indexReferenceFactory.createIndexReference( indexIdentifier );
         cleanupRule.add( indexReference );

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexProviderTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexProviderTest.java
@@ -105,6 +105,19 @@ public class LuceneSchemaIndexProviderTest
         getIndexAccessor( readOnlyConfig, readOnlyIndexProvider ).newUpdater( IndexUpdateMode.ONLINE);
     }
 
+    @Test
+    public void indexForceMustBeAllowedInReadOnlyMode() throws Exception
+    {
+        // IndexAccessor.force is used in check-pointing, and must be allowed in read-only mode as it would otherwise
+        // prevent backups from working.
+        Config readOnlyConfig = Config.embeddedDefaults( stringMap( GraphDatabaseSettings.read_only.name(), Settings.TRUE ) );
+        LuceneSchemaIndexProvider readOnlyIndexProvider = getLuceneSchemaIndexProvider( readOnlyConfig,
+                new DirectoryFactory.InMemoryDirectoryFactory(), fs, graphDbDir );
+
+        // We assert that 'force' does not throw an exception
+        getIndexAccessor( readOnlyConfig, readOnlyIndexProvider ).force();
+    }
+
     private void createEmptySchemaIndex( DirectoryFactory directoryFactory ) throws IOException
     {
         Config config = Config.defaults();


### PR DESCRIPTION
Taking an online backup of a read-only instance would previously throw a variety of exceptions, depending on its schema/legacy indexes. This fixes #10089.

This also fixes a plurality of bugs where create and drop of legacy indexes are concurrent with commits of changes to those indexes. These bugs had snuck in because the relevant test didn't have a proper test-name, and thus the test was never run by our build system.

Also fixed in this PR, is a bug in _relationship_ legacy indexes, where changes could be committed with different document types. This was already fixed for node indexes a long time ago, but that fix was apparently never applied to the relationship indexes.