### PR TITLE
Fixes problem with nondeterministic planning of optional matches

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompiler.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompiler.scala
@@ -113,7 +113,8 @@ case class CypherCompiler[Context <: CompilerContext](createExecutionPlan: Trans
   val irConstruction: Transformer[CompilerContext, BaseState, CompilationState] =
     ResolveTokens andThen
       CreatePlannerQuery.adds(CompilationContains[UnionQuery]) andThen
-      OptionalMatchRemover
+      OptionalMatchRemover andThen
+      OptionalMatchReorganizer
 
   val costBasedPlanning =
     QueryPlanner().adds(CompilationContains[LogicalPlan]) andThen

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/OptionalMatchReorganizer.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/OptionalMatchReorganizer.scala
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_2.planner.logical
+import org.neo4j.cypher.internal.compiler.v3_2.ast.convert.plannerQuery.PlannerQueryBuilder
+import org.neo4j.cypher.internal.compiler.v3_2.phases.CompilerContext
+import org.neo4j.cypher.internal.frontend.v3_2.phases.Condition
+import org.neo4j.cypher.internal.frontend.v3_2.{Rewriter, bottomUp}
+import org.neo4j.cypher.internal.ir.v3_2._
+
+import scala.collection.mutable
+
+object OptionalMatchReorganizer extends PlannerQueryRewriter {
+
+  override def instance(context: CompilerContext): Rewriter = OptionalMatchReorganizer._instance
+
+  override def description: String = "Reorganizes optional matches in a QG to make them easy to compare"
+
+  override def postConditions: Set[Condition] = Set.empty
+
+  private val _instance: Rewriter = bottomUp(Rewriter.lift {
+    case originalPQ@RegularPlannerQuery(qg, originalHorizon, originalTail) if qg.optionalMatches.size > 1 => qg
+      val clicks = mutable.Set[Seq[QueryGraph]]()
+      val remaining = mutable.ListBuffer(qg.optionalMatches:_*)
+      while(remaining.nonEmpty) {
+        val current = remaining.remove(0)
+        val dependentOptionalMatches = remaining.filter(qg => {
+          val overlaps = qg.dependencies intersect current.allCoveredIds
+          (overlaps -- qg.argumentIds).nonEmpty
+        })
+
+        remaining --= dependentOptionalMatches
+        clicks += current +: dependentOptionalMatches
+      }
+
+      if (clicks.size == 1) {
+        originalPQ
+      } else {
+        val newQg = cleanUpArgumentIds(qg.coveredIds, qg.copy(optionalMatches = clicks.head.toIndexedSeq))
+        val newTails = clicks.tail.foldRight[Option[PlannerQuery]](originalTail) {
+          case (optionalMatches, tailAcc) =>
+            val qg = QueryGraph.empty.withOptionalMatches(optionalMatches.toIndexedSeq)
+            val horizon =
+              if (tailAcc == originalTail) // The very last PQ should contain the original horizon, so we do not loose that
+                originalHorizon
+              else
+                PassthroughAllHorizon() // In all other cases, we just want data to flow through this horizon
+            Some(RegularPlannerQuery(qg, horizon, tailAcc))
+
+        }
+
+
+        val newTail = newTails.get
+
+        def fixup(incoming: Set[IdName], pq: PlannerQuery): PlannerQuery = {
+          val newPq = pq.withQueryGraph(cleanUpArgumentIds(incoming, pq.queryGraph))
+          if(newPq.tail == originalTail)
+            newPq
+          else {
+            val exposedVariables = newPq.horizon.exposedSymbols(newPq.queryGraph.coveredIds)
+            newPq.updateTail(fixup(exposedVariables, _))
+          }
+        }
+
+        val rewrittenPQ = originalPQ.withHorizon(PassthroughAllHorizon()).withQueryGraph(newQg).replaceTail(newTail)
+        fixup(originalPQ.queryGraph.argumentIds, rewrittenPQ)
+      }
+  })
+
+  private def cleanUpArgumentIds(incomingArgs: Set[IdName], queryGraph: QueryGraph) = {
+    PlannerQueryBuilder.setArgumentIdsOnOptionalMatches(queryGraph.withArgumentIds(incomingArgs))
+  }
+}

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/OptionalMatchReorganizerTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/OptionalMatchReorganizerTest.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_2.planner.logical
+
+import org.neo4j.cypher.internal.compiler.v3_2.SyntaxExceptionCreator
+import org.neo4j.cypher.internal.compiler.v3_2.ast.convert.plannerQuery.StatementConverters.toUnionQuery
+import org.neo4j.cypher.internal.compiler.v3_2.planner._
+import org.neo4j.cypher.internal.frontend.v3_2.Rewritable._
+import org.neo4j.cypher.internal.frontend.v3_2.ast.Query
+import org.neo4j.cypher.internal.frontend.v3_2.ast.rewriters.flattenBooleanOperators
+import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.frontend.v3_2.{DummyPosition, SemanticChecker, SemanticTable}
+import org.neo4j.cypher.internal.ir.v3_2._
+
+class OptionalMatchReorganizerTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
+
+  private val rewriter = OptionalMatchReorganizer.instance(null)
+
+  test("should move one optional match to after query horizon") {
+    /*
+    MATCH (a)
+    OPTIONAL MATCH (b)
+    OPTIONAL MATCH (c)
+     */
+    val optional1 = QueryGraph.empty.withPatternNodes(Set(IdName("b")))
+    val optional2 = QueryGraph.empty.withPatternNodes(Set(IdName("c")))
+    val root = QueryGraph.empty.
+      withPatternNodes(Set(IdName("a"))).
+      withAddedOptionalMatch(optional1).
+      withAddedOptionalMatch(optional2)
+    val projection = RegularQueryProjection(Map("a" -> varFor("a")))
+    val pq = RegularPlannerQuery(root, projection)
+
+    val expectedQG1 = QueryGraph.empty.
+      withPatternNodes(Set(IdName("a"))).
+      withAddedOptionalMatch(optional1)
+
+    val expectedQG2 = QueryGraph.empty.
+      withArgumentIds(Set(IdName("a"))).
+      withAddedOptionalMatch(optional2)
+
+    val tail = RegularPlannerQuery(expectedQG2, projection)
+    val expected = RegularPlannerQuery(expectedQG1, PassthroughAllHorizon(), Some(tail))
+
+    val query = pq.endoRewrite(rewriter)
+    query should equal(expected)
+  }
+
+  private def parseForRewriting(queryText: String) = parser.parse(queryText.replace("\r\n", "\n"))
+}

--- a/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/PlannerQuery.scala
+++ b/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/PlannerQuery.scala
@@ -47,6 +47,8 @@ sealed trait PlannerQuery {
     case Some(_) => throw new InternalException("Attempt to set a second tail on a query graph")
   }
 
+  def replaceTail(newTail: PlannerQuery): PlannerQuery = copy(tail = Some(newTail))
+
   def withoutHints(hintsToIgnore: GenTraversableOnce[Hint]) = copy(queryGraph = queryGraph.withoutHints(hintsToIgnore))
 
   def withHorizon(horizon: QueryHorizon): PlannerQuery = copy(horizon = horizon)


### PR DESCRIPTION
When multiple optional matches exist, and they do not have dependencies
between each other, the planner is free to solve them in any order. This
unfortunately causes a problem where the planner thinks it has failed to
solve the original query. This change changes the IR before planning so
we have a deterministic order to solve optional matches in.