### PR TITLE
Update fields in legacy indexes when removing keys.

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/IndexType.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/IndexType.java
@@ -374,6 +374,7 @@ public abstract class IndexType
         else
         {
             removeFieldsFromDocument( document, key, value );
+            restoreSortFields( document );
         }
     }
 

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSource.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSource.java
@@ -186,7 +186,7 @@ public class LuceneDataSource extends LifecycleAdapter
         }
 
         DocValuesType actualType = stringDocValuesTypeMap.putIfAbsent( key, expectedType );
-        if ( actualType != null && !actualType.equals( expectedType ) )
+        if ( actualType != null && !actualType.equals( DocValuesType.NONE ) && !actualType.equals( expectedType ) )
         {
             throw new IllegalArgumentException( String.format(
                     "Cannot index '%s' for key '%s', since this key has been used to index another %s.",

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSource.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/legacy/LuceneDataSource.java
@@ -189,8 +189,8 @@ public class LuceneDataSource extends LifecycleAdapter
         if ( actualType != null && !actualType.equals( DocValuesType.NONE ) && !actualType.equals( expectedType ) )
         {
             throw new IllegalArgumentException( String.format(
-                    "Cannot index '%s' for key '%s', since this key has been used to index another %s.",
-                    value, key, expectedTypeName ) );
+                    "Cannot index '%s' for key '%s', since this key has been used to index %s. Raw value of the index type is %s", value, key, expectedTypeName,
+                    actualType ) );
         }
     }
 

--- a/community/lucene-index/src/test/java/org/neo4j/index/LegacyIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/LegacyIndexTest.java
@@ -30,20 +30,23 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.index.Index;
+import org.neo4j.graphdb.index.IndexHits;
 import org.neo4j.graphdb.index.RelationshipIndex;
+import org.neo4j.index.lucene.QueryContext;
 import org.neo4j.index.lucene.ValueContext;
 import org.neo4j.test.rule.DatabaseRule;
-import org.neo4j.test.rule.ImpermanentDatabaseRule;
+import org.neo4j.test.rule.EmbeddedDatabaseRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class LegacyIndexTest
 {
     private static final RelationshipType TYPE = DynamicRelationshipType.withName( "TYPE" );
 
     @Rule
-    public final DatabaseRule db = new ImpermanentDatabaseRule();
+    public final DatabaseRule db = new EmbeddedDatabaseRule();
     @Rule
     public final ExpectedException expectedException = ExpectedException.none();
 
@@ -135,6 +138,114 @@ public class LegacyIndexTest
             Index<Node> nodeIndex = db.index().forNodes( indexName );
             nodeIndex.add( db.getNodeById( nodeId ), "key", ValueContext.numeric( 52 ) );
             tx.success();
+        }
+    }
+
+    @Test
+    public void shouldBeAbleToAddNodesAfterRemovalOfKey()
+    {
+        String indexName = "index";
+        long nodeId;
+        //add two keys and delete one of them
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.createNode();
+            nodeId = node.getId();
+            Index<Node> nodeIndex = db.index().forNodes( indexName );
+            nodeIndex.add( node, "key", "hej" );
+            nodeIndex.add( node, "keydelete", "hej" );
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Index<Node> nodeIndex = db.index().forNodes( indexName );
+            nodeIndex.remove( db.getNodeById( nodeId ), "keydelete" );
+            tx.success();
+        }
+
+        db.shutdownAndKeepStore();
+        db.getGraphDatabaseAPI();
+
+        //should be able to add more stuff to the index
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.createNode();
+            Index<Node> nodeIndex = db.index().forNodes( indexName );
+            nodeIndex.add( node, "key", "hej" );
+            tx.success();
+        }
+    }
+
+    @Test
+    public void indexContentsShouldStillBeOrderedAfterRemovalOfKey()
+    {
+        String indexName = "index";
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.index().forNodes( indexName );
+            tx.success();
+        }
+
+        long delete;
+        long first;
+        long second;
+        long third;
+        long fourth;
+        try ( Transaction tx = db.beginTx() )
+        {
+            Index<Node> nodeIndex = db.index().forNodes( indexName );
+            Node node = db.createNode();
+            delete = node.getId();
+            nodeIndex.add( node, "keydelte", "delete" );
+            node = db.createNode();
+            second = node.getId();
+            nodeIndex.add( node, "key", ValueContext.numeric( 2 ) );
+            nodeIndex.add( node, "keydelte", "delete" );
+
+            node = db.createNode();
+            fourth = node.getId();
+            nodeIndex.add( node, "key", ValueContext.numeric( 4 ) );
+            nodeIndex.add( node, "keydelte", "delete" );
+
+            node = db.createNode();
+            first = node.getId();
+            nodeIndex.add( node, "key", ValueContext.numeric( 1 ) );
+            nodeIndex.add( node, "keydelte", "delete" );
+
+            node = db.createNode();
+            third = node.getId();
+            nodeIndex.add( node, "key", ValueContext.numeric( 3 ) );
+            nodeIndex.add( node, "keydelte", "delete" );
+
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Index<Node> nodeIndex = db.index().forNodes( indexName );
+            IndexHits<Node> query = nodeIndex.query( "key", QueryContext.numericRange( "key", 2, 3 ) );
+            assertEquals( 2, query.size() );
+            query.forEachRemaining( node -> assertTrue( node.getId() == second || node.getId() == third ) );
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Index<Node> nodeIndex = db.index().forNodes( indexName );
+            nodeIndex.remove( db.getNodeById( delete ), "keydelete" );
+            nodeIndex.remove( db.getNodeById( first ), "keydelete" );
+            nodeIndex.remove( db.getNodeById( second ), "keydelete" );
+            nodeIndex.remove( db.getNodeById( third ), "keydelete" );
+            nodeIndex.remove( db.getNodeById( fourth ), "keydelete" );
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Index<Node> nodeIndex = db.index().forNodes( indexName );
+            IndexHits<Node> query = nodeIndex.query( "key", QueryContext.numericRange( "key", 2, 3 ) );
+            assertEquals( 2, query.size() );
+            query.forEachRemaining( node -> assertTrue( node.getId() == second || node.getId() == third ) );
         }
     }
 


### PR DESCRIPTION
Not doing this could potentially lead to incorrect index query results
after removal of an indexed key.

cl: Fix a bug where an entity could be temporarily excluded from some index query results if another key indexed on the same entity were removed.