### PR TITLE
Make the error message for missing a colon in the relationship type more helpful

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/HelpfulErrorMessagesTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/HelpfulErrorMessagesTest.scala
@@ -62,7 +62,7 @@ class HelpfulErrorMessagesTest extends ExecutionEngineFunSuite with NewPlannerTe
   test("should provide sensible error message when trying to add multiple relationship types on create") {
     withEachPlanner { execute =>
       val exception = intercept[SyntaxException] (execute("CREATE (a)-[:ASSOCIATED_WITH|:KNOWS]->(b)", Seq.empty))
-      exception.getMessage should include("A single relationship type must be specified for CREATE.")
+      exception.getMessage should include("A single relationship type must be specified for CREATE")
     }
   }
 
@@ -77,7 +77,7 @@ class HelpfulErrorMessagesTest extends ExecutionEngineFunSuite with NewPlannerTe
   test("should provide sensible error message when trying to add multiple relationship types on merge") {
     withEachPlanner { execute =>
       val exception = intercept[SyntaxException] (execute("MERGE (a)-[:ASSOCIATED_WITH|:KNOWS]->(b)", Seq.empty))
-      exception.getMessage should include("A single relationship type must be specified for MERGE.")
+      exception.getMessage should include("A single relationship type must be specified for MERGE")
     }
   }
 }

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/ast/Clause.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/ast/Clause.scala
@@ -216,7 +216,11 @@ case class Merge(pattern: Pattern, actions: Seq[MergeAction])(val position: Inpu
   private def checkRelTypes: SemanticCheck  =
     pattern.patternParts.foldSemanticCheck {
       case EveryPath(RelationshipChain(_, rel, _)) if rel.types.size != 1 =>
-        SemanticError("A single relationship type must be specified for MERGE", rel.position)
+      if (rel.types.size > 1) {
+        SemanticError("A single relationship type must be specified for MERGE.", rel.position)
+      } else {
+        SemanticError("Exactly one relationship type must be specified for MERGE. Did you forget to prefix your relationship type with a ':'?", rel.position)
+      }
       case _ => SemanticCheckResult.success
     }
 }
@@ -230,7 +234,11 @@ case class Create(pattern: Pattern)(val position: InputPosition) extends UpdateC
   private def checkRelTypes: SemanticCheck  =
     pattern.patternParts.foldSemanticCheck {
       case EveryPath(RelationshipChain(_, rel, _)) if rel.types.size != 1 =>
-        SemanticError("A single relationship type must be specified for CREATE", rel.position)
+      if (rel.types.size > 1) {
+        SemanticError("A single relationship type must be specified for CREATE.", rel.position)
+      } else {
+        SemanticError("Exactly one relationship type must be specified for CREATE. Did you forget to prefix your relationship type with a ':'?", rel.position)
+      }
       case _ => SemanticCheckResult.success
     }
 }

--- a/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/ast/Clause.scala
+++ b/community/cypher/frontend-3.1/src/main/scala/org/neo4j/cypher/internal/frontend/v3_1/ast/Clause.scala
@@ -217,7 +217,7 @@ case class Merge(pattern: Pattern, actions: Seq[MergeAction])(val position: Inpu
     pattern.patternParts.foldSemanticCheck {
       case EveryPath(RelationshipChain(_, rel, _)) if rel.types.size != 1 =>
       if (rel.types.size > 1) {
-        SemanticError("A single relationship type must be specified for MERGE.", rel.position)
+        SemanticError("A single relationship type must be specified for MERGE", rel.position)
       } else {
         SemanticError("Exactly one relationship type must be specified for MERGE. Did you forget to prefix your relationship type with a ':'?", rel.position)
       }
@@ -235,7 +235,7 @@ case class Create(pattern: Pattern)(val position: InputPosition) extends UpdateC
     pattern.patternParts.foldSemanticCheck {
       case EveryPath(RelationshipChain(_, rel, _)) if rel.types.size != 1 =>
       if (rel.types.size > 1) {
-        SemanticError("A single relationship type must be specified for CREATE.", rel.position)
+        SemanticError("A single relationship type must be specified for CREATE", rel.position)
       } else {
         SemanticError("Exactly one relationship type must be specified for CREATE. Did you forget to prefix your relationship type with a ':'?", rel.position)
       }

--- a/community/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/SpecSuiteErrorHandler.scala
+++ b/community/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/SpecSuiteErrorHandler.scala
@@ -145,7 +145,7 @@ case class SpecSuiteErrorHandler(typ: String, phase: String, detail: String) ext
       detail should equal(NON_CONSTANT_EXPRESSION)
     else if (msg.matches("Can't use non-deterministic \\(random\\) functions inside of aggregate functions\\."))
       detail should equal(NON_CONSTANT_EXPRESSION)
-    else if (msg.matches(semanticError("A single relationship type must be specified for ((CREATE)|(MERGE))\\.")) ||
+    else if (msg.matches(semanticError("A single relationship type must be specified for ((CREATE)|(MERGE))\\")) ||
       msg.matches(semanticError("Exactly one relationship type must be specified for ((CREATE)|(MERGE))\\. " +
         "Did you forget to prefix your relationship type with a \\'\\:\\'\\?")))
       detail should equal(NO_SINGLE_RELATIONSHIP_TYPE)

--- a/community/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/SpecSuiteErrorHandler.scala
+++ b/community/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/SpecSuiteErrorHandler.scala
@@ -145,7 +145,9 @@ case class SpecSuiteErrorHandler(typ: String, phase: String, detail: String) ext
       detail should equal(NON_CONSTANT_EXPRESSION)
     else if (msg.matches("Can't use non-deterministic \\(random\\) functions inside of aggregate functions\\."))
       detail should equal(NON_CONSTANT_EXPRESSION)
-    else if (msg.matches(semanticError("A single relationship type must be specified for ((CREATE)|(MERGE))")))
+    else if (msg.matches(semanticError("A single relationship type must be specified for ((CREATE)|(MERGE))\\.")) ||
+      msg.matches(semanticError("Exactly one relationship type must be specified for ((CREATE)|(MERGE))\\. " +
+        "Did you forget to prefix your relationship type with a \\'\\:\\'\\?")))
       detail should equal(NO_SINGLE_RELATIONSHIP_TYPE)
     else if (msg.matches(s"${DOTALL}Invalid input '.*': expected an identifier character, whitespace, '\\|', a length specification, a property map or '\\]' \\(line \\d+, column \\d+ \\(offset: \\d+\\)\\).*"))
       detail should equal(INVALID_RELATIONSHIP_PATTERN)


### PR DESCRIPTION
Semantic error now distinguish between if we have multiple types or no types. The fix is implemented for both CREATE and MERGE.

changelog: Fixes #6568 so that the error message for missing a colon in the relationship type becomes more helpful.