### PR TITLE
Proper fix for "not" error message if used right of "="

### DIFF
--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/ast/ResolvedFunctionInvocation.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/ast/ResolvedFunctionInvocation.scala
@@ -67,9 +67,13 @@ case class ResolvedFunctionInvocation(qualifiedName: QualifiedName,
   }
 
   override def semanticCheck(ctx: SemanticContext): SemanticCheck = fcnSignature match {
-    case None if qualifiedName == QualifiedName(Seq(), "not") => SemanticError(s"Unknown function '$qualifiedName'. " +
-      s"If you intended to use the negation expression, surround it with parentheses.", position)
-    case None => SemanticError(s"Unknown function '$qualifiedName'", position)
+    case None =>
+      qualifiedName match {
+        case QualifiedName(Seq(), qn) if qn.equalsIgnoreCase("not") =>
+          SemanticError(s"Unknown function '$qualifiedName'. " +
+            s"If you intended to use the negation expression, surround it with parentheses.", position)
+        case _ => SemanticError(s"Unknown function '$qualifiedName'", position)
+      }
     case Some(signature) =>
       val expectedNumArgs = signature.inputSignature.length
       val usedDefaultArgs = signature.inputSignature.drop(callArguments.length).flatMap(_.default)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExpressionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExpressionAcceptanceTest.scala
@@ -111,13 +111,22 @@ class ExpressionAcceptanceTest extends ExecutionEngineFunSuite with CypherCompar
   }
 
   test("not(), when right of a =, should give a helpful error message") {
-
     val query = "RETURN true = not(42 = 32)"
 
     // this should have the right error message for 3.1 and 3.2 after the next patch releases
     val config =  Configs.AbsolutelyAll - Configs.Version3_2 - Configs.Version3_1 - Configs.Version2_3 - Configs.AllRulePlanners
 
-    val result = failWithError(config, query,
+    failWithError(config, query,
       List("Unknown function 'not'. If you intended to use the negation expression, surround it with parentheses."))
+  }
+
+  test("NOT(), when right of a =, should give a helpful error message") {
+    val query = "RETURN true = NOT(42 = 32)"
+
+    // this should have the right error message for 3.1 and 3.2 after the next patch releases
+    val config =  Configs.AbsolutelyAll - Configs.Version3_2 - Configs.Version3_1 - Configs.Version2_3 - Configs.AllRulePlanners
+
+    failWithError(config, query,
+      List("Unknown function 'NOT'. If you intended to use the negation expression, surround it with parentheses."))
   }
 }


### PR DESCRIPTION
This PR adds to the already merged
https://github.com/neo4j/neo4j/pull/10262/ that did not fix the problem
in its entirety.