### PR TITLE
Preserve utf8 from Bolt

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPack.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPack.java
@@ -32,11 +32,11 @@ import org.neo4j.bolt.v1.packstream.PackStream;
 import org.neo4j.bolt.v1.packstream.PackType;
 import org.neo4j.bolt.v1.runtime.Neo4jError;
 import org.neo4j.collection.primitive.PrimitiveLongIntKeyValueArray;
-import org.neo4j.kernel.impl.util.BaseToObjectValueWriter;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.spatial.Point;
 import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.impl.util.BaseToObjectValueWriter;
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.AnyValueWriter;
 import org.neo4j.values.storable.TextArray;
@@ -427,7 +427,7 @@ public class Neo4jPack
             case BYTES:
                 return byteArray( unpackBytes() );
             case STRING:
-                return Values.stringValue( unpackString() );
+                return Values.utf8Value( unpackUTF8() );
             case INTEGER:
                 return Values.longValue( unpackLong() );
             case FLOAT:

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/Neo4jPackTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/Neo4jPackTest.java
@@ -36,6 +36,7 @@ import org.neo4j.bolt.v1.runtime.Neo4jError;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.impl.util.ValueUtils;
 import org.neo4j.values.AnyValue;
+import org.neo4j.values.storable.StringValue;
 import org.neo4j.values.storable.TextArray;
 import org.neo4j.values.storable.TextValue;
 import org.neo4j.values.storable.Values;
@@ -47,6 +48,7 @@ import org.neo4j.values.virtual.VirtualValues;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.neo4j.bolt.v1.messaging.example.Edges.ALICE_KNOWS_BOB;
 import static org.neo4j.bolt.v1.messaging.example.Nodes.ALICE;
 import static org.neo4j.bolt.v1.messaging.example.Paths.ALL_PATHS;
@@ -252,6 +254,7 @@ public class Neo4jPackTest
 
         // When
         AnyValue unpacked = unpacked( output.bytes() );
+        assertThat( unpacked, is( instanceOf( StringValue.UTF8StringValue.class ) ));
 
         // Then
         assertThat( unpacked, equalTo( textValue ) );

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/commands/expressions/Add.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/commands/expressions/Add.scala
@@ -19,13 +19,15 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.commands.expressions
 
-import org.neo4j.cypher.internal.util.v3_4.CypherTypeException
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.ExecutionContext
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.helpers.{IsList, TypeSafeMathSupport}
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.pipes.QueryState
+import org.neo4j.cypher.internal.util.v3_4.CypherTypeException
 import org.neo4j.cypher.internal.util.v3_4.symbols._
 import org.neo4j.values._
+import org.neo4j.values.storable.StringValue.UTF8StringValue
 import org.neo4j.values.storable._
+import org.neo4j.values.utils.UTF8Utils
 import org.neo4j.values.virtual.VirtualValues
 
 case class Add(a: Expression, b: Expression) extends Expression with TypeSafeMathSupport {
@@ -37,6 +39,7 @@ case class Add(a: Expression, b: Expression) extends Expression with TypeSafeMat
       case (x, y) if x == Values.NO_VALUE || y == Values.NO_VALUE => Values.NO_VALUE
       case (x: IntegralValue, y: IntegralValue) => Values.longValue(StrictMath.addExact(x.longValue(),y.longValue()))
       case (x: NumberValue, y: NumberValue) => Values.doubleValue(x.doubleValue() + y.doubleValue())
+      case (x: UTF8StringValue, y: UTF8StringValue) => UTF8Utils.add(x, y)
       case (x: TextValue, y: TextValue) => Values.stringValue(x.stringValue() + y.stringValue())
       case (IsList(x), IsList(y)) => VirtualValues.concat(x, y)
       case (IsList(x), y)         => VirtualValues.appendToList(x, y)

--- a/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
@@ -183,6 +183,11 @@ public abstract class StringValue extends TextValue
         {
             return value().length();
         }
+
+        public byte[] bytes()
+        {
+            return bytes;
+        }
     }
 }
 

