### PR TITLE
Calling properties on a null node without exception

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/predicates/Predicate.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/predicates/Predicate.scala
@@ -157,6 +157,7 @@ case class PropertyExists(variable: Expression, propertyKey: KeyToken) extends P
       propertyKey.getOptId(state.query).exists(state.query.relationshipOps.hasProperty(pc.id, _)))
     case IsMap(map) => Some(map(state.query).get(propertyKey.name) != Values.NO_VALUE)
     case null => None
+    case v: Value if v.asObject() == null => None
     case _ => throw new CypherTypeException("Expected " + variable + " to be a property container.")
   }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/predicates/Predicate.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/predicates/Predicate.scala
@@ -156,8 +156,7 @@ case class PropertyExists(variable: Expression, propertyKey: KeyToken) extends P
     case pc: EdgeValue => Some(
       propertyKey.getOptId(state.query).exists(state.query.relationshipOps.hasProperty(pc.id, _)))
     case IsMap(map) => Some(map(state.query).get(propertyKey.name) != Values.NO_VALUE)
-    case null => None
-    case v: Value if v.asObject() == null => None
+    case Values.NO_VALUE => None
     case _ => throw new CypherTypeException("Expected " + variable + " to be a property container.")
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -196,3 +196,5 @@ difficult to plan query number 3
 Match on multiple labels with OR
 Should handle EXISTS on node property when node is null
 Should handle NOT EXISTS on node property when node is null
+Should handle simple IS NOT NULL on node property when node is null
+Should handle complex IS NOT NULL on node property when node is null

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -194,3 +194,5 @@ difficult to plan query number 1
 difficult to plan query number 2
 difficult to plan query number 3
 Match on multiple labels with OR
+Should handle EXISTS on node property when node is null
+Should handle NOT EXISTS on node property when node is null

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/MatchAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/MatchAcceptance.feature
@@ -278,3 +278,44 @@ Feature: MatchAcceptance
       | t           | PendingCount |
       | (:TestNode) | 0            |
     And no side effects
+
+  Scenario: Should handle simple IS NOT NULL on node property when node is null
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:LBL1)
+      """
+    When executing query:
+      """
+      OPTIONAL MATCH (o:LBL1)-[]->(p)
+      WITH p
+      OPTIONAL MATCH (p)
+      WHERE p.prop2 IS NOT NULL
+      RETURN p
+      """
+    Then the result should be:
+      | p    |
+      | null |
+    And no side effects
+
+  Scenario: Should handle complex IS NOT NULL on node property when node is null
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:LBL1 {prop0:'foo'})-[:rel]->(:LBL1 {prop1:'bar'})
+      """
+    When executing query:
+      """
+      MATCH (n:LBL1 {prop0:'foo'})-[]->(o:LBL1) WHERE EXISTS(o.prop1)
+      WITH o
+      OPTIONAL MATCH (o)-[:rel1]->(p:LBL2)
+      WITH p
+      OPTIONAL MATCH (p)-[:rel2]->(e:LBL3)
+      WHERE p.prop2 IS NOT NULL
+      RETURN p
+      """
+    Then the result should be:
+      | p    |
+      | null |
+    And no side effects
+

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/MatchAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/MatchAcceptance.feature
@@ -244,3 +244,37 @@ Feature: MatchAcceptance
       | (:A:B) |
       | (:A:C) |
     And no side effects
+
+  Scenario: Should handle EXISTS on node property when node is null
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:TestNode)
+      """
+    When executing query:
+      """
+      MATCH (t:TestNode)
+      OPTIONAL MATCH (t)-[:LINKED]-(a:AnotherNode)
+      RETURN t, a.Status as s, exists(a.Status) as e
+      """
+    Then the result should be:
+      | t           | s    | e    |
+      | (:TestNode) | null | null |
+    And no side effects
+
+  Scenario: Should handle NOT EXISTS on node property when node is null
+    Given an empty graph
+    And having executed:
+        """
+        CREATE (:TestNode)
+        """
+    When executing query:
+        """
+        MATCH (t:TestNode)
+        OPTIONAL MATCH (t)-[:LINKED]-(a:AnotherNode)
+        RETURN t, SUM(CASE WHEN NOT EXISTS(a.Status) OR COALESCE(a.Status, 'Complete') <> 'Complete' THEN 1 ELSE 0 END) AS PendingCount
+        """
+    Then the result should be:
+      | t           | PendingCount |
+      | (:TestNode) | 0            |
+    And no side effects


### PR DESCRIPTION
Changelog: Fixes #10353 so that calling `exists` or `IS NOT null` on a property of a null node evaluates to null rather than throwing an exception