### PR TITLE
Raft message log line rewrite to aid machine readability.

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
@@ -87,6 +87,7 @@ import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.LifecycleStatus;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.LogProvider;
+import org.neo4j.time.Clocks;
 import org.neo4j.udc.UsageData;
 
 /**
@@ -206,7 +207,7 @@ public class EnterpriseCoreEditionModule extends EditionModule
         if ( config.get( CausalClusteringSettings.raft_messages_log_enable ) )
         {
             File logsDir = config.get( GraphDatabaseSettings.logs_directory );
-            messageLogger = life.add( new BetterMessageLogger<>( myself, raftMessagesLog( logsDir ) ) );
+            messageLogger = life.add( new BetterMessageLogger<>( myself, raftMessagesLog( logsDir ), Clocks.systemClock() ) );
         }
         else
         {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMessages.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMessages.java
@@ -674,7 +674,7 @@ public interface RaftMessages
         }
     }
 
-    class ClusterIdAwareMessage implements Message
+    class ClusterIdAwareMessage implements RaftMessage
     {
         private final ClusterId clusterId;
         private final RaftMessage message;
@@ -723,6 +723,17 @@ public interface RaftMessages
             return format( "{clusterId: %s, message: %s}", clusterId, message );
         }
 
+        @Override
+        public MemberId from()
+        {
+            return message.from();
+        }
+
+        @Override
+        public Type type()
+        {
+            return message.type();
+        }
     }
 
     class PruneRequest extends BaseRaftMessage

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/logging/BetterMessageLogger.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/logging/BetterMessageLogger.java
@@ -20,10 +20,12 @@
 package org.neo4j.causalclustering.logging;
 
 import java.io.PrintWriter;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Clock;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
 
+import org.neo4j.causalclustering.core.consensus.RaftMessages;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
 import static java.lang.String.format;
@@ -31,38 +33,59 @@ import static java.lang.String.valueOf;
 
 public class BetterMessageLogger<MEMBER> extends LifecycleAdapter implements MessageLogger<MEMBER>
 {
-    private final PrintWriter printWriter;
-    private DateFormat dateFormat = new SimpleDateFormat("HH:mm:ss.SSS");
+    private enum Direction {
+        INFO( "---" ),
+        OUTBOUND( "-->" ),
+        INBOUND( "<--" );
 
-    public BetterMessageLogger( MEMBER myself, PrintWriter printWriter )
-    {
-        this.printWriter = printWriter;
-        printWriter.println( "I am " + myself );
-        printWriter.flush();
-    }
+        public final String arrow;
 
-    private void log( MEMBER from, MEMBER to, Object message )
-    {
-        printWriter.println( format( "%s -->%s: %s: %s",
-                dateFormat.format( new Date() ), to, message.getClass().getSimpleName(), valueOf( message ) ) );
-        printWriter.flush();
-    }
-
-    @Override
-    public void log( MEMBER from, MEMBER to, Object... messages )
-    {
-        for ( Object message : messages )
+        Direction( String arrow )
         {
-            log( from, to, message );
+            this.arrow = arrow;
         }
     }
 
-    @Override
-    public void log( MEMBER to, Object message )
+    private final PrintWriter printWriter;
+    private final Clock clock;
+    private final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern( "yyyy-MM-dd HH:mm:ss.SSSZ" );
+
+    public BetterMessageLogger( MEMBER myself, PrintWriter printWriter, Clock clock )
     {
-        printWriter.println( format( "%s <--%s: %s",
-                dateFormat.format( new Date() ), message.getClass().getSimpleName(), valueOf( message ) ) );
+        this.printWriter = printWriter;
+        this.clock = clock;
+        log( myself, Direction.INFO, myself, "Info", "I am " + myself );
+    }
+
+    private void log( MEMBER me, Direction direction, MEMBER remote, String type, String message )
+    {
+        printWriter.println( format( "%s %s %s %s %s \"%s\"",
+                ZonedDateTime.now( clock ).format( dateTimeFormatter ), me, direction.arrow, remote, type, message ) );
         printWriter.flush();
+    }
+
+    @Override
+    public <M extends RaftMessages.RaftMessage> void logOutbound( MEMBER me, M message, MEMBER remote )
+    {
+        log( me, Direction.OUTBOUND, remote, nullSafeMessageType( message ), valueOf( message ) );
+    }
+
+    @Override
+    public <M extends RaftMessages.RaftMessage> void logInbound( MEMBER remote, M message, MEMBER me )
+    {
+        log( me, Direction.INBOUND, remote, nullSafeMessageType( message ), valueOf( message ) );
+    }
+
+    private <M extends RaftMessages.RaftMessage> String nullSafeMessageType( M message )
+    {
+        if( Objects.isNull( message ) )
+        {
+            return "null";
+        }
+        else
+        {
+            return message.type().toString();
+        }
     }
 
     @Override

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/logging/MessageLogger.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/logging/MessageLogger.java
@@ -19,9 +19,11 @@
  */
 package org.neo4j.causalclustering.logging;
 
