### PR TITLE
Fix bug in SingleRowSlottedPipe

### DIFF
--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/pipes/SingleRowSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/pipes/SingleRowSlottedPipe.scala
@@ -26,7 +26,10 @@ import org.neo4j.cypher.internal.v3_3.logical.plans.LogicalPlanId
 
 case class SingleRowSlottedPipe(pipelineInformation: PipelineInformation)(val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends Pipe {
 
-
-  def internalCreateResults(state: QueryState) =
-    Iterator(PrimitiveExecutionContext(pipelineInformation))
+  def internalCreateResults(state: QueryState) = {
+    val context = PrimitiveExecutionContext(pipelineInformation)
+    state.copyArgumentStateTo(context,
+      pipelineInformation.initialNumberOfLongs, pipelineInformation.initialNumberOfReferences)
+    Iterator(context)
+  }
 }


### PR DESCRIPTION
If a SingleRow appears on the right-hand side of a logical plan
it needs to copy the arguments from the query state, or we could
end up using uninitialized slots.