### PR TITLE
Transitive closure in where clauses

### DIFF
--- a/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/TransitiveClosureTest.scala
+++ b/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/TransitiveClosureTest.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_4.ast.rewriters
+
+import org.neo4j.cypher.internal.compiler.v3_4.phases.LogicalPlanState
+import org.neo4j.cypher.internal.compiler.v3_4.planner.AstRewritingTestSupport
+import org.neo4j.cypher.internal.compiler.v3_4.test_helpers.ContextHelper
+import org.neo4j.cypher.internal.frontend.v3_4.ast.Query
+import org.neo4j.cypher.internal.frontend.v3_4.ast.rewriters.{rewriteEqualityToInPredicate, transitiveClosure}
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
+
+class TransitiveClosureTest extends CypherFunSuite with AstRewritingTestSupport {
+
+  test("MATCH (a)-->(b) WHERE a.prop = b.prop AND b.prop = 42") {
+    shouldRewrite(
+      "MATCH (a)-->(b) WHERE a.prop = b.prop AND b.prop = 42",
+      "MATCH (a)-->(b) WHERE a.prop = 42 AND b.prop = 42")
+  }
+
+  test("MATCH (a)-->(b) WHERE b.prop = a.prop AND b.prop = 42") {
+    shouldRewrite(
+      "MATCH (a)-->(b) WHERE a.prop = b.prop AND b.prop = 42",
+      "MATCH (a)-->(b) WHERE a.prop = 42 AND b.prop = 42")
+  }
+
+  test("MATCH (a)-->(b) WHERE a.prop = b.prop OR b.prop = 42") {
+    shouldNotRewrite("MATCH (a)-->(b) WHERE a.prop = b.prop OR b.prop = 42")
+  }
+
+  test("MATCH (a)-->(b) WHERE a.prop = b.prop AND b.prop = b.prop2 AND b.prop2 = 42") {
+    shouldRewrite(
+      "MATCH (a)-->(b) WHERE a.prop = b.prop AND b.prop = b.prop2 AND b.prop2 = 42",
+      "MATCH (a)-->(b) WHERE a.prop = 42 AND b.prop = 42 AND b.prop2 = 42")
+  }
+
+  test("MATCH (a)-->(b) WHERE b.prop2 = 42 AND a.prop = b.prop AND b.prop = b.prop2") {
+    shouldRewrite(
+      "MATCH (a)-->(b) WHERE b.prop2 = 42 AND a.prop = b.prop AND b.prop = b.prop2",
+      "MATCH (a)-->(b) WHERE b.prop2 = 42 AND a.prop = 42 AND b.prop = 42")
+  }
+
+  test("MATCH (a)-->(b) WHERE (a.prop = b.prop AND b.prop = 42) OR (a.prop = b.prop2 AND b.prop2 = 42)") {
+    shouldRewrite(
+      "MATCH (a)-->(b) WHERE (a.prop = b.prop AND b.prop = 42) OR (a.prop = b.prop2 AND b.prop2 = 42)",
+      "MATCH (a)-->(b) WHERE (a.prop = 42 AND b.prop = 42) OR (a.prop = 42 AND b.prop2 = 42)")
+  }
+
+  test("MATCH (a)-->(b) WHERE (a.prop = b.prop AND b.prop = 42) OR (a.prop = b.prop AND b.prop2 = 43) OR (a.prop = b.prop AND b.prop2 = 44)") {
+    shouldRewrite(
+      "MATCH (a)-->(b) WHERE (a.prop = b.prop AND b.prop = 42) OR (a.prop = b.prop AND b.prop = 43) OR (a.prop = b.prop AND b.prop = 44)",
+      "MATCH (a)-->(b) WHERE (a.prop = 42 AND b.prop = 42) OR (a.prop = 43 AND b.prop = 43) OR (a.prop = 44 AND b.prop = 44)")
+  }
+
+  private def shouldRewrite(from: String, to: String) {
+    val original = parser.parse(from).asInstanceOf[Query]
+    val expected = parser.parse(to).asInstanceOf[Query]
+
+    val input = LogicalPlanState(null, null, null, Some(original))
+    val result = transitiveClosure.transform(input, ContextHelper.create())
+
+    result.statement should equal(expected)
+  }
+
+  private def shouldNotRewrite(q: String) {
+    shouldRewrite(q, q)
+  }
+}

