### PR TITLE
More consice logging about log rotation, pruning and checkpointing

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/counts/CountsTracker.java
@@ -106,14 +106,12 @@ public class CountsTracker extends AbstractKeyValueStore<CountsKey>
             @Override
             public void beforeRotation( File source, File target, Headers headers )
             {
-                log.info( format( "About to rotate counts store at transaction %d to [%s], from [%s].",
-                        headers.get( FileVersion.FILE_VERSION ).txId, target, source ) );
             }
 
             @Override
             public void rotationSucceeded( File source, File target, Headers headers )
             {
-                log.info( format( "Successfully rotated counts store at transaction %d to [%s], from [%s].",
+                log.info( format( "Rotated counts store at transaction %d to [%s], from [%s].",
                         headers.get( FileVersion.FILE_VERSION ).txId, target, source ) );
             }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LoggingLogFileMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/LoggingLogFileMonitor.java
@@ -81,13 +81,11 @@ public class LoggingLogFileMonitor implements
     @Override
     public void startedRotating( long currentVersion )
     {
-        log.info( format( "Rotating log version:%d", currentVersion ) );
     }
 
     @Override
     public void finishedRotating( long currentVersion )
     {
-        log.info( format( "Finished rotating log version:%d", currentVersion ) );
     }
 
     @Override
@@ -101,10 +99,10 @@ public class LoggingLogFileMonitor implements
     }
 
     @Override
-    public void opened( File logFile, long logVersion, long lastTransactionId, boolean clean )
+    public void created( File logFile, long logVersion, long lastTransactionId )
     {
-        log.info( format( "Opened logical log [%s] version=%d, lastTxId=%d (%s)",
-                logFile, logVersion, lastTransactionId, clean ? "clean" : "recovered" ) );
+        log.info( format( "Rotated to transaction log [%s] version=%d, last transaction in previous log=%d",
+                logFile, logVersion, lastTransactionId ) );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFile.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogFile.java
@@ -44,12 +44,12 @@ public class PhysicalLogFile implements LogFile, Lifecycle
 {
     public interface Monitor
     {
-        void opened( File logFile, long logVersion, long lastTransactionId, boolean clean );
+        void created( File logFile, long logVersion, long lastTransactionId );
 
         class Adapter implements Monitor
         {
             @Override
-            public void opened( File logFile, long logVersion, long lastTransactionId, boolean clean )
+            public void created( File logFile, long logVersion, long lastTransactionId )
             {
             }
         }
@@ -244,7 +244,7 @@ public class PhysicalLogFile implements LogFile, Lifecycle
             writeLogHeader( headerBuffer, forVersion, lastTxId );
             logHeaderCache.putHeader( forVersion, lastTxId );
             storeChannel.writeAll( headerBuffer );
-            monitor.opened( toOpen, forVersion, lastTxId, true );
+            monitor.created( toOpen, forVersion, lastTxId );
         }
         byte formatVersion = header == null ? CURRENT_LOG_VERSION : header.logFormatVersion;
         return new PhysicalLogVersionedStoreChannel( storeChannel, forVersion, formatVersion );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/SimpleTriggerInfo.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/SimpleTriggerInfo.java
@@ -40,7 +40,7 @@ public class SimpleTriggerInfo implements TriggerInfo
     public String describe( long transactionId )
     {
         String info = description == null ? triggerName : triggerName + " for " + description;
-        return "Check Pointing triggered by " + info + " [" + transactionId + "]: ";
+        return "Checkpoint triggered by " + info + " @ txId: " + transactionId;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruneStrategy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruneStrategy.java
@@ -21,5 +21,12 @@ package org.neo4j.kernel.impl.transaction.log.pruning;
 
 public interface LogPruneStrategy
 {
-    void prune( long upToLogVersion );
+    interface Monitor
+    {
+        void logsPruned( long upToVersion, long fromVersion, long toVersion );
+
+        void noLogsPruned( long upToVersion );
+    }
+
+    void prune( long upToVersion, Monitor monitor );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruneStrategyFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruneStrategyFactory.java
@@ -34,7 +34,7 @@ public class LogPruneStrategyFactory
     public static final LogPruneStrategy NO_PRUNING = new LogPruneStrategy()
     {
         @Override
-        public void prune( long upToLogVersion )
+        public void prune( long upToLogVersion, Monitor monitor )
         {
             // do nothing
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/ThresholdBasedPruneStrategy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/ThresholdBasedPruneStrategy.java
@@ -45,15 +45,15 @@ public class ThresholdBasedPruneStrategy implements LogPruneStrategy
     }
 
     @Override
-    public void prune( long upToLogVersion )
+    public void prune( long upToVersion, Monitor monitor )
     {
-        if ( upToLogVersion == INITIAL_LOG_VERSION )
+        if ( upToVersion == INITIAL_LOG_VERSION )
         {
             return;
         }
 
         threshold.init();
-        long upper = upToLogVersion - 1;
+        long upper = upToVersion - 1;
         boolean exceeded = false;
         while ( upper >= 0 )
         {
@@ -75,6 +75,7 @@ public class ThresholdBasedPruneStrategy implements LogPruneStrategy
 
         if ( !exceeded )
         {
+            monitor.noLogsPruned( upToVersion );
             return;
         }
 
@@ -97,7 +98,7 @@ public class ThresholdBasedPruneStrategy implements LogPruneStrategy
          * This if statement does nothing more complicated than checking if the next-to-last log would be prunned
          * and simply skipping it if so.
          */
-        if ( upper == upToLogVersion - 1 )
+        if ( upper == upToVersion - 1 )
         {
             upper--;
         }
@@ -108,5 +109,6 @@ public class ThresholdBasedPruneStrategy implements LogPruneStrategy
         {
             fileSystem.deleteFile( files.getLogFileForVersion( version ) );
         }
+        monitor.logsPruned( upToVersion, lower, upper );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/TransactionLogAppendAndRotateIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/TransactionLogAppendAndRotateIT.java
@@ -231,7 +231,7 @@ public class TransactionLogAppendAndRotateIT
         }
 
         @Override
-        public void opened( File logFile, long logVersion, long lastTransactionId, boolean clean )
+        public void created( File logFile, long logVersion, long lastTransactionId )
         {
         }
     }


### PR DESCRIPTION
Previously the logging regarding log rotation pruning and checkpoint was very
verbose w/o actually including much information, e.g check pointing was logged like this:

```
2017-10-03 17:56:19.589+0000 INFO [o.n.k.i.t.l.c.CheckPointerImpl] Check Pointing triggered by scheduler for time threshold [30731131]:  Starting check pointing...
2017-10-03 17:56:19.589+0000 INFO [o.n.k.i.t.l.c.CheckPointerImpl] Check Pointing triggered by scheduler for time threshold [30731131]:  Starting store flush...
2017-10-03 17:56:19.906+0000 INFO [o.n.k.i.s.c.CountsTracker] About to rotate counts store at transaction 30731131 to [.../graph.db/neostore.counts.db.a], from [.../graph.db/neostore.counts.db.b].
2017-10-03 17:56:19.936+0000 INFO [o.n.k.i.s.c.CountsTracker] Successfully rotated counts store at transaction 30731131 to [.../graph.db/neostore.counts.db.a], from [.../graph.db/neostore.counts.db.b].
2017-10-03 17:56:20.088+0000 INFO [o.n.k.i.t.l.c.CheckPointerImpl] Check Pointing triggered by scheduler for time threshold [30731131]:  Store flush completed
2017-10-03 17:56:20.089+0000 INFO [o.n.k.i.t.l.c.CheckPointerImpl] Check Pointing triggered by scheduler for time threshold [30731131]:  Starting appending check point entry into the tx log...
2017-10-03 17:56:20.091+0000 INFO [o.n.k.i.t.l.c.CheckPointerImpl] Check Pointing triggered by scheduler for time threshold [30731131]:  Appending check point entry into the tx log completed
2017-10-03 17:56:20.091+0000 INFO [o.n.k.i.t.l.c.CheckPointerImpl] Check Pointing triggered by scheduler for time threshold [30731131]:  Check pointing completed
```

Log pruning like this:

```
2017-10-03 17:56:20.091+0000 INFO [o.n.k.i.t.l.p.LogPruningImpl] Log Rotation [12546]:  Starting log pruning.
2017-10-03 17:56:20.091+0000 INFO [o.n.k.i.t.l.p.LogPruningImpl] Log Rotation [12546]:  Log pruning complete.
```

Log rotation like this:

```
2017-10-03 19:56:16.131+0000 INFO [o.n.k.NeoStoreDataSource] Rotating log version:45
2017-10-03 19:56:16.132+0000 INFO [o.n.k.NeoStoreDataSource] Opened logical log [.../graph.db/neostore.transaction.db.46] version=46, lastTxId=30731176 (clean)
2017-10-03 19:56:16.133+0000 INFO [o.n.k.NeoStoreDataSource] Finished rotating log version:45
```

These events happen quite frequently so a more consice format will make it easier to read and take up less space in the log.
The logging has been changed to look like, for check pointing:

```
2017-10-11 10:01:00.050+0000 INFO [o.n.k.i.t.l.c.CheckPointerImpl] Checkpoint triggered by scheduler for tx count threshold @ txId: 3193169 checkpoint started...
2017-10-11 10:01:00.092+0000 INFO [o.n.k.i.s.c.CountsTracker] Rotated counts store at transaction 3199085 to [.../graph.db/neostore.counts.db.b], from [.../graph.db/neostore.counts.db.a].
2017-10-11 10:01:00.317+0000 INFO [o.n.k.i.t.l.c.CheckPointerImpl] Checkpoint triggered by scheduler for tx count threshold @ txId: 3193169 checkpoint completed in 245ms
```

Log pruning:
```
2017-10-11 10:01:00.359+0000 INFO [o.n.k.i.t.l.p.LogPruningImpl] Pruned log versions 0-3, last checkpoint was made in version 7
```

Log rotation:
```
2017-10-11 10:01:01.271+0000 INFO [o.n.k.NeoStoreDataSource] Rotated to transaction log [.../graph.db/neostore.transaction.db.8] version=8, last transaction in previous log=3585572
```

which is less text and more information than the previous format had.