### PR TITLE
graphGetProperty return NO_VALUE not null

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -420,7 +420,7 @@ public class OperationsFacade
         statement.assertOpen();
         if ( propertyKeyId == StatementConstants.NO_SUCH_PROPERTY_KEY )
         {
-            return null;
+            return Values.NO_VALUE;
         }
         return dataRead().graphGetProperty( statement, propertyKeyId );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DataStatementArgumentVerificationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/DataStatementArgumentVerificationTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.neo4j.values.storable.Values.NO_VALUE;
 
 public class DataStatementArgumentVerificationTest
 {
@@ -48,7 +49,7 @@ public class DataStatementArgumentVerificationTest
         Value value = statement.nodeGetProperty( 17, StatementConstants.NO_SUCH_PROPERTY_KEY );
 
         // then
-        assertTrue( "should return NoProperty", value == Values.NO_VALUE );
+        assertTrue( "should return NoProperty", value == NO_VALUE );
     }
 
     @Test
@@ -62,7 +63,7 @@ public class DataStatementArgumentVerificationTest
         Value value = statement.relationshipGetProperty( 17, StatementConstants.NO_SUCH_PROPERTY_KEY );
 
         // then
-        assertEquals( "should return NoProperty", value, Values.NO_VALUE );
+        assertEquals( "should return NoProperty", value, NO_VALUE );
     }
 
     @Test
@@ -76,7 +77,7 @@ public class DataStatementArgumentVerificationTest
         Object value = statement.graphGetProperty( StatementConstants.NO_SUCH_PROPERTY_KEY );
 
         // then
-        assertNull( "should return NoProperty", value );
+        assertEquals( "should return NoProperty", value, NO_VALUE );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestGraphProperties.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestGraphProperties.java
@@ -106,6 +106,18 @@ public class TestGraphProperties
     }
 
     @Test
+    public void getNonExistentGraphPropertyWithDefaultValue() throws Exception
+    {
+        GraphDatabaseAPI db = (GraphDatabaseAPI) factory.newImpermanentDatabase();
+        PropertyContainer graphProperties = properties( db );
+        Transaction tx = db.beginTx();
+        assertEquals( "default", graphProperties.getProperty( "test", "default" ) );
+        tx.success();
+        tx.close();
+        db.shutdown();
+    }
+
+    @Test
     public void setManyGraphProperties() throws Exception
     {
         GraphDatabaseAPI db = (GraphDatabaseAPI) factory.newImpermanentDatabase();


### PR DESCRIPTION
Method `graphGetProperty` was returning a `null` instead of `NO_VALUE`
which causes a `NullPointerException`.