### PR TITLE
Changed new tests to only run with cost planner until next patch release

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateAcceptanceTest.scala
@@ -25,10 +25,11 @@ import org.neo4j.cypher.{ExecutionEngineFunSuite, NewPlannerTestSupport, QuerySt
 class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with NewPlannerTestSupport
   with CreateTempFileTestSupport {
 
+  // Version 3.1 = rule planner will work first after the next patch release 3.1.8
   test("handle null value in property map from parameter for create node") {
     val query = "CREATE (a {props}) RETURN a.foo, a.bar"
 
-    val result = updateWithBothPlanners(query, "props" -> Map("foo" -> null, "bar" -> "baz"))
+    val result = updateWithCostPlannerOnly(query, "props" -> Map("foo" -> null, "bar" -> "baz"))
 
     result.toSet should equal(Set(Map("a.foo" -> null, "a.bar" -> "baz")))
     assertStats(result, nodesCreated = 1, propertiesWritten = 1)
@@ -44,19 +45,21 @@ class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
     assertStats(result, propertiesWritten = 2)
   }
 
+  // Version 3.1 = rule planner will work first after the next patch release 3.1.8
   test("handle null value in property map from parameter for create relationship") {
     val query = "CREATE (a)-[r:REL {props}]->() RETURN r.foo, r.bar"
 
-    val result = updateWithBothPlanners(query, "props" -> Map("foo" -> null, "bar" -> "baz"))
+    val result = updateWithCostPlannerOnly(query, "props" -> Map("foo" -> null, "bar" -> "baz"))
 
     result.toSet should equal(Set(Map("r.foo" -> null, "r.bar" -> "baz")))
     assertStats(result, nodesCreated = 2, relationshipsCreated = 1, propertiesWritten = 1)
   }
 
+  // Version 3.1 = rule planner will work first after the next patch release 3.1.8
   test("handle null value in property map from parameter") {
     val query = "CREATE (a {props})-[r:REL {props}]->() RETURN a.foo, a.bar, r.foo, r.bar"
 
-    val result = updateWithBothPlanners(query, "props" -> Map("foo" -> null, "bar" -> "baz"))
+    val result = updateWithCostPlannerOnly(query, "props" -> Map("foo" -> null, "bar" -> "baz"))
 
     result.toSet should equal(Set(Map("a.foo" -> null, "a.bar" -> "baz", "r.foo" -> null, "r.bar" -> "baz")))
     assertStats(result, nodesCreated = 2, relationshipsCreated = 1, propertiesWritten = 2)


### PR DESCRIPTION
During forward merge of #10268 build for 3.2 broke:

https://build.neohq.net/viewLog.html?buildId=2306401&tab=buildResultsDiv&buildTypeId=Neo4j32_CompatibilityBuilds_X86ubuntuIbmjdk8fast

This is a fix for that which should be null forward merged