### PR TITLE
Allow to use NIOFSDirectory as directory implementations for lucene indexes

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/DirectoryFactory.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/DirectoryFactory.java
@@ -25,6 +25,7 @@ import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.Lock;
+import org.apache.lucene.store.NIOFSDirectory;
 import org.apache.lucene.store.NRTCachingDirectory;
 import org.apache.lucene.store.RAMDirectory;
 
@@ -58,13 +59,16 @@ public interface DirectoryFactory extends FileSystemAbstraction.ThirdPartyFileSy
                 FeatureToggles.getInteger( DirectoryFactory.class, "max_merge_size_mb", 5 );
         private final int MAX_CACHED_MB =
                 FeatureToggles.getInteger( DirectoryFactory.class, "max_cached_mb", 50 );
+        private final boolean USE_DEFAULT_DIRECTORY_FACTORY =
+                FeatureToggles.flag( DirectoryFactory.class, "default_directory_factory", true );
 
         @SuppressWarnings( "ResultOfMethodCallIgnored" )
         @Override
         public Directory open( File dir ) throws IOException
         {
             dir.mkdirs();
-            return new NRTCachingDirectory( FSDirectory.open( dir.toPath() ), MAX_MERGE_SIZE_MB, MAX_CACHED_MB );
+            FSDirectory directory = USE_DEFAULT_DIRECTORY_FACTORY ? FSDirectory.open( dir.toPath() ) : new NIOFSDirectory( dir.toPath() );
+            return new NRTCachingDirectory( directory, MAX_MERGE_SIZE_MB, MAX_CACHED_MB );
         }
 
         @Override


### PR DESCRIPTION
Add "default_directory_factory" feature toggle in DirectoryFactory
to be able to choose between default directory factory and NIOFSDirectory
for lucene indexes directory.