### PR TITLE
3.4 Added fix for broken addresses in IT in backup

### DIFF
--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/BackupCoreIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/BackupCoreIT.java
@@ -31,6 +31,7 @@ import java.util.Map;
 
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.core.CoreGraphDatabase;
+import org.neo4j.causalclustering.core.consensus.roles.Role;
 import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.CoreClusterMember;
 import org.neo4j.graphdb.Node;
@@ -74,7 +75,7 @@ public class BackupCoreIT
         {
             // Run backup
             DbRepresentation beforeChange = DbRepresentation.of( createSomeData( cluster ) );
-            String[] args = backupArguments( backupAddress( db.database() ), backupsDir, "" + db.serverId() );
+            String[] args = backupArguments( backupAddress( cluster ), backupsDir, "" + db.serverId() );
             assertEquals( 0, runBackupToolFromOtherJvmToGetExitCode( clusterRule.clusterDirectory(), args ) );
 
             // Add some new data
@@ -97,9 +98,9 @@ public class BackupCoreIT
         } ).database();
     }
 
-    static String backupAddress( GraphDatabaseFacade db )
+    static String backupAddress( Cluster cluster )
     {
-        return ":" + PortAuthority.allocatePort();
+        return cluster.getDbWithRole( Role.LEADER ).settingValue( "causal_clustering.transaction_listen_address" );
     }
 
     static String[] backupArguments( String from, File backupsDir, String name )

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/ClusterSeedingIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/ClusterSeedingIT.java
@@ -92,15 +92,15 @@ public class ClusterSeedingIT
         backupCluster.start();
         CoreGraphDatabase db = BackupCoreIT.createSomeData( backupCluster );
 
-        File backup = createBackup( db, "some-backup" );
+        File backup = createBackup( backupCluster, "some-backup" );
         backupCluster.shutdown();
 
         return backup;
     }
 
-    private File createBackup( CoreGraphDatabase db, String backupName ) throws Exception
+    private File createBackup( Cluster cluster, String backupName ) throws Exception
     {
-        String[] args = BackupCoreIT.backupArguments( backupAddress( db ), baseBackupDir, backupName );
+        String[] args = BackupCoreIT.backupArguments( backupAddress( cluster ), baseBackupDir, backupName );
         assertEquals( 0, runBackupToolFromOtherJvmToGetExitCode( testDir.absolutePath(), args ) );
         return new File( baseBackupDir, backupName );
     }
@@ -132,7 +132,7 @@ public class ClusterSeedingIT
         cluster.start();
 
         // when: creating a backup
-        File backupDir = createBackup( cluster.getCoreMemberById( 0 ).database(), "the-backup" );
+        File backupDir = createBackup( cluster, "the-backup" );
 
         // and: seeding new member with said backup
         CoreClusterMember newMember = cluster.addCoreMemberWithId( 3 );
@@ -154,7 +154,7 @@ public class ClusterSeedingIT
         createEmptyNodes( cluster, 100 );
 
         // when: creating a backup
-        File backupDir = createBackup( cluster.getCoreMemberById( 0 ).database(), "the-backup" );
+        File backupDir = createBackup( cluster, "the-backup" );
 
         // and: seeding new member with said backup
         CoreClusterMember newMember = cluster.addCoreMemberWithId( 3 );


### PR DESCRIPTION
Some backup integration tests (BackupCoreIT,ClusterSeedingIT) are using
incorrect addresses for backups. Applying corrects wrong addresses to be
cluster leaders.

https://build.neohq.net/viewLog.html?buildId=2132423