### PR TITLE
CsvInput verifies id spaces before starting import

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Groups.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Groups.java
@@ -48,7 +48,7 @@ public class Groups
         }
         else
         {
-            if ( global != globalMode.booleanValue() )
+            if ( global != globalMode )
             {
                 throw mixingOfGroupModesException();
             }
@@ -76,7 +76,7 @@ public class Groups
     public synchronized Group get( String name )
     {
         boolean global = name == null;
-        if ( globalMode != null && global != globalMode.booleanValue() )
+        if ( globalMode != null && global != globalMode )
         {
             throw mixingOfGroupModesException();
         }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/HeaderException.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/HeaderException.java
@@ -25,4 +25,9 @@ public class HeaderException extends InputException
     {
         super( message );
     }
+
+    public HeaderException( String message, Throwable cause )
+    {
+        super( message, cause );
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DataFactories.java
@@ -314,7 +314,7 @@ public class DataFactories
             else
             {
                 type = Type.PROPERTY;
-                extractor = extractors.valueOf( typeSpec );
+                extractor = parsePropertyType( typeSpec, extractors );
             }
 
             return new Header.Entry( name, type, groupName, extractor );
@@ -362,10 +362,23 @@ public class DataFactories
             else
             {
                 type = Type.PROPERTY;
-                extractor = extractors.valueOf( typeSpec );
+                extractor = parsePropertyType( typeSpec, extractors );
             }
 
             return new Header.Entry( name, type, groupName, extractor );
+        }
+
+    }
+
+    private static Extractor<?> parsePropertyType( String typeSpec, Extractors extractors )
+    {
+        try
+        {
+            return extractors.valueOf( typeSpec );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            throw new HeaderException( "Unable to parse header", e );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputRelationshipDeserialization.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputRelationshipDeserialization.java
@@ -49,8 +49,8 @@ public class InputRelationshipDeserialization extends InputEntityDeserialization
     @Override
     public void initialize()
     {
-        this.startNodeGroup = groups.getOrCreate( header.entry( Type.START_ID ).groupName() );
-        this.endNodeGroup = groups.getOrCreate( header.entry( Type.END_ID ).groupName() );
+        this.startNodeGroup = groups.get( header.entry( Type.START_ID ).groupName() );
+        this.endNodeGroup = groups.get( header.entry( Type.END_ID ).groupName() );
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/GroupsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/GroupsTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 import org.neo4j.test.Race;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
 
 public class GroupsTest
 {
@@ -49,5 +51,110 @@ public class GroupsTest
         // THEN
         Group otherGroup = groups.getOrCreate( "MyOtherGroup" );
         assertEquals( 1, otherGroup.id() );
+    }
+
+    @Test
+    public void shouldFailOnMixedGroupModeInGetOrCreate() throws Exception
+    {
+        // given
+        Groups groups = new Groups();
+        groups.getOrCreate( null );
+
+        try
+        {
+            // when
+            groups.getOrCreate( "Something" );
+            fail( "Should fail" );
+        }
+        catch ( IllegalStateException e )
+        {
+            // then OK
+        }
+    }
+
+    @Test
+    public void shouldFailOnMixedGroupModeInGetOrCreate2() throws Exception
+    {
+        // given
+        Groups groups = new Groups();
+        groups.getOrCreate( "Something" );
+
+        try
+        {
+            // when
+            groups.getOrCreate( null );
+            fail( "Should fail" );
+        }
+        catch ( IllegalStateException e )
+        {
+            // then OK
+        }
+    }
+
+    @Test
+    public void shouldGetCreatedGroup() throws Exception
+    {
+        // given
+        Groups groups = new Groups();
+        String name = "Something";
+        Group createdGroup = groups.getOrCreate( name );
+
+        // when
+        Group gottenGroup = groups.get( name );
+
+        // then
+        assertSame( createdGroup, gottenGroup );
+    }
+
+    @Test
+    public void shouldGetGlobalGroup() throws Exception
+    {
+        // given
+        Groups groups = new Groups();
+        groups.getOrCreate( null );
+
+        // when
+        Group group = groups.get( null );
+
+        // then
+        assertSame( Group.GLOBAL, group );
+    }
+
+    @Test
+    public void shouldFailOnMixedGroupModeInGet() throws Exception
+    {
+        // given
+        Groups groups = new Groups();
+        groups.getOrCreate( "Something" );
+
+        try
+        {
+            // when
+            groups.get( null );
+            fail( "Should fail" );
+        }
+        catch ( IllegalStateException e )
+        {
+            // then OK
+        }
+    }
+
+    @Test
+    public void shouldFailOnMixedGroupModeInGet2() throws Exception
+    {
+        // given
+        Groups groups = new Groups();
+        groups.getOrCreate( null );
+
+        try
+        {
+            // when
+            groups.get( "Something" );
+            fail( "Should fail" );
+        }
+        catch ( IllegalStateException e )
+        {
+            // then OK
+        }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/GroupsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/GroupsTest.java
@@ -25,7 +25,6 @@ import org.neo4j.test.Race;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
 
 public class GroupsTest
 {
@@ -53,42 +52,26 @@ public class GroupsTest
         assertEquals( 1, otherGroup.id() );
     }
 
-    @Test
+    @Test( expected = IllegalStateException.class )
     public void shouldFailOnMixedGroupModeInGetOrCreate() throws Exception
     {
         // given
         Groups groups = new Groups();
         groups.getOrCreate( null );
 
-        try
-        {
-            // when
-            groups.getOrCreate( "Something" );
-            fail( "Should fail" );
-        }
-        catch ( IllegalStateException e )
-        {
-            // then OK
-        }
+        // when
+        groups.getOrCreate( "Something" );
     }
 
-    @Test
+    @Test( expected = IllegalStateException.class )
     public void shouldFailOnMixedGroupModeInGetOrCreate2() throws Exception
     {
         // given
         Groups groups = new Groups();
         groups.getOrCreate( "Something" );
 
-        try
-        {
-            // when
-            groups.getOrCreate( null );
-            fail( "Should fail" );
-        }
-        catch ( IllegalStateException e )
-        {
-            // then OK
-        }
+        // when
+        groups.getOrCreate( null );
     }
 
     @Test
@@ -120,41 +103,25 @@ public class GroupsTest
         assertSame( Group.GLOBAL, group );
     }
 
-    @Test
+    @Test( expected = IllegalStateException.class )
     public void shouldFailOnMixedGroupModeInGet() throws Exception
     {
         // given
         Groups groups = new Groups();
         groups.getOrCreate( "Something" );
 
-        try
-        {
-            // when
-            groups.get( null );
-            fail( "Should fail" );
-        }
-        catch ( IllegalStateException e )
-        {
-            // then OK
-        }
+        // when
+        groups.get( null );
     }
 
-    @Test
+    @Test( expected = IllegalStateException.class )
     public void shouldFailOnMixedGroupModeInGet2() throws Exception
     {
         // given
         Groups groups = new Groups();
         groups.getOrCreate( null );
 
-        try
-        {
-            // when
-            groups.get( "Something" );
-            fail( "Should fail" );
-        }
-        catch ( IllegalStateException e )
-        {
-            // then OK
-        }
+        // when
+        groups.get( "Something" );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/CsvInputTest.java
@@ -1122,26 +1122,18 @@ public class CsvInputTest
         @Override
         public Iterator<DataFactory<ENTITY>> iterator()
         {
-            return Iterators.iterator( new DataFactory<ENTITY>()
+            return Iterators.iterator( config -> new Data<ENTITY>()
             {
                 @Override
-                public Data<ENTITY> create( Configuration config )
+                public CharReadable stream()
                 {
-                    return new Data<ENTITY>()
-                    {
+                    return last = factory.apply( config );
+                }
 
-                        @Override
-                        public CharReadable stream()
-                        {
-                            return last = factory.apply( config );
-                        }
-
-                        @Override
-                        public Decorator<ENTITY> decorator()
-                        {
-                            return decorator;
-                        }
-                    };
+                @Override
+                public Decorator<ENTITY> decorator()
+                {
+                    return decorator;
                 }
             } );
         }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecoratorIT.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecoratorIT.java
@@ -44,7 +44,9 @@ import static org.neo4j.csv.reader.Readables.wrap;
 import static org.neo4j.unsafe.impl.batchimport.input.InputEntityDecorators.NO_NODE_DECORATOR;
 import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.data;
 import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.defaultFormatNodeFileHeader;
+import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.defaultFormatRelationshipFileHeader;
 import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.nodeData;
+import static org.neo4j.unsafe.impl.batchimport.input.csv.DataFactories.relationshipData;
 
 public class ExternalPropertiesDecoratorIT
 {
@@ -72,7 +74,7 @@ public class ExternalPropertiesDecoratorIT
                 config, idType, UpdateBehaviour.ADD, collector ) );
         Input input = new CsvInput(
                 nodeData( data( decorator, () -> mainData( count ) ) ), defaultFormatNodeFileHeader(),
-                null, null,
+                relationshipData(), defaultFormatRelationshipFileHeader(),
                 idType, config,
                 collector, processors, true );
 


### PR DESCRIPTION
such that it will fail fast if there are relationship headers specifying
id spaces which no node header has will fail explaining just that instead of
treating all those relationships as bad.