### PR TITLE
Ability to concatenate arbitrary lists. Fixes #10021

### DIFF
--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/ArithmeticFunctions.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/ArithmeticFunctions.scala
@@ -62,13 +62,13 @@ case class Add(lhs: Expression, rhs: Expression)(val position: InputPosition)
         TypeSpec.none
 
     // [a] + [b] => [a, b]
-    val listTypes = lhsTypes constrain CTList(CTAny)
+    val listTypes = (lhsTypes leastUpperBounds CTList(CTAny) constrain CTList(CTAny)).covariant
 
     // [a] + b => [a, b]
     val lhsListTypes = listTypes | listTypes.unwrapLists
 
     // a + [b] => [a, b]
-    val rhsListTypes = lhsTypes.wrapInList
+    val rhsListTypes = CTList(CTAny).covariant
 
     valueTypes | lhsListTypes | rhsListTypes
   }
@@ -104,13 +104,14 @@ case class Add(lhs: Expression, rhs: Expression)(val position: InputPosition)
       val rhsListTypes = rhsTypes constrain CTList(CTAny)
       val lhsListInnerTypes = lhsListTypes.unwrapLists
       val rhsListInnerTypes = rhsListTypes.unwrapLists
+      val lhsScalarTypes = lhsTypes without CTList(CTAny)
+      val rhsScalarTypes = rhsTypes without CTList(CTAny)
 
