### PR TITLE
3.4 Backup Commercial SSL injection support

### DIFF
--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupSupportingClassesFactoryProvider.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupSupportingClassesFactoryProvider.java
@@ -19,9 +19,14 @@
  */
 package org.neo4j.backup;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
+
 import org.neo4j.helpers.Service;
 
-public class BackupSupportingClassesFactoryProvider extends Service
+public abstract class BackupSupportingClassesFactoryProvider extends Service
 {
 
     /**
@@ -39,5 +44,26 @@ public class BackupSupportingClassesFactoryProvider extends Service
     protected BackupSupportingClassesFactoryProvider()
     {
         super( "key", new String[0] );
+    }
+
+    public abstract AbstractBackupSupportingClassesFactory getFactory( BackupModuleResolveAtRuntime backupModuleResolveAtRuntime );
+
+    public static Optional<BackupSupportingClassesFactoryProvider> findBestProvider()
+    {
+        return StreamSupport.stream( load( BackupSupportingClassesFactoryProvider.class ).spliterator(), false )
+                .sorted( ( l, r ) -> r.getPriority() - l.getPriority() )
+                .findFirst();
+    }
+
+    /**
+     * The higher the priority value, the greater the preference
+     * @return
+     */
+    protected abstract int getPriority();
+
+    @Override
+    public String toString()
+    {
+        return super.getClass().getName();
     }
 }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/CommunityBackupSupportingClassesFactoryProvider.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/CommunityBackupSupportingClassesFactoryProvider.java
@@ -19,13 +19,23 @@
  */
 package org.neo4j.backup;
 
