### PR TITLE
Don't remove reserved fields from document when clearing

### DIFF
--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/IndexType.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/IndexType.java
@@ -383,9 +383,12 @@ public abstract class IndexType
         Set<String> names = new HashSet<>();
         for ( IndexableField field : document.getFields() )
         {
-            names.add( field.name() );
+            String name = field.name();
+            if ( LuceneExplicitIndex.isValidKey( name ) )
+            {
+                names.add( name );
+            }
         }
-        names.remove( LuceneExplicitIndex.KEY_DOC_ID );
         for ( String name : names )
         {
             document.removeFields( name );


### PR DESCRIPTION
Before we only preserved `KEY_DOC_ID`, this became a problem when removing and adding a property on relationship indexes in the same transaction. Then we ended up in a state where the indexed document
didn't contain a start and end node.

This fixes issue #4294