### PR TITLE
Fixes bug in pattern matching around pruning var expand

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/pruningVarExpander.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/plans/rewriter/pruningVarExpander.scala
@@ -96,7 +96,7 @@ case object pruningVarExpander extends Rewriter {
         val distinctSet = findDistinctSet(plan)
 
         val innerRewriter = topDown(Rewriter.lift {
-          case expand@VarExpand(lhs, fromId, dir, _, relTypes, toId, _, length, _, predicates) if distinctSet(expand) =>
+          case expand@VarExpand(lhs, fromId, dir, _, relTypes, toId, _, length, ExpandAll, predicates) if distinctSet(expand) =>
             if (length.min >= 4 && length.max.get >= 5)
               // These constants were selected by benchmarking on randomized graphs, with different
               // degrees of interconnection.

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -163,6 +163,7 @@ difficult to plan query number 1
 difficult to plan query number 2
 difficult to plan query number 3
 Match on multiple labels with OR
+Variable length path with both sides already bound
 
 //AggregationAcceptance.feature
 Multiple aggregations should work

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/MatchAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/MatchAcceptance.feature
@@ -167,3 +167,22 @@ Feature: MatchAcceptance
       | r.bar |
       | 2     |
     And no side effects
+
+  Scenario: Variable length path with both sides already bound
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (a:A {id: 1})-[:T]->(b:B {id: 2})
+      CREATE (a)-[:S]->(b)
+      CREATE (a)-[:T]->(:B)
+      CREATE (a)-[:T]->()-[:T]->(:B)
+      """
+    When executing query:
+      """
+      MATCH (a:A {id: 1})-[:S]->(b:B {id: 2}), (a)-[:T*1..2]->(b)
+      RETURN DISTINCT a.id, b.id
+      """
+    Then the result should be:
+      | a.id | b.id |
+      | 1    | 2    |
+    And no side effects


### PR DESCRIPTION
When both sides of a variable path where already available,
pruning var-expand should not be used, since it disregards the already
bound end-side.