### PR TITLE
Cleanups around Config and friends

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
@@ -262,7 +262,8 @@ public class ConsistencyCheckService
             }
             storeAccess.initialize();
             DirectStoreAccess stores = new DirectStoreAccess( storeAccess, labelScanStore, indexes );
-            FullCheck check = new FullCheck( progressFactory, statistics, numberOfThreads, checkConsistencyConfig );
+            FullCheck check = new FullCheck(
+                    progressFactory, statistics, numberOfThreads, checkConsistencyConfig, config );
             summary = check.execute( stores, new DuplicatingLog( log, reportLog ) );
         }
         finally

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/FullCheck.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/FullCheck.java
@@ -63,19 +63,19 @@ public class FullCheck
     private final int threads;
     private final Statistics statistics;
 
-    public FullCheck( Config tuningConfiguration, ProgressMonitorFactory progressFactory,
+    public FullCheck( Config config, ProgressMonitorFactory progressFactory,
             Statistics statistics, int threads )
     {
-        this( progressFactory, statistics, threads, new CheckConsistencyConfig( tuningConfiguration ) );
+        this( progressFactory, statistics, threads, new CheckConsistencyConfig( config ), config );
     }
 
     public FullCheck( ProgressMonitorFactory progressFactory, Statistics statistics, int threads,
-            CheckConsistencyConfig checkConsistencyConfig )
+                      CheckConsistencyConfig checkConsistencyConfig, Config config )
     {
         this.statistics = statistics;
         this.threads = threads;
         this.progressFactory = progressFactory;
-        this.samplingConfig = new IndexSamplingConfig( Config.defaults() );
+        this.samplingConfig = new IndexSamplingConfig( config );
         this.checkGraph = checkConsistencyConfig.isCheckGraph();
         this.checkIndexes = checkConsistencyConfig.isCheckIndexes();
         this.checkLabelScanStore = checkConsistencyConfig.isCheckLabelScanStore();

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/GraphStoreFixture.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/GraphStoreFixture.java
@@ -64,6 +64,7 @@ import org.neo4j.kernel.impl.store.NodeLabelsField;
 import org.neo4j.kernel.impl.store.NodeStore;
 import org.neo4j.kernel.impl.store.StoreAccess;
 import org.neo4j.kernel.impl.store.StoreFactory;
+import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.NeoStoreRecord;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
@@ -162,7 +163,10 @@ public abstract class GraphStoreFixture extends ConfigurablePageCacheRule implem
             fileSystem = new DefaultFileSystemAbstraction();
             PageCache pageCache = getPageCache( fileSystem );
             LogProvider logProvider = NullLogProvider.getInstance();
-            StoreFactory storeFactory = new StoreFactory( directory, pageCache, fileSystem, logProvider );
+            Config config = Config.defaults();
+            DefaultIdGeneratorFactory idGeneratorFactory = new DefaultIdGeneratorFactory( fileSystem );
+            StoreFactory storeFactory = new StoreFactory(
+                    directory, config, idGeneratorFactory, pageCache, fileSystem, logProvider );
             neoStore = storeFactory.openAllNeoStores();
             StoreAccess nativeStores;
             if ( keepStatistics )
@@ -179,7 +183,6 @@ public abstract class GraphStoreFixture extends ConfigurablePageCacheRule implem
             }
             nativeStores.initialize();
 
-            Config config = Config.defaults();
             IndexStoreView indexStoreView =
                     new NeoStoreIndexStoreView( LockService.NO_LOCK_SERVICE, nativeStores.getRawNeoStores() );
 

--- a/community/kernel/src/main/java/org/neo4j/helpers/Listeners.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Listeners.java
@@ -23,7 +23,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
-import javax.annotation.Nonnull;
 
 import static java.util.Collections.emptyList;
 import static java.util.Objects.requireNonNull;
@@ -50,7 +49,7 @@ public class Listeners<T> implements Iterable<T>
      *
      * @param other listeners to copy.
      */
