### PR TITLE
Fixes join failures in HA

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/MultiPaxosServerFactory.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/MultiPaxosServerFactory.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.cluster;
 
-import java.net.URI;
 import java.util.concurrent.Executor;
 
 import org.neo4j.cluster.com.message.MessageSender;
@@ -190,6 +189,7 @@ public class MultiPaxosServerFactory
                         internal( SnapshotMessage.join ) )
 
                 .rule( ClusterState.discovery, ClusterMessage.configurationResponse, ClusterState.joining,
+                        internal( ProposerMessage.join ),
                         internal( AcceptorMessage.join ),
                         internal( LearnerMessage.join ),
                         internal( AtomicBroadcastMessage.join ) )


### PR DESCRIPTION
There is a join path in HA which so far has been overlooked from
 a Proposer perspective. In that case, the Proposer state machine
 was left in the start state perpetually and the join would eventually
 fail because the join response would not be picked up.

This is a forward port of https://github.com/neo4j/neo4j/pull/8376