### PR TITLE
Merge multiple IN predicates

### DIFF
--- a/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/mergeInPredicatesTest.scala
+++ b/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/mergeInPredicatesTest.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_4.ast.rewriters
+
+import org.neo4j.cypher.internal.compiler.v3_4.planner.AstRewritingTestSupport
+import org.neo4j.cypher.internal.compiler.v3_4.test_helpers.ContextHelper
+import org.neo4j.cypher.internal.frontend.v3_4.ast.Query
+import org.neo4j.cypher.internal.frontend.v3_4.ast.rewriters.{CNFNormalizer, mergeInPredicates}
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
+
+class mergeInPredicatesTest extends CypherFunSuite with AstRewritingTestSupport {
+
+  test("MATCH (a) WHERE a.prop IN [1,2,3] AND a.prop IN [2,3,4] RETURN *") {
+    shouldRewrite(
+      "MATCH (a) WHERE a.prop IN [1,2,3] AND a.prop IN [2,3,4] RETURN *",
+      "MATCH (a) WHERE a.prop IN [2,3] RETURN *")
+  }
+
+  test("MATCH (a) WHERE a.prop IN [1,2,3] OR a.prop IN [2,3,4] RETURN *") {
+    shouldNotRewrite("MATCH (a) WHERE a.prop IN [1,2,3] OR a.prop IN [2,3,4] RETURN *")
+  }
+
+  test("MATCH (a) WHERE a.prop IN [1,2,3] AND a.prop IN [4,5,6] RETURN *") {
+    shouldRewrite(
+      "MATCH (a) WHERE a.prop IN [1,2,3] AND a.prop IN [4,5,6] RETURN *",
+      "MATCH (a) WHERE false RETURN *")
+  }
+
+  test("MATCH (a) WHERE a.prop IN [1,2,3] AND a.prop IN [2,3,4] AND a.prop IN [3,4,5] RETURN *") {
+    shouldRewrite(
+      "MATCH (a) WHERE a.prop IN [1,2,3] AND a.prop IN [2,3,4] AND a.prop IN [3,4,5] RETURN *",
+      "MATCH (a) WHERE a.prop IN [3] RETURN *")
+  }
+
+  test("MATCH (a) WHERE (a.prop IN [1,2,3] AND a.prop IN [2,3,4]) OR (a.prop IN [2,3,4] AND a.prop IN [3,4,5]) RETURN *") {
+    shouldRewrite(
+      "MATCH (a) WHERE (a.prop IN [1,2,3] AND a.prop IN [2,3,4]) OR (a.prop IN [2,3,4] AND a.prop IN [3,4,5]) RETURN *",
+      "MATCH (a) WHERE a.prop IN [2,3] OR a.prop IN [3,4] RETURN *")
+  }
+
+  test("MATCH (a) WHERE a.prop IN [1,2,3] AND a.foo IN ['foo', 'bar'] AND a.prop IN [2,3,4] AND a.foo IN ['bar'] RETURN *") {
+    shouldRewrite(
+      "MATCH (a) WHERE a.prop IN [1,2,3] AND a.foo IN ['foo','bar'] AND a.prop IN [2,3,4] AND a.foo IN ['bar'] RETURN *",
+      "MATCH (a) WHERE a.prop IN [2,3] AND a.foo IN ['bar'] RETURN *")
+  }
+
+  private def shouldRewrite(from: String, to: String) {
+    val original = parser.parse(from).asInstanceOf[Query]
+    val expected = parser.parse(to).asInstanceOf[Query]
+    val common = CNFNormalizer.instance(ContextHelper.create())
+    val result = mergeInPredicates(original)
+
+    common(result) should equal(common(expected))
+  }
+
+  private def shouldNotRewrite(q: String) {
+    shouldRewrite(q, q)
+  }
+}

--- a/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/mergeInPredicatesTest.scala
+++ b/community/cypher/cypher-compiler-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/mergeInPredicatesTest.scala
@@ -81,6 +81,11 @@ class mergeInPredicatesTest extends CypherFunSuite with AstRewritingTestSupport 
       "MATCH (a) WHERE a.prop IN [1,2,3,4] OR a.foo IN ['foo','bar'] RETURN *")
   }
 
