### PR TITLE
Log remote address for broken network connection

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/MessageProcessingHandler.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/MessageProcessingHandler.java
@@ -141,8 +141,7 @@ class MessageProcessingHandler implements BoltResponseHandler
         {
             // we tried to write error back to the client and realized that the underlying channel is closed
             // log a warning, client driver might have just been stopped and closed all socket connections
-            log.warn( "Unable to send error back to the client. " +
-                      "Communication channel is closed. Client has probably been stopped.", error.cause() );
+            log.warn( "Unable to send error back to the client. " + e.getMessage(), error.cause() );
         }
         catch ( Throwable t )
         {

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/transport/ChunkedOutput.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/transport/ChunkedOutput.java
@@ -163,7 +163,8 @@ public class ChunkedOutput implements PackOutput, BoltResponseMessageBoundaryHoo
         assert size <= maxChunkSize : size + " > " + maxChunkSize;
         if ( closed.get() )
         {
-            throw new PackOutputClosedException( "Unable to write to the closed output channel" );
+            throw new PackOutputClosedException( "Network channel towards " + channel.remoteAddress() + " is closed. " +
+                                                 "Client has probably been stopped." );
         }
         int toWriteSize = chunkOpen ? size : size + CHUNK_HEADER_SIZE;
         synchronized ( this )

--- a/integrationtests/src/test/java/org/neo4j/bolt/BoltFailuresIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/BoltFailuresIT.java
@@ -26,63 +26,42 @@ import org.junit.rules.RuleChain;
 import org.junit.rules.Timeout;
 
 import java.time.Clock;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 import org.neo4j.bolt.v1.runtime.BoltFactory;
 import org.neo4j.bolt.v1.runtime.MonitoredWorkerFactory.SessionMonitor;
 import org.neo4j.bolt.v1.runtime.WorkerFactory;
-import org.neo4j.bolt.v1.transport.BoltMessagingProtocolV1Handler;
 import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
-import org.neo4j.function.Predicates;
 import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.Result;
-import org.neo4j.graphdb.TransactionTerminatedException;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.IOUtils;
+import org.neo4j.kernel.configuration.BoltConnector;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.monitoring.Monitors;
-import org.neo4j.logging.AssertableLogProvider;
-import org.neo4j.logging.AssertableLogProvider.LogMatcher;
-import org.neo4j.logging.LogProvider;
 import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
 import org.neo4j.test.rule.TestDirectory;
 
-import static java.util.concurrent.CompletableFuture.runAsync;
-import static java.util.concurrent.TimeUnit.MINUTES;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
-import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.Connector.ConnectorType.BOLT;
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.boltConnector;
-import static org.neo4j.helpers.collection.Iterators.count;
-import static org.neo4j.helpers.collection.Iterators.single;
 import static org.neo4j.kernel.configuration.Settings.FALSE;
 import static org.neo4j.kernel.configuration.Settings.TRUE;
-import static org.neo4j.logging.AssertableLogProvider.inLog;
 
 public class BoltFailuresIT
 {
     private static final int TEST_TIMEOUT_SECONDS = 120;
-    private static final int PREDICATE_AWAIT_TIMEOUT_SECONDS = TEST_TIMEOUT_SECONDS / 2;
 
     private final TestDirectory dir = TestDirectory.testDirectory();
 
@@ -180,42 +159,6 @@ public class BoltFailuresIT
         throwsWhenRunMessageFails( ThrowingSessionMonitor::throwInProcessingDone );
     }
 
-    @Test
-    public void boltServerLogsRealErrorWhenDriverIsClosedWithRunningTransactions() throws Exception
-    {
-        AssertableLogProvider internalLogProvider = new AssertableLogProvider();
-        db = startTestDb( internalLogProvider );
-
-        // create a dummy node
-        db.execute( "CREATE (:Node)" ).close();
-
-        // lock that dummy node to make all subsequent writes wait on an exclusive lock
-        org.neo4j.graphdb.Transaction tx = db.beginTx();
-        Node node = single( db.findNodes( label( "Node" ) ) );
-        tx.acquireWriteLock( node );
-
-        Driver driver = createDriver();
-
-        // try to execute write query for the same node through the driver
-        Future<?> writeThroughDriverFuture = updateAllNodesAsync( driver );
-        // make sure this query is executing and visible in query listing
-        awaitNumberOfActiveQueriesToBe( 1 );
-
-        // close driver while it has ongoing transaction, it should get terminated
-        driver.close();
-
-        // driver transaction should fail
-        expectFailure( writeThroughDriverFuture );
-
-        // make sure there are no active queries
-        awaitNumberOfActiveQueriesToBe( 0 );
-
-        // verify that closing of the driver resulted in transaction termination on the server and correct log message
-        awaitLogToContainMessage( internalLogProvider, inLog( BoltMessagingProtocolV1Handler.class ).warn(
-                startsWith( "Unable to send error back to the client" ),
-                instanceOf( TransactionTerminatedException.class ) ) );
-    }
-
     private void throwsWhenInitMessageFails( Consumer<ThrowingSessionMonitor> monitorSetup,
             boolean shouldBeAbleToBeginTransaction )
     {
@@ -281,67 +224,13 @@ public class BoltFailuresIT
         return startDbWithBolt( newDbFactory().setMonitors( monitors ) );
     }
 
-    private GraphDatabaseService startTestDb( LogProvider internalLogProvider )
-    {
-        return startDbWithBolt( newDbFactory().setInternalLogProvider( internalLogProvider ) );
-    }
-
     private GraphDatabaseService startDbWithBolt( GraphDatabaseFactory dbFactory )
     {
         return dbFactory.newEmbeddedDatabaseBuilder( dir.graphDbDir() )
-                .setConfig( boltConnector( "0" ).type, BOLT.name() )
-                .setConfig( boltConnector( "0" ).enabled, TRUE )
+                .setConfig( new BoltConnector( "0" ).type, BOLT.name() )
+                .setConfig( new BoltConnector( "0" ).enabled, TRUE )
                 .setConfig( GraphDatabaseSettings.auth_enabled, FALSE )
                 .newGraphDatabase();
-    }
-
-    private void awaitNumberOfActiveQueriesToBe( int value ) throws TimeoutException
-    {
-        await( () ->
-        {
-            Result listQueriesResult = db.execute( "CALL dbms.listQueries()" );
-            return count( listQueriesResult ) == value + 1; // procedure call itself is also listed
-        } );
-    }
-
-    private void awaitLogToContainMessage( AssertableLogProvider logProvider, LogMatcher matcher )
-            throws TimeoutException
-    {
-        try
-        {
-            await( () -> logProvider.containsMatchingLogCall( matcher ) );
-        }
-        catch ( TimeoutException e )
-        {
-            System.err.println( "Expected log call did not happen. Full log:" );
-            System.err.println( logProvider.serialize() );
-            throw e;
-        }
-    }
-
-    private Future<?> updateAllNodesAsync( Driver driver )
-    {
-        return runAsync( () ->
-        {
-            try ( Session session = driver.session() )
-            {
-                session.run( "MATCH (n) SET n.prop = 42" ).consume();
-            }
-        } );
-    }
-
-    private static void expectFailure( Future<?> future ) throws TimeoutException, InterruptedException
-    {
-        try
-        {
-            future.get( 1, MINUTES );
-            fail( "Exception expected" );
-        }
-        catch ( ExecutionException e )
-        {
-            // expected
-            e.printStackTrace();
-        }
     }
 
     private static TestEnterpriseGraphDatabaseFactory newDbFactory()
@@ -362,11 +251,6 @@ public class BoltFailuresIT
         when( monitors.newMonitor( SessionMonitor.class ) ).thenReturn( sessionMonitor );
         when( monitors.hasListeners( SessionMonitor.class ) ).thenReturn( true );
         return monitors;
-    }
-
-    private static void await( Supplier<Boolean> condition ) throws TimeoutException
-    {
-        Predicates.await( condition, PREDICATE_AWAIT_TIMEOUT_SECONDS, SECONDS );
     }
 
     private static class BoltKernelExtensionWithWorkerFactory extends BoltKernelExtension


### PR DESCRIPTION
PR makes bolt server log client address when it's unable to write error back. Such error most probably means that client driver has been closed.