### PR TITLE
Makes configuration method for hazelcast instances package private

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastDiscoveryServiceFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastDiscoveryServiceFactory.java
@@ -51,7 +51,7 @@ public class HazelcastDiscoveryServiceFactory implements DiscoveryServiceFactory
                 logProvider, config, myself, topologyServiceRetryStrategy );
     }
 
-    private static void configureHazelcast( Config config, LogProvider logProvider )
+    static void configureHazelcast( Config config, LogProvider logProvider )
     {
         // tell hazelcast to not phone home
         GroupProperty.PHONE_HOME_ENABLED.setSystemProperty( "false" );


### PR DESCRIPTION
It may be necessary for subclasses to use this method or augment it
 in various ways.