### PR TITLE
Fixing error message of ORDER BY with null values

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/OrderByAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/OrderByAcceptanceTest.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import org.neo4j.cypher._
+import org.neo4j.graphdb._
+
+class OrderByAcceptanceTest extends ExecutionEngineFunSuite {
+
+  test("should order by a list property") {
+    graph.execute("MERGE (n {id: 0}) RETURN n")
+    graph.execute("MERGE (n {id: 1, prop: []}) RETURN n")
+
+    val exception = intercept[QueryExecutionException] {
+      graph.execute("MATCH (n) RETURN n ORDER BY n.prop")
+    }
+    exception.getMessage should be("Cannot perform ORDER BY on mixed types. Left: [] (String[]); Right: <null>")
+  }
+
+}

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/CypherSerializer.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/CypherSerializer.scala
@@ -54,7 +54,7 @@ trait CypherSerializer {
     case x               => x.toString
   }
 
-  protected def serializeWithType(x: Any)(implicit qs: QueryState) = s"${serialize(x, qs.query)} (${x.getClass.getSimpleName})"
+  protected def serializeWithType(x: Any)(implicit qs: QueryState) = s"${serialize(x, qs.query)}${Option(x).map(" (" +_.getClass.getSimpleName + ")").getOrElse("")}"
 
   private def makeString(m: QueryContext => Map[String, Any], qtx: QueryContext) = m(qtx).map {
     case (k, v) => k + " -> " + serialize(v, qtx)


### PR DESCRIPTION
Behavior was changed in 3.2. Please null forward merge and also do not include the test during the forward merge, since it asserts on 3.1 behavior.

changelog: [3.1] Fixes #9571 where a NullPointerException was thrown
when using ORDER BY with null values. Now we give a more comprehensive
error message.