### PR TITLE
Cleanup HostnamePortTest URI creation assumptions.

### DIFF
--- a/community/cypher/frontend-3.3/src/test/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/FunctionTestBase.scala
+++ b/community/cypher/frontend-3.3/src/test/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/FunctionTestBase.scala
@@ -2,27 +2,24 @@
  * Copyright (c) 2002-2017 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
- * This file is part of Neo4j.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Neo4j is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.neo4j.cypher.internal.frontend.v3_3.ast
 
-import org.neo4j.cypher.internal.frontend.v3_3.{SemanticCheckResult, SemanticState}
 import org.neo4j.cypher.internal.frontend.v3_3.ast.Expression.SemanticContext
 import org.neo4j.cypher.internal.frontend.v3_3.symbols.TypeSpec
 import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.frontend.v3_3.{SemanticCheckResult, SemanticState}
 
 abstract class FunctionTestBase(functionName: FunctionName) extends CypherFunSuite {
 

--- a/community/cypher/frontend-3.3/src/test/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/ReverseTest.scala
+++ b/community/cypher/frontend-3.3/src/test/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/ReverseTest.scala
@@ -2,20 +2,17 @@
  * Copyright (c) 2002-2017 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
- * This file is part of Neo4j.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Neo4j is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.neo4j.cypher.internal.frontend.v3_3.ast
 

--- a/community/kernel/src/test/java/org/neo4j/helpers/HostnamePortTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/HostnamePortTest.java
@@ -471,8 +471,6 @@ public class HostnamePortTest
         // When & Then
 
         assertFalse( hostnamePortSinglePort.matches( URI.create( "ha://" + unknownHost + ":1234" ) ) );
-        // no scheme means no ports and no host, so both null therefore comparison fails
-        assertFalse( hostnamePortSinglePort.matches( URI.create( unknownHost + ":1234" ) ) );
     }
 
     @Test
@@ -491,8 +489,6 @@ public class HostnamePortTest
         String host1 = InetAddress.getLocalHost().getHostName();
 
         assertFalse( hostnamePortSinglePort.matches( URI.create( "ha://" + host1 + ":1234" ) ) );
-        // no scheme means no ports and no host, so both null therefore comparison fails
-        assertFalse( hostnamePortSinglePort.matches( URI.create( host1 + ":1234" ) ) );
     }
 
     @Test


### PR DESCRIPTION
Cleanup incorrect assumption about ability to create URI for any host
and port if scheme is not specified.
Since URI should always have scheme defined and according to RFC 3986
it should be defined as
"scheme      = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )"
And hosts that start with a digit will break that assumption.