### PR TITLE
Less cryptic exception message for IdCapacityExceededException.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
@@ -1067,7 +1067,7 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord,HEAD
     public void updateRecord( RECORD record )
     {
         long id = record.getId();
-        IdValidator.assertValidId( id, recordFormat.getMaxId() );
+        IdValidator.assertValidId( getIdType(), id, recordFormat.getMaxId() );
 
         long pageId = pageIdForRecord( id );
         int offset = offsetForId( id );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/DefaultIdGeneratorFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/DefaultIdGeneratorFactory.java
@@ -58,15 +58,16 @@ public class DefaultIdGeneratorFactory implements IdGeneratorFactory
     public IdGenerator open( File fileName, int grabSize, IdType idType, Supplier<Long> highId, long maxId )
     {
         IdTypeConfiguration idTypeConfiguration = idTypeConfigurationProvider.getIdTypeConfiguration( idType );
-        IdGenerator generator = instantiate( fs, fileName, grabSize, maxId, idTypeConfiguration.allowAggressiveReuse(), highId );
+        IdGenerator generator = instantiate( fs, fileName, grabSize, maxId, idTypeConfiguration.allowAggressiveReuse(),
+                idType, highId );
         generators.put( idType, generator );
         return generator;
     }
 
     protected IdGenerator instantiate( FileSystemAbstraction fs, File fileName, int grabSize, long maxValue,
-            boolean aggressiveReuse, Supplier<Long> highId )
+            boolean aggressiveReuse, IdType idType, Supplier<Long> highId )
     {
-        return new IdGeneratorImpl( fs, fileName, grabSize, maxValue, aggressiveReuse, highId );
+        return new IdGeneratorImpl( fs, fileName, grabSize, maxValue, aggressiveReuse, idType, highId );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGeneratorImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGeneratorImpl.java
@@ -68,6 +68,7 @@ public class IdGeneratorImpl implements IdGenerator
     private final long max;
     private final IdContainer idContainer;
     private long highId;
+    private final IdType idType;
 
     /**
      * Opens the id generator represented by <CODE>fileName</CODE>. The
@@ -96,10 +97,12 @@ public class IdGeneratorImpl implements IdGenerator
      *             If no such file exist or if the id generator is sticky
      */
     public IdGeneratorImpl( FileSystemAbstraction fs, File file, int grabSize, long max, boolean aggressiveReuse,
-            Supplier<Long> highId )
+            IdType idType, Supplier<Long> highId )
     {
         this.max = max;
+        this.idType = idType;
         this.idContainer = new IdContainer( fs, file, grabSize, aggressiveReuse );
+
         /*
          * The highId supplier will be called only if the id container tells us that the information found in the
          * id file is not reliable (typically the file had to be created). Calling the supplier can be a potentially
@@ -140,7 +143,7 @@ public class IdGeneratorImpl implements IdGenerator
         {
             highId++;
         }
-        IdValidator.assertValidId( highId, max );
+        IdValidator.assertValidId( idType, highId, max );
         return highId++;
     }
 
@@ -182,7 +185,7 @@ public class IdGeneratorImpl implements IdGenerator
     @Override
     public synchronized void setHighId( long id )
     {
-        IdValidator.assertIdWithinCapacity( id, max );
+        IdValidator.assertIdWithinCapacity( idType, id, max );
         highId = id;
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/validation/IdCapacityExceededException.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/validation/IdCapacityExceededException.java
@@ -20,11 +20,15 @@
 package org.neo4j.kernel.impl.store.id.validation;
 
 import org.neo4j.kernel.impl.store.UnderlyingStorageException;
+import org.neo4j.kernel.impl.store.id.IdType;
+
+import static java.lang.String.format;
 
 public class IdCapacityExceededException extends UnderlyingStorageException
 {
-    public IdCapacityExceededException( long id, long maxId )
+    IdCapacityExceededException( IdType idType, long id, long maxId )
     {
-        super( "Record id " + id + " is out of range [0, " + maxId + "]" );
+        super( format( "Maximum id limit for %s has been reached. Generated id %d is out of permitted range [0, %d].",
+                idType.name(), id, maxId ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/validation/IdValidator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/validation/IdValidator.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.store.id.validation;
 
 import org.neo4j.kernel.impl.store.id.IdGenerator;
 import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
+import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 
 /**
@@ -58,13 +59,13 @@ public final class IdValidator
      * @param maxId the max allowed id.
      * @see IdGeneratorImpl#INTEGER_MINUS_ONE
      */
-    public static void assertValidId( long id, long maxId )
+    public static void assertValidId( IdType idType, long id, long maxId )
     {
         if ( isReservedId( id ) )
         {
             throw new ReservedIdException( id );
         }
-        assertIdWithinCapacity( id, maxId );
+        assertIdWithinCapacity( idType, id, maxId );
     }
 
     /**
@@ -74,10 +75,11 @@ public final class IdValidator
      * <li>less than the given max id
      * </ul>
      *
+     * @param idType
      * @param id the id to check.
      * @param maxId the max allowed id.
      */
-    public static void assertIdWithinCapacity( long id, long maxId )
+    public static void assertIdWithinCapacity( IdType idType, long id, long maxId )
     {
         if ( id < 0 )
         {
@@ -85,7 +87,7 @@ public final class IdValidator
         }
         if ( id > maxId )
         {
-            throw new IdCapacityExceededException( id, maxId );
+            throw new IdCapacityExceededException( idType, id, maxId );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/batchinsert/internal/BatchInserterImpl.java
@@ -49,12 +49,12 @@ import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.IteratorWrapper;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
+import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.tracing.PageCacheTracer;
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier;
-import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.exceptions.schema.AlreadyConstrainedException;
 import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
@@ -124,6 +124,7 @@ import org.neo4j.kernel.impl.store.format.RecordFormatSelector;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
+import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.store.id.validation.IdValidator;
 import org.neo4j.kernel.impl.store.record.ConstraintRule;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
@@ -818,7 +819,7 @@ public class BatchInserterImpl implements BatchInserter, IndexConfigStoreProvide
     @Override
     public void createNode( long id, Map<String, Object> properties, Label... labels )
     {
-        IdValidator.assertValidId( id, maxNodeId );
+        IdValidator.assertValidId( IdType.NODE, id, maxNodeId );
         if ( nodeStore.isInUse( id ) )
         {
             throw new IllegalArgumentException( "id=" + id + " already in use" );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/FreeIdsAfterRecoveryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/FreeIdsAfterRecoveryTest.java
@@ -19,13 +19,14 @@
  */
 package org.neo4j.kernel.impl.store;
 
-import java.io.File;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
+import java.io.File;
+
 import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
+import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
 import org.neo4j.kernel.impl.storemigration.StoreFileType;
 import org.neo4j.logging.NullLogProvider;
@@ -64,7 +65,8 @@ public class FreeIdsAfterRecoveryTest
 
         // populating its .id file with a bunch of ids
         File nodeIdFile = new File( directory.directory(), StoreFile.NODE_STORE.fileName( StoreFileType.ID ) );
-        IdGeneratorImpl idGenerator = new IdGeneratorImpl( fileSystemRule.get(), nodeIdFile, 10, 10_000, false, () -> highId );
+        IdGeneratorImpl idGenerator = new IdGeneratorImpl( fileSystemRule.get(), nodeIdFile, 10, 10_000, false,
+                IdType.NODE, () -> highId );
         for ( long id = 0; id < 15; id++ )
         {
             idGenerator.freeId( id );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorImplContractTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorImplContractTest.java
@@ -19,16 +19,17 @@
  */
 package org.neo4j.kernel.impl.store;
 
-import java.io.File;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.RuleChain;
 
+import java.io.File;
+
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.kernel.impl.store.id.IdGenerator;
 import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
+import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 
@@ -60,7 +61,7 @@ public class IdGeneratorImplContractTest extends IdGeneratorContractTest
     @Override
     protected IdGenerator openIdGenerator( int grabSize )
     {
-        return new IdGeneratorImpl( fs, idGeneratorFile(), grabSize, 1000, false, () -> 0L );
+        return new IdGeneratorImpl( fs, idGeneratorFile(), grabSize, 1000, false, IdType.NODE, () -> 0L );
     }
 
     @After

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/IdGeneratorTest.java
@@ -54,6 +54,7 @@ import org.neo4j.kernel.impl.store.format.standard.RelationshipRecordFormat;
 import org.neo4j.kernel.impl.store.format.standard.Standard;
 import org.neo4j.kernel.impl.store.id.IdGenerator;
 import org.neo4j.kernel.impl.store.id.IdGeneratorImpl;
+import org.neo4j.kernel.impl.store.id.IdType;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.rule.PageCacheRule;
@@ -113,21 +114,21 @@ public class IdGeneratorTest
     public void grabSizeCannotBeZero() throws Exception
     {
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-        new IdGeneratorImpl( fs, idGeneratorFile(), 0, 100, false, () -> 0L ).close();
+        new IdGeneratorImpl( fs, idGeneratorFile(), 0, 100, false, IdType.NODE, () -> 0L ).close();
     }
 
     @Test( expected = IllegalArgumentException.class )
     public void grabSizeCannotBeNegative() throws Exception
     {
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-        new IdGeneratorImpl( fs, idGeneratorFile(), -1, 100, false, () -> 0L ).close();
+        new IdGeneratorImpl( fs, idGeneratorFile(), -1, 100, false, IdType.NODE, () -> 0L ).close();
     }
 
     @Test( expected = IllegalStateException.class )
     public void createIdGeneratorMustRefuseOverwritingExistingFile() throws IOException
     {
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1008, 1000, false, () -> 0L );
+        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1008, 1000, false, IdType.NODE, () -> 0L );
         try
         {
             IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, true );
@@ -167,12 +168,12 @@ public class IdGeneratorTest
     public void mustOverwriteExistingFileIfRequested() throws Exception
     {
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1008, 1000, false, () -> 0L );
+        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1008, 1000, false, IdType.NODE, () -> 0L );
         long[] firstFirstIds = new long[]{idGenerator.nextId(), idGenerator.nextId(), idGenerator.nextId()};
         idGenerator.close();
 
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-        idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1008, 1000, false, () -> 0L );
+        idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1008, 1000, false, IdType.NODE, () -> 0L );
         long[] secondFirstIds = new long[]{idGenerator.nextId(), idGenerator.nextId(), idGenerator.nextId()};
         idGenerator.close();
 
@@ -186,10 +187,10 @@ public class IdGeneratorTest
         try
         {
             IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-            IdGenerator idGen = new IdGeneratorImpl( fs, idGeneratorFile(), 3, 1000, false, () -> 0L );
+            IdGenerator idGen = new IdGeneratorImpl( fs, idGeneratorFile(), 3, 1000, false, IdType.NODE, () -> 0L );
             try
             {
-                new IdGeneratorImpl( fs, idGeneratorFile(), 3, 1000, false, () -> 0L );
+                new IdGeneratorImpl( fs, idGeneratorFile(), 3, 1000, false, IdType.NODE, () -> 0L );
                 fail( "Opening sticky id generator should throw exception" );
             }
             catch ( StoreFailureException e )
@@ -213,7 +214,7 @@ public class IdGeneratorTest
         try
         {
             IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-            IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 3, 1000, false, () -> 0L );
+            IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 3, 1000, false, IdType.NODE, () -> 0L );
             for ( long i = 0; i < 7; i++ )
             {
                 assertEquals( i, idGenerator.nextId() );
@@ -224,7 +225,7 @@ public class IdGeneratorTest
             assertEquals( 7L, idGenerator.nextId() );
             idGenerator.freeId( 6 );
             closeIdGenerator( idGenerator );
-            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 5, 1000, false, () -> 0L );
+            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 5, 1000, false, IdType.NODE, () -> 0L );
             idGenerator.freeId( 2 );
             idGenerator.freeId( 4 );
             assertEquals( 1L, idGenerator.nextId() );
@@ -240,7 +241,7 @@ public class IdGeneratorTest
             assertEquals( 9L, idGenerator.nextId() );
             idGenerator.freeId( 9 );
             closeIdGenerator( idGenerator );
-            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 3, 1000, false, () -> 0L );
+            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 3, 1000, false, IdType.NODE, () -> 0L );
             assertEquals( 6L, idGenerator.nextId() );
             assertEquals( 8L, idGenerator.nextId() );
             assertEquals( 9L, idGenerator.nextId() );
