### PR TITLE
Compute plan descriptions lazily

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/InternalExecutionResult.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/InternalExecutionResult.scala
@@ -47,6 +47,7 @@ trait InternalExecutionResult extends Iterator[Map[String, Any]] with QueryResul
 
   def planDescriptionRequested: Boolean
   def executionPlanDescription(): InternalPlanDescription
+
   def executionPlanString(): String = executionPlanDescription().toString
 
   def queryType: InternalQueryType

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/PipeDecorator.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/pipes/PipeDecorator.scala
@@ -30,7 +30,7 @@ trait PipeDecorator {
 
   def decorate(pipe: Pipe, iter: Iterator[ExecutionContext]): Iterator[ExecutionContext]
 
-  def decorate(plan: InternalPlanDescription, verifyProfileReady: () => Unit): InternalPlanDescription
+  def decorate(plan: () => InternalPlanDescription, verifyProfileReady: () => Unit): () => InternalPlanDescription
 
   /*
    * Returns the inner decorator of this decorator. The inner decorator is used for nested expressions
@@ -42,7 +42,7 @@ trait PipeDecorator {
 object NullPipeDecorator extends PipeDecorator {
   def decorate(pipe: Pipe, iter: Iterator[ExecutionContext]): Iterator[ExecutionContext] = iter
 
-  def decorate(plan: InternalPlanDescription, verifyProfileReady: () => Unit): InternalPlanDescription = plan
+  def decorate(plan: () => InternalPlanDescription, verifyProfileReady: () => Unit): () => InternalPlanDescription = plan
 
   def decorate(pipe: Pipe, state: QueryState): QueryState = state
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/profiler/Profiler.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/profiler/Profiler.scala
@@ -79,8 +79,8 @@ class Profiler(databaseInfo: DatabaseInfo = DatabaseInfo.COMMUNITY) extends Pipe
   }
 
   def decorate(plan: () => InternalPlanDescription, verifyProfileReady: () => Unit): () => InternalPlanDescription = {
-    verifyProfileReady()
-    () => {}
+    () => {
+      verifyProfileReady()
       plan() map {
         input: InternalPlanDescription =>
           val rows = rowStats.get(input.id).map(_.count).getOrElse(0L)
@@ -95,6 +95,7 @@ class Profiler(databaseInfo: DatabaseInfo = DatabaseInfo.COMMUNITY) extends Pipe
             .addArgument(Arguments.PageCacheMisses(misses))
             .addArgument(Arguments.PageCacheHitRatio(hitRatio))
       }
+    }
   }
 
   def innerDecorator(owningPipe: Pipe): PipeDecorator = new PipeDecorator {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/profiler/Profiler.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/profiler/Profiler.scala
@@ -78,23 +78,23 @@ class Profiler(databaseInfo: DatabaseInfo = DatabaseInfo.COMMUNITY) extends Pipe
     databaseInfo.edition != Edition.community
   }
 
-  def decorate(plan: InternalPlanDescription, verifyProfileReady: () => Unit): InternalPlanDescription = {
+  def decorate(plan: () => InternalPlanDescription, verifyProfileReady: () => Unit): () => InternalPlanDescription = {
     verifyProfileReady()
+    () => {}
+      plan() map {
+        input: InternalPlanDescription =>
+          val rows = rowStats.get(input.id).map(_.count).getOrElse(0L)
+          val dbHits = dbHitsStats.get(input.id).map(_.count).getOrElse(0L)
+          val (hits: Long, misses: Long) = pageCacheStats.getOrElse(input.id, (0L, 0L))
+          val hitRatio = MathUtil.portion(hits, misses)
 
-    plan map {
-      input: InternalPlanDescription =>
-        val rows = rowStats.get(input.id).map(_.count).getOrElse(0L)
-        val dbHits = dbHitsStats.get(input.id).map(_.count).getOrElse(0L)
-        val (hits: Long, misses: Long) = pageCacheStats.getOrElse(input.id, (0L, 0L))
-        val hitRatio = MathUtil.portion(hits, misses)
-
-        input
-          .addArgument(Arguments.Rows(rows))
-          .addArgument(Arguments.DbHits(dbHits))
-          .addArgument(Arguments.PageCacheHits(hits))
-          .addArgument(Arguments.PageCacheMisses(misses))
-          .addArgument(Arguments.PageCacheHitRatio(hitRatio))
-    }
+          input
+            .addArgument(Arguments.Rows(rows))
+            .addArgument(Arguments.DbHits(dbHits))
+            .addArgument(Arguments.PageCacheHits(hits))
+            .addArgument(Arguments.PageCacheMisses(misses))
+            .addArgument(Arguments.PageCacheHitRatio(hitRatio))
+      }
   }
 
   def innerDecorator(owningPipe: Pipe): PipeDecorator = new PipeDecorator {
@@ -107,7 +107,7 @@ class Profiler(databaseInfo: DatabaseInfo = DatabaseInfo.COMMUNITY) extends Pipe
 
     def decorate(pipe: Pipe, iter: Iterator[ExecutionContext]): Iterator[ExecutionContext] = iter
 
-    def decorate(plan: InternalPlanDescription, verifyProfileReady: () => Unit): InternalPlanDescription =
+    def decorate(plan: () => InternalPlanDescription, verifyProfileReady: () => Unit): () => InternalPlanDescription =
       outerProfiler.decorate(plan, verifyProfileReady)
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/profiler/ProfilerTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/profiler/ProfilerTest.scala
@@ -46,10 +46,10 @@ class ProfilerTest extends CypherFunSuite {
 
     //WHEN
     materialize(pipe.createResults(queryState))
-    val decoratedResult = profiler.decorate(planDescription, verifyProfileReady = () => {})
+    val decoratedResult = profiler.decorate(() => planDescription, verifyProfileReady = () => {})
 
     //THEN
-    assertRecorded(decoratedResult, "foo", expectedRows = 10, expectedDbHits = 20)
+    assertRecorded(decoratedResult(), "foo", expectedRows = 10, expectedDbHits = 20)
   }
 
   test("report page cache statistics for simplest case") {
@@ -64,10 +64,10 @@ class ProfilerTest extends CypherFunSuite {
 
     //WHEN
     materialize(pipe.createResults(queryState))
-    val decoratedResult = profiler.decorate(planDescription, verifyProfileReady = () => {})
+    val decoratedResult = profiler.decorate(() => planDescription, verifyProfileReady = () => {})
 
     //THEN
-    assertRecorded(decoratedResult, "foo", expectedRows = 10, expectedDbHits = 20,
+    assertRecorded(decoratedResult(), "foo", expectedRows = 10, expectedDbHits = 20,
       expectedPageCacheHits = 2, expectedPageCacheMisses = 7)
   }
 
@@ -91,12 +91,12 @@ class ProfilerTest extends CypherFunSuite {
 
     //WHEN
     materialize(pipe3.createResults(queryState))
-    val decoratedResult = profiler.decorate(planDescription, verifyProfileReady = () => {})
+    val decoratedResult = profiler.decorate(() => planDescription, verifyProfileReady = () => {})
 
     //THEN
-    assertRecorded(decoratedResult, "foo", expectedRows = 10, expectedDbHits = 25)
-    assertRecorded(decoratedResult, "bar", expectedRows = 20, expectedDbHits = 40)
-    assertRecorded(decoratedResult, "baz", expectedRows = 1, expectedDbHits = 2)
+    assertRecorded(decoratedResult(), "foo", expectedRows = 10, expectedDbHits = 25)
+    assertRecorded(decoratedResult(), "bar", expectedRows = 20, expectedDbHits = 40)
+    assertRecorded(decoratedResult(), "baz", expectedRows = 1, expectedDbHits = 2)
   }
 
   test("report page cache statistic for multiple pipes case") {
@@ -113,12 +113,12 @@ class ProfilerTest extends CypherFunSuite {
 
     //WHEN
     materialize(pipe3.createResults(queryState))
-    val decoratedResult = profiler.decorate(planDescription, verifyProfileReady = () => {})
+    val decoratedResult = profiler.decorate(() => planDescription, verifyProfileReady = () => {})
 
     //THEN
-    assertRecorded(decoratedResult, "foo", expectedRows = 10, expectedDbHits = 25, expectedPageCacheHits = 2, expectedPageCacheMisses = 7)
-    assertRecorded(decoratedResult, "bar", expectedRows = 20, expectedDbHits = 40, expectedPageCacheHits = 10, expectedPageCacheMisses = 28)
-    assertRecorded(decoratedResult, "baz", expectedRows = 1, expectedDbHits = 2, expectedPageCacheHits = 25, expectedPageCacheMisses = 33)
+    assertRecorded(decoratedResult(), "foo", expectedRows = 10, expectedDbHits = 25, expectedPageCacheHits = 2, expectedPageCacheMisses = 7)
+    assertRecorded(decoratedResult(), "bar", expectedRows = 20, expectedDbHits = 40, expectedPageCacheHits = 10, expectedPageCacheMisses = 28)
+    assertRecorded(decoratedResult(), "baz", expectedRows = 1, expectedDbHits = 2, expectedPageCacheHits = 25, expectedPageCacheMisses = 33)
   }
 
   test("should count stuff going through Apply multiple times") {
@@ -140,10 +140,10 @@ class ProfilerTest extends CypherFunSuite {
 
     // WHEN we create the results,
     materialize(apply.createResults(queryState))
-    val decoratedResult = profiler.decorate(planDescription, verifyProfileReady = () => {})
+    val decoratedResult = profiler.decorate(() => planDescription, verifyProfileReady = () => {})
 
     // THEN
-    assertRecorded(decoratedResult, "rhs", expectedRows = 10 * 20, expectedDbHits = 10 * 30)
+    assertRecorded(decoratedResult(), "rhs", expectedRows = 10 * 20, expectedDbHits = 10 * 30)
   }
 
   test("count dbhits for NestedPipes") {
@@ -168,10 +168,10 @@ class ProfilerTest extends CypherFunSuite {
 
     // WHEN we create the results,
     materialize(pipeUnderInspection.createResults(queryState))
-    val decoratedResult = profiler.decorate(planDescription, verifyProfileReady = () => {})
+    val decoratedResult = profiler.decorate(() => planDescription, verifyProfileReady = () => {})
 
     // THEN the ProjectionNewPipe has correctly recorded the dbhits
-    assertRecorded(decoratedResult, "Projection", expectedRows = 1, expectedDbHits = DB_HITS)
+    assertRecorded(decoratedResult(), "Projection", expectedRows = 1, expectedDbHits = DB_HITS)
   }
 
   test("count page cache hits for NestedPipes") {
@@ -196,10 +196,10 @@ class ProfilerTest extends CypherFunSuite {
 
     // WHEN we create the results,
     materialize(pipeUnderInspection.createResults(queryState))
-    val decoratedResult = profiler.decorate(planDescription, verifyProfileReady = () => {})
+    val decoratedResult = profiler.decorate(() => planDescription, verifyProfileReady = () => {})
 
     // THEN the ProjectionNewPipe has correctly recorded the page cache hits
-    assertRecorded(decoratedResult, "Projection", expectedRows = 1, expectedDbHits = 2, expectedPageCacheHits = 3, expectedPageCacheMisses = 4)
+    assertRecorded(decoratedResult(), "Projection", expectedRows = 1, expectedDbHits = 2, expectedPageCacheHits = 3, expectedPageCacheMisses = 4)
   }
 
   test("count dbhits for deeply nested NestedPipes") {
@@ -232,10 +232,10 @@ class ProfilerTest extends CypherFunSuite {
       "innerInner" -> innerInnerPipe,
       "Projection" -> pipeUnderInspection
     )
-    val decoratedResult = profiler.decorate(description, verifyProfileReady = () => {})
+    val decoratedResult = profiler.decorate(() => description, verifyProfileReady = () => {})
 
     // THEN the ProjectionNewPipe has correctly recorded the dbhits
-    assertRecorded(decoratedResult, "Projection", expectedRows = 1, expectedDbHits = DB_HITS * 2)
+    assertRecorded(decoratedResult(), "Projection", expectedRows = 1, expectedDbHits = DB_HITS * 2)
   }
 
   test("should not count rows multiple times when the same pipe is used multiple times") {

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/CodeGenerator.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/CodeGenerator.scala
@@ -66,11 +66,15 @@ class CodeGenerator(val structure: CodeStructure[GeneratedQuery], clock: Clock, 
             None
         }
 
-        val descriptionTree = LogicalPlan2PlanDescription(plan, plannerName)
-        val description: InternalPlanDescription = query.code.foldLeft(descriptionTree) {
-          case (descriptionRoot, code) => descriptionRoot.addArgument(code)
-        }.addArgument(Runtime(CompiledRuntimeName.toTextOutput))
-          .addArgument(RuntimeImpl(CompiledRuntimeName.name))
+        val description = new Provider[InternalPlanDescription] {
+          override def get(): InternalPlanDescription = {
+            val d = LogicalPlan2PlanDescription(plan, plannerName)
+            query.code.foldLeft(d) {
+              case (descriptionRoot, code) => descriptionRoot.addArgument(code)
+            }.addArgument(Runtime(CompiledRuntimeName.toTextOutput))
+              .addArgument(RuntimeImpl(CompiledRuntimeName.name))
+          }
+        }
 
         val builder = new RunnablePlan {
           def apply(queryContext: QueryContext, execMode: ExecutionMode,


### PR DESCRIPTION
Turns out, computing the plan description is not free. It is 
actually quite expensive. For simple queries like `MATCH (n) RETURN n.prop`,
we spend 10% of the time creating the plan description even though we rarely
need it. Changes so that plan descriptions are computed lazily when asked for 
instead of on every executed query.
