### PR TITLE
Fix to nested simple case bug

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/commands/expressions/SimpleCase.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/commands/expressions/SimpleCase.scala
@@ -42,7 +42,7 @@ case class SimpleCase(expression: Expression, alternatives: Seq[(Expression, Exp
 
   private def alternativeExpressions = alternatives.map(_._2)
 
-  def arguments = (expression +: (alternativeComparison ++ alternativeExpressions)).distinct
+  def arguments = (expression +: (alternativeComparison ++ alternativeExpressions ++ default.map(Seq(_)).getOrElse(Seq()))).distinct
 
   def rewrite(f: (Expression) => Expression): Expression = {
     val newAlternatives = alternatives map {

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/commands/expressions/SimpleCaseTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/commands/expressions/SimpleCaseTest.scala
@@ -94,6 +94,11 @@ class SimpleCaseTest extends CypherFunSuite {
     assert(result == "default")
   }
 
+  test("arguments should contain all children") {
+    val caseExpr = SimpleCase(Literal(1), Seq((Literal(2), Literal(3))), Some(Literal(4)))
+    caseExpr.arguments should contain allOf(Literal(1), Literal(2), Literal(3), Literal(4))
+  }
+
   private def case_(in: Any, alternatives: (Any, Any)*): SimpleCase = {
     val mappedAlt: Seq[(Expression, Expression)] = alternatives.map {
       case (a, b) => (Literal(a), Literal(b))

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-31.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-31.txt
@@ -5,3 +5,5 @@ Ordering is well defined across all types, ascending
 Ordering is well defined across all types, descending
 Ordering for lists, ascending
 Ordering for lists, descending
+
+Shorthand case with filter should work as expected

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -134,6 +134,7 @@ Filter with AND/OR
 LIMIT 0 should stop side effects
 Id on null
 type on null
+Shorthand case with filter should work as expected
 
 //OrderByAcceptance.feature - Unsupported orderability
 ORDER BY nodes should return null results last in ascending order

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/CaseExpression.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/CaseExpression.feature
@@ -306,3 +306,25 @@ Feature: CaseExpression
       | x  |
       | [] |
     And no side effects
+
+  Scenario: Shorthand case with filter should work as expected
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:test)<-[:rel]-(:test_rel)
+      """
+    When executing query:
+      """
+      MATCH (t:test)
+      WITH COLLECT(t) AS ts
+      WITH
+      CASE 1
+          WHEN 0 THEN []
+          ELSE FILTER(t IN ts WHERE (t)<--())
+      END AS res
+      RETURN COUNT(res) AS count
+      """
+    Then the result should be:
+      | count  |
+      | 1      |
+    And no side effects


### PR DESCRIPTION
Make sure to update blacklists when forward-merging

Changelog: Fixes #9685 so nested function calls in ELSE inside shorthand CASE works correctly