### PR TITLE
Better error message when not is parsed as a function.

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExpressionAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExpressionAcceptanceTest.scala
@@ -20,6 +20,7 @@
 package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher._
+import org.neo4j.graphdb.QueryExecutionException
 
 class ExpressionAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with NewPlannerTestSupport {
 
@@ -83,5 +84,14 @@ class ExpressionAcceptanceTest extends ExecutionEngineFunSuite with QueryStatist
         Map("name" -> "Actor 1", "movies" -> Seq(
           Map("title" -> "Movie 2"),
           Map("title" -> "Movie 1"))))))
+  }
+
+  test("not(), when right of a =, should give a helpful error message") {
+    val query = "RETURN true = not(42 = 32)"
+
+    val thrown = intercept[QueryExecutionException] {
+      graph.execute(query)
+    }
+    thrown.getMessage should include("Unknown function 'not'. If you intended to use the negation expression, surround it with parentheses.")
   }
 }

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/ResolvedFunctionInvocation.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/ResolvedFunctionInvocation.scala
@@ -66,6 +66,8 @@ case class ResolvedFunctionInvocation(qualifiedName: QualifiedName,
   }
 
   override def semanticCheck(ctx: SemanticContext): SemanticCheck = fcnSignature match {
+    case None if qualifiedName == QualifiedName(Seq(), "not") => SemanticError(s"Unknown function '$qualifiedName'. " +
+      s"If you intended to use the negation expression, surround it with parentheses.", position)
     case None => SemanticError(s"Unknown function '$qualifiedName'", position)
     case Some(signature) =>
       val expectedNumArgs = signature.inputSignature.length


### PR DESCRIPTION
changelog: Fixes #2556 so that a sensible error message is generated when "not" is parsed as a function.