@@ -269,7 +270,7 @@ public class IdGeneratorTest
         try
         {
             IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-            IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 3, 1000, false, () -> 0L );
+            IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 3, 1000, false, IdType.NODE, () -> 0L );
             for ( long i = 0; i < 7; i++ )
             {
                 assertEquals( i, idGenerator.nextId() );
@@ -295,12 +296,12 @@ public class IdGeneratorTest
                 idGenerator.freeId( i );
             }
             closeIdGenerator( idGenerator );
-            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 2, 1000, false, () -> 0L );
+            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 2, 1000, false, IdType.NODE, () -> 0L );
             assertEquals( 5L, idGenerator.nextId() );
             assertEquals( 6L, idGenerator.nextId() );
             assertEquals( 3L, idGenerator.nextId() );
             closeIdGenerator( idGenerator );
-            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 30, 1000, false, () -> 0L );
+            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 30, 1000, false, IdType.NODE, () -> 0L );
 
             assertEquals( 0L, idGenerator.nextId() );
             assertEquals( 1L, idGenerator.nextId() );
@@ -324,7 +325,7 @@ public class IdGeneratorTest
         try
         {
             IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-            IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 2, 1000, false, () -> 0L );
+            IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 2, 1000, false, IdType.NODE, () -> 0L );
             closeIdGenerator( idGenerator );
             try
             {
@@ -342,7 +343,7 @@ public class IdGeneratorTest
             catch ( IllegalStateException e )
             { // good
             }
-            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 2, 1000, false, () -> 0L );
+            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 2, 1000, false, IdType.NODE, () -> 0L );
             assertEquals( 0L, idGenerator.nextId() );
             assertEquals( 1L, idGenerator.nextId() );
             assertEquals( 2L, idGenerator.nextId() );