-    public Listeners( @Nonnull Listeners<T> other )
+    public Listeners( Listeners<T> other )
     {
         requireNonNull( other, "prototype listeners can't be null" );
 
@@ -62,7 +61,7 @@ public class Listeners<T> implements Iterable<T>
      *
      * @param listener the listener to add.
      */
-    public void add( @Nonnull T listener )
+    public void add( T listener )
     {
         requireNonNull( listener, "added listener can't be null" );
 
@@ -74,7 +73,7 @@ public class Listeners<T> implements Iterable<T>
      *
      * @param listener the listener to remove.
      */
-    public void remove( @Nonnull T listener )
+    public void remove( T listener )
     {
         requireNonNull( listener, "removed listener can't be null" );
 
@@ -87,7 +86,7 @@ public class Listeners<T> implements Iterable<T>
      *
      * @param notification the notification to be applied to each listener.
      */
-    public void notify( @Nonnull Notification<T> notification )
+    public void notify( Notification<T> notification )
     {
         requireNonNull( notification, "notification can't be null" );
 
@@ -105,7 +104,7 @@ public class Listeners<T> implements Iterable<T>
      * @param executor the executor to submit notifications to.
      * @param notification the notification to be applied to each listener.
      */
-    public void notify( @Nonnull Executor executor, @Nonnull Notification<T> notification )
+    public void notify( Executor executor, Notification<T> notification )
     {
         requireNonNull( executor, "executor can't be null" );
         requireNonNull( notification, "notification can't be null" );

--- a/community/kernel/src/main/java/org/neo4j/helpers/Listeners.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Listeners.java
@@ -26,7 +26,6 @@ import java.util.concurrent.Executor;
 import javax.annotation.Nonnull;
 
 import static java.util.Collections.emptyList;
-import static java.util.Objects.requireNonNull;
 
 /**
  * Mutable thread-safe container of listeners that can be notified with {@link Notification}.
@@ -55,6 +54,14 @@ public class Listeners<T> implements Iterable<T>
         requireNonNull( other, "prototype listeners can't be null" );
 
         this.listeners = createListeners( other.listeners );
+    }
+
+    private void requireNonNull( Object obj, String message )
+    {
+        if ( obj == null )
+        {
+            throw new IllegalArgumentException( message );
+        }
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/helpers/Listeners.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Listeners.java
@@ -26,6 +26,7 @@ import java.util.concurrent.Executor;
 import javax.annotation.Nonnull;
 
 import static java.util.Collections.emptyList;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Mutable thread-safe container of listeners that can be notified with {@link Notification}.
@@ -54,14 +55,6 @@ public class Listeners<T> implements Iterable<T>
         requireNonNull( other, "prototype listeners can't be null" );
 
         this.listeners = createListeners( other.listeners );
-    }
-
-    private void requireNonNull( Object obj, String message )
-    {
-        if ( obj == null )
-        {
-            throw new IllegalArgumentException( message );
-        }
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.impl.factory;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Map;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.security.URLAccessRule;
@@ -116,13 +115,6 @@ public class PlatformModule
     public final StoreCopyCheckPointMutex storeCopyCheckPointMutex;
 
     public final RecoveryCleanupWorkCollector recoveryCleanupWorkCollector;
-
-    public PlatformModule( File providedStoreDir, Map<String,String> params, DatabaseInfo databaseInfo,
-            GraphDatabaseFacadeFactory.Dependencies externalDependencies, GraphDatabaseFacade graphDatabaseFacade )
-    {
-        this( providedStoreDir, Config.defaults( params ), databaseInfo, externalDependencies,
-                graphDatabaseFacade );
-    }
 
     public PlatformModule( File providedStoreDir, Config config, DatabaseInfo databaseInfo,
             GraphDatabaseFacadeFactory.Dependencies externalDependencies, GraphDatabaseFacade graphDatabaseFacade )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexAccessor.java
@@ -37,6 +37,7 @@ import org.neo4j.kernel.api.index.PropertyAccessor;
 import org.neo4j.kernel.api.index.SchemaIndexProvider;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
+import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.storageengine.api.schema.IndexReader;
 
 import static org.neo4j.helpers.collection.Iterators.asResourceIterator;
@@ -47,13 +48,22 @@ public class NativeSchemaNumberIndexAccessor<KEY extends SchemaNumberKey, VALUE 
         extends NativeSchemaNumberIndex<KEY,VALUE> implements IndexAccessor
 {
     private final NativeSchemaNumberIndexUpdater<KEY,VALUE> singleUpdater;
+    private final IndexSamplingConfig samplingConfig;
 
-    NativeSchemaNumberIndexAccessor( PageCache pageCache, FileSystemAbstraction fs, File storeFile,
-            Layout<KEY,VALUE> layout, RecoveryCleanupWorkCollector recoveryCleanupWorkCollector, SchemaIndexProvider.Monitor monitor,
-            IndexDescriptor descriptor, long indexId ) throws IOException
+    NativeSchemaNumberIndexAccessor(
+            PageCache pageCache,
+            FileSystemAbstraction fs,
+            File storeFile,
+            Layout<KEY,VALUE> layout,
+            RecoveryCleanupWorkCollector recoveryCleanupWorkCollector,
+            SchemaIndexProvider.Monitor monitor,
+            IndexDescriptor descriptor,
+            long indexId,
+            IndexSamplingConfig samplingConfig ) throws IOException
     {
         super( pageCache, fs, storeFile, layout, monitor, descriptor, indexId );
         singleUpdater = new NativeSchemaNumberIndexUpdater<>( layout.newKey(), layout.newValue() );
+        this.samplingConfig = samplingConfig;
         instantiateTree( recoveryCleanupWorkCollector, NO_HEADER_WRITER );
     }
 
@@ -95,7 +105,7 @@ public class NativeSchemaNumberIndexAccessor<KEY extends SchemaNumberKey, VALUE 
     public IndexReader newReader()
     {
         assertOpen();
-        return new NativeSchemaNumberIndexReader<>( tree, layout );
+        return new NativeSchemaNumberIndexReader<>( tree, layout, samplingConfig );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProvider.java
@@ -89,8 +89,8 @@ public class NativeSchemaNumberIndexProvider extends SchemaIndexProvider
     }
 
     @Override
-    public IndexAccessor getOnlineAccessor( long indexId, IndexDescriptor descriptor, IndexSamplingConfig samplingConfig )
-            throws IOException
+    public IndexAccessor getOnlineAccessor(
+            long indexId, IndexDescriptor descriptor, IndexSamplingConfig samplingConfig ) throws IOException
     {
         File storeFile = nativeIndexFileFromIndexId( indexId );
         NumberLayout layout;
@@ -105,8 +105,9 @@ public class NativeSchemaNumberIndexProvider extends SchemaIndexProvider
         default:
             throw new UnsupportedOperationException( "Can not create index accessor of type " + descriptor.type() );
         }
-        return new NativeSchemaNumberIndexAccessor<>( pageCache, fs, storeFile, layout, recoveryCleanupWorkCollector, monitor, descriptor,
-                indexId );
+        return new NativeSchemaNumberIndexAccessor<>(
+                pageCache, fs, storeFile, layout, recoveryCleanupWorkCollector, monitor, descriptor, indexId,
+                samplingConfig );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexReader.java
@@ -35,7 +35,6 @@ import org.neo4j.kernel.api.exceptions.index.IndexNotApplicableKernelException;
 import org.neo4j.kernel.api.schema.IndexQuery;
 import org.neo4j.kernel.api.schema.IndexQuery.ExactPredicate;
 import org.neo4j.kernel.api.schema.IndexQuery.NumberRangePredicate;
-import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.storageengine.api.schema.IndexSampler;
@@ -47,12 +46,15 @@ class NativeSchemaNumberIndexReader<KEY extends SchemaNumberKey, VALUE extends S
 {
     private final GBPTree<KEY,VALUE> tree;
     private final Layout<KEY,VALUE> layout;
+    private final IndexSamplingConfig samplingConfig;
     private final Set<RawCursor<Hit<KEY,VALUE>,IOException>> openSeekers;
 
-    NativeSchemaNumberIndexReader( GBPTree<KEY,VALUE> tree, Layout<KEY,VALUE> layout )
+    NativeSchemaNumberIndexReader(
+            GBPTree<KEY,VALUE> tree, Layout<KEY,VALUE> layout, IndexSamplingConfig samplingConfig )
     {
         this.tree = tree;
         this.layout = layout;
+        this.samplingConfig = samplingConfig;
         this.openSeekers = new HashSet<>();
     }
 
@@ -72,9 +74,8 @@ class NativeSchemaNumberIndexReader<KEY extends SchemaNumberKey, VALUE extends S
         // non-unique sampler which scans the index and counts (potentially duplicates, of which there will
         // be none in a unique index).
 
-        IndexSamplingConfig indexSamplingConfig = new IndexSamplingConfig( Config.defaults() );
         FullScanNonUniqueIndexSampler<KEY,VALUE> sampler =
-                new FullScanNonUniqueIndexSampler<>( tree, layout, indexSamplingConfig );
+                new FullScanNonUniqueIndexSampler<>( tree, layout, samplingConfig );
         return sampler::result;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreAccess.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreAccess.java
@@ -72,11 +72,6 @@ public class StoreAccess
         this.counts = store.getCounts();
     }
 
-    public StoreAccess( FileSystemAbstraction fileSystem, PageCache pageCache, File storeDir )
-    {
-        this( fileSystem, pageCache, storeDir, Config.defaults() );
-    }
-
     public StoreAccess( FileSystemAbstraction fileSystem, PageCache pageCache, File storeDir, Config config )
     {
         this( new StoreFactory( storeDir, config, new DefaultIdGeneratorFactory( fileSystem ), pageCache,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/StoreFactory.java
@@ -27,11 +27,11 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.store.format.RecordFormatPropertyConfigurator;
-import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
-import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.logging.LogProvider;
+
+import static org.neo4j.kernel.impl.store.format.RecordFormatSelector.selectForStoreOrConfig;
 
 /**
  * Factory for Store implementations. Can also be used to create empty stores.
@@ -70,24 +70,11 @@ public class StoreFactory
     private final RecordFormats recordFormats;
     private final OpenOption[] openOptions;
 
-    public StoreFactory( File storeDir, PageCache pageCache, FileSystemAbstraction fileSystem, LogProvider logProvider )
-    {
-        this( storeDir, Config.defaults(), new DefaultIdGeneratorFactory( fileSystem ), pageCache, fileSystem,
-                logProvider );
-    }
-
-    public StoreFactory( File storeDir, PageCache pageCache, FileSystemAbstraction fileSystem,
-            RecordFormats recordFormats, LogProvider logProvider )
-    {
-        this( storeDir, Config.defaults(), new DefaultIdGeneratorFactory( fileSystem ), pageCache, fileSystem,
-                recordFormats, logProvider );
-    }
-
     public StoreFactory( File storeDir, Config config, IdGeneratorFactory idGeneratorFactory, PageCache pageCache,
             FileSystemAbstraction fileSystemAbstraction, LogProvider logProvider )
     {
         this( storeDir, config, idGeneratorFactory, pageCache, fileSystemAbstraction,
-                RecordFormatSelector.selectForStoreOrConfig( config, storeDir, fileSystemAbstraction, pageCache, logProvider ),
+                selectForStoreOrConfig( config, storeDir, fileSystemAbstraction, pageCache, logProvider ),
                 logProvider );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/FreeIdKeeper.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/FreeIdKeeper.java
@@ -94,6 +94,11 @@ public class FreeIdKeeper implements Closeable
         this.freeIdCount = stackPosition / ID_ENTRY_SIZE;
     }
 
+    static long countFreeIds( StoreChannel channel ) throws IOException
+    {
+        return channel.size() / ID_ENTRY_SIZE;
+    }
+
     public void freeId( long id )
     {
         freeIds.add( id );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdContainer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdContainer.java
@@ -161,6 +161,14 @@ public class IdContainer
         }
     }
 
+    static long readDefragCount( FileSystemAbstraction fileSystem, File file ) throws IOException
+    {
+        try ( StoreChannel channel = fileSystem.open( file, "r" ) )
+        {
+            return FreeIdKeeper.countFreeIds( new OffsetChannel( channel, HEADER_SIZE ) );
+        }
+    }
+
     private void markAsSticky() throws IOException
     {
         ByteBuffer buffer = ByteBuffer.allocate( Byte.BYTES );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGeneratorImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGeneratorImpl.java
@@ -262,11 +262,33 @@ public class IdGeneratorImpl implements IdGenerator
         IdContainer.createEmptyIdFile( fs, fileName, highId, throwIfFileExists );
     }
 
+    /**
+     * Read the high-id count from the given id-file.
+     *
+     * Note that this method should only be used when the file is not currently in use by an IdGenerator, since this
+     * method does not take any in-memory state into account.
+     *
+     * @param fileSystem The file system to use for accessing the given file.
+     * @param file The path to the id-file from which to read the high-id.
+     * @return The high-id from the given file.
+     * @throws IOException If anything goes wrong when accessing the file, for instance if the file does not exist.
+     */
     public static long readHighId( FileSystemAbstraction fileSystem, File file ) throws IOException
     {
         return IdContainer.readHighId( fileSystem, file );
     }
 
+    /**
+     * Read the defragmented id count from the given id-file.
+     *
+     * Note that this method should only be used when the file is not currently in use by an IdGenerator, since this
+     * method does not take any in-memory state into account.
+     *
+     * @param fileSystem The file system to use for accessing the given file.
+     * @param file The path to the id-file from which to read the defrag count.
+     * @return The number of defragmented ids in the id-file.
+     * @throws IOException If anything goes wrong when accessing the file, for instance if the file does not exist.
+     */
     public static long readDefragCount( FileSystemAbstraction fileSystem, File file ) throws IOException
     {
         return IdContainer.readDefragCount( fileSystem, file );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGeneratorImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGeneratorImpl.java
@@ -267,6 +267,11 @@ public class IdGeneratorImpl implements IdGenerator
         return IdContainer.readHighId( fileSystem, file );
     }
 
+    public static long readDefragCount( FileSystemAbstraction fileSystem, File file ) throws IOException
+    {
+        return IdContainer.readDefragCount( fileSystem, file );
+    }
+
     @Override
     public synchronized long getNumberOfIdsInUse()
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/DatabaseMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/DatabaseMigrator.java
@@ -88,7 +88,8 @@ public class DatabaseMigrator
 
         ExplicitIndexMigrator explicitIndexMigrator = new ExplicitIndexMigrator( fs, indexProviders, logProvider );
         StoreMigrator storeMigrator = new StoreMigrator( fs, pageCache, config, logService );
-        NativeLabelScanStoreMigrator nativeLabelScanStoreMigrator = new NativeLabelScanStoreMigrator( fs, pageCache );
+        NativeLabelScanStoreMigrator nativeLabelScanStoreMigrator =
+                new NativeLabelScanStoreMigrator( fs, pageCache, config );
         CountsMigrator countsMigrator = new CountsMigrator( fs, pageCache, config );
 
         schemaIndexProviderMap.accept(

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/CountsMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/CountsMigrator.java
@@ -41,6 +41,8 @@ import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.format.StoreVersion;
 import org.neo4j.kernel.impl.store.format.standard.StandardV2_3;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
+import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
+import org.neo4j.kernel.impl.store.id.ReadOnlyIdGeneratorFactory;
 import org.neo4j.kernel.impl.storemigration.ExistingTargetStrategy;
 import org.neo4j.kernel.impl.storemigration.StoreFileType;
 import org.neo4j.kernel.impl.storemigration.StoreUpgrader;
@@ -154,8 +156,9 @@ public class CountsMigrator extends AbstractStoreMigrationParticipant
                 MetaDataStore.DEFAULT_NAME + StoreFactory.COUNTS_STORE );
 
         RecordFormats recordFormats = selectForVersion( expectedStoreVersion );
-        StoreFactory storeFactory = new StoreFactory( storeDirToReadFrom, pageCache, fileSystem, recordFormats,
-                logProvider );
+        IdGeneratorFactory idGeneratorFactory = new ReadOnlyIdGeneratorFactory( fileSystem );
+        StoreFactory storeFactory = new StoreFactory( storeDirToReadFrom, config, idGeneratorFactory, pageCache,
+                fileSystem, recordFormats, logProvider );
         try ( NeoStores neoStores = storeFactory
                 .openNeoStores( StoreType.NODE, StoreType.RELATIONSHIP, StoreType.LABEL_TOKEN,
                         StoreType.RELATIONSHIP_TYPE_TOKEN ) )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigrator.java
@@ -30,11 +30,15 @@ import org.neo4j.io.fs.FileHandle;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.index.IndexStoreView;
 import org.neo4j.kernel.impl.api.scan.FullLabelStream;
 import org.neo4j.kernel.impl.index.labelscan.NativeLabelScanStore;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.StoreFactory;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
+import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
+import org.neo4j.kernel.impl.store.id.ReadOnlyIdGeneratorFactory;
 import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
 import org.neo4j.kernel.impl.transaction.state.storeview.NeoStoreIndexStoreView;
 import org.neo4j.kernel.lifecycle.Lifespan;
@@ -48,13 +52,15 @@ public class NativeLabelScanStoreMigrator extends AbstractStoreMigrationParticip
 {
     private final FileSystemAbstraction fileSystem;
     private final PageCache pageCache;
+    private final Config config;
     private boolean nativeLabelScanStoreMigrated;
 
-    public NativeLabelScanStoreMigrator( FileSystemAbstraction fileSystem, PageCache pageCache )
+    public NativeLabelScanStoreMigrator( FileSystemAbstraction fileSystem, PageCache pageCache, Config config )
     {
         super( "Native label scan index" );
         this.fileSystem = fileSystem;
         this.pageCache = pageCache;
+        this.config = config;
     }
 
     @Override
@@ -129,8 +135,11 @@ public class NativeLabelScanStoreMigrator extends AbstractStoreMigrationParticip
 
     private StoreFactory getStoreFactory( File storeDir, String versionToMigrateFrom )
     {
-        return new StoreFactory( storeDir, pageCache, fileSystem,
-                        selectForVersion( versionToMigrateFrom ), NullLogProvider.getInstance() );
+        NullLogProvider logProvider = NullLogProvider.getInstance();
+        RecordFormats recordFormats = selectForVersion( versionToMigrateFrom );
+        IdGeneratorFactory idGeneratorFactory = new ReadOnlyIdGeneratorFactory( fileSystem );
+        return new StoreFactory( storeDir, config, idGeneratorFactory, pageCache, fileSystem,
+                recordFormats, logProvider );
     }
 
     private boolean isNativeLabelScanStoreMigrationRequired( File storeDir ) throws IOException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
@@ -69,6 +69,7 @@ import org.neo4j.kernel.impl.store.format.standard.MetaDataRecordFormat;
 import org.neo4j.kernel.impl.store.format.standard.NodeRecordFormat;
 import org.neo4j.kernel.impl.store.format.standard.RelationshipRecordFormat;
 import org.neo4j.kernel.impl.store.format.standard.StandardV2_3;
+import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.ReadOnlyIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.PrimitiveRecord;
@@ -491,8 +492,10 @@ public class StoreMigrator extends AbstractStoreMigrationParticipant
 
     private void createStore( File migrationDir, RecordFormats newFormat )
     {
-        StoreFactory storeFactory = new StoreFactory( new File( migrationDir.getPath() ), pageCache, fileSystem,
-                newFormat, NullLogProvider.getInstance() );
+        IdGeneratorFactory idGeneratorFactory = new ReadOnlyIdGeneratorFactory( fileSystem );
+        NullLogProvider logProvider = NullLogProvider.getInstance();
+        StoreFactory storeFactory = new StoreFactory(
+                migrationDir, config, idGeneratorFactory, pageCache, fileSystem, newFormat, logProvider );
         try ( NeoStores neoStores = storeFactory.openAllNeoStores( true ) )
         {
             neoStores.getMetaDataStore();

--- a/community/kernel/src/test/java/org/neo4j/helpers/ListenersTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/ListenersTest.java
@@ -38,7 +38,7 @@ import static org.neo4j.helpers.NamedThreadFactory.named;
 
 public class ListenersTest
 {
-    @Test( expected = IllegalArgumentException.class )
+    @Test( expected = NullPointerException.class )
     public void copyConstructorWithNull()
     {
         new Listeners<>( null );
@@ -54,7 +54,7 @@ public class ListenersTest
         assertEquals( Iterables.asList( original ), Iterables.asList( copy ) );
     }
 
-    @Test( expected = IllegalArgumentException.class )
+    @Test( expected = NullPointerException.class )
     public void addNull()
     {
         new Listeners<>().add( null );
@@ -70,7 +70,7 @@ public class ListenersTest
         assertArrayEquals( listenersArray, Iterables.asArray( Listener.class, listeners ) );
     }
 
-    @Test( expected = IllegalArgumentException.class )
+    @Test( expected = NullPointerException.class )
     public void removeNull()
     {
         new Listeners<>().remove( null );
@@ -94,7 +94,7 @@ public class ListenersTest
         assertEquals( singletonList( listener2 ), Iterables.asList( listeners ) );
     }
 
-    @Test( expected = IllegalArgumentException.class )
+    @Test( expected = NullPointerException.class )
     public void notifyWithNullNotification()
     {
         new Listeners<>().notify( null );
@@ -118,19 +118,19 @@ public class ListenersTest
         assertEquals( currentThread().getName(), listener2.threadName );
     }
 
-    @Test( expected = IllegalArgumentException.class )
+    @Test( expected = NullPointerException.class )
     public void notifyWithNullExecutorAndNullNotification()
     {
         new Listeners<>().notify( null, null );
     }
 
-    @Test( expected = IllegalArgumentException.class )
+    @Test( expected = NullPointerException.class )
     public void notifyWithNullExecutorAndNotification()
     {
         new Listeners<Listener>().notify( null, listener -> listener.process( "foo" ) );
     }
 
-    @Test( expected = IllegalArgumentException.class )
+    @Test( expected = NullPointerException.class )
     public void notifyWithExecutorAndNullNotification()
     {
         new Listeners<Listener>().notify( newSingleThreadExecutor(), null );

--- a/community/kernel/src/test/java/org/neo4j/helpers/ListenersTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/ListenersTest.java
@@ -38,7 +38,7 @@ import static org.neo4j.helpers.NamedThreadFactory.named;
 
 public class ListenersTest
 {
-    @Test( expected = NullPointerException.class )
+    @Test( expected = IllegalArgumentException.class )
     public void copyConstructorWithNull()
     {
         new Listeners<>( null );
@@ -54,7 +54,7 @@ public class ListenersTest
         assertEquals( Iterables.asList( original ), Iterables.asList( copy ) );
     }
 
-    @Test( expected = NullPointerException.class )
+    @Test( expected = IllegalArgumentException.class )
     public void addNull()
     {
         new Listeners<>().add( null );
@@ -70,7 +70,7 @@ public class ListenersTest
         assertArrayEquals( listenersArray, Iterables.asArray( Listener.class, listeners ) );
     }
 
-    @Test( expected = NullPointerException.class )
+    @Test( expected = IllegalArgumentException.class )
     public void removeNull()
     {
         new Listeners<>().remove( null );
@@ -94,7 +94,7 @@ public class ListenersTest
         assertEquals( singletonList( listener2 ), Iterables.asList( listeners ) );
     }
 
-    @Test( expected = NullPointerException.class )
+    @Test( expected = IllegalArgumentException.class )
     public void notifyWithNullNotification()
     {
         new Listeners<>().notify( null );
@@ -118,19 +118,19 @@ public class ListenersTest
         assertEquals( currentThread().getName(), listener2.threadName );
     }
 
-    @Test( expected = NullPointerException.class )
+    @Test( expected = IllegalArgumentException.class )
     public void notifyWithNullExecutorAndNullNotification()
     {
         new Listeners<>().notify( null, null );
     }
 
-    @Test( expected = NullPointerException.class )
+    @Test( expected = IllegalArgumentException.class )
     public void notifyWithNullExecutorAndNotification()
     {
         new Listeners<Listener>().notify( null, listener -> listener.process( "foo" ) );
     }
 
-    @Test( expected = NullPointerException.class )
+    @Test( expected = IllegalArgumentException.class )
     public void notifyWithExecutorAndNullNotification()
     {
         new Listeners<Listener>().notify( newSingleThreadExecutor(), null );

--- a/community/kernel/src/test/java/org/neo4j/kernel/RecoveryIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/RecoveryIT.java
@@ -71,6 +71,7 @@ import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.RecordStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.StoreType;
+import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 import org.neo4j.kernel.impl.store.record.RecordLoad;
 import org.neo4j.kernel.impl.storemigration.LogFiles;
@@ -442,13 +443,16 @@ public class RecoveryIT
 
     private void assertSameStoreContents( EphemeralFileSystemAbstraction fs1, EphemeralFileSystemAbstraction fs2, File storeDir )
     {
+        NullLogProvider logProvider = NullLogProvider.getInstance();
         try (
                 PageCache pageCache1 = new ConfiguringPageCacheFactory( fs1, defaults(), PageCacheTracer.NULL,
                         PageCursorTracerSupplier.NULL, NullLog.getInstance() ).getOrCreatePageCache();
                 PageCache pageCache2 = new ConfiguringPageCacheFactory( fs2, defaults(), PageCacheTracer.NULL,
                         PageCursorTracerSupplier.NULL, NullLog.getInstance() ).getOrCreatePageCache();
-                NeoStores store1 = new StoreFactory( storeDir, pageCache1, fs1, NullLogProvider.getInstance() ).openAllNeoStores();
-                NeoStores store2 = new StoreFactory( storeDir, pageCache2, fs2, NullLogProvider.getInstance() ).openAllNeoStores();
+                NeoStores store1 = new StoreFactory( storeDir, defaults(), new DefaultIdGeneratorFactory( fs1 ),
+                        pageCache1, fs1, logProvider ).openAllNeoStores();
+                NeoStores store2 = new StoreFactory( storeDir, defaults(), new DefaultIdGeneratorFactory( fs2 ),
+                        pageCache2, fs2, logProvider ).openAllNeoStores();
                 )
         {
             for ( StoreType storeType : StoreType.values() )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreNodeRelationshipCursorTest.java
@@ -41,6 +41,7 @@ import org.neo4j.kernel.impl.store.RecordCursors;
 import org.neo4j.kernel.impl.store.RecordStore;
 import org.neo4j.kernel.impl.store.RelationshipStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
+import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.Record;
 import org.neo4j.kernel.impl.store.record.RecordLoad;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
@@ -100,11 +101,14 @@ public class StoreNodeRelationshipCursorTest
     {
         File storeDir = directory.absolutePath();
         fs = new DefaultFileSystemAbstraction();
+        Config config = Config.defaults( pagecache_memory, "8m" );
         pageCache = new ConfiguringPageCacheFactory( fs,
-                Config.defaults( pagecache_memory, "8m" ), NULL,
-                PageCursorTracerSupplier.NULL, NullLog.getInstance() )
+                config, NULL, PageCursorTracerSupplier.NULL, NullLog.getInstance() )
                 .getOrCreatePageCache();
-        StoreFactory storeFactory = new StoreFactory( storeDir, pageCache, fs, NullLogProvider.getInstance() );
+        DefaultIdGeneratorFactory idGeneratorFactory = new DefaultIdGeneratorFactory( fs );
+        NullLogProvider logProvider = NullLogProvider.getInstance();
+        StoreFactory storeFactory =
+                new StoreFactory( storeDir, config, idGeneratorFactory, pageCache, fs, logProvider );
         neoStores = storeFactory.openAllNeoStores( true );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorePropertyCursorTest.java
@@ -38,6 +38,7 @@ import java.util.function.Consumer;
 import org.neo4j.cursor.Cursor;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.store.DynamicArrayStore;
 import org.neo4j.kernel.impl.store.DynamicRecordAllocator;
 import org.neo4j.kernel.impl.store.DynamicStringStore;
@@ -49,6 +50,7 @@ import org.neo4j.kernel.impl.store.RecordCursors;
 import org.neo4j.kernel.impl.store.RecordStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.format.standard.PropertyRecordFormat;
+import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
@@ -289,7 +291,10 @@ public class StorePropertyCursorTest
                 fs.deleteRecursively( storeDir );
             }
             fs.mkdirs( storeDir );
-            neoStores = new StoreFactory( storeDir, pageCache, fs, NullLogProvider.getInstance() )
+            Config config = Config.defaults();
+            DefaultIdGeneratorFactory idGeneratorFactory = new DefaultIdGeneratorFactory( fs );
+            NullLogProvider logProvider = NullLogProvider.getInstance();
+            neoStores = new StoreFactory( storeDir, config, idGeneratorFactory, pageCache, fs, logProvider )
                     .openAllNeoStores( true );
             propertyStore = neoStores.getPropertyStore();
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreSingleRelationshipCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StoreSingleRelationshipCursorTest.java
@@ -25,11 +25,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.RecordCursors;
 import org.neo4j.kernel.impl.store.RelationshipStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
+import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.util.InstanceCache;
 import org.neo4j.logging.NullLogProvider;
@@ -108,8 +110,10 @@ public class StoreSingleRelationshipCursorTest
 
     private StoreFactory getStoreFactory()
     {
-        return new StoreFactory( testDirectory.directory(), pageCacheRule.getPageCache( fileSystemRule.get() ),
-                fileSystemRule.get(), NullLogProvider.getInstance() );
+        return new StoreFactory(
+                testDirectory.directory(), Config.defaults(), new DefaultIdGeneratorFactory( fileSystemRule.get() ),
+                pageCacheRule.getPageCache( fileSystemRule.get() ), fileSystemRule.get(),
+                NullLogProvider.getInstance() );
     }
 
     private StoreSingleRelationshipCursor createRelationshipCursor()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ManyPropertyKeysIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/ManyPropertyKeysIT.java
@@ -38,10 +38,12 @@ import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.security.AnonymousContext;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.PropertyKeyTokenStore;
 import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
+import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.PropertyKeyTokenRecord;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
@@ -129,7 +131,9 @@ public class ManyPropertyKeysIT
     {
 
         PageCache pageCache = pageCacheRule.getPageCache( fileSystemRule.get() );
-        StoreFactory storeFactory = new StoreFactory( storeDir, pageCache, fileSystemRule.get(),
+        StoreFactory storeFactory = new StoreFactory(
+                storeDir, Config.defaults(), new DefaultIdGeneratorFactory( fileSystemRule.get() ), pageCache,
+                fileSystemRule.get(),
                 NullLogProvider.getInstance() );
         NeoStores neoStores = storeFactory.openAllNeoStores( true );
         PropertyKeyTokenStore store = neoStores.getPropertyKeyTokenStore();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexAccessorTest.java
@@ -44,7 +44,9 @@ import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.schema.IndexQuery;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
+import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.storageengine.api.schema.IndexSample;
 import org.neo4j.storageengine.api.schema.IndexSampler;
@@ -86,7 +88,14 @@ public abstract class NativeSchemaNumberIndexAccessorTest<KEY extends SchemaNumb
     @Before
     public void setupAccessor() throws IOException
     {
-        accessor = new NativeSchemaNumberIndexAccessor<>( pageCache, fs, indexFile, layout, IMMEDIATE, monitor, indexDescriptor, indexId );
+        IndexSamplingConfig samplingConfig = new IndexSamplingConfig( Config.defaults() );
+        createAccessorWithSamplingConfig( samplingConfig );
+    }
+
+    private void createAccessorWithSamplingConfig( IndexSamplingConfig samplingConfig ) throws IOException
+    {
+        accessor = new NativeSchemaNumberIndexAccessor<>(
+                pageCache, fs, indexFile, layout, IMMEDIATE, monitor, indexDescriptor, indexId, samplingConfig );
     }
 
     @After

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/FreeIdsAfterRecoveryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/FreeIdsAfterRecoveryTest.java
@@ -19,12 +19,14 @@
  */
 package org.neo4j.kernel.impl.store;
 
-import java.io.File;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
+import java.io.File;
+
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.storemigration.StoreFileType;
@@ -50,8 +52,10 @@ public class FreeIdsAfterRecoveryTest
     public void shouldCompletelyRebuildIdGeneratorsAfterCrash() throws Exception
     {
         // GIVEN
-        StoreFactory storeFactory = new StoreFactory( directory.directory(),
-                pageCacheRule.getPageCache( fileSystemRule.get() ), fileSystemRule.get(), NullLogProvider.getInstance() );
+        StoreFactory storeFactory = new StoreFactory(
+                directory.directory(), Config.defaults(), new DefaultIdGeneratorFactory( fileSystemRule.get() ),
+                pageCacheRule.getPageCache( fileSystemRule.get() ), fileSystemRule.get(),
+                NullLogProvider.getInstance() );
         long highId;
         try ( NeoStores stores = storeFactory.openAllNeoStores( true ) )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/MetaDataStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/MetaDataStoreTest.java
@@ -39,7 +39,9 @@ import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.io.pagecache.impl.DelegatingPageCursor;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.store.format.standard.Standard;
+import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.MetaDataRecord;
 import org.neo4j.kernel.impl.store.record.RecordLoad;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
@@ -112,7 +114,8 @@ public class MetaDataStoreTest
     private MetaDataStore newMetaDataStore() throws IOException
     {
         LogProvider logProvider = NullLogProvider.getInstance();
-        StoreFactory storeFactory = new StoreFactory( STORE_DIR, pageCacheWithFakeOverflow, fs, logProvider );
+        StoreFactory storeFactory = new StoreFactory( STORE_DIR, Config.defaults(), new DefaultIdGeneratorFactory( fs ),
+                pageCacheWithFakeOverflow, fs, logProvider );
         return storeFactory.openNeoStores( true, StoreType.META_DATA ).getMetaDataStore();
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresTest.java
@@ -64,8 +64,10 @@ import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngin
 import org.neo4j.kernel.impl.store.MetaDataStore.Position;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
 import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
+import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.format.standard.DynamicRecordFormat;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
+import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.store.record.PropertyBlock;
 import org.neo4j.kernel.impl.store.record.PropertyKeyTokenRecord;
@@ -118,6 +120,7 @@ import static org.neo4j.storageengine.api.Direction.BOTH;
 public class NeoStoresTest
 {
 
+    private static final NullLogProvider LOG_PROVIDER = NullLogProvider.getInstance();
     private final PageCacheRule pageCacheRule = new ConfigurablePageCacheRule();
     private final ExpectedException exception = ExpectedException.none();
     private final EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
@@ -537,7 +540,7 @@ public class NeoStoresTest
 
         Config config = Config.defaults();
         StoreFactory sf = new StoreFactory( storeDir, config, new DefaultIdGeneratorFactory( fileSystem ), pageCache,
-                fileSystem, NullLogProvider.getInstance() );
+                fileSystem, LOG_PROVIDER );
 
         NeoStores neoStores = sf.openAllNeoStores();
         assertEquals( 12, neoStores.getMetaDataStore().getCurrentLogVersion() );
@@ -594,7 +597,7 @@ public class NeoStoresTest
         // given
         Config config = Config.defaults();
         StoreFactory sf = new StoreFactory( dir.directory(), config, new DefaultIdGeneratorFactory( fs.get() ),
-                pageCacheRule.getPageCache( fs.get() ), fs.get(), NullLogProvider.getInstance() );
+                pageCacheRule.getPageCache( fs.get() ), fs.get(), LOG_PROVIDER );
 
         // when
         NeoStores neoStores = sf.openAllNeoStores( true );
@@ -623,7 +626,10 @@ public class NeoStoresTest
     public void shouldInitializeTheTxIdToOne()
     {
         StoreFactory factory =
-                new StoreFactory( new File( "graph.db/neostore" ), pageCache, fs.get(), NullLogProvider.getInstance() );
+                new StoreFactory(
+                        new File( "graph.db/neostore" ), Config.defaults(), new DefaultIdGeneratorFactory( fs.get() ),
+                        pageCache, fs.get(),
+                        LOG_PROVIDER );
 
         try ( NeoStores neoStores = factory.openAllNeoStores( true ) )
         {
@@ -642,7 +648,9 @@ public class NeoStoresTest
     {
         FileSystemAbstraction fileSystem = fs.get();
         File neoStoreDir = new File( "/tmp/graph.db/neostore" ).getAbsoluteFile();
-        StoreFactory factory = new StoreFactory( neoStoreDir, pageCache, fileSystem, NullLogProvider.getInstance() );
+        StoreFactory factory = new StoreFactory(
+                neoStoreDir, Config.defaults(), new DefaultIdGeneratorFactory( fileSystem ), pageCache, fileSystem,
+                LOG_PROVIDER );
 
         try ( NeoStores neoStores = factory.openAllNeoStores( true ) )
         {
@@ -719,7 +727,9 @@ public class NeoStoresTest
         // GIVEN
         FileSystemAbstraction fileSystem = fs.get();
         fileSystem.mkdirs( storeDir );
-        StoreFactory factory = new StoreFactory( storeDir, pageCache, fileSystem, NullLogProvider.getInstance() );
+        StoreFactory factory = new StoreFactory(
+                storeDir, Config.defaults(), new DefaultIdGeneratorFactory( fileSystem ), pageCache, fileSystem,
+                LOG_PROVIDER );
 
         try ( NeoStores neoStore = factory.openAllNeoStores( true ) )
         {
@@ -743,7 +753,9 @@ public class NeoStoresTest
         // GIVEN
         FileSystemAbstraction fileSystem = fs.get();
         fileSystem.mkdirs( storeDir );
-        StoreFactory factory = new StoreFactory( storeDir, pageCache, fileSystem, NullLogProvider.getInstance() );
+        StoreFactory factory = new StoreFactory(
+                storeDir, Config.defaults(), new DefaultIdGeneratorFactory( fileSystem ), pageCache, fileSystem,
+                LOG_PROVIDER );
 
         try ( NeoStores neoStore = factory.openAllNeoStores( true ) )
         {
@@ -769,7 +781,7 @@ public class NeoStoresTest
         Config defaults = Config.defaults( counts_store_rotation_timeout, "60m" );
         StoreFactory factory =
                 new StoreFactory( storeDir, defaults, new DefaultIdGeneratorFactory( fileSystem ), pageCache,
-                        fileSystem, NullLogProvider.getInstance() );
+                        fileSystem, LOG_PROVIDER );
         NeoStores neoStore = factory.openAllNeoStores( true );
 
         // let's hack the counts store so it fails to rotate and hence it fails to close as well...
@@ -828,7 +840,7 @@ public class NeoStoresTest
         fileSystem.deleteRecursively( storeDir );
         DefaultIdGeneratorFactory idFactory = new DefaultIdGeneratorFactory( fileSystem );
         StoreFactory factory = new StoreFactory( storeDir, Config.defaults(), idFactory, pageCache, fileSystem,
-                NullLogProvider.getInstance() );
+                LOG_PROVIDER );
 
         // when
         try ( NeoStores ignore = factory.openAllNeoStores( true ) )
@@ -846,7 +858,7 @@ public class NeoStoresTest
         fileSystem.deleteRecursively( storeDir );
         DefaultIdGeneratorFactory idFactory = new DefaultIdGeneratorFactory( fileSystem );
         StoreFactory factory = new StoreFactory( storeDir, Config.defaults(), idFactory, pageCache, fileSystem,
-                NullLogProvider.getInstance() );
+                LOG_PROVIDER );
         StoreType[] allStoreTypes = StoreType.values();
         StoreType[] allButLastStoreTypes = Arrays.copyOf( allStoreTypes, allStoreTypes.length - 1 );
 
@@ -896,8 +908,10 @@ public class NeoStoresTest
 
     private static StoreFactory newStoreFactory( File neoStoreDir, PageCache pageCache, FileSystemAbstraction fs )
     {
-        return new StoreFactory( neoStoreDir, pageCache, fs, RecordFormatSelector.defaultFormat(),
-                NullLogProvider.getInstance() );
+        RecordFormats recordFormats = RecordFormatSelector.defaultFormat();
+        Config config = Config.defaults();
+        IdGeneratorFactory idGeneratorFactory = new DefaultIdGeneratorFactory( fs );
+        return new StoreFactory( neoStoreDir, config, idGeneratorFactory, pageCache, fs, recordFormats, LOG_PROVIDER );
     }
 
     private Token createDummyIndex( int id, String key )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RecordStoreConsistentReadTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/RecordStoreConsistentReadTest.java
@@ -35,7 +35,9 @@ import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.store.allocator.ReusableRecordsAllocator;
+import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.LabelTokenRecord;
@@ -84,7 +86,8 @@ public abstract class RecordStoreConsistentReadTest<R extends AbstractBaseRecord
         PageCache pageCache = pageCacheRule.getPageCache( fs,
                 config().withInconsistentReads( nextReadIsInconsistent ) );
         File storeDir = new File( "stores" );
-        StoreFactory factory = new StoreFactory( storeDir, pageCache, fs, NullLogProvider.getInstance() );
+        StoreFactory factory = new StoreFactory( storeDir, Config.defaults(), new DefaultIdGeneratorFactory( fs ),
+                pageCache, fs, NullLogProvider.getInstance() );
         NeoStores neoStores = factory.openAllNeoStores( true );
         S store = initialiseStore( neoStores );
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestStoreAccess.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestStoreAccess.java
@@ -30,6 +30,7 @@ import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.recovery.RecoveryRequiredChecker;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.rule.PageCacheRule;
@@ -56,7 +57,7 @@ public class TestStoreAccess
             snapshot.deleteFile( messages );
 
             PageCache pageCache = pageCacheRule.getPageCache( snapshot );
-            new StoreAccess( snapshot, pageCache, storeDir ).initialize().close();
+            new StoreAccess( snapshot, pageCache, storeDir, Config.defaults() ).initialize().close();
             assertTrue( "Store should be unclean", isUnclean( snapshot ) );
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigratorTest.java
@@ -40,6 +40,7 @@ import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.labelscan.LabelScanWriter;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.scan.FullStoreChangeStream;
 import org.neo4j.kernel.impl.index.labelscan.NativeLabelScanStore;
 import org.neo4j.kernel.impl.store.MetaDataStore;
@@ -92,7 +93,7 @@ public class NativeLabelScanStoreMigratorTest
 
         fileSystem = fileSystemRule.get();
         pageCache = pageCacheRule.getPageCache( fileSystemRule );
-        indexMigrator = new NativeLabelScanStoreMigrator( fileSystem, pageCache );
+        indexMigrator = new NativeLabelScanStoreMigrator( fileSystem, pageCache, Config.defaults() );
         fileSystem.mkdirs( luceneLabelScanStore );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorIT.java
@@ -42,6 +42,7 @@ import org.neo4j.kernel.impl.store.TransactionId;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.format.standard.Standard;
 import org.neo4j.kernel.impl.store.format.standard.StandardV2_3;
+import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.storemigration.MigrationTestUtils;
 import org.neo4j.kernel.impl.storemigration.StoreUpgrader;
 import org.neo4j.kernel.impl.storemigration.StoreVersionCheck;
@@ -135,7 +136,8 @@ public class StoreMigratorIT
                 upgradableDatabase.currentVersion() );
 
         // THEN starting the new store should be successful
-        StoreFactory storeFactory = new StoreFactory( storeDirectory, pageCache, fs,
+        StoreFactory storeFactory = new StoreFactory(
+                storeDirectory, CONFIG, new DefaultIdGeneratorFactory( fs ), pageCache, fs,
                 logService.getInternalLogProvider() );
         storeFactory.openAllNeoStores().close();
     }
@@ -174,7 +176,8 @@ public class StoreMigratorIT
                 upgradableDatabase.currentVersion() );
 
         // THEN starting the new store should be successful
-        StoreFactory storeFactory = new StoreFactory( storeDirectory, pageCache, fs,
+        StoreFactory storeFactory = new StoreFactory(
+                storeDirectory, CONFIG, new DefaultIdGeneratorFactory( fs ), pageCache, fs,
                 logService.getInternalLogProvider() );
         storeFactory.openAllNeoStores().close();
         logProvider.assertNoLogCallContaining( "ERROR" );
@@ -214,7 +217,8 @@ public class StoreMigratorIT
 
         // THEN starting the new store should be successful
         StoreFactory storeFactory =
-                new StoreFactory( storeDirectory, pageCache, fs, logService.getInternalLogProvider() );
+                new StoreFactory( storeDirectory, CONFIG, new DefaultIdGeneratorFactory( fs ), pageCache, fs,
+                        logService.getInternalLogProvider() );
         storeFactory.openAllNeoStores().close();
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipGroupGetterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/RelationshipGroupGetterTest.java
@@ -26,10 +26,12 @@ import org.mockito.InOrder;
 
 import java.io.File;
 
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.RecordStore;
 import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.StoreType;
+import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.store.record.RecordLoad;
 import org.neo4j.kernel.impl.store.record.RelationshipGroupRecord;
@@ -62,7 +64,9 @@ public class RelationshipGroupGetterTest
         File dir = new File( "dir" );
         fs.get().mkdirs( dir );
         LogProvider logProvider = NullLogProvider.getInstance();
-        StoreFactory storeFactory = new StoreFactory( dir, pageCache.getPageCache( fs.get() ), fs.get(), logProvider );
+        StoreFactory storeFactory = new StoreFactory( dir, Config.defaults(), new DefaultIdGeneratorFactory( fs.get() ),
+                pageCache.getPageCache( fs.get() ), fs.get(),
+                logProvider );
         try ( NeoStores stores = storeFactory.openNeoStores( true, StoreType.RELATIONSHIP_GROUP ) )
         {
             RecordStore<RelationshipGroupRecord> store = spy( stores.getRelationshipGroupStore() );

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/builder/AbstractLuceneIndexBuilder.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/builder/AbstractLuceneIndexBuilder.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.api.impl.index.builder;
 
 import java.io.File;
+import java.util.Objects;
 
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
@@ -37,8 +38,13 @@ import org.neo4j.kernel.impl.factory.OperationalMode;
 public abstract class AbstractLuceneIndexBuilder<T extends AbstractLuceneIndexBuilder<T>>
 {
     protected LuceneIndexStorageBuilder storageBuilder = LuceneIndexStorageBuilder.create();
-    private Config config = Config.defaults();
+    private final Config config;
     private OperationalMode operationalMode = OperationalMode.single;
+
+    public AbstractLuceneIndexBuilder( Config config )
+    {
+        this.config = Objects.requireNonNull( config );
+    }
 
     /**
      * Specify index storage
@@ -85,17 +91,6 @@ public abstract class AbstractLuceneIndexBuilder<T extends AbstractLuceneIndexBu
     public T withIndexRootFolder( File indexRootFolder )
     {
         storageBuilder.withIndexFolder( indexRootFolder );
-        return (T) this;
-    }
-
-    /**
-     * Specify db config
-     * @param config configuration
-     * @return index builder
-     */
-    public T withConfig( Config config )
-    {
-        this.config = config;
         return (T) this;
     }
 

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexBuilder.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexBuilder.java
@@ -44,12 +44,14 @@ import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
 public class LuceneSchemaIndexBuilder extends AbstractLuceneIndexBuilder<LuceneSchemaIndexBuilder>
 {
     private final IndexDescriptor descriptor;
-    private IndexSamplingConfig samplingConfig = new IndexSamplingConfig( Config.defaults() );
+    private IndexSamplingConfig samplingConfig;
     private Factory<IndexWriterConfig> writerConfigFactory = IndexWriterConfigs::standard;
 
-    private LuceneSchemaIndexBuilder( IndexDescriptor descriptor )
+    private LuceneSchemaIndexBuilder( IndexDescriptor descriptor, Config config )
     {
+        super( config );
         this.descriptor = descriptor;
+        this.samplingConfig = new IndexSamplingConfig( config );
     }
 
     /**
@@ -58,9 +60,9 @@ public class LuceneSchemaIndexBuilder extends AbstractLuceneIndexBuilder<LuceneS
      * @return new LuceneSchemaIndexBuilder
      * @param descriptor The descriptor for this index
      */
-    public static LuceneSchemaIndexBuilder create( IndexDescriptor descriptor )
+    public static LuceneSchemaIndexBuilder create( IndexDescriptor descriptor, Config config )
     {
-        return new LuceneSchemaIndexBuilder( descriptor );
+        return new LuceneSchemaIndexBuilder( descriptor, config );
     }
 
     /**

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexProvider.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexProvider.java
@@ -83,9 +83,8 @@ public class LuceneSchemaIndexProvider extends SchemaIndexProvider
     @Override
     public IndexPopulator getPopulator( long indexId, IndexDescriptor descriptor, IndexSamplingConfig samplingConfig )
     {
-        SchemaIndex luceneIndex = LuceneSchemaIndexBuilder.create( descriptor )
+        SchemaIndex luceneIndex = LuceneSchemaIndexBuilder.create( descriptor, config )
                                         .withFileSystem( fileSystem )
-                                        .withConfig( config )
                                         .withOperationalMode( operationalMode )
                                         .withSamplingConfig( samplingConfig )
                                         .withIndexStorage( getIndexStorage( indexId ) )
@@ -109,8 +108,7 @@ public class LuceneSchemaIndexProvider extends SchemaIndexProvider
     public IndexAccessor getOnlineAccessor( long indexId, IndexDescriptor descriptor,
             IndexSamplingConfig samplingConfig ) throws IOException
     {
-        SchemaIndex luceneIndex = LuceneSchemaIndexBuilder.create( descriptor )
-                                            .withConfig( config )
+        SchemaIndex luceneIndex = LuceneSchemaIndexBuilder.create( descriptor, config )
                                             .withOperationalMode( operationalMode )
                                             .withSamplingConfig( samplingConfig )
                                             .withIndexStorage( getIndexStorage( indexId ) )
@@ -168,7 +166,7 @@ public class LuceneSchemaIndexProvider extends SchemaIndexProvider
 
     private boolean indexIsOnline( PartitionedIndexStorage indexStorage, IndexDescriptor descriptor ) throws IOException
     {
-        try ( SchemaIndex index = LuceneSchemaIndexBuilder.create( descriptor ).withIndexStorage( indexStorage ).build() )
+        try ( SchemaIndex index = LuceneSchemaIndexBuilder.create( descriptor, config ).withIndexStorage( indexStorage ).build() )
         {
             if ( index.exists() )
             {

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexPopulationIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexPopulationIT.java
@@ -41,6 +41,7 @@ import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.schema.IndexQuery;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.storageengine.api.schema.IndexSample;
@@ -90,7 +91,7 @@ public class LuceneSchemaIndexPopulationIT
     @Test
     public void partitionedIndexPopulation() throws Exception
     {
-        try ( SchemaIndex uniqueIndex = LuceneSchemaIndexBuilder.create( descriptor )
+        try ( SchemaIndex uniqueIndex = LuceneSchemaIndexBuilder.create( descriptor, Config.defaults() )
                 .withFileSystem( fileSystemRule.get() )
                 .withIndexRootFolder( new File( testDir.directory( "partitionIndex" + affectedNodes ), "uniqueIndex" + affectedNodes ) )
                 .build() )

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexUniquenessVerificationIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/LuceneSchemaIndexUniquenessVerificationIT.java
@@ -49,6 +49,7 @@ import org.neo4j.kernel.api.impl.schema.SchemaIndex;
 import org.neo4j.kernel.api.index.PropertyAccessor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.test.Randoms;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
@@ -83,7 +84,7 @@ public class LuceneSchemaIndexUniquenessVerificationIT
         System.setProperty( "luceneSchemaIndex.maxPartitionSize", String.valueOf( DOCS_PER_PARTITION ) );
 
         Factory<IndexWriterConfig> configFactory = new TestConfigFactory();
-        index = LuceneSchemaIndexBuilder.create( descriptor )
+        index = LuceneSchemaIndexBuilder.create( descriptor, Config.defaults() )
                 .withFileSystem( fileSystemRule.get() )
                 .withIndexRootFolder( new File( testDir.directory( "uniquenessVerification" ), "index" ) )
                 .withWriterConfig( configFactory )

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/AccessUniqueDatabaseIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/AccessUniqueDatabaseIndexTest.java
@@ -36,6 +36,7 @@ import org.neo4j.kernel.api.index.IndexQueryHelper;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 import org.neo4j.values.storable.Values;
@@ -139,7 +140,7 @@ public class AccessUniqueDatabaseIndexTest
 
     private LuceneIndexAccessor createAccessor( PartitionedIndexStorage indexStorage ) throws IOException
     {
-        SchemaIndex luceneIndex = LuceneSchemaIndexBuilder.create( index )
+        SchemaIndex luceneIndex = LuceneSchemaIndexBuilder.create( index, Config.defaults() )
                 .withIndexStorage( indexStorage )
                 .build();
         luceneIndex.open();

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DatabaseCompositeIndexAccessorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DatabaseCompositeIndexAccessorTest.java
@@ -47,6 +47,7 @@ import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.schema.IndexQuery;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.storageengine.api.schema.IndexSampler;
@@ -68,6 +69,7 @@ public class DatabaseCompositeIndexAccessorTest
     private static final int PROP_ID1 = 1;
     private static final int PROP_ID2 = 2;
     private static final IndexDescriptor DESCRIPTOR = IndexDescriptorFactory.forLabel( 0, PROP_ID1, PROP_ID2 );
+    private static final Config config = Config.defaults();
     @Rule
     public final ThreadingRule threading = new ThreadingRule();
     @ClassRule
@@ -94,7 +96,7 @@ public class DatabaseCompositeIndexAccessorTest
         return Arrays.asList(
                 arg( dirFactory1 ->
                 {
-                    SchemaIndex index = LuceneSchemaIndexBuilder.create( indexDescriptor )
+                    SchemaIndex index = LuceneSchemaIndexBuilder.create( indexDescriptor, config )
                             .withFileSystem( fileSystemRule.get() )
                             .withDirectoryFactory( dirFactory1 )
                             .withIndexRootFolder( new File( dir, "1" ) )
@@ -106,7 +108,7 @@ public class DatabaseCompositeIndexAccessorTest
                 } ),
                 arg( dirFactory1 ->
                 {
-                    SchemaIndex index = LuceneSchemaIndexBuilder.create( uniqueIndexDescriptor )
+                    SchemaIndex index = LuceneSchemaIndexBuilder.create( uniqueIndexDescriptor, config )
                             .withFileSystem( fileSystemRule.get() )
                             .withDirectoryFactory( dirFactory1 )
                             .withIndexRootFolder( new File( dir, "testIndex" ) )

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DatabaseIndexAccessorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/DatabaseIndexAccessorTest.java
@@ -47,6 +47,7 @@ import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.schema.IndexQuery;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.storageengine.api.schema.IndexSampler;
@@ -87,6 +88,7 @@ public class DatabaseIndexAccessorTest
     private DirectoryFactory.InMemoryDirectoryFactory dirFactory;
     private static final IndexDescriptor GENERAL_INDEX = IndexDescriptorFactory.forLabel( 0, PROP_ID );
     private static final IndexDescriptor UNIQUE_INDEX = IndexDescriptorFactory.uniqueForLabel( 1, PROP_ID );
+    private static final Config CONFIG = Config.defaults();
 
     @Parameterized.Parameters( name = "{0}" )
     public static Collection<Object[]> implementations()
@@ -95,7 +97,7 @@ public class DatabaseIndexAccessorTest
         return Arrays.asList(
                 arg( GENERAL_INDEX, dirFactory1 ->
                 {
-                    SchemaIndex index = LuceneSchemaIndexBuilder.create( GENERAL_INDEX )
+                    SchemaIndex index = LuceneSchemaIndexBuilder.create( GENERAL_INDEX, CONFIG )
                             .withFileSystem( fileSystemRule.get() )
                             .withDirectoryFactory( dirFactory1 )
                             .withIndexRootFolder( new File( dir, "1" ) )
@@ -107,7 +109,7 @@ public class DatabaseIndexAccessorTest
                 } ),
                 arg( UNIQUE_INDEX, dirFactory1 ->
                 {
-                    SchemaIndex index = LuceneSchemaIndexBuilder.create( UNIQUE_INDEX )
+                    SchemaIndex index = LuceneSchemaIndexBuilder.create( UNIQUE_INDEX, CONFIG )
                             .withFileSystem( fileSystemRule.get() )
                             .withDirectoryFactory( dirFactory1 )
                             .withIndexRootFolder( new File( dir, "testIndex" ) )

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexBuilderTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexBuilderTest.java
@@ -46,9 +46,8 @@ public class LuceneSchemaIndexBuilderTest
     @Test
     public void readOnlyIndexCreation() throws Exception
     {
-        try ( SchemaIndex schemaIndex = LuceneSchemaIndexBuilder.create( descriptor )
+        try ( SchemaIndex schemaIndex = LuceneSchemaIndexBuilder.create( descriptor, getReadOnlyConfig() )
                 .withFileSystem( fileSystemRule.get() )
-                .withConfig( getReadOnlyConfig() )
                 .withOperationalMode( OperationalMode.single )
                 .withIndexRootFolder( testDir.directory( "a" ) )
                 .build() )
@@ -60,8 +59,7 @@ public class LuceneSchemaIndexBuilderTest
     @Test
     public void writableIndexCreation() throws Exception
     {
-        try ( SchemaIndex schemaIndex = LuceneSchemaIndexBuilder.create( descriptor )
-                .withConfig( getDefaultConfig() )
+        try ( SchemaIndex schemaIndex = LuceneSchemaIndexBuilder.create( descriptor, getDefaultConfig() )
                 .withFileSystem( fileSystemRule.get() )
                 .withOperationalMode( OperationalMode.single )
                 .withIndexRootFolder( testDir.directory( "b" ) )

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexIT.java
@@ -43,6 +43,7 @@ import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.index.IndexUpdater;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.index.IndexUpdateMode;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
@@ -65,6 +66,7 @@ public class LuceneSchemaIndexIT
     public final DefaultFileSystemRule fileSystemRule = new DefaultFileSystemRule();
 
     private final IndexDescriptor descriptor = IndexDescriptorFactory.forLabel( 0, 0 );
+    private final Config config = Config.defaults();
 
     @Before
     public void before()
@@ -125,7 +127,7 @@ public class LuceneSchemaIndexIT
     @Test
     public void updateMultiplePartitionedIndex() throws IOException
     {
-        try ( SchemaIndex index = LuceneSchemaIndexBuilder.create( descriptor )
+        try ( SchemaIndex index = LuceneSchemaIndexBuilder.create( descriptor, config )
                 .withFileSystem( fileSystemRule.get() )
                 .withIndexRootFolder( testDir.directory( "partitionedIndexForUpdates" ) )
                 .build() )
@@ -147,7 +149,7 @@ public class LuceneSchemaIndexIT
     public void createPopulateDropIndex() throws Exception
     {
         File crudOperation = testDir.directory( "indexCRUDOperation" );
-        try ( SchemaIndex crudIndex = LuceneSchemaIndexBuilder.create( descriptor )
+        try ( SchemaIndex crudIndex = LuceneSchemaIndexBuilder.create( descriptor, config )
                 .withFileSystem( fileSystemRule.get() )
                 .withIndexRootFolder( new File( crudOperation, "crudIndex" ) )
                 .build() )
@@ -170,7 +172,7 @@ public class LuceneSchemaIndexIT
     @Test
     public void createFailPartitionedIndex() throws Exception
     {
-        try ( SchemaIndex failedIndex = LuceneSchemaIndexBuilder.create( descriptor )
+        try ( SchemaIndex failedIndex = LuceneSchemaIndexBuilder.create( descriptor, config )
                 .withFileSystem( fileSystemRule.get() )
                 .withIndexRootFolder( new File( testDir.directory( "failedIndexFolder" ), "failedIndex" ) )
                 .build() )
@@ -194,7 +196,7 @@ public class LuceneSchemaIndexIT
         SchemaIndex reopenIndex = null;
         try
         {
-            reopenIndex = LuceneSchemaIndexBuilder.create( descriptor )
+            reopenIndex = LuceneSchemaIndexBuilder.create( descriptor, config )
                     .withFileSystem( fileSystemRule.get() )
                     .withIndexRootFolder( new File( testDir.directory( "reopenIndexFolder" ), "reopenIndex" ) )
                     .build();
@@ -247,7 +249,7 @@ public class LuceneSchemaIndexIT
 
     private LuceneIndexAccessor createDefaultIndexAccessor() throws IOException
     {
-        SchemaIndex index = LuceneSchemaIndexBuilder.create( descriptor )
+        SchemaIndex index = LuceneSchemaIndexBuilder.create( descriptor, config )
                 .withFileSystem( fileSystemRule.get() )
                 .withIndexRootFolder( testDir.directory( "testIndex" ) )
                 .build();

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/LuceneSchemaIndexTest.java
@@ -34,6 +34,7 @@ import org.neo4j.io.IOUtils;
 import org.neo4j.kernel.api.impl.index.storage.DirectoryFactory;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 
@@ -137,7 +138,7 @@ public class LuceneSchemaIndexTest
 
     private SchemaIndex newSchemaIndex()
     {
-        LuceneSchemaIndexBuilder builder = LuceneSchemaIndexBuilder.create( descriptor );
+        LuceneSchemaIndexBuilder builder = LuceneSchemaIndexBuilder.create( descriptor, Config.defaults() );
         return builder
                 .withIndexRootFolder( new File( testDir.directory( "index" ), "testIndex" ) )
                 .withDirectoryFactory( dirFactory )

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueDatabaseIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueDatabaseIndexPopulatorTest.java
@@ -40,6 +40,7 @@ import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.schema.IndexQuery;
 import org.neo4j.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
+import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.index.sampling.IndexSamplingConfig;
@@ -71,9 +72,10 @@ public class NonUniqueDatabaseIndexPopulatorTest
         File folder = testDir.directory( "folder" );
         PartitionedIndexStorage indexStorage = new PartitionedIndexStorage( dirFactory, fileSystemRule.get(), folder, false );
 
-        index = LuceneSchemaIndexBuilder.create( IndexDescriptorFactory.forSchema( labelSchemaDescriptor ) )
-                .withIndexStorage( indexStorage )
-                .build();
+        IndexDescriptor descriptor = IndexDescriptorFactory.forSchema( labelSchemaDescriptor );
+        index = LuceneSchemaIndexBuilder.create( descriptor, Config.defaults() )
+                                        .withIndexStorage( indexStorage )
+                                        .build();
     }
 
     @After

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/UniqueDatabaseIndexPopulatorTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/schema/populator/UniqueDatabaseIndexPopulatorTest.java
@@ -49,6 +49,7 @@ import org.neo4j.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.storageengine.api.schema.IndexReader;
 import org.neo4j.storageengine.api.schema.IndexSample;
 import org.neo4j.test.OtherThreadExecutor;
@@ -98,7 +99,7 @@ public class UniqueDatabaseIndexPopulatorTest
     {
         File folder = testDir.directory( "folder" );
         indexStorage = new PartitionedIndexStorage( directoryFactory, fileSystemRule.get(), folder, false );
-        index = LuceneSchemaIndexBuilder.create( descriptor )
+        index = LuceneSchemaIndexBuilder.create( descriptor, Config.defaults() )
                 .withIndexStorage( indexStorage )
                 .build();
         schemaDescriptor = descriptor.schema();

--- a/community/neo4j/src/test/java/upgrade/StoreUpgraderTest.java
+++ b/community/neo4j/src/test/java/upgrade/StoreUpgraderTest.java
@@ -48,6 +48,7 @@ import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.format.standard.Standard;
 import org.neo4j.kernel.impl.store.format.standard.StandardV2_3;
+import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.storemigration.MigrationTestUtils;
 import org.neo4j.kernel.impl.storemigration.StoreMigrationParticipant;
 import org.neo4j.kernel.impl.storemigration.StoreUpgrader;
@@ -257,7 +258,9 @@ public class StoreUpgraderTest
         newUpgrader( upgradableDatabase, allowMigrateConfig, pageCache ).migrateIfNeeded( dbDirectory );
 
         // Then
-        StoreFactory factory = new StoreFactory( dbDirectory, pageCache, fileSystem, NullLogProvider.getInstance() );
+        StoreFactory factory = new StoreFactory(
+                dbDirectory, allowMigrateConfig, new DefaultIdGeneratorFactory( fileSystem ), pageCache, fileSystem,
+                NullLogProvider.getInstance() );
         try ( NeoStores neoStores = factory.openAllNeoStores() )
         {
             assertThat( neoStores.getMetaDataStore().getUpgradeTransaction(),

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/ResponsePackerIT.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/ResponsePackerIT.java
@@ -32,9 +32,11 @@ import org.neo4j.function.Suppliers;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.StoreFactory;
+import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
 import org.neo4j.logging.NullLogProvider;
@@ -106,7 +108,11 @@ public class ResponsePackerIT
     {
         File storeDir = new File( "/store/" );
         fs.mkdirs( storeDir );
-        StoreFactory storeFactory = new StoreFactory( storeDir, pageCache, fs, NullLogProvider.getInstance() );
+        Config config = Config.defaults();
+        DefaultIdGeneratorFactory idGeneratorFactory = new DefaultIdGeneratorFactory( fs );
+        NullLogProvider logProvider = NullLogProvider.getInstance();
+        StoreFactory storeFactory =
+                new StoreFactory( storeDir, config, idGeneratorFactory, pageCache, fs, logProvider );
         return storeFactory.openAllNeoStores( true );
     }
 }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/OnDiskLastTxIdGetterTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/OnDiskLastTxIdGetterTest.java
@@ -25,9 +25,11 @@ import org.junit.Test;
 import java.io.File;
 import java.util.function.LongSupplier;
 
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.ha.transaction.OnDiskLastTxIdGetter;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.StoreFactory;
+import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.rule.PageCacheRule;
@@ -54,8 +56,10 @@ public class OnDiskLastTxIdGetterTest
     @Test
     public void lastTransactionIdIsBaseTxIdWhileNeoStoresAreStopped()
     {
-        final StoreFactory storeFactory = new StoreFactory( new File( "store" ), pageCacheRule.getPageCache( fs.get() ),
-                fs.get(), NullLogProvider.getInstance() );
+        final StoreFactory storeFactory = new StoreFactory(
+                new File( "store" ), Config.defaults(), new DefaultIdGeneratorFactory( fs.get() ),
+                pageCacheRule.getPageCache( fs.get() ), fs.get(),
+                NullLogProvider.getInstance() );
         final NeoStores neoStores = storeFactory.openAllNeoStores( true );
         neoStores.close();
 

--- a/tools/src/main/java/org/neo4j/tools/dump/DumpCountsStore.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/DumpCountsStore.java
@@ -41,6 +41,7 @@ import org.neo4j.kernel.impl.store.SchemaStorage;
 import org.neo4j.kernel.impl.store.StoreFactory;
 import org.neo4j.kernel.impl.store.TokenStore;
 import org.neo4j.kernel.impl.store.counts.CountsTracker;
+import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.kvstore.HeaderField;
 import org.neo4j.kernel.impl.store.kvstore.Headers;
 import org.neo4j.kernel.impl.store.kvstore.MetadataVisitor;
@@ -77,9 +78,13 @@ public class DumpCountsStore implements CountsVisitor, MetadataVisitor, UnknownK
         try ( PageCache pages = createPageCache( fs );
               Lifespan life = new Lifespan() )
         {
+            NullLogProvider logProvider = NullLogProvider.getInstance();
+            Config config = Config.defaults();
             if ( fs.isDirectory( path ) )
             {
-                StoreFactory factory = new StoreFactory( path, pages, fs, NullLogProvider.getInstance() );
+                StoreFactory factory = new StoreFactory( path, Config.defaults(), new DefaultIdGeneratorFactory( fs ),
+                        pages, fs,
+                        logProvider );
 
                 NeoStores neoStores = factory.openAllNeoStores();
                 SchemaStorage schemaStorage = new SchemaStorage( neoStores.getSchemaStore() );
@@ -88,7 +93,7 @@ public class DumpCountsStore implements CountsVisitor, MetadataVisitor, UnknownK
             else
             {
                 VisitableCountsTracker tracker = new VisitableCountsTracker(
-                        NullLogProvider.getInstance(), fs, pages, Config.defaults(), path );
+                        logProvider, fs, pages, config, path );
                 if ( fs.fileExists( path ) )
                 {
                     tracker.visitFile( path, new DumpCountsStore( out ) );


### PR DESCRIPTION
The purpose of this exercise is greater enforcement of having just _one_ `Config` instance at runtime, since with dynamic settings it is now more important that everyone uses the same `Config` instance.