### PR TITLE
Fix shortest path in with clause bug

### DIFF
--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/helpers/ListSupport.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/helpers/ListSupport.scala
@@ -89,6 +89,7 @@ trait ListSupport {
     case x: Map[_, _]       => Iterable(x)
     case x: JavaMap[_, _]   => Iterable(x.asScala)
     case x: Traversable[_]  => x.toIterable
+    case x: Iterator[_]     => x.toIterable
     case x: JavaIterable[_] => x.asScala.map {
       case y: JavaMap[_, _] => y.asScala
       case y                => y

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/ast/ShortestPathExpression.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/ast/ShortestPathExpression.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.frontend.v3_1.symbols._
 
 case class ShortestPathExpression(pattern: ShortestPaths) extends Expression with SimpleTyping {
   def position = pattern.position
-  protected def possibleTypes = CTList(CTPath)
+  protected def possibleTypes = if (pattern.single) CTPath else CTList(CTPath)
 
   override def semanticCheck(ctx: SemanticContext) =
     pattern.declareVariables(Pattern.SemanticContext.Expression) chain

--- a/community/cypher/frontend-3.1/src/test/scala/org/neo4j/cypher/internal/frontend/v3_1/ast/ShortestPathExpressionTest.scala
+++ b/community/cypher/frontend-3.1/src/test/scala/org/neo4j/cypher/internal/frontend/v3_1/ast/ShortestPathExpressionTest.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.frontend.v3_1.ast
+
+import org.neo4j.cypher.internal.frontend.v3_1.symbols._
+import org.neo4j.cypher.internal.frontend.v3_1.{SemanticDirection, SemanticState}
+import org.neo4j.cypher.internal.frontend.v3_1.test_helpers.CypherFunSuite
+
+class ShortestPathExpressionTest extends CypherFunSuite with AstConstructionTestSupport {
+
+  test("should get correct types for shortestPath") {
+    // Given
+    val (exp, state) = makeShortestPathExpression(true)
+
+    // When
+    val result = exp.semanticCheck(Expression.SemanticContext.Simple)(state)
+
+    // Then
+    result.errors shouldBe empty
+    exp.types(result.state) should equal(TypeSpec.exact(CTPath))
+  }
+
+  test("should get correct types for allShortestPath") {
+    // Given
+    val (exp, state) = makeShortestPathExpression(false)
+
+    // When
+    val result = exp.semanticCheck(Expression.SemanticContext.Simple)(state)
+
+    // Then
+    result.errors shouldBe empty
+    exp.types(result.state) should equal(TypeSpec.exact(CTList(CTPath)))
+  }
+
+  private def makeShortestPathExpression(single: Boolean): (ShortestPathExpression, SemanticState) = {
+    val state = Seq("n", "k").foldLeft(SemanticState.clean) { (acc, n) =>
+      acc.specifyType(varFor(n), TypeSpec.exact(CTNode)).right.get
+    }
+    val pattern = chain(node(Some(varFor("n"))), relationship(None), node(Some(varFor("k"))))
+    (ShortestPathExpression(ShortestPaths(pattern, single) _), state)
+  }
+  private def chain(left: PatternElement, rel: RelationshipPattern, right: NodePattern): RelationshipChain = {
+    RelationshipChain(left, rel, right)_
+  }
+
+  private def relationship(id: Option[Variable]): RelationshipPattern = {
+    RelationshipPattern(id, optional = false, Seq.empty, None, None, SemanticDirection.OUTGOING)_
+  }
+
+  private def node(id: Option[Variable]): NodePattern = {
+    NodePattern(id, Seq.empty, None)_
+  }
+
+}


### PR DESCRIPTION
Semantic check claimed shortest path returned a list
Unwind didn't work for the Scala iterator returned by allShortestPaths
This PR fix the two bugs above and adds some testing

The new acceptance tests must be ported to CypherComparisonSupport when forward merging

Changelog: Fixes #8201 so shortestPath and allShortestPaths have the right type in WITH clauses
