### PR TITLE
Fix CypherComparisonSupport

### DIFF
--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/RewindableExecutionResult.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/RewindableExecutionResult.scala
@@ -31,11 +31,10 @@ import org.neo4j.cypher.internal.compatibility.v3_3.runtime._
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.executionplan._
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.InternalPlanDescription.Arguments
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription._
-import org.neo4j.cypher.internal.compiler.v3_3.CostBasedPlannerName
 import org.neo4j.cypher.internal.compiler.{v2_3, v3_1, v3_2}
-import org.neo4j.cypher.internal.frontend.v2_3.{SemanticDirection => SemanticDirection2_3, notification => notification_2_3}
-import org.neo4j.cypher.internal.frontend.v3_1.{SemanticDirection => SemanticDirection3_1, notification => notification_3_1, symbols => symbols3_1}
-import org.neo4j.cypher.internal.frontend.v3_2.{SemanticDirection => SemanticDirection3_2, notification => notification_3_2, symbols => symbols3_2}
+import org.neo4j.cypher.internal.frontend.v2_3.{SemanticDirection => SemanticDirection2_3}
+import org.neo4j.cypher.internal.frontend.v3_1.{SemanticDirection => SemanticDirection3_1, symbols => symbols3_1}
+import org.neo4j.cypher.internal.frontend.v3_2.{SemanticDirection => SemanticDirection3_2, symbols => symbols3_2}
 import org.neo4j.cypher.internal.frontend.v3_3.SemanticDirection.{BOTH, INCOMING, OUTGOING}
 import org.neo4j.cypher.internal.frontend.v3_3.{InputPosition, symbols}
 import org.neo4j.cypher.internal.javacompat.ExecutionResult
@@ -76,6 +75,12 @@ object RewindableExecutionResult {
               .addArgument(v2_3.planDescription.InternalPlanDescription.Arguments.Version("CYPHER 2.3"))
           }
         }
+      case other: v2_3.ExplainExecutionResult =>
+        val executionPlanDescription = other.executionPlanDescription
+          .addArgument(v2_3.planDescription.InternalPlanDescription.Arguments.Planner(planner.name))
+          .addArgument(v2_3.planDescription.InternalPlanDescription.Arguments.Runtime(runtime.name))
+          .addArgument(v2_3.planDescription.InternalPlanDescription.Arguments.Version("CYPHER 2.3"))
+        v2_3.ExplainExecutionResult(other.columns, executionPlanDescription, other.executionType.queryType(), other.notifications)
       case _ =>
         inner
     }
@@ -96,6 +101,12 @@ object RewindableExecutionResult {
               .addArgument(v3_1.planDescription.InternalPlanDescription.Arguments.Version("CYPHER 3.1"))
           }
         }
+      case other: v3_1.ExplainExecutionResult =>
+        val executionPlanDescription = other.executionPlanDescription
+          .addArgument(v3_1.planDescription.InternalPlanDescription.Arguments.Planner(planner.name))
+          .addArgument(v3_1.planDescription.InternalPlanDescription.Arguments.Runtime(runtime.name))
+          .addArgument(v3_1.planDescription.InternalPlanDescription.Arguments.Version("CYPHER 3.1"))
+        v3_1.ExplainExecutionResult(other.columns, executionPlanDescription, other.executionType, other.notifications)
       case _ =>
         inner
     }
@@ -116,6 +127,12 @@ object RewindableExecutionResult {
               .addArgument(v3_2.planDescription.InternalPlanDescription.Arguments.Version("CYPHER 3.2"))
           }
         }
+      case other: v3_2.ExplainExecutionResult =>
+        val executionPlanDescription = other.executionPlanDescription
+          .addArgument(v3_2.planDescription.InternalPlanDescription.Arguments.Planner(planner.name))
+          .addArgument(v3_2.planDescription.InternalPlanDescription.Arguments.Runtime(runtime.name))
+          .addArgument(v3_2.planDescription.InternalPlanDescription.Arguments.Version("CYPHER 3.2"))
+        v3_2.ExplainExecutionResult(other.columns, executionPlanDescription, other.executionType, other.notifications)
       case _ =>
         inner
     }
