### PR TITLE
Make inactivity_timeout_millis visible in docs

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
@@ -224,7 +224,6 @@ public class CausalClusteringSettings implements LoadableConfig
 
     @Description( "The catch up protocol times out if the given duration elapses with not network activity. " +
             "Every message received by the client from the server extends the time out duration." )
-    @Internal
     public static final Setting<Duration> catch_up_client_inactivity_timeout =
             setting( "causal_clustering.catch_up_client_inactivity_timeout", DURATION, "5s" );
 


### PR DESCRIPTION
This setting was previously marked as @Internal preventing
it from showing up in the configuration reference, but there
is no point in hiding it and some might even benefit from
tweaking it.