### PR TITLE
TransactionTemplate failed callback now called

### DIFF
--- a/community/common/src/main/java/org/neo4j/function/Predicates.java
+++ b/community/common/src/main/java/org/neo4j/function/Predicates.java
@@ -41,33 +41,25 @@ import static org.neo4j.function.ThrowingSupplier.throwingSupplier;
  */
 public class Predicates
 {
-    private static final Predicate TRUE = item -> true;
-
-    private static final Predicate FALSE = item -> false;
-
-    private static final Predicate NOT_NULL = Objects::nonNull;
     private static final int DEFAULT_POLL_INTERVAL = 20;
 
     private Predicates()
     {
     }
 
-    @SuppressWarnings( "unchecked" )
     public static <T> Predicate<T> alwaysTrue()
     {
-        return TRUE;
+        return x -> true;
     }
 
-    @SuppressWarnings( "unchecked" )
     public static <T> Predicate<T> alwaysFalse()
     {
-        return FALSE;
+        return x -> false;
     }
 
-    @SuppressWarnings( "unchecked" )
     public static <T> Predicate<T> notNull()
     {
-        return NOT_NULL;
+        return Objects::nonNull;
     }
 
     @SafeVarargs
@@ -112,18 +104,18 @@ public class Predicates
         };
     }
 
-    public static <T> Predicate<T> instanceOf( @Nonnull final Class clazz )
+    public static <T> Predicate<T> instanceOf( @Nonnull final Class<?> clazz )
     {
         return item -> item != null && clazz.isInstance( item );
     }
 
-    public static <T> Predicate<T> instanceOfAny( final Class... classes )
+    public static <T> Predicate<T> instanceOfAny( final Class<?>... classes )
     {
         return item ->
         {
             if ( item != null )
             {
-                for ( Class clazz : classes )
+                for ( Class<?> clazz : classes )
                 {
                     if ( clazz.isInstance( item ) )
                     {

--- a/community/kernel/src/main/java/org/neo4j/helpers/TransactionTemplate.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/TransactionTemplate.java
@@ -132,8 +132,7 @@ public class TransactionTemplate
         } );
     }
 
-    public <T> T execute( Function<Transaction, T> txFunction )
-            throws TransactionFailureException
+    public <T> T execute( Function<Transaction, T> txFunction ) throws TransactionFailureException
     {
         Throwable txEx = null;
         for ( int i = 0; i < retries; i++ )
@@ -163,28 +162,16 @@ public class TransactionTemplate
                 }
                 catch ( InterruptedException e )
                 {
-                    throw new TransactionFailureException( "Interrupted", e );
+                    TransactionFailureException interrupted = new TransactionFailureException( "Interrupted", e );
+                    monitor.failed( interrupted );
+                    throw interrupted;
                 }
 
                 monitor.retrying();
             }
         }
 
-        if ( txEx instanceof TransactionFailureException )
-        {
-            throw (TransactionFailureException) txEx;
-        }
-        else if ( txEx instanceof Error )
-        {
-            throw (Error) txEx;
-        }
-        else if ( txEx instanceof RuntimeException )
-        {
-            throw (RuntimeException) txEx;
-        }
-        else
-        {
-            throw new TransactionFailureException( "Failed", txEx );
-        }
+        monitor.failed( txEx );
+        throw new TransactionFailureException( "Failed", txEx );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/helpers/TransactionTemplateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/TransactionTemplateTest.java
@@ -35,9 +35,12 @@ import org.neo4j.graphdb.TransactionTerminatedException;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.test.rule.EmbeddedDatabaseRule;
 
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasProperty;
 import static org.junit.Assert.assertThat;
 
 public class TransactionTemplateTest
@@ -60,6 +63,16 @@ public class TransactionTemplateTest
                 .monitor( monitor )
                 .retries( 5 )
                 .backoff( 3, TimeUnit.MILLISECONDS );
