### PR TITLE
Return correct results for parameter maps in predicates

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -23,6 +23,7 @@ import org.neo4j.cypher._
 import org.neo4j.cypher.internal.compiler.v3_1.commands.expressions.PathImpl
 import org.neo4j.graphdb._
 import org.neo4j.helpers.collection.Iterators.single
+import org.neo4j.helpers.collection.MapUtil.map
 
 import scala.collection.JavaConverters._
 
@@ -600,6 +601,26 @@ return p""")
 
     resultNoAlias.close()
     resultWithAlias.close()
+  }
+
+  test("Parameter Maps on nodes in predicate should return correct results") {
+    val n1 = createNode("data" -> 3)
+    val n2 = createNode("data" -> 4)
+    val query = "MATCH (n) WHERE n = {param} RETURN n"
+    val result = graph.execute(query, map("param", map("data", new Integer(3))))
+
+    result.columnAs("n").asScala.toList should be(List(n1))
+  }
+
+  test("Parameter Maps on relationships in predicate should return correct results") {
+    val n1 = createNode()
+    val n2 = createNode()
+    val r1 = relate(n1, n2, "data" -> 3)
+    val r2 = relate(n1, n2, "data" -> 4)
+    val query = "MATCH ()-[r]->() WHERE r = {param} RETURN r"
+    val result = graph.execute(query, map("param", map("data", new Integer(3))))
+
+    result.columnAs("r").asScala.toList should be(List(r1))
   }
 
   /**

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/commands/predicates/Equivalent.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/commands/predicates/Equivalent.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v3_1.commands.predicates
 
 import org.neo4j.cypher.internal.compiler.v3_1.{CRS, GeographicPoint}
-import org.neo4j.graphdb.{Node, Path, Relationship}
+import org.neo4j.graphdb.{Node, Path, PropertyContainer, Relationship}
 
 import scala.collection.GenTraversableOnce
 import scala.collection.JavaConverters._
@@ -47,6 +47,8 @@ class Equivalent(protected val eagerizedValue: Any, val originalValue: Any) exte
       case (null, null) => true
       case (n1: Double, n2: Float) => mixedFloatEquality(n2, n1)
       case (n1: Float, n2: Double) => mixedFloatEquality(n1, n2)
+      case (n1: PropertyContainer, n2: Map[_, _]) => n1.getAllProperties.asScala == n2
+      case (n1: Map[_, _], n2: PropertyContainer) => n2.getAllProperties.asScala == n1
       case (a, b) => a == b
       case _ => false
     }


### PR DESCRIPTION
changelog: Fixes #1525. Comparing nodes and relationships to maps
in predicates returns correct results now.