### PR TITLE
PruningVarExpand should handle incoming null nodes

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/PruningVarLengthExpandPipe.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/PruningVarLengthExpandPipe.scala
@@ -264,12 +264,12 @@ case class PruningVarLengthExpandPipe(source: Pipe,
         row.get(fromName) match {
           case Some(node: NodeValue) =>
             val nextState = new PrePruningDFS(whenEmptied = this,
-              node = node,
-              path = new Array[Long](max),
-              pathLength = 0,
-              state = state,
-              row = row,
-              expandMap = Primitive.longObjectMap[FullExpandDepths]())
+                                              node = node,
+                                              path = new Array[Long](max),
+                                              pathLength = 0,
+                                              state = state,
+                                              row = row,
+                                              expandMap = Primitive.longObjectMap[FullExpandDepths]())
             nextState.next()
           case Some(x: Value) if x == Values.NO_VALUE =>
             (Empty, null)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/PruningVarLengthExpandPipe.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/PruningVarLengthExpandPipe.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.compatibility.v3_3.runtime.ExecutionContext
 import org.neo4j.cypher.internal.frontend.v3_3.{InternalException, SemanticDirection}
 import org.neo4j.cypher.internal.v3_3.logical.plans.LogicalPlanId
 import org.neo4j.kernel.impl.util.ValueUtils
-import org.neo4j.values.storable.Value
+import org.neo4j.values.storable.{Value, Values}
 import org.neo4j.values.virtual.{EdgeValue, NodeValue}
 
 case class PruningVarLengthExpandPipe(source: Pipe,
@@ -271,7 +271,7 @@ case class PruningVarLengthExpandPipe(source: Pipe,
               row = row,
               expandMap = Primitive.longObjectMap[FullExpandDepths]())
             nextState.next()
-          case Some(x: Value) if x.asObject() == null =>
+          case Some(x: Value) if x == Values.NO_VALUE =>
             (Empty, null)
           case _ =>
             throw new InternalException(s"Expected a node on `$fromName`")

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/PruningVarLengthExpandPipe.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/pipes/PruningVarLengthExpandPipe.scala
@@ -24,6 +24,7 @@ import org.neo4j.cypher.internal.compatibility.v3_3.runtime.ExecutionContext
 import org.neo4j.cypher.internal.frontend.v3_3.{InternalException, SemanticDirection}
 import org.neo4j.cypher.internal.v3_3.logical.plans.LogicalPlanId
 import org.neo4j.kernel.impl.util.ValueUtils
+import org.neo4j.values.storable.Value
 import org.neo4j.values.virtual.{EdgeValue, NodeValue}
 
 case class PruningVarLengthExpandPipe(source: Pipe,
@@ -260,18 +261,22 @@ case class PruningVarLengthExpandPipe(source: Pipe,
         (Empty, null)
       } else {
         val row = input.next()
-        val nextState = new PrePruningDFS(whenEmptied = this,
-                                          node = getNodeFromRow(row),
-                                          path = new Array[Long](max),
-                                          pathLength = 0,
-                                          state = state,
-                                          row = row,
-                                          expandMap = Primitive.longObjectMap[FullExpandDepths]())
-        nextState.next()
+        row.get(fromName) match {
+          case Some(node: NodeValue) =>
+            val nextState = new PrePruningDFS(whenEmptied = this,
+              node = node,
+              path = new Array[Long](max),
+              pathLength = 0,
+              state = state,
+              row = row,
+              expandMap = Primitive.longObjectMap[FullExpandDepths]())
+            nextState.next()
+          case Some(x: Value) if x.asObject() == null =>
+            (Empty, null)
+          case _ =>
+            throw new InternalException(s"Expected a node on `$fromName`")
+        }
       }
-
-    private def getNodeFromRow(row: ExecutionContext): NodeValue =
-      row.getOrElse(fromName, throw new InternalException(s"Expected a node on `$fromName`")).asInstanceOf[NodeValue]
   }
 
   trait CheckPath {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -845,68 +845,17 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
 
   test("Should handle optional match with null parts and distinct without NullPointerException") {
 
-    graph.execute("CREATE (:X {eid: 1})")
-
     val query =
       """
-        |  MATCH (x:X)
-        |  WITH x
-        |  OPTIONAL MATCH (x)<-[:L]-(req)
-        |  WITH x, req
-        |  OPTIONAL MATCH (req)<-[:Links *2]-(y:X)
-        |  RETURN DISTINCT
-        |    x.eid,
-        |    req.eid,
-        |    y.eid
+        |  OPTIONAL MATCH (req:Y)
+        |  WITH req
+        |  OPTIONAL MATCH (req)<-[*2]-(y)
+        |  RETURN DISTINCT req.eid, y.eid
       """.stripMargin
 
-    // TODO: Cost3.2 should work once we upgrade to fixed version of 3.2.x
+    // Fixed in 3.2.8
     val result = executeWith(Configs.CommunityInterpreted - Configs.Cost3_2, query)
 
-    result.toList should equal(List(Map("x.eid" -> 1, "req.eid" -> null, "y.eid" -> null)))
-  }
-
-  test("Should handle complex optional match with null parts and distinct without NullPointerException") {
-
-    graph.execute(
-      """
-        |CREATE (cust :DoorsObject {eid: 1})
-        |  CREATE (cust) <-[:Links]- (req :DoorsObject {eid: 1})
-        |  CREATE (reqM :DoorsFormalModule {eid: 1}) -[:Contains]-> (req)
-      """.stripMargin)
-
-    graph.execute(
-      """
-        |CREATE (cust :DoorsObject {eid: 2})
-        |  CREATE (cust) <-[:Links]- (req :DoorsObject {eid: 2})
-        |  CREATE (reqM :DoorsFormalModule {eid: 2}) -[:Contains]-> (req)
-        |  CREATE (req) <-[:Links]- (:Link) <-[:Links]- (tst :DoorsObject {eid: 2})
-        |  CREATE (tstM :DoorsFormalModule {eid: 2}) -[:Contains]-> (tst)
-      """.stripMargin)
-
-    val query =
-      """
-        |  MATCH (cust :DoorsObject)
-        |  WITH cust
-        |  OPTIONAL MATCH (cust)<-[:Links *1..]-(req :DoorsObject)<-[:Contains]-(reqM :DoorsFormalModule)
-        |  WITH DISTINCT cust, reqM, req
-        |  OPTIONAL MATCH (req)<-[:Links *2]-(tst :DoorsObject)<-[:Contains]-(tstM :DoorsFormalModule)
-        |  WITH cust, reqM, req, tstM, tst
-        |  RETURN DISTINCT
-        |    cust.eid,
-        |    reqM.eid,
-        |    tstM.eid
-      """.stripMargin
-
-    // TODO: Cost3.2 should work once we upgrade to fixed version of 3.2.x
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost3_2, query)
-
-    result.toList should equal(List(
-      Map("cust.eid" -> 1, "reqM.eid" -> 1, "tstM.eid" -> null),
-      Map("cust.eid" -> 1, "reqM.eid" -> null, "tstM.eid" -> null),
-      Map("cust.eid" -> 2, "reqM.eid" -> 2, "tstM.eid" -> 2),
-      Map("cust.eid" -> 2, "reqM.eid" -> 2, "tstM.eid" -> null),
-      Map("cust.eid" -> 2, "reqM.eid" -> null, "tstM.eid" -> null)
-    ))
+    result.toList should equal(List(Map("req.eid" -> null, "y.eid" -> null)))
   }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -842,4 +842,71 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     // Then
     result.toList should equal(List(Map("a" -> n)))
   }
+
+  test("Should handle optional match with null parts and distinct without NullPointerException") {
+
+    graph.execute("CREATE (:X {eid: 1})")
+
+    val query =
+      """
+        |  MATCH (x:X)
+        |  WITH x
+        |  OPTIONAL MATCH (x)<-[:L]-(req)
+        |  WITH x, req
+        |  OPTIONAL MATCH (req)<-[:Links *2]-(y:X)
+        |  RETURN DISTINCT
+        |    x.eid,
+        |    req.eid,
+        |    y.eid
+      """.stripMargin
+
+    // TODO: Cost3.2 should work once we upgrade to fixed version of 3.2.x
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost3_2, query)
+
+    result.toList should equal(List(Map("x.eid" -> 1, "req.eid" -> null, "y.eid" -> null)))
+  }
+
+  test("Should handle complex optional match with null parts and distinct without NullPointerException") {
+
+    graph.execute(
+      """
+        |CREATE (cust :DoorsObject {eid: 1})
+        |  CREATE (cust) <-[:Links]- (req :DoorsObject {eid: 1})
+        |  CREATE (reqM :DoorsFormalModule {eid: 1}) -[:Contains]-> (req)
+      """.stripMargin)
+
+    graph.execute(
+      """
+        |CREATE (cust :DoorsObject {eid: 2})
+        |  CREATE (cust) <-[:Links]- (req :DoorsObject {eid: 2})
+        |  CREATE (reqM :DoorsFormalModule {eid: 2}) -[:Contains]-> (req)
+        |  CREATE (req) <-[:Links]- (:Link) <-[:Links]- (tst :DoorsObject {eid: 2})
+        |  CREATE (tstM :DoorsFormalModule {eid: 2}) -[:Contains]-> (tst)
+      """.stripMargin)
+
+    val query =
+      """
+        |  MATCH (cust :DoorsObject)
+        |  WITH cust
+        |  OPTIONAL MATCH (cust)<-[:Links *1..]-(req :DoorsObject)<-[:Contains]-(reqM :DoorsFormalModule)
+        |  WITH DISTINCT cust, reqM, req
+        |  OPTIONAL MATCH (req)<-[:Links *2]-(tst :DoorsObject)<-[:Contains]-(tstM :DoorsFormalModule)
+        |  WITH cust, reqM, req, tstM, tst
+        |  RETURN DISTINCT
+        |    cust.eid,
+        |    reqM.eid,
+        |    tstM.eid
+      """.stripMargin
+
+    // TODO: Cost3.2 should work once we upgrade to fixed version of 3.2.x
+    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost3_2, query)
+
+    result.toList should equal(List(
+      Map("cust.eid" -> 1, "reqM.eid" -> 1, "tstM.eid" -> null),
+      Map("cust.eid" -> 1, "reqM.eid" -> null, "tstM.eid" -> null),
+      Map("cust.eid" -> 2, "reqM.eid" -> 2, "tstM.eid" -> 2),
+      Map("cust.eid" -> 2, "reqM.eid" -> 2, "tstM.eid" -> null),
+      Map("cust.eid" -> 2, "reqM.eid" -> null, "tstM.eid" -> null)
+    ))
+  }
 }


### PR DESCRIPTION
Changelog: Fixes #9492, so that PruningVarExpand after optional match will handle incoming null nodes