### PR TITLE
Do not hold thread reference in ExecutingQuery

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StackingQueryRegistrationOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StackingQueryRegistrationOperations.java
@@ -69,11 +69,13 @@ public class StackingQueryRegistrationOperations implements QueryRegistrationOpe
     {
         long queryId = lastQueryId.incrementAndGet();
         Thread thread = Thread.currentThread();
+        long threadId = thread.getId();
+        String threadName = thread.getName();
         ExecutingQuery executingQuery =
                 new ExecutingQuery( queryId, clientConnection, statement.username(), queryText, queryParameters,
                         statement.getTransaction().getMetaData(), statement.locks()::activeLockCount,
                         statement.getPageCursorTracer(),
-                        thread, clock, cpuClock, heapAllocation );
+                        threadId, threadName, clock, cpuClock, heapAllocation );
         registerExecutingQuery( statement, executingQuery );
         return executingQuery;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/query/ExecutingQueryStatusTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/query/ExecutingQueryStatusTest.java
@@ -19,12 +19,12 @@
  */
 package org.neo4j.kernel.api.query;
 
+import org.junit.Test;
+
 import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
-import org.junit.Test;
 
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer;
 import org.neo4j.kernel.impl.locking.ActiveLock;
@@ -32,7 +32,6 @@ import org.neo4j.resources.HeapAllocation;
 import org.neo4j.storageengine.api.lock.ResourceType;
 import org.neo4j.storageengine.api.lock.WaitStrategy;
 import org.neo4j.test.FakeCpuClock;
-import org.neo4j.test.FakeHeapAllocation;
 import org.neo4j.time.Clocks;
 import org.neo4j.time.FakeClock;
 
@@ -102,7 +101,9 @@ public class ExecutingQueryStatusTest
                                 null,
                                 null,
                                 null,
-                                PageCursorTracer.NULL, Thread.currentThread(),
+                                PageCursorTracer.NULL,
+                                Thread.currentThread().getId(),
+                                Thread.currentThread().getName(),
                                 clock,
                                 FakeCpuClock.NOT_AVAILABLE,
                                 HeapAllocation.NOT_AVAILABLE ), clock.nanos() );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ExecutingQueryListTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/ExecutingQueryListTest.java
@@ -28,9 +28,9 @@ import java.util.stream.Collectors;
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracer;
 import org.neo4j.kernel.api.query.ExecutingQuery;
 import org.neo4j.kernel.impl.query.clientconnection.ClientConnectionInfo;
+import org.neo4j.resources.CpuClock;
 import org.neo4j.resources.HeapAllocation;
 import org.neo4j.time.Clocks;
-import org.neo4j.resources.CpuClock;
 
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.equalTo;
@@ -118,7 +118,8 @@ public class ExecutingQueryListTest
     private ExecutingQuery createExecutingQuery( int queryId, String query )
     {
         return new ExecutingQuery( queryId, ClientConnectionInfo.EMBEDDED_CONNECTION, "me", query,
-                Collections.emptyMap(), Collections.emptyMap(), () -> 0, PageCursorTracer.NULL, Thread.currentThread(),
+                Collections.emptyMap(), Collections.emptyMap(), () -> 0, PageCursorTracer.NULL,
+                Thread.currentThread().getId(), Thread.currentThread().getName(),
                 Clocks.nanoClock(), CpuClock.CPU_CLOCK, HeapAllocation.HEAP_ALLOCATION );
     }
 }

--- a/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerTest.java
+++ b/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerTest.java
@@ -19,15 +19,15 @@
  */
 package org.neo4j.kernel.impl.query;
 
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
-import org.junit.Rule;
-import org.junit.Test;
 
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorCounters;
 import org.neo4j.kernel.api.query.ExecutingQuery;
@@ -496,6 +496,7 @@ public class QueryLoggerTest
             Map<String,Object> params,
             Map<String,Object> metaData )
     {
+        Thread thread = Thread.currentThread();
         return new ExecutingQuery( queryId++,
                 sessionInfo.withUsername( username ),
                 username,
@@ -558,7 +559,9 @@ public class QueryLoggerTest
                     {
                         return 0;
                     }
-                }, Thread.currentThread(),
+                },
+                thread.getId(),
+                thread.getName(),
                 clock,
                 cpuClock,
                 heapAllocation );


### PR DESCRIPTION
Holding original thread reference in ExecutingQuery can prevent thread objects
from being garbage collected, so update them to use thread id and name
directly instead.