+import org.neo4j.causalclustering.core.consensus.RaftMessages;
+
 public interface MessageLogger<MEMBER>
 {
-    void log( MEMBER from, MEMBER to, Object... message );
+    <M extends RaftMessages.RaftMessage> void logOutbound( MEMBER me, M message, MEMBER remote );
 
-    void log( MEMBER to, Object message );
+    <M extends RaftMessages.RaftMessage> void logInbound( MEMBER remote, M message, MEMBER me );
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/logging/NullMessageLogger.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/logging/NullMessageLogger.java
@@ -19,16 +19,18 @@
  */
 package org.neo4j.causalclustering.logging;
 
+import org.neo4j.causalclustering.core.consensus.RaftMessages;
+
 public class NullMessageLogger<MEMBER> implements MessageLogger<MEMBER>
 {
     @Override
-    public void log( MEMBER from, MEMBER to, Object... messages )
+    public <M extends RaftMessages.RaftMessage> void logOutbound( MEMBER me, M message, MEMBER remote )
     {
 
     }
 
     @Override
-    public void log( MEMBER to, Object message )
+    public <M extends RaftMessages.RaftMessage> void logInbound( MEMBER remote, M message, MEMBER me )
     {
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/LoggingInbound.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/LoggingInbound.java
@@ -19,10 +19,11 @@
  */
 package org.neo4j.causalclustering.messaging;
 
+import org.neo4j.causalclustering.core.consensus.RaftMessages;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.logging.MessageLogger;
 
-public class LoggingInbound<M extends Message> implements Inbound<M>
+public class LoggingInbound<M extends RaftMessages.RaftMessage> implements Inbound<M>
 {
     private final Inbound<M> inbound;
     private final MessageLogger<MemberId> messageLogger;
@@ -42,7 +43,7 @@ public class LoggingInbound<M extends Message> implements Inbound<M>
         {
             public synchronized void handle( M message )
             {
-                messageLogger.log( me, message );
+                messageLogger.logInbound( message.from(), message, me );
                 handler.handle( message );
             }
         } );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/LoggingOutbound.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/LoggingOutbound.java
@@ -19,9 +19,10 @@
  */
 package org.neo4j.causalclustering.messaging;
 
+import org.neo4j.causalclustering.core.consensus.RaftMessages;
 import org.neo4j.causalclustering.logging.MessageLogger;
 
-public class LoggingOutbound<MEMBER, MESSAGE extends Message> implements Outbound<MEMBER, MESSAGE>
+public class LoggingOutbound<MEMBER, MESSAGE extends RaftMessages.RaftMessage> implements Outbound<MEMBER, MESSAGE>
 {
     private final Outbound<MEMBER,MESSAGE> outbound;
     private final MEMBER me;
@@ -37,7 +38,7 @@ public class LoggingOutbound<MEMBER, MESSAGE extends Message> implements Outboun
     @Override
     public void send( MEMBER to, MESSAGE message )
     {
-        messageLogger.log( me, to, message );
+        messageLogger.logOutbound( me, message, to );
         outbound.send( to, message );
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/CatchUpTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/CatchUpTest.java
@@ -65,7 +65,7 @@ public class CatchUpTest
         // then
         for ( MemberId aMember : allMembers )
         {
-            assertThat( integerValues( fixture.members().withId( aMember ).raftLog() ), hasItems( 42 ) );
+            assertThat( fixture.messageLog(), integerValues( fixture.members().withId( aMember ).raftLog() ), hasItems( 42 ) );
         }
     }
 
@@ -115,7 +115,7 @@ public class CatchUpTest
         net.processMessages();
 
         // then
-        assertThat( integerValues( fixture.members().withId( sleepyId ).raftLog() ), hasItems( 10, 20, 30, 40 ) );
+        assertThat( fixture.messageLog(), integerValues( fixture.members().withId( sleepyId ).raftLog() ), hasItems( 10, 20, 30, 40 ) );
     }
 
     private List<Integer> integerValues( ReadableRaftLog log ) throws IOException

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/DirectNetworking.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/DirectNetworking.java
@@ -102,7 +102,7 @@ public class DirectNetworking
         }
     }
 
-    public class Inbound implements org.neo4j.causalclustering.messaging.Inbound
+    public class Inbound<M extends Message> implements org.neo4j.causalclustering.messaging.Inbound<M>
     {
         private final MemberId id;
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftMachineTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftMachineTest.java
@@ -401,16 +401,9 @@ public class RaftMachineTest
         // Given
         DirectNetworking network = new DirectNetworking();
         final MemberId newMember = member( 99 );
-        DirectNetworking.Inbound newMemberInbound = network.new Inbound( newMember );
+        DirectNetworking.Inbound<RaftMessages.RaftMessage> newMemberInbound = network.new Inbound<>( newMember );
         final OutboundMessageCollector messages = new OutboundMessageCollector();
-        newMemberInbound.registerHandler( new Inbound.MessageHandler<RaftMessages.RaftMessage>()
-        {
-            @Override
-            public void handle( RaftMessages.RaftMessage message )
-            {
-                messages.send( newMember, message );
-            }
-        } );
+        newMemberInbound.registerHandler( (Inbound.MessageHandler<RaftMessages.RaftMessage>) message -> messages.send( newMember, message ) );
 
         FakeClock fakeClock = Clocks.fakeClock();
         ControlledRenewableTimeoutService timeouts = new ControlledRenewableTimeoutService( fakeClock );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/membership/RaftGroupMembershipTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/membership/RaftGroupMembershipTest.java
@@ -71,8 +71,8 @@ public class RaftGroupMembershipTest
 
         // then
         assertThat( fixture.members(), hasCurrentMembers( new RaftTestGroup( new int[0] ) ) );
-        assertEquals( 0, fixture.members().withRole( LEADER ).size() );
-        assertEquals( 3, fixture.members().withRole( FOLLOWER ).size() );
+        assertEquals( fixture.messageLog(), 0, fixture.members().withRole( LEADER ).size() );
+        assertEquals( fixture.messageLog(), 3, fixture.members().withRole( FOLLOWER ).size() );
     }
 
     @Test
@@ -105,8 +105,8 @@ public class RaftGroupMembershipTest
 
         // then
         assertThat( fixture.members().withIds( finalMembers ), hasCurrentMembers( new RaftTestGroup( finalMembers ) ) );
-        assertEquals( 1, fixture.members().withRole( LEADER ).size() );
-        assertEquals( 3, fixture.members().withRole( FOLLOWER ).size() );
+        assertEquals( fixture.messageLog(),1, fixture.members().withRole( LEADER ).size() );
+        assertEquals( fixture.messageLog(),3, fixture.members().withRole( FOLLOWER ).size() );
     }
 
     @Test
