### PR TITLE
Close AbstractTraverserIterator resource only once

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/java/org/neo4j/internal/cypher/acceptance/TestProcedure.java
+++ b/community/cypher/acceptance-spec-suite/src/test/java/org/neo4j/internal/cypher/acceptance/TestProcedure.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.PathExpanderBuilder;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.traversal.Evaluation;
+import org.neo4j.graphdb.traversal.Evaluator;
+import org.neo4j.graphdb.traversal.Evaluators;
+import org.neo4j.graphdb.traversal.TraversalDescription;
+import org.neo4j.graphdb.traversal.Traverser;
+import org.neo4j.graphdb.traversal.Uniqueness;
+import org.neo4j.helpers.collection.Pair;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Description;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+
+import static org.neo4j.graphdb.Direction.BOTH;
+import static org.neo4j.graphdb.Direction.INCOMING;
+import static org.neo4j.graphdb.Direction.OUTGOING;
+import static org.neo4j.graphdb.traversal.Evaluation.EXCLUDE_AND_CONTINUE;
+import static org.neo4j.graphdb.traversal.Evaluation.EXCLUDE_AND_PRUNE;
+import static org.neo4j.graphdb.traversal.Evaluation.INCLUDE_AND_CONTINUE;
+import static org.neo4j.graphdb.traversal.Evaluation.INCLUDE_AND_PRUNE;
+
+public class TestProcedure
+{
+    @Context
+    public GraphDatabaseService db;
+
+    @Procedure("org.neo4j.test")
+    @Description("org.neo4j.test")
+    public Stream<TestResult> test() throws Exception {
+        return db.findNodes( Label.label("Tweet" ) ).stream().map( TestResult::new );
+    }
+
+    @Procedure("org.neo4j.testTraversal")
+    @Description("org.neo4j.testTraversal")
+    public Stream<TestResult> testTraversal() throws Exception {
+        TraversalDescription td = db.traversalDescription();
+        return db.findNodes( Label.label("Tweet" ) )
+                .stream()
+                .flatMap( node -> td.traverse( node ).stream().map( path -> new TestResult( path.startNode() ) ) );
+    }
+
+    @Procedure("apoc.path.expandConfig")
+    @Description("apoc.path.expandConfig(startNode <id>|Node|list, {minLevel,maxLevel,uniqueness,relationshipFilter,labelFilter,uniqueness:'RELATIONSHIP_PATH',bfs:true, filterStartNode:false}) yield path expand from start node following the given relationships from min to max-level adhering to the label filters")
+    public Stream<PathResult> expandConfig(@Name("start") Object start, @Name("config") Map<String,Object> config) throws Exception {
+        return expandConfigPrivate(start, config).map( PathResult::new );
+    }
+
+    private Stream<Path> expandConfigPrivate(@Name("start") Object start, @Name("config") Map<String,Object> config) throws Exception {
+        List<Node> nodes = startToNodes(start);
+
+        String uniqueness = (String) config.getOrDefault("uniqueness", Uniqueness.RELATIONSHIP_PATH.name());
+        String relationshipFilter = (String) config.getOrDefault("relationshipFilter", null);
+        String labelFilter = (String) config.getOrDefault("labelFilter", null);
+        long minLevel = toLong(config.getOrDefault("minLevel", "-1"));
+        long maxLevel = toLong(config.getOrDefault("maxLevel", "-1"));
+        boolean bfs = toBoolean(config.getOrDefault("bfs",true));
+        boolean filterStartNode = toBoolean(config.getOrDefault("filterStartNode", true));
+        long limit = toLong(config.getOrDefault("limit", "-1"));
+
+        return explorePathPrivate(nodes, relationshipFilter, labelFilter, minLevel, maxLevel, bfs,
+                getUniqueness(uniqueness), filterStartNode, limit);
+    }
+
+    public static Long toLong(Object value) {
+        if (value == null) return null;
+        if (value instanceof Number) return ((Number)value).longValue();
+        try {
+            return Long.parseLong(value.toString());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    public static boolean toBoolean(Object value) {
+        if ((value == null || value instanceof Number && (((Number) value).longValue()) == 0L || value instanceof String && (value.equals("") || ((String) value).equalsIgnoreCase("false") || ((String) value).equalsIgnoreCase("no")|| ((String) value).equalsIgnoreCase("0"))|| value instanceof Boolean && value.equals(false))) {
+            return false;
+        }
+        return true;
+    }
+
+    private Stream<Path> explorePathPrivate(Iterable<Node> startNodes
+            , String pathFilter
+            , String labelFilter
+            , long minLevel
+            , long maxLevel, boolean bfs, Uniqueness uniqueness, boolean filterStartNode, long limit) {
+        // LabelFilter
+        // -|Label|:Label|:Label excluded label list
+        // +:Label or :Label include labels
+
+        Traverser traverser = traverse(db.traversalDescription(), startNodes, pathFilter, labelFilter, minLevel, maxLevel, uniqueness,bfs,filterStartNode,limit);
+        return traverser.stream();
+    }
+
+    public static Traverser traverse(TraversalDescription traversalDescription, Iterable<Node> startNodes, String pathFilter, String labelFilter, long minLevel, long maxLevel, Uniqueness uniqueness, boolean bfs, boolean filterStartNode, long limit) {
+        TraversalDescription td = traversalDescription;
+        // based on the pathFilter definition now the possible relationships and directions must be shown
+
+        td = bfs ? td.breadthFirst() : td.depthFirst();
+
+        Iterable<Pair<RelationshipType, Direction>> relDirIterable = RelationshipTypeAndDirections.parse(pathFilter);
+
+        for (Pair<RelationshipType, Direction> pair: relDirIterable) {
+            if (pair.first() == null) {
+                td = td.expand( PathExpanderBuilder.allTypes(pair.other()).build());
+            } else {
+                td = td.relationships(pair.first(), pair.other());
+            }
+        }
+
+        if (minLevel != -1) td = td.evaluator( Evaluators.fromDepth((int) minLevel));
+        if (maxLevel != -1) td = td.evaluator(Evaluators.toDepth((int) maxLevel));
+
+        if (labelFilter != null && !labelFilter.trim().isEmpty()) {
+            td = td.evaluator(new LabelEvaluator(labelFilter, filterStartNode, limit, (int) minLevel));
+        }
+
+        td = td.uniqueness(uniqueness); // this is how Cypher works !! Uniqueness.RELATIONSHIP_PATH
+        // uniqueness should be set as last on the TraversalDescription
+        return td.traverse(startNodes);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Node> startToNodes(Object start) throws Exception {
+        if (start == null) return Collections.emptyList();
+        if (start instanceof Node) {
+            return Collections.singletonList((Node) start);
+        }
+        if (start instanceof Number) {
+            return Collections.singletonList(db.getNodeById(((Number) start).longValue()));
+        }
+        if (start instanceof List) {
+            List list = (List) start;
+            if (list.isEmpty()) return Collections.emptyList();
+
+            Object first = list.get(0);
+            if (first instanceof Node) return (List<Node>)list;
+            if (first instanceof Number) {
+                List<Node> nodes = new ArrayList<>();
+                for (Number n : ((List<Number>)list)) nodes.add(db.getNodeById(n.longValue()));
+                return nodes;
+            }
+        }
+        throw new Exception("Unsupported data type for start parameter a Node or an Identifier (long) of a Node must be given!");
+    }
+
+    private Uniqueness getUniqueness(String uniqueness) {
+        for (Uniqueness u : Uniqueness.values()) {
+            if (u.name().equalsIgnoreCase(uniqueness)) return u;
+        }
+        return Uniqueness.RELATIONSHIP_PATH;
+    }
+
+    public static class PathResult {
+        public Path path;
+
+        public PathResult(Path path) {
+            this.path = path;
+        }
+    }
+
+    public static class TestResult
+    {
+        public String value;
+
+        public TestResult( Node node )
+        {
+            this.value = "NodeWithId"+value;
+        }
+    }
+
+    public static class LabelEvaluator implements Evaluator
+    {
+        private Set<String> whitelistLabels;
+        private Set<String> blacklistLabels;
+        private Set<String> terminationLabels;
+        private Set<String> endNodeLabels;
+        private Evaluation whitelistAllowedEvaluation;
+        private boolean endNodesOnly;
+        private boolean filterStartNode;
+        private long limit = -1;
+        private long minLevel = -1;
+        private long resultCount = 0;
+
+        public LabelEvaluator(String labelFilter, boolean filterStartNode, long limit, int minLevel) {
+            this.filterStartNode = filterStartNode;
+            this.limit = limit;
+            this.minLevel = minLevel;
+            Map<Character, Set<String>> labelMap = new HashMap<>(4);
+
+            if (labelFilter !=  null && !labelFilter.isEmpty()) {
+
+                // parse the filter
+                // split on |
+                String[] defs = labelFilter.split("\\|");
+                Set<String> labels = null;
+
+                for (String def : defs) {
+                    char operator = def.charAt(0);
+                    switch (operator) {
+                    case '+':
+                    case '-':
+                    case '/':
+                    case '>':
+                        labels = labelMap.computeIfAbsent(operator, character -> new HashSet<>());
+                        def = def.substring(1);
+                    }
+
+                    if (def.startsWith(":")) {
+                        def = def.substring(1);
+                    }
+
+                    if (!def.isEmpty()) {
+                        labels.add(def);
+                    }
+                }
+            }
+
+            whitelistLabels = labelMap.computeIfAbsent('+', character -> Collections.emptySet());
+            blacklistLabels = labelMap.computeIfAbsent('-', character -> Collections.emptySet());
+            terminationLabels = labelMap.computeIfAbsent('/', character -> Collections.emptySet());
+            endNodeLabels = labelMap.computeIfAbsent('>', character -> Collections.emptySet());
+            endNodesOnly = !terminationLabels.isEmpty() || !endNodeLabels.isEmpty();
+            whitelistAllowedEvaluation = endNodesOnly ? EXCLUDE_AND_CONTINUE : INCLUDE_AND_CONTINUE;
+        }
+
+        @Override
+        public Evaluation evaluate(Path path) {
+            int depth = path.length();
+            Node check = path.endNode();
+
+            // if start node shouldn't be filtered, exclude/include based on if using termination/endnode filter or not
+            // minLevel evaluator will separately enforce exclusion if we're below minLevel
+            if (depth == 0 && !filterStartNode) {
+                return whitelistAllowedEvaluation;
+            }
+
+            // below minLevel always exclude; continue if blacklist and whitelist allow it
+            if (depth < minLevel) {
+                return labelExists(check, blacklistLabels) || !whitelistAllowed(check) ? EXCLUDE_AND_PRUNE : EXCLUDE_AND_CONTINUE;
+            }
+
+            // cut off expansion when we reach the limit
+            if (limit != -1 && resultCount >= limit) {
+                return EXCLUDE_AND_PRUNE;
+            }
+
+            Evaluation result = labelExists(check, blacklistLabels) ? EXCLUDE_AND_PRUNE :
+                                labelExists(check, terminationLabels) ? filterEndNode(check, true) :
+                                labelExists(check, endNodeLabels) ? filterEndNode(check, false) :
+                                whitelistAllowed(check) ? whitelistAllowedEvaluation : EXCLUDE_AND_PRUNE;
+
+            return result;
+        }
+
+        private boolean labelExists(Node node, Set<String> labels) {
+            if (labels.isEmpty()) {
+                return false;
+            }
+
+            for ( Label lab : node.getLabels() ) {
+                if (labels.contains(lab.name())) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private boolean whitelistAllowed(Node node) {
+            return whitelistLabels.isEmpty() || labelExists(node, whitelistLabels);
+        }
+
+        private Evaluation filterEndNode(Node node, boolean isTerminationFilter) {
+            resultCount++;
+            return isTerminationFilter || !whitelistAllowed(node) ? INCLUDE_AND_PRUNE : INCLUDE_AND_CONTINUE;
+        }
+    }
+
+    public static abstract class RelationshipTypeAndDirections {
+
+        public static final char BACKTICK = '`';
+
+        public static List<Pair<RelationshipType, Direction>> parse(String pathFilter) {
+            List<Pair<RelationshipType, Direction>> relsAndDirs = new ArrayList<>();
+            if (pathFilter == null) {
+                relsAndDirs.add(Pair.of(null, BOTH)); // todo can we remove this?
+            } else {
+                String[] defs = pathFilter.split("\\|");
+                for (String def : defs) {
+                    relsAndDirs.add(Pair.of(relationshipTypeFor(def), directionFor(def)));
+                }
+            }
+            return relsAndDirs;
+        }
+
+        private static Direction directionFor(String type) {
+            if (type.contains("<")) return INCOMING;
+            if (type.contains(">")) return OUTGOING;
+            return BOTH;
+        }
+
+        private static RelationshipType relationshipTypeFor(String name) {
+            if (name.indexOf(BACKTICK) > -1) name = name.substring(name.indexOf(BACKTICK)+1,name.lastIndexOf(BACKTICK));
+            else {
+                name = name.replaceAll("[<>:]", "");
+            }
+            return name.trim().isEmpty() ? null : RelationshipType.withName(name);
+        }
+    }
+}

--- a/community/cypher/acceptance-spec-suite/src/test/java/org/neo4j/internal/cypher/acceptance/TestProcedure.java
+++ b/community/cypher/acceptance-spec-suite/src/test/java/org/neo4j/internal/cypher/acceptance/TestProcedure.java
@@ -19,12 +19,7 @@
  */
 package org.neo4j.internal.cypher.acceptance;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -33,313 +28,108 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
-import org.neo4j.graphdb.PathExpanderBuilder;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.traversal.Evaluation;
 import org.neo4j.graphdb.traversal.Evaluator;
 import org.neo4j.graphdb.traversal.Evaluators;
 import org.neo4j.graphdb.traversal.TraversalDescription;
-import org.neo4j.graphdb.traversal.Traverser;
 import org.neo4j.graphdb.traversal.Uniqueness;
-import org.neo4j.helpers.collection.Pair;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Description;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 
-import static org.neo4j.graphdb.Direction.BOTH;
-import static org.neo4j.graphdb.Direction.INCOMING;
-import static org.neo4j.graphdb.Direction.OUTGOING;
 import static org.neo4j.graphdb.traversal.Evaluation.EXCLUDE_AND_CONTINUE;
 import static org.neo4j.graphdb.traversal.Evaluation.EXCLUDE_AND_PRUNE;
 import static org.neo4j.graphdb.traversal.Evaluation.INCLUDE_AND_CONTINUE;
-import static org.neo4j.graphdb.traversal.Evaluation.INCLUDE_AND_PRUNE;
 
 public class TestProcedure
 {
     @Context
     public GraphDatabaseService db;
 
-    @Procedure("org.neo4j.test")
-    @Description("org.neo4j.test")
-    public Stream<TestResult> test() throws Exception {
-        return db.findNodes( Label.label("Tweet" ) ).stream().map( TestResult::new );
+    @Procedure( "org.neo4j.movieTraversal" )
+    @Description( "org.neo4j.movieTraversal" )
+    public Stream<PathResult> movieTraversal( @Name( "start" ) Node start ) throws Exception
+    {
+        TraversalDescription td =
+                db.traversalDescription()
+                        .breadthFirst()
+                        .relationships( RelationshipType.withName( "ACTED_IN" ), Direction.BOTH )
+                        .relationships( RelationshipType.withName( "PRODUCED" ), Direction.BOTH )
+                        .relationships( RelationshipType.withName( "DIRECTED" ), Direction.BOTH )
+                        .evaluator( Evaluators.fromDepth( 3 ) )
+                        .evaluator( new LabelEvaluator( "Western", 1, 3 ) )
+                        .uniqueness( Uniqueness.NODE_GLOBAL );
+
+        return td.traverse( start ).stream().map( PathResult::new );
     }
 
-    @Procedure("org.neo4j.testTraversal")
-    @Description("org.neo4j.testTraversal")
-    public Stream<TestResult> testTraversal() throws Exception {
-        TraversalDescription td = db.traversalDescription();
-        return db.findNodes( Label.label("Tweet" ) )
-                .stream()
-                .flatMap( node -> td.traverse( node ).stream().map( path -> new TestResult( path.startNode() ) ) );
-    }
-
-    @Procedure("apoc.path.expandConfig")
-    @Description("apoc.path.expandConfig(startNode <id>|Node|list, {minLevel,maxLevel,uniqueness,relationshipFilter,labelFilter,uniqueness:'RELATIONSHIP_PATH',bfs:true, filterStartNode:false}) yield path expand from start node following the given relationships from min to max-level adhering to the label filters")
-    public Stream<PathResult> expandConfig(@Name("start") Object start, @Name("config") Map<String,Object> config) throws Exception {
-        return expandConfigPrivate(start, config).map( PathResult::new );
-    }
-
-    private Stream<Path> expandConfigPrivate(@Name("start") Object start, @Name("config") Map<String,Object> config) throws Exception {
-        List<Node> nodes = startToNodes(start);
-
-        String uniqueness = (String) config.getOrDefault("uniqueness", Uniqueness.RELATIONSHIP_PATH.name());
-        String relationshipFilter = (String) config.getOrDefault("relationshipFilter", null);
-        String labelFilter = (String) config.getOrDefault("labelFilter", null);
-        long minLevel = toLong(config.getOrDefault("minLevel", "-1"));
-        long maxLevel = toLong(config.getOrDefault("maxLevel", "-1"));
-        boolean bfs = toBoolean(config.getOrDefault("bfs",true));
-        boolean filterStartNode = toBoolean(config.getOrDefault("filterStartNode", true));
-        long limit = toLong(config.getOrDefault("limit", "-1"));
-
-        return explorePathPrivate(nodes, relationshipFilter, labelFilter, minLevel, maxLevel, bfs,
-                getUniqueness(uniqueness), filterStartNode, limit);
-    }
-
-    public static Long toLong(Object value) {
-        if (value == null) return null;
-        if (value instanceof Number) return ((Number)value).longValue();
-        try {
-            return Long.parseLong(value.toString());
-        } catch (NumberFormatException e) {
-            return null;
-        }
-    }
-
-    public static boolean toBoolean(Object value) {
-        if ((value == null || value instanceof Number && (((Number) value).longValue()) == 0L || value instanceof String && (value.equals("") || ((String) value).equalsIgnoreCase("false") || ((String) value).equalsIgnoreCase("no")|| ((String) value).equalsIgnoreCase("0"))|| value instanceof Boolean && value.equals(false))) {
-            return false;
-        }
-        return true;
-    }
-
-    private Stream<Path> explorePathPrivate(Iterable<Node> startNodes
-            , String pathFilter
-            , String labelFilter
-            , long minLevel
-            , long maxLevel, boolean bfs, Uniqueness uniqueness, boolean filterStartNode, long limit) {
-        // LabelFilter
-        // -|Label|:Label|:Label excluded label list
-        // +:Label or :Label include labels
-
-        Traverser traverser = traverse(db.traversalDescription(), startNodes, pathFilter, labelFilter, minLevel, maxLevel, uniqueness,bfs,filterStartNode,limit);
-        return traverser.stream();
-    }
-
-    public static Traverser traverse(TraversalDescription traversalDescription, Iterable<Node> startNodes, String pathFilter, String labelFilter, long minLevel, long maxLevel, Uniqueness uniqueness, boolean bfs, boolean filterStartNode, long limit) {
-        TraversalDescription td = traversalDescription;
-        // based on the pathFilter definition now the possible relationships and directions must be shown
-
-        td = bfs ? td.breadthFirst() : td.depthFirst();
-
-        Iterable<Pair<RelationshipType, Direction>> relDirIterable = RelationshipTypeAndDirections.parse(pathFilter);
-
-        for (Pair<RelationshipType, Direction> pair: relDirIterable) {
-            if (pair.first() == null) {
-                td = td.expand( PathExpanderBuilder.allTypes(pair.other()).build());
-            } else {
-                td = td.relationships(pair.first(), pair.other());
-            }
-        }
-
-        if (minLevel != -1) td = td.evaluator( Evaluators.fromDepth((int) minLevel));
-        if (maxLevel != -1) td = td.evaluator(Evaluators.toDepth((int) maxLevel));
-
-        if (labelFilter != null && !labelFilter.trim().isEmpty()) {
-            td = td.evaluator(new LabelEvaluator(labelFilter, filterStartNode, limit, (int) minLevel));
-        }
-
-        td = td.uniqueness(uniqueness); // this is how Cypher works !! Uniqueness.RELATIONSHIP_PATH
-        // uniqueness should be set as last on the TraversalDescription
-        return td.traverse(startNodes);
-    }
-
-    @SuppressWarnings("unchecked")
-    private List<Node> startToNodes(Object start) throws Exception {
-        if (start == null) return Collections.emptyList();
-        if (start instanceof Node) {
-            return Collections.singletonList((Node) start);
-        }
-        if (start instanceof Number) {
-            return Collections.singletonList(db.getNodeById(((Number) start).longValue()));
-        }
-        if (start instanceof List) {
-            List list = (List) start;
-            if (list.isEmpty()) return Collections.emptyList();
-
-            Object first = list.get(0);
-            if (first instanceof Node) return (List<Node>)list;
-            if (first instanceof Number) {
-                List<Node> nodes = new ArrayList<>();
-                for (Number n : ((List<Number>)list)) nodes.add(db.getNodeById(n.longValue()));
-                return nodes;
-            }
-        }
-        throw new Exception("Unsupported data type for start parameter a Node or an Identifier (long) of a Node must be given!");
-    }
-
-    private Uniqueness getUniqueness(String uniqueness) {
-        for (Uniqueness u : Uniqueness.values()) {
-            if (u.name().equalsIgnoreCase(uniqueness)) return u;
-        }
-        return Uniqueness.RELATIONSHIP_PATH;
-    }
-
-    public static class PathResult {
+    public static class PathResult
+    {
         public Path path;
 
-        public PathResult(Path path) {
-            this.path = path;
-        }
-    }
-
-    public static class TestResult
-    {
-        public String value;
-
-        public TestResult( Node node )
+        PathResult( Path path )
         {
-            this.value = "NodeWithId"+value;
+            this.path = path;
         }
     }
 
     public static class LabelEvaluator implements Evaluator
     {
-        private Set<String> whitelistLabels;
-        private Set<String> blacklistLabels;
-        private Set<String> terminationLabels;
         private Set<String> endNodeLabels;
-        private Evaluation whitelistAllowedEvaluation;
-        private boolean endNodesOnly;
-        private boolean filterStartNode;
         private long limit = -1;
         private long minLevel = -1;
         private long resultCount = 0;
 
-        public LabelEvaluator(String labelFilter, boolean filterStartNode, long limit, int minLevel) {
-            this.filterStartNode = filterStartNode;
+        LabelEvaluator( String endNodeLabel, long limit, int minLevel )
+        {
             this.limit = limit;
             this.minLevel = minLevel;
-            Map<Character, Set<String>> labelMap = new HashMap<>(4);
 
-            if (labelFilter !=  null && !labelFilter.isEmpty()) {
-
-                // parse the filter
-                // split on |
-                String[] defs = labelFilter.split("\\|");
-                Set<String> labels = null;
-
-                for (String def : defs) {
-                    char operator = def.charAt(0);
-                    switch (operator) {
-                    case '+':
-                    case '-':
-                    case '/':
-                    case '>':
-                        labels = labelMap.computeIfAbsent(operator, character -> new HashSet<>());
-                        def = def.substring(1);
-                    }
-
-                    if (def.startsWith(":")) {
-                        def = def.substring(1);
-                    }
-
-                    if (!def.isEmpty()) {
-                        labels.add(def);
-                    }
-                }
-            }
-
-            whitelistLabels = labelMap.computeIfAbsent('+', character -> Collections.emptySet());
-            blacklistLabels = labelMap.computeIfAbsent('-', character -> Collections.emptySet());
-            terminationLabels = labelMap.computeIfAbsent('/', character -> Collections.emptySet());
-            endNodeLabels = labelMap.computeIfAbsent('>', character -> Collections.emptySet());
-            endNodesOnly = !terminationLabels.isEmpty() || !endNodeLabels.isEmpty();
-            whitelistAllowedEvaluation = endNodesOnly ? EXCLUDE_AND_CONTINUE : INCLUDE_AND_CONTINUE;
+            endNodeLabels = Collections.singleton( endNodeLabel );
         }
 
         @Override
-        public Evaluation evaluate(Path path) {
+        public Evaluation evaluate( Path path )
+        {
             int depth = path.length();
             Node check = path.endNode();
 
-            // if start node shouldn't be filtered, exclude/include based on if using termination/endnode filter or not
-            // minLevel evaluator will separately enforce exclusion if we're below minLevel
-            if (depth == 0 && !filterStartNode) {
-                return whitelistAllowedEvaluation;
+            if ( depth < minLevel )
+            {
+                return EXCLUDE_AND_CONTINUE;
             }
 
-            // below minLevel always exclude; continue if blacklist and whitelist allow it
-            if (depth < minLevel) {
-                return labelExists(check, blacklistLabels) || !whitelistAllowed(check) ? EXCLUDE_AND_PRUNE : EXCLUDE_AND_CONTINUE;
-            }
-
-            // cut off expansion when we reach the limit
-            if (limit != -1 && resultCount >= limit) {
+            if ( limit != -1 && resultCount >= limit )
+            {
                 return EXCLUDE_AND_PRUNE;
             }
 
-            Evaluation result = labelExists(check, blacklistLabels) ? EXCLUDE_AND_PRUNE :
-                                labelExists(check, terminationLabels) ? filterEndNode(check, true) :
-                                labelExists(check, endNodeLabels) ? filterEndNode(check, false) :
-                                whitelistAllowed(check) ? whitelistAllowedEvaluation : EXCLUDE_AND_PRUNE;
-
-            return result;
+            return labelExists( check, endNodeLabels ) ? countIncludeAndContinue() : EXCLUDE_AND_CONTINUE;
         }
 
-        private boolean labelExists(Node node, Set<String> labels) {
-            if (labels.isEmpty()) {
+        private boolean labelExists( Node node, Set<String> labels )
+        {
+            if ( labels.isEmpty() )
+            {
                 return false;
             }
 
-            for ( Label lab : node.getLabels() ) {
-                if (labels.contains(lab.name())) {
+            for ( Label lab : node.getLabels() )
+            {
+                if ( labels.contains( lab.name() ) )
+                {
                     return true;
                 }
             }
             return false;
         }
 
-        private boolean whitelistAllowed(Node node) {
-            return whitelistLabels.isEmpty() || labelExists(node, whitelistLabels);
-        }
-
-        private Evaluation filterEndNode(Node node, boolean isTerminationFilter) {
+        private Evaluation countIncludeAndContinue()
+        {
             resultCount++;
-            return isTerminationFilter || !whitelistAllowed(node) ? INCLUDE_AND_PRUNE : INCLUDE_AND_CONTINUE;
-        }
-    }
-
-    public static abstract class RelationshipTypeAndDirections {
-
-        public static final char BACKTICK = '`';
-
-        public static List<Pair<RelationshipType, Direction>> parse(String pathFilter) {
-            List<Pair<RelationshipType, Direction>> relsAndDirs = new ArrayList<>();
-            if (pathFilter == null) {
-                relsAndDirs.add(Pair.of(null, BOTH)); // todo can we remove this?
-            } else {
-                String[] defs = pathFilter.split("\\|");
-                for (String def : defs) {
-                    relsAndDirs.add(Pair.of(relationshipTypeFor(def), directionFor(def)));
-                }
-            }
-            return relsAndDirs;
-        }
-
-        private static Direction directionFor(String type) {
-            if (type.contains("<")) return INCOMING;
-            if (type.contains(">")) return OUTGOING;
-            return BOTH;
-        }
-
-        private static RelationshipType relationshipTypeFor(String name) {
-            if (name.indexOf(BACKTICK) > -1) name = name.substring(name.indexOf(BACKTICK)+1,name.lastIndexOf(BACKTICK));
-            else {
-                name = name.replaceAll("[<>:]", "");
-            }
-            return name.trim().isEmpty() ? null : RelationshipType.withName(name);
+            return INCLUDE_AND_CONTINUE;
         }
     }
 }

--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ApocAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ApocAcceptanceTest.scala
@@ -1,0 +1,595 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import java.util
+import java.util.Collections
+import java.util.function.Consumer
+
+import org.junit.Assert.assertEquals
+import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport}
+import org.neo4j.graphdb.{GraphDatabaseService, Path, Result, Transaction}
+import org.neo4j.helpers.collection.Iterators
+import org.neo4j.kernel.impl.proc.Procedures
+
+class ApocAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupport {
+
+
+//  test("apa") {
+//    graph.getDependencyResolver.resolveDependency(classOf[Procedures]).registerProcedure(classOf[TestProcedure])
+//
+//    val n1 = createLabeledNode(Map("title" -> "The Matrix"), "Tweet")
+//    val n2 = createLabeledNode("User")
+//    relate(n2, n1, "POSTED")
+//
+//    val query =
+//      """MATCH (m:Tweet {title: 'The Matrix'})
+//         CALL org.neo4j.testTraversal() YIELD value RETURN count(*) AS c""".stripMargin;
+//
+//    val result = executeWithCostPlannerOnly(query)
+//    result.toList
+//  }
+
+  test("testLimitPlaysNiceWithMinLevel") {
+    graph.getDependencyResolver.resolveDependency(classOf[Procedures]).registerProcedure(classOf[TestProcedure])
+
+    graph.execute(movies)
+    graph.execute(bigbrother)
+
+    graph.execute("MATCH (c:Person) WHERE c.name in ['Clint Eastwood', 'Gene Hackman'] SET c:Western");
+
+    // hardcoded config:
+    // {relationshipFilter:'ACTED_IN|PRODUCED|DIRECTED', labelFilter:'>Western', uniqueness: 'NODE_GLOBAL', limit:1, minLevel:3}
+
+    testResult(graph.getGraphDatabaseService,
+      "MATCH (k:Person {name:'Keanu Reeves'}) " +
+        "CALL apoc.path.expandConfig(k, {relationshipFilter:'ACTED_IN|PRODUCED|DIRECTED', labelFilter:'>Western', uniqueness: 'NODE_GLOBAL', limit:1, minLevel:3}) yield path " +
+        "return path",
+      new Consumer[Result] {
+        override def accept(t: Result): Unit = {
+          val maps = Iterators.asList(t)
+          assertEquals(1, maps.size)
+          val path = maps.get(0).get("path").asInstanceOf[Path]
+          assertEquals("Clint Eastwood", path.endNode.getProperty("name"))
+        }
+      })
+  }
+
+  def testResult(db: GraphDatabaseService, call: String, resultConsumer: Consumer[Result]): Unit = {
+    testResult(db, call, null, resultConsumer)
+  }
+
+  def testResult(db: GraphDatabaseService, call: String, params: util.Map[String, AnyRef], resultConsumer: Consumer[Result]): Unit =
+  {
+    try {
+      val tx: Transaction = db.beginTx
+      try {
+        val p: util.Map[String, AnyRef] = if (params == null) Collections.emptyMap[String, AnyRef]
+        else params
+        resultConsumer.accept(db.execute(call, p))
+        tx.success()
+      } finally if (tx != null) tx.close()
+    }
+  }
+
+  val bigbrother = "MATCH (per:Person) MERGE (bb:BigBrother {name : 'Big Brother' })  MERGE (bb)-[:FOLLOWS]->(per)"
+
+  val movies = """CREATE (TheMatrix:Movie {title:'The Matrix', released:1999, tagline:'Welcome to the Real World'})
+  CREATE (Keanu:Person {name:'Keanu Reeves', born:1964})
+  CREATE (Carrie:Person {name:'Carrie-Anne Moss', born:1967})
+  CREATE (Laurence:Person {name:'Laurence Fishburne', born:1961})
+  CREATE (Hugo:Person {name:'Hugo Weaving', born:1960})
+  CREATE (AndyW:Person {name:'Andy Wachowski', born:1967})
+  CREATE (LanaW:Person {name:'Lana Wachowski', born:1965})
+  CREATE (JoelS:Person {name:'Joel Silver', born:1952})
+  CREATE
+  (Keanu)-[:ACTED_IN {roles:['Neo']}]->(TheMatrix),
+  (Carrie)-[:ACTED_IN {roles:['Trinity']}]->(TheMatrix),
+  (Laurence)-[:ACTED_IN {roles:['Morpheus']}]->(TheMatrix),
+  (Hugo)-[:ACTED_IN {roles:['Agent Smith']}]->(TheMatrix),
+  (AndyW)-[:DIRECTED]->(TheMatrix),
+  (LanaW)-[:DIRECTED]->(TheMatrix),
+  (JoelS)-[:PRODUCED]->(TheMatrix)
+
+  CREATE (Emil:Person {name:"Emil Eifrem", born:1978})
+  CREATE (Emil)-[:ACTED_IN {roles:["Emil"]}]->(TheMatrix)
+
+  CREATE (TheMatrixReloaded:Movie {title:'The Matrix Reloaded', released:2003, tagline:'Free your mind'})
+  CREATE
+  (Keanu)-[:ACTED_IN {roles:['Neo']}]->(TheMatrixReloaded),
+  (Carrie)-[:ACTED_IN {roles:['Trinity']}]->(TheMatrixReloaded),
+  (Laurence)-[:ACTED_IN {roles:['Morpheus']}]->(TheMatrixReloaded),
+  (Hugo)-[:ACTED_IN {roles:['Agent Smith']}]->(TheMatrixReloaded),
+  (AndyW)-[:DIRECTED]->(TheMatrixReloaded),
+  (LanaW)-[:DIRECTED]->(TheMatrixReloaded),
+  (JoelS)-[:PRODUCED]->(TheMatrixReloaded)
+
+  CREATE (TheMatrixRevolutions:Movie {title:'The Matrix Revolutions', released:2003, tagline:'Everything that has a beginning has an end'})
+  CREATE
+  (Keanu)-[:ACTED_IN {roles:['Neo']}]->(TheMatrixRevolutions),
+  (Carrie)-[:ACTED_IN {roles:['Trinity']}]->(TheMatrixRevolutions),
+  (Laurence)-[:ACTED_IN {roles:['Morpheus']}]->(TheMatrixRevolutions),
+  (Hugo)-[:ACTED_IN {roles:['Agent Smith']}]->(TheMatrixRevolutions),
+  (AndyW)-[:DIRECTED]->(TheMatrixRevolutions),
+  (LanaW)-[:DIRECTED]->(TheMatrixRevolutions),
+  (JoelS)-[:PRODUCED]->(TheMatrixRevolutions)
+
+  CREATE (TheDevilsAdvocate:Movie {title:"The Devil's Advocate", released:1997, tagline:'Evil has its winning ways'})
+  CREATE (Charlize:Person {name:'Charlize Theron', born:1975})
+  CREATE (Al:Person {name:'Al Pacino', born:1940})
+  CREATE (Taylor:Person {name:'Taylor Hackford', born:1944})
+  CREATE
+  (Keanu)-[:ACTED_IN {roles:['Kevin Lomax']}]->(TheDevilsAdvocate),
+  (Charlize)-[:ACTED_IN {roles:['Mary Ann Lomax']}]->(TheDevilsAdvocate),
+  (Al)-[:ACTED_IN {roles:['John Milton']}]->(TheDevilsAdvocate),
+  (Taylor)-[:DIRECTED]->(TheDevilsAdvocate)
+
+  CREATE (AFewGoodMen:Movie {title:"A Few Good Men", released:1992, tagline:"In the heart of the nation's capital, in a courthouse of the U.S. government, one man will stop at nothing to keep his honor, and one will stop at nothing to find the truth."})
+  CREATE (TomC:Person {name:'Tom Cruise', born:1962})
+  CREATE (JackN:Person {name:'Jack Nicholson', born:1937})
+  CREATE (DemiM:Person {name:'Demi Moore', born:1962})
+  CREATE (KevinB:Person {name:'Kevin Bacon', born:1958})
+  CREATE (KieferS:Person {name:'Kiefer Sutherland', born:1966})
+  CREATE (NoahW:Person {name:'Noah Wyle', born:1971})
+  CREATE (CubaG:Person {name:'Cuba Gooding Jr.', born:1968})
+  CREATE (KevinP:Person {name:'Kevin Pollak', born:1957})
+  CREATE (JTW:Person {name:'J.T. Walsh', born:1943})
+  CREATE (JamesM:Person {name:'James Marshall', born:1967})
+  CREATE (ChristopherG:Person {name:'Christopher Guest', born:1948})
+  CREATE (RobR:Person {name:'Rob Reiner', born:1947})
+  CREATE (AaronS:Person {name:'Aaron Sorkin', born:1961})
+  CREATE
+  (TomC)-[:ACTED_IN {roles:['Lt. Daniel Kaffee']}]->(AFewGoodMen),
+  (JackN)-[:ACTED_IN {roles:['Col. Nathan R. Jessup']}]->(AFewGoodMen),
+  (DemiM)-[:ACTED_IN {roles:['Lt. Cdr. JoAnne Galloway']}]->(AFewGoodMen),
+  (KevinB)-[:ACTED_IN {roles:['Capt. Jack Ross']}]->(AFewGoodMen),
+  (KieferS)-[:ACTED_IN {roles:['Lt. Jonathan Kendrick']}]->(AFewGoodMen),
+  (NoahW)-[:ACTED_IN {roles:['Cpl. Jeffrey Barnes']}]->(AFewGoodMen),
+  (CubaG)-[:ACTED_IN {roles:['Cpl. Carl Hammaker']}]->(AFewGoodMen),
+  (KevinP)-[:ACTED_IN {roles:['Lt. Sam Weinberg']}]->(AFewGoodMen),
+  (JTW)-[:ACTED_IN {roles:['Lt. Col. Matthew Andrew Markinson']}]->(AFewGoodMen),
+  (JamesM)-[:ACTED_IN {roles:['Pfc. Louden Downey']}]->(AFewGoodMen),
+  (ChristopherG)-[:ACTED_IN {roles:['Dr. Stone']}]->(AFewGoodMen),
+  (AaronS)-[:ACTED_IN {roles:['Man in Bar']}]->(AFewGoodMen),
+  (RobR)-[:DIRECTED]->(AFewGoodMen),
+  (AaronS)-[:WROTE]->(AFewGoodMen)
+
+  CREATE (TopGun:Movie {title:"Top Gun", released:1986, tagline:'I feel the need, the need for speed.'})
+  CREATE (KellyM:Person {name:'Kelly McGillis', born:1957})
+  CREATE (ValK:Person {name:'Val Kilmer', born:1959})
+  CREATE (AnthonyE:Person {name:'Anthony Edwards', born:1962})
+  CREATE (TomS:Person {name:'Tom Skerritt', born:1933})
+  CREATE (MegR:Person {name:'Meg Ryan', born:1961})
+  CREATE (TonyS:Person {name:'Tony Scott', born:1944})
+  CREATE (JimC:Person {name:'Jim Cash', born:1941})
+  CREATE
+  (TomC)-[:ACTED_IN {roles:['Maverick']}]->(TopGun),
+  (KellyM)-[:ACTED_IN {roles:['Charlie']}]->(TopGun),
+  (ValK)-[:ACTED_IN {roles:['Iceman']}]->(TopGun),
+  (AnthonyE)-[:ACTED_IN {roles:['Goose']}]->(TopGun),
+  (TomS)-[:ACTED_IN {roles:['Viper']}]->(TopGun),
+  (MegR)-[:ACTED_IN {roles:['Carole']}]->(TopGun),
+  (TonyS)-[:DIRECTED]->(TopGun),
+  (JimC)-[:WROTE]->(TopGun)
+
+  CREATE (JerryMaguire:Movie {title:'Jerry Maguire', released:2000, tagline:'The rest of his life begins now.'})
+  CREATE (ReneeZ:Person {name:'Renee Zellweger', born:1969})
+  CREATE (KellyP:Person {name:'Kelly Preston', born:1962})
+  CREATE (JerryO:Person {name:"Jerry O'Connell", born:1974})
+  CREATE (JayM:Person {name:'Jay Mohr', born:1970})
+  CREATE (BonnieH:Person {name:'Bonnie Hunt', born:1961})
+  CREATE (ReginaK:Person {name:'Regina King', born:1971})
+  CREATE (JonathanL:Person {name:'Jonathan Lipnicki', born:1996})
+  CREATE (CameronC:Person {name:'Cameron Crowe', born:1957})
+  CREATE
+  (TomC)-[:ACTED_IN {roles:['Jerry Maguire']}]->(JerryMaguire),
+  (CubaG)-[:ACTED_IN {roles:['Rod Tidwell']}]->(JerryMaguire),
+  (ReneeZ)-[:ACTED_IN {roles:['Dorothy Boyd']}]->(JerryMaguire),
+  (KellyP)-[:ACTED_IN {roles:['Avery Bishop']}]->(JerryMaguire),
+  (JerryO)-[:ACTED_IN {roles:['Frank Cushman']}]->(JerryMaguire),
+  (JayM)-[:ACTED_IN {roles:['Bob Sugar']}]->(JerryMaguire),
+  (BonnieH)-[:ACTED_IN {roles:['Laurel Boyd']}]->(JerryMaguire),
+  (ReginaK)-[:ACTED_IN {roles:['Marcee Tidwell']}]->(JerryMaguire),
+  (JonathanL)-[:ACTED_IN {roles:['Ray Boyd']}]->(JerryMaguire),
+  (CameronC)-[:DIRECTED]->(JerryMaguire),
+  (CameronC)-[:PRODUCED]->(JerryMaguire),
+  (CameronC)-[:WROTE]->(JerryMaguire)
+
+  CREATE (StandByMe:Movie {title:"Stand By Me", released:1986, tagline:"For some, it's the last real taste of innocence, and the first real taste of life. But for everyone, it's the time that memories are made of."})
+  CREATE (RiverP:Person {name:'River Phoenix', born:1970})
+  CREATE (CoreyF:Person {name:'Corey Feldman', born:1971})
+  CREATE (WilW:Person {name:'Wil Wheaton', born:1972})
+  CREATE (JohnC:Person {name:'John Cusack', born:1966})
+  CREATE (MarshallB:Person {name:'Marshall Bell', born:1942})
+  CREATE
+  (WilW)-[:ACTED_IN {roles:['Gordie Lachance']}]->(StandByMe),
+  (RiverP)-[:ACTED_IN {roles:['Chris Chambers']}]->(StandByMe),
+  (JerryO)-[:ACTED_IN {roles:['Vern Tessio']}]->(StandByMe),
+  (CoreyF)-[:ACTED_IN {roles:['Teddy Duchamp']}]->(StandByMe),
+  (JohnC)-[:ACTED_IN {roles:['Denny Lachance']}]->(StandByMe),
+  (KieferS)-[:ACTED_IN {roles:['Ace Merrill']}]->(StandByMe),
+  (MarshallB)-[:ACTED_IN {roles:['Mr. Lachance']}]->(StandByMe),
+  (RobR)-[:DIRECTED]->(StandByMe)
+
+  CREATE (AsGoodAsItGets:Movie {title:'As Good as It Gets', released:1997, tagline:'A comedy from the heart that goes for the throat.'})
+  CREATE (HelenH:Person {name:'Helen Hunt', born:1963})
+  CREATE (GregK:Person {name:'Greg Kinnear', born:1963})
+  CREATE (JamesB:Person {name:'James L. Brooks', born:1940})
+  CREATE
+  (JackN)-[:ACTED_IN {roles:['Melvin Udall']}]->(AsGoodAsItGets),
+  (HelenH)-[:ACTED_IN {roles:['Carol Connelly']}]->(AsGoodAsItGets),
+  (GregK)-[:ACTED_IN {roles:['Simon Bishop']}]->(AsGoodAsItGets),
+  (CubaG)-[:ACTED_IN {roles:['Frank Sachs']}]->(AsGoodAsItGets),
+  (JamesB)-[:DIRECTED]->(AsGoodAsItGets)
+
+  CREATE (WhatDreamsMayCome:Movie {title:'What Dreams May Come', released:1998, tagline:'After life there is more. The end is just the beginning.'})
+  CREATE (AnnabellaS:Person {name:'Annabella Sciorra', born:1960})
+  CREATE (MaxS:Person {name:'Max von Sydow', born:1929})
+  CREATE (WernerH:Person {name:'Werner Herzog', born:1942})
+  CREATE (Robin:Person {name:'Robin Williams', born:1951})
+  CREATE (VincentW:Person {name:'Vincent Ward', born:1956})
+  CREATE
+  (Robin)-[:ACTED_IN {roles:['Chris Nielsen']}]->(WhatDreamsMayCome),
+  (CubaG)-[:ACTED_IN {roles:['Albert Lewis']}]->(WhatDreamsMayCome),
+  (AnnabellaS)-[:ACTED_IN {roles:['Annie Collins-Nielsen']}]->(WhatDreamsMayCome),
+  (MaxS)-[:ACTED_IN {roles:['The Tracker']}]->(WhatDreamsMayCome),
+  (WernerH)-[:ACTED_IN {roles:['The Face']}]->(WhatDreamsMayCome),
+  (VincentW)-[:DIRECTED]->(WhatDreamsMayCome)
+
+  CREATE (SnowFallingonCedars:Movie {title:'Snow Falling on Cedars', released:1999, tagline:'First loves last. Forever.'})
+  CREATE (EthanH:Person {name:'Ethan Hawke', born:1970})
+  CREATE (RickY:Person {name:'Rick Yune', born:1971})
+  CREATE (JamesC:Person {name:'James Cromwell', born:1940})
+  CREATE (ScottH:Person {name:'Scott Hicks', born:1953})
+  CREATE
+  (EthanH)-[:ACTED_IN {roles:['Ishmael Chambers']}]->(SnowFallingonCedars),
+  (RickY)-[:ACTED_IN {roles:['Kazuo Miyamoto']}]->(SnowFallingonCedars),
+  (MaxS)-[:ACTED_IN {roles:['Nels Gudmundsson']}]->(SnowFallingonCedars),
+  (JamesC)-[:ACTED_IN {roles:['Judge Fielding']}]->(SnowFallingonCedars),
+  (ScottH)-[:DIRECTED]->(SnowFallingonCedars)
+
+  CREATE (YouveGotMail:Movie {title:"You've Got Mail", released:1998, tagline:'At odds in life... in love on-line.'})
+  CREATE (ParkerP:Person {name:'Parker Posey', born:1968})
+  CREATE (DaveC:Person {name:'Dave Chappelle', born:1973})
+  CREATE (SteveZ:Person {name:'Steve Zahn', born:1967})
+  CREATE (TomH:Person {name:'Tom Hanks', born:1956})
+  CREATE (NoraE:Person {name:'Nora Ephron', born:1941})
+  CREATE
+  (TomH)-[:ACTED_IN {roles:['Joe Fox']}]->(YouveGotMail),
+  (MegR)-[:ACTED_IN {roles:['Kathleen Kelly']}]->(YouveGotMail),
+  (GregK)-[:ACTED_IN {roles:['Frank Navasky']}]->(YouveGotMail),
+  (ParkerP)-[:ACTED_IN {roles:['Patricia Eden']}]->(YouveGotMail),
+  (DaveC)-[:ACTED_IN {roles:['Kevin Jackson']}]->(YouveGotMail),
+  (SteveZ)-[:ACTED_IN {roles:['George Pappas']}]->(YouveGotMail),
+  (NoraE)-[:DIRECTED]->(YouveGotMail)
+
+  CREATE (SleeplessInSeattle:Movie {title:'Sleepless in Seattle', released:1993, tagline:'What if someone you never met, someone you never saw, someone you never knew was the only someone for you?'})
+  CREATE (RitaW:Person {name:'Rita Wilson', born:1956})
+  CREATE (BillPull:Person {name:'Bill Pullman', born:1953})
+  CREATE (VictorG:Person {name:'Victor Garber', born:1949})
+  CREATE (RosieO:Person {name:"Rosie O'Donnell", born:1962})
+  CREATE
+  (TomH)-[:ACTED_IN {roles:['Sam Baldwin']}]->(SleeplessInSeattle),
+  (MegR)-[:ACTED_IN {roles:['Annie Reed']}]->(SleeplessInSeattle),
+  (RitaW)-[:ACTED_IN {roles:['Suzy']}]->(SleeplessInSeattle),
+  (BillPull)-[:ACTED_IN {roles:['Walter']}]->(SleeplessInSeattle),
+  (VictorG)-[:ACTED_IN {roles:['Greg']}]->(SleeplessInSeattle),
+  (RosieO)-[:ACTED_IN {roles:['Becky']}]->(SleeplessInSeattle),
+  (NoraE)-[:DIRECTED]->(SleeplessInSeattle)
+
+  CREATE (JoeVersustheVolcano:Movie {title:'Joe Versus the Volcano', released:1990, tagline:'A story of love, lava and burning desire.'})
+  CREATE (JohnS:Person {name:'John Patrick Stanley', born:1950})
+  CREATE (Nathan:Person {name:'Nathan Lane', born:1956})
+  CREATE
+  (TomH)-[:ACTED_IN {roles:['Joe Banks']}]->(JoeVersustheVolcano),
+  (MegR)-[:ACTED_IN {roles:['DeDe', 'Angelica Graynamore', 'Patricia Graynamore']}]->(JoeVersustheVolcano),
+  (Nathan)-[:ACTED_IN {roles:['Baw']}]->(JoeVersustheVolcano),
+  (JohnS)-[:DIRECTED]->(JoeVersustheVolcano)
+
+  CREATE (WhenHarryMetSally:Movie {title:'When Harry Met Sally', released:1998, tagline:'At odds in life... in love on-line.'})
+  CREATE (BillyC:Person {name:'Billy Crystal', born:1948})
+  CREATE (CarrieF:Person {name:'Carrie Fisher', born:1956})
+  CREATE (BrunoK:Person {name:'Bruno Kirby', born:1949})
+  CREATE
+  (BillyC)-[:ACTED_IN {roles:['Harry Burns']}]->(WhenHarryMetSally),
+  (MegR)-[:ACTED_IN {roles:['Sally Albright']}]->(WhenHarryMetSally),
+  (CarrieF)-[:ACTED_IN {roles:['Marie']}]->(WhenHarryMetSally),
+  (BrunoK)-[:ACTED_IN {roles:['Jess']}]->(WhenHarryMetSally),
+  (RobR)-[:DIRECTED]->(WhenHarryMetSally),
+  (RobR)-[:PRODUCED]->(WhenHarryMetSally),
+  (NoraE)-[:PRODUCED]->(WhenHarryMetSally),
+  (NoraE)-[:WROTE]->(WhenHarryMetSally)
+
+  CREATE (ThatThingYouDo:Movie {title:'That Thing You Do', released:1996, tagline:'In every life there comes a time when that thing you dream becomes that thing you do'})
+  CREATE (LivT:Person {name:'Liv Tyler', born:1977})
+  CREATE
+  (TomH)-[:ACTED_IN {roles:['Mr. White']}]->(ThatThingYouDo),
+  (LivT)-[:ACTED_IN {roles:['Faye Dolan']}]->(ThatThingYouDo),
+  (Charlize)-[:ACTED_IN {roles:['Tina']}]->(ThatThingYouDo),
+  (TomH)-[:DIRECTED]->(ThatThingYouDo)
+
+  CREATE (TheReplacements:Movie {title:'The Replacements', released:2000, tagline:'Pain heals, Chicks dig scars... Glory lasts forever'})
+  CREATE (Brooke:Person {name:'Brooke Langton', born:1970})
+  CREATE (Gene:Person {name:'Gene Hackman', born:1930})
+  CREATE (Orlando:Person {name:'Orlando Jones', born:1968})
+  CREATE (Howard:Person {name:'Howard Deutch', born:1950})
+  CREATE
+  (Keanu)-[:ACTED_IN {roles:['Shane Falco']}]->(TheReplacements),
+  (Brooke)-[:ACTED_IN {roles:['Annabelle Farrell']}]->(TheReplacements),
+  (Gene)-[:ACTED_IN {roles:['Jimmy McGinty']}]->(TheReplacements),
+  (Orlando)-[:ACTED_IN {roles:['Clifford Franklin']}]->(TheReplacements),
+  (Howard)-[:DIRECTED]->(TheReplacements)
+
+  CREATE (RescueDawn:Movie {title:'RescueDawn', released:2006, tagline:"Based on the extraordinary true story of one man's fight for freedom"})
+  CREATE (ChristianB:Person {name:'Christian Bale', born:1974})
+  CREATE (ZachG:Person {name:'Zach Grenier', born:1954})
+  CREATE
+  (MarshallB)-[:ACTED_IN {roles:['Admiral']}]->(RescueDawn),
+  (ChristianB)-[:ACTED_IN {roles:['Dieter Dengler']}]->(RescueDawn),
+  (ZachG)-[:ACTED_IN {roles:['Squad Leader']}]->(RescueDawn),
+  (SteveZ)-[:ACTED_IN {roles:['Duane']}]->(RescueDawn),
+  (WernerH)-[:DIRECTED]->(RescueDawn)
+
+  CREATE (TheBirdcage:Movie {title:'The Birdcage', released:1996, tagline:'Come as you are'})
+  CREATE (MikeN:Person {name:'Mike Nichols', born:1931})
+  CREATE
+  (Robin)-[:ACTED_IN {roles:['Armand Goldman']}]->(TheBirdcage),
+  (Nathan)-[:ACTED_IN {roles:['Albert Goldman']}]->(TheBirdcage),
+  (Gene)-[:ACTED_IN {roles:['Sen. Kevin Keeley']}]->(TheBirdcage),
+  (MikeN)-[:DIRECTED]->(TheBirdcage)
+
+  CREATE (Unforgiven:Movie {title:'Unforgiven', released:1992, tagline:"It's a hell of a thing, killing a man"})
+  CREATE (RichardH:Person {name:'Richard Harris', born:1930})
+  CREATE (ClintE:Person {name:'Clint Eastwood', born:1930})
+  CREATE
+  (RichardH)-[:ACTED_IN {roles:['English Bob']}]->(Unforgiven),
+  (ClintE)-[:ACTED_IN {roles:['Bill Munny']}]->(Unforgiven),
+  (Gene)-[:ACTED_IN {roles:['Little Bill Daggett']}]->(Unforgiven),
+  (ClintE)-[:DIRECTED]->(Unforgiven)
+
+  CREATE (JohnnyMnemonic:Movie {title:'Johnny Mnemonic', released:1995, tagline:'The hottest data on earth. In the coolest head in town'})
+  CREATE (Takeshi:Person {name:'Takeshi Kitano', born:1947})
+  CREATE (Dina:Person {name:'Dina Meyer', born:1968})
+  CREATE (IceT:Person {name:'Ice-T', born:1958})
+  CREATE (RobertL:Person {name:'Robert Longo', born:1953})
+  CREATE
+  (Keanu)-[:ACTED_IN {roles:['Johnny Mnemonic']}]->(JohnnyMnemonic),
+  (Takeshi)-[:ACTED_IN {roles:['Takahashi']}]->(JohnnyMnemonic),
+  (Dina)-[:ACTED_IN {roles:['Jane']}]->(JohnnyMnemonic),
+  (IceT)-[:ACTED_IN {roles:['J-Bone']}]->(JohnnyMnemonic),
+  (RobertL)-[:DIRECTED]->(JohnnyMnemonic)
+
+  CREATE (CloudAtlas:Movie {title:'Cloud Atlas', released:2012, tagline:'Everything is connected'})
+  CREATE (HalleB:Person {name:'Halle Berry', born:1966})
+  CREATE (JimB:Person {name:'Jim Broadbent', born:1949})
+  CREATE (TomT:Person {name:'Tom Tykwer', born:1965})
+  CREATE
+  (TomH)-[:ACTED_IN {roles:['Zachry', 'Dr. Henry Goose', 'Isaac Sachs', 'Dermot Hoggins']}]->(CloudAtlas),
+  (Hugo)-[:ACTED_IN {roles:['Bill Smoke', 'Haskell Moore', 'Tadeusz Kesselring', 'Nurse Noakes', 'Boardman Mephi', 'Old Georgie']}]->(CloudAtlas),
+  (HalleB)-[:ACTED_IN {roles:['Luisa Rey', 'Jocasta Ayrs', 'Ovid', 'Meronym']}]->(CloudAtlas),
+  (JimB)-[:ACTED_IN {roles:['Vyvyan Ayrs', 'Captain Molyneux', 'Timothy Cavendish']}]->(CloudAtlas),
+  (TomT)-[:DIRECTED]->(CloudAtlas),
+  (AndyW)-[:DIRECTED]->(CloudAtlas),
+  (LanaW)-[:DIRECTED]->(CloudAtlas)
+
+  CREATE (TheDaVinciCode:Movie {title:'The Da Vinci Code', released:2006, tagline:'Break The Codes'})
+  CREATE (IanM:Person {name:'Ian McKellen', born:1939})
+  CREATE (AudreyT:Person {name:'Audrey Tautou', born:1976})
+  CREATE (PaulB:Person {name:'Paul Bettany', born:1971})
+  CREATE (RonH:Person {name:'Ron Howard', born:1954})
+  CREATE
+  (TomH)-[:ACTED_IN {roles:['Dr. Robert Langdon']}]->(TheDaVinciCode),
+  (IanM)-[:ACTED_IN {roles:['Sir Leight Teabing']}]->(TheDaVinciCode),
+  (AudreyT)-[:ACTED_IN {roles:['Sophie Neveu']}]->(TheDaVinciCode),
+  (PaulB)-[:ACTED_IN {roles:['Silas']}]->(TheDaVinciCode),
+  (RonH)-[:DIRECTED]->(TheDaVinciCode)
+
+  CREATE (VforVendetta:Movie {title:'V for Vendetta', released:2006, tagline:'Freedom! Forever!'})
+  CREATE (NatalieP:Person {name:'Natalie Portman', born:1981})
+  CREATE (StephenR:Person {name:'Stephen Rea', born:1946})
+  CREATE (JohnH:Person {name:'John Hurt', born:1940})
+  CREATE (BenM:Person {name: 'Ben Miles', born:1967})
+  CREATE
+  (Hugo)-[:ACTED_IN {roles:['V']}]->(VforVendetta),
+  (NatalieP)-[:ACTED_IN {roles:['Evey Hammond']}]->(VforVendetta),
+  (StephenR)-[:ACTED_IN {roles:['Eric Finch']}]->(VforVendetta),
+  (JohnH)-[:ACTED_IN {roles:['High Chancellor Adam Sutler']}]->(VforVendetta),
+  (BenM)-[:ACTED_IN {roles:['Dascomb']}]->(VforVendetta),
+  (JamesM)-[:DIRECTED]->(VforVendetta),
+  (AndyW)-[:PRODUCED]->(VforVendetta),
+  (LanaW)-[:PRODUCED]->(VforVendetta),
+  (JoelS)-[:PRODUCED]->(VforVendetta),
+  (AndyW)-[:WROTE]->(VforVendetta),
+  (LanaW)-[:WROTE]->(VforVendetta)
+
+  CREATE (SpeedRacer:Movie {title:'Speed Racer', released:2008, tagline:'Speed has no limits'})
+  CREATE (EmileH:Person {name:'Emile Hirsch', born:1985})
+  CREATE (JohnG:Person {name:'John Goodman', born:1960})
+  CREATE (SusanS:Person {name:'Susan Sarandon', born:1946})
+  CREATE (MatthewF:Person {name:'Matthew Fox', born:1966})
+  CREATE (ChristinaR:Person {name:'Christina Ricci', born:1980})
+  CREATE (Rain:Person {name:'Rain', born:1982})
+  CREATE
+  (EmileH)-[:ACTED_IN {roles:['Speed Racer']}]->(SpeedRacer),
+  (JohnG)-[:ACTED_IN {roles:['Pops']}]->(SpeedRacer),
+  (SusanS)-[:ACTED_IN {roles:['Mom']}]->(SpeedRacer),
+  (MatthewF)-[:ACTED_IN {roles:['Racer X']}]->(SpeedRacer),
+  (ChristinaR)-[:ACTED_IN {roles:['Trixie']}]->(SpeedRacer),
+  (Rain)-[:ACTED_IN {roles:['Taejo Togokahn']}]->(SpeedRacer),
+  (BenM)-[:ACTED_IN {roles:['Cass Jones']}]->(SpeedRacer),
+  (AndyW)-[:DIRECTED]->(SpeedRacer),
+  (LanaW)-[:DIRECTED]->(SpeedRacer),
+  (AndyW)-[:WROTE]->(SpeedRacer),
+  (LanaW)-[:WROTE]->(SpeedRacer),
+  (JoelS)-[:PRODUCED]->(SpeedRacer)
+
+  CREATE (NinjaAssassin:Movie {title:'Ninja Assassin', released:2009, tagline:'Prepare to enter a secret world of assassins'})
+  CREATE (NaomieH:Person {name:'Naomie Harris'})
+  CREATE
+  (Rain)-[:ACTED_IN {roles:['Raizo']}]->(NinjaAssassin),
+  (NaomieH)-[:ACTED_IN {roles:['Mika Coretti']}]->(NinjaAssassin),
+  (RickY)-[:ACTED_IN {roles:['Takeshi']}]->(NinjaAssassin),
+  (BenM)-[:ACTED_IN {roles:['Ryan Maslow']}]->(NinjaAssassin),
+  (JamesM)-[:DIRECTED]->(NinjaAssassin),
+  (AndyW)-[:PRODUCED]->(NinjaAssassin),
+  (LanaW)-[:PRODUCED]->(NinjaAssassin),
+  (JoelS)-[:PRODUCED]->(NinjaAssassin)
+
+  CREATE (TheGreenMile:Movie {title:'The Green Mile', released:1999, tagline:"Walk a mile you'll never forget."})
+  CREATE (MichaelD:Person {name:'Michael Clarke Duncan', born:1957})
+  CREATE (DavidM:Person {name:'David Morse', born:1953})
+  CREATE (SamR:Person {name:'Sam Rockwell', born:1968})
+  CREATE (GaryS:Person {name:'Gary Sinise', born:1955})
+  CREATE (PatriciaC:Person {name:'Patricia Clarkson', born:1959})
+  CREATE (FrankD:Person {name:'Frank Darabont', born:1959})
+  CREATE
+  (TomH)-[:ACTED_IN {roles:['Paul Edgecomb']}]->(TheGreenMile),
+  (MichaelD)-[:ACTED_IN {roles:['John Coffey']}]->(TheGreenMile),
+  (DavidM)-[:ACTED_IN {roles:['Brutus "Brutal" Howell']}]->(TheGreenMile),
+  (BonnieH)-[:ACTED_IN {roles:['Jan Edgecomb']}]->(TheGreenMile),
+  (JamesC)-[:ACTED_IN {roles:['Warden Hal Moores']}]->(TheGreenMile),
+  (SamR)-[:ACTED_IN {roles:['"Wild Bill" Wharton']}]->(TheGreenMile),
+  (GaryS)-[:ACTED_IN {roles:['Burt Hammersmith']}]->(TheGreenMile),
+  (PatriciaC)-[:ACTED_IN {roles:['Melinda Moores']}]->(TheGreenMile),
+  (FrankD)-[:DIRECTED]->(TheGreenMile)
+
+  CREATE (FrostNixon:Movie {title:'Frost/Nixon', released:2008, tagline:'400 million people were waiting for the truth.'})
+  CREATE (FrankL:Person {name:'Frank Langella', born:1938})
+  CREATE (MichaelS:Person {name:'Michael Sheen', born:1969})
+  CREATE (OliverP:Person {name:'Oliver Platt', born:1960})
+  CREATE
+  (FrankL)-[:ACTED_IN {roles:['Richard Nixon']}]->(FrostNixon),
+  (MichaelS)-[:ACTED_IN {roles:['David Frost']}]->(FrostNixon),
+  (KevinB)-[:ACTED_IN {roles:['Jack Brennan']}]->(FrostNixon),
+  (OliverP)-[:ACTED_IN {roles:['Bob Zelnick']}]->(FrostNixon),
+  (SamR)-[:ACTED_IN {roles:['James Reston, Jr.']}]->(FrostNixon),
+  (RonH)-[:DIRECTED]->(FrostNixon)
+
+  CREATE (Hoffa:Movie {title:'Hoffa', released:1992, tagline:"He didn't want law. He wanted justice."})
+  CREATE (DannyD:Person {name:'Danny DeVito', born:1944})
+  CREATE (JohnR:Person {name:'John C. Reilly', born:1965})
+  CREATE
+  (JackN)-[:ACTED_IN {roles:['Hoffa']}]->(Hoffa),
+  (DannyD)-[:ACTED_IN {roles:['Robert "Bobby" Ciaro']}]->(Hoffa),
+  (JTW)-[:ACTED_IN {roles:['Frank Fitzsimmons']}]->(Hoffa),
+  (JohnR)-[:ACTED_IN {roles:['Peter "Pete" Connelly']}]->(Hoffa),
+  (DannyD)-[:DIRECTED]->(Hoffa)
+
+  CREATE (Apollo13:Movie {title:'Apollo 13', released:1995, tagline:'Houston, we have a problem.'})
+  CREATE (EdH:Person {name:'Ed Harris', born:1950})
+  CREATE (BillPax:Person {name:'Bill Paxton', born:1955})
+  CREATE
+  (TomH)-[:ACTED_IN {roles:['Jim Lovell']}]->(Apollo13),
+  (KevinB)-[:ACTED_IN {roles:['Jack Swigert']}]->(Apollo13),
+  (EdH)-[:ACTED_IN {roles:['Gene Kranz']}]->(Apollo13),
+  (BillPax)-[:ACTED_IN {roles:['Fred Haise']}]->(Apollo13),
+  (GaryS)-[:ACTED_IN {roles:['Ken Mattingly']}]->(Apollo13),
+  (RonH)-[:DIRECTED]->(Apollo13)
+
+  CREATE (Twister:Movie {title:'Twister', released:1996, tagline:"Don't Breathe. Don't Look Back."})
+  CREATE (PhilipH:Person {name:'Philip Seymour Hoffman', born:1967})
+  CREATE (JanB:Person {name:'Jan de Bont', born:1943})
+  CREATE
+  (BillPax)-[:ACTED_IN {roles:['Bill Harding']}]->(Twister),
+  (HelenH)-[:ACTED_IN {roles:['Dr. Jo Harding']}]->(Twister),
+  (ZachG)-[:ACTED_IN {roles:['Eddie']}]->(Twister),
+  (PhilipH)-[:ACTED_IN {roles:['Dustin "Dusty" Davis']}]->(Twister),
+  (JanB)-[:DIRECTED]->(Twister)
+
+  CREATE (CastAway:Movie {title:'Cast Away', released:2000, tagline:'At the edge of the world, his journey begins.'})
+  CREATE (RobertZ:Person {name:'Robert Zemeckis', born:1951})
+  CREATE
+  (TomH)-[:ACTED_IN {roles:['Chuck Noland']}]->(CastAway),
+  (HelenH)-[:ACTED_IN {roles:['Kelly Frears']}]->(CastAway),
+  (RobertZ)-[:DIRECTED]->(CastAway)
+
+  CREATE (OneFlewOvertheCuckoosNest:Movie {title:"One Flew Over the Cuckoo's Nest", released:1975, tagline:"If he's crazy, what does that make you?"})
+  CREATE (MilosF:Person {name:'Milos Forman', born:1932})
+  CREATE
+  (JackN)-[:ACTED_IN {roles:['Randle McMurphy']}]->(OneFlewOvertheCuckoosNest),
+  (DannyD)-[:ACTED_IN {roles:['Martini']}]->(OneFlewOvertheCuckoosNest),
+  (MilosF)-[:DIRECTED]->(OneFlewOvertheCuckoosNest)
+
+  CREATE (SomethingsGottaGive:Movie {title:"Something's Gotta Give", released:2003})
+  CREATE (DianeK:Person {name:'Diane Keaton', born:1946})
+  CREATE (NancyM:Person {name:'Nancy Meyers', born:1949})
+  CREATE
+  (JackN)-[:ACTED_IN {roles:['Harry Sanborn']}]->(SomethingsGottaGive),
+  (DianeK)-[:ACTED_IN {roles:['Erica Barry']}]->(SomethingsGottaGive),
+  (Keanu)-[:ACTED_IN {roles:['Julian Mercer']}]->(SomethingsGottaGive),
+  (NancyM)-[:DIRECTED]->(SomethingsGottaGive),
+  (NancyM)-[:PRODUCED]->(SomethingsGottaGive),
+  (NancyM)-[:WROTE]->(SomethingsGottaGive)
+
+  CREATE (BicentennialMan:Movie {title:'Bicentennial Man', released:1999, tagline:"One robot's 200 year journey to become an ordinary man."})
+  CREATE (ChrisC:Person {name:'Chris Columbus', born:1958})
+  CREATE
+  (Robin)-[:ACTED_IN {roles:['Andrew Marin']}]->(BicentennialMan),
+  (OliverP)-[:ACTED_IN {roles:['Rupert Burns']}]->(BicentennialMan),
+  (ChrisC)-[:DIRECTED]->(BicentennialMan)
+
+  CREATE (CharlieWilsonsWar:Movie {title:"Charlie Wilson's War", released:2007, tagline:"A stiff drink. A little mascara. A lot of nerve. Who said they couldn't bring down the Soviet empire."})
+  CREATE (JuliaR:Person {name:'Julia Roberts', born:1967})
+  CREATE
+  (TomH)-[:ACTED_IN {roles:['Rep. Charlie Wilson']}]->(CharlieWilsonsWar),
+  (JuliaR)-[:ACTED_IN {roles:['Joanne Herring']}]->(CharlieWilsonsWar),
+  (PhilipH)-[:ACTED_IN {roles:['Gust Avrakotos']}]->(CharlieWilsonsWar),
+  (MikeN)-[:DIRECTED]->(CharlieWilsonsWar)
+
+  CREATE (ThePolarExpress:Movie {title:'The Polar Express', released:2004, tagline:'This Holiday Season… Believe'})
+  CREATE
+  (TomH)-[:ACTED_IN {roles:['Hero Boy', 'Father', 'Conductor', 'Hobo', 'Scrooge', 'Santa Claus']}]->(ThePolarExpress),
+  (RobertZ)-[:DIRECTED]->(ThePolarExpress)
+
+  CREATE (ALeagueofTheirOwn:Movie {title:'A League of Their Own', released:1992, tagline:'Once in a lifetime you get a chance to do something different.'})
+  CREATE (Madonna:Person {name:'Madonna', born:1954})
+  CREATE (GeenaD:Person {name:'Geena Davis', born:1956})
+  CREATE (LoriP:Person {name:'Lori Petty', born:1963})
+  CREATE (PennyM:Person {name:'Penny Marshall', born:1943})
+  CREATE
+  (TomH)-[:ACTED_IN {roles:['Jimmy Dugan']}]->(ALeagueofTheirOwn),
+  (GeenaD)-[:ACTED_IN {roles:['Dottie Hinson']}]->(ALeagueofTheirOwn),
+  (LoriP)-[:ACTED_IN {roles:['Kit Keller']}]->(ALeagueofTheirOwn),
+  (RosieO)-[:ACTED_IN {roles:['Doris Murphy']}]->(ALeagueofTheirOwn),
+  (Madonna)-[:ACTED_IN {roles:['"All the Way" Mae Mordabito']}]->(ALeagueofTheirOwn),
+  (BillPax)-[:ACTED_IN {roles:['Bob Hinson']}]->(ALeagueofTheirOwn),
+  (PennyM)-[:DIRECTED]->(ALeagueofTheirOwn)
+
+  CREATE (PaulBlythe:Person {name:'Paul Blythe'})
+  CREATE (AngelaScope:Person {name:'Angela Scope'})
+  CREATE (JessicaThompson:Person {name:'Jessica Thompson'})
+  CREATE (JamesThompson:Person {name:'James Thompson'})
+
+  CREATE
+  (JamesThompson)-[:FOLLOWS]->(JessicaThompson),
+  (AngelaScope)-[:FOLLOWS]->(JessicaThompson),
+  (PaulBlythe)-[:FOLLOWS]->(AngelaScope)
+
+  CREATE
+  (JessicaThompson)-[:REVIEWED {summary:'An amazing journey', rating:95}]->(CloudAtlas),
+  (JessicaThompson)-[:REVIEWED {summary:'Silly, but fun', rating:65}]->(TheReplacements),
+  (JamesThompson)-[:REVIEWED {summary:'The coolest football movie ever', rating:100}]->(TheReplacements),
+  (AngelaScope)-[:REVIEWED {summary:'Pretty funny at times', rating:62}]->(TheReplacements),
+  (JessicaThompson)-[:REVIEWED {summary:'Dark, but compelling', rating:85}]->(Unforgiven),
+  (JessicaThompson)-[:REVIEWED {summary:"Slapstick redeemed only by the Robin Williams and Gene Hackman's stellar performances", rating:45}]->(TheBirdcage),
+  (JessicaThompson)-[:REVIEWED {summary:'A solid romp', rating:68}]->(TheDaVinciCode),
+  (JamesThompson)-[:REVIEWED {summary:'Fun, but a little far fetched', rating:65}]->(TheDaVinciCode)
+"""
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/AbstractTraverserIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/traversal/AbstractTraverserIterator.java
@@ -27,7 +27,7 @@ abstract class AbstractTraverserIterator extends PrefetchingResourceIterator<Pat
 {
     protected int numberOfPathsReturned;
     protected int numberOfRelationshipsTraversed;
-    private final Resource resource;
+    private Resource resource;
 
     protected AbstractTraverserIterator( Resource resource )
     {
@@ -61,6 +61,10 @@ abstract class AbstractTraverserIterator extends PrefetchingResourceIterator<Pat
     @Override
     public void close()
     {
-        resource.close();
+        if ( resource != null )
+        {
+            resource.close();
+            resource = null;
+        }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/AbstractTraverserIteratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/AbstractTraverserIteratorTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.traversal;
+
+import org.junit.Test;
+
+import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.Resource;
+import org.neo4j.graphdb.traversal.BranchState;
+import org.neo4j.graphdb.traversal.Evaluation;
+import org.neo4j.graphdb.traversal.TraversalBranch;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class AbstractTraverserIteratorTest
+{
+    @Test
+    public void shouldCloseResourceOnce()
+    {
+        AbstractTraverserIterator iter = new AbstractTraverserIterator( new AssertOneClose() )
+        {
+
+            @Override
+            protected Path fetchNextOrNull()
+            {
+                return null;
+            }
+
+            @Override
+            public boolean isUniqueFirst( TraversalBranch branch )
+            {
+                return false;
+            }
+
+            @Override
+            public boolean isUnique( TraversalBranch branch )
+            {
+                return false;
+            }
+
+            @Override
+            public <STATE> Evaluation evaluate( TraversalBranch branch, BranchState<STATE> state )
+            {
+                return null;
+            }
+        };
+
+        iter.close();
+        iter.close(); // should not fail
+    }
+
+    private static class AssertOneClose implements Resource
+    {
+        boolean isClosed = false;
+
+        @Override
+        public void close()
+        {
+            assertThat("resource is closed", isClosed, equalTo(false));
+            isClosed = true;
+        }
+    }
+}


### PR DESCRIPTION
As statements are reference counted, it is not idea to let the AbstractTraverserIterator close it's resource (statement) more than once. This was exposed with the increased strictness of asserting that statements are open before operations.

changelog: Fix a bug that would cause exceptions with the message `The statement has been closed.` when using the traversal API from inside procedures.