### PR TITLE
3.2 raft pre voting

### DIFF
--- a/community/common/src/main/java/org/neo4j/function/UncaughtCheckedException.java
+++ b/community/common/src/main/java/org/neo4j/function/UncaughtCheckedException.java
@@ -22,7 +22,7 @@ package org.neo4j.function;
 import java.util.Optional;
 
 /**
- * Wrapper around checked exceptions for rethrowing them as runtime exceotions when the signature of the containing method
+ * Wrapper around checked exceptions for rethrowing them as runtime exceptions when the signature of the containing method
  * cannot be changed to declare them.
  *
  * Thrown by {@link ThrowingFunction#catchThrown(Class, ThrowingFunction)}
@@ -42,7 +42,7 @@ public class UncaughtCheckedException extends RuntimeException
     }
 
     /**
-     * Check the that the cause has the given type and if succesful, return it.
+     * Check that the cause has the given type and if successful, return it.
      *
      * @param clazz class object for the desired type of the cause
      * @param <E> the desired type of the cause

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
@@ -73,6 +73,10 @@ public class CausalClusteringSettings implements LoadableConfig
     public static final Setting<Boolean> refuse_to_be_leader =
             setting( "causal_clustering.refuse_to_be_leader", BOOLEAN, FALSE );
 
+    @Description( "Enable pre-voting extension to the Raft protocol (this is breaking and must match between the core cluster members)" )
+    public static final Setting<Boolean> enable_pre_voting =
+            setting( "causal_clustering.enable_pre_voting", BOOLEAN, FALSE );
+
     @Description( "The maximum batch size when catching up (in unit of entries)" )
     public static final Setting<Integer> catchup_batch_size =
             setting( "causal_clustering.catchup_batch_size", INTEGER, "64" );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/ConsensusModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/ConsensusModule.java
@@ -136,9 +136,12 @@ public class ConsensusModule
 
         raftTimeoutService = new DelayedRenewableTimeoutService( systemClock(), logProvider );
 
+        boolean supportsPreVoting = config.get( CausalClusteringSettings.enable_pre_voting );
+
         raftMachine = new RaftMachine( myself, termState, voteState, raftLog, electionTimeout, heartbeatInterval,
                 raftTimeoutService, outbound, logProvider, raftMembershipManager, logShipping, inFlightCache,
-                RefuseToBeLeaderStrategy.shouldRefuseToBeLeader( config, logProvider.getLog( getClass() ) ), platformModule.monitors, systemClock() );
+                RefuseToBeLeaderStrategy.shouldRefuseToBeLeader( config, logProvider.getLog( getClass() ) ),
+               supportsPreVoting, platformModule.monitors, systemClock() );
 
         life.add( new RaftCoreTopologyConnector( coreTopologyService, raftMachine ) );
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/MajorityIncludingSelfQuorum.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/MajorityIncludingSelfQuorum.java
@@ -19,9 +19,16 @@
  */
 package org.neo4j.causalclustering.core.consensus;
 
+import java.util.Collection;
+
 public class MajorityIncludingSelfQuorum
 {
     private static final int MIN_QUORUM = 2;
+
+    public static boolean isQuorum( Collection<?> cluster, Collection<?> countNotIncludingMyself )
+    {
+        return isQuorum( cluster.size(), countNotIncludingMyself.size() );
+    }
 
     public static boolean isQuorum( int clusterSize, int countNotIncludingSelf )
     {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMachine.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMachine.java
@@ -97,7 +97,8 @@ public class RaftMachine implements LeaderLocator, CoreMetaData
             RaftLog entryLog, long electionTimeout, long heartbeatInterval,
             RenewableTimeoutService renewableTimeoutService, Outbound<MemberId,RaftMessages.RaftMessage> outbound,
             LogProvider logProvider, RaftMembershipManager membershipManager, RaftLogShippingManager logShipping,
-            InFlightCache inFlightCache, boolean refuseToBecomeLeader, Monitors monitors, Clock clock )
+            InFlightCache inFlightCache, boolean refuseToBecomeLeader, boolean supportPreVoting, Monitors monitors,
+            Clock clock )
     {
         this.myself = myself;
         this.electionTimeout = electionTimeout;
@@ -115,7 +116,7 @@ public class RaftMachine implements LeaderLocator, CoreMetaData
 
         this.inFlightCache = inFlightCache;
         this.state = new RaftState( myself, termStorage, membershipManager, entryLog, voteStorage, inFlightCache,
-                logProvider );
+                logProvider, supportPreVoting );
 
         leaderNotFoundMonitor = monitors.newMonitor( LeaderNotFoundMonitor.class );
     }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Appending.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Appending.java
@@ -50,11 +50,12 @@ class Appending
         }
 
         outcome.renewElectionTimeout();
+        outcome.setPreElection( false );
         outcome.setNextTerm( request.leaderTerm() );
         outcome.setLeader( request.from() );
         outcome.setLeaderCommit( request.leaderCommit() );
 