@@ -295,7 +312,13 @@ object RewindableExecutionResult {
 
     override def javaColumnAs[T](column: String): ResourceIterator[T] = inner.javaColumnAs(column)
 
-    override def executionPlanDescription(): InternalPlanDescription = lift(inner.executionPlanDescription())
+    override def executionPlanDescription(): InternalPlanDescription = {
+      var description = lift(inner.executionPlanDescription())
+      if (!description.arguments.exists(_.isInstanceOf[Arguments.Version])) {
+        description = description.addArgument(planDescription.InternalPlanDescription.Arguments.Version("CYPHER 3.1"))
+      }
+      description
+    }
 
     private def lift(planDescription: v3_1.planDescription.InternalPlanDescription): InternalPlanDescription = {
 
@@ -434,7 +457,13 @@ object RewindableExecutionResult {
 
     override def javaColumnAs[T](column: String): ResourceIterator[T] = inner.javaColumnAs(column)
 
-    override def executionPlanDescription(): InternalPlanDescription = lift(inner.executionPlanDescription())
+    override def executionPlanDescription(): InternalPlanDescription = {
+      var description = lift(inner.executionPlanDescription())
+      if (!description.arguments.exists(_.isInstanceOf[Arguments.Version])) {
+        description = description.addArgument(planDescription.InternalPlanDescription.Arguments.Version("CYPHER 3.2"))
+      }
+      description
+    }
 
     private def lift(planDescription: v3_2.planDescription.InternalPlanDescription): InternalPlanDescription = {
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/RewindableExecutionResult.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/RewindableExecutionResult.scala
@@ -73,6 +73,7 @@ object RewindableExecutionResult {
               .executionPlanDescription()
               .addArgument(v2_3.planDescription.InternalPlanDescription.Arguments.Planner(planner.name))
               .addArgument(v2_3.planDescription.InternalPlanDescription.Arguments.Runtime(runtime.name))
+              .addArgument(v2_3.planDescription.InternalPlanDescription.Arguments.Version("CYPHER 2.3"))
           }
         }
       case _ =>
@@ -92,6 +93,7 @@ object RewindableExecutionResult {
               .executionPlanDescription()
               .addArgument(v3_1.planDescription.InternalPlanDescription.Arguments.Planner(planner.name))
               .addArgument(v3_1.planDescription.InternalPlanDescription.Arguments.Runtime(runtime.name))
+              .addArgument(v3_1.planDescription.InternalPlanDescription.Arguments.Version("CYPHER 3.1"))
           }
         }
       case _ =>
@@ -111,6 +113,7 @@ object RewindableExecutionResult {
               .executionPlanDescription()
               .addArgument(v3_2.planDescription.InternalPlanDescription.Arguments.Planner(planner.name))
               .addArgument(v3_2.planDescription.InternalPlanDescription.Arguments.Runtime(runtime.name))
+              .addArgument(v3_2.planDescription.InternalPlanDescription.Arguments.Version("CYPHER 3.2"))
           }
         }
       case _ =>

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
@@ -430,39 +430,23 @@ object CypherComparisonSupport {
     def prepare(): Unit = newRuntimeMonitor.clear()
 
     def checkResultForSuccess(query: String, internalExecutionResult: InternalExecutionResult): Unit = {
-      internalExecutionResult.executionPlanDescription().arguments.collect {
-        case IPDRuntime(reportedRuntime) if (!runtime.acceptedRuntimeNames.contains(reportedRuntime)) =>
-          fail(s"did not use ${runtime.acceptedRuntimeNames} runtime - instead $reportedRuntime was used. Scenario $name")
-        case IPDPlanner(reportedPlanner) if (!planner.acceptedPlannerNames.contains(reportedPlanner)) =>
+      val (reportedRuntime: String, reportedPlanner: String, reportedVersion: String) = extractConfiguration(internalExecutionResult)
+      // Rule planner only exists in 3.1 and earlier
+      val rulePlannerFallback = Planners.Rule.acceptedPlannerNames.contains(reportedPlanner) && Versions.V3_1.acceptedVersionNames.contains(reportedVersion)
+
+      if (!runtime.acceptedRuntimeNames.contains(reportedRuntime))
+        fail(s"did not use ${runtime.acceptedRuntimeNames} runtime - instead $reportedRuntime was used. Scenario $name")
+      if (!planner.acceptedPlannerNames.contains(reportedPlanner))
           fail(s"did not use ${planner.acceptedPlannerNames} planner - instead $reportedPlanner was used. Scenario $name")
-        case IPDVersion(reportedVersion) if(!version.acceptedVersionNames.contains(reportedVersion)) =>
+      if(!(version.acceptedVersionNames.contains(reportedVersion) || rulePlannerFallback))
           fail(s"did not use ${version.acceptedVersionNames} version - instead $reportedVersion was used. Scenario $name")
-      }
     }
 
     def checkResultForFailure(query: String, internalExecutionResult: Try[InternalExecutionResult]): Unit = {
       internalExecutionResult match {
         case Failure(_) => // not unexpected
         case Success(result) =>
-          val arguments = result.executionPlanDescription().arguments
-          val reportedRuntime = arguments.collectFirst {
-            case IPDRuntime(reportedRuntime) => reportedRuntime
-          }
-          val reportedPlanner = arguments.collectFirst {
-            case IPDPlanner(reportedPlanner) => reportedPlanner
-          }
-          val reportedVersion = arguments.collectFirst {
-            case IPDVersion(reportedVersion) => reportedVersion
-          }
-
-          // Neo4j versions 3.2 and earlier do not accurately report when they used procedure runtime/planner,
-          // in executionPlanDescription. In those versions, a missing runtime/planner is assumed to mean procedure
-          val versionsWithUnreportedProcedureUsage = (Versions.V2_3 -> Versions.V3_2) + Versions.Default
-          val (reportedRuntimeName, reportedPlannerName, reportedVersionName) =
-            if (versionsWithUnreportedProcedureUsage.versions.contains(version))
-              (reportedRuntime.getOrElse("PROCEDURE"), reportedPlanner.getOrElse("PROCEDURE"), reportedVersion.getOrElse("NONE"))
-            else
-              (reportedRuntime.get, reportedPlanner.get, reportedVersion.get)
+          val (reportedRuntimeName: String, reportedPlannerName: String, reportedVersionName: String) = extractConfiguration(result)
 
           if (runtime.acceptedRuntimeNames.contains(reportedRuntimeName)
             && planner.acceptedPlannerNames.contains(reportedPlannerName)
@@ -470,6 +454,29 @@ object CypherComparisonSupport {
             fail(s"Unexpectedly succeeded using $name for query $query, with $reportedVersionName and $reportedRuntimeName runtime and $reportedPlannerName planner.")
           }
       }
+    }
+
+    private def extractConfiguration(result: InternalExecutionResult): (String, String, String) = {
+      val arguments = result.executionPlanDescription().arguments
+      val reportedRuntime = arguments.collectFirst {
+        case IPDRuntime(reportedRuntime) => reportedRuntime
+      }
+      val reportedPlanner = arguments.collectFirst {
+        case IPDPlanner(reportedPlanner) => reportedPlanner
+      }
+      val reportedVersion = arguments.collectFirst {
+        case IPDVersion(reportedVersion) => reportedVersion
+      }
+
+      // Neo4j versions 3.2 and earlier do not accurately report when they used procedure runtime/planner,
+      // in executionPlanDescription. In those versions, a missing runtime/planner is assumed to mean procedure
+      val versionsWithUnreportedProcedureUsage = (Versions.V2_3 -> Versions.V3_2) + Versions.Default
+      val (reportedRuntimeName, reportedPlannerName, reportedVersionName) =
+        if (versionsWithUnreportedProcedureUsage.versions.contains(version))
+          (reportedRuntime.getOrElse("PROCEDURE"), reportedPlanner.getOrElse("PROCEDURE"), reportedVersion.getOrElse("NONE"))
+        else
+          (reportedRuntime.get, reportedPlanner.get, reportedVersion.get)
+      (reportedRuntimeName, reportedPlannerName, reportedVersionName)
     }
 
     def +(other: TestConfiguration): TestConfiguration = other + this

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeCompatibilityAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeCompatibilityAcceptanceTest.scala
@@ -124,17 +124,10 @@ class MergeNodeCompatibilityAcceptanceTest extends ExecutionEngineFunSuite with 
 
       // when
       val results =
-        executeWith(expectedSucceed, "merge (a:Person {id: 23, mail: 'emil@neo.com'}) on create set a.country='Sweden' return a", expectedDifferentResults = Configs.AbsolutelyAll)
-      val result = results.columnAs("a").next().asInstanceOf[Node]
+        executeWith(expectedSucceed, "merge (a:Person {id: 23, mail: 'emil@neo.com'}) on create set a.country='Sweden' return a.id, a.mail, a.country, labels(a)")
 
       // then
-      countNodes() should equal(1)
-      labels(result) should equal(Set("Person"))
-      graph.inTx {
-        result.getProperty("id") should equal(23)
-        result.getProperty("country") should equal("Sweden")
-        result.getProperty("mail") should equal("emil@neo.com")
-      }
+      results.toSet should equal(Set(Map("a.id" -> 23, "a.mail" -> "emil@neo.com", "a.country" -> "Sweden", "labels(a)" -> List("Person"))))
     }
 
     test(s"$constraintCreator: should_create_on_merge_using_multiple_unique_indexes_and_labels_if_found_no_nodes") {
@@ -144,17 +137,10 @@ class MergeNodeCompatibilityAcceptanceTest extends ExecutionEngineFunSuite with 
 
       // when
       val results =
-        executeWith(expectedSucceed, "merge (a:Person:User {id: 23, mail: 'emil@neo.com'}) on create set a.country='Sweden' return a", expectedDifferentResults = Configs.AbsolutelyAll)
-      val result = results.columnAs("a").next().asInstanceOf[Node]
+        executeWith(expectedSucceed, "merge (a:Person:User {id: 23, mail: 'emil@neo.com'}) on create set a.country='Sweden' return a.id, a.mail, a.country, labels(a)")
 
       // then
-      countNodes() should equal(1)
-      labels(result) should equal(Set("Person", "User"))
-      graph.inTx {
-        result.getProperty("id") should equal(23)
-        result.getProperty("country") should equal("Sweden")
-        result.getProperty("mail") should equal("emil@neo.com")
-      }
+      results.toSet should equal(Set(Map("a.id" -> 23, "a.mail" -> "emil@neo.com", "a.country" -> "Sweden", "labels(a)" -> List("Person", "User"))))
     }
 
     test(s"$constraintCreator: should_fail_on_merge_using_multiple_unique_indexes_if_found_different_nodes") {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartAcceptanceTest.scala
@@ -24,7 +24,7 @@ import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
 
 class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with CypherComparisonSupport {
 
-  val expectedToSucceed = Configs.CommunityInterpreted
+  val expectedToSucceed = Configs.CommunityInterpreted - Configs.Cost3_2
   val expectedToSucceedNoCost = Configs.CommunityInterpreted - Configs.Cost - Configs.Cost3_2
 
   test("START n=node:index(key = \"value\") RETURN n") {


### PR DESCRIPTION
Some tests were returning nodes/relationships, this isn't handled by the test framework since there's no guarantee that the nodes will get the same id between runs.

Also fixes a bug with reporting versions for older versions.