### PR TITLE
Turn off compiled runtime for multiple aggregations

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -163,3 +163,6 @@ difficult to plan query number 1
 difficult to plan query number 2
 difficult to plan query number 3
 Match on multiple labels with OR
+
+//AggregationAcceptance.feature
+Multiple aggregations should work

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/AggregationAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/AggregationAcceptance.feature
@@ -39,3 +39,28 @@ Feature: AggregationAcceptance
       | aCount | zCount |
       | 1      | 1      |
     And no side effects
+
+  Scenario: Multiple aggregations should work
+    And having executed:
+      """
+      CREATE (zadie: AUTHOR {name: "Zadie Smith"})
+      CREATE (zadie)-[:WROTE]->(:BOOK {book: "White teeth"})
+      CREATE (zadie)-[:WROTE]->(:BOOK {book: "The Autograph Man"})
+      CREATE (zadie)-[:WROTE]->(:BOOK {book: "On Beauty"})
+      CREATE (zadie)-[:WROTE]->(:BOOK {book: "NW"})
+      CREATE (zadie)-[:WROTE]->(:BOOK {book: "Swing Time"})
+      """
+    When executing query:
+     """
+     MATCH (a)-[r]->(b)
+     RETURN b.book as book, count(r), count(distinct a)
+     ORDER BY book
+     """
+    Then the result should be:
+      | book                | count(r) | count(distinct a) |
+      | 'NW'                | 1        | 1                 |
+      | 'On Beauty'         | 1        | 1                 |
+      | 'Swing Time'        | 1        | 1                 |
+      | 'The Autograph Man' | 1        | 1                 |
+      | 'White teeth'       | 1        | 1                 |
+    And no side effects


### PR DESCRIPTION
The compiled runtime is not doing the right thing when having multiple
aggregations, e.g.
```
MATCH (a)-->(b)
RETURN a.prop, count(a.p1), count(b.p2)
```

This PR disables the compiled runtime from queries that contains more than one aggregation.