+    }
+
+    @Test
+    public void shouldForceUserToCallWith() throws Exception
+    {
+        expected.expectCause( allOf(
+                instanceOf( IllegalArgumentException.class ),
+                hasProperty( "message", is( "You need to call 'with(GraphDatabaseService)' on the template in order to use it" ) ) ) );
+        TransactionTemplate transactionTemplate = new TransactionTemplate();
+        transactionTemplate.execute( transaction -> null );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/helpers/TransactionTemplateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/TransactionTemplateTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.helpers;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.TransactionFailureException;
+import org.neo4j.graphdb.TransactionTerminatedException;
+import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.test.rule.EmbeddedDatabaseRule;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.Assert.assertThat;
+
+public class TransactionTemplateTest
+{
+    @Rule
+    public EmbeddedDatabaseRule databaseRule = new EmbeddedDatabaseRule();
+
+    @Rule
+    public final ExpectedException expected = ExpectedException.none();
+
+    private TransactionTemplate template;
+    private CountingMonitor monitor;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        monitor = new CountingMonitor();
+        template = new TransactionTemplate()
+                .with( databaseRule.getGraphDatabaseAPI() )
+                .monitor( monitor )
+                .retries( 5 )
+                .backoff( 3, TimeUnit.MILLISECONDS );
+    }
+
+    @Test
+    public void validateGraphDatabaseService() throws Exception
+    {
+        expected.expect( NullPointerException.class );
+        template.with( null );
+    }
+
+    @Test
+    public void validateRetires() throws Exception
+    {
+        expected.expect( IllegalArgumentException.class );
+        template.retries( 0 );
+    }
+
+    @Test
+    public void validateBackoff() throws Exception
+    {
+        expected.expect( IllegalArgumentException.class );
+        template.backoff( -10, TimeUnit.SECONDS );
+    }
+
+    @Test
+    public void validateMonitor() throws Exception
+    {
+        expected.expect( NullPointerException.class );
+        template.monitor( null );
+    }
+
+    @Test
+    public void validateRetryOn() throws Exception
+    {
+        expected.expect( NullPointerException.class );
+        template.retryOn( null );
+    }
+
+    @Test
+    public void shouldRetryOnError() throws Exception
+    {
+        IllegalArgumentException ex = new IllegalArgumentException();
+        template.execute( new FailingRetryConsumer( 3, ex ) );
+
+        assertThat( monitor.numRetry, is( 3 ) );
+        assertThat( monitor.failures, contains( ex, ex, ex ) );
+        assertThat( monitor.fails, empty() );
+    }
+
+    @Test
+    public void shouldFailIfAllRetiresFail() throws Exception
+    {
+        IllegalArgumentException ex = new IllegalArgumentException();
+        try
+        {
+            template.execute( new FailingRetryConsumer( 10, ex ) );
+        }
+        catch ( TransactionFailureException ignored )
+        {
+        }
+
+        assertThat( monitor.numRetry, is( 4 ) );
+        assertThat( monitor.failures, contains( ex, ex, ex, ex, ex ) );
+        assertThat( monitor.fails, contains( ex ) );
+    }
+
+    @Test
+    public void defaultExceptionsForExit() throws Exception
+    {
+        Error error = new Error();
+        TransactionTerminatedException terminatedException = new TransactionTerminatedException( Status.Transaction.TransactionTerminated );
+
+        try
+        {
+            template.execute( (Consumer<Transaction>) tx ->
+            {
+                throw error;
+            } );
+        }
+        catch ( TransactionFailureException ex )
+        {
+            // Expected
+        }
+
+        try
+        {
+            template.execute( (Consumer<Transaction>) tx ->
+            {
+                throw terminatedException;
+            } );
+        }
+        catch ( TransactionFailureException ignored )
+        {
+        }
+
+        assertThat( monitor.numRetry, is( 0 ) );
+        assertThat( monitor.failures, contains( error, terminatedException ) );
+        assertThat( monitor.fails, contains( error, terminatedException ) );
+    }
+
+    @Test
+    public void overrideRetryExceptions() throws Exception
+    {
+        template = template.retryOn( e -> !IllegalArgumentException.class.isInstance( e ) );
+        IllegalArgumentException e = new IllegalArgumentException();
+        try
+        {
+            template.execute( (Consumer<Transaction>) tx ->
+            {
+                throw e;
+            } );
+        }
+        catch ( TransactionFailureException ignored )
+        {
+        }
+
+        assertThat( monitor.numRetry, is( 0 ) );
+        assertThat( monitor.failures, contains( e ) );
+        assertThat( monitor.fails, contains( e ) );
+    }
+
+    @Test
+    public void overrideRetryShouldOverrideDefaults() throws Exception
+    {
+        template = template.retryOn( e -> !IllegalArgumentException.class.isInstance( e ) );
+
+        TransactionTerminatedException fakeException = new TransactionTerminatedException( Status.Transaction.TransactionTerminated );
+        template.execute( new FailingRetryConsumer( 1, fakeException ) );
+
+        assertThat( monitor.numRetry, is( 1 ) );
+        assertThat( monitor.failures, contains( fakeException ) );
+        assertThat( monitor.fails, empty() );
+    }
+
+    private static class FailingRetryConsumer implements Consumer<Transaction>
+    {
+        private final int successAfter;
+        private final RuntimeException fakeException;
+        private int tries;
+
+        private FailingRetryConsumer( int successAfter, RuntimeException fakeException )
+        {
+            this.successAfter = successAfter;
+            this.fakeException = fakeException;
+        }
+
+        @Override
+        public void accept( Transaction transaction )
+        {
+            if ( tries++ < successAfter )
+            {
+                throw fakeException;
+            }
+        }
+    }
+
+    private static class CountingMonitor implements TransactionTemplate.Monitor
+    {
+        int numRetry;
+        List<Throwable> fails = new ArrayList<>();
+        List<Throwable> failures = new ArrayList<>();
+
+        @Override
+        public void failure( Throwable ex )
+        {
+            failures.add( ex );
+        }
+
+        @Override
+        public void failed( Throwable ex )
+        {
+            fails.add( ex );
+        }
+
+        @Override
+        public void retrying()
+        {
+            numRetry++;
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/helpers/TransactionTemplateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/TransactionTemplateTest.java
@@ -73,13 +73,15 @@ public class TransactionTemplateTest
     public void validateRetires() throws Exception
     {
         expected.expect( IllegalArgumentException.class );
-        template.retries( 0 );
+        expected.expectMessage( "Number of retries must be greater than or equal to 0" );
+        template.retries( -1 );
     }
 
     @Test
     public void validateBackoff() throws Exception
     {
         expected.expect( IllegalArgumentException.class );
+        expected.expectMessage( "Backoff time must be a positive number" );
         template.backoff( -10, TimeUnit.SECONDS );
     }
 
@@ -120,8 +122,8 @@ public class TransactionTemplateTest
         {
         }
 
-        assertThat( monitor.numRetry, is( 4 ) );
-        assertThat( monitor.failures, contains( ex, ex, ex, ex, ex ) );
+        assertThat( monitor.numRetry, is( 5 ) );
+        assertThat( monitor.failures, contains( ex, ex, ex, ex, ex, ex ) ); // 5 retires results in 6 total failures
         assertThat( monitor.fails, contains( ex ) );
     }
 


### PR DESCRIPTION
`TransactionTemplate` has a monitor with method `failed()` that was never called. Now it's called when all the retires have failed. 

Fixes issue #4582