### PR TITLE
Minor importer performance tweaks

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeDegreeCountStage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/NodeDegreeCountStage.java
@@ -36,7 +36,7 @@ public class NodeDegreeCountStage extends Stage
 {
     public NodeDegreeCountStage( Configuration config, RelationshipStore store, NodeRelationshipCache cache )
     {
-        super( "Node Degrees", config, ORDER_SEND_DOWNSTREAM );
+        super( "Node Degrees", config );
         add( new BatchFeedStep( control(), config, forwards( 0, store.getHighId(), config ), store.getRecordSize() ) );
         add( new ReadRecordsStep<>( control(), config, false, store, null ) );
         add( new CalculateDenseNodesStep( control(), config, cache ) );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ParallelBatchImporter.java
@@ -185,7 +185,7 @@ public class ParallelBatchImporter implements BatchImporter
             }
             // Import relationships (unlinked), properties
             Configuration relationshipConfig =
-                    configWithRecordsPerPageBasedBatchSize( config, neoStore.getNodeStore() );
+                    configWithRecordsPerPageBasedBatchSize( config, neoStore.getRelationshipStore() );
             RelationshipStage unlinkedRelationshipStage =
                     new RelationshipStage( relationshipConfig, writeMonitor, relationships, idMapper,
                             badCollector, inputCache, neoStore, storeUpdateMonitor );
@@ -201,9 +201,7 @@ public class ParallelBatchImporter implements BatchImporter
             nodeRelationshipCache.setHighNodeId( neoStore.getNodeStore().getHighId() );
             NodeDegreeCountStage nodeDegreeStage = new NodeDegreeCountStage( relationshipConfig,
                     neoStore.getRelationshipStore(), nodeRelationshipCache );
-            neoStore.startFlushingPageCache();
             executeStage( nodeDegreeStage );
-            neoStore.stopFlushingPageCache();
 
             linkData( nodeRelationshipCache, neoStore, unlinkedRelationshipStage.getDistribution(),
                     availableMemory );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/DynamicTaskExecutor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/DynamicTaskExecutor.java
@@ -31,7 +31,9 @@ import org.neo4j.function.Suppliers;
 
 import static java.lang.Integer.max;
 import static java.lang.Integer.min;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 import static org.neo4j.helpers.Exceptions.launderedException;
 
 /**
@@ -40,8 +42,6 @@ import static org.neo4j.helpers.Exceptions.launderedException;
  */
 public class DynamicTaskExecutor<LOCAL> implements TaskExecutor<LOCAL>
 {
-    public static final ParkStrategy DEFAULT_PARK_STRATEGY = new ParkStrategy.Park( 10, MILLISECONDS );
-
     private final BlockingQueue<Task<LOCAL>> queue;
     private final ParkStrategy parkStrategy;
     private final String processorThreadNamePrefix;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/AbstractStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/AbstractStep.java
@@ -30,6 +30,7 @@ import org.neo4j.concurrent.WorkSync;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.impl.util.MovingAverage;
 import org.neo4j.unsafe.impl.batchimport.Configuration;
+import org.neo4j.unsafe.impl.batchimport.executor.ParkStrategy;
 import org.neo4j.unsafe.impl.batchimport.stats.ProcessingStats;
 import org.neo4j.unsafe.impl.batchimport.stats.StatsProvider;
 import org.neo4j.unsafe.impl.batchimport.stats.StepStats;
@@ -37,12 +38,16 @@ import org.neo4j.unsafe.impl.batchimport.stats.StepStats;
 import static java.lang.String.format;
 import static java.lang.System.currentTimeMillis;
 import static java.util.Arrays.asList;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static org.apache.commons.lang3.SystemUtils.IS_OS_WINDOWS;
 
 /**
  * Basic implementation of a {@link Step}. Does the most plumbing job of building a step implementation.
  */
 public abstract class AbstractStep<T> implements Step<T>
 {
+    public static final ParkStrategy PARK = new ParkStrategy.Park( IS_OS_WINDOWS ? 10_000 : 500, MICROSECONDS );
+
     private final StageControl control;
     private volatile String name;
     @SuppressWarnings( "rawtypes" )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProcessorStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/ProcessorStep.java
@@ -30,7 +30,6 @@ import org.neo4j.unsafe.impl.batchimport.stats.StatsProvider;
 
 import static java.lang.System.currentTimeMillis;
 import static java.lang.System.nanoTime;
-import static org.neo4j.unsafe.impl.batchimport.executor.DynamicTaskExecutor.DEFAULT_PARK_STRATEGY;
 
 /**
  * {@link Step} that uses {@link TaskExecutor} as a queue and execution mechanism.
@@ -65,8 +64,7 @@ public abstract class ProcessorStep<T> extends AbstractStep<T>
     public void start( int orderingGuarantees )
     {
         super.start( orderingGuarantees );
-        this.executor = new DynamicTaskExecutor<>( 1, maxProcessors, config.maxNumberOfProcessors(),
-                DEFAULT_PARK_STRATEGY, name(), Sender::new );
+        this.executor = new DynamicTaskExecutor<>( 1, maxProcessors, config.maxNumberOfProcessors(), PARK, name(), Sender::new );
     }
 
     @Override


### PR DESCRIPTION
- NodeDegreeCountStage was flushing and ordering the batches, which was unnecessary.
  it was also using the wrong batch size such that readers wouldn't have their own
  pages entirely.
- Uses the same PARK time for windows/linux everywhere in the step/execution code.