### PR TITLE
Fix bug in UnwindSlottedPipe

### DIFF
--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/pipes/UnwindSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/pipes/UnwindSlottedPipe.scala
@@ -63,7 +63,9 @@ case class UnwindSlottedPipe(source: Pipe, collection: Expression, offset: Int, 
       } else {
         if (input.hasNext) {
           currentInputRow = input.next()
-          val value: AnyValue = collection(currentInputRow, state)
+          nextItem = PrimitiveExecutionContext(pipeline)
+          currentInputRow.copyTo(nextItem)
+          val value: AnyValue = collection(nextItem, state)
           unwindIterator = makeTraversable(value).iterator.asScala
           prefetch()
         }


### PR DESCRIPTION
We need to also copy the first incoming row since it can have a
different slot configuration than the pipeline that contains
the Unwind.