--- a/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
@@ -20,6 +20,7 @@
 package org.neo4j.values.storable;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 
 import static java.lang.String.format;
 
@@ -120,11 +121,11 @@ public abstract class StringValue extends TextValue
      * Just as a normal StringValue but is backed by a byte array and does string
      * serialization lazily.
       *
-      * TODO in this implementation most operation will actually load the string
-      * such as hashCode, length, equals etc. These could be implemented using
-      * the byte array directly
+      * TODO in this implementation most operations will actually load the string
+      * such as hashCode, length. These could be implemented using
+      * the byte array directly in later optimizations
      */
-    static final class UTF8StringValue extends StringValue
+    public static final class UTF8StringValue extends StringValue
     {
         private volatile String value;
         private final byte[] bytes;
@@ -143,6 +144,19 @@ public abstract class StringValue extends TextValue
         public <E extends Exception> void writeTo( ValueWriter<E> writer ) throws E
         {
             writer.writeUTF8( bytes, offset, length );
+        }
+
+        @Override
+        public boolean equals( Value value )
+        {
+            if ( value instanceof UTF8StringValue )
+            {
+                return Arrays.equals( bytes, ((UTF8StringValue) value).bytes );
+            }
+            else
+            {
+                return super.equals( value );
+            }
         }
 
         @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/Values.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Values.java
@@ -23,6 +23,8 @@ import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Comparator;
 
+import org.neo4j.values.storable.StringValue.UTF8StringValue;
+
 import static java.lang.String.format;
 
 /**
@@ -107,14 +109,14 @@ public final class Values
 
     public static final Value NO_VALUE = NoValue.NO_VALUE;
 
-    public static TextValue utf8Value( byte[] bytes )
+    public static UTF8StringValue utf8Value( byte[] bytes )
     {
         return utf8Value( bytes, 0, bytes.length );
     }
 
-    public static TextValue utf8Value( byte[] bytes, int offset, int length )
+    public static UTF8StringValue utf8Value( byte[] bytes, int offset, int length )
     {
-        return new StringValue.UTF8StringValue( bytes, offset, length );
+        return new UTF8StringValue( bytes, offset, length );
     }
 
     public static TextValue stringValue( String value )

--- a/community/values/src/main/java/org/neo4j/values/utils/UTF8Utils.java
+++ b/community/values/src/main/java/org/neo4j/values/utils/UTF8Utils.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.utils;
+
+import org.neo4j.values.storable.StringValue.UTF8StringValue;
+
+import static org.neo4j.values.storable.Values.utf8Value;
+
+/**
+ * Utility class for operations on utf-8 values.
+ */
+public final class UTF8Utils
+{
+    private UTF8Utils()
+    {
+        throw new UnsupportedOperationException( "Do not instantiate" );
+    }
+
+    /**
+     * Add two values.
+     * @param a value to add
+     * @param b value to add
+     * @return the value a + b
+     */
+    public static UTF8StringValue add( UTF8StringValue a, UTF8StringValue b )
+    {
+        byte[] bytesA = a.bytes();
+        byte[] bytesB = b.bytes();
+
+        byte[] bytes = new byte[bytesA.length + bytesB.length];
+        System.arraycopy( bytesA, 0, bytes, 0, bytesA.length );
+        System.arraycopy( bytesB, 0, bytes, bytesA.length, bytesB.length );
+        return utf8Value(bytes);
+    }
+}


### PR DESCRIPTION
There is no need to directly convert string values coming from
Bolt to `java.lang.String` directly, we can preserve it as a
`UTF8StringValue` until we actually need the value. Currently
this will not give much in performance except for queries like
`RETURN 'hello world'`, since most string operations currently
requires an actual string instance. However going forward we can
be smarter about preserving the `UTF8StringValue`.