### PR TITLE
Fix a bug that prevented page cache metrics from the Causal Cluster replication from being reported

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -63,6 +63,7 @@ import org.neo4j.kernel.impl.core.StartupStatisticsProvider;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.core.TokenNotFoundException;
 import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.impl.pagecache.PublishPageCacheTracerMetricsAfterStart;
 import org.neo4j.kernel.impl.proc.ProcedureConfig;
 import org.neo4j.kernel.impl.proc.ProcedureGDSFactory;
 import org.neo4j.kernel.impl.proc.ProcedureTransactionProvider;
@@ -225,6 +226,8 @@ public class DataSourceModule
         life.add( new MonitorGc( config, logging.getInternalLog( MonitorGc.class ) ) );
 
         life.add( nodeManager );
+
+        life.add( new PublishPageCacheTracerMetricsAfterStart( platformModule.tracers.pageCursorTracerSupplier ) );
 
         life.add( new DatabaseAvailability( platformModule.availabilityGuard, platformModule.transactionMonitor,
                 config.get( GraphDatabaseSettings.shutdown_transaction_end_timeout ).toMillis() ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PublishPageCacheTracerMetricsAfterStart.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PublishPageCacheTracerMetricsAfterStart.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.pagecache;
+
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+
+public class PublishPageCacheTracerMetricsAfterStart extends LifecycleAdapter
+{
+    private final PageCursorTracerSupplier pageCursorTracerSupplier;
+
+    public PublishPageCacheTracerMetricsAfterStart( PageCursorTracerSupplier pageCursorTracerSupplier )
+    {
+        this.pageCursorTracerSupplier = pageCursorTracerSupplier;
+    }
+
+    @Override
+    public void start() throws Throwable
+    {
+        // This will be called in the final stages of starting up a database, and will report any paging tracer
+        // events caused by the startup process in the starting thread.
+        pageCursorTracerSupplier.get().reportEvents();
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/CoreStateMachinesModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/CoreStateMachinesModule.java
@@ -52,6 +52,7 @@ import org.neo4j.causalclustering.core.state.storage.DurableStateStorage;
 import org.neo4j.causalclustering.core.state.storage.StateStorage;
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.CommitProcessFactory;
 import org.neo4j.kernel.impl.core.LabelTokenHolder;
@@ -172,9 +173,10 @@ public class CoreStateMachinesModule
                 new ReplicatedTokenStateMachine<>( relationshipTypeTokenRegistry, new RelationshipTypeToken.Factory(),
                         logProvider );
 
+        PageCursorTracerSupplier cursorTracerSupplier = platformModule.tracers.pageCursorTracerSupplier;
         ReplicatedTransactionStateMachine replicatedTxStateMachine =
                 new ReplicatedTransactionStateMachine( commandIndexTracker, replicatedLockTokenStateMachine,
-                        config.get( state_machine_apply_max_batch_size ), logProvider );
+                        config.get( state_machine_apply_max_batch_size ), logProvider, cursorTracerSupplier );
 
         dependencies.satisfyDependencies( replicatedTxStateMachine );
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransactionStateMachine.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/tx/ReplicatedTransactionStateMachine.java
@@ -26,6 +26,7 @@ import org.neo4j.causalclustering.core.state.Result;
 import org.neo4j.causalclustering.core.state.machines.StateMachine;
 import org.neo4j.causalclustering.core.state.machines.id.CommandIndexTracker;
 import org.neo4j.causalclustering.core.state.machines.locks.ReplicatedLockTokenStateMachine;
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.impl.api.TransactionCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionQueue;
@@ -47,17 +48,21 @@ public class ReplicatedTransactionStateMachine implements StateMachine<Replicate
     private final ReplicatedLockTokenStateMachine lockTokenStateMachine;
     private final int maxBatchSize;
     private final Log log;
+    private final PageCursorTracerSupplier pageCursorTracerSupplier;
 
     private TransactionQueue queue;
     private long lastCommittedIndex = -1;
 
     public ReplicatedTransactionStateMachine( CommandIndexTracker commandIndexTracker,
-            ReplicatedLockTokenStateMachine lockStateMachine, int maxBatchSize, LogProvider logProvider )
+                                              ReplicatedLockTokenStateMachine lockStateMachine, int maxBatchSize,
+                                              LogProvider logProvider,
+                                              PageCursorTracerSupplier pageCursorTracerSupplier )
     {
         this.commandIndexTracker = commandIndexTracker;
         this.lockTokenStateMachine = lockStateMachine;
         this.maxBatchSize = maxBatchSize;
         this.log = logProvider.getLog( getClass() );
+        this.pageCursorTracerSupplier = pageCursorTracerSupplier;
     }
 
     public synchronized void installCommitProcess( TransactionCommitProcess commitProcess, long lastCommittedIndex )
@@ -65,7 +70,10 @@ public class ReplicatedTransactionStateMachine implements StateMachine<Replicate
         this.lastCommittedIndex = lastCommittedIndex;
         log.info( format("Updated lastCommittedIndex to %d", lastCommittedIndex) );
         this.queue = new TransactionQueue( maxBatchSize,  (first, last) ->
-            commitProcess.commit( first, CommitEvent.NULL, TransactionApplicationMode.EXTERNAL ) );
+        {
+            commitProcess.commit( first, CommitEvent.NULL, TransactionApplicationMode.EXTERNAL );
+            pageCursorTracerSupplier.get().reportEvents(); // Report paging metrics for the commit
+        } );
     }
 
     @Override

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/tx/CommitProcessStateMachineCollaborationTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/tx/CommitProcessStateMachineCollaborationTest.java
@@ -25,6 +25,7 @@ import org.neo4j.causalclustering.core.replication.DirectReplicator;
 import org.neo4j.causalclustering.core.state.machines.id.CommandIndexTracker;
 import org.neo4j.causalclustering.core.state.machines.locks.ReplicatedLockTokenRequest;
 import org.neo4j.causalclustering.core.state.machines.locks.ReplicatedLockTokenStateMachine;
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.impl.api.TransactionCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionToApply;
@@ -50,7 +51,8 @@ public class CommitProcessStateMachineCollaborationTest
         TransactionCommitProcess localCommitProcess = mock( TransactionCommitProcess.class );
         ReplicatedTransactionStateMachine stateMachine =
                 new ReplicatedTransactionStateMachine( mock( CommandIndexTracker.class ),
-                        lockState( finalLockSessionId ), 16, NullLogProvider.getInstance() );
+                        lockState( finalLockSessionId ), 16, NullLogProvider.getInstance(),
+                        PageCursorTracerSupplier.NULL );
         stateMachine.installCommitProcess( localCommitProcess, -1L );
 
         DirectReplicator<ReplicatedTransaction> replicator = new DirectReplicator<>( stateMachine );


### PR DESCRIPTION
Ensure that page cache events from the core state applier (the data replication in Causal Cluster) publishes the page curser trace numbers