### PR TITLE
Change database panic message.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/DatabaseHealth.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/DatabaseHealth.java
@@ -28,8 +28,8 @@ import static org.neo4j.helpers.Exceptions.withCause;
 
 public class DatabaseHealth
 {
-    private static final String panicMessage = "Database has encountered some problem, "
-            + "please perform necessary action (tx recovery/restart)";
+    private static final String panicMessage = "Critical error has encountered (see database logs for more details). " +
+            "Please restart the database.";
     private static final Class<?>[] CRITICAL_EXCEPTIONS = new Class[]{OutOfMemoryError.class};
 
     private volatile boolean healthy = true;

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/DatabaseHealth.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/DatabaseHealth.java
@@ -28,8 +28,8 @@ import static org.neo4j.helpers.Exceptions.withCause;
 
 public class DatabaseHealth
 {
-    private static final String panicMessage = "Critical error has encountered (see database logs for more details). " +
-            "Please restart the database.";
+    private static final String panicMessage = "The database has encountered a critical error, " +
+            "and needs to be restarted. Please see database logs for more details.";
     private static final Class<?>[] CRITICAL_EXCEPTIONS = new Class[]{OutOfMemoryError.class};
 
     private volatile boolean healthy = true;

--- a/community/kernel/src/test/java/org/neo4j/kernel/internal/DatabaseHealthTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/internal/DatabaseHealthTest.java
@@ -73,7 +73,7 @@ public class DatabaseHealthTest
         // THEN
         logProvider.assertAtLeastOnce(
                 inLog( DatabaseHealth.class ).error(
-                        is("Database panic: Database has encountered some problem, please perform necessary action (tx recovery/restart)" ),
+                        is("Database panic: Critical error has encountered (see database logs for more details). Please restart the database." ),
                         sameInstance( exception )
                 )
         );

--- a/community/kernel/src/test/java/org/neo4j/kernel/internal/DatabaseHealthTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/internal/DatabaseHealthTest.java
@@ -73,7 +73,8 @@ public class DatabaseHealthTest
         // THEN
         logProvider.assertAtLeastOnce(
                 inLog( DatabaseHealth.class ).error(
-                        is("Database panic: Critical error has encountered (see database logs for more details). Please restart the database." ),
+                        is( "Database panic: The database has encountered a critical error, " +
+                                "and needs to be restarted. Please see database logs for more details." ),
                         sameInstance( exception )
                 )
         );


### PR DESCRIPTION
Previous message was confusing and was asking people to do "tx recovery/restart"
"Tx" was confusing and some people tried to find those methods in a transaction
objects in driver/kernel/etc api.
Also it can be quite problematic to do only recovery on your own.
New panic message:
Critical error has encountered (see database logs for more details). Please restart the database.