-        if ( !Follower.logHistoryMatches( state, request.prevLogIndex(), request.prevLogTerm(), log ) )
+        if ( !Follower.logHistoryMatches( state, request.prevLogIndex(), request.prevLogTerm() ) )
         {
             assert request.prevLogIndex() > -1 && request.prevLogTerm() > -1;
             RaftMessages.AppendEntries.Response appendResponse = new RaftMessages.AppendEntries.Response(

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Election.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Election.java
@@ -30,7 +30,7 @@ import org.neo4j.logging.Log;
 
 public class Election
 {
-    public static boolean start( ReadableRaftState ctx, Outcome outcome, Log log ) throws IOException
+    public static boolean startRealElection( ReadableRaftState ctx, Outcome outcome, Log log ) throws IOException
     {
         Set<MemberId> currentMembers = ctx.votingMembers();
         if ( currentMembers == null || !currentMembers.contains( ctx.myself() ) )
@@ -52,6 +52,28 @@ public class Election
 
         outcome.setVotedFor( ctx.myself() );
         log.info( "Election started with vote request: %s and members: %s", voteForMe, currentMembers );
+        return true;
+    }
+
+    public static boolean startPreElection( ReadableRaftState ctx, Outcome outcome, Log log ) throws IOException
+    {
+        Set<MemberId> currentMembers = ctx.votingMembers();
+        if ( currentMembers == null || !currentMembers.contains( ctx.myself() ) )
+        {
+            log.info( "Pre-election attempted but not started, current members are %s, I am %s",
+                    currentMembers, ctx.myself()  );
+            return false;
+        }
+
+        RaftMessages.PreVote.Request preVoteForMe =
+                new RaftMessages.PreVote.Request( ctx.myself(), outcome.getTerm(), ctx.myself(), ctx.entryLog()
+                        .appendIndex(), ctx.entryLog().readEntryTerm( ctx.entryLog().appendIndex() ) );
+
+        currentMembers.stream().filter( member -> !member.equals( ctx.myself() ) ).forEach( member ->
+                outcome.addOutgoingMessage( new RaftMessages.Directed( member, preVoteForMe ) )
+        );
+
+        log.info( "Pre-election started with: %s and members: %s", preVoteForMe, currentMembers );
         return true;
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Follower.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Follower.java
@@ -30,12 +30,13 @@ import org.neo4j.causalclustering.core.consensus.state.ReadableRaftState;
 import org.neo4j.logging.Log;
 
 import static java.lang.Long.min;
+import static org.neo4j.causalclustering.core.consensus.MajorityIncludingSelfQuorum.isQuorum;
 import static org.neo4j.causalclustering.core.consensus.roles.Role.CANDIDATE;
 import static org.neo4j.causalclustering.core.consensus.roles.Role.FOLLOWER;
 
 class Follower implements RaftMessageHandler
 {
-    static boolean logHistoryMatches( ReadableRaftState ctx, long leaderSegmentPrevIndex, long leaderSegmentPrevTerm, Log log )
+    static boolean logHistoryMatches( ReadableRaftState ctx, long leaderSegmentPrevIndex, long leaderSegmentPrevTerm )
             throws IOException
     {
         // NOTE: A prevLogIndex before or at our log's prevIndex means that we
@@ -47,11 +48,8 @@ class Follower implements RaftMessageHandler
         long localLogPrevIndex = ctx.entryLog().prevIndex();
         long localSegmentPrevTerm = ctx.entryLog().readEntryTerm( leaderSegmentPrevIndex );
 
-        boolean logHistoryMatches =
-                leaderSegmentPrevIndex > -1 &&
-                (leaderSegmentPrevIndex <= localLogPrevIndex || localSegmentPrevTerm == leaderSegmentPrevTerm);
-
-        return logHistoryMatches;
+        return leaderSegmentPrevIndex > -1 &&
+        (leaderSegmentPrevIndex <= localLogPrevIndex || localSegmentPrevTerm == leaderSegmentPrevTerm);
     }
 
     static void commitToLogOnUpdate( ReadableRaftState ctx, long indexOfLastNewEntry, long leaderCommit, Outcome outcome )
@@ -80,62 +78,238 @@ class Follower implements RaftMessageHandler
     @Override
     public Outcome handle( RaftMessages.RaftMessage message, ReadableRaftState ctx, Log log ) throws IOException
     {
-        Outcome outcome = new Outcome( FOLLOWER, ctx );
+        return message.dispatch( visitor( ctx, log ) );
+    }
 
-        switch ( message.type() )
+    private abstract static class Handler implements RaftMessages.Handler<Outcome, IOException>
+    {
+        protected final ReadableRaftState ctx;
+        protected final Log log;
+        protected final Outcome outcome;
+
+        Handler( ReadableRaftState ctx, Log log )
         {
-            case HEARTBEAT:
-            {
-                Heart.beat( ctx, outcome, (Heartbeat) message, log );
-                break;
-            }
-
-            case APPEND_ENTRIES_REQUEST:
-            {
-                Appending.handleAppendEntriesRequest( ctx, outcome, (AppendEntries.Request) message, log );
-                break;
-            }
-
-            case VOTE_REQUEST:
-            {
-                Voting.handleVoteRequest( ctx, outcome, (RaftMessages.Vote.Request) message, log );
-                break;
-            }
-
-            case LOG_COMPACTION_INFO:
-            {
-                handleLeaderLogCompaction( ctx, outcome, (RaftMessages.LogCompactionInfo) message );
-                break;
-            }
-
-            case ELECTION_TIMEOUT:
-            {
-                log.info( "Election timeout triggered" );
-                if ( Election.start( ctx, outcome, log ) )
-                {
-                    outcome.setNextRole( CANDIDATE );
-                    log.info( "Moving to CANDIDATE state after successfully starting election" );
-                }
-                break;
-            }
-
-            case VOTE_RESPONSE:
-            {
-                RaftMessages.Vote.Response voteResponse = (RaftMessages.Vote.Response) message;
-                log.info( "Late vote response: %s", voteResponse );
-                break;
-            }
-
-            case PRUNE_REQUEST:
-            {
-                Pruning.handlePruneRequest( outcome, (RaftMessages.PruneRequest) message );
-                break;
-            }
-
-            default:
-                break;
+            this.ctx = ctx;
+            this.log = log;
+            this.outcome = new Outcome( FOLLOWER, ctx );
         }
 
-        return outcome;
+        @Override
+        public Outcome handle( Heartbeat heartbeat ) throws IOException
+        {
+            Heart.beat( ctx, outcome, heartbeat, log );
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( AppendEntries.Request request ) throws IOException
+        {
+            Appending.handleAppendEntriesRequest( ctx, outcome, request, log );
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.Vote.Request request ) throws IOException
+        {
+            Voting.handleVoteRequest( ctx, outcome, request, log );
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.LogCompactionInfo logCompactionInfo ) throws IOException
+        {
+            handleLeaderLogCompaction( ctx, outcome, logCompactionInfo );
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.Vote.Response response ) throws IOException
+        {
+            log.info( "Late vote response: %s", response );
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.PruneRequest pruneRequest ) throws IOException
+        {
+            Pruning.handlePruneRequest( outcome, pruneRequest );
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( AppendEntries.Response response ) throws IOException
+        {
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.HeartbeatResponse heartbeatResponse ) throws IOException
+        {
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.Timeout.Heartbeat heartbeat ) throws IOException
+        {
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.NewEntry.Request request ) throws IOException
+        {
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.NewEntry.BatchRequest batchRequest ) throws IOException
+        {
+            return outcome;
+        }
+    }
+
+    abstract class PreVoteSupportedHandler extends Handler
+    {
+
+        PreVoteSupportedHandler( ReadableRaftState ctx, Log log )
+        {
+            super( ctx, log );
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.Timeout.Election election ) throws IOException
+        {
+            log.info( "Election timeout triggered" );
+            if ( Election.startPreElection( ctx, outcome, log ) )
+            {
+                outcome.setPreElection( true );
+            }
+            return outcome;
+        }
+    }
+
+    class PreVoteActiveHandler extends PreVoteSupportedHandler
+    {
+
+        PreVoteActiveHandler( ReadableRaftState ctx, Log log )
+        {
+            super( ctx, log );
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.PreVote.Request request ) throws IOException
+        {
+            Voting.handlePreVoteRequest( ctx, outcome, request, log );
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.PreVote.Response res ) throws IOException
+        {
+            if ( res.term() > ctx.term() )
+            {
+                outcome.setNextTerm( res.term() );
+                log.info( "Aborting pre-election after receiving pre-vote response from %s at term %d (I am at %d)",
+                        res.from(), res.term(), ctx.term() );
+                return outcome;
+            }
+            else if ( res.term() < ctx.term() || !res.voteGranted() )
+            {
+                return outcome;
+            }
+
+            if ( !res.from().equals( ctx.myself() ) )
+            {
+                outcome.addPreVoteForMe( res.from() );
+            }
+
+            if ( isQuorum( ctx.votingMembers(), outcome.getPreVotesForMe() ) )
+            {
+                outcome.renewElectionTimeout();
+                outcome.setPreElection( false );
+                if ( Election.startRealElection( ctx, outcome, log ) )
+                {
+                    outcome.setNextRole( CANDIDATE );
+                    log.info( "Moving to CANDIDATE state after successful pre-election stage" );
+                }
+            }
+            return outcome;
+        }
+    }
+
+    class PreVoteInactiveHandler extends PreVoteSupportedHandler
+    {
+
+        PreVoteInactiveHandler( ReadableRaftState ctx, Log log )
+        {
+            super( ctx, log );
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.PreVote.Response response ) throws IOException
+        {
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.PreVote.Request request ) throws IOException
+        {
+            outcome.addOutgoingMessage( new RaftMessages.Directed(
+                    request.from(),
+                    new RaftMessages.PreVote.Response( ctx.myself(), outcome.getTerm(), false )
+            ) );
+            return outcome;
+        }
+    }
+
+    class PreVoteUnsupportedHandler extends Handler
+    {
+
+        PreVoteUnsupportedHandler( ReadableRaftState ctx, Log log )
+        {
+            super( ctx, log );
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.Timeout.Election election ) throws IOException
+        {
+            log.info( "Election timeout triggered" );
+            if ( Election.startRealElection( ctx, outcome, log ) )
+            {
+                outcome.setNextRole( CANDIDATE );
+                log.info( "Moving to CANDIDATE state after successfully starting election" );
+            }
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.PreVote.Response response ) throws IOException
+        {
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.PreVote.Request request ) throws IOException
+        {
+            return outcome;
+        }
+    }
+
+    private Handler visitor( ReadableRaftState ctx, Log log )
+    {
+        if ( ctx.supportPreVoting() )
+        {
+            if ( ctx.isPreElection() )
+            {
+                return new PreVoteActiveHandler( ctx, log );
+            }
+            else
+            {
+                return new PreVoteInactiveHandler( ctx, log );
+            }
+        }
+        else
+        {
+            return new PreVoteUnsupportedHandler( ctx, log );
+        }
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Heart.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Heart.java
@@ -37,13 +37,14 @@ class Heart
         }
 
         outcome.renewElectionTimeout();
+        outcome.setPreElection( false );
         outcome.setNextTerm( request.leaderTerm() );
         outcome.setLeader( request.from() );
         outcome.setLeaderCommit( request.commitIndex() );
         outcome.addOutgoingMessage( new RaftMessages.Directed( request.from(),
                 new RaftMessages.HeartbeatResponse( state.myself() ) ) );
 
-        if ( !Follower.logHistoryMatches( state, request.commitIndex(), request.commitIndexTerm(), log ) )
+        if ( !Follower.logHistoryMatches( state, request.commitIndex(), request.commitIndexTerm() ) )
         {
             return;
         }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/state/ReadableRaftState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/state/ReadableRaftState.java
@@ -52,4 +52,10 @@ public interface ReadableRaftState
     ReadableRaftLog entryLog();
 
     long commitIndex();
+
+    boolean supportPreVoting();
+
+    boolean isPreElection();
+
+    Set<MemberId> preVotesForMe();
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/RaftMessageDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/RaftMessageDecoder.java
@@ -41,6 +41,8 @@ import static org.neo4j.causalclustering.core.consensus.RaftMessages.Type.HEARTB
 import static org.neo4j.causalclustering.core.consensus.RaftMessages.Type.HEARTBEAT_RESPONSE;
 import static org.neo4j.causalclustering.core.consensus.RaftMessages.Type.LOG_COMPACTION_INFO;
 import static org.neo4j.causalclustering.core.consensus.RaftMessages.Type.NEW_ENTRY_REQUEST;
+import static org.neo4j.causalclustering.core.consensus.RaftMessages.Type.PRE_VOTE_REQUEST;
+import static org.neo4j.causalclustering.core.consensus.RaftMessages.Type.PRE_VOTE_RESPONSE;
 import static org.neo4j.causalclustering.core.consensus.RaftMessages.Type.VOTE_REQUEST;
 import static org.neo4j.causalclustering.core.consensus.RaftMessages.Type.VOTE_RESPONSE;
 
@@ -82,6 +84,23 @@ public class RaftMessageDecoder extends ByteToMessageDecoder
             boolean voteGranted = channel.get() == 1;
 
             result = new RaftMessages.Vote.Response( from, term, voteGranted );
+        }
+        else if ( messageType.equals( PRE_VOTE_REQUEST ) )
+        {
+            MemberId candidate = retrieveMember( channel );
+
+            long term = channel.getLong();
+            long lastLogIndex = channel.getLong();
+            long lastLogTerm = channel.getLong();
+
+            result = new RaftMessages.PreVote.Request( from, term, candidate, lastLogIndex, lastLogTerm );
+        }
+        else if ( messageType.equals( PRE_VOTE_RESPONSE ) )
+        {
+            long term = channel.getLong();
+            boolean voteGranted = channel.get() == 1;
+
+            result = new RaftMessages.PreVote.Response( from, term, voteGranted );
         }
         else if ( messageType.equals( APPEND_ENTRIES_REQUEST ) )
         {

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftMachineBuilder.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftMachineBuilder.java
@@ -99,7 +99,7 @@ public class RaftMachineBuilder
                         retryTimeMillis, catchupBatchSize, maxAllowedShippingLag, inFlightCache );
         RaftMachine raft = new RaftMachine( member, termState, voteState, raftLog, electionTimeout,
                 heartbeatInterval, renewableTimeoutService, outbound, logProvider,
-                membershipManager, logShipping, inFlightCache, false, monitors, clock );
+                membershipManager, logShipping, inFlightCache, false, false, monitors, clock );
         inbound.registerHandler( ( incomingMessage ) ->
         {
             try

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/ComparableRaftState.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/ComparableRaftState.java
@@ -50,12 +50,14 @@ public class ComparableRaftState implements ReadableRaftState
     private long leaderCommit = -1;
     private MemberId votedFor = null;
     private Set<MemberId> votesForMe = new HashSet<>();
+    private Set<MemberId> preVotesForMe = new HashSet<>();
     private Set<MemberId> heartbeatResponses = new HashSet<>();
     private long lastLogIndexBeforeWeBecameLeader = -1;
     private FollowerStates<MemberId> followerStates = new FollowerStates<>();
     protected final RaftLog entryLog;
     private final InFlightCache inFlightCache;
     private long commitIndex = -1;
+    private boolean isPreElection = false;
 
     ComparableRaftState( MemberId myself, Set<MemberId> votingMembers, Set<MemberId> replicationMembers,
                          RaftLog entryLog, InFlightCache inFlightCache, LogProvider logProvider )
@@ -152,6 +154,24 @@ public class ComparableRaftState implements ReadableRaftState
         return commitIndex;
     }
 
+    @Override
+    public boolean supportPreVoting()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isPreElection()
+    {
+        return isPreElection;
+    }
+
+    @Override
+    public Set<MemberId> preVotesForMe()
+    {
+        return preVotesForMe;
+    }
+
     public void update( Outcome outcome ) throws IOException
     {
         term = outcome.getTerm();
@@ -160,6 +180,7 @@ public class ComparableRaftState implements ReadableRaftState
         votesForMe = outcome.getVotesForMe();
         lastLogIndexBeforeWeBecameLeader = outcome.getLastLogIndexBeforeWeBecameLeader();
         followerStates = outcome.getFollowerStates();
+        isPreElection = outcome.isPreElection();
 
         for ( RaftLogCommand logCommand : outcome.getLogCommands() )
         {

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/FollowerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/FollowerTest.java
@@ -20,9 +20,6 @@
 package org.neo4j.causalclustering.core.consensus.roles;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -38,7 +35,6 @@ import org.neo4j.causalclustering.core.consensus.membership.RaftTestGroup;
 import org.neo4j.causalclustering.core.consensus.outcome.Outcome;
 import org.neo4j.causalclustering.core.consensus.state.RaftState;
 import org.neo4j.causalclustering.identity.MemberId;
-import org.neo4j.causalclustering.messaging.Inbound;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.NullLogProvider;
 
@@ -55,7 +51,6 @@ import static org.neo4j.causalclustering.core.consensus.state.RaftStateBuilder.r
 import static org.neo4j.causalclustering.identity.RaftTestMember.member;
 import static org.neo4j.helpers.collection.Iterators.asSet;
 
-@RunWith(MockitoJUnitRunner.class)
 public class FollowerTest
 {
     private MemberId myself = member( 0 );
@@ -63,9 +58,6 @@ public class FollowerTest
     /* A few members that we use at will in tests. */
     private MemberId member1 = member( 1 );
     private MemberId member2 = member( 2 );
-
-    @Mock
-    private Inbound inbound;
 
     @Test
     public void followerShouldTransitToCandidateAndInstigateAnElectionAfterTimeout() throws Exception

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/LeaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/LeaderTest.java
@@ -45,9 +45,13 @@ import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
 
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
@@ -325,6 +329,68 @@ public class LeaderTest
     }
 
     @Test
+    public void shouldSendCompactionInfoIfFailureWithNoEarlierEntries() throws Exception
+    {
+        // given
+        Leader leader = new Leader();
+        long term = 1;
+        long leaderPrevIndex = 3;
+        long followerIndex = leaderPrevIndex - 1;
+
+        InMemoryRaftLog raftLog = new InMemoryRaftLog();
+        raftLog.skip( leaderPrevIndex, term );
+
+        RaftState state = raftState()
+                .term( term )
+                .entryLog( raftLog )
+                .build();
+
+        RaftMessages.AppendEntries.Response incomingResponse = appendEntriesResponse()
+                .failure()
+                .term( term )
+                .appendIndex( followerIndex )
+                .from( member1 ).build();
+
+        // when
+        Outcome outcome = leader.handle( incomingResponse, state, log() );
+
+        // then
+        RaftMessages.RaftMessage outgoingMessage = messageFor( outcome, member1 );
+        assertThat( outgoingMessage, instanceOf( RaftMessages.LogCompactionInfo.class ) );
+
+        RaftMessages.LogCompactionInfo typedOutgoingMessage = (RaftMessages.LogCompactionInfo) outgoingMessage;
+        assertThat( typedOutgoingMessage.prevIndex(), equalTo( leaderPrevIndex ) );
+    }
+
+    @Test
+    public void shouldIgnoreAppendResponsesFromOldTerms() throws Exception
+    {
+        // given
+        Leader leader = new Leader();
+        long leaderTerm = 5;
+        long followerTerm = 3;
+
+        RaftState state = raftState()
+                .term( leaderTerm )
+                .build();
+
+                RaftMessages.AppendEntries.Response incomingResponse = appendEntriesResponse()
+                .failure()
+                .term( followerTerm )
+                .from( member1 ).build();
+
+        // when
+        Outcome outcome = leader.handle( incomingResponse, state, log() );
+
+        // then
+        assertThat( outcome.getTerm(), equalTo( leaderTerm ) );
+        assertThat( outcome.getRole(), equalTo( LEADER ) );
+
+        assertThat( outcome.getOutgoingMessages(), empty() );
+        assertThat( outcome.getShipCommands(), empty() );
+    }
+
+    @Test
     public void leaderShouldRejectAppendEntriesResponseWithNewerTermAndBecomeAFollower() throws Exception
     {
         // given
@@ -556,6 +622,167 @@ public class LeaderTest
 
         // then
         assertEquals( 2, state.commitIndex() );
+    }
+
+    @Test
+    public void shouldSendNegativeResponseForVoteRequestFromTermNotGreaterThanLeader() throws Exception
+    {
+        // given
+        long leaderTerm = 5;
+        long leaderCommitIndex = 10;
+        long rivalTerm = leaderTerm - 1;
+
+        Leader leader = new Leader();
+        RaftState state = raftState()
+                .term( leaderTerm )
+                .commitIndex( leaderCommitIndex )
+                .build();
+
+        // when
+        Outcome outcome = leader.handle( new RaftMessages.Vote.Request( member1, rivalTerm, member1, leaderCommitIndex, leaderTerm ), state, log() );
+
+        // then
+        assertThat( outcome.getRole(), equalTo( LEADER) );
+        assertThat( outcome.getTerm(), equalTo( leaderTerm ) );
+
+        RaftMessages.RaftMessage response = messageFor( outcome, member1 );
+        assertThat( response, instanceOf( RaftMessages.Vote.Response.class ) );
+        RaftMessages.Vote.Response typedResponse = (RaftMessages.Vote.Response) response;
+        assertThat( typedResponse.voteGranted(), equalTo( false ) );
+    }
+
+    @Test
+    public void shouldStepDownIfReceiveVoteRequestFromGreaterTermThanLeader() throws Exception
+    {
+        // given
+        long leaderTerm = 1;
+        long leaderCommitIndex = 10;
+        long rivalTerm = leaderTerm + 1;
+
+        Leader leader = new Leader();
+        RaftState state = raftState()
+                .term( leaderTerm )
+                .commitIndex( leaderCommitIndex )
+                .build();
+
+        // when
+        Outcome outcome = leader.handle( new RaftMessages.Vote.Request( member1, rivalTerm, member1, leaderCommitIndex, leaderTerm ), state, log() );
+
+        // then
+        assertThat( outcome.getRole(), equalTo( FOLLOWER ) );
+        assertThat( outcome.getLeader(), nullValue() );
+        assertThat( outcome.getTerm(), equalTo( rivalTerm ) );
+
+        RaftMessages.RaftMessage response = messageFor( outcome, member1 );
+        assertThat( response, instanceOf( RaftMessages.Vote.Response.class ) );
+        RaftMessages.Vote.Response typedResponse = (RaftMessages.Vote.Response) response;
+        assertThat( typedResponse.voteGranted(), equalTo( true ) );
+    }
+
+    @Test
+    public void shouldIgnoreHeartbeatFromOlderTerm() throws Exception
+    {
+        // given
+        long leaderTerm = 5;
+        long leaderCommitIndex = 10;
+        long rivalTerm = leaderTerm - 1;
+
+        Leader leader = new Leader();
+        RaftState state = raftState()
+                .term( leaderTerm )
+                .commitIndex( leaderCommitIndex )
+                .build();
+
+        // when
+        Outcome outcome = leader.handle( new RaftMessages.Heartbeat( member1, rivalTerm, leaderCommitIndex, leaderTerm ), state, log() );
+
+        // then
+        assertThat( outcome.getRole(), equalTo( LEADER) );
+        assertThat( outcome.getTerm(), equalTo( leaderTerm ) );
+    }
+
+    @Test
+    public void shouldStepDownIfHeartbeatReceivedWithGreaterOrEqualTerm() throws Exception
+    {
+        // given
+        long leaderTerm = 1;
+        long leaderCommitIndex = 10;
+        long rivalTerm = leaderTerm + 1;
+
+        Leader leader = new Leader();
+        RaftState state = raftState()
+                .term( leaderTerm )
+                .commitIndex( leaderCommitIndex )
+                .build();
+
+        // when
+        Outcome outcome = leader.handle( new RaftMessages.Heartbeat( member1, rivalTerm, leaderCommitIndex, leaderTerm ), state, log() );
+
+        // then
+        assertThat( outcome.getRole(), equalTo( FOLLOWER ) );
+        assertThat( outcome.getLeader(), equalTo( member1 ) );
+        assertThat( outcome.getTerm(), equalTo( rivalTerm ) );
+    }
+
+    @Test
+    public void shouldRespondNegativelyToAppendEntriesRequestFromEarlierTerm() throws Exception
+    {
+        // given
+        long leaderTerm = 5;
+        long leaderCommitIndex = 10;
+        long rivalTerm = leaderTerm - 1;
+        long logIndex = 20;
+        RaftLogEntry[] entries = { new RaftLogEntry( rivalTerm, ReplicatedInteger.valueOf( 99 ) ) };
+
+        Leader leader = new Leader();
+        RaftState state = raftState()
+                .term( leaderTerm )
+                .commitIndex( leaderCommitIndex )
+                .build();
+
+        // when
+        Outcome outcome = leader.handle( new RaftMessages.AppendEntries.Request( member1, rivalTerm, logIndex, leaderTerm, entries, leaderCommitIndex ), state, log() );
+
+        // then
+        assertThat( outcome.getRole(), equalTo( LEADER) );
+        assertThat( outcome.getTerm(), equalTo( leaderTerm ) );
+
+        RaftMessages.RaftMessage response = messageFor( outcome, member1 );
+        assertThat( response, instanceOf( RaftMessages.AppendEntries.Response.class ) );
+        RaftMessages.AppendEntries.Response typedResponse = (RaftMessages.AppendEntries.Response) response;
+        assertThat( typedResponse.term(), equalTo( leaderTerm ) );
+        assertThat( typedResponse.success(), equalTo( false ) );
+    }
+
+    @Test
+    public void shouldStepDownIfAppendEntriesRequestFromLaterTerm() throws Exception
+    {
+        // given
+        long leaderTerm = 1;
+        long leaderCommitIndex = 10;
+        long rivalTerm = leaderTerm + 1;
+        long logIndex = 20;
+        RaftLogEntry[] entries = { new RaftLogEntry( rivalTerm, ReplicatedInteger.valueOf( 99 ) ) };
+
+        Leader leader = new Leader();
+        RaftState state = raftState()
+                .term( leaderTerm )
+                .commitIndex( leaderCommitIndex )
+                .build();
+
+        // when
+        Outcome outcome = leader.handle( new RaftMessages.AppendEntries.Request( member1, rivalTerm, logIndex, leaderTerm, entries, leaderCommitIndex ), state, log() );
+
+        // then
+        assertThat( outcome.getRole(), equalTo( FOLLOWER ) );
+        assertThat( outcome.getLeader(), equalTo( member1 ) );
+        assertThat( outcome.getTerm(), equalTo( rivalTerm ) );
+
+        RaftMessages.RaftMessage response = messageFor( outcome, member1 );
+        assertThat( response, instanceOf( RaftMessages.AppendEntries.Response.class ) );
+        RaftMessages.AppendEntries.Response typedResponse = (RaftMessages.AppendEntries.Response) response;
+        assertThat( typedResponse.term(), equalTo( rivalTerm ) );
+        // Not checking success or failure of append
     }
 
     private Log log()

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/PreVotingInitiatorTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/PreVotingInitiatorTest.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.consensus.roles;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import org.neo4j.causalclustering.core.consensus.RaftMessages;
+import org.neo4j.causalclustering.core.consensus.outcome.Outcome;
+import org.neo4j.causalclustering.core.consensus.state.RaftState;
+import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.NullLogProvider;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.causalclustering.core.consensus.MessageUtils.messageFor;
+import static org.neo4j.causalclustering.core.consensus.roles.Role.CANDIDATE;
+import static org.neo4j.causalclustering.core.consensus.roles.Role.FOLLOWER;
+import static org.neo4j.causalclustering.core.consensus.state.RaftStateBuilder.raftState;
+import static org.neo4j.causalclustering.identity.RaftTestMember.member;
+import static org.neo4j.helpers.collection.Iterators.asSet;
+
+public class PreVotingInitiatorTest
+{
+    private MemberId myself = member( 0 );
+
+    /* A few members that we use at will in tests. */
+    private MemberId member1 = member( 1 );
+    private MemberId member2 = member( 2 );
+    private MemberId member3 = member( 3 );
+    private MemberId member4 = member( 4 );
+
+    @Test
+    public void shouldSetPreElectionOnElectionTimeout() throws Exception
+    {
+        // given
+        RaftState state = initialState();
+
+        // when
+        Outcome outcome = new Follower().handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome );
+
+        // then
+        assertThat( outcome.getRole(), equalTo( FOLLOWER ) );
+        assertThat( outcome.isPreElection(), equalTo( true ) );
+    }
+
+    @Test
+    public void shouldSendPreVoteRequestsOnElectionTimeout() throws Exception
+    {
+        // given
+        RaftState state = initialState();
+
+        // when
+        Outcome outcome = new Follower().handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome );
+
+        // then
+        assertThat( messageFor( outcome, member1 ).type(), equalTo( RaftMessages.Type.PRE_VOTE_REQUEST ) );
+        assertThat( messageFor( outcome, member2 ).type(), equalTo( RaftMessages.Type.PRE_VOTE_REQUEST ) );
+    }
+
+    @Test
+    public void shouldProceedToRealElectionIfReceiveQuorumOfPositiveResponses() throws Exception
+    {
+        // given
+        RaftState state = initialState();
+
+        Follower underTest = new Follower();
+
+        Outcome outcome1 = underTest.handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome1 );
+
+        // when
+        Outcome outcome2 = underTest.handle( new RaftMessages.PreVote.Response( member1, 0L, true ), state, log() );
+
+        // then
+        assertThat( outcome2.getRole(), equalTo( CANDIDATE ) );
+        assertThat( outcome2.isPreElection(), equalTo( false ) );
+        assertThat( outcome2.getPreVotesForMe(), contains( member1 ) );
+    }
+
+    @Test
+    public void shouldIgnorePositiveResponsesFromOlderTerm() throws Exception
+    {
+        // given
+        RaftState state = raftState()
+                .myself( myself )
+                .term( 1 )
+                .supportsPreVoting( true )
+                .votingMembers( asSet( myself, member1, member2 ) )
+                .build();
+
+        Follower underTest = new Follower();
+
+        Outcome outcome1 = underTest.handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome1 );
+
+        // when
+        Outcome outcome2 = underTest.handle( new RaftMessages.PreVote.Response( member1, 0L, true ), state, log() );
+
+        // then
+        assertThat( outcome2.getRole(), equalTo( FOLLOWER ) );
+        assertThat( outcome2.isPreElection(), equalTo( true ) );
+        assertThat( outcome2.getPreVotesForMe(), empty() );
+    }
+
+    @Test
+    public void shouldIgnorePositiveResponsesIfNotInPreVotingStage() throws Exception
+    {
+        // given
+        RaftState state = raftState()
+                .myself( myself )
+                .supportsPreVoting( true )
+                .votingMembers( asSet( myself, member1, member2 ) )
+                .build();
+
+        Follower underTest = new Follower();
+
+        // when
+        Outcome outcome = underTest.handle( new RaftMessages.PreVote.Response( member1, 0L, true ), state, log() );
+
+        // then
+        assertThat( outcome.getRole(), equalTo( FOLLOWER ) );
+        assertThat( outcome.isPreElection(), equalTo( false ) );
+        assertThat( outcome.getPreVotesForMe(), empty() );
+    }
+
+    @Test
+    public void shouldNotMoveToRealElectionWithoutQuorum() throws Exception
+    {
+        // given
+        RaftState state = raftState()
+                .myself( myself )
+                .supportsPreVoting( true )
+                .votingMembers( asSet( myself, member1, member2, member3, member4 ) )
+                .build();
+
+        Follower underTest = new Follower();
+        Outcome outcome1 = underTest.handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome1 );
+
+        // when
+        Outcome outcome2 = underTest.handle( new RaftMessages.PreVote.Response( member1, 0L, true ), state, log() );
+
+        // then
+        assertThat( outcome2.getRole(), equalTo( FOLLOWER ) );
+        assertThat( outcome2.isPreElection(), equalTo( true ) );
+        assertThat( outcome2.getPreVotesForMe(), contains( member1 ) );
+    }
+
+    @Test
+    public void shouldMoveToRealElectionWithQuorumOf5() throws Exception
+    {
+        // given
+        RaftState state = raftState()
+                .myself( myself )
+                .supportsPreVoting( true )
+                .votingMembers( asSet( myself, member1, member2, member3, member4 ) )
+                .build();
+
+        Follower underTest = new Follower();
+        Outcome outcome1 = underTest.handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome1 );
+
+        // when
+        Outcome outcome2 = underTest.handle( new RaftMessages.PreVote.Response( member1, 0L, true ), state, log() );
+        state.update( outcome2 );
+        Outcome outcome3 = underTest.handle( new RaftMessages.PreVote.Response( member2, 0L, true ), state, log() );
+
+        // then
+        assertThat( outcome3.getRole(), equalTo( CANDIDATE ) );
+        assertThat( outcome3.isPreElection(), equalTo( false ) );
+    }
+
+    @Test
+    public void shouldNotCountVotesFromSameMemberTwice() throws Exception
+    {
+        // given
+        RaftState state = raftState()
+                .myself( myself )
+                .supportsPreVoting( true )
+                .votingMembers( asSet( myself, member1, member2, member3, member4 ) )
+                .build();
+
+        Follower underTest = new Follower();
+        Outcome outcome1 = underTest.handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome1 );
+
+        // when
+        Outcome outcome2 = underTest.handle( new RaftMessages.PreVote.Response( member1, 0L, true ), state, log() );
+        state.update( outcome2 );
+        Outcome outcome3 = underTest.handle( new RaftMessages.PreVote.Response( member1, 0L, true ), state, log() );
+
+        // then
+        assertThat( outcome3.getRole(), equalTo( FOLLOWER ) );
+        assertThat( outcome3.isPreElection(), equalTo( true ) );
+    }
+
+    @Test
+    public void shouldResetPreVotesWhenMovingBackToFollower() throws Exception
+    {
+        // given
+        RaftState state = initialState();
+
+        Outcome outcome1 = new Follower().handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome1 );
+        Outcome outcome2 = new Follower().handle( new RaftMessages.PreVote.Response( member1, 0L, true ), state, log() );
+        assertThat( CANDIDATE, equalTo( outcome2.getRole() ) );
+        assertThat( outcome2.getPreVotesForMe(), contains( member1 ) );
+
+        // when
+        Outcome outcome3 = new Candidate().handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+
+        // then
+        assertThat( outcome3.getPreVotesForMe(), empty() );
+    }
+
+    @Test
+    public void shouldSendRealVoteRequestsIfReceivePositiveResponses() throws Exception
+    {
+        // given
+        RaftState state = initialState();
+
+        Follower underTest = new Follower();
+
+        Outcome outcome1 = underTest.handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome1 );
+
+        // when
+        Outcome outcome2 = underTest.handle( new RaftMessages.PreVote.Response( member1, 0L, true ), state, log() );
+
+        // then
+        assertThat( messageFor( outcome2, member1 ).type(), equalTo( RaftMessages.Type.VOTE_REQUEST ) );
+        assertThat( messageFor( outcome2, member2 ).type(), equalTo( RaftMessages.Type.VOTE_REQUEST ) );
+    }
+
+    @Test
+    public void shouldNotProceedToRealElectionIfReceiveNegativeResponses() throws Exception
+    {
+                // given
+        RaftState state = initialState();
+
+        Follower underTest = new Follower();
+
+        Outcome outcome1 = underTest.handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome1 );
+
+        // when
+        Outcome outcome2 = underTest.handle( new RaftMessages.PreVote.Response( member1, 0L, false ), state, log() );
+        state.update( outcome2 );
+        Outcome outcome3 = underTest.handle( new RaftMessages.PreVote.Response( member2, 0L, false ), state, log() );
+
+        // then
+        assertThat( outcome3.getRole(), equalTo( FOLLOWER ) );
+        assertThat( outcome3.isPreElection(), equalTo( true ) );
+        assertThat( outcome3.getPreVotesForMe(), empty() );
+    }
+
+    @Test
+    public void shouldNotSendRealVoteRequestsIfReceiveNegativeResponses() throws Exception
+    {
+        // given
+        RaftState state = initialState();
+
+        Follower underTest = new Follower();
+
+        Outcome outcome1 = underTest.handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome1 );
+
+        // when
+        Outcome outcome2 = underTest.handle( new RaftMessages.PreVote.Response( member1, 0L, false ), state, log() );
+        state.update( outcome2 );
+        Outcome outcome3 = underTest.handle( new RaftMessages.PreVote.Response( member2, 0L, false ), state, log() );
+
+        // then
+        assertThat( outcome2.getOutgoingMessages(), empty() );
+        assertThat( outcome3.getOutgoingMessages(), empty() );
+    }
+
+    @Test
+    public void shouldResetPreVoteIfReceiveHeartbeatFromLeader() throws Exception
+    {
+        // given
+        RaftState state = initialState();
+
+        Follower underTest = new Follower();
+
+        Outcome outcome1 = underTest.handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome1 );
+
+        // when
+        Outcome outcome2 = underTest.handle( new RaftMessages.Heartbeat( member1, 0L, 0L, 0L ), state, log() );
+
+        // then
+        assertThat( outcome2.getRole(), equalTo( FOLLOWER ) );
+        assertThat( outcome2.isPreElection(), equalTo( false ) );
+        assertThat( outcome2.getPreVotesForMe(), empty() );
+    }
+
+    @Test
+    public void shouldNotSendPreVoteRequestsIfReceiveHeartbeatFromLeader() throws Exception
+    {
+        // given
+        RaftState state = initialState();
+
+        Follower underTest = new Follower();
+
+        Outcome outcome1 = underTest.handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome1 );
+
+        // when
+        Outcome outcome2 = underTest.handle( new RaftMessages.Heartbeat( member1, 0L, 0L, 0L ), state, log() );
+        state.update( outcome2 );
+        Outcome outcome3 = underTest.handle( new RaftMessages.PreVote.Response( member2, 0L, true ), state, log() );
+
+        // then
+        assertThat( outcome3.isPreElection(), equalTo( false ) );
+    }
+
+    private Log log()
+    {
+        return NullLogProvider.getInstance().getLog( getClass() );
+    }
+
+    private RaftState initialState() throws IOException
+    {
+        return raftState()
+                .myself( myself )
+                .supportsPreVoting( true )
+                .votingMembers( asSet( myself, member1, member2 ) )
+                .build();
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/PreVotingVoterTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/PreVotingVoterTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.consensus.roles;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import org.neo4j.causalclustering.core.consensus.RaftMessages;
+import org.neo4j.causalclustering.core.consensus.outcome.Outcome;
+import org.neo4j.causalclustering.core.consensus.state.RaftState;
+import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.NullLogProvider;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.causalclustering.core.consensus.MessageUtils.messageFor;
+import static org.neo4j.causalclustering.core.consensus.state.RaftStateBuilder.raftState;
+import static org.neo4j.causalclustering.identity.RaftTestMember.member;
+import static org.neo4j.helpers.collection.Iterators.asSet;
+
+public class PreVotingVoterTest
+{
+    private MemberId myself = member( 0 );
+
+    /* A few members that we use at will in tests. */
+    private MemberId member1 = member( 1 );
+    private MemberId member2 = member( 2 );
+
+    @Test
+    public void shouldRespondPositivelyIfWouldVoteForCandidate() throws Exception
+    {
+        // given
+        RaftState raftState = initialState();
+
+        // when
+        Outcome outcome = new Follower().handle( new RaftMessages.PreVote.Request( member1, 0, member1, 0, 0 ), raftState, log() );
+
+        // then
+        RaftMessages.RaftMessage raftMessage = messageFor( outcome, member1 );
+        assertThat( raftMessage.type(), equalTo( RaftMessages.Type.PRE_VOTE_RESPONSE ) );
+        assertThat( ( (RaftMessages.PreVote.Response)raftMessage ).voteGranted() , equalTo( true )  );
+    }
+
+    @Test
+    public void shouldRespondPositivelyEvenIfAlreadyVotedInRealElection() throws Exception
+    {
+        // given
+        RaftState raftState = initialState();
+        raftState.update( new Follower().handle( new RaftMessages.Vote.Request( member1, 0, member1, 0, 0 ), raftState, log() ) );
+
+        // when
+        Outcome outcome = new Follower().handle( new RaftMessages.PreVote.Request( member2, 0, member2, 0, 0 ), raftState, log() );
+
+        // then
+        RaftMessages.RaftMessage raftMessage = messageFor( outcome, member2 );
+        assertThat( raftMessage.type(), equalTo( RaftMessages.Type.PRE_VOTE_RESPONSE ) );
+        assertThat( ( (RaftMessages.PreVote.Response)raftMessage ).voteGranted() , equalTo( true )  );
+    }
+
+    @Test
+    public void shouldRespondNegativelyIfLeaderAndRequestNotFromGreaterTerm() throws Exception
+    {
+        // given
+        RaftState raftState = initialState();
+
+        // when
+        Outcome outcome = new Leader().handle( new RaftMessages.PreVote.Request( member1, Long.MIN_VALUE, member1, 0, 0 ), raftState, log() );
+
+        // then
+        RaftMessages.RaftMessage raftMessage = messageFor( outcome, member1 );
+        assertThat( raftMessage.type(), equalTo( RaftMessages.Type.PRE_VOTE_RESPONSE ) );
+        assertThat( ( (RaftMessages.PreVote.Response)raftMessage ).voteGranted() , equalTo( false )  );
+    }
+
+    @Test
+    public void shouldRespondPositivelyIfLeaderAndRequestFromGreaterTerm() throws Exception
+    {
+        // given
+        RaftState raftState = initialState();
+
+        // when
+        Outcome outcome = new Leader().handle( new RaftMessages.PreVote.Request( member1, Long.MAX_VALUE, member1, 0, 0 ), raftState, log() );
+
+        // then
+        RaftMessages.RaftMessage raftMessage = messageFor( outcome, member1 );
+        assertThat( raftMessage.type(), equalTo( RaftMessages.Type.PRE_VOTE_RESPONSE ) );
+        assertThat( ( (RaftMessages.PreVote.Response)raftMessage ).voteGranted() , equalTo( true )  );
+    }
+
+    @Test
+    public void shouldRespondNegativelyIfNotInPreVoteMyself() throws Exception
+    {
+        // given
+        RaftState raftState = raftState()
+                .myself( myself )
+                .supportsPreVoting( true )
+                .votingMembers( asSet( myself, member1, member2 ) )
+                .setPreElection( false )
+                .build();
+
+        // when
+        Outcome outcome = new Follower().handle( new RaftMessages.PreVote.Request( member1, 0, member1, 0, 0 ), raftState, log() );
+
+        // then
+        RaftMessages.RaftMessage raftMessage = messageFor( outcome, member1 );
+        assertThat( raftMessage.type(), equalTo( RaftMessages.Type.PRE_VOTE_RESPONSE ) );
+        assertThat( ( (RaftMessages.PreVote.Response)raftMessage ).voteGranted() , equalTo( false )  );
+    }
+
+    @Test
+    public void shouldRespondNegativelyIfWouldNotVoteForCandidate() throws Exception
+    {
+        // given
+        RaftState raftState = raftState()
+                .myself( myself )
+                .term( 1 )
+                .setPreElection( true )
+                .supportsPreVoting( true )
+                .votingMembers( asSet( myself, member1, member2 ) )
+                .build();
+
+        // when
+        Outcome outcome = new Follower().handle( new RaftMessages.PreVote.Request( member1, 0, member1, 0, 0 ), raftState, log() );
+
+        // then
+        RaftMessages.RaftMessage raftMessage = messageFor( outcome, member1 );
+        assertThat( raftMessage.type(), equalTo( RaftMessages.Type.PRE_VOTE_RESPONSE ) );
+        assertThat( ( (RaftMessages.PreVote.Response)raftMessage ).voteGranted() , equalTo( false )  );
+    }
+
+    @Test
+    public void shouldRespondPositivelyToMultipleMembersIfWouldVoteForAny() throws Exception
+    {
+        // given
+        RaftState raftState = initialState();
+
+        // when
+        Outcome outcome1 = new Follower().handle( new RaftMessages.PreVote.Request( member1, 0, member1, 0, 0 ), raftState, log() );
+        raftState.update( outcome1 );
+        Outcome outcome2 = new Follower().handle( new RaftMessages.PreVote.Request( member2, 0, member2, 0, 0 ), raftState, log() );
+        raftState.update( outcome2 );
+
+        // then
+        RaftMessages.RaftMessage raftMessage = messageFor( outcome2, member2 );
+
+        assertThat( raftMessage.type(), equalTo( RaftMessages.Type.PRE_VOTE_RESPONSE ) );
+        assertThat( ( (RaftMessages.PreVote.Response)raftMessage ).voteGranted() , equalTo( true )  );
+    }
+
+    @Test
+    public void shouldUseTermFromRequestIfHigherThanOwn() throws Exception
+    {
+        // given
+        RaftState raftState = initialState();
+        long newTerm = 1;
+
+        // when
+        Outcome outcome = new Follower().handle( new RaftMessages.PreVote.Request( member1, newTerm, member1, 0, 0 ), raftState, log() );
+
+        // then
+        RaftMessages.RaftMessage raftMessage = messageFor( outcome, member1 );
+
+        assertThat( raftMessage.type(), equalTo( RaftMessages.Type.PRE_VOTE_RESPONSE ) );
+        assertThat( ( (RaftMessages.PreVote.Response)raftMessage ).term() , equalTo( newTerm )  );
+    }
+
+    private RaftState initialState() throws IOException
+    {
+        return raftState()
+                .myself( myself )
+                .supportsPreVoting( true )
+                .setPreElection( true )
+                .votingMembers( asSet( myself, member1, member2 ) )
+                .build();
+    }
+
+    private Log log()
+    {
+        return NullLogProvider.getInstance().getLog( getClass() );
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/state/RaftStateBuilder.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/state/RaftStateBuilder.java
@@ -58,10 +58,13 @@ public class RaftStateBuilder
     public long leaderCommit = -1;
     private MemberId votedFor;
     private RaftLog entryLog = new InMemoryRaftLog();
+    private boolean supportPreVoting;
     private Set<MemberId> votesForMe = emptySet();
+    private Set<MemberId> preVotesForMe = emptySet();
     private long lastLogIndexBeforeWeBecameLeader = -1;
     public long commitIndex = -1;
     private FollowerStates<MemberId> followerStates = new FollowerStates<>();
+    private boolean isPreElection = false;
 
     public RaftStateBuilder myself( MemberId myself )
     {
@@ -117,6 +120,12 @@ public class RaftStateBuilder
         return this;
     }
 
+    public RaftStateBuilder supportsPreVoting( boolean supportPreVoting )
+    {
+        this.supportPreVoting = supportPreVoting;
+        return this;
+    }
+
     public RaftStateBuilder lastLogIndexBeforeWeBecameLeader( long lastLogIndexBeforeWeBecameLeader )
     {
         this.lastLogIndexBeforeWeBecameLeader = lastLogIndexBeforeWeBecameLeader;
@@ -129,6 +138,12 @@ public class RaftStateBuilder
         return this;
     }
 
+    public RaftStateBuilder setPreElection( boolean isPreElection )
+    {
+        this.isPreElection = isPreElection;
+        return this;
+    }
+
     public RaftState build() throws IOException
     {
         StateStorage<TermState> termStore = new InMemoryStateStorage<>( new TermState() );
@@ -136,14 +151,14 @@ public class RaftStateBuilder
         StubMembership membership = new StubMembership( votingMembers, replicationMembers );
 
         RaftState state = new RaftState( myself, termStore, membership, entryLog,
-                voteStore, new ConsecutiveInFlightCache(), NullLogProvider.getInstance() );
+                voteStore, new ConsecutiveInFlightCache(), NullLogProvider.getInstance(), supportPreVoting );
 
         Collection<RaftMessages.Directed> noMessages = Collections.emptyList();
         List<RaftLogCommand> noLogCommands = Collections.emptyList();
 
-        state.update( new Outcome( null, term, leader, leaderCommit, votedFor, votesForMe,
+        state.update( new Outcome( null, term, leader, leaderCommit, votedFor, votesForMe, preVotesForMe,
                 lastLogIndexBeforeWeBecameLeader, followerStates, false, noLogCommands,
-                noMessages, emptySet(), commitIndex, emptySet() ) );
+                noMessages, emptySet(), commitIndex, emptySet(), isPreElection ) );
 
         return state;
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/state/RaftStateTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/state/RaftStateTest.java
@@ -66,7 +66,7 @@ public class RaftStateTest
         InFlightCache cache = new ConsecutiveInFlightCache();
         RaftState raftState = new RaftState( member( 0 ),
                 new InMemoryStateStorage<>( new TermState() ), new FakeMembership(), new InMemoryRaftLog(),
-                new InMemoryStateStorage<>( new VoteState() ), cache, NullLogProvider.getInstance() );
+                new InMemoryStateStorage<>( new VoteState() ), cache, NullLogProvider.getInstance(), false );
 
         List<RaftLogCommand> logCommands = new LinkedList<RaftLogCommand>()
         {{
@@ -79,8 +79,8 @@ public class RaftStateTest
         }};
 
         Outcome raftTestMemberOutcome =
-                new Outcome( CANDIDATE, 0, null, -1, null, emptySet(), -1, initialFollowerStates(), true,
-                        logCommands, emptyOutgoingMessages(), emptySet(), -1, emptySet() );
+                new Outcome( CANDIDATE, 0, null, -1, null, emptySet(), emptySet(), -1, initialFollowerStates(), true,
+                        logCommands, emptyOutgoingMessages(), emptySet(), -1, emptySet(), false );
 
         //when
         raftState.update(raftTestMemberOutcome);
@@ -101,14 +101,15 @@ public class RaftStateTest
                 new InMemoryStateStorage<>( new TermState() ),
                 new FakeMembership(), new InMemoryRaftLog(),
                 new InMemoryStateStorage<>( new VoteState( ) ),
-                new ConsecutiveInFlightCache(), NullLogProvider.getInstance() );
+                new ConsecutiveInFlightCache(), NullLogProvider.getInstance(),
+                false );
 
