### PR TITLE
Fixes edge-case with merging two nodes in GBPTree

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
@@ -921,7 +921,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
         try ( PageCursor cursor = openRootCursor( PagedFile.PF_SHARED_READ_LOCK ) )
         {
             new TreePrinter<>( bTreeNode, layout, stableGeneration( generation ), unstableGeneration( generation ) )
-                .printTree( cursor, System.out, printValues, printPosition, printState );
+                .printTree( cursor, cursor, System.out, printValues, printPosition, printState );
         }
     }
 

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/InternalTreeLogic.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/InternalTreeLogic.java
@@ -1225,6 +1225,9 @@ class InternalTreeLogic<KEY,VALUE>
             StructurePropagation<KEY> structurePropagation, int keyCount, int rightSiblingKeyCount,
             long stableGeneration, long unstableGeneration ) throws IOException
     {
+        // Read the right-most key from the right sibling to use when comparing whether or not
+        // a common parent covers the keys in right sibling too
+        bTreeNode.keyAt( rightSiblingCursor, structurePropagation.rightKey, rightSiblingKeyCount - 1 );
         merge( cursor, keyCount, rightSiblingCursor, rightSiblingKeyCount, stableGeneration, unstableGeneration );
 
         // Propagate change
@@ -1234,14 +1237,15 @@ class InternalTreeLogic<KEY,VALUE>
         structurePropagation.midChild = rightSiblingCursor.getCurrentPageId();
         structurePropagation.hasRightKeyReplace = true;
         structurePropagation.keyReplaceStrategy = BUBBLE;
-        bTreeNode.keyAt( rightSiblingCursor, structurePropagation.rightKey, rightSiblingKeyCount - 1 );
     }
 
     private void mergeFromLeftSiblingLeaf( PageCursor cursor, PageCursor leftSiblingCursor,
             StructurePropagation<KEY> structurePropagation, int keyCount, int leftSiblingKeyCount,
             long stableGeneration, long unstableGeneration ) throws IOException
     {
-        // Move stuff and update key count
+        // Read the left-most key from the left sibling to use when comparing whether or not
+        // a common parent covers the keys in left sibling too
+        bTreeNode.keyAt( leftSiblingCursor, structurePropagation.leftKey, 0 );
         merge( leftSiblingCursor, leftSiblingKeyCount, cursor, keyCount, stableGeneration, unstableGeneration );
 
         // Propagate change
@@ -1251,7 +1255,6 @@ class InternalTreeLogic<KEY,VALUE>
         structurePropagation.leftChild = cursor.getCurrentPageId();
         structurePropagation.hasLeftKeyReplace = true;
         structurePropagation.keyReplaceStrategy = BUBBLE;
-        bTreeNode.keyAt( cursor, structurePropagation.leftKey, 0 );
     }
 
     private void merge( PageCursor leftSiblingCursor, int leftSiblingKeyCount, PageCursor rightSiblingCursor,

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNode.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeNode.java
@@ -188,6 +188,10 @@ class TreeNode<KEY,VALUE>
 
     static void setKeyCount( PageCursor cursor, int count )
     {
+        if ( count < 0 )
+        {
+            throw new IllegalArgumentException( "Invalid key count, " + count + ". On tree node " + cursor.getCurrentPageId() + "." );
+        }
         cursor.putInt( BYTE_POS_KEYCOUNT, count );
     }
 

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyIT.java
@@ -87,7 +87,7 @@ public class GBPTreeConcurrencyIT
     @Rule
     public final RuleChain rules = outerRule( fs ).around( directory ).around( pageCacheRule ).around( random );
 
-    private final Layout<MutableLong,MutableLong> layout = new SimpleLongLayout();
+    private Layout<MutableLong,MutableLong> layout;
     private GBPTree<MutableLong,MutableLong> index;
     private final ExecutorService threadPool =
             Executors.newFixedThreadPool( Runtime.getRuntime().availableProcessors() );
@@ -101,7 +101,8 @@ public class GBPTreeConcurrencyIT
     private GBPTree<MutableLong,MutableLong> createIndex( GBPTree.Monitor monitor )
             throws IOException
     {
-        int pageSize = 256;
+        int pageSize = 512;
+        layout = new SimpleLongLayout( random.intBetween( 0, 10 ) );
         PageCache pageCache =
                 pageCacheRule.getPageCache( fs.get(), config().withPageSize( pageSize ).withAccessChecks( true ) );
         return index = new GBPTreeBuilder<>( pageCache, directory.file( "index" ), layout ).build();

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
@@ -135,7 +135,7 @@ public class GBPTreeTest
         }
 
         // WHEN
-        SimpleLongLayout otherLayout = new SimpleLongLayout( "Something else" );
+        SimpleLongLayout otherLayout = new SimpleLongLayout( 0, "Something else" );
         try ( GBPTree<MutableLong,MutableLong> ignored = index().with( otherLayout ).build() )
         {
             fail( "Should not load" );

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTest.java
@@ -1529,7 +1529,7 @@ public class InternalTreeLogicTest
     {
         long currentPageId = cursor.getCurrentPageId();
         cursor.next( rootId );
-        new TreePrinter<>( node, layout, stableGeneration, unstableGeneration ).printTree( cursor, System.out, true, true, true );
+        new TreePrinter<>( node, layout, stableGeneration, unstableGeneration ).printTree( cursor, cursor, System.out, true, true, true );
         cursor.next( currentPageId );
     }
 


### PR DESCRIPTION
There was an edge case where, if max key count in leaves were odd, would read the wrong key to bubble upwards to the parent(s) when merging a node into its right sibling. This would in turn make the wrong structural changes to the tree, resulting in a negative key count in a parent, instead of actually removing the expected key from another parent. This would later result in reading garbage data (recognized on read by throwing exception saying something like reading BROKEN/BROKEN pointer pair) when reading data from that node.

This PR fixes this by reading the correct key on merge, also doing the read _before_ merging the nodes together, as to make the code easier to understand. Existing trees affected by this will have to be deleted and rebuilt.