-import org.neo4j.helpers.Service;
-
-public class CommunityBackupSupportingClassesFactoryProvider extends Service
+public class CommunityBackupSupportingClassesFactoryProvider extends BackupSupportingClassesFactoryProvider
 {
     public CommunityBackupSupportingClassesFactoryProvider()
     {
         super( null );
+    }
+
+    @Override
+    public AbstractBackupSupportingClassesFactory getFactory( BackupModuleResolveAtRuntime backupModuleResolveAtRuntime )
+    {
+        return new CommunityBackupSupportingClassesFactory( backupModuleResolveAtRuntime );
+    }
+
+    @Override
+    protected int getPriority()
+    {
+        return 0;
     }
 
     /**

--- a/enterprise/backup/src/main/java/org/neo4j/backup/CommunityBackupSupportingClassesFactoryProvider.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/CommunityBackupSupportingClassesFactoryProvider.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.backup;
 
+import org.neo4j.helpers.Service;
+
+@Service.Implementation( BackupSupportingClassesFactoryProvider.class )
 public class CommunityBackupSupportingClassesFactoryProvider extends BackupSupportingClassesFactoryProvider
 {
     public CommunityBackupSupportingClassesFactoryProvider()

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommandProvider.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommandProvider.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 
 import org.neo4j.OnlineBackupCommandSection;
@@ -91,8 +92,15 @@ public class OnlineBackupCommandProvider extends AdminCommand.Provider
 
         return new OnlineBackupCommand( outsideWorld,
                 onlineBackupContextLoader,
-                new CommunityBackupSupportingClassesFactory( backupModuleResolveAtRuntime ),
+                BackupSupportingClassesFactoryProvider.findBestProvider()
+                        .orElseThrow( noProviderException() )
+                        .getFactory( backupModuleResolveAtRuntime ),
                 new BackupFlowFactory( backupModuleResolveAtRuntime )
         );
+    }
+
+    private static Supplier<IllegalStateException> noProviderException()
+    {
+        return () -> new IllegalStateException( "Unable to find a suitable backup supporting classes provider in the classpath" );
     }
 }

--- a/enterprise/backup/src/main/resources/META-INF/services/org.neo4j.backup.BackupSupportingClassesFactoryProvider
+++ b/enterprise/backup/src/main/resources/META-INF/services/org.neo4j.backup.BackupSupportingClassesFactoryProvider
@@ -1,0 +1,1 @@
+org.neo4j.backup.CommunityBackupSupportingClassesFactoryProvider

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupSupportingClassesFactoryProviderTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupSupportingClassesFactoryProviderTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.backup;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+public class BackupSupportingClassesFactoryProviderTest
+{
+
+    @Test
+    public void canLoadCommunitySupportingClassesFactory()
+    {
+        assertEquals( 1, findInstancesOf( CommunityBackupSupportingClassesFactoryProvider.class, allAvailableSupportingClassesFactories() ).size() );
+        assertEquals( 2, allAvailableSupportingClassesFactories().size() );
+    }
+
+    @Test
+    public void testCommunityModuleIsPrioritisedOverSslModule()
+    {
+        assertEquals( CommunityBackupSupportingClassesFactoryProvider.class, BackupSupportingClassesFactoryProvider.findBestProvider().get().getClass() );
+    }
+
+    public static Collection<BackupSupportingClassesFactoryProvider> allAvailableSupportingClassesFactories()
+    {
+        Collection<BackupSupportingClassesFactoryProvider> discovered = new ArrayList<>();
+        BackupSupportingClassesFactoryProvider.load( BackupSupportingClassesFactoryProvider.class ).forEach( discovered::add );
+        return discovered;
+    }
+
+    public static <DESIRED extends BackupSupportingClassesFactoryProvider> Collection<DESIRED> findInstancesOf( Class<DESIRED> desiredClass,
+            Collection<? extends BackupSupportingClassesFactoryProvider> collection )
+    {
+        return collection
+                .stream()
+                .filter( isOfClass( desiredClass ) )
+                .map( i -> (DESIRED) i )
+                .collect( Collectors.toList() );
+    }
+
+    private static Predicate<BackupSupportingClassesFactoryProvider> isOfClass( Class<? extends BackupSupportingClassesFactoryProvider> desiredClass )
+    {
+        return factory -> desiredClass.equals( factory.getClass() );
+    }
+}

--- a/enterprise/backup/src/test/java/org/neo4j/backup/DummyCommercialBackupSupportingClassesFactoryProvider.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/DummyCommercialBackupSupportingClassesFactoryProvider.java
@@ -19,20 +19,28 @@
  */
 package org.neo4j.backup;
 
-import org.neo4j.causalclustering.handlers.NoOpPipelineHandlerAppenderFactory;
 import org.neo4j.causalclustering.handlers.PipelineHandlerAppenderFactory;
 import org.neo4j.kernel.impl.util.Dependencies;
 
-public class CommunityBackupSupportingClassesFactory extends AbstractBackupSupportingClassesFactory
+public class DummyCommercialBackupSupportingClassesFactoryProvider extends BackupSupportingClassesFactoryProvider
 {
-    public CommunityBackupSupportingClassesFactory( BackupModuleResolveAtRuntime backupModuleResolveAtRuntime )
+
+    @Override
+    public AbstractBackupSupportingClassesFactory getFactory( BackupModuleResolveAtRuntime backupModuleResolveAtRuntime )
     {
-        super( backupModuleResolveAtRuntime );
+        return new AbstractBackupSupportingClassesFactory( backupModuleResolveAtRuntime )
+        {
+            @Override
+            protected PipelineHandlerAppenderFactory getPipelineHandlerAppenderFactory()
+            {
+                return null;
+            }
+        };
     }
 
     @Override
-    protected PipelineHandlerAppenderFactory getPipelineHandlerAppenderFactory()
+    protected int getPriority()
     {
-        return new NoOpPipelineHandlerAppenderFactory();
+        return -1;
     }
 }

--- a/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandProviderTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandProviderTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.backup;
+
+import org.junit.Test;
+
+import org.neo4j.causalclustering.handlers.NoOpPipelineHandlerAppenderFactory;
+import org.neo4j.commandline.admin.OutsideWorld;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class OnlineBackupCommandProviderTest
+{
+    @Test
+    public void communityBackupSupportingFactory()
+    {
+        BackupModuleResolveAtRuntime backupModuleResolveAtRuntime = mock( BackupModuleResolveAtRuntime.class );
+        OutsideWorld outsideWorld = mock( OutsideWorld.class );
+        when( backupModuleResolveAtRuntime.getOutsideWorld() ).thenReturn( outsideWorld );
+
+        BackupSupportingClassesFactoryProvider provider = BackupSupportingClassesFactoryProvider.findBestProvider().get();
+        AbstractBackupSupportingClassesFactory factory = provider.getFactory( backupModuleResolveAtRuntime );
+        assertEquals( NoOpPipelineHandlerAppenderFactory.class, factory
+                .getPipelineHandlerAppenderFactory()
+                .getClass() );
+    }
+}

--- a/enterprise/backup/src/test/resources/META-INF/services/org.neo4j.backup.BackupSupportingClassesFactoryProvider
+++ b/enterprise/backup/src/test/resources/META-INF/services/org.neo4j.backup.BackupSupportingClassesFactoryProvider
@@ -1,0 +1,1 @@
+org.neo4j.backup.DummyCommercialBackupSupportingClassesFactoryProvider


### PR DESCRIPTION
Before this commit, backups use a hardcoded NoOp SSL solution. Applying
this commit provides classpath injection of the commercial encrypted
backup capability.