--- a/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/LogicalPlanningTestSupport2.scala
@@ -145,6 +145,7 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
       AstRewriting(newPlain, literalExtraction = Never) andThen
       RewriteProcedureCalls andThen
       Namespacer andThen
+      transitiveClosure andThen
       rewriteEqualityToInPredicate andThen
       CNFNormalizer andThen
       LateAstRewriting andThen

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/transitiveClosure.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/transitiveClosure.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypher.internal.frontend.v3_4.ast.rewriters
+
+import org.neo4j.cypher.internal.frontend.v3_4.ast.Where
+import org.neo4j.cypher.internal.frontend.v3_4.phases.{BaseContext, Condition}
+import org.neo4j.cypher.internal.util.v3_4.Foldable._
+import org.neo4j.cypher.internal.util.v3_4.{Rewriter, topDown}
+import org.neo4j.cypher.internal.v3_4.expressions._
+
+import scala.annotation.tailrec
+
+/**
+  * Transitive closure of where clauses.
+  *
+  * Given a where clause, `WHERE a.prop = b.prop AND b.prop = 42` we rewrite the query
+  * into `WHERE a.prop = 42 AND b.prop = 42`
+  */
+case object transitiveClosure extends StatementRewriter {
+
+  override def description: String = "transitive closure in where clauses"
+
+  override def instance(ignored: BaseContext): Rewriter = transitiveClosureRewriter
+
+  override def postConditions: Set[Condition] = Set.empty
+
+  private case object transitiveClosureRewriter extends Rewriter {
+
+    def apply(that: AnyRef): AnyRef = instance.apply(that)
+
+    private val instance: Rewriter = topDown(Rewriter.lift {
+      case where@Where(expression) =>
+        recurse(where, w => w.endoRewrite(whereRewriter))
+    })
+
+    @tailrec
+    private def recurse(in: Where, f: Where => Where): Where = {
+      val out = f(in)
+      if (in == out) out
+      else recurse(out, f)
+    }
+
+    //Collects property equalities, e.g `a.prop = 42`
+    private def collect(e: Expression): Map[Property, Expression] = e.treeFold(Map.empty[Property, Expression]) {
+      case _: Or => (acc) => (acc, None)
+      case _: And => (acc) => (acc, Some(identity))
+      case Equals(_: Property, _: Property) => (acc) => (acc, None)
+      case Equals(p: Property, other) => (acc) => (acc + (p -> other), None)
+    }
+
+    private val whereRewriter: Rewriter = topDown(Rewriter.lift {
+      case and@And(lhs, rhs) =>
+        val inner = andRewriter(collect(lhs) ++ collect(rhs))
+        and.copy(lhs = lhs.endoRewrite(inner), rhs = rhs.endoRewrite(inner))(and.position)
+    })
+
+    private def andRewriter(map: Map[Property, Expression]): Rewriter = topDown(Rewriter.lift {
+      case equals@Equals(p1: Property, p2: Property) if map.contains(p2) =>
+        equals.copy(rhs = map(p2))(equals.position)
+    })
+  }
+
+}

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/CompilationPhases.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/CompilationPhases.scala
@@ -34,6 +34,7 @@ object CompilationPhases {
   def lateAstRewriting: Transformer[BaseContext, BaseState, BaseState] =
     SemanticAnalysis(warn = false) andThen
       Namespacer andThen
+      transitiveClosure andThen
       rewriteEqualityToInPredicate andThen
       CNFNormalizer andThen
       LateAstRewriting


### PR DESCRIPTION
For queries like

```
MATCH (n)-->(m) WHERE n.prop = m.prop AND m.prop = 42 RETURN *
```

we can safely rewrite the query to

```
MATCH (n)-->(m) WHERE n.prop = 42 AND m.prop = 42 RETURN *
```

Also rewrites queries of the form

```
MATCH (n)-->(m) WHERE m.prop = n.prop AND m.prop = 42 RETURN *
```

which is turned into

```
MATCH (n)-->(m) WHERE m.prop = 42 AND n.prop = 42 RETURN *
```