### PR TITLE
Move parameter extraction to a later phase

### DIFF
--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/CypherCompilerAstCacheAcceptanceTest.scala
@@ -127,7 +127,7 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
     counter.counts should equal(CacheCounts(hits = 1, misses = 1, flushes = 1))
   }
 
-  test("should not care about value in cache") {
+  test("Constant values in query should use same plan") {
     runQuery("return 42 AS a")
     runQuery("return 53 AS a")
     runQuery("return 76 AS a")
@@ -135,7 +135,7 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
     counter.counts should equal(CacheCounts(hits = 2, misses = 1, flushes = 1))
   }
 
-  test("should fold constants") {
+  test("should fold to constants and use the same plan") {
     runQuery("return 42 AS a")
     runQuery("return 5 + 3 AS a")
     runQuery("return 5 - 3 AS a")

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/CypherCompilerAstCacheAcceptanceTest.scala
@@ -127,6 +127,24 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
     counter.counts should equal(CacheCounts(hits = 1, misses = 1, flushes = 1))
   }
 
+  test("should not care about value in cache") {
+    runQuery("return 42 AS a")
+    runQuery("return 53 AS a")
+    runQuery("return 76 AS a")
+
+    counter.counts should equal(CacheCounts(hits = 2, misses = 1, flushes = 1))
+  }
+
+  test("should fold constants") {
+    runQuery("return 42 AS a")
+    runQuery("return 5 + 3 AS a")
+    runQuery("return 5 - 3 AS a")
+    runQuery("return 7 / 6 AS a")
+    runQuery("return 7 * 6 AS a")
+
+    counter.counts should equal(CacheCounts(hits = 4, misses = 1, flushes = 1))
+  }
+
   test("should keep different cache entries for different literal types") {
     runQuery("WITH 1 as x RETURN x")      // miss
     runQuery("WITH 2 as x RETURN x")      // hit


### PR DESCRIPTION
Parameter extraction and constant folding was not aligned meaning that for expressions
where constants were folded, like `RETURN 1 +3`, we didn't get any autoparameterization.