+  test("MATCH (n) RETURN n.prop IN [1,2,3] AND n.prop IN [3,4,5]") {
+    shouldRewrite("MATCH (n) RETURN n.prop IN [1,2,3] AND n.prop IN [3,4,5] AS FOO",
+                  "MATCH (n) RETURN n.prop IN [3] AS FOO")
+  }
+
   private def shouldRewrite(from: String, to: String) {
     val original = parser.parse(from).asInstanceOf[Query]
     val expected = parser.parse(to).asInstanceOf[Query]

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/mergeInPredicates.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/mergeInPredicates.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypher.internal.frontend.v3_4.ast.rewriters
+
+import org.neo4j.cypher.internal.frontend.v3_4.ast.Where
+import org.neo4j.cypher.internal.util.v3_4.Foldable._
+import org.neo4j.cypher.internal.util.v3_4.{Rewriter, bottomUp}
+import org.neo4j.cypher.internal.v3_4.expressions._
+
+/**
+  * Merges multiple IN predicates into one.
+  *
+  * For example, MATCH (n) WHERE n.prop IN [1,2,3] AND [2,3,4] RETURN n.prop
+  * will be rewritten into MATCH (n) WHERE n.prop IN [2,3]
+  *
+  * NOTE: this rewriter must be applied before auto parameterization, since after
+  * that we are just dealing with parameters.
+  */
+case object mergeInPredicates extends Rewriter {
+
+  def apply(that: AnyRef): AnyRef = inner.apply(that)
+
+  private val inner: Rewriter = bottomUp(Rewriter.lift {
+    case where@Where(e) =>
+      val rewrittenPredicates = e.endoRewrite(bottomUp(Rewriter.lift {
+        case and@And(lhs, rhs) =>
+          val rewriter = inRewriter(collectInPredicates(lhs, rhs))
+          val newLhs = lhs.endoRewrite(rewriter)
+          val newRhs = rhs.endoRewrite(rewriter)
+          if (newLhs == newRhs) newLhs
+          else and.copy(lhs = newLhs, rhs = newRhs)(and.position)
+      }))
+
+      where.copy(expression = rewrittenPredicates)(where.position)
+  })
+
+  private def inRewriter(map: Map[Expression, Seq[Expression]]) = bottomUp(Rewriter.lift({
+    case in@In(a, l@ListLiteral(_)) =>
+      val expressions = map(a)
+      if (expressions.nonEmpty) in.copy(rhs = l.copy(map(a))(l.position))(in.position)
+      else False()(in.position)
+  }))
+
+  //Collect all a IN [..] as a map, with {a -> [...], ...}
+  private def collectInPredicates(expressions: Expression*): Map[Expression, Seq[Expression]] = {
+    val maps = expressions.map(_.treeFold(Map.empty[Expression, Seq[Expression]]) {
+      case In(a, ListLiteral(exprs)) => (map) => {
+        val values = map.get(a).map(current => current intersect exprs).getOrElse(exprs).distinct
+        (map + (a -> values), None)
+      }
+    })
+    maps.reduceLeft((acc, current) => {
+      val sharedKeys = acc.keySet intersect current.keySet
+      val updates = sharedKeys.map(k => k -> (acc(k) intersect current(k)).distinct)
+      acc ++ updates ++ (current -- sharedKeys)
+    })
+  }
+}
+
+//Actual   :Query(None,SingleQuery(List(Match(false,Pattern(List(EveryPath(NodePattern(Some(Variable(a)),List(),None)))),List(),Some(Where(
+//
+// And(
+//  And(
+//    And(
+//      In(Property(Variable(a),PropertyKeyName(prop)),ListLiteral(List(SignedDecimalIntegerLiteral(2), SignedDecimalIntegerLiteral(3)))),
+//      In(Property(Variable(a),PropertyKeyName(foo)),ListLiteral(List(StringLiteral(bar))))),
+//    In(Property(Variable(a),PropertyKeyName(prop)),ListLiteral(List(SignedDecimalIntegerLiteral(2), SignedDecimalIntegerLiteral(3))))),
+// In(Property(Variable(a),PropertyKeyName(foo)),ListLiteral(List(StringLiteral(bar)))))))), Return(false,ReturnItems(true,List()),None,None,None,None,Set()))))

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/PreparatoryRewriting.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/PreparatoryRewriting.scala
@@ -16,9 +16,9 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_4.phases
 
-import org.neo4j.cypher.internal.util.v3_4.inSequence
 import org.neo4j.cypher.internal.frontend.v3_4.ast.rewriters._
 import org.neo4j.cypher.internal.frontend.v3_4.phases.CompilationPhaseTracer.CompilationPhase.AST_REWRITE
+import org.neo4j.cypher.internal.util.v3_4.inSequence
 
 case object PreparatoryRewriting extends Phase[BaseContext, BaseState, BaseState] {
 
@@ -30,7 +30,8 @@ case object PreparatoryRewriting extends Phase[BaseContext, BaseState, BaseState
       normalizeReturnClauses(context.exceptionCreator),
       normalizeWithClauses(context.exceptionCreator),
       expandCallWhere,
-      replaceAliasedFunctionInvocations))
+      replaceAliasedFunctionInvocations,
+      mergeInPredicates))
 
     from.withStatement(rewrittenStatement)
   }


### PR DESCRIPTION
For queries with multiple in on the same identifier separated by AND
we can merge into to one big list.

Examples:
```
MATCH (a) WHERE a.prop IN [1,2,3] AND a.prop IN [2,3,4] RETURN * =>
MATCH (a) WHERE a.prop IN [2,3]  RETURN *
```

```
MATCH (a) WHERE a.prop IN [1,2,3] AND a.prop IN [5,6,7] RETURN * =>
MATCH (a) WHERE FALSE RETURN *
```

```
MATCH (a) WHERE a.prop IN [1,2,3] OR a.prop IN [2,3,4] RETURN * =>
MATCH (a) WHERE a.prop IN [1,2,3,4]  RETURN *
```