### PR TITLE
Fixes issue including seed in RandomRule

### DIFF
--- a/community/common/src/test/java/org/neo4j/test/rule/RandomRule.java
+++ b/community/common/src/test/java/org/neo4j/test/rule/RandomRule.java
@@ -21,6 +21,7 @@ package org.neo4j.test.rule;
 
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
+import org.junit.runners.model.MultipleFailureException;
 import org.junit.runners.model.Statement;
 
 import java.lang.annotation.ElementType;
@@ -91,8 +92,25 @@ public class RandomRule implements TestRule
                 }
                 catch ( Throwable t )
                 {
-                    throw Exceptions.withMessage( t, t.getMessage() + ": random seed used:" + seed );
+                    if ( t instanceof MultipleFailureException )
+                    {
+                        MultipleFailureException multipleFailures = (MultipleFailureException) t;
+                        for ( Throwable failure : multipleFailures.getFailures() )
+                        {
+                            enhanceFailureWithSeed( failure );
+                        }
+                    }
+                    else
+                    {
+                        enhanceFailureWithSeed( t );
+                    }
+                    throw t;
                 }
+            }
+
+            private void enhanceFailureWithSeed( Throwable t )
+            {
+                Exceptions.withMessage( t, t.getMessage() + ": random seed used:" + seed );
             }
         };
     }


### PR DESCRIPTION
Tests that fails and also has RandomRule will have their error message
decorated with the random seed used in the test. In scenarios where
there were failure @After method or other rules failing in their "after"
code would make it so that the seed would prevent this seed from
being visible in the final printer error from the test.

This fixes that by specifically catering for this scenario, where junit
throws a specific multi-failure exception. The RandomRule will see this
and decorate all of those failures so that it becomes visible again.