-        raftState.update( new Outcome( CANDIDATE, 1, null, -1, null, emptySet(), -1, initialFollowerStates(), true, emptyLogCommands(),
-                emptyOutgoingMessages(), emptySet(), -1, emptySet() ) );
+        raftState.update( new Outcome( CANDIDATE, 1, null, -1, null, emptySet(), emptySet(), -1, initialFollowerStates(), true, emptyLogCommands(),
+                emptyOutgoingMessages(), emptySet(), -1, emptySet(), false ) );
 
         // when
-        raftState.update( new Outcome( CANDIDATE, 1, null, -1, null, emptySet(), -1, new FollowerStates<>(), true, emptyLogCommands(),
-                emptyOutgoingMessages(), emptySet(), -1, emptySet() ) );
+        raftState.update( new Outcome( CANDIDATE, 1, null, -1, null, emptySet(), emptySet(), -1, new FollowerStates<>(), true, emptyLogCommands(),
+                emptyOutgoingMessages(), emptySet(), -1, emptySet(), false ) );
 
         // then
         assertEquals( 0, raftState.followerStates().size() );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/vote/VotingTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/vote/VotingTest.java
@@ -20,9 +20,8 @@
 package org.neo4j.causalclustering.core.consensus.vote;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.neo4j.causalclustering.core.consensus.roles.Voting;
