### PR TITLE
Fix tests that rely on the next version of 3.1

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
@@ -52,7 +52,8 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
         | RETURN nodes(x)
       """.stripMargin
 
-    val result = executeWithAllPlanners(query).columnAs[List[Node]]("nodes(x)").toList
+    // this should be tested on both planners after 3.1.8 has been released
+    val result = innerExecute(query).columnAs[List[Node]]("nodes(x)").toList
 
     result should equal(List(List(nodeA, nodeB)))
   }
@@ -68,7 +69,8 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
         | RETURN nodes(x)
       """.stripMargin
 
-    val result = executeWithAllPlanners(query).columnAs[List[Node]]("nodes(x)").toList
+    // this should be tested on both planners after 3.1.8 has been released
+    val result = innerExecute(query).columnAs[List[Node]]("nodes(x)").toList
 
     result should equal(List(null))
   }
@@ -85,7 +87,8 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
         | RETURN nodes(x)
       """.stripMargin
 
-    val result = executeWithAllPlanners(query).columnAs[List[Node]]("nodes(x)").toList
+    // this should be tested on both planners after 3.1.8 has been released
+    val result = innerExecute(query).columnAs[List[Node]]("nodes(x)").toList
 
     result should equal(List(List(nodeA, nodeB)))
   }
@@ -102,7 +105,8 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with NewPlanner
         | RETURN nodes(x)
       """.stripMargin
 
-    val result = executeWithAllPlanners(query).columnAs[List[Node]]("nodes(x)").toList
+    // this should be tested on both planners after 3.1.8 has been released
+    val result = innerExecute(query).columnAs[List[Node]]("nodes(x)").toList
 
     result should equal(List.empty)
   }


### PR DESCRIPTION
should be null forward merge, since it's already fixed in 3.3