@@ -381,7 +382,7 @@ public class IdGeneratorTest
         try
         {
             IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-            IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 128, capacity * 2, false, () -> 0L );
+            IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 128, capacity * 2, false, IdType.NODE, () -> 0L );
             for ( int i = 0; i < capacity; i++ )
             {
                 idGenerator.nextId();
@@ -393,7 +394,7 @@ public class IdGeneratorTest
                 freedIds.put( i, this );
             }
             closeIdGenerator( idGenerator );
-            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 2000, capacity * 2, false, () -> 0L );
+            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 2000, capacity * 2, false, IdType.NODE, () -> 0L );
             long oldId = -1;
             for ( int i = 0; i < capacity - 1; i += 2 )
             {
@@ -418,7 +419,7 @@ public class IdGeneratorTest
         try
         {
             IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-            IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 128, capacity * 2, false, () -> 0L );
+            IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 128, capacity * 2, false, IdType.NODE, () -> 0L );
             for ( int i = 0; i < capacity; i++ )
             {
                 idGenerator.nextId();
@@ -430,7 +431,7 @@ public class IdGeneratorTest
                 freedIds.put( i, this );
             }
             closeIdGenerator( idGenerator );
-            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 2000, capacity * 2, false, () -> 0L );
+            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 2000, capacity * 2, false, IdType.NODE, () -> 0L );
             for ( int i = 0; i < capacity; i += 2 )
             {
                 assertEquals( this, freedIds.remove( idGenerator.nextId() ) );
@@ -455,7 +456,7 @@ public class IdGeneratorTest
         int capacity = random.nextInt( 1024 ) + 1024;
         int grabSize = random.nextInt( 128 ) + 128;
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), grabSize, capacity * 2, false, () -> 0L );
+        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), grabSize, capacity * 2, false, IdType.NODE, () -> 0L );
         List<Long> idsTaken = new ArrayList<>();
         float releaseIndex = 0.25f;
         float closeIndex = 0.05f;