@@ -33,7 +32,6 @@ import org.neo4j.logging.NullLog;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(MockitoJUnitRunner.class)
 public class VotingTest
 {
     MemberId candidate = new MemberId( UUID.randomUUID() );
@@ -56,7 +54,7 @@ public class VotingTest
                 logTerm,
                 appendIndex,
                 appendIndex,
-                null,
+                Optional.empty(),
                 log
         ) );
     }
@@ -72,7 +70,7 @@ public class VotingTest
                 logTerm,
                 appendIndex,
                 appendIndex,
-                null,
+                Optional.empty(),
                 log
         ) );
     }
@@ -88,7 +86,7 @@ public class VotingTest
                 logTerm - 1,
                 appendIndex,
                 appendIndex,
-                null,
+                Optional.empty(),
                 log
         ) );
     }
@@ -104,7 +102,7 @@ public class VotingTest
                 logTerm,
                 appendIndex,
                 appendIndex - 1,
-                null,
+                Optional.empty(),
                 log
         ) );
     }
@@ -120,7 +118,7 @@ public class VotingTest
                 logTerm,
                 appendIndex,
                 appendIndex,
-                null,
+                Optional.empty(),
                 log
         ) );
     }
@@ -136,7 +134,7 @@ public class VotingTest
                 logTerm,
                 appendIndex,
                 appendIndex + 1,
