### PR TITLE
 Fix bug for create/merge relationship in slotted runtime

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateAcceptanceTest.scala
@@ -91,4 +91,25 @@ class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
     result.executionPlanDescription()
   }
 
+  //Not TCK material
+  // This test exposed a bug in the slotted runtime where it could mix up long slots with ref slots
+  test("should not accidentally create relationship between the wrong nodes") {
+    val a = createLabeledNode("A")
+    val b = createLabeledNode("B")
+
+    val query =
+      """
+        |MATCH (a:A), (b:B)
+        |WITH a, b as x
+        |CREATE (x)-[r:T]->(x)
+        |WITH r
+        |MATCH (:B)-[:T]->(:B)
+        |RETURN count(*) as c
+      """.stripMargin
+
+    val result = graph.execute(query)
+
+    assert(result.hasNext)
+    result.next.get("c") shouldEqual(1)
+  }
 }

--- a/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -208,6 +208,10 @@ Failing when using a variable that is already bound in CREATE
 // Updating queries
 Fail when imposing new predicates on a variable that is already bound
 Create a relationship with the correct direction
+Nodes are not created when aliases are applied to variable names
+Only a single node is created when an alias is applied to a variable name
+Nodes are not created when aliases are applied to variable names multiple times
+Only a single node is created when an alias is applied to a variable name multiple times
 A bound node should be recognized after projection with WITH + MERGE pattern
 Delete nodes
 Detach delete node

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/SlottedPipeBuilder.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/SlottedPipeBuilder.scala
@@ -214,14 +214,14 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
         DistinctSlottedPipe(source, pipeline, grouping)(id)
 
       case CreateRelationship(_, idName, IdName(startNode), typ, IdName(endNode), props) =>
-        val fromOffset = pipeline(startNode).offset
-        val endOffset = pipeline(endNode).offset
+        val fromOffset = pipeline.getLongOffsetFor(startNode)
+        val endOffset = pipeline.getLongOffsetFor(endNode)
         CreateRelationshipSlottedPipe(source, idName.name, fromOffset, LazyType(typ)(context.semanticTable), endOffset,
                                        pipeline, props.map(convertExpressions))(id = id)
 
       case MergeCreateRelationship(_, idName, IdName(startNode), typ, IdName(endNode), props) =>
-        val fromOffset = pipeline(startNode).offset
-        val endOffset = pipeline(endNode).offset
+        val fromOffset = pipeline.getLongOffsetFor(startNode)
+        val endOffset = pipeline.getLongOffsetFor(endNode)
         MergeCreateRelationshipSlottedPipe(source, idName.name, fromOffset, LazyType(typ)(context.semanticTable),
                                             endOffset, pipeline, props.map(convertExpressions))(id = id)
 


### PR DESCRIPTION
The slotted pipe builder should not mix up long slots and
reference slots for create/merge relationship.

We currently only support long slots in these pipes, so getting nodes
in reference slots should generate a compile time error and fall back
to interpreted runtime.