### PR TITLE
Fix deadlock between index close and index add

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/LuceneDataSource.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/LuceneDataSource.java
@@ -298,7 +298,7 @@ public class LuceneDataSource extends LifecycleAdapter
         {
             return syncGetIndexSearcher( identifier );
         }
-        synchronized ( searcher )
+        synchronized ( this )
         {
             /*
              * We need to get again a reference to the searcher because it might be so that


### PR DESCRIPTION
`this` is instance of `LuceneDataSource`

T1 want to delete index 1
T2 want to add to index 1

T1 `closeIndex` synchronized on `this`
T2 `getIndexSearcher` synchronize on searcher for index 1
T1 BLOCKED on `searcher.dispose` on searcher for index 1,
   which internally synchronize on searcher. Held by T2.
T2 BLOCKED on `syncGetIndexSearcher`, synchronized on `this`.
   Held by T1.
DEADLOCK

Instead of synchronizing on found searcher, T2 synchronize
on `this` avoiding grabbing locks in reverse order.