@@ -145,9 +145,9 @@ public class RaftGroupMembershipTest
         net.processMessages();
 
         // then
-        assertThat( fixture.members().withIds( finalMembers ), hasCurrentMembers( new RaftTestGroup( finalMembers ) ) );
-        assertEquals( 1, fixture.members().withRole( LEADER ).size() );
-        assertEquals( 5, fixture.members().withRole( FOLLOWER ).size() );
+        assertThat( fixture.messageLog(), fixture.members().withIds( finalMembers ), hasCurrentMembers( new RaftTestGroup( finalMembers ) ) );
+        assertEquals( fixture.messageLog(), 1, fixture.members().withRole( LEADER ).size() );
+        assertEquals( fixture.messageLog(), 5, fixture.members().withRole( FOLLOWER ).size() );
     }
 
     @Test
@@ -173,9 +173,9 @@ public class RaftGroupMembershipTest
         net.processMessages();
 
         // then
-        assertThat( fixture.members().withIds( finalMembers ), hasCurrentMembers( new RaftTestGroup( finalMembers ) ) );
-        assertEquals( 1, fixture.members().withIds( finalMembers ).withRole( LEADER ).size() );
-        assertEquals( 1, fixture.members().withIds( finalMembers ).withRole( FOLLOWER ).size() );
+        assertThat( fixture.messageLog(), fixture.members().withIds( finalMembers ), hasCurrentMembers( new RaftTestGroup( finalMembers ) ) );
+        assertEquals( fixture.messageLog(), 1, fixture.members().withIds( finalMembers ).withRole( LEADER ).size() );
+        assertEquals( fixture.messageLog(), 1, fixture.members().withIds( finalMembers ).withRole( FOLLOWER ).size() );
     }
 
     @Test
@@ -205,8 +205,8 @@ public class RaftGroupMembershipTest
 
         // then
         assertThat( fixture.members().withIds( finalMembers ), hasCurrentMembers( new RaftTestGroup( finalMembers ) ) );