@@ -479,7 +480,7 @@ public class IdGeneratorTest
                 {
                     closeIdGenerator( idGenerator );
                     grabSize = random.nextInt( 128 ) + 128;
-                    idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), grabSize, capacity * 2, false, () -> 0L );
+                    idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), grabSize, capacity * 2, false, IdType.NODE, () -> 0L );
                 }
             }
             closeIdGenerator( idGenerator );
@@ -502,7 +503,7 @@ public class IdGeneratorTest
             PropertyKeyTokenRecordFormat recordFormat = new PropertyKeyTokenRecordFormat();
             IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
             IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1,
-                    recordFormat.getMaxId(), false, () -> 0L );
+                    recordFormat.getMaxId(), false, IdType.NODE, () -> 0L );
             idGenerator.setHighId( recordFormat.getMaxId() );
             long id = idGenerator.nextId();
             assertEquals( recordFormat.getMaxId(), id );
@@ -516,7 +517,7 @@ public class IdGeneratorTest
             { // good, capacity exceeded
             }
             closeIdGenerator( idGenerator );
-            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, recordFormat.getMaxId(), false, () -> 0L );
+            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, recordFormat.getMaxId(), false, IdType.NODE, () -> 0L );
             assertEquals( recordFormat.getMaxId() + 1, idGenerator.getHighId() );
             id = idGenerator.nextId();
             assertEquals( recordFormat.getMaxId(), id );
