### PR TITLE
Only output progress if printing to console in consistency checker

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
@@ -33,8 +33,8 @@ import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.commandline.arguments.Arguments;
 import org.neo4j.commandline.arguments.OptionalBooleanArg;
 import org.neo4j.commandline.arguments.common.OptionalCanonicalPath;
-import org.neo4j.consistency.checking.full.ConsistencyFlags;
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
+import org.neo4j.consistency.checking.full.ConsistencyFlags;
 import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.helpers.Strings;
 import org.neo4j.helpers.collection.MapUtil;
@@ -181,8 +181,16 @@ public class CheckConsistencyCommand implements AdminCommand
         {
             File storeDir = backupPath.map( Path::toFile ).orElse( config.get( database_path ) );
             checkDbState( storeDir, config );
+
+            // Only output progress indicator if a console receives the output
+            ProgressMonitorFactory progressMonitorFactory = ProgressMonitorFactory.NONE;
+            if ( System.console() != null )
+            {
+                progressMonitorFactory = ProgressMonitorFactory.textual( System.out );
+            }
+
             ConsistencyCheckService.Result consistencyCheckResult = consistencyCheckService
-                    .runFullConsistencyCheck( storeDir, config, ProgressMonitorFactory.textual( System.err ),
+                    .runFullConsistencyCheck( storeDir, config, progressMonitorFactory,
                             FormattedLogProvider.toOutputStream( System.out ), fileSystem, verbose,
                             reportDir.toFile(),
                             new ConsistencyFlags(


### PR DESCRIPTION
The progress indicator outputs to `stderr` and that is considered as a failure by some tools.
The reason `stderr` is used is to allow piping of the output without the progress indicator clogging it up.

This PR moves the output to `stdout` and only prints it when the receiver is a console. 

Closes issue #3466