-        assertEquals( 1, fixture.members().withIds( finalMembers ).withRole( LEADER ).size() );
-        assertEquals( 1, fixture.members().withIds( finalMembers ).withRole( FOLLOWER ).size() );
+        assertEquals( fixture.messageLog(), 1, fixture.members().withIds( finalMembers ).withRole( LEADER ).size() );
+        assertEquals( fixture.messageLog(), 1, fixture.members().withIds( finalMembers ).withRole( FOLLOWER ).size() );
     }
 
     @Test
@@ -247,8 +247,8 @@ public class RaftGroupMembershipTest
 
         // then
         assertThat( fixture.members().withIds( finalMembers ), hasCurrentMembers( new RaftTestGroup( finalMembers ) ) );
-        assertEquals( 1, fixture.members().withIds( finalMembers ).withRole( LEADER ).size() );
-        assertEquals( 3, fixture.members().withIds( finalMembers ).withRole( FOLLOWER ).size() );
+        assertEquals( fixture.messageLog(), 1, fixture.members().withIds( finalMembers ).withRole( LEADER ).size() );
+        assertEquals( fixture.messageLog(), 3, fixture.members().withIds( finalMembers ).withRole( FOLLOWER ).size() );
     }
 
     @Test
@@ -277,8 +277,8 @@ public class RaftGroupMembershipTest
         net.processMessages();
 
         // then
-        assertThat( fixture.members().withIds( finalMembers ), hasCurrentMembers( new RaftTestGroup( finalMembers ) ) );
-        assertTrue( fixture.members().withId( stable1 ).raftInstance().isLeader() ||
+        assertThat( fixture.messageLog(), fixture.members().withIds( finalMembers ), hasCurrentMembers( new RaftTestGroup( finalMembers ) ) );
+        assertTrue( fixture.messageLog(), fixture.members().withId( stable1 ).raftInstance().isLeader() ||
                 fixture.members().withId( stable2 ).raftInstance().isLeader() );
     }
 
@@ -318,8 +318,8 @@ public class RaftGroupMembershipTest
         net.processMessages();
 
         // then
-        assertTrue( fixture.members().withId( leader2 ).raftInstance().isLeader() );
-        assertThat( fixture.members().withIds( allMembers ), hasCurrentMembers( new RaftTestGroup( allMembers ) ) );
+        assertTrue( fixture.messageLog(), fixture.members().withId( leader2 ).raftInstance().isLeader() );
+        assertThat( fixture.messageLog(), fixture.members().withIds( allMembers ), hasCurrentMembers( new RaftTestGroup( allMembers ) ) );
     }
 
     @Test
@@ -356,8 +356,8 @@ public class RaftGroupMembershipTest
         net.processMessages();
 
         // then
-        assertTrue( fixture.members().withId( leader ).raftInstance().isLeader() );
-        assertThat( fixture.members().withIds( allMembers ), hasCurrentMembers( new RaftTestGroup( allMembers ) ) );
+        assertTrue( fixture.messageLog(), fixture.members().withId( leader ).raftInstance().isLeader() );
+        assertThat( fixture.messageLog(), fixture.members().withIds( allMembers ), hasCurrentMembers( new RaftTestGroup( allMembers ) ) );
     }
 
     @Test
@@ -384,10 +384,10 @@ public class RaftGroupMembershipTest
         net.processMessages();
 
         // then
-        assertTrue( fixture.members().withId( leader2 ).raftInstance().isLeader() );
-        assertFalse( fixture.members().withId( stable ).raftInstance().isLeader() );
-        assertEquals( 1, fixture.members().withIds( leader2, stable ).withRole( LEADER ).size() );
-        assertEquals( 1, fixture.members().withIds( leader2, stable ).withRole( FOLLOWER ).size() );
+        assertTrue( fixture.messageLog(), fixture.members().withId( leader2 ).raftInstance().isLeader() );
+        assertFalse( fixture.messageLog(), fixture.members().withId( stable ).raftInstance().isLeader() );
+        assertEquals( fixture.messageLog(), 1, fixture.members().withIds( leader2, stable ).withRole( LEADER ).size() );
+        assertEquals( fixture.messageLog(), 1, fixture.members().withIds( leader2, stable ).withRole( FOLLOWER ).size() );
     }
 
     private Matcher<? super RaftTestFixture.Members> hasCurrentMembers( final RaftTestGroup raftGroup )


### PR DESCRIPTION
Include date, both to and from members, type of message rather than class of message, arranged as space separated fields and with message quoted.