### PR TITLE
Handle null values in parameter list for rule planner

### DIFF
--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/mutation/CreateNode.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/mutation/CreateNode.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v3_1.mutation
 
 import org.neo4j.cypher.internal.compiler.v3_1._
-import org.neo4j.cypher.internal.compiler.v3_1.commands.expressions.{Expression, Literal}
+import org.neo4j.cypher.internal.compiler.v3_1.commands.expressions.{Expression, Literal, Null}
 import org.neo4j.cypher.internal.compiler.v3_1.commands.values.KeyToken
 import org.neo4j.cypher.internal.compiler.v3_1.executionplan.{Effects, _}
 import org.neo4j.cypher.internal.compiler.v3_1.helpers.ListSupport
@@ -44,6 +44,7 @@ case class CreateNode(key: String, properties: Map[String, Expression], labels: 
   def exec(context: ExecutionContext, state: QueryState): Iterator[ExecutionContext] = {
     def fromAnyToLiteral(x: Map[String, Any]): Map[String, Expression] = x.map {
       case (k, v:Any) => k -> Literal(v)
+      case (k, null) => k -> Null()
     }
 
     def createNodeWithPropertiesAndLabels(props: Map[String, Expression]): ExecutionContext = {

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/mutation/GraphElementPropertyFunctions.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/mutation/GraphElementPropertyFunctions.scala
@@ -66,11 +66,13 @@ trait GraphElementPropertyFunctions extends ListSupport {
 
     pc match {
       case n: Node => map.foreach {
+        case (_, null) =>
         case (key, value) =>
           state.query.nodeOps.setProperty(n.getId, state.query.getOrCreatePropertyKeyId(key), makeValueNeoSafe(value))
       }
 
       case r: Relationship => map.foreach {
+        case (_, null) =>
         case (key, value) =>
           state.query.relationshipOps.setProperty(r.getId, state.query.getOrCreatePropertyKeyId(key), makeValueNeoSafe(value))
       }


### PR DESCRIPTION
#The rule planner didn't handle null values in a parameter map when setting properties.

changelog: Fixes #3870 so that null values in a parameter map is ignored on CREATE.