-      // [a] + [b] => [a, b]
-      (lhsListTypes intersect rhsListTypes) |
-        // [a] + b => [a, b]
-        (rhsTypes intersectOrCoerce lhsListInnerTypes).wrapInList |
-        // a + [b] => [a, b]
-        (lhsTypes intersectOrCoerce rhsListInnerTypes).wrapInList
+      val bothListMergedTypes = (lhsListInnerTypes coerceOrLeastUpperBound rhsListInnerTypes).wrapInList
+      val lhListMergedTypes = (rhsScalarTypes coerceOrLeastUpperBound lhsListInnerTypes).wrapInList
+      val rhListMergedTypes = (lhsScalarTypes coerceOrLeastUpperBound rhsListInnerTypes).wrapInList
+
+      bothListMergedTypes | lhListMergedTypes | rhListMergedTypes
     }
 
     stringTypes | numberTypes | listTypes

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/symbols/TypeRange.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/symbols/TypeRange.scala
@@ -58,6 +58,23 @@ case class TypeRange(lower: CypherType, upper: Option[CypherType]) {
 
   def constrain(aType: CypherType): Option[TypeRange] = this & TypeRange(aType, None)
 
+  def without(aType: CypherType): Option[TypeRange] = {
+    if (aType.isAssignableFrom(lower)) {
+      None
+    } else if (lower.isAssignableFrom(aType)) {
+      upper match {
+        case None => Some(TypeRange(lower, aType.parentType))
+        case Some(up) =>
+          if (aType.isAssignableFrom(up))
+            Some(TypeRange(lower, aType.parentType))
+          else
+            Some(this)
+      }
+    } else {
+      Some(this)
+    }
+  }
+
   /**
    * @param other the other range to determine LUBs in combination with
    * @return a set of TypeRanges that cover the LUBs for all combinations of individual types between both TypeRanges

--- a/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/symbols/TypeSpec.scala
+++ b/community/cypher/frontend-3.2/src/main/scala/org/neo4j/cypher/internal/frontend/v3_2/symbols/TypeSpec.scala
@@ -93,6 +93,16 @@ class TypeSpec private (private val ranges: Seq[TypeRange]) extends Equals {
       coercions intersect that
   }
 
+  def coerceOrLeastUpperBound(that: TypeSpec): TypeSpec = {
+    val coerced = coercions intersect that
+    if (coerced.nonEmpty)
+      coerced
+    else
+      this leastUpperBounds that
+  }
+
+  def without(aType: CypherType): TypeSpec = TypeSpec(ranges.flatMap(_ without aType))
+
   def constrain(that: CypherType): TypeSpec = TypeSpec(ranges.flatMap(_ constrain that))
 
   def constrainOrCoerce(that: CypherType): TypeSpec = {
@@ -112,6 +122,8 @@ class TypeSpec private (private val ranges: Seq[TypeRange]) extends Equals {
   def wrapInCovariantList: TypeSpec = TypeSpec(ranges.map { r =>
     r.covariant.reparent(CTList)
   })
+
+  def covariant: TypeSpec = TypeSpec(ranges.map(_.covariant))
 
   def unwrapLists: TypeSpec = TypeSpec(ranges.map(_.reparent { case c: ListType => c.innerType }))
 

--- a/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/AddTest.scala
+++ b/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/AddTest.scala
@@ -72,13 +72,35 @@ class AddTest extends InfixExpressionTestBase(Add(_, _)(DummyPosition(0))) {
 
   test("shouldFailTypeCheckForIncompatibleArguments") {
     testInvalidApplication(CTInteger, CTBoolean)(
-      "Type mismatch: expected Float, Integer, String or List<Integer> but was Boolean"
+      "Type mismatch: expected Float, Integer, String or List<T> but was Boolean"
     )
-    testInvalidApplication(CTList(CTInteger), CTString)(
-      "Type mismatch: expected Integer, List<Integer> or List<List<Integer>> but was String"
-    )
-    testInvalidApplication(CTList(CTInteger), CTList(CTString))(
-      "Type mismatch: expected Integer, List<Integer> or List<List<Integer>> but was List<String>"
-    )
+  }
+
+  test("should concatenate different typed lists") {
+    testValidTypes(CTList(CTInteger), CTList(CTString))(CTList(CTAny))
+  }
+
+  test("should concatenate vector element of other type after list") {
+    testValidTypes(CTInteger, CTList(CTString))(CTList(CTAny))
+  }
+
+  test("should concatenate vector element of other type before list") {
+    testValidTypes(CTList(CTInteger), CTString)(CTList(CTAny))
+  }
+
+  test("should concatenate same typed lists") {
+    testValidTypes(CTList(CTInteger), CTList(CTInteger))(CTList(CTInteger))
+  }
+
+  test("should concatenate nested lists") {
+    testValidTypes(CTList(CTList(CTInteger)), CTList(CTList(CTInteger)))(CTList(CTList(CTInteger)))
+    testValidTypes(CTList(CTList(CTInteger)), CTList(CTInteger))(CTList(CTAny))
+    testValidTypes(CTList(CTList(CTInteger)), CTInteger)(CTList(CTAny))
+  }
+
+  test("should work with ORed types") {
+    testValidTypes(CTInteger | CTList(CTString), CTList(CTString) | CTInteger)(CTList(CTAny) | CTList(CTString) | CTInteger)
+    testValidTypes(CTInteger | CTList(CTInteger), CTString)(CTString | CTList(CTAny))
+    testValidTypes(CTInteger | CTList(CTInteger), CTBoolean)(CTList(CTAny))
   }
 }

--- a/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/FunctionTestBase.scala
+++ b/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/FunctionTestBase.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.frontend.v3_2.ast
+
+import org.neo4j.cypher.internal.frontend.v3_2.{SemanticCheckResult, SemanticState}
+import org.neo4j.cypher.internal.frontend.v3_2.ast.Expression.SemanticContext
+import org.neo4j.cypher.internal.frontend.v3_2.symbols.TypeSpec
+import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
+
+abstract class FunctionTestBase(functionName: FunctionName) extends CypherFunSuite {
+
+  protected val context: SemanticContext = SemanticContext.Simple
+
+  protected def evaluateWithTypes(lhsTypes: TypeSpec): (SemanticCheckResult, Expression) = {
+    val lhs = DummyExpression(lhsTypes)
+
+    val expression = FunctionInvocation(lhs, functionName)
+
+    val state = lhs.semanticCheck(context)(SemanticState.clean).state
+    (expression.semanticCheck(context)(state), expression)
+  }
+
+  protected def testValidTypes(lhsTypes: TypeSpec)(expected: TypeSpec) {
+    val (result, expression) = evaluateWithTypes(lhsTypes)
+    result.errors shouldBe empty
+    expression.types(result.state) should equal(expected)
+  }
+
+  protected def testInvalidApplication(lhsTypes: TypeSpec)(message: String) {
+    val (result, _) = evaluateWithTypes(lhsTypes)
+    result.errors should not be empty
+    result.errors.head.msg should equal(message)
+  }
+}

--- a/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/ReverseTest.scala
+++ b/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/ast/ReverseTest.scala
@@ -17,19 +17,25 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.frontend.v3_2.ast.functions
+package org.neo4j.cypher.internal.frontend.v3_2.ast
 
-import org.neo4j.cypher.internal.frontend.v3_2.SemanticCheck
-import org.neo4j.cypher.internal.frontend.v3_2.ast.{Expression, Function, FunctionInvocation}
+import org.neo4j.cypher.internal.frontend.v3_2.ast.functions.Reverse
 import org.neo4j.cypher.internal.frontend.v3_2.symbols._
 
-case object Reverse extends Function  {
-  def name = "reverse"
+class ReverseTest extends FunctionTestBase(FunctionName(Reverse.name)(null)) {
 
-  override protected def semanticCheck(ctx: Expression.SemanticContext, invocation: FunctionInvocation): SemanticCheck = {
-    checkArgs(invocation, 1) ifOkChain {
-      invocation.arguments(0).expectType(CTList(CTAny).covariant | CTString) chain
-        invocation.specifyType(invocation.arguments(0).types(_))
-    }
+  test("should reverse strings") {
+    testValidTypes(CTString)(CTString)
   }
+
+  test("should reverse lists") {
+    testValidTypes(CTList(CTNode))(CTList(CTNode))
+  }
+
+  test("should not reverse numbers") {
+    testInvalidApplication(CTInteger)(
+      "Type mismatch: expected String or List<T> but was Integer"
+    )
+  }
+
 }

--- a/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/symbols/TypeRangeTest.scala
+++ b/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/symbols/TypeRangeTest.scala
@@ -205,4 +205,13 @@ class TypeRangeTest extends CypherFunSuite {
     TypeRange(CTString, None).reparent(CTList) should equal(TypeRange(CTList(CTString), None))
     TypeRange(CTAny, CTNumber).reparent(CTList) should equal(TypeRange(CTList(CTAny), CTList(CTNumber)))
   }
+
+  test("without") {
+    TypeRange(CTAny, CTInteger).without(CTNumber) should equal(Some(TypeRange(CTAny, CTNumber.parentType)))
+    TypeRange(CTAny, CTNumber).without(CTInteger) should equal(Some(TypeRange(CTAny, CTNumber)))
+    TypeRange(CTAny, None).without(CTInteger) should equal(Some(TypeRange(CTAny, CTInteger.parentType)))
+    TypeRange(CTInteger, None).without(CTNumber) should equal(None)
+    TypeRange(CTInteger, None).without(CTString) should equal(Some(TypeRange(CTInteger, None)))
+    TypeRange(CTAny, CTNumber).without(CTString) should equal(Some(TypeRange(CTAny, CTNumber)))
+  }
 }

--- a/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/symbols/TypeSpecTest.scala
+++ b/community/cypher/frontend-3.2/src/test/scala/org/neo4j/cypher/internal/frontend/v3_2/symbols/TypeSpecTest.scala
@@ -259,7 +259,6 @@ class TypeSpecTest extends CypherFunSuite {
     CTNumber intersectOrCoerce CTFloat should equal(TypeSpec.none)
     CTList(CTAny).covariant intersectOrCoerce CTBoolean should equal(CTBoolean.invariant)
     CTNumber.covariant intersectOrCoerce CTBoolean should equal(TypeSpec.none)
-    CTList(CTAny).covariant intersectOrCoerce CTBoolean should equal(CTBoolean.invariant)
     CTInteger intersectOrCoerce CTString should equal(TypeSpec.none)
   }
 
@@ -269,8 +268,15 @@ class TypeSpecTest extends CypherFunSuite {
     CTNumber constrainOrCoerce CTFloat should equal(TypeSpec.none)
     CTList(CTAny).covariant constrainOrCoerce CTBoolean should equal(CTBoolean.invariant)
     CTNumber.covariant constrainOrCoerce CTBoolean should equal(TypeSpec.none)
-    CTList(CTAny).covariant constrainOrCoerce CTBoolean should equal(CTBoolean.invariant)
     CTInteger constrainOrCoerce CTString should equal(TypeSpec.none)
+  }
+
+  test("should leastUpperBound with coercions") {
+    CTInteger coerceOrLeastUpperBound CTFloat should equal(CTFloat.invariant)
+    CTNumber coerceOrLeastUpperBound CTFloat should equal(CTNumber.invariant)
+    CTList(CTAny).covariant coerceOrLeastUpperBound CTBoolean should equal(CTBoolean.invariant) // ?
+    CTNumber.covariant coerceOrLeastUpperBound CTBoolean should equal(CTAny.invariant)
+    CTInteger coerceOrLeastUpperBound CTString should equal(CTAny.invariant)
   }
 
   test("equal TypeSpecs should equal") {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ReverseAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ReverseAcceptanceTest.scala
@@ -71,4 +71,18 @@ class ReverseAcceptanceTest extends ExecutionEngineFunSuite with QueryStatistics
     // Then
     results should equal ("[487, 521, abc, 4923]")
   }
+
+  test("reverse should be able to concatenate to original list") {
+    // When
+    val query =
+      """
+        | WITH range(1, 2) AS xs
+        | RETURN xs + reverse(xs) AS res
+        | """.stripMargin
+
+    val results = graph.execute(query).columnAs("res").next().toString
+
+    // Then
+    results should equal ("[1, 2, 2, 1]")
+  }
 }


### PR DESCRIPTION
Also fix reverse type in sematic checking.

Previously, the semantic checking did not allow concatenating mixed typed lists (and scalars). This PR fixes that.

changelog: Fixes #10021 so that we can concatenate and reverse lists of mixed types