@@ -563,7 +564,7 @@ public class IdGeneratorTest
         deleteIdGeneratorFile();
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
         long maxValue = format.getMaxId();
-        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, maxValue - 1, false, () -> 0L );
+        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, maxValue - 1, false, IdType.NODE, () -> 0L );
         long id = maxValue - 2;
         idGenerator.setHighId( id );
         assertEquals( id, idGenerator.nextId() );
@@ -591,7 +592,7 @@ public class IdGeneratorTest
     {
         deleteIdGeneratorFile();
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, format.getMaxId(), false, () -> 0L );
+        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, format.getMaxId(), false, IdType.NODE, () -> 0L );
         long id = (long) Math.pow( 2, 32 ) - 3;
         idGenerator.setHighId( id );
         assertEquals( id, idGenerator.nextId() );
@@ -607,7 +608,7 @@ public class IdGeneratorTest
     public void makeSureMagicMinusOneCannotBeReturnedEvenIfFreed() throws Exception
     {
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, new NodeRecordFormat().getMaxId(), false, () -> 0L );
+        IdGenerator idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, new NodeRecordFormat().getMaxId(), false, IdType.NODE, () -> 0L );
         long magicMinusOne = (long) Math.pow( 2, 32 ) - 1;
         idGenerator.setHighId( magicMinusOne );
         assertEquals( magicMinusOne + 1, idGenerator.nextId() );
@@ -615,7 +616,7 @@ public class IdGeneratorTest
         idGenerator.freeId( magicMinusOne );
         closeIdGenerator( idGenerator );
 
-        idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, new NodeRecordFormat().getMaxId(), false, () -> 0L );
+        idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 1, new NodeRecordFormat().getMaxId(), false, IdType.NODE, () -> 0L );
         assertEquals( magicMinusOne - 1, idGenerator.nextId() );
         assertEquals( magicMinusOne + 2, idGenerator.nextId() );
         closeIdGenerator( idGenerator );
@@ -693,7 +694,7 @@ public class IdGeneratorTest
     public void delete() throws Exception
     {
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-        IdGeneratorImpl idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 10, 1000, false, () -> 0L );
+        IdGeneratorImpl idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 10, 1000, false, IdType.NODE, () -> 0L );
         long id = idGenerator.nextId();
         idGenerator.nextId();
         idGenerator.freeId( id );
@@ -701,7 +702,7 @@ public class IdGeneratorTest
         idGenerator.delete();
         assertFalse( idGeneratorFile().exists() );
         IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
-        idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 10, 1000, false, () -> 0L );
+        idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), 10, 1000, false, IdType.NODE, () -> 0L );
         assertEquals( id, idGenerator.nextId() );
         idGenerator.close();
     }
@@ -715,7 +716,7 @@ public class IdGeneratorTest
             IdGeneratorImpl.createGenerator( fs, idGeneratorFile(), 0, false );
             final int grabSize = 10;
             int rounds = 10;
