### PR TITLE
Have systemd treat exit code 143 as success

### DIFF
--- a/new-packaging/src/common/neo4j.service
+++ b/new-packaging/src/common/neo4j.service
@@ -11,6 +11,7 @@ Group=neo4j
 Environment="NEO4J_CONF=/etc/neo4j" "NEO4J_HOME=/var/lib/neo4j"
 LimitNOFILE=60000
 TimeoutSec=120
+SuccessExitStatus=143
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
changelog: Have systemd treat exit code 143 as success

Since java exits with code 143 when stopped the service should treat
this as a graceful exit.