### PR TITLE
Procedures and arbitrary objects

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/BaseToObjectValueWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/BaseToObjectValueWriter.java
@@ -388,6 +388,12 @@ public abstract class BaseToObjectValueWriter<E extends Exception> implements An
         writeValue( value );
     }
 
+    @Override
+    public void writeJavaObject( Object object )
+    {
+        writeValue( object );
+    }
+
     private interface Writer
     {
         void write( Object value );

--- a/community/kernel/src/main/java/org/neo4j/helpers/BaseToObjectValueWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/BaseToObjectValueWriter.java
@@ -100,12 +100,6 @@ public abstract class BaseToObjectValueWriter<E extends Exception> implements An
     }
 
     @Override
-    public void writeVirtualNodeHack( Object node )
-    {
-        writeValue( node );
-    }
-
-    @Override
     public void writeEdgeReference( long edgeId ) throws RuntimeException
     {
         writeValue( newRelationshipProxyById( edgeId ) );
@@ -119,12 +113,6 @@ public abstract class BaseToObjectValueWriter<E extends Exception> implements An
         {
             writeValue( newRelationshipProxyById( edgeId ) );
         }
-    }
-
-    @Override
-    public void writeVirtualEdgeHack( Object relationship )
-    {
-        writeValue( relationship );
     }
 
     @Override
@@ -389,7 +377,7 @@ public abstract class BaseToObjectValueWriter<E extends Exception> implements An
     }
 
     @Override
-    public void writeJavaObject( Object object )
+    public void writeArbitraryJavaObject( Object object )
     {
         writeValue( object );
     }

--- a/community/kernel/src/main/java/org/neo4j/helpers/NodeProxyWrappingNodeValue.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/NodeProxyWrappingNodeValue.java
@@ -67,7 +67,7 @@ public class NodeProxyWrappingNodeValue extends NodeValue
 
         if ( id() < 0 )
         {
-            writer.writeVirtualNodeHack( node );
+            writer.writeArbitraryJavaObject( node );
         }
 
         writer.writeNode( node.getId(), l, p );

--- a/community/kernel/src/main/java/org/neo4j/helpers/RelationshipProxyWrappingEdgeValue.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/RelationshipProxyWrappingEdgeValue.java
@@ -64,7 +64,7 @@ public class RelationshipProxyWrappingEdgeValue extends EdgeValue
 
         if ( id() < 0 )
         {
-            writer.writeVirtualEdgeHack( relationship );
+            writer.writeArbitraryJavaObject( relationship );
         }
 
         writer.writeEdge( id(), startNode().id(), endNode().id(), type(), p );

--- a/community/kernel/src/main/java/org/neo4j/helpers/ValueUtils.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/ValueUtils.java
@@ -20,7 +20,6 @@
 package org.neo4j.helpers;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -37,6 +36,7 @@ import org.neo4j.graphdb.spatial.Geometry;
 import org.neo4j.graphdb.spatial.Point;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.values.AnyValue;
+import org.neo4j.values.AnyValueWriter;
 import org.neo4j.values.storable.NumberValue;
 import org.neo4j.values.storable.TextValue;
 import org.neo4j.values.storable.Values;
@@ -129,8 +129,7 @@ public final class ValueUtils
             }
             else
             {
-                throw new IllegalArgumentException(
-                        String.format( "Cannot convert %s to AnyValue", object.getClass().getName() ) );
+                return new JavaObjectAnyValue( object );
             }
         }
     }
@@ -292,5 +291,39 @@ public final class ValueUtils
     public static EdgeValue fromRelationshipProxy( Relationship relationship )
     {
         return new RelationshipProxyWrappingEdgeValue( relationship );
+    }
+
+    public static final class JavaObjectAnyValue extends AnyValue
+    {
+        private final Object object;
+        //The object is null checked before calling constructor
+        private JavaObjectAnyValue( Object object )
+        {
+            assert object != null;
+            this.object = object;
+        }
+
+        public Object asObject()
+        {
+            return object;
+        }
+
+        @Override
+        protected boolean eq( Object other )
+        {
+            return other != null && other.equals( object );
+        }
+
+        @Override
+        protected int computeHash()
+        {
+            return object.hashCode();
+        }
+
+        @Override
+        public <E extends Exception> void writeTo( AnyValueWriter<E> writer ) throws E
+        {
+            writer.writeJavaObject( object );
+        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/helpers/ValueUtils.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/ValueUtils.java
@@ -323,7 +323,7 @@ public final class ValueUtils
         @Override
         public <E extends Exception> void writeTo( AnyValueWriter<E> writer ) throws E
         {
-            writer.writeJavaObject( object );
+            writer.writeArbitraryJavaObject( object );
         }
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/AnyValueWriter.java
+++ b/community/values/src/main/java/org/neo4j/values/AnyValueWriter.java
@@ -54,17 +54,14 @@ public interface AnyValueWriter<E extends Exception> extends ValueWriter<E>
 
     void endPoint() throws E;
 
-    default void writeVirtualNodeHack( Object node )
-    {
-        // do nothing, this is an ugly hack.
-    }
-
-    default void writeVirtualEdgeHack( Object relationship )
-    {
-        // do nothing, this is an ugly hack.
-    }
-
-    default void writeJavaObject( Object object )
+    /**
+     * This is a temporary hack in order to support some cases for procedures where we
+     * hadn't been careful enough about sanitizing inputs
+     *
+     * @param object the object to serialize.
+     */
+    @Deprecated
+    default void writeArbitraryJavaObject( Object object )
     {
         // do nothing, this is an ugly hack.
     }

--- a/community/values/src/main/java/org/neo4j/values/AnyValueWriter.java
+++ b/community/values/src/main/java/org/neo4j/values/AnyValueWriter.java
@@ -63,4 +63,9 @@ public interface AnyValueWriter<E extends Exception> extends ValueWriter<E>
     {
         // do nothing, this is an ugly hack.
     }
+
+    default void writeJavaObject( Object object )
+    {
+        // do nothing, this is an ugly hack.
+    }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProcedureCallSupportAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProcedureCallSupportAcceptanceTest.scala
@@ -111,4 +111,22 @@ class ProcedureCallSupportAcceptanceTest extends ProcedureCallAcceptanceTest {
       "prop"
     )
   }
+
+
+  //NOTE this is unwanted behaviour, however since we were careless about sanitizing inputs (https://xkcd.com/327/)
+  //we are stuck with this behavior until 4.0, consider it extremely deprecated and remove as soon as possible.
+  test("Support passing arbitrary object in and out of a procedure") {
+    // Given
+    registerDummyInOutProcedure(Neo4jTypes.NTAny)
+    class Arbitrary {
+      val foo = 42
+    }
+    val value = new Arbitrary
+
+    // When
+    val result = graph.execute("CALL my.first.proc({p})", map("p",value))
+
+    // Then
+    result.next().get("out0") should equal(value)
+  }
 }


### PR DESCRIPTION
It has never been the intention but apparently we haven't been sanitizing input as we should have.

![](https://imgs.xkcd.com/comics/exploits_of_a_mom.png)

This has lead to that we have supported arbitrary objects being sent around between procedures and apparently this is now in heavy use.
