### PR TITLE
More verbose logging for dynamic configuration changes

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/ConfigTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/ConfigTest.java
@@ -369,13 +369,16 @@ public class ConfigTest
         Log log = mock( Log.class );
         config.setLogger( log );
 
-        config.updateDynamicSetting( MyDynamicSettings.boolSetting.name(), "false" );
-        config.updateDynamicSetting( MyDynamicSettings.boolSetting.name(), "true" );
-        config.updateDynamicSetting( MyDynamicSettings.boolSetting.name(), "" );
+        config.updateDynamicSetting( MyDynamicSettings.boolSetting.name(), "false", "test" );
+        config.updateDynamicSetting( MyDynamicSettings.boolSetting.name(), "true", "test" );
+        config.updateDynamicSetting( MyDynamicSettings.boolSetting.name(), "", "test" );
 
-        verify( log ).info("Setting changed: '%s' changed from '%s' to '%s'", MyDynamicSettings.boolSetting.name(), "true", "false" );
-        verify( log ).info("Setting changed: '%s' changed from '%s' to '%s'", MyDynamicSettings.boolSetting.name(), "false", "true" );
-        verify( log ).info("Setting changed: '%s' changed from '%s' to '%s'", MyDynamicSettings.boolSetting.name(), "true", "true" );
+        verify( log ).info("Setting changed: '%s' changed from '%s' to '%s' via '%s'",
+                MyDynamicSettings.boolSetting.name(), "default (true)", "false", "test" );
+        verify( log ).info("Setting changed: '%s' changed from '%s' to '%s' via '%s'",
+                MyDynamicSettings.boolSetting.name(), "false", "true", "test" );
+        verify( log ).info("Setting changed: '%s' changed from '%s' to '%s' via '%s'",
+                MyDynamicSettings.boolSetting.name(), "true", "default (true)", "test" );
         verifyNoMoreInteractions( log );
     }
 }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
@@ -282,7 +282,7 @@ public class EnterpriseBuiltInDbmsProcedures
         assertAdmin();
 
         Config config = resolver.resolveDependency( Config.class );
-        config.updateDynamicSetting( setting, value ); // throws if something goes wrong
+        config.updateDynamicSetting( setting, value, "dbms.setConfigValue" ); // throws if something goes wrong
     }
 
     /*


### PR DESCRIPTION
Logging now includes the origin of the change and an indication of whether the value is default or not.