### PR TITLE
Allow usage of system timezone for database logs

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/logging/BoltMessageLog.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/logging/BoltMessageLog.java
@@ -22,6 +22,7 @@ package org.neo4j.bolt.logging;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -42,12 +43,13 @@ public class BoltMessageLog extends LifecycleAdapter
 
     private final Log inner;
 
-    public BoltMessageLog( FileSystemAbstraction fileSystem, File logFile, Executor executor ) throws IOException
+    public BoltMessageLog( FileSystemAbstraction fileSystem, ZoneId logTimeZone, File logFile, Executor executor ) throws IOException
     {
         RotatingFileOutputStreamSupplier outputStreamSupplier = new RotatingFileOutputStreamSupplier( fileSystem,
                 logFile, ROTATION_THRESHOLD_BYTES, ROTATION_DELAY_MS, MAX_ARCHIVES, executor );
         DateTimeFormatter isoDateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
-        FormattedLog formattedLog = FormattedLog.withUTCTimeZone().withDateTimeFormatter( isoDateTimeFormatter )
+        FormattedLog formattedLog = FormattedLog.withZoneId( logTimeZone )
+                .withDateTimeFormatter( isoDateTimeFormatter )
                 .toOutputStream( outputStreamSupplier );
         formattedLog.setLevel( Level.DEBUG );
 

--- a/community/bolt/src/main/java/org/neo4j/bolt/logging/BoltMessageLogging.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/logging/BoltMessageLogging.java
@@ -19,10 +19,11 @@
  */
 package org.neo4j.bolt.logging;
 
-import java.io.File;
-import java.util.concurrent.Executor;
-
 import io.netty.channel.Channel;
+
+import java.io.File;
+import java.time.ZoneId;
+import java.util.concurrent.Executor;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -64,7 +65,8 @@ public class BoltMessageLogging
             {
                 File boltLogFile = config.get( GraphDatabaseSettings.bolt_log_filename );
                 Executor executor = scheduler.executor( JobScheduler.Groups.boltLogRotation );
-                return new BoltMessageLog( fs, boltLogFile, executor );
+                ZoneId logTimeZoneId = config.get( GraphDatabaseSettings.log_timezone ).getZoneId();
+                return new BoltMessageLog( fs, logTimeZoneId, boltLogFile, executor );
             }
             catch ( Throwable t )
             {

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
@@ -22,6 +22,7 @@ package org.neo4j.consistency;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -36,6 +37,7 @@ import org.neo4j.commandline.arguments.common.OptionalCanonicalPath;
 import org.neo4j.consistency.checking.full.CheckConsistencyConfig;
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Strings;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
@@ -180,10 +182,11 @@ public class CheckConsistencyCommand implements AdminCommand
         {
             File storeDir = backupPath.map( Path::toFile ).orElse( config.get( database_path ) );
             checkDbState( storeDir, config );
+            ZoneId logTimeZone = config.get( GraphDatabaseSettings.log_timezone ).getZoneId();
             ConsistencyCheckService.Result consistencyCheckResult = consistencyCheckService
                     .runFullConsistencyCheck( storeDir, config, ProgressMonitorFactory.textual( System.err ),
-                            FormattedLogProvider.toOutputStream( System.out ), fileSystem, verbose,
-                            reportDir.toFile(),
+                            FormattedLogProvider.withZoneId( logTimeZone ).toOutputStream( System.out ),
+                            fileSystem, verbose, reportDir.toFile(),
                             new CheckConsistencyConfig(
                                     checkGraph, checkIndexes, checkLabelScanStore, checkPropertyOwners ) );
 

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckTool.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckTool.java
@@ -22,11 +22,13 @@ package org.neo4j.consistency;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 
 import org.neo4j.consistency.checking.full.CheckConsistencyConfig;
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;
 import org.neo4j.helpers.Strings;
 import org.neo4j.helpers.collection.MapUtil;
@@ -111,7 +113,8 @@ public class ConsistencyCheckTool
 
         checkDbState( storeDir, tuningConfiguration );
 
-        LogProvider logProvider = FormattedLogProvider.toOutputStream( systemOut );
+        ZoneId logTimeZone = tuningConfiguration.get( GraphDatabaseSettings.log_timezone ).getZoneId();
+        LogProvider logProvider = FormattedLogProvider.withZoneId( logTimeZone ).toOutputStream( systemOut );
         try
         {
             return consistencyCheckService.runFullConsistencyCheck( storeDir, tuningConfiguration,

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckToolTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckToolTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.mockito.stubbing.Answer;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -103,7 +102,7 @@ public class ConsistencyCheckToolTest
             Mockito.when( service.runFullConsistencyCheck( any( File.class ), any( Config.class ),
                     any( ProgressMonitorFactory.class ), any( LogProvider.class ), any( FileSystemAbstraction.class ),
                     eq( false ), any( CheckConsistencyConfig.class ) ) )
-                    .then( (Answer<ConsistencyCheckService.Result>) invocationOnMock ->
+                    .then( invocationOnMock ->
                     {
                         LogProvider provider = invocationOnMock.getArgumentAt( 3, LogProvider.class );
                         provider.getLog( "test" ).info( "testMessage" );
@@ -220,15 +219,15 @@ public class ConsistencyCheckToolTest
         runConsistencyCheckToolWith( fs.get(), storeDirectory.graphDbDir().getAbsolutePath() );
     }
 
-    private void checkLogRecordTimeZone( ConsistencyCheckService service, String[] args, int i, String s )
-            throws ToolFailureException, IOException
+    private void checkLogRecordTimeZone( ConsistencyCheckService service, String[] args, int hoursShift,
+            String timeZoneSuffix ) throws ToolFailureException, IOException
     {
-        TimeZone.setDefault( TimeZone.getTimeZone( ZoneOffset.ofHours( i ) ) );
+        TimeZone.setDefault( TimeZone.getTimeZone( ZoneOffset.ofHours( hoursShift ) ) );
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         PrintStream printStream = new PrintStream( outputStream );
         runConsistencyCheckToolWith( service, printStream, args );
         String logLine = readLogLine( outputStream );
-        assertTrue( logLine, logLine.contains( s ) );
+        assertTrue( logLine, logLine.contains( timeZoneSuffix ) );
     }
 
     private String readLogLine( ByteArrayOutputStream outputStream ) throws IOException

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckToolTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckToolTest.java
@@ -19,26 +19,37 @@
  */
 package org.neo4j.consistency;
 
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.util.Properties;
-
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.time.ZoneOffset;
+import java.util.Properties;
+import java.util.TimeZone;
 
 import org.neo4j.consistency.ConsistencyCheckTool.ToolFailureException;
 import org.neo4j.consistency.checking.full.CheckConsistencyConfig;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.LogProvider;
+import org.neo4j.logging.LogTimeZone;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
@@ -80,6 +91,38 @@ public class ConsistencyCheckToolTest
         verify( service ).runFullConsistencyCheck( eq( storeDir ), any( Config.class ),
                 any( ProgressMonitorFactory.class ), any( LogProvider.class ), any( FileSystemAbstraction.class ),
                 anyBoolean(), any( CheckConsistencyConfig.class ) );
+    }
+
+    @Test
+    public void consistencyCheckerLogUseSystemTimezoneIfConfigurable() throws Exception
+    {
+        TimeZone defaultTimeZone = TimeZone.getDefault();
+        try
+        {
+            ConsistencyCheckService service = mock( ConsistencyCheckService.class );
+            Mockito.when( service.runFullConsistencyCheck( any( File.class ), any( Config.class ),
+                    any( ProgressMonitorFactory.class ), any( LogProvider.class ), any( FileSystemAbstraction.class ),
+                    eq( false ), any( CheckConsistencyConfig.class ) ) )
+                    .then( (Answer<ConsistencyCheckService.Result>) invocationOnMock ->
+                    {
+                        LogProvider provider = invocationOnMock.getArgumentAt( 3, LogProvider.class );
+                        provider.getLog( "test" ).info( "testMessage" );
+                        return ConsistencyCheckService.Result.success( new File( StringUtils.EMPTY ) );
+                    } );
+            File storeDir = storeDirectory.directory();
+            File configFile = storeDirectory.file( Config.DEFAULT_CONFIG_FILE_NAME );
+            Properties properties = new Properties();
+            properties.setProperty( GraphDatabaseSettings.log_timezone.name(), LogTimeZone.SYSTEM.name() );
+            properties.store( new FileWriter( configFile ), null );
+            String[] args = {storeDir.getPath(), "-config", configFile.getPath()};
+
+            checkLogRecordTimeZone( service, args, 5, "+0500" );
+            checkLogRecordTimeZone( service, args, -5, "-0500" );
+        }
+        finally
+        {
+            TimeZone.setDefault( defaultTimeZone );
+        }
     }
 
     @Test
@@ -177,6 +220,24 @@ public class ConsistencyCheckToolTest
         runConsistencyCheckToolWith( fs.get(), storeDirectory.graphDbDir().getAbsolutePath() );
     }
 
+    private void checkLogRecordTimeZone( ConsistencyCheckService service, String[] args, int i, String s )
+            throws ToolFailureException, IOException
+    {
+        TimeZone.setDefault( TimeZone.getTimeZone( ZoneOffset.ofHours( i ) ) );
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        PrintStream printStream = new PrintStream( outputStream );
+        runConsistencyCheckToolWith( service, printStream, args );
+        String logLine = readLogLine( outputStream );
+        assertTrue( logLine, logLine.contains( s ) );
+    }
+
+    private String readLogLine( ByteArrayOutputStream outputStream ) throws IOException
+    {
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream( outputStream.toByteArray() );
+        BufferedReader bufferedReader = new BufferedReader( new InputStreamReader( byteArrayInputStream ) );
+        return bufferedReader.readLine();
+    }
+
     private void createGraphDbAndKillIt() throws Exception
     {
         final GraphDatabaseService db = new TestGraphDatabaseFactory()
@@ -204,10 +265,16 @@ public class ConsistencyCheckToolTest
     private void runConsistencyCheckToolWith( ConsistencyCheckService
             consistencyCheckService, String... args ) throws ToolFailureException, IOException
     {
+        runConsistencyCheckToolWith( consistencyCheckService, mock( PrintStream.class ), args );
+    }
+
+    private void runConsistencyCheckToolWith( ConsistencyCheckService
+            consistencyCheckService, PrintStream printStream, String... args ) throws ToolFailureException, IOException
+    {
         try ( FileSystemAbstraction fileSystemAbstraction = new DefaultFileSystemAbstraction() )
         {
-            new ConsistencyCheckTool( consistencyCheckService, fileSystemAbstraction, mock( PrintStream.class ),
-                    mock( PrintStream.class ) ).run( args );
+            new ConsistencyCheckTool( consistencyCheckService, fileSystemAbstraction, printStream, printStream )
+                    .run( args );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -45,6 +45,7 @@ import org.neo4j.kernel.configuration.Title;
 import org.neo4j.kernel.configuration.ssl.SslPolicyConfigValidator;
 import org.neo4j.kernel.impl.cache.MonitorGc;
 import org.neo4j.logging.Level;
+import org.neo4j.logging.LogTimeZone;
 
 import static org.neo4j.kernel.configuration.Settings.ANY;
 import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
@@ -299,6 +300,10 @@ public class GraphDatabaseSettings implements LoadableConfig
     @Description( "Debug log level threshold." )
     public static final Setting<Level> store_internal_log_level = setting( "dbms.logs.debug.level",
             options( Level.class ), "INFO" );
+
+    @Description( "Database logs timezone." )
+    public static final Setting<LogTimeZone> log_timezone =
+            setting( "dbms.logs.timezone", options( LogTimeZone.class ), LogTimeZone.UTC.name() );
 
     @Description( "Maximum time to wait for active transaction completion when rotating counts store" )
     @Internal

--- a/community/kernel/src/main/java/org/neo4j/helpers/Format.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Format.java
@@ -29,6 +29,20 @@ import org.neo4j.io.ByteUnit;
 
 public class Format
 {
+    private static final String[] BYTE_SIZES = { "B", "kB", "MB", "GB" };
+
+    public static final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss.SSSZ";
+    public static final String TIME_FORMAT = "HH:mm:ss.SSS";
+
+    /**
+     * Default time zone is UTC (+00:00) so that comparing timestamped logs from different
+     * sources is an easier task.
+     */
+    public static final TimeZone DEFAULT_TIME_ZONE = TimeZone.getTimeZone( "UTC" );
+
+    private static final ThreadLocalFormat DATE = new ThreadLocalFormat( DATE_FORMAT );
+    private static final ThreadLocalFormat TIME = new ThreadLocalFormat( TIME_FORMAT );
+
     public static String date()
     {
         return date( DEFAULT_TIME_ZONE );
@@ -180,20 +194,6 @@ public class Format
     {
         // No instances
     }
-
-    private static final String[] BYTE_SIZES = { "B", "kB", "MB", "GB" };
-
-    public static final String DATE_FORMAT = "yyyy-MM-dd HH:mm:ss.SSSZ";
-    public static final String TIME_FORMAT = "HH:mm:ss.SSS";
-
-    /**
-     * Default time zone is UTC (+00:00) so that comparing timestamped logs from different
-     * sources is an easier task.
-     */
-    public static final TimeZone DEFAULT_TIME_ZONE = TimeZone.getTimeZone( "UTC" );
-
-    private static final ThreadLocalFormat DATE = new ThreadLocalFormat( DATE_FORMAT );
-    private static final ThreadLocalFormat TIME = new ThreadLocalFormat( TIME_FORMAT );
 
     private static class ThreadLocalFormat extends ThreadLocal<DateFormat>
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -277,8 +277,8 @@ public class PlatformModule
         {
             builder.withLevel( debugContext, Level.DEBUG );
         }
-        builder.withDefaultLevel( config.get( GraphDatabaseSettings.store_internal_log_level ) );
-        builder.withTimeZone( config.get( GraphDatabaseSettings.log_timezone ).getZoneId() );
+        builder.withDefaultLevel( config.get( GraphDatabaseSettings.store_internal_log_level ) )
+               .withTimeZone( config.get( GraphDatabaseSettings.log_timezone ).getZoneId() );
 
         File logFile = config.get( store_internal_log_path );
         if ( !logFile.getParentFile().exists() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -278,6 +278,7 @@ public class PlatformModule
             builder.withLevel( debugContext, Level.DEBUG );
         }
         builder.withDefaultLevel( config.get( GraphDatabaseSettings.store_internal_log_level ) );
+        builder.withTimeZone( config.get( GraphDatabaseSettings.log_timezone ).getZoneId() );
 
         File logFile = config.get( store_internal_log_path );
         if ( !logFile.getParentFile().exists() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/StoreLogService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/logging/StoreLogService.java
@@ -23,6 +23,8 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executor;
@@ -53,6 +55,7 @@ public class StoreLogService extends AbstractLogService implements Lifecycle
         };
         private Map<String, Level> logLevels = new HashMap<>();
         private Level defaultLevel = Level.INFO;
+        private ZoneId timeZoneId = ZoneOffset.UTC;
         private File debugLog;
 
         private Builder()
@@ -94,6 +97,12 @@ public class StoreLogService extends AbstractLogService implements Lifecycle
             return this;
         }
 
+        public Builder withTimeZone( ZoneId timeZoneId )
+        {
+            this.timeZoneId = timeZoneId;
+            return this;
+        }
+
         public Builder withDefaultLevel( Level defaultLevel )
         {
             this.defaultLevel = defaultLevel;
@@ -112,7 +121,7 @@ public class StoreLogService extends AbstractLogService implements Lifecycle
             {
                 throw new IllegalArgumentException( "Debug log can't be null; set its value using `withInternalLog`" );
             }
-            return new StoreLogService( userLogProvider, fileSystem, debugLog, logLevels, defaultLevel,
+            return new StoreLogService( userLogProvider, fileSystem, debugLog, logLevels, defaultLevel, timeZoneId,
                     internalLogRotationThreshold, internalLogRotationDelay, maxInternalLogArchives, rotationExecutor,
                     rotationListener );
         }
@@ -143,6 +152,7 @@ public class StoreLogService extends AbstractLogService implements Lifecycle
             File internalLog,
             Map<String, Level> logLevels,
             Level defaultLevel,
+            ZoneId logTimeZone,
             long internalLogRotationThreshold,
             long internalLogRotationDelay,
             int maxInternalLogArchives,
@@ -154,7 +164,7 @@ public class StoreLogService extends AbstractLogService implements Lifecycle
             fileSystem.mkdirs( internalLog.getParentFile() );
         }
 
-        final FormattedLogProvider.Builder internalLogBuilder = FormattedLogProvider.withUTCTimeZone()
+        final FormattedLogProvider.Builder internalLogBuilder = FormattedLogProvider.withZoneId( logTimeZone )
                 .withDefaultLogLevel( defaultLevel ).withLogLevels( logLevels );
 
         FormattedLogProvider internalLogProvider;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfigurableStandalonePageCacheFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfigurableStandalonePageCacheFactory.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.impl.pagecache;
 
+import java.time.ZoneId;
+
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
@@ -65,7 +67,8 @@ public final class ConfigurableStandalonePageCacheFactory
             PageCursorTracerSupplier pageCursorTracerSupplier, Config config )
     {
         config.augmentDefaults( GraphDatabaseSettings.pagecache_memory, "8M" );
-        FormattedLogProvider logProvider = FormattedLogProvider.toOutputStream( System.err );
+        ZoneId logTimeZone = config.get( GraphDatabaseSettings.log_timezone ).getZoneId();
+        FormattedLogProvider logProvider = FormattedLogProvider.withZoneId( logTimeZone ).toOutputStream( System.err );
         ConfiguringPageCacheFactory pageCacheFactory = new ConfiguringPageCacheFactory(
                 fileSystem, config, pageCacheTracer, pageCursorTracerSupplier,
                 logProvider.getLog( PageCache.class ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/SystemTimeZoneLoggingIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/SystemTimeZoneLoggingIT.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.configuration;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.ZoneOffset;
+import java.util.TimeZone;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.logging.LogTimeZone;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.test.rule.TestDirectory;
+
+import static org.junit.Assert.assertTrue;
+
+public class SystemTimeZoneLoggingIT
+{
+    @Rule
+    public TestDirectory testDirectory = TestDirectory.testDirectory();
+
+    @Test
+    public void databaseLogsUseSystemTimeZoneIfConfigure() throws IOException
+    {
+        TimeZone defaultTimeZone = TimeZone.getDefault();
+        try
+        {
+            checkStartLogLine( 5, "+0500" );
+            checkStartLogLine( -7, "-0700" );
+        }
+        finally
+        {
+            TimeZone.setDefault( defaultTimeZone );
+        }
+    }
+
+    private void checkStartLogLine( int hoursShift, String timeZoneSuffix ) throws IOException
+    {
+        TimeZone.setDefault( TimeZone.getTimeZone( ZoneOffset.ofHours( hoursShift ) ) );
+        File storeDir = testDirectory.directory( String.valueOf( hoursShift ) );
+        GraphDatabaseService database = new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir )
+                .setConfig( GraphDatabaseSettings.log_timezone, LogTimeZone.SYSTEM.name() ).newGraphDatabase();
+        database.shutdown();
+        Path databasePath = storeDir.toPath();
+        Path debugLog = Paths.get( "logs", "debug.log" );
+        String debugLogLine = getLogLine( databasePath, debugLog );
+        assertTrue( debugLogLine, debugLogLine.contains( timeZoneSuffix ) );
+    }
+
+    private String getLogLine( Path databasePath, Path logFilePath ) throws IOException
+    {
+        return Files.readAllLines( databasePath.resolve( logFilePath ) ).get( 0 );
+    }
+}

--- a/community/logging/src/main/java/org/neo4j/logging/LogTimeZone.java
+++ b/community/logging/src/main/java/org/neo4j/logging/LogTimeZone.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.logging;
+
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+
+public enum LogTimeZone
+{
+    UTC
+            {
+                @Override
+                public ZoneId getZoneId()
+                {
+                    return ZoneOffset.UTC;
+                }
+            },
+    SYSTEM
+            {
+                @Override
+                public ZoneId getZoneId()
+                {
+                    return ZoneId.systemDefault();
+                }
+            };
+
+    public abstract ZoneId getZoneId();
+}

--- a/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
@@ -33,7 +33,6 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import org.neo4j.graphdb.DependencyResolver;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.helpers.ListenSocketAddress;
 import org.neo4j.helpers.RunCarefully;
@@ -88,6 +87,7 @@ import org.neo4j.udc.UsageData;
 
 import static java.lang.Math.round;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.log_timezone;
 import static org.neo4j.helpers.collection.Iterables.map;
 import static org.neo4j.scheduler.JobScheduler.Groups.serverTransactionTimeout;
 import static org.neo4j.server.configuration.ServerSettings.http_log_path;
@@ -363,7 +363,7 @@ public abstract class AbstractNeoServer implements NeoServer
 
         AsyncRequestLog requestLog = new AsyncRequestLog(
                 dependencyResolver.resolveDependency( FileSystemAbstraction.class ),
-                config.get( GraphDatabaseSettings.log_timezone ).getZoneId(),
+                config.get( log_timezone ).getZoneId(),
                 config.get( http_log_path ).toString(),
                 config.get( http_logging_rotation_size ),
                 config.get( http_logging_rotation_keep_number ) );

--- a/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
@@ -33,6 +33,7 @@ import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.helpers.ListenSocketAddress;
 import org.neo4j.helpers.RunCarefully;
@@ -362,6 +363,7 @@ public abstract class AbstractNeoServer implements NeoServer
 
         AsyncRequestLog requestLog = new AsyncRequestLog(
                 dependencyResolver.resolveDependency( FileSystemAbstraction.class ),
+                config.get( GraphDatabaseSettings.log_timezone ).getZoneId(),
                 config.get( http_log_path ).toString(),
                 config.get( http_logging_rotation_size ),
                 config.get( http_logging_rotation_keep_number ) );

--- a/community/server/src/main/java/org/neo4j/server/ServerBootstrapper.java
+++ b/community/server/src/main/java/org/neo4j/server/ServerBootstrapper.java
@@ -172,6 +172,7 @@ public abstract class ServerBootstrapper implements Bootstrapper
     private static LogProvider setupLogging( Config config )
     {
         LogProvider userLogProvider = FormattedLogProvider.withoutRenderingContext()
+                            .withZoneId( config.get( GraphDatabaseSettings.log_timezone ).getZoneId() )
                             .withDefaultLogLevel( config.get( GraphDatabaseSettings.store_internal_log_level ) )
                             .toOutputStream( System.out );
         JULBridge.resetJUL();

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
@@ -22,6 +22,7 @@ package org.neo4j.backup;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.ZoneId;
 import java.util.Optional;
 
 import org.neo4j.commandline.admin.AdminCommand;
@@ -37,6 +38,7 @@ import org.neo4j.commandline.arguments.common.OptionalCanonicalPath;
 import org.neo4j.consistency.ConsistencyCheckService;
 import org.neo4j.consistency.ConsistencyCheckSettings;
 import org.neo4j.consistency.checking.full.CheckConsistencyConfig;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.HostnamePort;
 import org.neo4j.helpers.TimeUtil;
 import org.neo4j.helpers.collection.MapUtil;
@@ -237,10 +239,11 @@ public class OnlineBackupCommand implements AdminCommand
             try
             {
                 outsideWorld.stdOutLine( "Doing consistency check..." );
+                ZoneId logTimeZone = config.get( GraphDatabaseSettings.log_timezone ).getZoneId();
                 ConsistencyCheckService.Result ccResult = consistencyCheckService
                         .runFullConsistencyCheck( destination, config,
                                 ProgressMonitorFactory.textual( outsideWorld.errorStream() ),
-                                FormattedLogProvider.toOutputStream( outsideWorld.outStream() ),
+                                FormattedLogProvider.withZoneId( logTimeZone ).toOutputStream( outsideWorld.outStream() ),
                                 outsideWorld.fileSystem(),
                                 false, reportDir.toFile(),
                                 new CheckConsistencyConfig( checkGraph, checkIndexes, checkLabelScanStore,

--- a/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLoggerKernelExtension.java
+++ b/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLoggerKernelExtension.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.impl.query;
 import java.io.Closeable;
 import java.io.File;
 import java.io.OutputStream;
+import java.time.ZoneId;
 import java.util.EnumSet;
 import java.util.function.BooleanSupplier;
 import java.util.function.LongSupplier;
@@ -85,6 +86,7 @@ public class QueryLoggerKernelExtension extends KernelExtensionFactory<QueryLogg
                 BooleanSupplier queryLogEnabled = () -> config.get( GraphDatabaseSettings.log_queries );
                 Long rotationThreshold = config.get( GraphDatabaseSettings.log_queries_rotation_threshold );
                 int maxArchives = config.get( GraphDatabaseSettings.log_queries_max_archives );
+                ZoneId logTimeZoneId = config.get( GraphDatabaseSettings.log_timezone ).getZoneId();
                 EnumSet<QueryLogEntryContent> flags = EnumSet.noneOf( QueryLogEntryContent.class );
                 for ( QueryLogEntryContent flag : QueryLogEntryContent.values() )
                 {
@@ -94,7 +96,7 @@ public class QueryLoggerKernelExtension extends KernelExtensionFactory<QueryLogg
                     }
                 }
 
-                FormattedLog.Builder logBuilder = FormattedLog.withUTCTimeZone();
+                FormattedLog.Builder logBuilder = FormattedLog.withZoneId( logTimeZoneId );
                 Log log;
                 if ( rotationThreshold == 0 )
                 {

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/log/SecurityLog.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/log/SecurityLog.java
@@ -21,18 +21,20 @@ package org.neo4j.server.security.enterprise.log;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.FormattedLog;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.Logger;
 import org.neo4j.logging.RotatingFileOutputStreamSupplier;
+import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.server.security.enterprise.configuration.SecuritySettings;
 
 import static org.neo4j.helpers.Strings.escape;
@@ -44,8 +46,10 @@ public class SecurityLog extends LifecycleAdapter implements Log
 
     public SecurityLog( Config config, FileSystemAbstraction fileSystem, Executor executor ) throws IOException
     {
-        FormattedLog.Builder builder = FormattedLog.withUTCTimeZone();
+        ZoneId logTimeZoneId = config.get( GraphDatabaseSettings.log_timezone ).getZoneId();
         File logFile = config.get( SecuritySettings.security_log_filename );
+
+        FormattedLog.Builder builder = FormattedLog.withZoneId( logTimeZoneId );
 
         rotatingSupplier = new RotatingFileOutputStreamSupplier( fileSystem, logFile,
                 config.get( SecuritySettings.store_security_log_rotation_threshold ),

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/ArbiterBootstrapper.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/ArbiterBootstrapper.java
@@ -23,6 +23,7 @@ import org.jboss.netty.channel.ChannelException;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.ZoneId;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Timer;
@@ -32,6 +33,7 @@ import org.neo4j.cluster.ClusterSettings;
 import org.neo4j.cluster.client.ClusterClientModule;
 import org.neo4j.cluster.protocol.election.NotElectableElectionCredentialsProvider;
 import org.neo4j.function.Predicates;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemLifecycleAdapter;
@@ -129,7 +131,9 @@ public class ArbiterBootstrapper implements Bootstrapper, AutoCloseable
         File logFile = config.get( store_internal_log_path );
         try
         {
-            return StoreLogService.withUserLogProvider( FormattedLogProvider.toOutputStream( System.out ) )
+            ZoneId zoneId = config.get( GraphDatabaseSettings.log_timezone ).getZoneId();
+            FormattedLogProvider logProvider = FormattedLogProvider.withZoneId( zoneId ).toOutputStream( System.out );
+            return StoreLogService.withUserLogProvider( logProvider )
                     .withInternalLog( logFile )
                     .build( fileSystem );
         }

--- a/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/runtime/DatabaseActions.java
+++ b/packaging/neo4j-desktop/src/main/java/org/neo4j/desktop/runtime/DatabaseActions.java
@@ -20,12 +20,14 @@
 package org.neo4j.desktop.runtime;
 
 import java.net.BindException;
+import java.time.ZoneId;
 import java.util.HashSet;
 import java.util.Set;
 
 import org.neo4j.desktop.model.DesktopModel;
 import org.neo4j.desktop.model.exceptions.UnableToStartServerException;
 import org.neo4j.desktop.ui.MainWindow;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.GraphDatabaseDependencies;
 import org.neo4j.kernel.StoreLockException;
 import org.neo4j.kernel.configuration.Config;
@@ -61,7 +63,8 @@ public class DatabaseActions
         Config config = model.getConfig();
         Monitors monitors = new Monitors();
 
-        LogProvider userLogProvider = FormattedLogProvider.toOutputStream( System.out );
+        ZoneId logTimeZone = config.get( GraphDatabaseSettings.log_timezone ).getZoneId();
+        LogProvider userLogProvider = FormattedLogProvider.withZoneId( logTimeZone ).toOutputStream( System.out );
         GraphDatabaseDependencies dependencies = GraphDatabaseDependencies.newDependencies()
                 .userLogProvider( userLogProvider ).monitors( monitors );
 


### PR DESCRIPTION
Previously all database logs where using UTC only for time in all logs.
This PR will allow to change behaviour and use system timezone for all the logs
using newly introduced "dbms.logs.timezone" database setting.

Current possible setting values are:
UTC(default value) - log in UTC;
SYSTEM - log in a system default timezone.