-            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), grabSize, 1000, true, () -> 0L );
+            idGenerator = new IdGeneratorImpl( fs, idGeneratorFile(), grabSize, 1000, true, IdType.NODE, () -> 0L );
 
             for ( int i = 0; i < rounds; i++ )
             {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NodeStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NodeStoreTest.java
@@ -19,6 +19,12 @@
  */
 package org.neo4j.kernel.impl.store;
 
+import org.apache.commons.lang3.mutable.MutableBoolean;
+import org.junit.After;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -28,12 +34,6 @@ import java.util.Collections;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 import java.util.stream.LongStream;
-
-import org.apache.commons.lang3.mutable.MutableBoolean;
-import org.junit.After;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
 
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveLongSet;
@@ -375,9 +375,9 @@ public class NodeStoreTest
         {
             @Override
             protected IdGenerator instantiate( FileSystemAbstraction fs, File fileName, int grabSize, long maxValue,
-                    boolean aggressiveReuse, Supplier<Long> highId )
+                    boolean aggressiveReuse, IdType idType, Supplier<Long> highId )
             {
-                return spy( super.instantiate( fs, fileName, grabSize, maxValue, aggressiveReuse, highId ) );
+                return spy( super.instantiate( fs, fileName, grabSize, maxValue, aggressiveReuse, idType, highId ) );
             }
         } );
         StoreFactory factory = new StoreFactory( storeDir, Config.defaults(), idGeneratorFactory, pageCache, fs,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/IdGeneratorImplTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/IdGeneratorImplTest.java
@@ -19,22 +19,20 @@
  */
 package org.neo4j.kernel.impl.store.id;
 
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 import java.io.File;
 import java.util.function.Supplier;
 
-import org.junit.Rule;
-import org.junit.Test;
-
 import org.neo4j.kernel.impl.store.id.validation.IdCapacityExceededException;
 import org.neo4j.kernel.impl.store.id.validation.NegativeIdException;
-import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -45,7 +43,8 @@ public class IdGeneratorImplTest
     @Rule
     public final EphemeralFileSystemRule fsr = new EphemeralFileSystemRule();
     @Rule
-    public final TestDirectory testDirectory = TestDirectory.testDirectory();
+    public ExpectedException expectedException = ExpectedException.none();
+
     private final File file = new File( "ids" );
 
     @Test
@@ -53,18 +52,12 @@ public class IdGeneratorImplTest
     {
         // GIVEN
         IdGeneratorImpl.createGenerator( fsr.get(), file, 0, false );
-        IdGenerator idGenerator = new IdGeneratorImpl( fsr.get(), file, 100, 100, false, () -> 0L );
+        IdGenerator idGenerator = new IdGeneratorImpl( fsr.get(), file, 100, 100, false, IdType.NODE, () -> 0L );
+
+        expectedException.expect( NegativeIdException.class );
 
         // WHEN
-        try
-        {
-            idGenerator.setHighId( -1 );
-            fail( "Should have failed" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( NegativeIdException.class ) );
-        }
+        idGenerator.setHighId( -1 );
     }
 
     @Test
@@ -72,22 +65,17 @@ public class IdGeneratorImplTest
     {
         long maxId = 10;
         IdGeneratorImpl.createGenerator( fsr.get(), file, 0, false );
-        IdGenerator idGenerator = new IdGeneratorImpl( fsr.get(), file, 1, maxId, false, () -> 0L );
+        IdGenerator idGenerator = new IdGeneratorImpl( fsr.get(), file, 1, maxId, false, IdType.NODE, () -> 0L );
 
         for ( long i = 0; i <= maxId; i++ )
         {
             idGenerator.nextId();
         }
 
-        try
-        {
-            idGenerator.nextId();
-            fail( "Should have failed" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( IdCapacityExceededException.class ) );
-        }
+        expectedException.expect( IdCapacityExceededException.class );
+        expectedException.expectMessage( "Maximum id limit for NODE has been reached. Generated id 11 is out of " +
+                "permitted range [0, 10]." );
+        idGenerator.nextId();
     }
 
     @Test
@@ -95,17 +83,11 @@ public class IdGeneratorImplTest
     {
         long maxId = 10;
         IdGeneratorImpl.createGenerator( fsr.get(), file, 0, false );
-        IdGenerator idGenerator = new IdGeneratorImpl( fsr.get(), file, 1, maxId, false, () -> 0L );
+        IdGenerator idGenerator = new IdGeneratorImpl( fsr.get(), file, 1, maxId, false, IdType.RELATIONSHIP_TYPE_TOKEN, () -> 0L );
 
-        try
-        {
-            idGenerator.setHighId( maxId + 1 );
-            fail( "Should have failed" );
-        }
-        catch ( Exception e )
-        {
-            assertThat( e, instanceOf( IdCapacityExceededException.class ) );
-        }
+        expectedException.expect( IdCapacityExceededException.class );
+        expectedException.expectMessage( "Maximum id limit for RELATIONSHIP_TYPE_TOKEN has been reached. Generated id 11 is out of permitted range [0, 10]." );
+        idGenerator.setHighId( maxId + 1 );
     }
 
     /**
@@ -116,7 +98,7 @@ public class IdGeneratorImplTest
     public void highIdCouldBeSetToReservedId()
     {
         IdGeneratorImpl.createGenerator( fsr.get(), file, 0, false );
-        IdGenerator idGenerator = new IdGeneratorImpl( fsr.get(), file, 1, Long.MAX_VALUE, false, () -> 0L );
+        IdGenerator idGenerator = new IdGeneratorImpl( fsr.get(), file, 1, Long.MAX_VALUE, false, IdType.NODE, () -> 0L );
 
         idGenerator.setHighId( IdGeneratorImpl.INTEGER_MINUS_ONE );
 
@@ -127,12 +109,12 @@ public class IdGeneratorImplTest
     public void correctDefragCountWhenHaveIdsInFile()
     {
         IdGeneratorImpl.createGenerator( fsr.get(), file, 100, false );
-        IdGenerator idGenerator = new IdGeneratorImpl( fsr.get(), file, 100, 100, true, () -> 100L );
+        IdGenerator idGenerator = new IdGeneratorImpl( fsr.get(), file, 100, 100, true, IdType.NODE, () -> 100L );
 
         idGenerator.freeId( 5 );
         idGenerator.close();
 
-        IdGenerator reloadedIdGenerator = new IdGeneratorImpl( fsr.get(), file, 100, 100, true, () -> 100L );
+        IdGenerator reloadedIdGenerator = new IdGeneratorImpl( fsr.get(), file, 100, 100, true, IdType.NODE, () -> 100L );
         assertEquals( 1, reloadedIdGenerator.getDefragCount() );
         assertEquals( 5, reloadedIdGenerator.nextId() );
         assertEquals( 0, reloadedIdGenerator.getDefragCount() );
@@ -157,12 +139,12 @@ public class IdGeneratorImplTest
     {
         // Given
         IdGeneratorImpl.createGenerator( fsr.get(), file, 42, false );
-        IdGeneratorImpl idGenerator = new IdGeneratorImpl( fsr.get(), file, 100, 100, false, () -> 42L );
+        IdGeneratorImpl idGenerator = new IdGeneratorImpl( fsr.get(), file, 100, 100, false, IdType.NODE, () -> 42L );
 
         idGenerator.close();
 
         // When
-        idGenerator = new IdGeneratorImpl( fsr.get(), file, 100, 100, false, () -> 0L );
+        idGenerator = new IdGeneratorImpl( fsr.get(), file, 100, 100, false, IdType.NODE, () -> 0L );
 
         // Then
         assertThat( idGenerator.getHighId(), equalTo( 42L ) );
@@ -179,7 +161,7 @@ public class IdGeneratorImplTest
 
         // Wheb
         // The id generator is started
-        IdGeneratorImpl idGenerator = new IdGeneratorImpl( fsr.get(), file, 100, 100, false, highId );
+        IdGeneratorImpl idGenerator = new IdGeneratorImpl( fsr.get(), file, 100, 100, false, IdType.NODE, highId );
 
         // Then
         // The highId supplier must have been called to get the high id
@@ -199,7 +181,7 @@ public class IdGeneratorImplTest
 
         // When
         // An IdGenerator is created over the previous properly closed file
-        IdGenerator idGenerator = new IdGeneratorImpl( fsr.get(), file, 100, 100, false, highId );
+        IdGenerator idGenerator = new IdGeneratorImpl( fsr.get(), file, 100, 100, false, IdType.NODE, highId );
         idGenerator.close();
 
         // Then


### PR DESCRIPTION
Include idType into exception message for IdCapacityExceededException
for the user to be able to see what kind of entities actually can't be created.