### PR TITLE
 Allow transaction logs to be located in a separate folder.

### DIFF
--- a/community/command-line/src/main/java/org/neo4j/commandline/Util.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/Util.java
@@ -63,6 +63,20 @@ public class Util
         }
     }
 
+    public static boolean isSameOrChildFile( File parent, File candidate )
+    {
+        Path canonicalCandidate = canonicalPath( candidate );
+        Path canonicalParentPath = canonicalPath( parent );
+        return canonicalCandidate.startsWith( canonicalParentPath );
+    }
+
+    public static boolean isSameOrChildPath( Path parent, Path candidate )
+    {
+        Path normalizedCandidate = candidate.normalize();
+        Path normalizedParent = parent.normalize();
+        return normalizedCandidate.startsWith( normalizedParent );
+    }
+
     public static void checkLock( Path databaseDirectory ) throws CommandFailed
     {
         try ( FileSystemAbstraction fileSystem = new DefaultFileSystemAbstraction();

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
@@ -36,7 +36,6 @@ import org.neo4j.commandline.arguments.OptionalBooleanArg;
 import org.neo4j.commandline.arguments.common.OptionalCanonicalPath;
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
 import org.neo4j.consistency.checking.full.ConsistencyFlags;
-import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Strings;
 import org.neo4j.helpers.collection.MapUtil;
@@ -51,7 +50,7 @@ import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.FormattedLogProvider;
 
 import static java.lang.String.format;
-import static org.neo4j.dbms.DatabaseManagementSystemSettings.database_path;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.database_path;
 
 public class CheckConsistencyCommand implements AdminCommand
 {
@@ -253,7 +252,7 @@ public class CheckConsistencyCommand implements AdminCommand
     private static Config loadNeo4jConfig( Path homeDir, Path configDir, String databaseName,
             Map<String,String> additionalConfig )
     {
-        additionalConfig.put( DatabaseManagementSystemSettings.active_database.name(), databaseName );
+        additionalConfig.put( GraphDatabaseSettings.active_database.name(), databaseName );
 
         return Config.fromFile( configDir.resolve( Config.DEFAULT_CONFIG_FILE_NAME ) ).withHome( homeDir ).withConnectorsDisabled()
                 .withSettings( additionalConfig ).build();

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
@@ -234,7 +234,7 @@ public class CheckConsistencyCommand implements AdminCommand
                       .createPageCache( fileSystem, additionalConfiguration ) )
         {
             RecoveryRequiredChecker requiredChecker =
-                    new RecoveryRequiredChecker( fileSystem, pageCache, new Monitors() );
+                    new RecoveryRequiredChecker( fileSystem, pageCache, additionalConfiguration, new Monitors() );
             if ( requiredChecker.isRecoveryRequiredAt( storeDir ) )
             {
                 throw new CommandFailed(

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckTool.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckTool.java
@@ -26,8 +26,8 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 
-import org.neo4j.consistency.checking.full.ConsistencyFlags;
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
+import org.neo4j.consistency.checking.full.ConsistencyFlags;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;
 import org.neo4j.helpers.Strings;
@@ -137,7 +137,8 @@ public class ConsistencyCheckTool
     {
         try ( PageCache pageCache = ConfigurableStandalonePageCacheFactory.createPageCache( fs, tuningConfiguration ) )
         {
-            RecoveryRequiredChecker requiredChecker = new RecoveryRequiredChecker( fs, pageCache, new Monitors() );
+            RecoveryRequiredChecker requiredChecker = new RecoveryRequiredChecker( fs, pageCache,
+                    tuningConfiguration, new Monitors() );
             if ( requiredChecker.isRecoveryRequiredAt( storeDir ) )
             {
                 throw new ToolFailureException( Strings.joinAsLines(

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckToolTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckToolTest.java
@@ -67,20 +67,21 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.neo4j.graphdb.Label.label;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.logical_logs_location;
 
 public class ConsistencyCheckToolTest
 {
-    private final TestDirectory storeDirectory = TestDirectory.testDirectory();
+    private final TestDirectory testDirectory = TestDirectory.testDirectory();
     private final EphemeralFileSystemRule fs = new EphemeralFileSystemRule();
 
     @Rule
-    public RuleChain ruleChain = RuleChain.outerRule( storeDirectory ).around( fs );
+    public RuleChain ruleChain = RuleChain.outerRule( testDirectory ).around( fs );
 
     @Test
     public void runsConsistencyCheck() throws Exception
     {
         // given
-        File storeDir = storeDirectory.directory();
+        File storeDir = testDirectory.directory();
         String[] args = {storeDir.getPath()};
         ConsistencyCheckService service = mock( ConsistencyCheckService.class );
 
@@ -109,8 +110,8 @@ public class ConsistencyCheckToolTest
                         provider.getLog( "test" ).info( "testMessage" );
                         return ConsistencyCheckService.Result.success( new File( StringUtils.EMPTY ) );
                     } );
-            File storeDir = storeDirectory.directory();
-            File configFile = storeDirectory.file( Config.DEFAULT_CONFIG_FILE_NAME );
+            File storeDir = testDirectory.directory();
+            File configFile = testDirectory.file( Config.DEFAULT_CONFIG_FILE_NAME );
             Properties properties = new Properties();
             properties.setProperty( GraphDatabaseSettings.log_timezone.name(), LogTimeZone.SYSTEM.name() );
             properties.store( new FileWriter( configFile ), null );
@@ -129,7 +130,7 @@ public class ConsistencyCheckToolTest
     public void appliesDefaultTuningConfigurationForConsistencyChecker() throws Exception
     {
         // given
-        File storeDir = storeDirectory.directory();
+        File storeDir = testDirectory.directory();
         String[] args = {storeDir.getPath()};
         ConsistencyCheckService service = mock( ConsistencyCheckService.class );
 
@@ -148,8 +149,8 @@ public class ConsistencyCheckToolTest
     public void passesOnConfigurationIfProvided() throws Exception
     {
         // given
-        File storeDir = storeDirectory.directory();
-        File configFile = storeDirectory.file( Config.DEFAULT_CONFIG_FILE_NAME );
+        File storeDir = testDirectory.directory();
+        File configFile = testDirectory.file( Config.DEFAULT_CONFIG_FILE_NAME );
         Properties properties = new Properties();
         properties.setProperty( ConsistencyCheckSettings.consistency_check_property_owners.name(), "true" );
         properties.store( new FileWriter( configFile ), null );
@@ -192,8 +193,8 @@ public class ConsistencyCheckToolTest
     public void exitWithFailureIfConfigSpecifiedButConfigFileDoesNotExist() throws Exception
     {
         // given
-        File configFile = storeDirectory.file( "nonexistent_file" );
-        String[] args = {storeDirectory.directory().getPath(), "-config", configFile.getPath()};
+        File configFile = testDirectory.file( "nonexistent_file" );
+        String[] args = {testDirectory.directory().getPath(), "-config", configFile.getPath()};
         ConsistencyCheckService service = mock( ConsistencyCheckService.class );
 
         try
@@ -217,18 +218,30 @@ public class ConsistencyCheckToolTest
     {
         createGraphDbAndKillIt( Config.defaults() );
 
-        runConsistencyCheckToolWith( fs.get(), storeDirectory.graphDbDir().getAbsolutePath() );
+        runConsistencyCheckToolWith( fs.get(), testDirectory.graphDbDir().getAbsolutePath() );
     }
 
     @Test( expected = ToolFailureException.class )
-    public void failOnNotCleanlyShutdownStoreWithLogsInCustomLocation() throws Exception
+    public void failOnNotCleanlyShutdownStoreWithLogsInCustomRelativeLocation() throws Exception
     {
-        File customConfigFile = storeDirectory.file( "customConfig" );
-        File otherLocation = storeDirectory.directory( "otherLocation" );
-        Config customConfig = Config.defaults( GraphDatabaseSettings.logical_logs_location, otherLocation.getName() );
+        File customConfigFile = testDirectory.file( "customConfig" );
+        Config customConfig = Config.defaults( logical_logs_location, "otherLocation" );
         createGraphDbAndKillIt( customConfig );
         MapUtil.store( customConfig.getRaw(), customConfigFile );
-        String[] args = {storeDirectory.graphDbDir().getPath(), "-config", customConfigFile.getPath()};
+        String[] args = {testDirectory.graphDbDir().getPath(), "-config", customConfigFile.getPath()};
+
+        runConsistencyCheckToolWith( fs.get(), args );
+    }
+
+    @Test( expected = ToolFailureException.class )
+    public void failOnNotCleanlyShutdownStoreWithLogsInCustomAbsoluteLocation() throws Exception
+    {
+        File customConfigFile = testDirectory.file( "customConfig" );
+        File otherLocation = testDirectory.directory( "otherLocation" );
+        Config customConfig = Config.defaults( logical_logs_location, otherLocation.getAbsolutePath() );
+        createGraphDbAndKillIt( customConfig );
+        MapUtil.store( customConfig.getRaw(), customConfigFile );
+        String[] args = {testDirectory.graphDbDir().getPath(), "-config", customConfigFile.getPath()};
 
         runConsistencyCheckToolWith( fs.get(), args );
     }
@@ -255,7 +268,7 @@ public class ConsistencyCheckToolTest
     {
         final GraphDatabaseService db = new TestGraphDatabaseFactory()
                 .setFileSystem( fs.get() )
-                .newImpermanentDatabaseBuilder( storeDirectory.graphDbDir() )
+                .newImpermanentDatabaseBuilder( testDirectory.graphDbDir() )
                 .setConfig( config.getRaw()  )
                 .newGraphDatabase();
 

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/CsvImporter.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/CsvImporter.java
@@ -30,7 +30,6 @@ import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.commandline.dbms.config.WrappedBatchImporterConfigurationForNeo4jAdmin;
 import org.neo4j.commandline.dbms.config.WrappedCsvInputConfigurationForNeo4jAdmin;
-import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -43,7 +42,6 @@ import org.neo4j.unsafe.impl.batchimport.input.csv.CsvInput;
 import org.neo4j.unsafe.impl.batchimport.input.csv.IdType;
 
 import static java.nio.charset.Charset.defaultCharset;
-
 import static org.neo4j.kernel.impl.util.Converters.withDefault;
 import static org.neo4j.tooling.ImportTool.csvConfiguration;
 import static org.neo4j.tooling.ImportTool.extractInputFiles;
@@ -100,7 +98,7 @@ class CsvImporter implements Importer
     public void doImport() throws IOException
     {
         FileSystemAbstraction fs = outsideWorld.fileSystem();
-        File storeDir = databaseConfig.get( DatabaseManagementSystemSettings.database_path );
+        File storeDir = databaseConfig.get( GraphDatabaseSettings.database_path );
         File logsDir = databaseConfig.get( GraphDatabaseSettings.logs_directory );
         File reportFile = new File( reportFileName );
 

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DatabaseImporter.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DatabaseImporter.java
@@ -30,7 +30,7 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.util.Converters;
 import org.neo4j.kernel.impl.util.Validators;
 
-import static org.neo4j.dbms.DatabaseManagementSystemSettings.database_path;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.database_path;
 
 class DatabaseImporter implements Importer
 {

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
@@ -32,8 +32,8 @@ import org.neo4j.commandline.admin.AdminCommand;
 import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.arguments.Arguments;
-import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.dbms.archive.Dumper;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.StoreLockException;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.util.Validators;
@@ -41,7 +41,7 @@ import org.neo4j.kernel.internal.locker.StoreLocker;
 
 import static java.lang.String.format;
 import static org.neo4j.commandline.Util.canonicalPath;
-import static org.neo4j.dbms.DatabaseManagementSystemSettings.database_path;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.database_path;
 
 public class DumpCommand implements AdminCommand
 {
@@ -102,7 +102,7 @@ public class DumpCommand implements AdminCommand
         return Config.fromFile( configDir.resolve( Config.DEFAULT_CONFIG_FILE_NAME ) )
                 .withHome( homeDir )
                 .withConnectorsDisabled()
-                .withSetting( DatabaseManagementSystemSettings.active_database, databaseName )
+                .withSetting( GraphDatabaseSettings.active_database, databaseName )
                 .build().get( database_path ).toPath();
     }
 

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DumpCommand.java
@@ -42,6 +42,7 @@ import org.neo4j.kernel.internal.locker.StoreLocker;
 import static java.lang.String.format;
 import static org.neo4j.commandline.Util.canonicalPath;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.database_path;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.logical_logs_location;
 
 public class DumpCommand implements AdminCommand
 {
@@ -66,7 +67,10 @@ public class DumpCommand implements AdminCommand
     {
         String database = arguments.parse( args ).get( "database" );
         Path archive = calculateArchive( database, arguments.getMandatoryPath( "to" ) );
-        Path databaseDirectory = canonicalPath( toDatabaseDirectory( database ) );
+
+        Config config = buildConfig( database );
+        Path databaseDirectory = canonicalPath( getDatabaseDirectory( config ) );
+        Path transactionLogsDirectory = canonicalPath( getTransactionalLogsDirectory( config ) );
 
         try
         {
@@ -79,7 +83,7 @@ public class DumpCommand implements AdminCommand
 
         try ( Closeable ignored = StoreLockChecker.check( databaseDirectory ) )
         {
-            dump( database, databaseDirectory, archive );
+            dump( database, databaseDirectory, transactionLogsDirectory, archive );
         }
         catch ( StoreLockException e )
         {
@@ -97,13 +101,23 @@ public class DumpCommand implements AdminCommand
         }
     }
 
-    private Path toDatabaseDirectory( String databaseName )
+    private Path getDatabaseDirectory( Config config )
+    {
+        return config.get( database_path ).toPath();
+    }
+
+    private Path getTransactionalLogsDirectory( Config config )
+    {
+        return config.get( logical_logs_location ).toPath();
+    }
+
+    private Config buildConfig( String databaseName )
     {
         return Config.fromFile( configDir.resolve( Config.DEFAULT_CONFIG_FILE_NAME ) )
                 .withHome( homeDir )
                 .withConnectorsDisabled()
                 .withSetting( GraphDatabaseSettings.active_database, databaseName )
-                .build().get( database_path ).toPath();
+                .build();
     }
 
     private Path calculateArchive( String database, Path to )
@@ -111,11 +125,12 @@ public class DumpCommand implements AdminCommand
         return Files.isDirectory( to ) ? to.resolve( database + ".dump" ) : to;
     }
 
-    private void dump( String database, Path databaseDirectory, Path archive ) throws CommandFailed
+    private void dump( String database, Path databaseDirectory, Path transactionalLogsDirectory, Path archive )
+            throws CommandFailed
     {
         try
         {
-            dumper.dump( databaseDirectory, archive, this::isStoreLock );
+            dumper.dump( databaseDirectory, transactionalLogsDirectory, archive, this::isStoreLock );
         }
         catch ( FileAlreadyExistsException e )
         {

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
@@ -34,7 +34,7 @@ import org.neo4j.commandline.arguments.MandatoryNamedArg;
 import org.neo4j.commandline.arguments.OptionalBooleanArg;
 import org.neo4j.commandline.arguments.OptionalNamedArg;
 import org.neo4j.commandline.arguments.OptionalNamedArgWithMetadata;
-import org.neo4j.dbms.DatabaseManagementSystemSettings;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.configuration.Config;
@@ -250,7 +250,7 @@ public class ImportCommand implements AdminCommand
             Config config =
                     loadNeo4jConfig( homeDir, configDir, database, loadAdditionalConfig( additionalConfigFile ) );
             Validators.CONTAINS_NO_EXISTING_DATABASE
-                    .validate( config.get( DatabaseManagementSystemSettings.database_path ) );
+                    .validate( config.get( GraphDatabaseSettings.database_path ) );
 
             Importer importer = importerFactory.getImporterForMode( mode, Args.parse( args ), config, outsideWorld );
             importer.doImport();
@@ -288,7 +288,7 @@ public class ImportCommand implements AdminCommand
     {
         return Config.fromFile( configDir.resolve( Config.DEFAULT_CONFIG_FILE_NAME ) )
                 .withHome( homeDir )
-                .withSetting( DatabaseManagementSystemSettings.active_database, databaseName )
+                .withSetting( GraphDatabaseSettings.active_database, databaseName )
                 .withSettings( additionalConfig )
                 .withConnectorsDisabled().build();
     }

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/LoadCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/LoadCommand.java
@@ -32,9 +32,9 @@ import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.arguments.Arguments;
 import org.neo4j.commandline.arguments.OptionalBooleanArg;
 import org.neo4j.commandline.arguments.common.MandatoryCanonicalPath;
-import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.dbms.archive.IncorrectFormat;
 import org.neo4j.dbms.archive.Loader;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.configuration.Config;
 
@@ -42,7 +42,7 @@ import static java.util.Objects.requireNonNull;
 import static org.neo4j.commandline.Util.canonicalPath;
 import static org.neo4j.commandline.Util.checkLock;
 import static org.neo4j.commandline.Util.wrapIOException;
-import static org.neo4j.dbms.DatabaseManagementSystemSettings.database_path;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.database_path;
 
 public class LoadCommand implements AdminCommand
 {
@@ -85,7 +85,7 @@ public class LoadCommand implements AdminCommand
         return Config.fromFile( configDir.resolve( Config.DEFAULT_CONFIG_FILE_NAME ) )
                 .withHome( homeDir )
                 .withConnectorsDisabled()
-                .withSetting( DatabaseManagementSystemSettings.active_database, databaseName )
+                .withSetting( GraphDatabaseSettings.active_database, databaseName )
                 .build().get( database_path ).toPath();
     }
 

--- a/community/dbms/src/main/java/org/neo4j/dbms/DatabaseManagementSystemSettings.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/DatabaseManagementSystemSettings.java
@@ -21,35 +21,19 @@ package org.neo4j.dbms;
 
 import java.io.File;
 
-import org.neo4j.configuration.Description;
 import org.neo4j.configuration.Internal;
 import org.neo4j.configuration.LoadableConfig;
 import org.neo4j.graphdb.config.Setting;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 
 import static org.neo4j.kernel.configuration.Settings.PATH;
-import static org.neo4j.kernel.configuration.Settings.STRING;
 import static org.neo4j.kernel.configuration.Settings.derivedSetting;
-import static org.neo4j.kernel.configuration.Settings.pathSetting;
-import static org.neo4j.kernel.configuration.Settings.setting;
 
 public class DatabaseManagementSystemSettings implements LoadableConfig
 {
-    @Description( "Name of the database to load" )
-    public static final Setting<String> active_database = setting( "dbms.active_database", STRING, "graph.db" );
-
-    @Description( "Path of the data directory. You must not configure more than one Neo4j installation to use the " +
-            "same data directory." )
-    public static final Setting<File> data_directory = pathSetting( "dbms.directories.data", "data" );
-
-    @Internal
-    public static final Setting<File> database_path = derivedSetting( "unsupported.dbms.directories.database",
-            data_directory, active_database,
-            ( data, current ) -> new File( new File( data, "databases" ), current ),
-            PATH );
-
     @Internal
     public static final Setting<File> auth_store_directory = derivedSetting( "unsupported.dbms.directories.auth",
-            data_directory,
+            GraphDatabaseSettings.data_directory,
             data -> new File( data, "dbms" ),
             PATH );
 }

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/CsvImporterTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/CsvImporterTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.neo4j.commandline.admin.RealOutsideWorld;
-import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Args;
 import org.neo4j.kernel.configuration.Config;
@@ -62,7 +61,7 @@ public class CsvImporterTest
         {
             Config config = Config.builder()
                     .withSettings( additionalConfig() )
-                    .withSetting( DatabaseManagementSystemSettings.database_path, dbDir.getAbsolutePath() )
+                    .withSetting( GraphDatabaseSettings.database_path, dbDir.getAbsolutePath() )
                     .withSetting( GraphDatabaseSettings.logs_directory, logDir.getAbsolutePath() ).build();
 
             CsvImporter csvImporter = new CsvImporter(
@@ -80,7 +79,7 @@ public class CsvImporterTest
 
     private Map<String,String> additionalConfig()
     {
-        return stringMap( DatabaseManagementSystemSettings.database_path.name(), getDatabasePath(),
+        return stringMap( GraphDatabaseSettings.database_path.name(), getDatabasePath(),
                 GraphDatabaseSettings.logs_directory.name(), getLogsDirectory() );
     }
 

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DatabaseImporterTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DatabaseImporterTest.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 
 import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.admin.NullOutsideWorld;
-import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
@@ -128,7 +127,7 @@ public class DatabaseImporterTest
     {
         HashMap<String,String> additionalConfig = new HashMap<>();
         additionalConfig.put( GraphDatabaseSettings.neo4j_home.name(), homeDir.toString() );
-        additionalConfig.put( DatabaseManagementSystemSettings.active_database.name(), databaseName );
+        additionalConfig.put( GraphDatabaseSettings.active_database.name(), databaseName );
         return Config.defaults( additionalConfig );
     }
 

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DumpCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DumpCommandTest.java
@@ -43,6 +43,7 @@ import org.neo4j.commandline.admin.CommandLocator;
 import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.admin.Usage;
 import org.neo4j.dbms.archive.Dumper;
+import org.neo4j.graphdb.config.Setting;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
@@ -68,6 +69,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.neo4j.dbms.archive.TestUtils.withPermissions;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.data_directory;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.logical_logs_location;
 
 public class DumpCommandTest
 {
@@ -97,7 +99,8 @@ public class DumpCommandTest
     public void shouldDumpTheDatabaseToTheArchive() throws Exception
     {
         execute( "foo.db" );
-        verify( dumper ).dump( eq( homeDir.resolve( "data/databases/foo.db" ) ), eq( archive ), any() );
+        verify( dumper ).dump( eq( homeDir.resolve( "data/databases/foo.db" ) ),
+                eq( homeDir.resolve( "data/databases/foo.db" ) ), eq( archive ), any() );
     }
 
     @Test
@@ -107,10 +110,25 @@ public class DumpCommandTest
         Path databaseDir = dataDir.resolve( "databases/foo.db" );
         putStoreInDirectory( databaseDir );
         Files.write( configDir.resolve( Config.DEFAULT_CONFIG_FILE_NAME ),
-                asList( format( "%s=%s", data_directory.name(), dataDir.toString().replace( '\\', '/' ) ) ) );
+                asList( formatProperty( data_directory, dataDir ) ) );
 
         execute( "foo.db" );
-        verify( dumper ).dump( eq( databaseDir ), any(), any() );
+        verify( dumper ).dump( eq( databaseDir ), eq( databaseDir ), any(), any() );
+    }
+
+    @Test
+    public void shouldCalculateTheTxLogDirectoryFromConfig() throws Exception
+    {
+        Path dataDir = testDirectory.directory( "some-other-path" ).toPath();
+        Path txLogsDir = testDirectory.directory( "txLogsPath" ).toPath();
+        Path databaseDir = dataDir.resolve( "databases/foo.db" );
+        putStoreInDirectory( databaseDir );
+        Files.write( configDir.resolve( Config.DEFAULT_CONFIG_FILE_NAME ),
+                asList( formatProperty( data_directory, dataDir ),
+                        formatProperty( logical_logs_location, txLogsDir ) ) );
+
+        execute( "foo.db" );
+        verify( dumper ).dump( eq( databaseDir ), eq( txLogsDir ), any(), any() );
     }
 
     @Test
@@ -132,7 +150,7 @@ public class DumpCommandTest
                 asList( format( "%s=%s", data_directory.name(), dataDir.toString().replace( '\\', '/' ) ) ) );
 
         execute( "foo.db" );
-        verify( dumper ).dump( eq( realDatabaseDir ), any(), any() );
+        verify( dumper ).dump( eq( realDatabaseDir ), eq( realDatabaseDir ), any(), any() );
     }
 
     @Test
@@ -141,7 +159,7 @@ public class DumpCommandTest
     {
         File to = testDirectory.directory( "some-dir" );
         new DumpCommand( homeDir, configDir, dumper ).execute( new String[]{"--database=" + "foo.db", "--to=" + to} );
-        verify( dumper ).dump( any( Path.class ), eq( to.toPath().resolve( "foo.db.dump" ) ), any() );
+        verify( dumper ).dump( any( Path.class ), any( Path.class ), eq( to.toPath().resolve( "foo.db.dump" ) ), any() );
     }
 
     @Test
@@ -149,7 +167,8 @@ public class DumpCommandTest
     {
         new DumpCommand( homeDir, configDir, dumper )
                 .execute( new String[]{"--database=" + "foo.db", "--to=foo.dump"} );
-        verify( dumper ).dump( any( Path.class ), eq( Paths.get( new File( "foo.dump" ).getCanonicalPath() ) ), any() );
+        verify( dumper ).dump( any( Path.class ), any( Path.class ),
+                eq( Paths.get( new File( "foo.dump" ).getCanonicalPath() ) ), any() );
     }
 
     @Test
@@ -158,7 +177,7 @@ public class DumpCommandTest
     {
         Files.createFile( archive );
         execute( "foo.db" );
-        verify( dumper ).dump( any(), eq( archive ), any() );
+        verify( dumper ).dump( any(), any(), eq( archive ), any() );
     }
 
     @Test
@@ -190,7 +209,7 @@ public class DumpCommandTest
     @Test
     public void shouldReleaseTheStoreLockEvenIfThereIsAnError() throws Exception
     {
-        doThrow( IOException.class ).when( dumper ).dump( any(), any(), any() );
+        doThrow( IOException.class ).when( dumper ).dump( any(), any(), any(), any() );
 
         try
         {
@@ -213,7 +232,7 @@ public class DumpCommandTest
         {
             assertThat( Files.exists( databaseDirectory ), equalTo( false ) );
             return null;
-        } ).when( dumper ).dump( any(), any(), any() );
+        } ).when( dumper ).dump( any(), any(), any(), any() );
 
         execute( "foo.db" );
     }
@@ -249,11 +268,11 @@ public class DumpCommandTest
         doAnswer( invocation ->
         {
             //noinspection unchecked
-            Predicate<Path> exclude = invocation.getArgument( 2 );
+            Predicate<Path> exclude = invocation.getArgument( 3 );
             assertThat( exclude.test( Paths.get( StoreLocker.STORE_LOCK_FILENAME ) ), is( true ) );
             assertThat( exclude.test( Paths.get( "some-other-file" ) ), is( false ) );
             return null;
-        } ).when( dumper ).dump( any(), any(), any() );
+        } ).when( dumper ).dump(any(), any(), any(), any() );
 
         execute( "foo.db" );
     }
@@ -265,10 +284,10 @@ public class DumpCommandTest
         Path databaseDir = dataDir.resolve( "databases/graph.db" );
         putStoreInDirectory( databaseDir );
         Files.write( configDir.resolve( Config.DEFAULT_CONFIG_FILE_NAME ),
-                asList( format( "%s=%s", data_directory.name(), dataDir.toString().replace( '\\', '/' ) ) ) );
+                asList( formatProperty( data_directory, dataDir ) ) );
 
         new DumpCommand( homeDir, configDir, dumper ).execute( new String[]{"--to=" + archive} );
-        verify( dumper ).dump( eq( databaseDir ), any(), any() );
+        verify( dumper ).dump( eq( databaseDir ), eq( databaseDir ), any(), any() );
     }
 
     @Test
@@ -288,7 +307,7 @@ public class DumpCommandTest
     @Test
     public void shouldGiveAClearErrorIfTheArchiveAlreadyExists() throws Exception
     {
-        doThrow( new FileAlreadyExistsException( "the-archive-path" ) ).when( dumper ).dump( any(), any(), any() );
+        doThrow( new FileAlreadyExistsException( "the-archive-path" ) ).when( dumper ).dump( any(), any(), any(), any() );
         try
         {
             execute( "foo.db" );
@@ -317,7 +336,7 @@ public class DumpCommandTest
     @Test
     public void shouldGiveAClearMessageIfTheArchivesParentDoesntExist() throws Exception
     {
-        doThrow( new NoSuchFileException( archive.getParent().toString() ) ).when( dumper ).dump( any(), any(), any() );
+        doThrow( new NoSuchFileException( archive.getParent().toString() ) ).when( dumper ).dump(any(), any(), any(), any() );
         try
         {
             execute( "foo.db" );
@@ -331,10 +350,10 @@ public class DumpCommandTest
     }
 
     @Test
-    public void shouldWrapIOExceptionsCarefulllyBecauseCriticalInformationIsOftenEncodedInTheirNameButMissingFromTheirMessage()
+    public void shouldWrapIOExceptionsCarefullyBecauseCriticalInformationIsOftenEncodedInTheirNameButMissingFromTheirMessage()
             throws Exception
     {
-        doThrow( new IOException( "the-message" ) ).when( dumper ).dump( any(), any(), any() );
+        doThrow( new IOException( "the-message" ) ).when( dumper ).dump(any(), any(), any(), any() );
         try
         {
             execute( "foo.db" );
@@ -383,7 +402,7 @@ public class DumpCommandTest
                 .execute( new String[]{"--database=" + database, "--to=" + archive} );
     }
 
-    private void assertCanLockStore( Path databaseDirectory ) throws IOException
+    private static void assertCanLockStore( Path databaseDirectory ) throws IOException
     {
         try ( FileSystemAbstraction fileSystem = new DefaultFileSystemAbstraction();
               StoreLocker storeLocker = new StoreLocker( fileSystem, databaseDirectory.toFile() ) )
@@ -392,10 +411,15 @@ public class DumpCommandTest
         }
     }
 
-    private void putStoreInDirectory( Path storeDir ) throws IOException
+    private static void putStoreInDirectory( Path storeDir ) throws IOException
     {
         Files.createDirectories( storeDir );
         Path storeFile = storeDir.resolve( StoreFileType.STORE.augment( MetaDataStore.DEFAULT_NAME ) );
         Files.createFile( storeFile );
+    }
+
+    private static String formatProperty( Setting setting, Path path )
+    {
+        return format( "%s=%s", setting.name(), path.toString().replace( '\\', '/' ) );
     }
 }

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DumpCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DumpCommandTest.java
@@ -66,8 +66,8 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.neo4j.dbms.DatabaseManagementSystemSettings.data_directory;
 import static org.neo4j.dbms.archive.TestUtils.withPermissions;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.data_directory;
 
 public class DumpCommandTest
 {

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/LoadCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/LoadCommandTest.java
@@ -63,7 +63,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.neo4j.dbms.DatabaseManagementSystemSettings.data_directory;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.data_directory;
 
 public class LoadCommandTest
 {

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/UtilTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/UtilTest.java
@@ -19,15 +19,24 @@
  */
 package org.neo4j.commandline.dbms;
 
+import org.junit.Rule;
 import org.junit.Test;
 
 import org.neo4j.commandline.Util;
+import org.neo4j.test.rule.TestDirectory;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.commandline.Util.isSameOrChildFile;
+import static org.neo4j.commandline.Util.isSameOrChildPath;
 import static org.neo4j.commandline.Util.neo4jVersion;
 
 public class UtilTest
 {
+    @Rule
+    public final TestDirectory directory = TestDirectory.testDirectory();
+
     @Test
     public void canonicalPath() throws Exception
     {
@@ -38,5 +47,30 @@ public class UtilTest
     public void returnsAVersion() throws Exception
     {
         assertNotNull( "A version should be returned", neo4jVersion() );
+    }
+
+    @Test
+    public void correctlyIdentifySameOrChildFile()
+    {
+        assertTrue( isSameOrChildFile( directory.directory(), directory.directory( "a" ) ) );
+        assertTrue( isSameOrChildFile( directory.directory(), directory.directory() ) );
+        assertTrue( isSameOrChildFile( directory.directory( "/a/./b" ), directory.directory( "a/b" ) ) );
+        assertTrue( isSameOrChildFile( directory.directory( "a/b" ), directory.directory( "/a/./b" ) ) );
+
+        assertFalse( isSameOrChildFile( directory.directory( "a" ), directory.directory( "b" ) ) );
+    }
+
+    @Test
+    public void correctlyIdentifySameOrChildPath()
+    {
+        assertTrue( isSameOrChildPath( directory.directory().toPath(), directory.directory( "a" ).toPath() ) );
+        assertTrue( isSameOrChildPath( directory.directory().toPath(), directory.directory().toPath() ) );
+        assertTrue( isSameOrChildPath( directory.directory( "/a/./b" ).toPath(),
+                directory.directory( "a/b" ).toPath() ) );
+        assertTrue( isSameOrChildPath( directory.directory( "a/b" ).toPath(),
+                directory.directory( "/a/./b" ).toPath() ) );
+
+        assertFalse( isSameOrChildPath( directory.directory( "a" ).toPath(),
+                directory.directory( "b" ).toPath() ) );
     }
 }

--- a/community/dbms/src/test/java/org/neo4j/dbms/DatabaseManagementSystemSettingsTest.java
+++ b/community/dbms/src/test/java/org/neo4j/dbms/DatabaseManagementSystemSettingsTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import java.io.File;
 
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.configuration.Config;
 
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -33,8 +34,8 @@ public class DatabaseManagementSystemSettingsTest
     @Test
     public void shouldPutDatabaseDirectoriesIntoDataDatabases()
     {
-        Config config = Config.defaults( DatabaseManagementSystemSettings.data_directory, "the-data-directory" );
-        assertThat( config.get( DatabaseManagementSystemSettings.database_path ),
+        Config config = Config.defaults( GraphDatabaseSettings.data_directory, "the-data-directory" );
+        assertThat( config.get( GraphDatabaseSettings.database_path ),
                 equalTo( new File( "the-data-directory/databases/graph.db" ) ) );
     }
 }

--- a/community/dbms/src/test/java/org/neo4j/dbms/archive/DumperTest.java
+++ b/community/dbms/src/test/java/org/neo4j/dbms/archive/DumperTest.java
@@ -19,6 +19,10 @@
  */
 package org.neo4j.dbms.archive;
 
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
@@ -28,15 +32,10 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 
-import org.apache.commons.lang3.SystemUtils;
-import org.junit.Rule;
-import org.junit.Test;
-
 import org.neo4j.function.Predicates;
 import org.neo4j.test.rule.TestDirectory;
 
 import static java.util.Collections.emptySet;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
@@ -54,7 +53,7 @@ public class DumperTest
         Files.write( archive, new byte[0] );
         try
         {
-            new Dumper().dump( directory, archive, Predicates.alwaysFalse() );
+            new Dumper().dump( directory, directory, archive, Predicates.alwaysFalse() );
             fail( "Expected an exception" );
         }
         catch ( FileAlreadyExistsException e )
@@ -70,7 +69,7 @@ public class DumperTest
         Path archive = testDirectory.file( "the-archive.dump" ).toPath();
         try
         {
-            new Dumper().dump( directory, archive, Predicates.alwaysFalse() );
+            new Dumper().dump( directory, directory, archive, Predicates.alwaysFalse() );
             fail( "Expected an exception" );
         }
         catch ( NoSuchFileException e )
@@ -86,7 +85,7 @@ public class DumperTest
         Path archive = testDirectory.file( "subdir/the-archive.dump" ).toPath();
         try
         {
-            new Dumper().dump( directory, archive, Predicates.alwaysFalse() );
+            new Dumper().dump( directory, directory, archive, Predicates.alwaysFalse() );
             fail( "Expected an exception" );
         }
         catch ( NoSuchFileException e )
@@ -103,7 +102,7 @@ public class DumperTest
         Files.write( archive.getParent(), new byte[0] );
         try
         {
-            new Dumper().dump( directory, archive, Predicates.alwaysFalse() );
+            new Dumper().dump( directory, directory, archive, Predicates.alwaysFalse() );
             fail( "Expected an exception" );
         }
         catch ( FileSystemException e )
@@ -122,7 +121,7 @@ public class DumperTest
         Files.createDirectories( archive.getParent() );
         try ( Closeable ignored = TestUtils.withPermissions( archive.getParent(), emptySet() ) )
         {
-            new Dumper().dump( directory, archive, Predicates.alwaysFalse() );
+            new Dumper().dump( directory, directory, archive, Predicates.alwaysFalse() );
             fail( "Expected an exception" );
         }
         catch ( AccessDeniedException e )

--- a/community/dbms/src/test/java/org/neo4j/dbms/archive/LoaderTest.java
+++ b/community/dbms/src/test/java/org/neo4j/dbms/archive/LoaderTest.java
@@ -19,6 +19,11 @@
  */
 package org.neo4j.dbms.archive;
 
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
@@ -29,20 +34,13 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.Random;
 
-import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
-import org.apache.commons.lang3.SystemUtils;
-import org.junit.Rule;
-import org.junit.Test;
-
 import org.neo4j.test.rule.TestDirectory;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeFalse;
-
 import static org.neo4j.dbms.archive.TestUtils.withPermissions;
 
 public class LoaderTest
@@ -57,7 +55,7 @@ public class LoaderTest
         Path destination = testDirectory.file( "the-destination" ).toPath();
         try
         {
-            new Loader().load( archive, destination );
+            new Loader().load( archive, destination, destination );
             fail( "Expected an exception" );
         }
         catch ( NoSuchFileException e )
@@ -74,7 +72,7 @@ public class LoaderTest
         Path destination = testDirectory.file( "the-destination" ).toPath();
         try
         {
-            new Loader().load( archive, destination );
+            new Loader().load( archive, destination, destination );
             fail( "Expected an exception" );
         }
         catch ( IncorrectFormat e )
@@ -98,7 +96,7 @@ public class LoaderTest
         Path destination = testDirectory.file( "the-destination" ).toPath();
         try
         {
-            new Loader().load( archive, destination );
+            new Loader().load( archive, destination, destination );
             fail( "Expected an exception" );
         }
         catch ( IncorrectFormat e )
@@ -114,12 +112,29 @@ public class LoaderTest
         Path destination = testDirectory.directory( "the-destination" ).toPath();
         try
         {
-            new Loader().load( archive, destination );
+            new Loader().load( archive, destination, destination );
             fail( "Expected an exception" );
         }
         catch ( FileAlreadyExistsException e )
         {
             assertEquals( destination.toString(), e.getMessage() );
+        }
+    }
+
+    @Test
+    public void shouldGiveAClearErrorIfTheDestinationTxLogAlreadyExists() throws IOException, IncorrectFormat
+    {
+        Path archive = testDirectory.file( "the-archive.dump" ).toPath();
+        Path destination = testDirectory.file( "the-destination" ).toPath();
+        Path txLogsDestination = testDirectory.directory( "txLogsDestination" ).toPath();
+        try
+        {
+            new Loader().load( archive, destination, txLogsDestination );
+            fail( "Expected an exception" );
+        }
+        catch ( FileAlreadyExistsException e )
+        {
+            assertEquals( txLogsDestination.toString(), e.getMessage() );
         }
     }
 
@@ -131,12 +146,30 @@ public class LoaderTest
         Path destination = testDirectory.directory( "subdir/the-destination" ).toPath();
         try
         {
-            new Loader().load( archive, destination );
+            new Loader().load( archive, destination, destination );
             fail( "Expected an exception" );
         }
         catch ( NoSuchFileException e )
         {
             assertEquals( destination.getParent().toString(), e.getMessage() );
+        }
+    }
+
+    @Test
+    public void shouldGiveAClearErrorMessageIfTheTxLogsParentDirectoryDoesntExist()
+            throws IOException, IncorrectFormat
+    {
+        Path archive = testDirectory.file( "the-archive.dump" ).toPath();
+        Path destination = testDirectory.file( "destination" ).toPath();
+        Path txLogsDestination = testDirectory.directory( "subdir/txLogs" ).toPath();
+        try
+        {
+            new Loader().load( archive, destination, txLogsDestination );
+            fail( "Expected an exception" );
+        }
+        catch ( NoSuchFileException e )
+        {
+            assertEquals( txLogsDestination.getParent().toString(), e.getMessage() );
         }
     }
 
@@ -149,7 +182,7 @@ public class LoaderTest
         Files.write( destination.getParent(), new byte[0] );
         try
         {
-            new Loader().load( archive, destination );
+            new Loader().load( archive, destination, destination );
             fail( "Expected an exception" );
         }
         catch ( FileSystemException e )
@@ -169,12 +202,33 @@ public class LoaderTest
         Files.createDirectories( destination.getParent() );
         try ( Closeable ignored = withPermissions( destination.getParent(), emptySet() ) )
         {
-            new Loader().load( archive, destination );
+            new Loader().load( archive, destination, destination );
             fail( "Expected an exception" );
         }
         catch ( AccessDeniedException e )
         {
             assertEquals( destination.getParent().toString(), e.getMessage() );
+        }
+    }
+
+    @Test
+    public void shouldGiveAClearErrorMessageIfTheTxLogsParentDirectoryIsNotWritable()
+            throws IOException, IncorrectFormat
+    {
+        assumeFalse( "We haven't found a way to reliably tests permissions on Windows", SystemUtils.IS_OS_WINDOWS );
+
+        Path archive = testDirectory.file( "the-archive.dump" ).toPath();
+        Path destination = testDirectory.file( "destination" ).toPath();
+        Path txLogsDrectory = testDirectory.directory( "subdir/txLogs" ).toPath();
+        Files.createDirectories( txLogsDrectory.getParent() );
+        try ( Closeable ignored = withPermissions( txLogsDrectory.getParent(), emptySet() ) )
+        {
+            new Loader().load( archive, destination, txLogsDrectory );
+            fail( "Expected an exception" );
+        }
+        catch ( AccessDeniedException e )
+        {
+            assertEquals( txLogsDrectory.getParent().toString(), e.getMessage() );
         }
     }
 }

--- a/community/io/src/main/java/org/neo4j/io/fs/DefaultFileSystemAbstraction.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/DefaultFileSystemAbstraction.java
@@ -179,6 +179,12 @@ public class DefaultFileSystemAbstraction implements FileSystemAbstraction
     }
 
     @Override
+    public void copyToDirectory( File file, File toDirectory ) throws IOException
+    {
+        FileUtils.copyFileToDirectory( file, toDirectory );
+    }
+
+    @Override
     public void copyFile( File from, File to ) throws IOException
     {
         FileUtils.copyFile( from, to );

--- a/community/io/src/main/java/org/neo4j/io/fs/DelegateFileSystemAbstraction.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/DelegateFileSystemAbstraction.java
@@ -228,6 +228,12 @@ public class DelegateFileSystemAbstraction implements FileSystemAbstraction
     }
 
     @Override
+    public void copyToDirectory( File file, File toDirectory ) throws IOException
+    {
+        Files.copy( path( file ), toDirectory.toPath().resolve( file.getName() ) );
+    }
+
+    @Override
     public void copyFile( File from, File to ) throws IOException
     {
         Files.copy( path( from ), path( to ) );

--- a/community/io/src/main/java/org/neo4j/io/fs/FileSystemAbstraction.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/FileSystemAbstraction.java
@@ -82,6 +82,8 @@ public interface FileSystemAbstraction extends Closeable
 
     void moveToDirectory( File file, File toDirectory ) throws IOException;
 
+    void copyToDirectory( File file, File toDirectory ) throws IOException;
+
     void copyFile( File from, File to ) throws IOException;
 
     void copyRecursively( File fromDirectory, File toDirectory ) throws IOException;

--- a/community/io/src/main/java/org/neo4j/io/fs/FileUtils.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/FileUtils.java
@@ -51,6 +51,7 @@ import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.BasicFileAttributes;
 
@@ -190,6 +191,30 @@ public class FileUtils
         return target;
     }
 
+    /**
+     * Utility method that copy a file from its current location to the
+     * provided target directory.
+     *
+     * @param file file that needs to be copied.
+     * @param targetDirectory the destination directory
+     * @throws IOException
+     */
+    public static void copyFileToDirectory( File file, File targetDirectory ) throws IOException
+    {
+        if ( !targetDirectory.exists() )
+        {
+            Files.createDirectories( targetDirectory.toPath() );
+        }
+        if ( !targetDirectory.isDirectory() )
+        {
+            throw new IllegalArgumentException(
+                    "Move target must be a directory, not " + targetDirectory );
+        }
+
+        File target = new File( targetDirectory, file.getName() );
+        copyFile( file, target );
+    }
+
     public static void renameFile( File srcFile, File renameToFile, CopyOption... copyOptions ) throws IOException
     {
         Files.move( srcFile.toPath(), renameToFile.toPath(), copyOptions );
@@ -264,22 +289,7 @@ public class FileUtils
     {
         //noinspection ResultOfMethodCallIgnored
         dstFile.getParentFile().mkdirs();
-        try ( FileInputStream input = new FileInputStream( srcFile );
-              FileOutputStream output = new FileOutputStream( dstFile ) )
-        {
-            int bufferSize = 1024;
-            byte[] buffer = new byte[bufferSize];
-            int bytesRead;
-            while ( (bytesRead = input.read( buffer )) != -1 )
-            {
-                output.write( buffer, 0, bytesRead );
-            }
-        }
-        catch ( IOException e )
-        {
-            // Because the message from this cause may not mention which file it's about
-            throw new IOException( "Could not copy '" + srcFile + "' to '" + dstFile + "'", e );
-        }
+        Files.copy( srcFile.toPath(), dstFile.toPath(), StandardCopyOption.REPLACE_EXISTING );
     }
 
     public static void copyRecursively( File fromDirectory, File toDirectory ) throws IOException

--- a/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialFileSystemAbstraction.java
@@ -194,6 +194,7 @@ public class AdversarialFileSystemAbstraction implements FileSystemAbstraction
         delegate.copyToDirectory( file, toDirectory );
     }
 
+    @Override
     public boolean isDirectory( File file )
     {
         adversary.injectFailure( SecurityException.class );

--- a/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/fs/AdversarialFileSystemAbstraction.java
@@ -186,6 +186,14 @@ public class AdversarialFileSystemAbstraction implements FileSystemAbstraction
     }
 
     @Override
+    public void copyToDirectory( File file, File toDirectory ) throws IOException
+    {
+        adversary.injectFailure(
+                SecurityException.class, IllegalArgumentException.class, FileNotFoundException.class,
+                NullPointerException.class, IOException.class );
+        delegate.copyToDirectory( file, toDirectory );
+    }
+
     public boolean isDirectory( File file )
     {
         adversary.injectFailure( SecurityException.class );

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/DelegatingFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/DelegatingFileSystemAbstraction.java
@@ -66,6 +66,12 @@ public class DelegatingFileSystemAbstraction implements FileSystemAbstraction
     }
 
     @Override
+    public void copyToDirectory( File file, File toDirectory ) throws IOException
+    {
+        delegate.copyToDirectory( file, toDirectory );
+    }
+
+    @Override
     public boolean mkdir( File fileName )
     {
         return delegate.mkdir( fileName );

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/EphemeralFileSystemAbstraction.java
@@ -541,6 +541,13 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
     }
 
     @Override
+    public void copyToDirectory( File file, File toDirectory ) throws IOException
+    {
+        File targetFile = new File( toDirectory, file.getName() );
+        copyFile( file, targetFile );
+    }
+
+    @Override
     public void copyFile( File from, File to ) throws IOException
     {
         EphemeralFileData data = files.get( canonicalFile( from ) );
@@ -626,6 +633,7 @@ public class EphemeralFileSystemAbstraction implements FileSystemAbstraction
         try ( StoreChannel source = fromFs.open( from, OpenMode.READ );
               StoreChannel sink = this.open( to, OpenMode.READ_WRITE ) )
         {
+            sink.truncate( 0 );
             for ( int available; (available = (int) (source.size() - source.position())) > 0; )
             {
                 buffer.clear();

--- a/community/io/src/test/java/org/neo4j/graphdb/mockfs/SelectiveFileSystemAbstraction.java
+++ b/community/io/src/test/java/org/neo4j/graphdb/mockfs/SelectiveFileSystemAbstraction.java
@@ -168,6 +168,12 @@ public class SelectiveFileSystemAbstraction implements FileSystemAbstraction
     }
 
     @Override
+    public void copyToDirectory( File file, File toDirectory ) throws IOException
+    {
+        chooseFileSystem( file ).copyToDirectory( file, toDirectory );
+    }
+
+    @Override
     public void copyFile( File from, File to ) throws IOException
     {
         chooseFileSystem( from ).copyFile( from, to );

--- a/community/io/src/test/java/org/neo4j/test/rule/fs/FileSystemRule.java
+++ b/community/io/src/test/java/org/neo4j/test/rule/fs/FileSystemRule.java
@@ -186,6 +186,12 @@ public abstract class FileSystemRule<FS extends FileSystemAbstraction> extends E
     }
 
     @Override
+    public void copyToDirectory( File file, File toDirectory ) throws IOException
+    {
+        fs.copyToDirectory( file, toDirectory );
+    }
+
+    @Override
     public void copyFile( File from, File to ) throws IOException
     {
         fs.copyFile( from, to );

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -74,6 +74,7 @@ import static org.neo4j.kernel.configuration.Settings.options;
 import static org.neo4j.kernel.configuration.Settings.optionsIgnoreCase;
 import static org.neo4j.kernel.configuration.Settings.pathSetting;
 import static org.neo4j.kernel.configuration.Settings.range;
+import static org.neo4j.kernel.configuration.Settings.relativePathSetting;
 import static org.neo4j.kernel.configuration.Settings.setting;
 
 /**
@@ -432,6 +433,9 @@ public class GraphDatabaseSettings implements LoadableConfig
     @Internal
     public static final Setting<Boolean> enable_native_schema_index =
             setting( "unsupported.dbms.enable_native_schema_index", BOOLEAN, TRUE );
+
+    @Description( "Location where Neo4j keeps the logical transaction logs." )
+    public static final Setting<File> logical_logs_location = relativePathSetting( "dbms.tx_log.location", "" );
 
     // Store settings
     @Description( "Make Neo4j keep the logical transaction logs for being able to backup the database. " +

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -74,7 +74,6 @@ import static org.neo4j.kernel.configuration.Settings.options;
 import static org.neo4j.kernel.configuration.Settings.optionsIgnoreCase;
 import static org.neo4j.kernel.configuration.Settings.pathSetting;
 import static org.neo4j.kernel.configuration.Settings.range;
-import static org.neo4j.kernel.configuration.Settings.relativePathSetting;
 import static org.neo4j.kernel.configuration.Settings.setting;
 
 /**
@@ -435,7 +434,7 @@ public class GraphDatabaseSettings implements LoadableConfig
             setting( "unsupported.dbms.enable_native_schema_index", BOOLEAN, TRUE );
 
     @Description( "Location where Neo4j keeps the logical transaction logs." )
-    public static final Setting<File> logical_logs_location = relativePathSetting( "dbms.tx_log.location", "" );
+    public static final Setting<File> logical_logs_location = pathSetting( "dbms.tx_log.location", "" );
 
     // Store settings
     @Description( "Make Neo4j keep the logical transaction logs for being able to backup the database. " +

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -101,6 +101,19 @@ public class GraphDatabaseSettings implements LoadableConfig
     public static final Setting<File> neo4j_home =
             setting( "unsupported.dbms.directories.neo4j_home", PATH, NO_DEFAULT );
 
+    @Description( "Name of the database to load" )
+    public static final Setting<String> active_database = setting( "dbms.active_database", STRING, "graph.db" );
+
+    @Description( "Path of the data directory. You must not configure more than one Neo4j installation to use the " +
+            "same data directory." )
+    public static final Setting<File> data_directory = pathSetting( "dbms.directories.data", "data" );
+
+    @Internal
+    public static final Setting<File> database_path = derivedSetting( "unsupported.dbms.directories.database",
+            data_directory, active_database,
+            ( data, current ) -> new File( new File( data, "databases" ), current ),
+            PATH );
+
     @Title( "Read only database" )
     @Description( "Only allow read operations from this Neo4j instance. " +
             "This mode still requires write access to the directory for lock purposes." )
@@ -434,7 +447,8 @@ public class GraphDatabaseSettings implements LoadableConfig
             setting( "unsupported.dbms.enable_native_schema_index", BOOLEAN, TRUE );
 
     @Description( "Location where Neo4j keeps the logical transaction logs." )
-    public static final Setting<File> logical_logs_location = pathSetting( "dbms.tx_log.location", "" );
+    public static final Setting<File> logical_logs_location =
+            pathSetting( "dbms.directories.tx_log", "", database_path );
 
     // Store settings
     @Description( "Make Neo4j keep the logical transaction logs for being able to backup the database. " +

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Settings.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Settings.java
@@ -336,6 +336,11 @@ public class Settings
         return new FileSetting( name, defaultValue );
     }
 
+    public static Setting<File> pathSetting( String name, String defaultValue, Setting<File> relativeRoot )
+    {
+        return new FileSetting( name, defaultValue, relativeRoot );
+    }
+
     private static <T> BiFunction<String,Function<String, String>, String> inheritedValue(
             final BiFunction<String,Function<String,String>, String> lookup, final Setting<T> inheritedSetting )
     {
@@ -1322,11 +1327,18 @@ public class Settings
     {
         private final String name;
         private final String defaultValue;
+        private final Setting<File> relativeRoot;
 
         FileSetting( String name, String defaultValue )
         {
+            this( name, defaultValue, GraphDatabaseSettings.neo4j_home );
+        }
+
+        FileSetting( String name, String defaultValue, Setting<File> relativeRoot )
+        {
             this.name = name;
             this.defaultValue = defaultValue;
+            this.relativeRoot = relativeRoot;
         }
 
         @Override
@@ -1369,14 +1381,14 @@ public class Settings
             }
             else
             {
-                return new File( GraphDatabaseSettings.neo4j_home.apply( config ), setting );
+                return new File( relativeRoot.apply( config ), setting );
             }
         }
 
         @Override
         public String valueDescription()
         {
-            return "A filesystem path; relative paths are resolved against the installation root, _<neo4j-home>_";
+            return "A filesystem path; relative paths are resolved against the root, _<" + relativeRoot.name() + ">_";
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Settings.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Settings.java
@@ -55,6 +55,7 @@ import static java.lang.Double.parseDouble;
 import static java.lang.Float.parseFloat;
 import static java.lang.Integer.parseInt;
 import static java.lang.Long.parseLong;
+import static java.lang.String.format;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.default_advertised_address;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.default_listen_address;
 import static org.neo4j.io.fs.FileUtils.fixSeparatorsInPath;
@@ -330,60 +331,14 @@ public class Settings
         };
     }
 
+    public static Setting<File> relativePathSetting( String name, String defaultValue )
+    {
+        return new FileSetting( name, defaultValue, false );
+    }
+
     public static Setting<File> pathSetting( String name, String defaultValue )
     {
-        return new ScopeAwareSetting<File>()
-        {
-            @Override
-            protected String provideName()
-            {
-                return name;
-            }
-
-            @Override
-            public String getDefaultValue()
-            {
-                return defaultValue;
-            }
-
-            @Override
-            public File from( Configuration config )
-            {
-                return config.get( this );
-            }
-
-            @Override
-            public File apply( Function<String, String> config )
-            {
-                String value = config.apply( name() );
-                if ( value == null )
-                {
-                    value = defaultValue;
-                }
-                if ( value == null )
-                {
-                    return null;
-                }
-
-                String setting = fixSeparatorsInPath( value );
-                File settingFile = new File( setting );
-
-                if ( settingFile.isAbsolute() )
-                {
-                    return settingFile;
-                }
-                else
-                {
-                    return new File( GraphDatabaseSettings.neo4j_home.apply( config ), setting );
-                }
-            }
-
-            @Override
-            public String valueDescription()
-            {
-                return "A filesystem path; relative paths are resolved against the installation root, _<neo4j-home>_";
-            }
-        };
+        return new FileSetting( name, defaultValue, true );
     }
 
     private static <T> BiFunction<String,Function<String, String>, String> inheritedValue(
@@ -734,7 +689,7 @@ public class Settings
             }
             catch ( NumberFormatException e )
             {
-                throw new IllegalArgumentException( String.format( "%s is not a valid size, must be e.g. 10, 5K, 1M, " +
+                throw new IllegalArgumentException( format( "%s is not a valid size, must be e.g. 10, 5K, 1M, " +
                         "11G", value ) );
             }
         }
@@ -935,7 +890,7 @@ public class Settings
             @Override
             public String toString()
             {
-                return String.format( MATCHES_PATTERN_MESSAGE, regex );
+                return format( MATCHES_PATTERN_MESSAGE, regex );
             }
         };
     }
@@ -983,7 +938,7 @@ public class Settings
             @Override
             public String toString()
             {
-                return String.format( MATCHES_PATTERN_MESSAGE, regex );
+                return format( MATCHES_PATTERN_MESSAGE, regex );
             }
         };
     }
@@ -997,7 +952,7 @@ public class Settings
             {
                 if ( value != null && value.compareTo( min ) < 0 )
                 {
-                    throw new IllegalArgumentException( String.format( "minimum allowed value is: %s", min ) );
+                    throw new IllegalArgumentException( format( "minimum allowed value is: %s", min ) );
                 }
                 return value;
             }
@@ -1019,7 +974,7 @@ public class Settings
             {
                 if ( value != null && value.compareTo( max ) > 0 )
                 {
-                    throw new IllegalArgumentException( String.format( "maximum allowed value is: %s", max ) );
+                    throw new IllegalArgumentException( format( "maximum allowed value is: %s", max ) );
                 }
                 return value;
             }
@@ -1045,7 +1000,7 @@ public class Settings
             @Override
             public String toString()
             {
-                return String.format( "is in the range `%s` to `%s`", min, max );
+                return format( "is in the range `%s` to `%s`", min, max );
             }
         };
     }
@@ -1076,7 +1031,7 @@ public class Settings
             {
                 String description = message;
                 if ( valueFunction != null
-                     && !String.format( MATCHES_PATTERN_MESSAGE, ANY ).equals(
+                     && !format( MATCHES_PATTERN_MESSAGE, ANY ).equals(
                              valueFunction.toString() ) )
                 {
                     description += " (" + valueFunction.toString() + ")";
@@ -1311,7 +1266,7 @@ public class Settings
                 }
                 catch ( Exception e )
                 {
-                    throw new IllegalArgumentException( String.format( "Missing mandatory setting '%s'", name() ) );
+                    throw new IllegalArgumentException( format( "Missing mandatory setting '%s'", name() ) );
                 }
             }
 
@@ -1365,6 +1320,78 @@ public class Settings
             }
 
             return builder.toString();
+        }
+    }
+
+    private static class FileSetting extends ScopeAwareSetting<File>
+    {
+        private final String name;
+        private final String defaultValue;
+        private final boolean absolutePathAllowed;
+
+        FileSetting( String name, String defaultValue, boolean absolutePathAllowed )
+        {
+            this.name = name;
+            this.defaultValue = defaultValue;
+            this.absolutePathAllowed = absolutePathAllowed;
+        }
+
+        @Override
+        protected String provideName()
+        {
+            return name;
+        }
+
+        @Override
+        public String getDefaultValue()
+        {
+            return defaultValue;
+        }
+
+        @Override
+        public File from( Configuration config )
+        {
+            return config.get( this );
+        }
+
+        @Override
+        public File apply( Function<String, String> config )
+        {
+            String value = config.apply( name() );
+            if ( value == null )
+            {
+                value = defaultValue;
+            }
+            if ( value == null )
+            {
+                return null;
+            }
+
+            String setting = fixSeparatorsInPath( value );
+            File settingFile = new File( setting );
+
+            if ( settingFile.isAbsolute() )
+            {
+                if ( absolutePathAllowed )
+                {
+                    return settingFile;
+                }
+                else
+                {
+                    throw new IllegalArgumentException(
+                            format( "Absolute path is not allowed for setting %s.", name() ) );
+                }
+            }
+            else
+            {
+                return new File( GraphDatabaseSettings.neo4j_home.apply( config ), setting );
+            }
+        }
+
+        @Override
+        public String valueDescription()
+        {
+            return "A filesystem path; relative paths are resolved against the installation root, _<neo4j-home>_";
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/Settings.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/Settings.java
@@ -331,14 +331,9 @@ public class Settings
         };
     }
 
-    public static Setting<File> relativePathSetting( String name, String defaultValue )
-    {
-        return new FileSetting( name, defaultValue, false );
-    }
-
     public static Setting<File> pathSetting( String name, String defaultValue )
     {
-        return new FileSetting( name, defaultValue, true );
+        return new FileSetting( name, defaultValue );
     }
 
     private static <T> BiFunction<String,Function<String, String>, String> inheritedValue(
@@ -1327,13 +1322,11 @@ public class Settings
     {
         private final String name;
         private final String defaultValue;
-        private final boolean absolutePathAllowed;
 
-        FileSetting( String name, String defaultValue, boolean absolutePathAllowed )
+        FileSetting( String name, String defaultValue )
         {
             this.name = name;
             this.defaultValue = defaultValue;
-            this.absolutePathAllowed = absolutePathAllowed;
         }
 
         @Override
@@ -1372,15 +1365,7 @@ public class Settings
 
             if ( settingFile.isAbsolute() )
             {
-                if ( absolutePathAllowed )
-                {
-                    return settingFile;
-                }
-                else
-                {
-                    throw new IllegalArgumentException(
-                            format( "Absolute path is not allowed for setting %s.", name() ) );
-                }
+                return settingFile;
             }
             else
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -179,10 +179,6 @@ public class PlatformModule
         diagnosticsManager = life.add( dependencies
                 .satisfyDependency( new DiagnosticsManager( logging.getInternalLog( DiagnosticsManager.class ) ) ) );
 
-        // TODO please fix the bad dependencies instead of doing this.
-        // this was the place of the XaDataSourceManager. NeoStoreXaDataSource is create further down than
-        // (specifically) KernelExtensions, which creates an interesting out-of-order issue with #doAfterRecovery().
-        // Anyways please fix this.
         dependencies.satisfyDependency( dataSourceManager );
 
         availabilityGuard = dependencies.satisfyDependency( createAvailabilityGuard() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/recovery/RecoveryRequiredChecker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/recovery/RecoveryRequiredChecker.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.transaction.log.ReadableClosablePositionAwareChannel;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
@@ -44,11 +45,13 @@ public class RecoveryRequiredChecker
     private final FileSystemAbstraction fs;
     private final PageCache pageCache;
     private final Monitors monitors;
+    private Config config;
 
-    public RecoveryRequiredChecker( FileSystemAbstraction fs, PageCache pageCache, Monitors monitors )
+    public RecoveryRequiredChecker( FileSystemAbstraction fs, PageCache pageCache, Config config, Monitors monitors )
     {
         this.fs = fs;
         this.pageCache = pageCache;
+        this.config = config;
         this.monitors = monitors;
     }
 
@@ -62,7 +65,9 @@ public class RecoveryRequiredChecker
         }
 
         LogEntryReader<ReadableClosablePositionAwareChannel> reader = new VersionAwareLogEntryReader<>();
-        LogFiles logFiles = LogFilesBuilder.activeFilesBuilder( dataDir, fs, pageCache ).withLogEntryReader( reader ).build();
+        LogFiles logFiles = LogFilesBuilder.activeFilesBuilder( dataDir, fs, pageCache )
+                                           .withConfig( config )
+                                           .withLogEntryReader( reader ).build();
         LogTailScanner tailScanner = new LogTailScanner( logFiles, reader, monitors );
         return new RecoveryStartInformationProvider( tailScanner, NO_MONITOR ).get().isRecoveryRequired();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigrator.java
@@ -309,7 +309,7 @@ public class StoreMigrator extends AbstractStoreMigrationParticipant
                                           : new TransactionId( lastTransactionId, UNKNOWN_TX_CHECKSUM, UNKNOWN_TX_COMMIT_TIMESTAMP );
     }
 
-    private LogPosition extractTransactionLogPosition( File neoStore, File storeDir, long lastTxId ) throws IOException
+    LogPosition extractTransactionLogPosition( File neoStore, File storeDir, long lastTxId ) throws IOException
     {
         long lastClosedTxLogVersion =
                 MetaDataStore.getRecord( pageCache, neoStore, Position.LAST_CLOSED_TRANSACTION_LOG_VERSION );
@@ -327,7 +327,9 @@ public class StoreMigrator extends AbstractStoreMigrationParticipant
             return new LogPosition( BASE_TX_LOG_VERSION, BASE_TX_LOG_BYTE_OFFSET );
         }
 
-        LogFiles logFiles = LogFilesBuilder.activeFilesBuilder( storeDir,fileSystem, pageCache ).build();
+        LogFiles logFiles = LogFilesBuilder.activeFilesBuilder( storeDir,fileSystem, pageCache )
+                                           .withConfig( config )
+                                           .build();
         long logVersion = logFiles.getHighestLogVersion();
         if ( logVersion == -1 )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadOnlyTransactionStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadOnlyTransactionStore.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.transaction.log.TransactionMetadataCache.TransactionMetadata;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
 import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
@@ -41,13 +42,14 @@ public class ReadOnlyTransactionStore implements Lifecycle, LogicalTransactionSt
     private final LifeSupport life = new LifeSupport();
     private final LogicalTransactionStore physicalStore;
 
-    public ReadOnlyTransactionStore( PageCache pageCache, FileSystemAbstraction fs, File fromPath, Monitors monitors )
-            throws IOException
+    public ReadOnlyTransactionStore( PageCache pageCache, FileSystemAbstraction fs, File fromPath, Config config,
+            Monitors monitors ) throws IOException
     {
         TransactionMetadataCache transactionMetadataCache = new TransactionMetadataCache( 100 );
         LogEntryReader<ReadableClosablePositionAwareChannel> logEntryReader = new VersionAwareLogEntryReader<>();
         LogFiles logFiles = LogFilesBuilder
                 .activeFilesBuilder( fromPath, fs, pageCache ).withLogEntryReader( logEntryReader )
+                .withConfig( config )
                 .build();
         physicalStore = new PhysicalLogicalTransactionStore( logFiles, transactionMetadataCache, logEntryReader,
                 monitors, true );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/LogFiles.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/LogFiles.java
@@ -39,6 +39,10 @@ public interface LogFiles extends Lifecycle
 
     File[] logFiles();
 
+    boolean isLogFile( File file );
+
+    File logFilesDirectory();
+
     File getLogFileForVersion( long version );
 
     File getHighestLogFile();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFiles.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFiles.java
@@ -60,11 +60,13 @@ public class TransactionLogFiles extends LifecycleAdapter implements LogFiles
     private final LogFileCreationMonitor monitor;
     private final TransactionLogFilesHelper fileHelper;
     private final TransactionLogFile logFile;
+    private final File logsDirectory;
 
-    TransactionLogFiles( File directory, String name, TransactionLogFilesContext context )
+    TransactionLogFiles( File logsDirectory, String name, TransactionLogFilesContext context )
     {
         this.logFilesContext = context;
-        this.fileHelper = new TransactionLogFilesHelper( directory, name );
+        this.logsDirectory = logsDirectory;
+        this.fileHelper = new TransactionLogFilesHelper( logsDirectory, name );
         this.fileSystem = context.getFileSystem();
         this.monitor = context.getLogFileCreationMonitor();
         this.logHeaderCache = new LogHeaderCache( 1000 );
@@ -106,6 +108,18 @@ public class TransactionLogFiles extends LifecycleAdapter implements LogFiles
     public File[] logFiles()
     {
         return fileSystem.listFiles( fileHelper.getParentDirectory(), fileHelper.getLogFilenameFilter() );
+    }
+
+    @Override
+    public boolean isLogFile( File file )
+    {
+        return fileHelper.getLogFilenameFilter().accept( null, file.getName() );
+    }
+
+    @Override
+    public File logFilesDirectory()
+    {
+        return logsDirectory;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFiles.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFiles.java
@@ -51,6 +51,7 @@ public class TransactionLogFiles extends LifecycleAdapter implements LogFiles
 {
     public static final String DEFAULT_NAME = "neostore.transaction.db";
     public static final FilenameFilter DEFAULT_FILENAME_FILTER = TransactionLogFilesHelper.DEFAULT_FILENAME_FILTER;
+    private static final File[] EMPTY_FILES_ARRAY = {};
 
     private final TransactionLogFilesContext logFilesContext;
     private final TransactionLogFileInformation logFileInformation;
@@ -107,7 +108,12 @@ public class TransactionLogFiles extends LifecycleAdapter implements LogFiles
     @Override
     public File[] logFiles()
     {
-        return fileSystem.listFiles( fileHelper.getParentDirectory(), fileHelper.getLogFilenameFilter() );
+        File[] files = fileSystem.listFiles( fileHelper.getParentDirectory(), fileHelper.getLogFilenameFilter() );
+        if ( files == null )
+        {
+            return EMPTY_FILES_ARRAY;
+        }
+        return files;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFilesHelper.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFilesHelper.java
@@ -31,7 +31,7 @@ class TransactionLogFilesHelper
     private static final String VERSION_SUFFIX = ".";
     private static final String REGEX_VERSION_SUFFIX = "\\.";
 
-    public static final FilenameFilter DEFAULT_FILENAME_FILTER = new LogicalLogFilenameFilter( REGEX_DEFAULT_NAME );
+    static final FilenameFilter DEFAULT_FILENAME_FILTER = new LogicalLogFilenameFilter( REGEX_DEFAULT_NAME );
 
     private final File logBaseName;
     private final FilenameFilter logFileFilter;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListing.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListing.java
@@ -34,9 +34,9 @@ import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.impl.api.ExplicitIndexProviderLookup;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
-import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.StoreType;
 import org.neo4j.kernel.impl.store.format.RecordFormat;
+import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
 import org.neo4j.kernel.spi.explicitindex.IndexImplementation;
 import org.neo4j.storageengine.api.StorageEngine;
 import org.neo4j.storageengine.api.StoreFileMetadata;
@@ -47,17 +47,22 @@ import static org.neo4j.helpers.collection.Iterators.resourceIterator;
 public class NeoStoreFileListing
 {
     private final File storeDir;
+    private final LogFiles logFiles;
     private final LabelScanStore labelScanStore;
     private final IndexingService indexingService;
     private final ExplicitIndexProviderLookup explicitIndexProviders;
     private final StorageEngine storageEngine;
     private final Function<File,StoreFileMetadata> toNotAStoreTypeFile =
             file -> new StoreFileMetadata( file, RecordFormat.NO_RECORD_SIZE );
+    private final Function<File, StoreFileMetadata> logFileMapper =
+            file -> new StoreFileMetadata( file, RecordFormat.NO_RECORD_SIZE, true );
 
-    public NeoStoreFileListing( File storeDir, LabelScanStore labelScanStore, IndexingService indexingService,
+    public NeoStoreFileListing( File storeDir, LogFiles logFiles,
+            LabelScanStore labelScanStore, IndexingService indexingService,
             ExplicitIndexProviderLookup explicitIndexProviders, StorageEngine storageEngine )
     {
         this.storeDir = storeDir;
+        this.logFiles = logFiles;
         this.labelScanStore = labelScanStore;
         this.indexingService = indexingService;
         this.explicitIndexProviders = explicitIndexProviders;
@@ -100,20 +105,20 @@ public class NeoStoreFileListing
 
     private void gatherNonRecordStores( Collection<StoreFileMetadata> files, boolean includeLogs )
     {
-        final File[] storeFiles = storeDir.listFiles();
-        if ( storeFiles == null )
+        File[] indexFiles = storeDir.listFiles( ( dir, name ) -> name.equals( IndexConfigStore.INDEX_DB_FILE_NAME ) );
+        if ( indexFiles != null )
         {
-            return;
-        }
-        for ( File file : storeFiles )
-        {
-            if ( file.getName().equals( IndexConfigStore.INDEX_DB_FILE_NAME ) )
+            for ( File file : indexFiles )
             {
                 files.add( toNotAStoreTypeFile.apply( file ) );
             }
-            else if ( includeLogs && transactionLogFile( file.getName() ) )
+        }
+        if ( includeLogs )
+        {
+            File[] logFiles = this.logFiles.logFiles();
+            for ( File logFile : logFiles )
             {
-                files.add( toNotAStoreTypeFile.apply( file ) );
+                files.add( logFileMapper.apply( logFile ) );
             }
         }
     }
@@ -153,11 +158,6 @@ public class NeoStoreFileListing
     private void gatherNeoStoreFiles( final Collection<StoreFileMetadata> targetFiles )
     {
         targetFiles.addAll( storageEngine.listStorageFiles() );
-    }
-
-    private boolean transactionLogFile( String name )
-    {
-        return name.startsWith( MetaDataStore.DEFAULT_NAME + ".transaction" ) && !name.endsWith( ".active" );
     }
 
     private static final class MultiResource implements Resource

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StoreFileMetadata.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StoreFileMetadata.java
@@ -25,11 +25,18 @@ public class StoreFileMetadata
 {
     private final File file;
     private final int recordSize;
+    private final boolean isLogFile;
 
     public StoreFileMetadata( File file, int recordSize )
     {
+        this( file, recordSize, false );
+    }
+
+    public StoreFileMetadata( File file, int recordSize, boolean isLogFile )
+    {
         this.file = file;
         this.recordSize = recordSize;
+        this.isLogFile = isLogFile;
     }
 
     public File file()
@@ -40,5 +47,10 @@ public class StoreFileMetadata
     public int recordSize()
     {
         return recordSize;
+    }
+
+    public boolean isLogFile()
+    {
+        return isLogFile;
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/graphdb/TransactionLogsInSeparateLocationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/TransactionLogsInSeparateLocationIT.java
@@ -56,6 +56,15 @@ public class TransactionLogsInSeparateLocationIT
         verifyTransactionLogs( txDirectory, storeDir );
     }
 
+    @Test
+    public void databaseWithTransactionLogsInSeparateAbsoluteLocation() throws IOException
+    {
+        File storeDir = testDirectory.graphDbDir();
+        File txDirectory = testDirectory.directory( "transaction-logs" );
+        performTransactions( txDirectory.getAbsolutePath(), storeDir );
+        verifyTransactionLogs( txDirectory, storeDir );
+    }
+
     private void performTransactions( String txPath, File storeDir ) throws IOException
     {
         GraphDatabaseService database = new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir )

--- a/community/kernel/src/test/java/org/neo4j/graphdb/TransactionLogsInSeparateLocationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/TransactionLogsInSeparateLocationIT.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.impl.transaction.log.PhysicalLogVersionedStoreChannel;
+import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
+import org.neo4j.kernel.impl.transaction.log.files.LogFilesBuilder;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+import org.neo4j.test.rule.fs.FileSystemRule;
+
+import static org.hamcrest.Matchers.greaterThan;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class TransactionLogsInSeparateLocationIT
+{
+    @Rule
+    public final TestDirectory testDirectory = TestDirectory.testDirectory();
+    @Rule
+    public final FileSystemRule fileSystemRule = new DefaultFileSystemRule();
+
+    @Test
+    public void databaseWithTransactionLogsInSeparateRelativeLocation() throws IOException
+    {
+        File storeDir = testDirectory.graphDbDir();
+        File txDirectory = new File( storeDir, "transaction-logs" );
+        performTransactions( txDirectory.getName(), storeDir );
+        verifyTransactionLogs( txDirectory, storeDir );
+    }
+
+    private void performTransactions( String txPath, File storeDir ) throws IOException
+    {
+        GraphDatabaseService database = new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir )
+                .setConfig( GraphDatabaseSettings.logical_logs_location, txPath )
+                .newGraphDatabase();
+        for ( int i = 0; i < 10; i++ )
+        {
+            try ( Transaction transaction = database.beginTx() )
+            {
+                Node node = database.createNode();
+                node.setProperty( "a", "b" );
+                node.setProperty( "c", "d" );
+                transaction.success();
+            }
+        }
+        database.shutdown();
+    }
+
+    private void verifyTransactionLogs( File txDirectory, File storeDir ) throws IOException
+    {
+        FileSystemAbstraction fileSystem = fileSystemRule.get();
+        LogFiles storeDirLogs = LogFilesBuilder.logFilesBasedOnlyBuilder( storeDir, fileSystem ).build();
+        assertFalse( storeDirLogs.versionExists( 0 ) );
+
+        LogFiles txDirectoryLogs = LogFilesBuilder.logFilesBasedOnlyBuilder( txDirectory, fileSystem ).build();
+        assertTrue( txDirectoryLogs.versionExists( 0 ) );
+        try ( PhysicalLogVersionedStoreChannel physicalLogVersionedStoreChannel = txDirectoryLogs.openForVersion( 0 ) )
+        {
+            assertThat( physicalLogVersionedStoreChannel.size(), greaterThan( 0L ) );
+        }
+    }
+
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/SettingsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/SettingsTest.java
@@ -60,6 +60,7 @@ import static org.neo4j.kernel.configuration.Settings.max;
 import static org.neo4j.kernel.configuration.Settings.min;
 import static org.neo4j.kernel.configuration.Settings.pathSetting;
 import static org.neo4j.kernel.configuration.Settings.range;
+import static org.neo4j.kernel.configuration.Settings.relativePathSetting;
 import static org.neo4j.kernel.configuration.Settings.setting;
 
 public class SettingsTest
@@ -104,6 +105,22 @@ public class SettingsTest
     public void shouldHaveAUsefulToStringWhichIsUsedAsTheValidValuesInDocumentation()
     {
         assertThat( pathSetting( "", NO_DEFAULT ).toString(), containsString( "A filesystem path" ) );
+    }
+
+    @Test( expected = IllegalArgumentException.class )
+    public void relativePathSettingsDoesNotAllowAbsolutePath()
+    {
+        Setting<File> setting = relativePathSetting( "some.settings", new File( "." ).getAbsolutePath() );
+        Config.defaults().get( setting );
+    }
+
+    @Test
+    public void relativePathResolvePathAgainstNeo4jHome()
+    {
+        Setting<File> setting = relativePathSetting( "some.setting", "test" );
+        Config config = Config.defaults();
+        config.augmentDefaults( GraphDatabaseSettings.neo4j_home, "/root" );
+        assertEquals( "/root/test", config.get( setting ).getAbsolutePath() );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/SettingsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/SettingsTest.java
@@ -60,7 +60,6 @@ import static org.neo4j.kernel.configuration.Settings.max;
 import static org.neo4j.kernel.configuration.Settings.min;
 import static org.neo4j.kernel.configuration.Settings.pathSetting;
 import static org.neo4j.kernel.configuration.Settings.range;
-import static org.neo4j.kernel.configuration.Settings.relativePathSetting;
 import static org.neo4j.kernel.configuration.Settings.setting;
 
 public class SettingsTest
@@ -105,22 +104,6 @@ public class SettingsTest
     public void shouldHaveAUsefulToStringWhichIsUsedAsTheValidValuesInDocumentation()
     {
         assertThat( pathSetting( "", NO_DEFAULT ).toString(), containsString( "A filesystem path" ) );
-    }
-
-    @Test( expected = IllegalArgumentException.class )
-    public void relativePathSettingsDoesNotAllowAbsolutePath()
-    {
-        Setting<File> setting = relativePathSetting( "some.settings", new File( "." ).getAbsolutePath() );
-        Config.defaults().get( setting );
-    }
-
-    @Test
-    public void relativePathResolvePathAgainstNeo4jHome()
-    {
-        Setting<File> setting = relativePathSetting( "some.setting", "test" );
-        Config config = Config.defaults();
-        config.augmentDefaults( GraphDatabaseSettings.neo4j_home, "/root" );
-        assertEquals( "/root/test", config.get( setting ).getAbsolutePath() );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/recovery/RecoveryRequiredCheckerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/recovery/RecoveryRequiredCheckerTest.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
@@ -42,6 +41,7 @@ import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.logical_logs_location;
 
 public class RecoveryRequiredCheckerTest
 {
@@ -55,13 +55,11 @@ public class RecoveryRequiredCheckerTest
     private final Monitors monitors = new Monitors();
     private EphemeralFileSystemAbstraction fileSystem;
     private File storeDir;
-    private File customtransactionLogsLocation;
 
     @Before
     public void setup()
     {
         storeDir = testDirectory.graphDbDir();
-        customtransactionLogsLocation = new File( storeDir, "tx-logs" );
         fileSystem = fileSystemRule.get();
         new TestGraphDatabaseFactory().setFileSystem( fileSystem ).newImpermanentDatabase( storeDir ).shutdown();
     }
@@ -108,8 +106,16 @@ public class RecoveryRequiredCheckerTest
     @Test
     public void shouldBeAbleToRecoverBrokenStoreWithLogsInSeparateRelativeLocation() throws Exception
     {
-        Config config = Config.defaults( GraphDatabaseSettings.logical_logs_location,
-                customtransactionLogsLocation.getName() );
+        File customTransactionLogsLocation = new File( storeDir, "tx-logs" );
+        Config config = Config.defaults( logical_logs_location, customTransactionLogsLocation.getName() );
+        recoverBrokenStoreWithConfig( config );
+    }
+
+    @Test
+    public void shouldBeAbleToRecoverBrokenStoreWithLogsInSeparateAbsoluteLocation() throws Exception
+    {
+        File customTransactionLogsLocation = testDirectory.directory( "tx-logs" );
+        Config config = Config.defaults( logical_logs_location, customTransactionLogsLocation.getAbsolutePath() );
         recoverBrokenStoreWithConfig( config );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestStoreAccess.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/TestStoreAccess.java
@@ -81,7 +81,7 @@ public class TestStoreAccess
     private boolean isUnclean( FileSystemAbstraction fileSystem ) throws IOException
     {
         PageCache pageCache = pageCacheRule.getPageCache( fileSystem );
-
-        return new RecoveryRequiredChecker( fileSystem, pageCache, monitors ).isRecoveryRequiredAt( storeDir );
+        RecoveryRequiredChecker requiredChecker = new RecoveryRequiredChecker( fileSystem, pageCache, Config.defaults(), monitors );
+        return requiredChecker.isRecoveryRequiredAt( storeDir );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorTest.java
@@ -145,10 +145,17 @@ public class StoreMigratorTest
     @Test
     public void extractTransactionInformationFromLogsInCustomRelativeLocation() throws Exception
     {
-        // given
         File storeDir = directory.graphDbDir();
         File customLogLocation = new File( storeDir, "customLogLocation" );
         extractTransactionalInformationFromLogs( customLogLocation.getName(), customLogLocation, storeDir );
+    }
+
+    @Test
+    public void extractTransactionInformationFromLogsInCustomAbsoluteLocation() throws Exception
+    {
+        File storeDir = directory.graphDbDir();
+        File customLogLocation = directory.directory( "customLogLocation" );
+        extractTransactionalInformationFromLogs( customLogLocation.getAbsolutePath(), customLogLocation, storeDir );
     }
 
     private void extractTransactionalInformationFromLogs( String path, File customLogLocation, File storeDir ) throws IOException

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/StoreMigratorTest.java
@@ -27,18 +27,24 @@ import org.junit.rules.RuleChain;
 import java.io.File;
 import java.io.IOException;
 
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.kernel.impl.logging.SimpleLogService;
+import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.TransactionId;
+import org.neo4j.kernel.impl.store.format.standard.MetaDataRecordFormat;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_2;
 import org.neo4j.kernel.impl.transaction.log.LogPosition;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
 import org.neo4j.logging.NullLogProvider;
+import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.rule.PageCacheRule;
 import org.neo4j.test.rule.RandomRule;
 import org.neo4j.test.rule.TestDirectory;
@@ -46,7 +52,9 @@ import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.logical_logs_location;
 import static org.neo4j.kernel.impl.store.MetaDataStore.DEFAULT_NAME;
 import static org.neo4j.kernel.impl.store.MetaDataStore.Position.LAST_TRANSACTION_CHECKSUM;
 import static org.neo4j.kernel.impl.store.MetaDataStore.Position.LAST_TRANSACTION_COMMIT_TIMESTAMP;
@@ -132,6 +140,44 @@ public class StoreMigratorTest
         assertEquals( txId, actual.transactionId() );
         assertEquals( TransactionIdStore.UNKNOWN_TX_CHECKSUM, actual.checksum() );
         assertEquals( TransactionIdStore.UNKNOWN_TX_COMMIT_TIMESTAMP, actual.commitTimestamp() );
+    }
+
+    @Test
+    public void extractTransactionInformationFromLogsInCustomRelativeLocation() throws Exception
+    {
+        // given
+        File storeDir = directory.graphDbDir();
+        File customLogLocation = new File( storeDir, "customLogLocation" );
+        extractTransactionalInformationFromLogs( customLogLocation.getName(), customLogLocation, storeDir );
+    }
+
+    private void extractTransactionalInformationFromLogs( String path, File customLogLocation, File storeDir ) throws IOException
+    {
+        LogService logService = new SimpleLogService( NullLogProvider.getInstance(), NullLogProvider.getInstance() );
+        File neoStore = new File( storeDir, DEFAULT_NAME );
+
+        GraphDatabaseService database = new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir )
+                .setConfig( logical_logs_location, path ).newGraphDatabase();
+        for ( int i = 0; i < 10; i++ )
+        {
+            try ( Transaction transaction = database.beginTx() )
+            {
+                Node node = database.createNode();
+                transaction.success();
+            }
+        }
+        database.shutdown();
+
+        MetaDataStore.setRecord( pageCache, neoStore, MetaDataStore.Position.LAST_CLOSED_TRANSACTION_LOG_VERSION,
+                MetaDataRecordFormat.FIELD_NOT_PRESENT );
+        Config config = Config.defaults( logical_logs_location, path );
+        StoreMigrator migrator = new StoreMigrator( fileSystemRule.get(), pageCache, config, logService );
+        LogPosition logPosition = migrator.extractTransactionLogPosition( neoStore, storeDir, 100 );
+
+        File[] logFiles = customLogLocation.listFiles();
+        assertNotNull( logFiles );
+        assertEquals( 0, logPosition.getLogVersion() );
+        assertEquals( logFiles[0].length(), logPosition.getByteOffset() );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/files/LogFilesBuilderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/files/LogFilesBuilderTest.java
@@ -26,19 +26,21 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 
-import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.io.ByteUnit;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.transaction.SimpleLogVersionRepository;
 import org.neo4j.kernel.impl.transaction.SimpleTransactionIdStore;
 import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.test.rule.PageCacheRule;
 import org.neo4j.test.rule.TestDirectory;
-import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.logical_logs_location;
 import static org.neo4j.kernel.impl.transaction.log.files.LogFilesBuilder.activeFilesBuilder;
 import static org.neo4j.kernel.impl.transaction.log.files.LogFilesBuilder.builder;
 import static org.neo4j.kernel.impl.transaction.log.files.LogFilesBuilder.logFilesBasedOnlyBuilder;
@@ -48,17 +50,17 @@ public class LogFilesBuilderTest
     @Rule
     public final TestDirectory testDirectory = TestDirectory.testDirectory();
     @Rule
-    public final EphemeralFileSystemRule fileSystemRule = new EphemeralFileSystemRule();
+    public final DefaultFileSystemRule fileSystemRule = new DefaultFileSystemRule();
     @Rule
     public final PageCacheRule pageCacheRule = new PageCacheRule();
 
-    private File directory;
-    private EphemeralFileSystemAbstraction fileSystem;
+    private File storeDirectory;
+    private DefaultFileSystemAbstraction fileSystem;
 
     @Before
     public void setUp() throws Exception
     {
-        directory = testDirectory.directory();
+        storeDirectory = testDirectory.directory();
         fileSystem = fileSystemRule.get();
     }
 
@@ -66,7 +68,7 @@ public class LogFilesBuilderTest
     public void buildActiveFilesOnlyContext() throws IOException
     {
         PageCache pageCache = pageCacheRule.getPageCache( fileSystem );
-        TransactionLogFilesContext context = activeFilesBuilder( directory, fileSystem, pageCache ).buildContext();
+        TransactionLogFilesContext context = activeFilesBuilder( storeDirectory, fileSystem, pageCache ).buildContext();
 
         assertEquals( fileSystem, context.getFileSystem() );
         assertNotNull( context.getLogEntryReader() );
@@ -79,7 +81,7 @@ public class LogFilesBuilderTest
     @Test
     public void buildFilesBasedContext() throws IOException
     {
-        TransactionLogFilesContext context = logFilesBasedOnlyBuilder( directory, fileSystem ).buildContext();
+        TransactionLogFilesContext context = logFilesBasedOnlyBuilder( storeDirectory, fileSystem ).buildContext();
         assertEquals( fileSystem, context.getFileSystem() );
         assertSame( LogFileCreationMonitor.NO_MONITOR, context.getLogFileCreationMonitor() );
     }
@@ -87,8 +89,8 @@ public class LogFilesBuilderTest
     @Test
     public void buildDefaultContext() throws IOException
     {
-        TransactionLogFilesContext context =
-                builder( directory, fileSystem ).withLogVersionRepository( new SimpleLogVersionRepository( 2 ) )
+        TransactionLogFilesContext context = builder( storeDirectory, fileSystem )
+                        .withLogVersionRepository( new SimpleLogVersionRepository( 2 ) )
                         .withTransactionIdStore( new SimpleTransactionIdStore() ).buildContext();
         assertEquals( fileSystem, context.getFileSystem() );
         assertNotNull( context.getLogEntryReader() );
@@ -108,7 +110,7 @@ public class LogFilesBuilderTest
         dependencies.satisfyDependency( transactionIdStore );
 
         TransactionLogFilesContext context =
-                builder( directory, fileSystem ).withDependencies( dependencies ).buildContext();
+                builder( storeDirectory, fileSystem ).withDependencies( dependencies ).buildContext();
 
         assertEquals( fileSystem, context.getFileSystem() );
         assertNotNull( context.getLogEntryReader() );
@@ -118,27 +120,41 @@ public class LogFilesBuilderTest
         assertEquals( 2, context.getLogVersionRepository().getCurrentLogVersion() );
     }
 
+    @Test
+    public void buildContextWithCustomLogFilesLocations() throws Throwable
+    {
+        String customLogLocation = "customLogLocation";
+        Config customLogLocationConfig = Config.defaults( logical_logs_location, customLogLocation );
+        LogFiles logFiles = builder( storeDirectory, fileSystem ).withConfig( customLogLocationConfig )
+                .withLogVersionRepository( new SimpleLogVersionRepository() )
+                .withTransactionIdStore( new SimpleTransactionIdStore() ).build();
+        logFiles.init();
+        logFiles.start();
+
+        assertEquals( new File( storeDirectory, customLogLocation ), logFiles.getHighestLogFile().getParentFile() );
+    }
+
     @Test( expected = NullPointerException.class )
     public void failToBuildFullContextWithoutLogVersionRepo() throws IOException
     {
-        builder( directory, fileSystem ).withTransactionIdStore( new SimpleTransactionIdStore() ).buildContext();
+        builder( storeDirectory, fileSystem ).withTransactionIdStore( new SimpleTransactionIdStore() ).buildContext();
     }
 
     @Test( expected = NullPointerException.class )
     public void failToBuildFullContextWithoutTransactionIdStore() throws IOException
     {
-        builder( directory, fileSystem ).withLogVersionRepository( new SimpleLogVersionRepository( 2 ) ).buildContext();
+        builder( storeDirectory, fileSystem ).withLogVersionRepository( new SimpleLogVersionRepository( 2 ) ).buildContext();
     }
 
     @Test( expected = UnsupportedOperationException.class )
     public void fileBasedOperationsContextFailOnLastCommittedTransactionIdAccess() throws IOException
     {
-        logFilesBasedOnlyBuilder( directory, fileSystem ).buildContext().getLastCommittedTransactionId();
+        logFilesBasedOnlyBuilder( storeDirectory, fileSystem ).buildContext().getLastCommittedTransactionId();
     }
 
     @Test( expected = UnsupportedOperationException.class )
     public void fileBasedOperationsContextFailOnLogVersionRepositoryAccess() throws IOException
     {
-        logFilesBasedOnlyBuilder( directory, fileSystem ).buildContext().getLogVersionRepository();
+        logFilesBasedOnlyBuilder( storeDirectory, fileSystem ).buildContext().getLogVersionRepository();
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/files/LogFilesBuilderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/files/LogFilesBuilderTest.java
@@ -134,6 +134,20 @@ public class LogFilesBuilderTest
         assertEquals( new File( storeDirectory, customLogLocation ), logFiles.getHighestLogFile().getParentFile() );
     }
 
+    @Test
+    public void buildContextWithCustomAbsoluteLogFilesLocations() throws Throwable
+    {
+        File customLogDirectory = testDirectory.directory( "absoluteCustomLogDirectory" );
+        Config customLogLocationConfig = Config.defaults( logical_logs_location, customLogDirectory.getAbsolutePath() );
+        LogFiles logFiles = builder( storeDirectory, fileSystem ).withConfig( customLogLocationConfig )
+                .withLogVersionRepository( new SimpleLogVersionRepository() )
+                .withTransactionIdStore( new SimpleTransactionIdStore() ).build();
+        logFiles.init();
+        logFiles.start();
+
+        assertEquals( customLogDirectory, logFiles.getHighestLogFile().getParentFile() );
+    }
+
     @Test( expected = NullPointerException.class )
     public void failToBuildFullContextWithoutLogVersionRepo() throws IOException
     {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFilesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFilesTest.java
@@ -36,7 +36,9 @@ import org.neo4j.test.rule.fs.FileSystemRule;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class TransactionLogFilesTest
@@ -172,6 +174,15 @@ public class TransactionLogFilesTest
 
         // when
         logFiles.getLogVersion( file );
+    }
+
+    @Test
+    public void isLogFile() throws IOException
+    {
+        LogFiles logFiles = createLogFiles();
+        assertFalse( logFiles.isLogFile( new File( "aaa.tx.log" ) ) );
+        assertTrue( logFiles.isLogFile( new File( "filename.0" ) ) );
+        assertTrue( logFiles.isLogFile( new File( "filename.17" ) ) );
     }
 
     private LogFiles createLogFiles() throws IOException

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFilesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFilesTest.java
@@ -47,13 +47,13 @@ public class TransactionLogFilesTest
     public final TestDirectory testDirectory = TestDirectory.testDirectory();
     @Rule
     public final FileSystemRule fileSystemRule = new DefaultFileSystemRule();
-    private File logDirectory;
+    private File storeDirectory;
     private final String filename = "filename";
 
     @Before
     public void setUp() throws Exception
     {
-        logDirectory = testDirectory.directory();
+        storeDirectory = testDirectory.directory();
     }
 
     @Test
@@ -67,7 +67,7 @@ public class TransactionLogFilesTest
         final File versionFileName = files.getLogFileForVersion( version );
 
         // then
-        final File expected = new File( logDirectory, getVersionedLogFileName( version ) );
+        final File expected = new File( storeDirectory, getVersionedLogFileName( version ) );
         assertEquals( expected, versionFileName );
     }
 
@@ -77,10 +77,10 @@ public class TransactionLogFilesTest
         // given
         LogFiles files = createLogFiles();
 
-        fileSystemRule.create( new File( logDirectory, getVersionedLogFileName( "1" ) ) );
-        fileSystemRule.create( new File( logDirectory, getVersionedLogFileName( "some", "2" ) ) );
-        fileSystemRule.create( new File( logDirectory, getVersionedLogFileName( "3" ) ) );
-        fileSystemRule.create( new File( logDirectory, filename ) );
+        fileSystemRule.create( new File( storeDirectory, getVersionedLogFileName( "1" ) ) );
+        fileSystemRule.create( new File( storeDirectory, getVersionedLogFileName( "some", "2" ) ) );
+        fileSystemRule.create( new File( storeDirectory, getVersionedLogFileName( "3" ) ) );
+        fileSystemRule.create( new File( storeDirectory, filename ) );
 
         // when
         final List<File> seenFiles = new ArrayList<>();
@@ -94,8 +94,8 @@ public class TransactionLogFilesTest
 
         // then
         assertThat( seenFiles, containsInAnyOrder(
-                new File( logDirectory, getVersionedLogFileName( filename, "1" ) ),
-                new File( logDirectory, getVersionedLogFileName( filename, "3" ) ) )  );
+                new File( storeDirectory, getVersionedLogFileName( filename, "1" ) ),
+                new File( storeDirectory, getVersionedLogFileName( filename, "3" ) ) )  );
         assertThat( seenVersions, containsInAnyOrder( 1L, 3L ) );
     }
 
@@ -105,10 +105,10 @@ public class TransactionLogFilesTest
         // given
         LogFiles files = createLogFiles();
 
-        fileSystemRule.create( new File( logDirectory, getVersionedLogFileName( "1" ) ) );
-        fileSystemRule.create( new File( logDirectory, getVersionedLogFileName( "some", "4" ) ) );
-        fileSystemRule.create( new File( logDirectory, getVersionedLogFileName( "3" ) ) );
-        fileSystemRule.create( new File( logDirectory, filename ) );
+        fileSystemRule.create( new File( storeDirectory, getVersionedLogFileName( "1" ) ) );
+        fileSystemRule.create( new File( storeDirectory, getVersionedLogFileName( "some", "4" ) ) );
+        fileSystemRule.create( new File( storeDirectory, getVersionedLogFileName( "3" ) ) );
+        fileSystemRule.create( new File( storeDirectory, filename ) );
 
         // when
         final long highestLogVersion = files.getHighestLogVersion();
@@ -123,8 +123,8 @@ public class TransactionLogFilesTest
         // given
         LogFiles files = createLogFiles();
 
-        fileSystemRule.create( new File( logDirectory, getVersionedLogFileName( "some", "4" ) ) );
-        fileSystemRule.create( new File( logDirectory, filename ) );
+        fileSystemRule.create( new File( storeDirectory, getVersionedLogFileName( "some", "4" ) ) );
+        fileSystemRule.create( new File( storeDirectory, filename ) );
 
         // when
         final long highestLogVersion = files.getHighestLogVersion();
@@ -188,7 +188,7 @@ public class TransactionLogFilesTest
     private LogFiles createLogFiles() throws IOException
     {
         return LogFilesBuilder
-                .builder( logDirectory, fileSystemRule )
+                .builder( storeDirectory, fileSystemRule )
                 .withLogFileName( filename )
                 .withTransactionIdStore( new SimpleTransactionIdStore() )
                 .withLogVersionRepository( new SimpleLogVersionRepository() )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/stresstest/workload/Runner.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/stresstest/workload/Runner.java
@@ -70,7 +70,7 @@ public class Runner implements Callable<Long>
         {
             TransactionIdStore transactionIdStore = new SimpleTransactionIdStore();
             TransactionMetadataCache transactionMetadataCache = new TransactionMetadataCache( 100_000 );
-            LogFiles logFiles = life.add( createPhysicalLogFiles( transactionIdStore, fileSystem ) );
+            LogFiles logFiles = life.add( createLogFiles( transactionIdStore, fileSystem ) );
 
             TransactionAppender transactionAppender = life.add(
                     createBatchingTransactionAppender( transactionIdStore, transactionMetadataCache, logFiles ) );
@@ -115,7 +115,7 @@ public class Runner implements Callable<Long>
                 transactionMetadataCache, transactionIdStore, IdOrderingQueue.BYPASS, databaseHealth );
     }
 
-    private LogFiles createPhysicalLogFiles( TransactionIdStore transactionIdStore,
+    private LogFiles createLogFiles( TransactionIdStore transactionIdStore,
             FileSystemAbstraction fileSystemAbstraction ) throws IOException
     {
         SimpleLogVersionRepository logVersionRepository = new SimpleLogVersionRepository();

--- a/community/kernel/src/test/java/org/neo4j/test/AdversarialPageCacheGraphDatabaseFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/test/AdversarialPageCacheGraphDatabaseFactory.java
@@ -20,12 +20,12 @@
 package org.neo4j.test;
 
 import java.io.File;
-import java.util.Map;
 
 import org.neo4j.adversaries.Adversary;
 import org.neo4j.adversaries.pagecache.AdversarialPageCache;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
@@ -61,6 +61,7 @@ public class AdversarialPageCacheGraphDatabaseFactory
                     protected PlatformModule createPlatform( File storeDir, Config config,
                             Dependencies dependencies, GraphDatabaseFacade facade )
                     {
+                        config.augment( GraphDatabaseSettings.database_path, storeDir.getAbsolutePath() );
                         return new PlatformModule( storeDir, config, databaseInfo, dependencies, facade )
                         {
                             @Override

--- a/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
@@ -259,6 +259,7 @@ public class TestGraphDatabaseFactory extends GraphDatabaseFactory
         protected PlatformModule createPlatform( File storeDir, Config config, Dependencies dependencies,
                 GraphDatabaseFacade graphDatabaseFacade )
         {
+            config.augment( GraphDatabaseSettings.database_path, storeDir.getAbsolutePath() );
             if ( impermanent )
             {
                 config.augment( ephemeral, TRUE );

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/AbstractInProcessServerBuilder.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/AbstractInProcessServerBuilder.java
@@ -54,8 +54,8 @@ import org.neo4j.server.AbstractNeoServer;
 import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.configuration.ThirdPartyJaxRsPackage;
 
-import static org.neo4j.dbms.DatabaseManagementSystemSettings.data_directory;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.auth_enabled;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.data_directory;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
 import static org.neo4j.helpers.collection.Iterables.append;
 import static org.neo4j.io.file.Files.createOrOpenAsOuputStream;

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTestIT.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTestIT.java
@@ -42,7 +42,6 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
 import org.neo4j.bolt.v1.transport.socket.client.SocketConnection;
-import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.ResourceIterable;
@@ -179,8 +178,8 @@ public class InProcessBuilderTestIT
         // When
         // create graph db with one node upfront
         Path dir = Files.createTempDirectory( getClass().getSimpleName() + "_shouldRunBuilderOnExistingStorageDir" );
-        File storeDir = Config.defaults( DatabaseManagementSystemSettings.data_directory, dir.toString() )
-                .get( DatabaseManagementSystemSettings.database_path );
+        File storeDir = Config.defaults( GraphDatabaseSettings.data_directory, dir.toString() )
+                .get( GraphDatabaseSettings.database_path );
         try
         {
             GraphDatabaseService db = new TestGraphDatabaseFactory().newEmbeddedDatabase( storeDir );

--- a/community/server/src/main/java/org/neo4j/server/CommunityNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/CommunityNeoServer.java
@@ -24,7 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.neo4j.dbms.DatabaseManagementSystemSettings;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.factory.CommunityEditionModule;
 import org.neo4j.kernel.impl.factory.DatabaseInfo;
@@ -53,7 +53,7 @@ public class CommunityNeoServer extends AbstractNeoServer
 {
     protected static final GraphFactory COMMUNITY_FACTORY = ( config, dependencies ) ->
     {
-        File storeDir = config.get( DatabaseManagementSystemSettings.database_path );
+        File storeDir = config.get( GraphDatabaseSettings.database_path );
         return new GraphDatabaseFacadeFactory( DatabaseInfo.COMMUNITY, CommunityEditionModule::new )
                 .newFacade( storeDir, config, dependencies );
     };

--- a/community/server/src/main/java/org/neo4j/server/database/LifecycleManagingDatabase.java
+++ b/community/server/src/main/java/org/neo4j/server/database/LifecycleManagingDatabase.java
@@ -21,8 +21,8 @@ package org.neo4j.server.database;
 
 import java.io.File;
 
-import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
@@ -67,7 +67,7 @@ public class LifecycleManagingDatabase implements Database
     @Override
     public File getLocation()
     {
-        return config.get( DatabaseManagementSystemSettings.database_path );
+        return config.get( GraphDatabaseSettings.database_path );
     }
 
     @Override

--- a/community/server/src/test/java/org/neo4j/server/BaseBootstrapperTestIT.java
+++ b/community/server/src/test/java/org/neo4j/server/BaseBootstrapperTestIT.java
@@ -41,7 +41,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.neo4j.bolt.v1.transport.integration.Neo4jWithSocket.DEFAULT_CONNECTOR_KEY;
-import static org.neo4j.dbms.DatabaseManagementSystemSettings.data_directory;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.data_directory;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.forced_kernel_id;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.logs_directory;
 import static org.neo4j.helpers.collection.MapUtil.store;

--- a/community/server/src/test/java/org/neo4j/server/ServerBootstrapperTest.java
+++ b/community/server/src/test/java/org/neo4j/server/ServerBootstrapperTest.java
@@ -27,7 +27,6 @@ import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
-
 import javax.annotation.Nonnull;
 
 import org.neo4j.helpers.collection.MapUtil;
@@ -42,8 +41,7 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
-
-import static org.neo4j.dbms.DatabaseManagementSystemSettings.database_path;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.database_path;
 
 public class ServerBootstrapperTest
 {

--- a/community/server/src/test/java/org/neo4j/server/ServerTestUtils.java
+++ b/community/server/src/test/java/org/neo4j/server/ServerTestUtils.java
@@ -33,7 +33,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 
-import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.configuration.ssl.LegacySslPolicyConfig;
@@ -90,7 +89,7 @@ public class ServerTestUtils
 
     public static void addDefaultRelativeProperties( Map<String,String> properties, File temporaryFolder )
     {
-        addRelativeProperty( temporaryFolder, properties, DatabaseManagementSystemSettings.data_directory );
+        addRelativeProperty( temporaryFolder, properties, GraphDatabaseSettings.data_directory );
         addRelativeProperty( temporaryFolder, properties, GraphDatabaseSettings.logs_directory );
         addRelativeProperty( temporaryFolder, properties, LegacySslPolicyConfig.certificates_directory );
         properties.put( GraphDatabaseSettings.pagecache_memory.name(), "8m" );

--- a/community/server/src/test/java/org/neo4j/server/configuration/ConfigFileBuilder.java
+++ b/community/server/src/test/java/org/neo4j/server/configuration/ConfigFileBuilder.java
@@ -23,8 +23,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
-import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.config.Setting;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.server.ServerTestUtils;
 
@@ -45,7 +45,7 @@ public class ConfigFileBuilder
         //initialize config with defaults that doesn't pollute
         //workspace with generated data
         this.config = MapUtil.stringMap(
-                DatabaseManagementSystemSettings.data_directory.name(), directory.getAbsolutePath() + "/data",
+                GraphDatabaseSettings.data_directory.name(), directory.getAbsolutePath() + "/data",
                 ServerSettings.management_api_path.name(), "http://localhost:7474/db/manage/",
                 ServerSettings.rest_api_path.name(), "http://localhost:7474/db/data/" );
     }

--- a/community/server/src/test/java/org/neo4j/server/configuration/ConfigLoaderTest.java
+++ b/community/server/src/test/java/org/neo4j/server/configuration/ConfigLoaderTest.java
@@ -222,7 +222,7 @@ public class ConfigLoaderTest
     {
         File configFile = ConfigFileBuilder
                 .builder( folder.getRoot() )
-                .withoutSetting( DatabaseManagementSystemSettings.data_directory )
+                .withoutSetting( GraphDatabaseSettings.data_directory )
                 .build();
         Config config = Config.fromFile( configFile ).withHome( folder.getRoot() ).build();
 
@@ -234,7 +234,7 @@ public class ConfigLoaderTest
     public void shouldSetAValueForAuthStoreLocation() throws IOException
     {
         File configFile = ConfigFileBuilder.builder( folder.getRoot() )
-                .withSetting( DatabaseManagementSystemSettings.data_directory, "the-data-dir" )
+                .withSetting( GraphDatabaseSettings.data_directory, "the-data-dir" )
                 .build();
         Config config = Config.fromFile( configFile ).withHome( folder.getRoot() ).build();
 
@@ -246,7 +246,7 @@ public class ConfigLoaderTest
     public void shouldNotOverwriteAuthStoreLocationIfProvided() throws IOException
     {
         File configFile = ConfigFileBuilder.builder( folder.getRoot() )
-                .withSetting( DatabaseManagementSystemSettings.data_directory, "the-data-dir" )
+                .withSetting( GraphDatabaseSettings.data_directory, "the-data-dir" )
                 .withSetting( GraphDatabaseSettings.auth_store, "foo/bar/auth" )
                 .build();
         Config config = Config.fromFile( configFile ).withHome( folder.getRoot() ).build();

--- a/community/server/src/test/java/org/neo4j/server/database/TestLifecycleManagedDatabase.java
+++ b/community/server/src/test/java/org/neo4j/server/database/TestLifecycleManagedDatabase.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 
-import org.neo4j.dbms.DatabaseManagementSystemSettings;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.GraphDatabaseDependencies;
 import org.neo4j.kernel.StoreLockException;
 import org.neo4j.kernel.configuration.Config;
@@ -66,7 +66,7 @@ public class TestLifecycleManagedDatabase
         dataDirectory = createTempDir();
 
         dbFactory = createGraphFactory();
-        dbConfig = Config.defaults( DatabaseManagementSystemSettings.data_directory, dataDirectory.getAbsolutePath() );
+        dbConfig = Config.defaults( GraphDatabaseSettings.data_directory, dataDirectory.getAbsolutePath() );
         theDatabase = newDatabase();
     }
 
@@ -142,7 +142,7 @@ public class TestLifecycleManagedDatabase
     {
         theDatabase.start();
         assertThat( theDatabase.getLocation().getAbsolutePath(),
-                is( dbConfig.get( DatabaseManagementSystemSettings.database_path ).getAbsolutePath() ) );
+                is( dbConfig.get( GraphDatabaseSettings.database_path ).getAbsolutePath() ) );
     }
 
     private LifecycleManagingDatabase.GraphFactory createGraphFactory()

--- a/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
@@ -117,8 +117,7 @@ public class CommunityServerBuilder
         final File configFile = buildBefore();
 
         Log log = logProvider.getLog( getClass() );
-        Config config = Config.fromFile( configFile ).withHome( configFile.getParentFile() )
-                .withServerDefaults().build();
+        Config config = Config.fromFile( configFile ).withServerDefaults().build();
         config.setLogger( log );
         return build( configFile, config, GraphDatabaseDependencies.newDependencies().userLogProvider( logProvider )
                 .monitors( new Monitors() ) );
@@ -207,6 +206,8 @@ public class CommunityServerBuilder
                 new File( temporaryFolder, "certificates" ).getAbsolutePath() );
         properties.put( GraphDatabaseSettings.logs_directory.name(),
                 new File( temporaryFolder, "logs" ).getAbsolutePath() );
+        properties.put( GraphDatabaseSettings.logical_logs_location.name(),
+                new File( temporaryFolder, "transaction-logs" ).getAbsolutePath() );
         properties.put( GraphDatabaseSettings.pagecache_memory.name(), "8m" );
 
         for ( Object key : arbitraryProperties.keySet() )

--- a/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
@@ -117,7 +117,8 @@ public class CommunityServerBuilder
         final File configFile = buildBefore();
 
         Log log = logProvider.getLog( getClass() );
-        Config config = Config.fromFile( configFile ).withServerDefaults().build();
+        Config config = Config.fromFile( configFile ).withHome( configFile.getParentFile() )
+                .withServerDefaults().build();
         config.setLogger( log );
         return build( configFile, config, GraphDatabaseDependencies.newDependencies().userLogProvider( logProvider )
                 .monitors( new Monitors() ) );

--- a/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
+++ b/community/server/src/test/java/org/neo4j/server/helpers/CommunityServerBuilder.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.ListenSocketAddress;
 import org.neo4j.kernel.GraphDatabaseDependencies;
@@ -79,7 +78,7 @@ public class CommunityServerBuilder
 
     private static LifecycleManagingDatabase.GraphFactory IN_MEMORY_DB = ( config, dependencies ) ->
     {
-        File storeDir = config.get( DatabaseManagementSystemSettings.database_path );
+        File storeDir = config.get( GraphDatabaseSettings.database_path );
         config.augment( stringMap( GraphDatabaseFacadeFactory.Configuration.ephemeral.name(), "true",
                 new BoltConnector( "bolt" ).listen_address.name(), "localhost:0" ) );
         return new ImpermanentGraphDatabase( storeDir, config,
@@ -155,7 +154,7 @@ public class CommunityServerBuilder
 
         if ( dataDir != null )
         {
-            properties.put( DatabaseManagementSystemSettings.data_directory.name(), dataDir );
+            properties.put( GraphDatabaseSettings.data_directory.name(), dataDir );
         }
 
         if ( maxThreads != null )

--- a/community/server/src/test/java/org/neo4j/server/integration/StartupLoggingIT.java
+++ b/community/server/src/test/java/org/neo4j/server/integration/StartupLoggingIT.java
@@ -33,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.configuration.BoltConnector;
@@ -47,10 +46,8 @@ import org.neo4j.test.rule.SuppressOutput;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.server.ExclusiveServerTestBase;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import static java.util.Arrays.asList;
-
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.neo4j.bolt.v1.transport.integration.Neo4jWithSocket.DEFAULT_CONNECTOR_KEY;
 import static org.neo4j.server.AbstractNeoServer.NEO4J_IS_STARTING_MESSAGE;
 
@@ -62,7 +59,7 @@ public class StartupLoggingIT extends ExclusiveServerTestBase
     @Before
     public void setUp() throws IOException
     {
-        FileUtils.deleteRecursively( ServerTestUtils.getRelativeFile( DatabaseManagementSystemSettings.data_directory ) );
+        FileUtils.deleteRecursively( ServerTestUtils.getRelativeFile( GraphDatabaseSettings.data_directory ) );
     }
 
     @Rule
@@ -111,7 +108,7 @@ public class StartupLoggingIT extends ExclusiveServerTestBase
         relativeProperties.put( bolt.enabled.name(), "true" );
         relativeProperties.put( bolt.listen_address.name(), "localhost:" + PortAuthority.allocatePort() );
 
-        relativeProperties.put( DatabaseManagementSystemSettings.database_path.name(),
+        relativeProperties.put( GraphDatabaseSettings.database_path.name(),
                 homeDir.absolutePath().getAbsolutePath() );
         return relativeProperties;
     }

--- a/community/server/src/test/java/org/neo4j/server/rest/AutoIndexWithNonDefaultConfigurationThroughRESTAPIIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/AutoIndexWithNonDefaultConfigurationThroughRESTAPIIT.java
@@ -29,7 +29,6 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
 
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.server.CommunityNeoServer;
 import org.neo4j.server.helpers.CommunityServerBuilder;
 import org.neo4j.server.helpers.FunctionalTestHelper;
@@ -57,7 +56,6 @@ public class AutoIndexWithNonDefaultConfigurationThroughRESTAPIIT extends Exclus
         server = CommunityServerBuilder.serverOnRandomPorts()
                 .usingDataDir( staticFolder.getRoot().getAbsolutePath() )
                 .withAutoIndexingEnabledForNodes( "foo", "bar" )
-                .withProperty( GraphDatabaseSettings.neo4j_home.name(), staticFolder.getRoot().getAbsolutePath() )
                 .build();
         server.start();
         functionalTestHelper = new FunctionalTestHelper( server );

--- a/community/server/src/test/java/org/neo4j/server/rest/AutoIndexWithNonDefaultConfigurationThroughRESTAPIIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/AutoIndexWithNonDefaultConfigurationThroughRESTAPIIT.java
@@ -29,6 +29,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
 
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.server.CommunityNeoServer;
 import org.neo4j.server.helpers.CommunityServerBuilder;
 import org.neo4j.server.helpers.FunctionalTestHelper;
@@ -56,6 +57,7 @@ public class AutoIndexWithNonDefaultConfigurationThroughRESTAPIIT extends Exclus
         server = CommunityServerBuilder.serverOnRandomPorts()
                 .usingDataDir( staticFolder.getRoot().getAbsolutePath() )
                 .withAutoIndexingEnabledForNodes( "foo", "bar" )
+                .withProperty( GraphDatabaseSettings.neo4j_home.name(), staticFolder.getRoot().getAbsolutePath() )
                 .build();
         server.start();
         functionalTestHelper = new FunctionalTestHelper( server );

--- a/enterprise/backup/src/main/java/org/neo4j/backup/AbstractBackupSupportingClassesFactory.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/AbstractBackupSupportingClassesFactory.java
@@ -29,13 +29,10 @@ import org.neo4j.causalclustering.catchup.tx.TransactionLogCatchUpFactory;
 import org.neo4j.causalclustering.catchup.tx.TxPullClient;
 import org.neo4j.causalclustering.handlers.PipelineHandlerAppender;
 import org.neo4j.causalclustering.handlers.PipelineHandlerAppenderFactory;
-import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.configuration.ssl.SslPolicyLoader;
 import org.neo4j.kernel.impl.pagecache.ConfigurableStandalonePageCacheFactory;
-import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
 import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.LogProvider;
@@ -94,8 +91,8 @@ public abstract class AbstractBackupSupportingClassesFactory
         TxPullClient txPullClient = new TxPullClient( catchUpClient, monitors );
         StoreCopyClient storeCopyClient = new StoreCopyClient( catchUpClient, logProvider );
 
-        RemoteStore remoteStore =
-                new RemoteStore( logProvider, fileSystemAbstraction, pageCache, storeCopyClient, txPullClient, transactionLogCatchUpFactory, monitors );
+        RemoteStore remoteStore = new RemoteStore( logProvider, fileSystemAbstraction, pageCache, storeCopyClient,
+                txPullClient, transactionLogCatchUpFactory, config, monitors );
 
         return backupDelegator( remoteStore, catchUpClient, storeCopyClient );
     }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupDelegator.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupDelegator.java
@@ -70,7 +70,7 @@ public class BackupDelegator extends LifecycleAdapter
     {
         try
         {
-            return remoteStore.tryCatchingUp( fromAddress, expectedStoreId, storeDir );
+            return remoteStore.tryCatchingUp( fromAddress, expectedStoreId, storeDir, true );
         }
         catch ( IOException e )
         {

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupFlow.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupFlow.java
@@ -20,7 +20,6 @@
 package org.neo4j.backup;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
@@ -30,10 +29,7 @@ import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.consistency.ConsistencyCheckService;
 import org.neo4j.consistency.checking.full.ConsistencyFlags;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
-import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
-import org.neo4j.kernel.impl.transaction.log.files.LogFilesBuilder;
 import org.neo4j.logging.LogProvider;
 
 import static java.lang.String.format;
@@ -103,30 +99,6 @@ class BackupFlow
         if ( requiredArgs.isDoConsistencyCheck() )
         {
             performConsistencyCheck( onlineBackupContext.getConfig(), requiredArgs, consistencyFlags, destination );
-        }
-        cleanupTransactionLogFiles( destination );
-    }
-
-    /**
-     * As result of backup database should be fully restored and it should be safe to delete any transaction log
-     * files that available since they also can be configured to live in a separate place on the instance where db
-     * will be restored.
-     * @param backupFolder backup folder
-     */
-    private void cleanupTransactionLogFiles( File backupFolder ) throws CommandFailed
-    {
-        try
-        {
-            FileSystemAbstraction fileSystem = outsideWorld.fileSystem();
-            LogFiles logFiles = LogFilesBuilder.logFilesBasedOnlyBuilder( backupFolder, fileSystem ).build();
-            for ( File file : logFiles.logFiles() )
-            {
-                fileSystem.deleteFile( file );
-            }
-        }
-        catch ( IOException e )
-        {
-            throw new CommandFailed( format( "Fail to cleanup transaction logs." ), e );
         }
     }
 

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupFlow.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupFlow.java
@@ -20,6 +20,7 @@
 package org.neo4j.backup;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
@@ -29,7 +30,10 @@ import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.consistency.ConsistencyCheckService;
 import org.neo4j.consistency.checking.full.ConsistencyFlags;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
+import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
+import org.neo4j.kernel.impl.transaction.log.files.LogFilesBuilder;
 import org.neo4j.logging.LogProvider;
 
 import static java.lang.String.format;
@@ -99,6 +103,30 @@ class BackupFlow
         if ( requiredArgs.isDoConsistencyCheck() )
         {
             performConsistencyCheck( onlineBackupContext.getConfig(), requiredArgs, consistencyFlags, destination );
+        }
+        cleanupTransactionLogFiles( destination );
+    }
+
+    /**
+     * As result of backup database should be fully restored and it should be safe to delete any transaction log
+     * files that available since they also can be configured to live in a separate place on the instance where db
+     * will be restored.
+     * @param backupFolder backup folder
+     */
+    private void cleanupTransactionLogFiles( File backupFolder ) throws CommandFailed
+    {
+        try
+        {
+            FileSystemAbstraction fileSystem = outsideWorld.fileSystem();
+            LogFiles logFiles = LogFilesBuilder.logFilesBasedOnlyBuilder( backupFolder, fileSystem ).build();
+            for ( File file : logFiles.logFiles() )
+            {
+                fileSystem.deleteFile( file );
+            }
+        }
+        catch ( IOException e )
+        {
+            throw new CommandFailed( format( "Fail to cleanup transaction logs." ), e );
         }
     }
 

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupProtocolService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupProtocolService.java
@@ -66,8 +66,6 @@ import org.neo4j.kernel.impl.storemigration.UpgradeNotAllowedByConfigurationExce
 import org.neo4j.kernel.impl.transaction.log.MissingLogDataException;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
-import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
-import org.neo4j.kernel.impl.transaction.log.files.LogFilesBuilder;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.lifecycle.Lifespan;
 import org.neo4j.kernel.monitoring.ByteCounterMonitor;
@@ -166,7 +164,6 @@ class BackupProtocolService
             bumpDebugDotLogFileVersion( debugLogFile, timestamp );
             boolean consistent = checkDbConsistency( fileSystem, targetDirectory, consistencyCheck, tuningConfiguration, pageCache );
             clearIdFiles( fileSystem, targetDirectory );
-            clearTransactionLogFiles( fileSystem, targetDirectory );
             return new BackupOutcome( lastCommittedTx, consistent );
         }
         catch ( Exception e )
@@ -221,7 +218,6 @@ class BackupProtocolService
             bumpDebugDotLogFileVersion( debugLogFile, backupStartTime );
             boolean consistent = checkDbConsistency( fileSystem, targetDirectory, consistencyCheck, config, pageCache );
             clearIdFiles( fileSystem, targetDirectory );
-            clearTransactionLogFiles( fileSystem, targetDirectory );
             return new BackupOutcome( lastCommittedTx, consistent );
         }
         catch ( IOException e )
@@ -416,17 +412,6 @@ class BackupProtocolService
             kernelExtensions.add( factory );
         }
         return kernelExtensions;
-    }
-
-    private void clearTransactionLogFiles( FileSystemAbstraction fileSystem, File targetDirectory ) throws IOException
-    {
-        LogFiles logFiles = LogFilesBuilder.logFilesBasedOnlyBuilder( targetDirectory, fileSystem ).build();
-        File[] files = logFiles.logFiles();
-        for ( File file : files )
-        {
-            fileSystem.deleteFile( file );
-        }
-
     }
 
     private void clearIdFiles( FileSystemAbstraction fileSystem, File targetDirectory ) throws IOException

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupRecoveryService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupRecoveryService.java
@@ -22,6 +22,7 @@ package org.neo4j.backup;
 import java.io.File;
 import java.util.Map;
 
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
@@ -33,6 +34,7 @@ public class BackupRecoveryService
     public void recoverWithDatabase( File targetDirectory, PageCache pageCache, Config config )
     {
         Map<String,String> configParams = config.getRaw();
+        configParams.put( GraphDatabaseSettings.logical_logs_location.name(), targetDirectory.getAbsolutePath() );
         GraphDatabaseAPI targetDb = startTemporaryDb( targetDirectory, pageCache, configParams );
         targetDb.shutdown();
     }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupStrategyWrapper.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupStrategyWrapper.java
@@ -20,16 +20,12 @@
 package org.neo4j.backup;
 
 import java.io.File;
-import java.util.Map;
 
 import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.helpers.OptionalHostnamePort;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.lifecycle.LifeSupport;
-
-import static org.neo4j.backup.BackupProtocolService.startTemporaryDb;
 
 class BackupStrategyWrapper
 {

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommandConfigLoader.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommandConfigLoader.java
@@ -24,7 +24,6 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 import org.neo4j.commandline.admin.CommandFailed;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.configuration.Config;
 
@@ -39,11 +38,10 @@ class OnlineBackupCommandConfigLoader
         this.configDir = configDir;
     }
 
-    Config loadConfig( Optional<Path> additionalConfig, Path folder ) throws CommandFailed
+    Config loadConfig( Optional<Path> additionalConfig ) throws CommandFailed
     {
         Config config = Config.fromFile( configDir.resolve( Config.DEFAULT_CONFIG_FILE_NAME ) ).withHome( homeDir )
                 .withConnectorsDisabled().build();
-        config.augment( GraphDatabaseSettings.logical_logs_location, folder.toAbsolutePath().toString() );
         return withAdditionalConfig( additionalConfig, config );
     }
 

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommandConfigLoader.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommandConfigLoader.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 
 import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.configuration.Config;
 
@@ -38,10 +39,12 @@ class OnlineBackupCommandConfigLoader
         this.configDir = configDir;
     }
 
-    Config loadConfig( Optional<Path> additionalConfig ) throws CommandFailed
+    Config loadConfig( Optional<Path> additionalConfig, Path folder ) throws CommandFailed
     {
-        return withAdditionalConfig( additionalConfig,
-                Config.fromFile( configDir.resolve( Config.DEFAULT_CONFIG_FILE_NAME ) ).withHome( homeDir ).withConnectorsDisabled().build() );
+        Config config = Config.fromFile( configDir.resolve( Config.DEFAULT_CONFIG_FILE_NAME ) ).withHome( homeDir )
+                .withConnectorsDisabled().build();
+        config.augment( GraphDatabaseSettings.logical_logs_location, folder.toAbsolutePath().toString() );
+        return withAdditionalConfig( additionalConfig, config );
     }
 
     private Config withAdditionalConfig( Optional<Path> additionalConfig, Config config ) throws CommandFailed

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupContextLoader.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupContextLoader.java
@@ -49,8 +49,7 @@ public class OnlineBackupContextLoader
         try
         {
             OnlineBackupRequiredArguments requiredArguments = backupCommandArgumentHandler.establishRequiredArguments( commandlineArgs );
-            Config config = onlineBackupCommandConfigLoader.loadConfig( requiredArguments.getAdditionalConfig(),
-                    requiredArguments.getFolder() );
+            Config config = onlineBackupCommandConfigLoader.loadConfig( requiredArguments.getAdditionalConfig() );
             ConsistencyFlags consistencyFlags = backupCommandArgumentHandler.readFlagsFromArgumentsOrDefaultToConfig( config );
 
             return new OnlineBackupContext( requiredArguments, config, consistencyFlags );

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupContextLoader.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupContextLoader.java
@@ -49,7 +49,8 @@ public class OnlineBackupContextLoader
         try
         {
             OnlineBackupRequiredArguments requiredArguments = backupCommandArgumentHandler.establishRequiredArguments( commandlineArgs );
-            Config config = onlineBackupCommandConfigLoader.loadConfig( requiredArguments.getAdditionalConfig() );
+            Config config = onlineBackupCommandConfigLoader.loadConfig( requiredArguments.getAdditionalConfig(),
+                    requiredArguments.getFolder() );
             ConsistencyFlags consistencyFlags = backupCommandArgumentHandler.readFlagsFromArgumentsOrDefaultToConfig( config );
 
             return new OnlineBackupContext( requiredArguments, config, consistencyFlags );

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupRequiredArguments.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupRequiredArguments.java
@@ -36,8 +36,7 @@ public class OnlineBackupRequiredArguments
     private final Path reportDir;
 
     public OnlineBackupRequiredArguments( OptionalHostnamePort address, Path folder, String name, boolean fallbackToFull, boolean doConsistencyCheck,
-            long timeout,
-            Optional<Path> additionalConfig, Path reportDir )
+            long timeout, Optional<Path> additionalConfig, Path reportDir )
     {
         this.address = address;
         this.folder = folder;

--- a/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCli.java
+++ b/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCli.java
@@ -29,7 +29,7 @@ import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.arguments.Arguments;
 import org.neo4j.commandline.arguments.MandatoryNamedArg;
 import org.neo4j.commandline.arguments.OptionalBooleanArg;
-import org.neo4j.dbms.DatabaseManagementSystemSettings;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
@@ -53,7 +53,7 @@ public class RestoreDatabaseCli implements AdminCommand
     {
         return Config.fromFile( configDir.resolve( Config.DEFAULT_CONFIG_FILE_NAME ) )
                 .withHome( homeDir )
-                .withSetting( DatabaseManagementSystemSettings.active_database, databaseName )
+                .withSetting( GraphDatabaseSettings.active_database, databaseName )
                 .withConnectorsDisabled().build();
     }
 

--- a/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCommand.java
+++ b/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCommand.java
@@ -23,30 +23,35 @@ import java.io.File;
 import java.io.IOException;
 
 import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
+import org.neo4j.kernel.impl.transaction.log.files.LogFilesBuilder;
 import org.neo4j.kernel.impl.util.Validators;
 
 import static java.lang.String.format;
 import static org.neo4j.commandline.Util.checkLock;
-import static org.neo4j.dbms.DatabaseManagementSystemSettings.database_path;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.database_path;
 
 public class RestoreDatabaseCommand
 {
     private FileSystemAbstraction fs;
     private final File fromPath;
     private final File databaseDir;
+    private final File transactionLogsDirectory;
     private String databaseName;
     private boolean forceOverwrite;
 
-    public RestoreDatabaseCommand( FileSystemAbstraction fs, File fromPath, Config config,
-                                   String databaseName, boolean forceOverwrite )
+    public RestoreDatabaseCommand( FileSystemAbstraction fs, File fromPath, Config config, String databaseName,
+            boolean forceOverwrite )
     {
         this.fs = fs;
         this.fromPath = fromPath;
         this.databaseName = databaseName;
         this.forceOverwrite = forceOverwrite;
         this.databaseDir = config.get( database_path ).getAbsoluteFile();
+        this.transactionLogsDirectory = config.get( GraphDatabaseSettings.logical_logs_location ).getAbsoluteFile();
     }
 
     public void execute() throws IOException, CommandFailed
@@ -75,6 +80,18 @@ public class RestoreDatabaseCommand
         checkLock( databaseDir.toPath() );
 
         fs.deleteRecursively( databaseDir );
-        fs.copyRecursively( fromPath, databaseDir );
+        if ( !databaseDir.equals( transactionLogsDirectory ) )
+        {
+            fs.deleteRecursively( transactionLogsDirectory );
+        }
+        LogFiles backupLogFiles = LogFilesBuilder.logFilesBasedOnlyBuilder( fromPath, fs ).build();
+        File[] files = fromPath.listFiles();
+        if ( files != null )
+        {
+            for ( File file : files )
+            {
+                fs.copyToDirectory( file, backupLogFiles.isLogFile( file ) ? transactionLogsDirectory : databaseDir );
+            }
+        }
     }
 }

--- a/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCommand.java
+++ b/enterprise/backup/src/main/java/org/neo4j/restore/RestoreDatabaseCommand.java
@@ -32,6 +32,7 @@ import org.neo4j.kernel.impl.util.Validators;
 
 import static java.lang.String.format;
 import static org.neo4j.commandline.Util.checkLock;
+import static org.neo4j.commandline.Util.isSameOrChildFile;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.database_path;
 
 public class RestoreDatabaseCommand
@@ -80,7 +81,8 @@ public class RestoreDatabaseCommand
         checkLock( databaseDir.toPath() );
 
         fs.deleteRecursively( databaseDir );
-        if ( !databaseDir.equals( transactionLogsDirectory ) )
+
+        if ( !isSameOrChildFile( databaseDir, transactionLogsDirectory ) )
         {
             fs.deleteRecursively( transactionLogsDirectory );
         }

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupDelegatorTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupDelegatorTest.java
@@ -73,7 +73,7 @@ public class BackupDelegatorTest
         subject.tryCatchingUp( fromAddress, expectedStoreId, storeDir );
 
         // then
-        verify( remoteStore ).tryCatchingUp( fromAddress, expectedStoreId, storeDir );
+        verify( remoteStore ).tryCatchingUp( fromAddress, expectedStoreId, storeDir, true );
     }
 
     @Test

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupFlowTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupFlowTest.java
@@ -35,6 +35,7 @@ import org.neo4j.consistency.ConsistencyCheckService;
 import org.neo4j.consistency.checking.full.ConsistencyCheckIncompleteException;
 import org.neo4j.consistency.checking.full.ConsistencyFlags;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
+import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.logging.LogProvider;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -53,26 +54,28 @@ public class BackupFlowTest
     public ExpectedException expectedException = ExpectedException.none();
 
     // dependencies
-    final ConsistencyCheckService consistencyCheckService = mock( ConsistencyCheckService.class );
-    final OutsideWorld outsideWorld = mock( OutsideWorld.class );
-    final LogProvider logProvider = mock( LogProvider.class );
-    final BackupStrategyWrapper firstStrategy = mock( BackupStrategyWrapper.class );
-    final BackupStrategyWrapper secondStrategy = mock( BackupStrategyWrapper.class );
+    private final ConsistencyCheckService consistencyCheckService = mock( ConsistencyCheckService.class );
+    private final OutsideWorld outsideWorld = mock( OutsideWorld.class );
+    private final FileSystemAbstraction fileSystem = mock( FileSystemAbstraction.class );
+    private final LogProvider logProvider = mock( LogProvider.class );
+    private final BackupStrategyWrapper firstStrategy = mock( BackupStrategyWrapper.class );
+    private final BackupStrategyWrapper secondStrategy = mock( BackupStrategyWrapper.class );
 
     BackupFlow subject;
 
     // test method parameter mocks
-    final OnlineBackupContext onlineBackupContext = mock( OnlineBackupContext.class );
-    final OnlineBackupRequiredArguments requiredArguments = mock( OnlineBackupRequiredArguments.class );
+    private final OnlineBackupContext onlineBackupContext = mock( OnlineBackupContext.class );
+    private final OnlineBackupRequiredArguments requiredArguments = mock( OnlineBackupRequiredArguments.class );
 
     // mock returns
-    private ProgressMonitorFactory progressMonitorFactory = mock( ProgressMonitorFactory.class );
-    private Path reportDir = mock( Path.class );
-    private ConsistencyCheckService.Result consistencyCheckResult = mock( ConsistencyCheckService.Result.class );
+    private final ProgressMonitorFactory progressMonitorFactory = mock( ProgressMonitorFactory.class );
+    private final Path reportDir = mock( Path.class );
+    private final ConsistencyCheckService.Result consistencyCheckResult = mock( ConsistencyCheckService.Result.class );
 
     @Before
     public void setup()
     {
+        when( outsideWorld.fileSystem() ).thenReturn( fileSystem );
         when( onlineBackupContext.getRequiredArguments() ).thenReturn( requiredArguments );
         when( requiredArguments.getReportDir() ).thenReturn( reportDir );
         subject = new BackupFlow( consistencyCheckService, outsideWorld, logProvider, progressMonitorFactory,

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupIT.java
@@ -510,11 +510,11 @@ public class BackupIT
             LogFiles logFiles = LogFilesBuilder.logFilesBasedOnlyBuilder( new File( backupStore ), fileSystemRule.get() ).build();
 
             backup.full( backupStore );
-            assertThat( logFiles.logFiles(), Matchers.emptyArray() );
+            assertThat( logFiles.logFiles(), Matchers.arrayWithSize( 1 ) );
 
             DbRepresentation representation = addLotsOfData( db );
             backup.incremental( backupStore );
-            assertThat( logFiles.logFiles(), Matchers.emptyArray() );
+            assertThat( logFiles.logFiles(), Matchers.arrayWithSize( 1 ) );
 
             assertEquals( representation, getDbRepresentation() );
         }

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupIT.java
@@ -20,6 +20,7 @@
 package org.neo4j.backup;
 
 import org.apache.commons.io.FileUtils;
+import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -66,6 +67,8 @@ import org.neo4j.kernel.impl.store.format.standard.Standard;
 import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
 import org.neo4j.kernel.impl.storemigration.StoreFileType;
 import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
+import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
+import org.neo4j.kernel.impl.transaction.log.files.LogFilesBuilder;
 import org.neo4j.ports.allocation.PortAuthority;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.TestGraphDatabaseFactory;
@@ -493,6 +496,34 @@ public class BackupIT
         }
     }
 
+    @Test
+    public void backupDatabaseWithCustomTransactionLogsLocation() throws IOException
+    {
+        int backupPort = PortAuthority.allocatePort();
+        GraphDatabaseService db = startGraphDatabase( serverPath, true, backupPort, "customLogLocation" );
+        try
+        {
+            createInitialDataset( db );
+
+            OnlineBackup backup = OnlineBackup.from( "127.0.0.1", backupPort );
+            String backupStore = backupPath.getPath();
+            LogFiles logFiles = LogFilesBuilder.logFilesBasedOnlyBuilder( new File( backupStore ), fileSystemRule.get() ).build();
+
+            backup.full( backupStore );
+            assertThat( logFiles.logFiles(), Matchers.emptyArray() );
+
+            DbRepresentation representation = addLotsOfData( db );
+            backup.incremental( backupStore );
+            assertThat( logFiles.logFiles(), Matchers.emptyArray() );
+
+            assertEquals( representation, getDbRepresentation() );
+        }
+        finally
+        {
+            db.shutdown();
+        }
+    }
+
     private void ensureStoresHaveIdFiles( File path ) throws IOException
     {
         for ( StoreFile file : StoreFile.values() )
@@ -638,6 +669,12 @@ public class BackupIT
 
     private GraphDatabaseService startGraphDatabase( File storeDir, boolean withOnlineBackup, Integer backupPort )
     {
+        return startGraphDatabase( storeDir, withOnlineBackup, backupPort, "" );
+    }
+
+    private GraphDatabaseService startGraphDatabase( File storeDir, boolean withOnlineBackup, Integer backupPort,
+            String logLocation )
+    {
         GraphDatabaseFactory dbFactory = new TestGraphDatabaseFactory()
         {
             @Override
@@ -668,7 +705,8 @@ public class BackupIT
         GraphDatabaseBuilder graphDatabaseBuilder = dbFactory.newEmbeddedDatabaseBuilder( storeDir )
                 .setConfig( OnlineBackupSettings.online_backup_enabled, String.valueOf( withOnlineBackup ) )
                 .setConfig( GraphDatabaseSettings.keep_logical_logs, Settings.TRUE )
-                .setConfig( GraphDatabaseSettings.record_format, recordFormatName );
+                .setConfig( GraphDatabaseSettings.record_format, recordFormatName )
+                .setConfig( GraphDatabaseSettings.logical_logs_location, logLocation );
 
         if ( backupPort != null )
         {

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupProtocolServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupProtocolServiceIT.java
@@ -1087,7 +1087,7 @@ public class BackupProtocolServiceIT
         LifeSupport life = new LifeSupport();
         PageCache pageCache = pageCacheRule.getPageCache( fileSystem );
         LogicalTransactionStore transactionStore =
-                life.add( new ReadOnlyTransactionStore( pageCache, fileSystem, backupDir, monitors ) );
+                life.add( new ReadOnlyTransactionStore( pageCache, fileSystem, backupDir, Config.defaults(), monitors ) );
         life.start();
         try ( IOCursor<CommittedTransactionRepresentation> cursor =
                       transactionStore.getTransactions( txId ) )

--- a/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandConfigLoaderTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandConfigLoaderTest.java
@@ -85,7 +85,7 @@ public class OnlineBackupCommandConfigLoaderTest
 
         // expect
         assertFalse( additionalConf.exists() );
-        subject.loadConfig( Optional.of( additionalConf.toPath() ), homeDir );
+        subject.loadConfig( Optional.of( additionalConf.toPath() ) );
     }
 
     @Test
@@ -101,7 +101,7 @@ public class OnlineBackupCommandConfigLoaderTest
         appendToFile( homeDirConfigFile, "causal_clustering.raft_in_queue_max_batch=21" );
 
         // when
-        Config config  = subject.loadConfig( Optional.empty(), homeDir );
+        Config config  = subject.loadConfig( Optional.empty() );
 
         // then
         assertEquals( Integer.valueOf( 4 ), config.get( CausalClusteringSettings.expected_core_cluster_size ) );
@@ -121,7 +121,7 @@ public class OnlineBackupCommandConfigLoaderTest
         appendToFile( additionalConfigFile, "causal_clustering.expected_core_cluster_size=5" );
 
         // when
-        Config config = subject.loadConfig( Optional.of( additionalConfigFile.toPath() ), homeDir );
+        Config config = subject.loadConfig( Optional.of( additionalConfigFile.toPath() ) );
 
         // then
         assertEquals( Integer.valueOf( 5 ), config.get( CausalClusteringSettings.expected_core_cluster_size ) );

--- a/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandConfigLoaderTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandConfigLoaderTest.java
@@ -23,7 +23,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.rules.TemporaryFolder;
 
 import java.io.BufferedWriter;
 import java.io.File;
@@ -35,7 +34,6 @@ import java.util.Optional;
 
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.commandline.admin.CommandFailed;
-import org.neo4j.graphdb.config.InvalidSettingException;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.test.rule.TestDirectory;
 
@@ -87,7 +85,7 @@ public class OnlineBackupCommandConfigLoaderTest
 
         // expect
         assertFalse( additionalConf.exists() );
-        subject.loadConfig( Optional.of( additionalConf.toPath() ) );
+        subject.loadConfig( Optional.of( additionalConf.toPath() ), homeDir );
     }
 
     @Test
@@ -103,7 +101,7 @@ public class OnlineBackupCommandConfigLoaderTest
         appendToFile( homeDirConfigFile, "causal_clustering.raft_in_queue_max_batch=21" );
 
         // when
-        Config config  = subject.loadConfig( Optional.empty() );
+        Config config  = subject.loadConfig( Optional.empty(), homeDir );
 
         // then
         assertEquals( Integer.valueOf( 4 ), config.get( CausalClusteringSettings.expected_core_cluster_size ) );
@@ -123,7 +121,7 @@ public class OnlineBackupCommandConfigLoaderTest
         appendToFile( additionalConfigFile, "causal_clustering.expected_core_cluster_size=5" );
 
         // when
-        Config config = subject.loadConfig( Optional.of( additionalConfigFile.toPath() ) );
+        Config config = subject.loadConfig( Optional.of( additionalConfigFile.toPath() ), homeDir );
 
         // then
         assertEquals( Integer.valueOf( 5 ), config.get( CausalClusteringSettings.expected_core_cluster_size ) );

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/BackupCoreIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/BackupCoreIT.java
@@ -24,7 +24,6 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -36,19 +35,15 @@ import org.neo4j.causalclustering.discovery.CoreClusterMember;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.MapUtil;
-import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.enterprise.configuration.OnlineBackupSettings;
 import org.neo4j.kernel.impl.store.format.standard.Standard;
-import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
-import org.neo4j.kernel.impl.transaction.log.files.LogFilesBuilder;
 import org.neo4j.ports.allocation.PortAuthority;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.causalclustering.ClusterRule;
 import org.neo4j.test.rule.SuppressOutput;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.util.TestHelpers.runBackupToolFromOtherJvmToGetExitCode;
@@ -82,8 +77,6 @@ public class BackupCoreIT
             String[] args = backupArguments( backupAddress( cluster ), backupsDir, "" + db.serverId() );
             assertEquals( 0, runBackupToolFromOtherJvmToGetExitCode( clusterRule.clusterDirectory(), args ) );
 
-            checkThatTxLogFilesDoesNotExist( db );
-
             // Add some new data
             DbRepresentation afterChange = DbRepresentation.of( createSomeData( cluster ) );
 
@@ -92,14 +85,6 @@ public class BackupCoreIT
             assertEquals( beforeChange, backupRepresentation );
             assertNotEquals( backupRepresentation, afterChange );
         }
-    }
-
-    private void checkThatTxLogFilesDoesNotExist( CoreClusterMember db ) throws IOException
-    {
-        FileSystemAbstraction fileSystemAbstraction =
-                db.database().getDependencyResolver().resolveDependency( FileSystemAbstraction.class );
-        LogFiles logFiles = LogFilesBuilder.logFilesBasedOnlyBuilder( backupsDir, fileSystemAbstraction ).build();
-        assertFalse( logFiles.versionExists( 0 ) );
     }
 
     static CoreGraphDatabase createSomeData( Cluster cluster ) throws Exception

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/ClusterSeedingIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/ClusterSeedingIT.java
@@ -32,16 +32,17 @@ import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.CoreClusterMember;
 import org.neo4j.causalclustering.discovery.IpFamily;
 import org.neo4j.causalclustering.discovery.SharedDiscoveryService;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.enterprise.configuration.OnlineBackupSettings;
 import org.neo4j.kernel.impl.store.format.standard.Standard;
+import org.neo4j.restore.RestoreDatabaseCommand;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 
 import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.causalclustering.BackupCoreIT.backupAddress;
 import static org.neo4j.causalclustering.discovery.Cluster.dataMatchesEventually;
@@ -136,7 +137,8 @@ public class ClusterSeedingIT
 
         // and: seeding new member with said backup
         CoreClusterMember newMember = cluster.addCoreMemberWithId( 3 );
-        fsa.copyRecursively( backupDir, newMember.storeDir() );
+        String databaseName = newMember.getMemberConfig().get( GraphDatabaseSettings.active_database );
+        new RestoreDatabaseCommand( fsa, backupDir, newMember.getMemberConfig(), databaseName, true ).execute();
         newMember.start();
 
         // then
@@ -158,7 +160,8 @@ public class ClusterSeedingIT
 
         // and: seeding new member with said backup
         CoreClusterMember newMember = cluster.addCoreMemberWithId( 3 );
-        fsa.copyRecursively( backupDir, newMember.storeDir() );
+        String databaseName = newMember.getMemberConfig().get( GraphDatabaseSettings.active_database );
+        new RestoreDatabaseCommand( fsa, backupDir, newMember.getMemberConfig(), databaseName, true ).execute();
         newMember.start();
 
         // then

--- a/enterprise/backup/src/test/java/org/neo4j/restore/RestoreDatabaseCommandIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/restore/RestoreDatabaseCommandIT.java
@@ -24,24 +24,29 @@ import org.junit.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.PrintStream;
 
+import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.commandline.admin.CommandLocator;
 import org.neo4j.commandline.admin.Usage;
-import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.enterprise.configuration.OnlineBackupSettings;
+import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
+import org.neo4j.kernel.impl.transaction.log.files.LogFilesBuilder;
 import org.neo4j.kernel.internal.locker.StoreLocker;
-import org.neo4j.ports.allocation.PortAuthority;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 
+import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -64,7 +69,7 @@ public class RestoreDatabaseCommandIT
         Config config = configWith( databaseName, directory.absolutePath().getAbsolutePath() );
 
         File fromPath = new File( directory.absolutePath(), "from" );
-        File toPath = config.get( DatabaseManagementSystemSettings.database_path );
+        File toPath = config.get( GraphDatabaseSettings.database_path );
         int fromNodeCount = 10;
         int toNodeCount = 20;
 
@@ -93,7 +98,7 @@ public class RestoreDatabaseCommandIT
         Config config = configWith( databaseName, directory.absolutePath().getAbsolutePath() );
 
         File fromPath = new File( directory.absolutePath(), "from" );
-        File toPath = config.get( DatabaseManagementSystemSettings.database_path );
+        File toPath = config.get( GraphDatabaseSettings.database_path );
 
         createDbAt( fromPath, 0 );
         createDbAt( toPath, 0 );
@@ -121,7 +126,7 @@ public class RestoreDatabaseCommandIT
         Config config = configWith( databaseName, directory.absolutePath().getAbsolutePath() );
 
         File fromPath = new File( directory.absolutePath(), "from" );
-        File toPath = config.get( DatabaseManagementSystemSettings.database_path );
+        File toPath = config.get( GraphDatabaseSettings.database_path );
 
         createDbAt( toPath, 0 );
 
@@ -171,7 +176,7 @@ public class RestoreDatabaseCommandIT
         Config config = configWith( databaseName, directory.absolutePath().getAbsolutePath() );
 
         File fromPath = new File( directory.absolutePath(), "from" );
-        File toPath = config.get( DatabaseManagementSystemSettings.database_path );
+        File toPath = config.get( GraphDatabaseSettings.database_path );
         int fromNodeCount = 10;
         int toNodeCount = 20;
 
@@ -192,6 +197,42 @@ public class RestoreDatabaseCommandIT
         }
 
         copiedDb.shutdown();
+    }
+
+    @Test
+    public void restoreTransactionLogsInCustomDirectoryForTargetDatabaseWhenConfigured()
+            throws IOException, CommandFailed
+    {
+        String databaseName = "to";
+        Config config = configWith( databaseName, directory.absolutePath().getAbsolutePath() );
+        File customTxLogDirectory = directory.directory( "customLogicalLog" );
+        String customTransactionLogDirectory = customTxLogDirectory.getAbsolutePath();
+        config.augmentDefaults( GraphDatabaseSettings.logical_logs_location, customTransactionLogDirectory );
+
+        File fromPath = new File( directory.absolutePath(), "from" );
+        File toPath = config.get( GraphDatabaseSettings.database_path );
+        int fromNodeCount = 10;
+        int toNodeCount = 20;
+        createDbAt( fromPath, fromNodeCount );
+
+        GraphDatabaseService db = new GraphDatabaseFactory()
+                .newEmbeddedDatabaseBuilder( toPath )
+                .setConfig( OnlineBackupSettings.online_backup_enabled, Settings.FALSE )
+                .setConfig( GraphDatabaseSettings.logical_logs_location, customTransactionLogDirectory )
+                .newGraphDatabase();
+        createTestData( toNodeCount, db );
+        db.shutdown();
+
+        // when
+        new RestoreDatabaseCommand( fileSystemRule.get(), fromPath, config, databaseName, true ).execute();
+
+        LogFiles fromStoreLogFiles = LogFilesBuilder.logFilesBasedOnlyBuilder( fromPath, fileSystemRule.get() ).build();
+        LogFiles toStoreLogFiles = LogFilesBuilder.logFilesBasedOnlyBuilder( toPath, fileSystemRule.get() ).build();
+        LogFiles customLogLocationLogFiles = LogFilesBuilder.logFilesBasedOnlyBuilder( customTxLogDirectory, fileSystemRule.get() ).build();
+        assertThat( toStoreLogFiles.logFiles(), emptyArray() );
+        assertThat( customLogLocationLogFiles.logFiles(), arrayWithSize( 1 ) );
+        assertEquals( fromStoreLogFiles.getLogFileForVersion( 0 ).length(),
+                customLogLocationLogFiles.getLogFileForVersion( 0 ).length() );
     }
 
     @Test
@@ -227,18 +268,24 @@ public class RestoreDatabaseCommandIT
 
     private static Config configWith( String databaseName, String dataDirectory )
     {
-        return Config.defaults( stringMap( DatabaseManagementSystemSettings.active_database.name(), databaseName,
-                DatabaseManagementSystemSettings.data_directory.name(), dataDirectory ) );
+        return Config.defaults( stringMap( GraphDatabaseSettings.active_database.name(), databaseName,
+                GraphDatabaseSettings.data_directory.name(), dataDirectory ) );
     }
 
     private void createDbAt( File fromPath, int nodesToCreate )
     {
-        GraphDatabaseFactory factory = new GraphDatabaseFactory();
-
-        GraphDatabaseService db = factory.newEmbeddedDatabaseBuilder( fromPath )
-                .setConfig( OnlineBackupSettings.online_backup_server, "127.0.0.1:" + PortAuthority.allocatePort() )
+        GraphDatabaseService db = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( fromPath )
+                .setConfig( OnlineBackupSettings.online_backup_enabled, Settings.FALSE )
+                .setConfig( GraphDatabaseSettings.logical_logs_location, fromPath.getAbsolutePath() )
                 .newGraphDatabase();
 
+        createTestData( nodesToCreate, db );
+
+        db.shutdown();
+    }
+
+    private void createTestData( int nodesToCreate, GraphDatabaseService db )
+    {
         try ( Transaction tx = db.beginTx() )
         {
             for ( int i = 0; i < nodesToCreate; i++ )
@@ -247,7 +294,5 @@ public class RestoreDatabaseCommandIT
             }
             tx.success();
         }
-
-        db.shutdown();
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/CopiedStoreRecovery.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/CopiedStoreRecovery.java
@@ -100,7 +100,6 @@ public class CopiedStoreRecovery extends LifecycleAdapter
                 .setUserLogProvider( NullLogProvider.getInstance() )
                 .newEmbeddedDatabaseBuilder( tempStore )
                 .setConfig( OnlineBackupSettings.online_backup_enabled, Settings.FALSE )
-                .setConfig( GraphDatabaseSettings.logs_directory, tempStore.getAbsolutePath() )
                 .setConfig( GraphDatabaseSettings.keep_logical_logs, Settings.TRUE )
                 .setConfig( GraphDatabaseSettings.allow_upgrade,
                         config.get( GraphDatabaseSettings.allow_upgrade ).toString() )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/CopiedStoreRecovery.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/CopiedStoreRecovery.java
@@ -28,6 +28,7 @@ import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
+import org.neo4j.kernel.impl.enterprise.configuration.OnlineBackupSettings;
 import org.neo4j.kernel.impl.storemigration.UpgradeNotAllowedByConfigurationException;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.NullLogProvider;
@@ -98,7 +99,7 @@ public class CopiedStoreRecovery extends LifecycleAdapter
                 .setKernelExtensions( kernelExtensions )
                 .setUserLogProvider( NullLogProvider.getInstance() )
                 .newEmbeddedDatabaseBuilder( tempStore )
-                .setConfig( "dbms.backup.enabled", Settings.FALSE )
+                .setConfig( OnlineBackupSettings.online_backup_enabled, Settings.FALSE )
                 .setConfig( GraphDatabaseSettings.logs_directory, tempStore.getAbsolutePath() )
                 .setConfig( GraphDatabaseSettings.keep_logical_logs, Settings.TRUE )
                 .setConfig( GraphDatabaseSettings.allow_upgrade,

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabase.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabase.java
@@ -36,6 +36,7 @@ import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
 import org.neo4j.kernel.impl.store.StoreFile;
 import org.neo4j.kernel.impl.store.StoreType;
 import org.neo4j.kernel.impl.transaction.log.TransactionAppender;
+import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
 import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
 import org.neo4j.kernel.impl.util.watcher.FileSystemWatcherService;
 import org.neo4j.kernel.internal.DatabaseHealth;
@@ -67,20 +68,25 @@ public class LocalDatabase implements Lifecycle
     private volatile AvailabilityRequirement currentRequirement;
 
     private volatile TransactionCommitProcess localCommit;
+    private LogFiles logFiles;
 
-    public LocalDatabase( File storeDir, StoreFiles storeFiles, DataSourceManager dataSourceManager,
-            Supplier<DatabaseHealth> databaseHealthSupplier, FileSystemWatcherService watcherService,
+    public LocalDatabase( File storeDir,
+            StoreFiles storeFiles,
+            LogFiles logFiles,
+            DataSourceManager dataSourceManager,
+            Supplier<DatabaseHealth> databaseHealthSupplier,
+            FileSystemWatcherService watcherService,
             AvailabilityGuard availabilityGuard,
             LogProvider logProvider )
     {
         this.storeDir = storeDir;
         this.storeFiles = storeFiles;
+        this.logFiles = logFiles;
         this.dataSourceManager = dataSourceManager;
         this.databaseHealthSupplier = databaseHealthSupplier;
         this.availabilityGuard = availabilityGuard;
         this.watcherService = watcherService;
         this.log = logProvider.getLog( getClass() );
-
         raiseAvailabilityGuard( NOT_STOPPED );
     }
 
@@ -182,7 +188,7 @@ public class LocalDatabase implements Lifecycle
 
     public void delete() throws IOException
     {
-        storeFiles.delete( storeDir );
+        storeFiles.delete( storeDir, logFiles );
     }
 
     public boolean isEmpty() throws IOException
@@ -203,8 +209,8 @@ public class LocalDatabase implements Lifecycle
 
     void replaceWith( File sourceDir ) throws IOException
     {
-        storeFiles.delete( storeDir );
-        storeFiles.moveTo( sourceDir, storeDir );
+        storeFiles.delete( storeDir, logFiles );
+        storeFiles.moveTo( sourceDir, storeDir, logFiles );
     }
 
     public NeoStoreDataSource dataSource()

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStore.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStore.java
@@ -162,8 +162,8 @@ public class RemoteStore
     private CatchupResult pullTransactions( AdvertisedSocketAddress from, StoreId expectedStoreId, File storeDir, long fromTxId, boolean asPartOfStoreCopy )
             throws IOException, StoreCopyFailedException
     {
-        try ( TransactionLogCatchUpWriter writer = transactionLogFactory.create( storeDir, fs, pageCache, logProvider,
-                fromTxId, asPartOfStoreCopy ) )
+        try ( TransactionLogCatchUpWriter writer = transactionLogFactory.create( storeDir, fs, pageCache, config,
+                logProvider, fromTxId, asPartOfStoreCopy ) )
         {
             log.info( "Pulling transactions from: %d", fromTxId );
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyProcess.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyProcess.java
@@ -37,8 +37,8 @@ public class StoreCopyProcess
     private final Log log;
     private final RemoteStore remoteStore;
 
-    public StoreCopyProcess( FileSystemAbstraction fs, PageCache pageCache, LocalDatabase localDatabase, CopiedStoreRecovery copiedStoreRecovery,
-            RemoteStore remoteStore, LogProvider logProvider )
+    public StoreCopyProcess( FileSystemAbstraction fs, PageCache pageCache, LocalDatabase localDatabase,
+            CopiedStoreRecovery copiedStoreRecovery, RemoteStore remoteStore, LogProvider logProvider )
     {
         this.fs = fs;
         this.pageCache = pageCache;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreFiles.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreFiles.java
@@ -106,6 +106,7 @@ public class StoreFiles
 
     public void moveTo( File source, File target, LogFiles logFiles ) throws IOException
     {
+        fs.mkdirs( logFiles.logFilesDirectory() );
         for ( File candidate : fs.listFiles( source, fileFilter ) )
         {
             File destination = logFiles.isLogFile( candidate) ? logFiles.logFilesDirectory() : target;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreFiles.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreFiles.java
@@ -33,6 +33,7 @@ import org.neo4j.io.fs.FileHandle;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.impl.store.MetaDataStore;
+import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
 
 public class StoreFiles
 {
@@ -60,7 +61,7 @@ public class StoreFiles
         this.fileFilter = fileFilter;
     }
 
-    public void delete( File storeDir ) throws IOException
+    public void delete( File storeDir, LogFiles logFiles ) throws IOException
     {
         // 'files' can be null if the directory doesn't exist. This is fine, we just ignore it then.
         File[] files = fs.listFiles( storeDir, fileFilter );
@@ -69,6 +70,15 @@ public class StoreFiles
             for ( File file : files )
             {
                 fs.deleteRecursively( file );
+            }
+        }
+
+        File[] txLogs = fs.listFiles( logFiles.logFilesDirectory() );
+        if ( txLogs != null )
+        {
+            for ( File txLog : txLogs )
+            {
+                fs.deleteFile( txLog );
             }
         }
 
@@ -94,11 +104,12 @@ public class StoreFiles
         }
     }
 
-    public void moveTo( File source, File target ) throws IOException
+    public void moveTo( File source, File target, LogFiles logFiles ) throws IOException
     {
         for ( File candidate : fs.listFiles( source, fileFilter ) )
         {
-            fs.moveToDirectory( candidate, target );
+            File destination = logFiles.isLogFile( candidate) ? logFiles.logFilesDirectory() : target;
+            fs.moveToDirectory( candidate, destination );
         }
 
         Iterable<FileHandle> fileHandles = acceptedPageCachedFiles( source )::iterator;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/TemporaryStoreDirectory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/TemporaryStoreDirectory.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
+import org.neo4j.kernel.impl.transaction.log.files.LogFilesBuilder;
 
 public class TemporaryStoreDirectory implements AutoCloseable
 {
@@ -31,12 +33,14 @@ public class TemporaryStoreDirectory implements AutoCloseable
 
     private final File tempStoreDir;
     private final StoreFiles storeFiles;
+    private LogFiles tempLogFiles;
 
     public TemporaryStoreDirectory( FileSystemAbstraction fs, PageCache pageCache, File parent ) throws IOException
     {
         this.tempStoreDir = new File( parent, TEMP_COPY_DIRECTORY_NAME );
         storeFiles = new StoreFiles( fs, pageCache, ( directory, name ) -> true );
-        storeFiles.delete( tempStoreDir );
+        tempLogFiles = LogFilesBuilder.logFilesBasedOnlyBuilder( tempStoreDir, fs ).build();
+        storeFiles.delete( tempStoreDir, tempLogFiles );
     }
 
     public File storeDir()
@@ -47,6 +51,6 @@ public class TemporaryStoreDirectory implements AutoCloseable
     @Override
     public void close() throws IOException
     {
-        storeFiles.delete( tempStoreDir );
+        storeFiles.delete( tempStoreDir, tempLogFiles );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpFactory.java
@@ -30,9 +30,10 @@ import org.neo4j.logging.LogProvider;
 public class TransactionLogCatchUpFactory
 {
     public TransactionLogCatchUpWriter create( File storeDir, FileSystemAbstraction fs, PageCache pageCache,
-            Config config, LogProvider logProvider, long fromTxId, boolean asPartOfStoreCopy ) throws IOException
+            Config config, LogProvider logProvider, long fromTxId, boolean asPartOfStoreCopy, boolean keepTxLogsInStoreDir )
+            throws IOException
     {
         return new TransactionLogCatchUpWriter( storeDir, fs, pageCache, config, logProvider, fromTxId,
-                asPartOfStoreCopy );
+                asPartOfStoreCopy, keepTxLogsInStoreDir );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpFactory.java
@@ -24,13 +24,15 @@ import java.io.IOException;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.logging.LogProvider;
 
 public class TransactionLogCatchUpFactory
 {
     public TransactionLogCatchUpWriter create( File storeDir, FileSystemAbstraction fs, PageCache pageCache,
-            LogProvider logProvider, long fromTxId, boolean asPartOfStoreCopy ) throws IOException
+            Config config, LogProvider logProvider, long fromTxId, boolean asPartOfStoreCopy ) throws IOException
     {
-        return new TransactionLogCatchUpWriter( storeDir, fs, pageCache, logProvider, fromTxId, asPartOfStoreCopy );
+        return new TransactionLogCatchUpWriter( storeDir, fs, pageCache, config, logProvider, fromTxId,
+                asPartOfStoreCopy );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpWriter.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpWriter.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.LogPosition;
@@ -52,14 +53,19 @@ public class TransactionLogCatchUpWriter implements TxPullResponseListener, Auto
     private long lastTxId = -1;
     private long expectedTxId;
 
-    TransactionLogCatchUpWriter( File storeDir, FileSystemAbstraction fs, PageCache pageCache,
+    TransactionLogCatchUpWriter( File storeDir, FileSystemAbstraction fs, PageCache pageCache, Config config,
             LogProvider logProvider, long fromTxId, boolean asPartOfStoreCopy ) throws IOException
     {
         this.pageCache = pageCache;
         this.log = logProvider.getLog( getClass() );
         this.asPartOfStoreCopy = asPartOfStoreCopy;
-        this.logFiles = LogFilesBuilder.activeFilesBuilder( storeDir, fs, pageCache )
-                .withLastCommittedTransactionIdSupplier( () -> fromTxId - 1 ).build();
+        LogFilesBuilder logFilesBuilder = LogFilesBuilder.activeFilesBuilder( storeDir, fs, pageCache )
+                .withLastCommittedTransactionIdSupplier( () -> fromTxId - 1 );
+        if ( !asPartOfStoreCopy )
+        {
+            logFilesBuilder.withConfig( config );
+        }
+        this.logFiles = logFilesBuilder.build();
         this.lifespan.add( logFiles );
         this.writer = new TransactionLogWriter( new LogEntryWriter( logFiles.getLogFile().getWriter() ) );
         this.storeDir = storeDir;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpWriter.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpWriter.java
@@ -54,14 +54,14 @@ public class TransactionLogCatchUpWriter implements TxPullResponseListener, Auto
     private long expectedTxId;
 
     TransactionLogCatchUpWriter( File storeDir, FileSystemAbstraction fs, PageCache pageCache, Config config,
-            LogProvider logProvider, long fromTxId, boolean asPartOfStoreCopy ) throws IOException
+            LogProvider logProvider, long fromTxId, boolean asPartOfStoreCopy, boolean keepTxLogsInStoreDir ) throws IOException
     {
         this.pageCache = pageCache;
         this.log = logProvider.getLog( getClass() );
         this.asPartOfStoreCopy = asPartOfStoreCopy;
         LogFilesBuilder logFilesBuilder = LogFilesBuilder.activeFilesBuilder( storeDir, fs, pageCache )
                 .withLastCommittedTransactionIdSupplier( () -> fromTxId - 1 );
-        if ( !asPartOfStoreCopy )
+        if ( !keepTxLogsInStoreDir )
         {
             logFilesBuilder.withConfig( config );
         }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
@@ -64,7 +64,6 @@ import org.neo4j.causalclustering.messaging.RaftChannelInitializer;
 import org.neo4j.causalclustering.messaging.RaftOutbound;
 import org.neo4j.causalclustering.messaging.SenderService;
 import org.neo4j.com.storecopy.StoreUtil;
-import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.function.Predicates;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
@@ -105,7 +104,6 @@ import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.lifecycle.LifecycleStatus;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.LogProvider;
-import org.neo4j.ssl.SslPolicy;
 import org.neo4j.time.Clocks;
 import org.neo4j.udc.UsageData;
 
@@ -175,7 +173,7 @@ public class EnterpriseCoreEditionModule extends EditionModule
         final LifeSupport life = platformModule.life;
         final Monitors monitors = platformModule.monitors;
 
-        final File dataDir = config.get( DatabaseManagementSystemSettings.data_directory );
+        final File dataDir = config.get( GraphDatabaseSettings.data_directory );
         final ClusterStateDirectory clusterStateDirectory = new ClusterStateDirectory( dataDir, storeDir, false );
         try
         {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
@@ -126,13 +126,13 @@ public class CoreServerModule
         RemoteStore remoteStore = new RemoteStore( logProvider, fileSystem, platformModule.pageCache,
                 new StoreCopyClient( catchUpClient, logProvider ),
                 new TxPullClient( catchUpClient, platformModule.monitors ), new TransactionLogCatchUpFactory(),
-                platformModule.monitors );
+                config, platformModule.monitors );
 
         CopiedStoreRecovery copiedStoreRecovery = new CopiedStoreRecovery( config, platformModule.kernelExtensions.listFactories(), platformModule.pageCache );
         life.add( copiedStoreRecovery );
 
-        StoreCopyProcess storeCopyProcess =
-                new StoreCopyProcess( fileSystem, platformModule.pageCache, localDatabase, copiedStoreRecovery, remoteStore, logProvider );
+        StoreCopyProcess storeCopyProcess = new StoreCopyProcess( fileSystem, platformModule.pageCache, localDatabase,
+                copiedStoreRecovery, remoteStore, logProvider );
 
         LifeSupport servicesToStopOnStoreCopy = new LifeSupport();
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CoreBootstrapper.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/CoreBootstrapper.java
@@ -125,6 +125,7 @@ public class CoreBootstrapper
     {
         ReadOnlyTransactionIdStore readOnlyTransactionIdStore = new ReadOnlyTransactionIdStore( pageCache, storeDir );
         LogFiles logFiles = LogFilesBuilder.activeFilesBuilder( storeDir, fs, pageCache )
+                .withConfig( config )
                 .withLastCommittedTransactionIdSupplier( () -> readOnlyTransactionIdStore.getLastClosedTransactionId() - 1 )
                 .build();
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloader.java
@@ -127,7 +127,8 @@ public class CoreStateDownloader
             else
             {
                 StoreId localStoreId = localDatabase.storeId();
-                CatchupResult catchupResult = remoteStore.tryCatchingUp( fromAddress, localStoreId, localDatabase.storeDir() );
+                CatchupResult catchupResult = remoteStore.tryCatchingUp( fromAddress, localStoreId, localDatabase
+                        .storeDir(), false );
 
                 if ( catchupResult == E_TRANSACTION_PRUNED )
                 {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
@@ -20,6 +20,7 @@
 package org.neo4j.causalclustering.readreplica;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -97,6 +98,8 @@ import org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory;
 import org.neo4j.kernel.impl.transaction.log.LogicalTransactionStore;
 import org.neo4j.kernel.impl.transaction.log.TransactionAppender;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
+import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
+import org.neo4j.kernel.impl.transaction.log.files.LogFilesBuilder;
 import org.neo4j.kernel.impl.transaction.log.files.TransactionLogFiles;
 import org.neo4j.kernel.impl.util.Dependencies;
 import org.neo4j.kernel.internal.DatabaseHealth;
@@ -217,14 +220,16 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
         DelayedRenewableTimeoutService catchupTimeoutService = new DelayedRenewableTimeoutService( Clocks.systemClock(), logProvider );
 
         StoreFiles storeFiles = new StoreFiles( fileSystem, pageCache );
+        LogFiles logFiles = buildLocalDatabaseLogFiles( platformModule, fileSystem, storeDir, config );
 
         LocalDatabase localDatabase =
-                new LocalDatabase( platformModule.storeDir, storeFiles, platformModule.dataSourceManager, databaseHealthSupplier, watcherService,
-                        platformModule.availabilityGuard, logProvider );
+                new LocalDatabase( platformModule.storeDir, storeFiles, logFiles, platformModule.dataSourceManager,
+                        databaseHealthSupplier,
+                        watcherService, platformModule.availabilityGuard, logProvider );
 
         RemoteStore remoteStore = new RemoteStore( platformModule.logging.getInternalLogProvider(), fileSystem, platformModule.pageCache,
                 new StoreCopyClient( catchUpClient, logProvider ), new TxPullClient( catchUpClient, platformModule.monitors ),
-                new TransactionLogCatchUpFactory(), platformModule.monitors );
+                new TransactionLogCatchUpFactory(), config, platformModule.monitors );
 
         CopiedStoreRecovery copiedStoreRecovery = new CopiedStoreRecovery( config, platformModule.kernelExtensions.listFactories(), platformModule.pageCache );
 
@@ -232,7 +237,8 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
 
         LifeSupport servicesToStopOnStoreCopy = new LifeSupport();
 
-        StoreCopyProcess storeCopyProcess = new StoreCopyProcess( fileSystem, pageCache, localDatabase, copiedStoreRecovery, remoteStore, logProvider );
+        StoreCopyProcess storeCopyProcess = new StoreCopyProcess( fileSystem, pageCache, localDatabase,
+                copiedStoreRecovery, remoteStore, logProvider );
 
         ConnectToRandomCoreServerStrategy defaultStrategy = new ConnectToRandomCoreServerStrategy();
         defaultStrategy.inject( topologyService, config, logProvider, myself );
@@ -374,5 +380,18 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
         Map<String,String> overrideBackupSettings = new HashMap<>(  );
         overrideBackupSettings.put( OnlineBackupSettings.online_backup_enabled.name(), Settings.FALSE );
         return overrideBackupSettings;
+    }
+
+    private LogFiles buildLocalDatabaseLogFiles( PlatformModule platformModule, FileSystemAbstraction fileSystem,
+            File storeDir, Config config )
+    {
+        try
+        {
+            return LogFilesBuilder.activeFilesBuilder( storeDir, fileSystem, platformModule.pageCache ).withConfig( config ).build();
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( e );
+        }
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/commandline/dbms/UnbindFromClusterCommand.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/commandline/dbms/UnbindFromClusterCommand.java
@@ -31,7 +31,7 @@ import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.commandline.arguments.Arguments;
-import org.neo4j.dbms.DatabaseManagementSystemSettings;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.StoreLockException;
 import org.neo4j.kernel.configuration.Config;
@@ -61,7 +61,7 @@ public class UnbindFromClusterCommand implements AdminCommand
     private static Config loadNeo4jConfig( Path homeDir, Path configDir, String databaseName )
     {
         return fromFile( configDir.resolve( Config.DEFAULT_CONFIG_FILE_NAME ) )
-                .withSetting( DatabaseManagementSystemSettings.active_database, databaseName )
+                .withSetting( GraphDatabaseSettings.active_database, databaseName )
                 .withHome( homeDir ).build();
     }
 
@@ -71,8 +71,8 @@ public class UnbindFromClusterCommand implements AdminCommand
         try
         {
             Config config = loadNeo4jConfig( homeDir, configDir, arguments.parse( args ).get( "database" ) );
-            File dataDirectory = config.get( DatabaseManagementSystemSettings.data_directory );
-            Path pathToSpecificDatabase = config.get( DatabaseManagementSystemSettings.database_path ).toPath();
+            File dataDirectory = config.get( GraphDatabaseSettings.data_directory );
+            Path pathToSpecificDatabase = config.get( GraphDatabaseSettings.database_path ).toPath();
 
             boolean hasDatabase = true;
             try

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/RestoreClusterUtils.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/RestoreClusterUtils.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.causalclustering.backup;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.io.File;
 
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -37,14 +39,22 @@ public class RestoreClusterUtils
     {
     }
 
-    public static File createClassicNeo4jStore( File base, FileSystemAbstraction fileSystem, int nodesToCreate, String recordFormat )
+    public static File createClassicNeo4jStore( File base, FileSystemAbstraction fileSystem, int nodesToCreate,
+            String recordFormat )
     {
-        File existingDbDir = new File( base, "existing" );
+        return createClassicNeo4jStore( base, fileSystem, nodesToCreate, recordFormat, StringUtils.EMPTY );
+    }
+
+    public static File createClassicNeo4jStore( File base, FileSystemAbstraction fileSystem,
+            int nodesToCreate, String recordFormat, String logicalLogsLocation )
+    {
+        File storeDir = new File( base, "existing" );
         GraphDatabaseService db = new TestGraphDatabaseFactory()
                 .setFileSystem( fileSystem )
-                .newEmbeddedDatabaseBuilder( existingDbDir )
+                .newEmbeddedDatabaseBuilder( storeDir )
                 .setConfig( GraphDatabaseSettings.record_format, recordFormat )
                 .setConfig( OnlineBackupSettings.online_backup_enabled, Boolean.FALSE.toString() )
+                .setConfig( GraphDatabaseSettings.logical_logs_location, logicalLogsLocation )
                 .newGraphDatabase();
 
         for ( int i = 0; i < (nodesToCreate / 2); i++ )
@@ -60,6 +70,6 @@ public class RestoreClusterUtils
 
         db.shutdown();
 
-        return existingDbDir;
+        return storeDir;
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/CopiedStoreRecoveryTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/CopiedStoreRecoveryTest.java
@@ -22,6 +22,7 @@ package org.neo4j.causalclustering.catchup.storecopy;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
 
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.io.pagecache.PageCache;
@@ -34,7 +35,7 @@ import static org.mockito.Mockito.mock;
 public class CopiedStoreRecoveryTest
 {
     @Test
-    public void shouldThrowIfAlreadyShutdown()
+    public void shouldThrowIfAlreadyShutdown() throws IOException
     {
         // Given
         CopiedStoreRecovery copiedStoreRecovery =

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabaseTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/LocalDatabaseTest.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.time.Clock;
 
 import org.neo4j.kernel.AvailabilityGuard;
+import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
 import org.neo4j.kernel.impl.transaction.state.DataSourceManager;
 import org.neo4j.kernel.impl.util.watcher.FileSystemWatcherService;
 import org.neo4j.kernel.internal.DatabaseHealth;
@@ -167,7 +168,7 @@ public class LocalDatabaseTest
     private static LocalDatabase newLocalDatabase( AvailabilityGuard availabilityGuard,
             DataSourceManager dataSourceManager, FileSystemWatcherService fileWatcher )
     {
-        return new LocalDatabase( new File( "." ), mock( StoreFiles.class ), dataSourceManager,
+        return new LocalDatabase( new File( "." ), mock( StoreFiles.class ), mock( LogFiles.class ), dataSourceManager,
                 () -> mock( DatabaseHealth.class ), fileWatcher, availabilityGuard,
                 NullLogProvider.getInstance() );
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStoreTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStoreTest.java
@@ -31,6 +31,7 @@ import org.neo4j.causalclustering.catchup.tx.TxPullClient;
 import org.neo4j.causalclustering.identity.StoreId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
@@ -60,7 +61,7 @@ public class RemoteStoreTest
         TransactionLogCatchUpWriter writer = mock( TransactionLogCatchUpWriter.class );
 
         RemoteStore remoteStore = new RemoteStore( NullLogProvider.getInstance(), mock( FileSystemAbstraction.class ),
-                null, storeCopyClient, txPullClient, factory( writer ), new Monitors() );
+                null, storeCopyClient, txPullClient, factory( writer ), Config.defaults(), new Monitors() );
 
         // when
         AdvertisedSocketAddress localhost = new AdvertisedSocketAddress( "127.0.0.1", 1234 );
@@ -90,7 +91,7 @@ public class RemoteStoreTest
         TransactionLogCatchUpWriter writer = mock( TransactionLogCatchUpWriter.class );
 
         RemoteStore remoteStore = new RemoteStore( NullLogProvider.getInstance(), mock( FileSystemAbstraction.class ),
-                null, storeCopyClient, txPullClient, factory( writer ), new Monitors() );
+                null, storeCopyClient, txPullClient, factory( writer ), Config.defaults(), new Monitors() );
 
         // when
         remoteStore.copy( localhost, wantedStoreId, new File( "destination" ) );
@@ -112,7 +113,7 @@ public class RemoteStoreTest
 
         RemoteStore remoteStore = new RemoteStore( NullLogProvider.getInstance(), mock( FileSystemAbstraction.class ),
                 null,
-                storeCopyClient, txPullClient, factory( writer ), new Monitors() );
+                storeCopyClient, txPullClient, factory( writer ), Config.defaults(), new Monitors() );
 
         doThrow( StoreCopyFailedException.class ).when( txPullClient )
                 .pullTransactions( isNull(), eq( storeId ), anyLong(), any() );
@@ -135,7 +136,8 @@ public class RemoteStoreTest
     {
         TransactionLogCatchUpFactory factory = mock( TransactionLogCatchUpFactory.class );
         when( factory.create( isNull(), any( FileSystemAbstraction.class ),
-                isNull(), any( LogProvider.class ), anyLong(), anyBoolean() ) ).thenReturn( writer );
+                isNull(), any( LogProvider.class ), anyLong(), anyBoolean() ) )
+                .thenReturn( writer );
         return factory;
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStoreTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStoreTest.java
@@ -136,7 +136,7 @@ public class RemoteStoreTest
     {
         TransactionLogCatchUpFactory factory = mock( TransactionLogCatchUpFactory.class );
         when( factory.create( isNull(), any( FileSystemAbstraction.class ), isNull(), any( Config.class ),
-                any( LogProvider.class ), anyLong(), anyBoolean() ) ).thenReturn( writer );
+                any( LogProvider.class ), anyLong(), anyBoolean(), anyBoolean() ) ).thenReturn( writer );
         return factory;
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStoreTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStoreTest.java
@@ -135,9 +135,8 @@ public class RemoteStoreTest
     private TransactionLogCatchUpFactory factory( TransactionLogCatchUpWriter writer ) throws IOException
     {
         TransactionLogCatchUpFactory factory = mock( TransactionLogCatchUpFactory.class );
-        when( factory.create( isNull(), any( FileSystemAbstraction.class ),
-                isNull(), any( LogProvider.class ), anyLong(), anyBoolean() ) )
-                .thenReturn( writer );
+        when( factory.create( isNull(), any( FileSystemAbstraction.class ), isNull(), any( Config.class ),
+                any( LogProvider.class ), anyLong(), anyBoolean() ) ).thenReturn( writer );
         return factory;
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreFilesTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/StoreFilesTest.java
@@ -40,6 +40,8 @@ import org.neo4j.io.fs.OpenMode;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.MetaDataStore.Position;
+import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
+import org.neo4j.kernel.impl.transaction.log.files.LogFilesBuilder;
 import org.neo4j.test.rule.PageCacheRule;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
@@ -67,6 +69,7 @@ public class StoreFilesTest
     private EphemeralFileSystemAbstraction pc;
     private PageCache pageCache;
     private StoreFiles storeFiles;
+    private LogFiles logFiles;
 
     public StoreFilesTest()
     {
@@ -93,6 +96,7 @@ public class StoreFilesTest
         pc = hiddenFileSystemRule.get();
         pageCache = pageCacheRule.getPageCache( pc );
         storeFiles = new StoreFiles( fs, pageCache );
+        logFiles = LogFilesBuilder.logFilesBasedOnlyBuilder( testDirectory.directory(), fs ).build();
     }
 
     private void createOnFileSystem( File file ) throws IOException
@@ -128,7 +132,7 @@ public class StoreFilesTest
         assertTrue( fs.fileExists( a ) );
         assertTrue( pc.fileExists( b ) );
 
-        storeFiles.delete( dir );
+        storeFiles.delete( dir, logFiles );
 
         assertFalse( fs.fileExists( a ) );
         assertFalse( pc.fileExists( b ) );
@@ -150,7 +154,7 @@ public class StoreFilesTest
 
         FilenameFilter filter = ( directory, name ) -> !name.equals( "c" ) && !name.equals( "d" );
         storeFiles = new StoreFiles( fs, pageCache, filter );
-        storeFiles.delete( dir );
+        storeFiles.delete( dir, logFiles );
 
         assertFalse( fs.fileExists( a ) );
         assertFalse( pc.fileExists( b ) );
@@ -175,7 +179,7 @@ public class StoreFilesTest
 
         FilenameFilter filter = ( directory, name ) -> !name.startsWith( "ignore" );
         storeFiles = new StoreFiles( fs, pageCache, filter );
-        storeFiles.delete( dir );
+        storeFiles.delete( dir, logFiles );
 
         assertFalse( fs.fileExists( a ) );
         assertFalse( pc.fileExists( b ) );
@@ -189,7 +193,7 @@ public class StoreFilesTest
         File dir = getBaseDir();
         File sub = new File( dir, "sub" );
 
-        storeFiles.delete( sub );
+        storeFiles.delete( sub, logFiles );
     }
 
     @Test
@@ -208,7 +212,7 @@ public class StoreFilesTest
         createOnFileSystem( new File( tgt, ".fs-ignore" ) );
         createOnPageCache( new File( tgt, ".pc-ignore" ) );
 
-        storeFiles.moveTo( src, tgt );
+        storeFiles.moveTo( src, tgt, logFiles );
 
         assertFalse( fs.fileExists( a ) );
         assertFalse( pc.fileExists( b ) );
@@ -233,7 +237,7 @@ public class StoreFilesTest
         createOnFileSystem( new File( tgt, ".fs-ignore" ) );
         createOnPageCache( new File( tgt, ".pc-ignore" ) );
 
-        storeFiles.moveTo( src, tgt );
+        storeFiles.moveTo( src, tgt, logFiles );
 
         assertFalse( fs.fileExists( a ) );
         assertFalse( pc.fileExists( b ) );
@@ -264,7 +268,7 @@ public class StoreFilesTest
 
         FilenameFilter filter = ( directory, name ) -> !name.startsWith( "ignore" );
         storeFiles = new StoreFiles( fs, pageCache, filter );
-        storeFiles.moveTo( src, tgt );
+        storeFiles.moveTo( src, tgt, logFiles );
 
         assertFalse( fs.fileExists( a ) );
         assertFalse( pc.fileExists( b ) );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpWriterTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/TransactionLogCatchUpWriterTest.java
@@ -106,17 +106,17 @@ public class TransactionLogCatchUpWriterTest
     @Test
     public void shouldCreateTransactionLogWithCheckpoint() throws Exception
     {
-        createTransactionLogWithCheckpoint( Config.defaults() );
+        createTransactionLogWithCheckpoint( Config.defaults(), true );
     }
 
     @Test
     public void createTransactionLogWithCheckpointInCustomLocation() throws IOException
     {
         createTransactionLogWithCheckpoint( Config.defaults( GraphDatabaseSettings.logical_logs_location,
-                "custom-tx-logs") );
+                "custom-tx-logs"), false );
     }
 
-    private void createTransactionLogWithCheckpoint( Config config ) throws IOException
+    private void createTransactionLogWithCheckpoint( Config config, boolean logsInStoreDir ) throws IOException
     {
         org.neo4j.kernel.impl.store.StoreId storeId = simulateStoreCopy();
 
@@ -124,7 +124,7 @@ public class TransactionLogCatchUpWriterTest
         int endTxId = fromTxId + 5;
 
         TransactionLogCatchUpWriter catchUpWriter = new TransactionLogCatchUpWriter( storeDir, fs, pageCache, config,
-                NullLogProvider.getInstance(), fromTxId, partOfStoreCopy );
+                NullLogProvider.getInstance(), fromTxId, partOfStoreCopy, logsInStoreDir );
 
         // when
         for ( int i = fromTxId; i <= endTxId; i++ )
@@ -136,7 +136,7 @@ public class TransactionLogCatchUpWriterTest
 
         // then
         LogFilesBuilder logFilesBuilder = LogFilesBuilder.activeFilesBuilder( storeDir, fs, pageCache );
-        if ( !partOfStoreCopy )
+        if ( !logsInStoreDir )
         {
             logFilesBuilder.withConfig( config );
         }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/RebuildReplicatedIdGeneratorsTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/machines/id/RebuildReplicatedIdGeneratorsTest.java
@@ -90,7 +90,6 @@ public class RebuildReplicatedIdGeneratorsTest
             reopenedStores.makeStoreOk();
             assertEquals( 51L, reopenedStores.getNodeStore().nextId() );
         }
-
     }
 
     private ReplicatedIdGeneratorFactory getIdGenerationFactory( FileSystemAbstraction fileSystemAbstraction )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderTest.java
@@ -44,6 +44,7 @@ import org.neo4j.logging.NullLogProvider;
 
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -95,7 +96,7 @@ public class CoreStateDownloaderTest
         downloader.downloadSnapshot( remoteMember );
 
         // then
-        verify( remoteStore, never() ).tryCatchingUp( any(), any(), any() );
+        verify( remoteStore, never() ).tryCatchingUp( any(), any(), any(), anyBoolean() );
         verify( storeCopyProcess ).replaceWithStoreFrom( remoteAddress, remoteStoreId );
     }
 
@@ -136,7 +137,7 @@ public class CoreStateDownloaderTest
 
         // then
         verify( remoteStore, never() ).copy( any(), any(), any() );
-        verify( remoteStore, never() ).tryCatchingUp( any(), any(), any() );
+        verify( remoteStore, never() ).tryCatchingUp( any(), any(), any(), anyBoolean() );
     }
 
     @Test
@@ -145,13 +146,14 @@ public class CoreStateDownloaderTest
         // given
         when( localDatabase.isEmpty() ).thenReturn( false );
         when( remoteStore.getStoreId( remoteAddress ) ).thenReturn( storeId );
-        when( remoteStore.tryCatchingUp( remoteAddress, storeId, storeDir ) ).thenReturn( SUCCESS_END_OF_STREAM );
+        when( remoteStore.tryCatchingUp( remoteAddress, storeId, storeDir, false ) )
+                .thenReturn( SUCCESS_END_OF_STREAM );
 
         // when
         downloader.downloadSnapshot( remoteMember );
 
         // then
-        verify( remoteStore ).tryCatchingUp( remoteAddress, storeId, storeDir );
+        verify( remoteStore ).tryCatchingUp( remoteAddress, storeId, storeDir, false );
         verify( remoteStore, never() ).copy( any(), any(), any() );
     }
 
@@ -161,13 +163,13 @@ public class CoreStateDownloaderTest
         // given
         when( localDatabase.isEmpty() ).thenReturn( false );
         when( remoteStore.getStoreId( remoteAddress ) ).thenReturn( storeId );
-        when( remoteStore.tryCatchingUp( remoteAddress, storeId, storeDir ) ).thenReturn( E_TRANSACTION_PRUNED );
+        when( remoteStore.tryCatchingUp( remoteAddress, storeId, storeDir, false ) ).thenReturn( E_TRANSACTION_PRUNED );
 
         // when
         downloader.downloadSnapshot( remoteMember );
 
         // then
-        verify( remoteStore ).tryCatchingUp( remoteAddress, storeId, storeDir );
+        verify( remoteStore ).tryCatchingUp( remoteAddress, storeId, storeDir, false );
         verify( storeCopyProcess ).replaceWithStoreFrom( remoteAddress, storeId );
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreClusterMember.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreClusterMember.java
@@ -124,12 +124,14 @@ public class CoreClusterMember implements ClusterMember<GraphDatabaseFacade>
         this.neo4jHome = new File( parentDir, "server-core-" + serverId );
         config.put( GraphDatabaseSettings.neo4j_home.name(), neo4jHome.getAbsolutePath() );
         config.put( GraphDatabaseSettings.logs_directory.name(), new File( neo4jHome, "logs" ).getAbsolutePath() );
+        config.put( GraphDatabaseSettings.logical_logs_location.name(), "core-tx-logs-" + serverId );
 
         this.discoveryServiceFactory = discoveryServiceFactory;
         File dataDir = new File( neo4jHome, "data" );
         clusterStateDir = ClusterStateDirectory.withoutInitializing( dataDir ).get();
         raftLogDir = new File( clusterStateDir, RAFT_LOG_DIRECTORY_NAME );
         storeDir = new File( new File( dataDir, "databases" ), "graph.db" );
+
         //noinspection ResultOfMethodCallIgnored
         storeDir.mkdirs();
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreClusterMember.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreClusterMember.java
@@ -67,6 +67,7 @@ public class CoreClusterMember implements ClusterMember<GraphDatabaseFacade>
     private final String boltAdvertisedSocketAddress;
     private final int discoveryPort;
     protected CoreGraphDatabase database;
+    private final Config memberConfig;
 
     public CoreClusterMember( int serverId,
                               int discoveryPort,
@@ -131,6 +132,7 @@ public class CoreClusterMember implements ClusterMember<GraphDatabaseFacade>
         clusterStateDir = ClusterStateDirectory.withoutInitializing( dataDir ).get();
         raftLogDir = new File( clusterStateDir, RAFT_LOG_DIRECTORY_NAME );
         storeDir = new File( new File( dataDir, "databases" ), "graph.db" );
+        memberConfig = Config.defaults( config );
 
         //noinspection ResultOfMethodCallIgnored
         storeDir.mkdirs();
@@ -154,7 +156,7 @@ public class CoreClusterMember implements ClusterMember<GraphDatabaseFacade>
     @Override
     public void start()
     {
-        database = new CoreGraphDatabase( storeDir, Config.defaults( config ),
+        database = new CoreGraphDatabase( storeDir, memberConfig,
                 GraphDatabaseDependencies.newDependencies(), discoveryServiceFactory );
     }
 
@@ -177,6 +179,11 @@ public class CoreClusterMember implements ClusterMember<GraphDatabaseFacade>
     public File storeDir()
     {
         return storeDir;
+    }
+
+    public Config getMemberConfig()
+    {
+        return memberConfig;
     }
 
     public RaftLogPruner raftLogPruner()

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ReadReplica.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ReadReplica.java
@@ -97,9 +97,11 @@ public class ReadReplica implements ClusterMember
         config.put( CausalClusteringSettings.transaction_listen_address.name(), listenAddress( listenAddress, txPort ) );
         config.put( OnlineBackupSettings.online_backup_server.name(), listenAddress( listenAddress, backupPort ) );
         config.put( GraphDatabaseSettings.logs_directory.name(), new File( neo4jHome, "logs" ).getAbsolutePath() );
+        config.put( GraphDatabaseSettings.logical_logs_location.name(), "replica-tx-logs-" + serverId );
 
         this.discoveryServiceFactory = discoveryServiceFactory;
         storeDir = new File( new File( new File( neo4jHome, "data" ), "databases" ), "graph.db" );
+
         //noinspection ResultOfMethodCallIgnored
         storeDir.mkdirs();
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterCustomLogLocationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterCustomLogLocationIT.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.scenarios;
+
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+
+import org.neo4j.causalclustering.discovery.Cluster;
+import org.neo4j.causalclustering.discovery.CoreClusterMember;
+import org.neo4j.causalclustering.discovery.ReadReplica;
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
+import org.neo4j.test.causalclustering.ClusterRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.kernel.impl.transaction.log.files.LogFilesBuilder.logFilesBasedOnlyBuilder;
+
+public class ClusterCustomLogLocationIT
+{
+    @Rule
+    public final ClusterRule clusterRule = new ClusterRule( getClass() )
+            .withNumberOfCoreMembers( 3 )
+            .withNumberOfReadReplicas( 2 );
+
+    @Test
+    public void clusterWithCustomTransactionLogLocation() throws Exception
+    {
+        Cluster cluster = clusterRule.startCluster();
+
+        for ( int i = 0; i < 10; i++ )
+        {
+            cluster.coreTx( ( db, tx ) ->
+            {
+                db.createNode();
+                tx.success();
+            } );
+        }
+
+        Collection<CoreClusterMember> coreClusterMembers = cluster.coreMembers();
+        for ( CoreClusterMember coreClusterMember : coreClusterMembers )
+        {
+            DependencyResolver dependencyResolver = coreClusterMember.database().getDependencyResolver();
+            LogFiles logFiles = dependencyResolver.resolveDependency( LogFiles.class );
+            assertEquals( logFiles.logFilesDirectory().getName(), "core-tx-logs-" + coreClusterMember.serverId() );
+            assertTrue( logFiles.hasAnyEntries( 0 ) );
+            File[] coreLogDirectories = coreClusterMember.homeDir().listFiles( file -> file.getName().startsWith( "core" ) );
+            assertThat( coreLogDirectories, Matchers.arrayWithSize( 1 ) );
+
+            logFileInStoreDirectoryDoesNotExist( coreClusterMember.storeDir(), dependencyResolver );
+        }
+
+        Collection<ReadReplica> readReplicas = cluster.readReplicas();
+        for ( ReadReplica readReplica : readReplicas )
+        {
+            readReplica.txPollingClient().upToDateFuture().get();
+            DependencyResolver dependencyResolver = readReplica.database().getDependencyResolver();
+            LogFiles logFiles = dependencyResolver.resolveDependency( LogFiles.class );
+            assertEquals( logFiles.logFilesDirectory().getName(), "replica-tx-logs-" + readReplica.serverId() );
+            assertTrue( logFiles.hasAnyEntries( 0 ) );
+            File[] replicaLogDirectories = readReplica.homeDir().listFiles( file -> file.getName().startsWith( "replica" ) );
+            assertThat( replicaLogDirectories, Matchers.arrayWithSize( 1 ) );
+
+            logFileInStoreDirectoryDoesNotExist( readReplica.storeDir(), dependencyResolver );
+        }
+    }
+
+    private void logFileInStoreDirectoryDoesNotExist( File storeDir, DependencyResolver dependencyResolver ) throws IOException
+    {
+        FileSystemAbstraction fileSystem = dependencyResolver.resolveDependency( FileSystemAbstraction.class );
+        LogFiles storeLogFiles = logFilesBasedOnlyBuilder( storeDir, fileSystem ).build();
+        assertFalse( storeLogFiles.versionExists( 0 ) );
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterCustomLogLocationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterCustomLogLocationIT.java
@@ -69,7 +69,7 @@ public class ClusterCustomLogLocationIT
             LogFiles logFiles = dependencyResolver.resolveDependency( LogFiles.class );
             assertEquals( logFiles.logFilesDirectory().getName(), "core-tx-logs-" + coreClusterMember.serverId() );
             assertTrue( logFiles.hasAnyEntries( 0 ) );
-            File[] coreLogDirectories = coreClusterMember.homeDir().listFiles( file -> file.getName().startsWith( "core" ) );
+            File[] coreLogDirectories = coreClusterMember.storeDir().listFiles( file -> file.getName().startsWith( "core" ) );
             assertThat( coreLogDirectories, Matchers.arrayWithSize( 1 ) );
 
             logFileInStoreDirectoryDoesNotExist( coreClusterMember.storeDir(), dependencyResolver );
@@ -83,7 +83,7 @@ public class ClusterCustomLogLocationIT
             LogFiles logFiles = dependencyResolver.resolveDependency( LogFiles.class );
             assertEquals( logFiles.logFilesDirectory().getName(), "replica-tx-logs-" + readReplica.serverId() );
             assertTrue( logFiles.hasAnyEntries( 0 ) );
-            File[] replicaLogDirectories = readReplica.homeDir().listFiles( file -> file.getName().startsWith( "replica" ) );
+            File[] replicaLogDirectories = readReplica.storeDir().listFiles( file -> file.getName().startsWith( "replica" ) );
             assertThat( replicaLogDirectories, Matchers.arrayWithSize( 1 ) );
 
             logFileInStoreDirectoryDoesNotExist( readReplica.storeDir(), dependencyResolver );

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/MoveAfterCopy.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/MoveAfterCopy.java
@@ -21,20 +21,23 @@ package org.neo4j.com.storecopy;
 
 import java.io.File;
 import java.nio.file.StandardCopyOption;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
+@FunctionalInterface
 public interface MoveAfterCopy
 {
-    void move( Stream<FileMoveAction> moves, File fromDirectory, File toDirectory ) throws Exception;
+    void move( Stream<FileMoveAction> moves, File fromDirectory, Function<File, File> destinationFunction ) throws
+            Exception;
 
     static MoveAfterCopy moveReplaceExisting()
     {
-        return ( moves, fromDirectory, toDirectory ) ->
+        return ( moves, fromDirectory, destinationFunction ) ->
         {
             Iterable<FileMoveAction> itr = moves::iterator;
             for ( FileMoveAction move : itr )
             {
-                move.move( toDirectory, StandardCopyOption.REPLACE_EXISTING );
+                move.move( destinationFunction.apply( move.file() ), StandardCopyOption.REPLACE_EXISTING );
             }
         };
     }

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/StoreCopyClient.java
@@ -339,8 +339,7 @@ public class StoreCopyClient
                 .setConfig( "dbms.backup.enabled", Settings.FALSE )
                 .setConfig( GraphDatabaseSettings.logs_directory, tempStore.getAbsolutePath() )
                 .setConfig( GraphDatabaseSettings.keep_logical_logs, Settings.TRUE )
-                .setConfig( GraphDatabaseSettings.logical_logs_location,
-                        config.get( GraphDatabaseSettings.logical_logs_location ).toString() )
+                .setConfig( GraphDatabaseSettings.logical_logs_location, tempStore.getAbsolutePath() )
                 .setConfig( GraphDatabaseSettings.allow_upgrade,
                         config.get( GraphDatabaseSettings.allow_upgrade ).toString() )
                 .newGraphDatabase();

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
@@ -160,8 +160,8 @@ public class StoreCopyClientTest
     @Test
     public void storeCopyClientUseCustomTransactionLogLocationWhenConfigured() throws Exception
     {
-        final File copyDir = new File( directory.directory(), "copy" );
-        final File originalDir = new File( directory.directory(), "original" );
+        final File copyDir = new File( directory.directory(), "copyCustomLocation" );
+        final File originalDir = new File( directory.directory(), "originalCustomLocation" );
         PageCache pageCache = pageCacheRule.getPageCache( fileSystem );
         File copyCustomLogFilesLocation = new File( copyDir, "CopyCustomLogFilesLocation" );
         File originalCustomLogFilesLocation = new File( originalDir, "originalCustomLogFilesLocation" );
@@ -183,6 +183,7 @@ public class StoreCopyClientTest
                 fileSystem, true );
 
         copier.copyStore( storeCopyRequest, CancellationRequest.NEVER_CANCELLED, MoveAfterCopy.moveReplaceExisting() );
+        original.shutdown();
 
         assertFalse( new File( copyDir, TEMP_COPY_DIRECTORY_NAME ).exists() );
 

--- a/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
+++ b/enterprise/com/src/test/java/org/neo4j/com/storecopy/StoreCopyClientTest.java
@@ -52,6 +52,8 @@ import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
 import org.neo4j.kernel.impl.transaction.log.checkpoint.StoreCopyCheckPointMutex;
 import org.neo4j.kernel.impl.transaction.log.entry.LogHeader;
+import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
+import org.neo4j.kernel.impl.transaction.log.files.LogFilesBuilder;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.NullLogProvider;
@@ -62,28 +64,31 @@ import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.neo4j.com.storecopy.StoreUtil.TEMP_COPY_DIRECTORY_NAME;
 import static org.neo4j.graphdb.Label.label;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.logical_logs_location;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.record_format;
 
 public class StoreCopyClientTest
 {
-    private final TestDirectory testDir = TestDirectory.testDirectory();
+    private final TestDirectory directory = TestDirectory.testDirectory();
     private final PageCacheRule pageCacheRule = new PageCacheRule();
     private final CleanupRule cleanup = new CleanupRule();
     private final DefaultFileSystemRule fileSystemRule = new DefaultFileSystemRule();
 
     @Rule
-    public TestRule rules = RuleChain.outerRule( testDir ).around( fileSystemRule ).
+    public TestRule rules = RuleChain.outerRule( directory ).around( fileSystemRule ).
                                       around( pageCacheRule ).around( cleanup );
 
     private FileSystemAbstraction fileSystem;
@@ -99,8 +104,8 @@ public class StoreCopyClientTest
             throws Exception
     {
         // given
-        final File copyDir = new File( testDir.directory(), "copy" );
-        final File originalDir = new File( testDir.directory(), "original" );
+        final File copyDir = new File( directory.directory(), "copy" );
+        final File originalDir = new File( directory.directory(), "original" );
 
         final AtomicBoolean cancelStoreCopy = new AtomicBoolean( false );
         StoreCopyClient.Monitor storeCopyMonitor = new StoreCopyClient.Monitor.Adapter()
@@ -129,7 +134,7 @@ public class StoreCopyClientTest
         }
 
         StoreCopyClient.StoreCopyRequester storeCopyRequest =
-                spy( new LocalStoreCopyRequester( original, originalDir, fileSystem ) );
+                spy( new LocalStoreCopyRequester( original, originalDir, fileSystem, false ) );
 
         // when
         copier.copyStore( storeCopyRequest, cancelStoreCopy::get, MoveAfterCopy.moveReplaceExisting() );
@@ -153,6 +158,48 @@ public class StoreCopyClientTest
     }
 
     @Test
+    public void storeCopyClientUseCustomTransactionLogLocationWhenConfigured() throws Exception
+    {
+        final File copyDir = new File( directory.directory(), "copy" );
+        final File originalDir = new File( directory.directory(), "original" );
+        PageCache pageCache = pageCacheRule.getPageCache( fileSystem );
+        File copyCustomLogFilesLocation = new File( copyDir, "CopyCustomLogFilesLocation" );
+        File originalCustomLogFilesLocation = new File( originalDir, "originalCustomLogFilesLocation" );
+
+        Config config = Config.defaults( logical_logs_location, copyCustomLogFilesLocation.getName() );
+        StoreCopyClient copier = new StoreCopyClient(
+                copyDir, config, loadKernelExtensions(), NullLogProvider.getInstance(), fileSystem, pageCache,
+                new StoreCopyClient.Monitor.Adapter(), false );
+
+        GraphDatabaseAPI original = (GraphDatabaseAPI) new TestGraphDatabaseFactory()
+                .newEmbeddedDatabaseBuilder( originalDir )
+                .setConfig( logical_logs_location, originalCustomLogFilesLocation.getName() )
+                .newGraphDatabase();
+        generateTransactions( original );
+        long logFileSize =
+                original.getDependencyResolver().resolveDependency( LogFiles.class ).getLogFileForVersion( 0 ).length();
+
+        StoreCopyClient.StoreCopyRequester storeCopyRequest = new LocalStoreCopyRequester( original, originalDir,
+                fileSystem, true );
+
+        copier.copyStore( storeCopyRequest, CancellationRequest.NEVER_CANCELLED, MoveAfterCopy.moveReplaceExisting() );
+
+        assertFalse( new File( copyDir, TEMP_COPY_DIRECTORY_NAME ).exists() );
+
+        LogFiles customLogFiles = LogFilesBuilder.logFilesBasedOnlyBuilder( copyCustomLogFilesLocation, fileSystem ).build();
+        assertTrue( customLogFiles.versionExists( 0 ) );
+        assertThat( customLogFiles.getLogFileForVersion( 0 ).length(), greaterThanOrEqualTo( logFileSize ) );
+
+        LogFiles logFiles = LogFilesBuilder.logFilesBasedOnlyBuilder( copyDir, fileSystem ).build();
+        assertFalse( logFiles.versionExists( 0 ) );
+
+        new TestGraphDatabaseFactory()
+                .newEmbeddedDatabaseBuilder( copyDir )
+                .setConfig( logical_logs_location, copyCustomLogFilesLocation.getName() )
+                .newGraphDatabase().shutdown();
+    }
+
+    @Test
     public void storeCopyClientMustWorkWithStandardRecordFormat() throws Exception
     {
         checkStoreCopyClientWithRecordFormats( Standard.LATEST_NAME );
@@ -164,35 +211,13 @@ public class StoreCopyClientTest
         checkStoreCopyClientWithRecordFormats( HighLimit.NAME );
     }
 
-    private void checkStoreCopyClientWithRecordFormats( String recordFormatsName ) throws Exception
-    {
-        final File copyDir = new File( testDir.directory(), "copy" );
-        final File originalDir = new File( testDir.directory(), "original" );
-        PageCache pageCache = pageCacheRule.getPageCache( fileSystem );
-        Config config = Config.defaults( record_format, recordFormatsName );
-        StoreCopyClient copier = new StoreCopyClient(
-                copyDir, config, loadKernelExtensions(), NullLogProvider.getInstance(), fileSystem, pageCache,
-                new StoreCopyClient.Monitor.Adapter(), false );
-
-        final GraphDatabaseAPI original = (GraphDatabaseAPI) startDatabase( originalDir, recordFormatsName );
-        StoreCopyClient.StoreCopyRequester storeCopyRequest = new LocalStoreCopyRequester( original, originalDir,
-                fileSystem );
-
-        copier.copyStore( storeCopyRequest, CancellationRequest.NEVER_CANCELLED, MoveAfterCopy.moveReplaceExisting() );
-
-        assertFalse( new File( copyDir, TEMP_COPY_DIRECTORY_NAME ).exists() );
-
-        // Must not throw
-        startDatabase( copyDir, recordFormatsName ).shutdown();
-    }
-
     @Test
     public void shouldEndUpWithAnEmptyStoreIfCancellationRequestIssuedJustBeforeRecoveryTakesPlace()
             throws Exception
     {
         // given
-        final File copyDir = new File( testDir.directory(), "copy" );
-        final File originalDir = new File( testDir.directory(), "original" );
+        final File copyDir = new File( directory.directory(), "copy" );
+        final File originalDir = new File( directory.directory(), "original" );
 
         final AtomicBoolean cancelStoreCopy = new AtomicBoolean( false );
         StoreCopyClient.Monitor storeCopyMonitor = new StoreCopyClient.Monitor.Adapter()
@@ -219,7 +244,7 @@ public class StoreCopyClientTest
         }
 
         StoreCopyClient.StoreCopyRequester storeCopyRequest =
-                spy( new LocalStoreCopyRequester( original, originalDir, fileSystem ) );
+                spy( new LocalStoreCopyRequester( original, originalDir, fileSystem, false ) );
 
         // when
         copier.copyStore( storeCopyRequest, cancelStoreCopy::get, MoveAfterCopy.moveReplaceExisting() );
@@ -243,8 +268,8 @@ public class StoreCopyClientTest
     public void shouldResetNeoStoreLastTransactionOffsetForNonForensicCopy() throws Exception
     {
         // GIVEN
-        File initialStore = testDir.directory( "initialStore" );
-        File backupStore = testDir.directory( "backupStore" );
+        File initialStore = directory.directory( "initialStore" );
+        File backupStore = directory.directory( "backupStore" );
 
         PageCache pageCache = pageCacheRule.getPageCache( fileSystem );
         createInitialDatabase( initialStore );
@@ -259,7 +284,7 @@ public class StoreCopyClientTest
                         .getInstance(), fileSystem, pageCache, new StoreCopyClient.Monitor.Adapter(), false );
         CancellationRequest falseCancellationRequest = () -> false;
         StoreCopyClient.StoreCopyRequester storeCopyRequest =
-                new LocalStoreCopyRequester( (GraphDatabaseAPI) initialDatabase, initialStore, fileSystem );
+                new LocalStoreCopyRequester( (GraphDatabaseAPI) initialDatabase, initialStore, fileSystem, false );
 
         // WHEN
         copier.copyStore( storeCopyRequest, falseCancellationRequest, MoveAfterCopy.moveReplaceExisting() );
@@ -277,8 +302,8 @@ public class StoreCopyClientTest
     public void shouldDeleteTempCopyFolderOnFailures() throws Exception
     {
         // GIVEN
-        File initialStore = testDir.directory( "initialStore" );
-        File backupStore = testDir.directory( "backupStore" );
+        File initialStore = directory.directory( "initialStore" );
+        File backupStore = directory.directory( "backupStore" );
 
         PageCache pageCache = pageCacheRule.getPageCache( fileSystem );
         GraphDatabaseService initialDatabase = createInitialDatabase( initialStore );
@@ -289,7 +314,7 @@ public class StoreCopyClientTest
 
         RuntimeException exception = new RuntimeException( "Boom!" );
         StoreCopyClient.StoreCopyRequester storeCopyRequest =
-                new LocalStoreCopyRequester( (GraphDatabaseAPI) initialDatabase, initialStore, fileSystem )
+                new LocalStoreCopyRequester( (GraphDatabaseAPI) initialDatabase, initialStore, fileSystem, false )
                 {
                     @Override
                     public void done()
@@ -311,6 +336,28 @@ public class StoreCopyClientTest
 
         // THEN
         assertFalse( new File( backupStore, TEMP_COPY_DIRECTORY_NAME ).exists() );
+    }
+
+    private void checkStoreCopyClientWithRecordFormats( String recordFormatsName ) throws Exception
+    {
+        final File copyDir = new File( directory.directory(), "copy" );
+        final File originalDir = new File( directory.directory(), "original" );
+        PageCache pageCache = pageCacheRule.getPageCache( fileSystem );
+        Config config = Config.defaults( record_format, recordFormatsName );
+        StoreCopyClient copier = new StoreCopyClient(
+                copyDir, config, loadKernelExtensions(), NullLogProvider.getInstance(), fileSystem, pageCache,
+                new StoreCopyClient.Monitor.Adapter(), false );
+
+        final GraphDatabaseAPI original = (GraphDatabaseAPI) startDatabase( originalDir, recordFormatsName );
+        StoreCopyClient.StoreCopyRequester storeCopyRequest = new LocalStoreCopyRequester( original, originalDir,
+                fileSystem, false );
+
+        copier.copyStore( storeCopyRequest, CancellationRequest.NEVER_CANCELLED, MoveAfterCopy.moveReplaceExisting() );
+
+        assertFalse( new File( copyDir, TEMP_COPY_DIRECTORY_NAME ).exists() );
+
+        // Must not throw
+        startDatabase( copyDir, recordFormatsName ).shutdown();
     }
 
     private GraphDatabaseService createInitialDatabase( File initialStore )
@@ -352,6 +399,18 @@ public class StoreCopyClientTest
         return kernelExtensions;
     }
 
+    private void generateTransactions( GraphDatabaseAPI original )
+    {
+        for ( int i = 0; i < 10; i++ )
+        {
+            try ( Transaction transaction = original.beginTx() )
+            {
+                original.createNode();
+                transaction.success();
+            }
+        }
+    }
+
     private static class LocalStoreCopyRequester implements StoreCopyClient.StoreCopyRequester
     {
         private final GraphDatabaseAPI original;
@@ -359,12 +418,15 @@ public class StoreCopyClientTest
         private final FileSystemAbstraction fs;
 
         private Response<?> response;
+        private boolean includeLogs;
 
-        LocalStoreCopyRequester( GraphDatabaseAPI original, File originalDir, FileSystemAbstraction fs )
+        LocalStoreCopyRequester( GraphDatabaseAPI original, File originalDir, FileSystemAbstraction fs,
+                boolean includeLogs )
         {
             this.original = original;
             this.originalDir = originalDir;
             this.fs = fs;
+            this.includeLogs = includeLogs;
         }
 
         @Override
@@ -388,7 +450,7 @@ public class StoreCopyClientTest
             RequestContext requestContext = new StoreCopyServer( neoStoreDataSource, checkPointer, fs,
                     originalDir, new Monitors().newMonitor( StoreCopyServer.Monitor.class ), pageCache,
                     new StoreCopyCheckPointMutex() )
-                    .flushStoresAndStreamStoreFiles( "test", writer, false );
+                    .flushStoresAndStreamStoreFiles( "test", writer, includeLogs );
 
             final StoreId storeId =
                     original.getDependencyResolver().resolveDependency( RecordStorageEngine.class )

--- a/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomIT.java
+++ b/enterprise/fulltext-addon/src/test/java/org/neo4j/kernel/api/impl/fulltext/integrations/bloom/BloomIT.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.api.impl.fulltext.integrations.bloom;
 
-import org.apache.commons.lang3.SystemUtils;
 import org.apache.lucene.analysis.en.EnglishAnalyzer;
 import org.apache.lucene.analysis.sv.SwedishAnalyzer;
 import org.junit.After;
@@ -28,7 +27,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import java.io.File;
 import java.util.Date;
 
 import org.neo4j.consistency.ConsistencyCheckService;
@@ -57,8 +55,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
 import static org.neo4j.kernel.api.impl.fulltext.integrations.bloom.BloomFulltextConfig.bloom_enabled;
 
 public class BloomIT
@@ -89,8 +85,8 @@ public class BloomIT
     public void before() throws Exception
     {
         GraphDatabaseFactory factory = new GraphDatabaseFactory();
-        builder = factory.newEmbeddedDatabaseBuilder( testDirectory.graphDbDir() );
-        builder.setConfig( bloom_enabled, "true" );
+        builder = factory.newEmbeddedDatabaseBuilder( testDirectory.graphDbDir() )
+                         .setConfig( bloom_enabled, "true" );
     }
 
     @After
@@ -604,58 +600,4 @@ public class BloomIT
         assertEquals( "ONLINE", result.next().get( "state" ) );
         assertFalse( result.hasNext() );
     }
-
-    @Test
-    public void failureToStartUpMustNotPreventShutDown() throws Exception
-    {
-        // Ignore this test on Windows because the test relies on file permissions to trigger failure modes in
-        // the code. Unfortunately, file permissions are an incredible pain to work with on Windows.
-        assumeFalse( SystemUtils.IS_OS_WINDOWS );
-
-        // Create the store directory and all its files, and add a bit of data to it
-        GraphDatabaseService db = getDb();
-        db.execute( String.format( SET_NODE_KEYS, "\"prop\"" ) );
-
-        try ( Transaction tx = db.beginTx() )
-        {
-            db.createNode().setProperty( "prop", "bla bla bla" );
-            tx.success();
-        }
-        db.shutdown();
-
-        File dir = testDirectory.graphDbDir();
-        assertTrue( dir.setReadable( false ) );
-        try
-        {
-            // Making the directory not readable ought to cause problems for the database as it tries to start up
-            getDb().shutdown();
-            fail( "Should not have started up and shut down cleanly on an unreadable store directory" );
-        }
-        catch ( Exception e )
-        {
-            // Good
-        }
-        catch ( Throwable th )
-        {
-            makeReadable( dir, th );
-            throw th;
-        }
-        makeReadable( dir, null );
     }
-
-    private void makeReadable( File dir, Throwable th )
-    {
-        if ( !dir.setReadable( true ) )
-        {
-            AssertionError error = new AssertionError( "Failed to make " + dir + " writable again!" );
-            if ( th != null )
-            {
-                th.addSuppressed( error );
-            }
-            else
-            {
-                throw error;
-            }
-        }
-    }
-}

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveCopyThenBranchTest.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SwitchToSlaveCopyThenBranchTest.java
@@ -29,6 +29,7 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
@@ -231,7 +232,7 @@ public class SwitchToSlaveCopyThenBranchTest
         doAnswer( invocation ->
         {
             MoveAfterCopy moveAfterCopy = invocation.getArgument( 2 );
-            moveAfterCopy.move( Stream.empty(), new File( "" ), new File( "" ) );
+            moveAfterCopy.move( Stream.empty(), new File( "" ), Function.identity() );
             return null;
         } ).when( storeCopyClient ).copyStore(
                 any( StoreCopyClient.StoreCopyRequester.class ),

--- a/enterprise/kernel/src/test/java/org/neo4j/util/TestHelpers.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/util/TestHelpers.java
@@ -25,22 +25,16 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.neo4j.commandline.admin.AdminTool;
-import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.helpers.HostnamePort;
 import org.neo4j.helpers.ListenSocketAddress;
 import org.neo4j.io.proc.ProcessUtil;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.enterprise.configuration.OnlineBackupSettings;
-import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.ProcessStreamHandler;
-import org.neo4j.test.rule.DatabaseRule;
-import org.neo4j.test.rule.EmbeddedDatabaseRule;
 
 import static java.lang.String.format;
 import static org.neo4j.kernel.configuration.Settings.listenAddress;
-import static org.neo4j.kernel.configuration.Settings.setting;
 
 public class TestHelpers
 {

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseNeoServer.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/EnterpriseNeoServer.java
@@ -30,15 +30,15 @@ import java.util.regex.Pattern;
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.core.CoreGraphDatabase;
 import org.neo4j.causalclustering.readreplica.ReadReplicaGraphDatabase;
-import org.neo4j.dbms.DatabaseManagementSystemSettings;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.enterprise.EnterpriseGraphDatabase;
 import org.neo4j.kernel.ha.HaSettings;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
-import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.kernel.impl.enterprise.configuration.EnterpriseEditionSettings;
 import org.neo4j.kernel.impl.enterprise.configuration.EnterpriseEditionSettings.Mode;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory.Dependencies;
 import org.neo4j.kernel.impl.util.UnsatisfiedDependencyException;
 import org.neo4j.logging.LogProvider;
@@ -65,25 +65,25 @@ public class EnterpriseNeoServer extends CommunityNeoServer
 
     private static final GraphFactory HA_FACTORY = ( config, dependencies ) ->
     {
-        File storeDir = config.get( DatabaseManagementSystemSettings.database_path );
+        File storeDir = config.get( GraphDatabaseSettings.database_path );
         return new HighlyAvailableGraphDatabase( storeDir, config, dependencies );
     };
 
     private static final GraphFactory ENTERPRISE_FACTORY = ( config, dependencies ) ->
     {
-        File storeDir = config.get( DatabaseManagementSystemSettings.database_path );
+        File storeDir = config.get( GraphDatabaseSettings.database_path );
         return new EnterpriseGraphDatabase( storeDir, config, dependencies );
     };
 
     private static final GraphFactory CORE_FACTORY = ( config, dependencies ) ->
     {
-        File storeDir = config.get( DatabaseManagementSystemSettings.database_path );
+        File storeDir = config.get( GraphDatabaseSettings.database_path );
         return new CoreGraphDatabase( storeDir, config, dependencies );
     };
 
     private static final GraphFactory READ_REPLICA_FACTORY = ( config, dependencies ) ->
     {
-        File storeDir = config.get( DatabaseManagementSystemSettings.database_path );
+        File storeDir = config.get( GraphDatabaseSettings.database_path );
         return new ReadReplicaGraphDatabase( storeDir, config, dependencies );
     };
 

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/EnterpriseBootstrapperTestIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/EnterpriseBootstrapperTestIT.java
@@ -45,7 +45,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.neo4j.dbms.DatabaseManagementSystemSettings.data_directory;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.data_directory;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.logs_directory;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.store_internal_log_level;
 import static org.neo4j.helpers.collection.MapUtil.store;

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/jmx/ServerManagementIT.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/enterprise/jmx/ServerManagementIT.java
@@ -23,7 +23,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
-import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.GraphDatabaseDependencies;
 import org.neo4j.kernel.configuration.Config;
@@ -70,17 +69,17 @@ public class ServerManagementIT
         server.start();
 
         assertNotNull( server.getDatabase().getGraph() );
-        assertEquals( config.get( DatabaseManagementSystemSettings.database_path ).getAbsolutePath(),
+        assertEquals( config.get( GraphDatabaseSettings.database_path ).getAbsolutePath(),
                 server.getDatabase().getLocation().getAbsolutePath() );
 
         // Change the database location
-        config.augment( DatabaseManagementSystemSettings.data_directory, dataDirectory2 );
+        config.augment( GraphDatabaseSettings.data_directory, dataDirectory2 );
         ServerManagement bean = new ServerManagement( server );
         bean.restartServer();
 
         // Then
         assertNotNull( server.getDatabase().getGraph() );
-        assertEquals( config.get( DatabaseManagementSystemSettings.database_path ).getAbsolutePath(),
+        assertEquals( config.get( GraphDatabaseSettings.database_path ).getAbsolutePath(),
                 server.getDatabase().getLocation().getAbsolutePath() );
     }
 

--- a/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIT.java
+++ b/integrationtests/src/test/java/org/neo4j/storeupgrade/StoreUpgradeIT.java
@@ -39,7 +39,6 @@ import java.util.Optional;
 import java.util.Properties;
 
 import org.neo4j.backup.OnlineBackupSettings;
-import org.neo4j.dbms.DatabaseManagementSystemSettings;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
@@ -49,12 +48,12 @@ import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.api.KernelAPI;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
-import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.api.security.AnonymousContext;
 import org.neo4j.kernel.configuration.BoltConnector;
@@ -171,15 +170,15 @@ public class StoreUpgradeIT
         public void serverDatabaseShouldStartOnOlderStoreWhenUpgradeIsEnabled() throws Throwable
         {
             File rootDir = testDir.directory();
-            File storeDir = Config.defaults( DatabaseManagementSystemSettings.data_directory, rootDir.toString() )
-                    .get( DatabaseManagementSystemSettings.database_path );
+            File storeDir = Config.defaults( GraphDatabaseSettings.data_directory, rootDir.toString() )
+                    .get( GraphDatabaseSettings.database_path );
 
             store.prepareDirectory( storeDir );
 
             File configFile = new File( rootDir, Config.DEFAULT_CONFIG_FILE_NAME );
             Properties props = new Properties();
             props.putAll( ServerTestUtils.getDefaultRelativeProperties() );
-            props.setProperty( DatabaseManagementSystemSettings.data_directory.name(), rootDir.getAbsolutePath() );
+            props.setProperty( GraphDatabaseSettings.data_directory.name(), rootDir.getAbsolutePath() );
             props.setProperty( GraphDatabaseSettings.logs_directory.name(), rootDir.getAbsolutePath() );
             props.setProperty( GraphDatabaseSettings.allow_upgrade.name(), "true" );
             props.setProperty( GraphDatabaseSettings.pagecache_memory.name(), "8m" );

--- a/tools/src/main/java/org/neo4j/tools/applytx/ApplyTransactionsCommand.java
+++ b/tools/src/main/java/org/neo4j/tools/applytx/ApplyTransactionsCommand.java
@@ -95,7 +95,7 @@ public class ApplyTransactionsCommand extends ArgsCommand
         out.println( "Applied transactions up to and including " + lastApplied );
     }
 
-    private long applyTransactions( File fromPath, GraphDatabaseAPI toDb, Config config,
+    private long applyTransactions( File fromPath, GraphDatabaseAPI toDb, Config toConfig,
             long fromTxExclusive, long toTxInclusive, PrintStream out )
             throws IOException, TransactionFailureException
     {
@@ -109,7 +109,7 @@ public class ApplyTransactionsCommand extends ArgsCommand
               PageCache pageCache = StandalonePageCacheFactory.createPageCache( fileSystem ) )
         {
             LogicalTransactionStore source = life.add( new ReadOnlyTransactionStore( pageCache, fileSystem, fromPath,
-                    config, new Monitors() ) );
+                    Config.defaults(), new Monitors() ) );
             life.start();
             long lastAppliedTx = fromTxExclusive;
             // Some progress if there are more than a couple of transactions to apply

--- a/tools/src/main/java/org/neo4j/tools/applytx/ApplyTransactionsCommand.java
+++ b/tools/src/main/java/org/neo4j/tools/applytx/ApplyTransactionsCommand.java
@@ -33,6 +33,7 @@ import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.impl.muninn.StandalonePageCacheFactory;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.TransactionRepresentationCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionToApply;
 import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
@@ -66,8 +67,9 @@ public class ApplyTransactionsCommand extends ArgsCommand
     @Override
     protected void run( Args args, PrintStream out ) throws Exception
     {
-        TransactionIdStore txIdStore = to.get().getDependencyResolver().resolveDependency(
-                TransactionIdStore.class );
+        DependencyResolver dependencyResolver = to.get().getDependencyResolver();
+        TransactionIdStore txIdStore = dependencyResolver.resolveDependency( TransactionIdStore.class );
+        Config config = dependencyResolver.resolveDependency( Config.class );
         long fromTx = txIdStore.getLastCommittedTransaction().transactionId();
         long toTx;
         if ( args.orphans().isEmpty() )
@@ -89,12 +91,12 @@ public class ApplyTransactionsCommand extends ArgsCommand
             toTx = Long.parseLong( whereTo );
         }
 
-        long lastApplied = applyTransactions( from, to.get(), fromTx, toTx, out );
+        long lastApplied = applyTransactions( from, to.get(), config, fromTx, toTx, out );
         out.println( "Applied transactions up to and including " + lastApplied );
     }
 
-    private long applyTransactions( File fromPath, GraphDatabaseAPI toDb, long fromTxExclusive, long toTxInclusive,
-            PrintStream out )
+    private long applyTransactions( File fromPath, GraphDatabaseAPI toDb, Config config,
+            long fromTxExclusive, long toTxInclusive, PrintStream out )
             throws IOException, TransactionFailureException
     {
         DependencyResolver resolver = toDb.getDependencyResolver();
@@ -107,7 +109,7 @@ public class ApplyTransactionsCommand extends ArgsCommand
               PageCache pageCache = StandalonePageCacheFactory.createPageCache( fileSystem ) )
         {
             LogicalTransactionStore source = life.add( new ReadOnlyTransactionStore( pageCache, fileSystem, fromPath,
-                    new Monitors() ) );
+                    config, new Monitors() ) );
             life.start();
             long lastAppliedTx = fromTxExclusive;
             // Some progress if there are more than a couple of transactions to apply

--- a/tools/src/main/java/org/neo4j/tools/migration/StoreMigration.java
+++ b/tools/src/main/java/org/neo4j/tools/migration/StoreMigration.java
@@ -131,7 +131,8 @@ public class StoreMigration
                     kernelContext, GraphDatabaseDependencies.newDependencies().kernelExtensions(),
                     deps, ignore() ) );
 
-            final LogFiles logFiles = LogFilesBuilder.activeFilesBuilder( storeDirectory, fs, pageCache ).build();
+            final LogFiles logFiles = LogFilesBuilder.activeFilesBuilder( storeDirectory, fs, pageCache )
+                    .withConfig( config ).build();
             LogTailScanner tailScanner = new LogTailScanner( logFiles, new VersionAwareLogEntryReader<>(), monitors );
 
             // Add the kernel store migrator


### PR DESCRIPTION
Previously transaction logs were always located in the same directory as a store.
This PR will allow changing that by specifying "logical_logs_location"
with a path to a folder where transaction logs should be stored.
This will allow placing transaction logs on a separate dedicated drive.

CC integration tests will always put transaction logs in separate directories.
HA should be able to copy store from another instance with custom
transactional logs directory and place them into the correct directory
for that specific instance.
Backup will put transaction logs together with store files and restore command will properly put them into configured transaction logs folder