-                null,
+                Optional.empty(),
                 log
         ) );
     }
@@ -152,7 +150,7 @@ public class VotingTest
                 logTerm + 1,
                 appendIndex,
                 appendIndex - 1,
-                null,
+                Optional.empty(),
                 log
         ) );
     }
@@ -168,7 +166,7 @@ public class VotingTest
                 logTerm + 1,
                 appendIndex,
                 appendIndex,
-                null,
+                Optional.empty(),
                 log
         ) );
     }
@@ -184,7 +182,7 @@ public class VotingTest
                 logTerm + 1,
                 appendIndex,
                 appendIndex + 1,
-                null,
+                Optional.empty(),
                 log
         ) );
     }
@@ -200,7 +198,7 @@ public class VotingTest
                 logTerm,
                 appendIndex,
                 appendIndex,
-                otherMember,
+                Optional.of( otherMember ),
                 log
         ) );
     }
@@ -216,7 +214,7 @@ public class VotingTest
                 logTerm,
                 appendIndex,
                 appendIndex,
-                candidate,
+                Optional.of( candidate ),
                 log
         ) );
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/PreElectionIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/PreElectionIT.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.scenarios;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
+import org.neo4j.causalclustering.core.consensus.roles.Role;
+import org.neo4j.causalclustering.discovery.Cluster;
+import org.neo4j.causalclustering.discovery.CoreClusterMember;
+import org.neo4j.test.Race;
+import org.neo4j.test.assertion.Assert;
+import org.neo4j.test.causalclustering.ClusterRule;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class PreElectionIT
+{
+    @Rule
+    public ClusterRule clusterRule = new ClusterRule( getClass() )
+            .withNumberOfCoreMembers( 3 )
+            .withNumberOfReadReplicas( 0 )
+            .withSharedCoreParam( CausalClusteringSettings.leader_election_timeout, "10s" )
+            .withSharedCoreParam( CausalClusteringSettings.enable_pre_voting, "true" );
+
+    private Cluster cluster;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        cluster = clusterRule.startCluster();
+    }
+
+    @Test
+    public void shouldActuallyStartAClusterWithPreVoting() throws Exception
+    {
+        // pass
+    }
+
+    @Test
+    public void shouldStartAnElectionIfAllServersHaveTimedOutOnHeartbeats() throws Exception
+    {
+        Collection<CompletableFuture<Void>> futures = new ArrayList<>( cluster.coreMembers().size() );
+
+        // given
+        long initialTerm = cluster.awaitLeader().raft().term();
+
+        // when
+        for ( CoreClusterMember member : cluster.coreMembers() )
+        {
+            if ( Role.FOLLOWER == member.raft().currentRole() )
+            {
+                futures.add( CompletableFuture.runAsync( Race.throwing( () -> member.raft().triggerElection() ) ) );
+            }
+        }
+
+        // then
+        Assert.assertEventually(
+                "Should be on a new term following an election",
+                () -> cluster.awaitLeader().raft().term(), not( equalTo( initialTerm ) ),
+                1,
+                TimeUnit.MINUTES );
+
+        // cleanup
+        for ( CompletableFuture<Void> future : futures )
+        {
+            future.cancel( false );
+        }
+    }
+
+    @Test
+    public void shouldNotStartAnElectionIfAMinorityOfServersHaveTimedOutOnHeartbeats() throws Exception
+    {
+        // given
+        CoreClusterMember follower = cluster.awaitCoreMemberWithRole( Role.FOLLOWER, 1, TimeUnit.MINUTES );
+
+        // when
+        follower.raft().triggerElection();
+
+        // then
+        try
+        {
+            cluster.awaitCoreMemberWithRole( Role.CANDIDATE, 1, TimeUnit.MINUTES );
+            fail( "Should not have started an election if less than a quorum have timed out" );
+        }
+        catch ( TimeoutException e )
+        {
+            // pass
+        }
+    }
+
+    @Test
+    public void shouldStartElectionIfLeaderRemoved() throws Exception
+    {
+        // given
+        CoreClusterMember oldLeader = cluster.awaitLeader();
+
+        // when
+        cluster.removeCoreMember( oldLeader );
+
+        // then
+        CoreClusterMember newLeader = cluster.awaitLeader();
+
+        assertThat( newLeader.serverId(), not( equalTo( oldLeader.serverId() ) ) );
+    }
+}


### PR DESCRIPTION
Includes introduction of a visitor for raft messages used by message handling and marshalling (not unmarshalling as that is against the enum value, could be done with another visitor...). The visitor is safer (cannot forget to handle a message, cannot forget last break/else, no casting) and can be used in inheritance, but is a little more verbose and may be counter intuitive to someone not familiar with the pattern.

changelog: Implement a pre-election stage in Raft protocol
This should reduce the incidence of unnecessary elections caused by a disruptive follower, for example rejoining the cluster after a network partition.
This is a breaking change and must be explicitly enabled with `causal_clustering.enable_pre_voting=true`.
