### PR TITLE
Consolidate the Config instances

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Config.java
@@ -280,6 +280,8 @@ public class Config implements DiagnosticsProvider, Configuration
     /**
      * Augment the existing config with new settings, overriding any conflicting settings, but keeping all old
      * non-overlapping ones.
+     * <p>
+     * Note that this method can <em>only</em> be used before the database has started.
      *
      * @param changes settings to add and override
      */
@@ -287,6 +289,24 @@ public class Config implements DiagnosticsProvider, Configuration
     {
         Map<String,String> params = new HashMap<>( this.params );
         params.putAll( changes );
+        replaceSettings( params, false );
+        return this;
+    }
+
+    /**
+     * Augment the existing config with a new setting, overriding any existing setting by that name, but keeping all old
+     * non-overlapping ones.
+     * <p>
+     * Note that this method can <em>only</em> be used before the database has started.
+     *
+     * @param settingName The name of the setting to change.
+     * @param value The new value for the setting.
+     * @return This Config instance.
+     */
+    public Config augment( String settingName, String value )
+    {
+        Map<String,String> params = new HashMap<>( this.params );
+        params.put( settingName, value );
         replaceSettings( params, false );
         return this;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.impl.factory;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Map;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.security.URLAccessRule;
@@ -110,13 +109,6 @@ public class PlatformModule
     public final SystemNanoClock clock;
 
     public final StoreCopyCheckPointMutex storeCopyCheckPointMutex;
-
-    public PlatformModule( File providedStoreDir, Map<String,String> params, DatabaseInfo databaseInfo,
-            GraphDatabaseFacadeFactory.Dependencies externalDependencies, GraphDatabaseFacade graphDatabaseFacade )
-    {
-        this( providedStoreDir, Config.embeddedDefaults().with( params ), databaseInfo, externalDependencies,
-                graphDatabaseFacade );
-    }
 
     public PlatformModule( File providedStoreDir, Config config, DatabaseInfo databaseInfo,
             GraphDatabaseFacadeFactory.Dependencies externalDependencies, GraphDatabaseFacade graphDatabaseFacade )

--- a/community/kernel/src/test/java/org/neo4j/test/ImpermanentGraphDatabase.java
+++ b/community/kernel/src/test/java/org/neo4j/test/ImpermanentGraphDatabase.java
@@ -43,7 +43,6 @@ import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
 
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
-import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.GraphDatabaseDependencies.newDependencies;
 import static org.neo4j.kernel.configuration.Settings.TRUE;
 import static org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory.Configuration.ephemeral;
@@ -184,21 +183,8 @@ public class ImpermanentGraphDatabase extends EmbeddedGraphDatabase
 
     private static Config withForcedInMemoryConfiguration( Config config )
     {
-        return config.with( stringMap( ephemeral.name(), TRUE ) )
-                .withDefaults( stringMap( pagecache_memory.name(), "8M" ) );
+        return config.augment( ephemeral.name(), TRUE ).augment( pagecache_memory.name(), "8M" );
     }
-
-    /*private static Map<String, String> withForcedInMemoryConfiguration( Map<String, String> params )
-    {
-        Map<String, String> result = new HashMap<>( params );
-        // To signal to index provides that we should be in-memory
-        result.put( ephemeral.name(), TRUE );
-        if ( !result.containsKey( pagecache_memory.name() ) )
-        {
-            result.put( pagecache_memory.name(), "8M" );
-        }
-        return result;
-    }*/
 
     protected static class ImpermanentPlatformModule extends PlatformModule
     {
@@ -206,7 +192,7 @@ public class ImpermanentGraphDatabase extends EmbeddedGraphDatabase
                                           Dependencies dependencies,
                                           GraphDatabaseFacade graphDatabaseFacade )
         {
-            super( storeDir, withForcedInMemoryConfiguration(config), databaseInfo, dependencies, graphDatabaseFacade );
+            super( storeDir, withForcedInMemoryConfiguration( config ), databaseInfo, dependencies, graphDatabaseFacade );
         }
 
         @Override

--- a/enterprise/kernel/src/main/java/org/neo4j/graphdb/factory/EnterpriseGraphDatabaseFactory.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/graphdb/factory/EnterpriseGraphDatabaseFactory.java
@@ -52,7 +52,7 @@ public class EnterpriseGraphDatabaseFactory extends GraphDatabaseFactory
             public GraphDatabaseService newDatabase( Config config )
             {
                 return new EnterpriseGraphDatabase( storeDir,
-                        config.with( stringMap( "unsupported.dbms.ephemeral", "false" ) ),
+                        config.augment( stringMap( "unsupported.dbms.ephemeral", "false" ) ),
                         state.databaseDependencies() );
             }
         };

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseBootstrapper.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseBootstrapper.java
@@ -35,10 +35,10 @@ import org.neo4j.server.NeoServer;
 public class EnterpriseBootstrapper extends CommunityBootstrapper
 {
     @Override
-    protected NeoServer createNeoServer( Config configurator, GraphDatabaseDependencies dependencies,
+    protected NeoServer createNeoServer( Config config, GraphDatabaseDependencies dependencies,
             LogProvider userLogProvider )
     {
-        return new EnterpriseNeoServer( configurator, dependencies, userLogProvider );
+        return new EnterpriseNeoServer( config, dependencies, userLogProvider );
     }
 
     @Override

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/EnterpriseBootstrapperTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/EnterpriseBootstrapperTest.java
@@ -167,11 +167,11 @@ public class EnterpriseBootstrapperTest extends BaseBootstrapperTest
         private LogProvider userLogProvider;
 
         @Override
-        protected NeoServer createNeoServer( Config configurator, GraphDatabaseDependencies dependencies,
-                LogProvider userLogProvider )
+        protected NeoServer createNeoServer( Config config, GraphDatabaseDependencies dependencies,
+                                             LogProvider userLogProvider )
         {
             this.userLogProvider = userLogProvider;
-            return super.createNeoServer( configurator, dependencies, userLogProvider );
+            return super.createNeoServer( config, dependencies, userLogProvider );
         }
 
         LogProvider getUserLogProvider()


### PR DESCRIPTION
`Config` increasingly has identity, and is moving further and further away from being an immutable value. Therefor, we need to make sure that we only have one `Config` instance at runtime.