### PR TITLE
Remove leak of values into public API

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/BatchInserter.java
@@ -25,7 +25,6 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.schema.ConstraintCreator;
 import org.neo4j.graphdb.schema.IndexCreator;
-import org.neo4j.values.storable.Value;
 
 /**
  * The batch inserter drops support for transactions and concurrency in favor
@@ -162,7 +161,7 @@ public interface BatchInserter
      *
      * @return map containing this node's properties.
      */
-    Map<String,Value> getNodeProperties( long nodeId );
+    Map<String,Object> getNodeProperties( long nodeId );
 
     /**
      * Returns an iterable over all the relationship ids connected to node with
@@ -226,7 +225,7 @@ public interface BatchInserter
      * @param relId the id of the relationship.
      * @return map containing the relationship's properties.
      */
-    Map<String,Value> getRelationshipProperties( long relId );
+    Map<String,Object> getRelationshipProperties( long relId );
 
     /**
      * Removes the property named {@code property} from the node with id

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
@@ -921,7 +921,7 @@ public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvide
     }
 
     @Override
-    public Map<String,Value> getNodeProperties( long nodeId )
+    public Map<String,Object> getNodeProperties( long nodeId )
     {
         NodeRecord record = getNodeRecord( nodeId ).forReadingData();
         if ( record.getNextProp() != Record.NO_NEXT_PROPERTY.intValue() )
@@ -969,7 +969,7 @@ public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvide
     }
 
     @Override
-    public Map<String,Value> getRelationshipProperties( long relId )
+    public Map<String,Object> getRelationshipProperties( long relId )
     {
         RelationshipRecord record = recordAccess.getRelRecords().getOrLoad( relId, null ).forChangingData();
         if ( record.getNextProp() != Record.NO_NEXT_PROPERTY.intValue() )
@@ -1026,14 +1026,14 @@ public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvide
         return "EmbeddedBatchInserter[" + storeDir + "]";
     }
 
-    private Map<String, Value> getPropertyChain( long nextProp )
+    private Map<String, Object> getPropertyChain( long nextProp )
     {
-        final Map<String, Value> map = new HashMap<>();
+        final Map<String, Object> map = new HashMap<>();
         propertyTraverser.getPropertyChain( nextProp, recordAccess.getPropertyRecords(), propBlock ->
         {
             String key = propertyKeyTokens.byId( propBlock.getKeyIndexId() ).name();
             Value propertyValue = propBlock.newPropertyValue( propertyStore );
-            map.put( key, propertyValue );
+            map.put( key, propertyValue.asObject() );
         } );
         return map;
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/FileSystemClosingBatchInserter.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/FileSystemClosingBatchInserter.java
@@ -31,7 +31,6 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.unsafe.batchinsert.BatchInserter;
 import org.neo4j.unsafe.batchinsert.BatchRelationship;
-import org.neo4j.values.storable.Value;
 
 public class FileSystemClosingBatchInserter implements BatchInserter, IndexConfigStoreProvider
 {
@@ -114,7 +113,7 @@ public class FileSystemClosingBatchInserter implements BatchInserter, IndexConfi
     }
 
     @Override
-    public Map<String,Value> getNodeProperties( long nodeId )
+    public Map<String,Object> getNodeProperties( long nodeId )
     {
         return delegate.getNodeProperties( nodeId );
     }
@@ -150,7 +149,7 @@ public class FileSystemClosingBatchInserter implements BatchInserter, IndexConfi
     }
 
     @Override
-    public Map<String,Value> getRelationshipProperties( long relId )
+    public Map<String,Object> getRelationshipProperties( long relId )
     {
         return delegate.getRelationshipProperties( relId );
     }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/batchinsert/internal/BatchInsertTest.java
@@ -283,7 +283,7 @@ public class BatchInsertTest
         inserter.setNodeProperty( id2, "array", array2 );
 
         // Then
-        assertThat( inserter.getNodeProperties( id1 ).get( "array" ), equalTo( Values.of( array1 ) ) );
+        assertThat( inserter.getNodeProperties( id1 ).get( "array" ), equalTo( array1 ) );
     }
 
     @Test
@@ -1058,8 +1058,8 @@ public class BatchInsertTest
         batchInserter.setNodeProperty( nodeId, "additional", "something" );
 
         // THEN there should be no problems doing so
-        assertEquals( Values.of( "YetAnotherOne" ), batchInserter.getNodeProperties( nodeId ).get( "name" ) );
-        assertEquals( Values.of( "something" ), batchInserter.getNodeProperties( nodeId ).get( "additional" ) );
+        assertEquals( "YetAnotherOne", batchInserter.getNodeProperties( nodeId ).get( "name" ) );
+        assertEquals("something", batchInserter.getNodeProperties( nodeId ).get( "additional" ) );
     }
 
     /**
@@ -1119,7 +1119,7 @@ public class BatchInsertTest
         batchInserter.setNodeProperty( id, "test", "small test" );
 
         // THEN
-        assertEquals( Values.of( "small test" ), batchInserter.getNodeProperties( id ).get( "test" ) );
+        assertEquals( "small test", batchInserter.getNodeProperties( id ).get( "test" ) );
     }
 
     @Test
@@ -1138,7 +1138,7 @@ public class BatchInsertTest
         batchInserter.setNodeProperty( id, "count", "something" );
 
         // THEN
-        assertEquals( Values.of( "something" ), batchInserter.getNodeProperties( id ).get( "count" ) );
+        assertEquals( "something", batchInserter.getNodeProperties( id ).get( "count" ) );
     }
 
     @Test
@@ -1475,8 +1475,15 @@ public class BatchInsertTest
     private void setAndGet( BatchInserter inserter, Object value )
     {
         long nodeId = inserter.createNode( map( "key", value ) );
-        Value readValue = inserter.getNodeProperties( nodeId ).get( "key" );
-        assertEquals( Values.of( value ), readValue );
+        Object readValue = inserter.getNodeProperties( nodeId ).get( "key" );
+        if ( readValue.getClass().isArray() )
+        {
+            assertTrue( Arrays.equals( (int[])value, (int[])readValue ) );
+        }
+        else
+        {
+            assertEquals( value, readValue );
+        }
     }
 
     private int[] intArray()
@@ -1536,23 +1543,11 @@ public class BatchInsertTest
 
     private Map<String,Object> getNodeProperties( BatchInserter inserter, long nodeId )
     {
-        Map<String,Value> asValues = inserter.getNodeProperties( nodeId );
-        return valueMapToObjectMap( asValues );
+        return inserter.getNodeProperties( nodeId );
     }
 
     private Map<String,Object> getRelationshipProperties( BatchInserter inserter, long relId )
     {
-        Map<String,Value> asValues = inserter.getRelationshipProperties( relId );
-        return valueMapToObjectMap( asValues );
-    }
-
-    private Map<String,Object> valueMapToObjectMap( Map<String,Value> asValues )
-    {
-        Map<String,Object> asObjects = new HashMap<>();
-        for ( Map.Entry<String,Value> entry : asValues.entrySet() )
-        {
-            asObjects.put( entry.getKey(), entry.getValue().asObjectCopy() );
-        }
-        return asObjects;
+        return inserter.getRelationshipProperties( relId );
     }
 }


### PR DESCRIPTION
We messed up and managed to leak `Value` into a public API. Let's remove
as quick as possible.