### PR TITLE
New cache for in-flight Raft entries

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
@@ -28,6 +28,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.logging.Level;
 
+import org.neo4j.causalclustering.core.consensus.log.cache.InFlightCacheFactory;
 import org.neo4j.configuration.Description;
 import org.neo4j.configuration.Internal;
 import org.neo4j.configuration.LoadableConfig;
@@ -123,6 +124,19 @@ public class CausalClusteringSettings implements LoadableConfig
     public static final Setting<List<AdvertisedSocketAddress>> initial_discovery_members =
             setting( "causal_clustering.initial_discovery_members", list( ",", ADVERTISED_SOCKET_ADDRESS ),
                     NO_DEFAULT );
+
+    @Description( "Type of in-flight cache." )
+    public static final Setting<InFlightCacheFactory.Type> in_flight_cache_type =
+            setting( "causal_clustering.in_flight_cache.type", options( InFlightCacheFactory.Type.class, true ),
+                    InFlightCacheFactory.Type.CONSECUTIVE.name() );
+
+    @Description( "The maximum number of entries in the in-flight cache." )
+    public static final Setting<Integer> in_flight_cache_max_entries =
+            setting( "causal_clustering.in_flight_cache.max_entries", INTEGER, "1024" );
+
+    @Description( "The maximum number of bytes in the in-flight cache." )
+    public static final Setting<Long> in_flight_cache_max_bytes =
+            setting( "causal_clustering.in_flight_cache.max_bytes", BYTES, "2G" );
 
     public enum DiscoveryType
     {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/CircularBuffer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/CircularBuffer.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.consensus.log.cache;
+
+import static java.lang.Math.floorMod;
+import static java.util.Arrays.fill;
+
+/**
+ * <pre>
+ * Design
+ *
+ * S: start index
+ * E: end index
+ *
+ * When S == E the buffer is empty.
+ *
+ * Examples:
+ *
+ *              S
+ *              v
+ * Empty   [ | | | | | | ]
+ *              ^
+ *              E
+ *
+ *
+ *                S
+ *                v
+ * Size 2  [ | | | | | | ]
+ *                    ^
+ *                    E
+ *
+ *
+ *                 S
+ *                 v
+ * Full   [ | | | | | | ]
+ *               ^
+ *               E
+ *
+ * New items are put at the current E, and then E is moved one step forward (circularly).
+ * The item at E is never a valid item.
+ *
+ * If moving E one step forward moves it onto S
+ * - then it knocks an element out
+ * - and S is also moved one step forward
+ *
+ * The S element has index 0.
+ * Removing an element moves S forward (circularly).
+ *
+ * @param <V> type of elements.
+ */
+public class CircularBuffer<V>
+{
+    private final int arraySize; // externally visible capacity is arraySize - 1
+    private Object[] elementArr;
+
+    private int S;
+    private int E;
+
+    CircularBuffer( int capacity )
+    {
+        if ( capacity <= 0 )
+        {
+            throw new IllegalArgumentException( "Capacity must be > 0." );
+        }
+
+        this.arraySize = capacity + 1; // 1 item as sentinel (can't hold entries)
+        this.elementArr = new Object[arraySize];
+    }
+
+    /**
+     * Clears the underlying buffer and fills the provided eviction array with all evicted elements.
+     * The provided array must have the same capacity as the circular buffer.
+     *
+     * @param evictions Caller-provided array for evictions.
+     */
+    public void clear( V[] evictions )
+    {
+        if ( evictions.length != arraySize - 1 )
+        {
+            throw new IllegalArgumentException( "The eviction array must be of the same size as the capacity of the circular buffer." );
+        }
+
+        int i = 0;
+        while ( S != E )
+        {
+            //noinspection unchecked
+            evictions[i++] = (V) elementArr[S];
+            S = pos( S, 1 );
+        }
+
+        S = 0;
+        E = 0;
+
+        fill( elementArr, null );
+    }
+
+    private int pos( int base, int delta )
+    {
+        return floorMod( base + delta, arraySize );
+    }
+
+    /**
+     * Append to the end of the buffer, possibly overwriting the
+     * oldest entry.
+     *
+     * @return any knocked out item, or null if nothing was knocked out.
+     */
+    public V append( V e )
+    {
+        elementArr[E] = e;
+        E = pos( E, 1 );
+        if ( E == S )
+        {
+            //noinspection unchecked
+            V old = (V) elementArr[E];
+            elementArr[E] = null;
+            S = pos( S, 1 );
+            return old;
+        }
+        else
+        {
+            return null;
+        }
+    }
+
+    public V read( int idx )
+    {
+        //noinspection unchecked
+        return (V) elementArr[pos( S, idx )];
+    }
+
+    public V remove()
+    {
+        if ( S == E )
+        {
+            return null;
+        }
+        //noinspection unchecked
+        V e = (V) elementArr[S];
+        elementArr[S] = null;
+        S = pos( S, 1 );
+        return e;
+    }
+
+    public V removeHead()
+    {
+        if ( S == E )
+        {
+            return null;
+        }
+
+        E = pos( E, -1 );
+        //noinspection unchecked
+        V e = (V) elementArr[E];
+        elementArr[E] = null;
+        return e;
+    }
+
+    public int size()
+    {
+        return floorMod( E - S, arraySize );
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/ConsecutiveCache.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/ConsecutiveCache.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.consensus.log.cache;
+
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
+
+/**
+ * Keeps elements over a limited consecutive range cached.
+ *
+ * @param <V> The type of element to cache.
+ */
+class ConsecutiveCache<V>
+{
+    private final CircularBuffer<V> circle;
+    private long endIndex = -1;
+
+    ConsecutiveCache( int capacity )
+    {
+        this.circle = new CircularBuffer<>( capacity );
+    }
+
+    private long firstIndex()
+    {
+        return endIndex - circle.size() + 1;
+    }
+
+    void put( long idx, V e, V[] evictions )
+    {
+        if ( idx < 0 )
+        {
+            throw new IllegalArgumentException( format( "Index must be >= 0 (was %d)", idx ) );
+        }
+        if ( e == null )
+        {
+            throw new IllegalArgumentException( "Null entries are not accepted" );
+        }
+
+        if ( idx == endIndex + 1 )
+        {
+            evictions[0] = circle.append( e );
+            endIndex = endIndex + 1;
+        }
+        else
+        {
+            circle.clear( evictions );
+            circle.append( e );
+            endIndex = idx;
+        }
+    }
+
+    V get( long idx )
+    {
+        if ( idx < 0 )
+        {
+            throw new IllegalArgumentException( format( "Index must be >= 0 (was %d)", idx ) );
+        }
+
+        if ( idx > endIndex || idx < firstIndex() )
+        {
+            return null;
+        }
+
+        return circle.read( toIntExact( idx - firstIndex() ) );
+    }
+
+    public void clear( V[] evictions )
+    {
+        circle.clear( evictions );
+    }
+
+    public int size()
+    {
+        return circle.size();
+    }
+
+    public void prune( long upToIndex, V[] evictions )
+    {
+        long index = firstIndex();
+        int i = 0;
+        while ( index <= min( upToIndex, endIndex ) )
+        {
+            evictions[i] = circle.remove();
+            assert evictions[i] != null;
+            i++;
+            index++;
+        }
+    }
+
+    public V remove()
+    {
+        return circle.remove();
+    }
+
+    public void truncate( long fromIndex, V[] evictions )
+    {
+        if ( fromIndex > endIndex )
+        {
+            return;
+        }
+        long index = max( fromIndex, firstIndex() );
+        int i = 0;
+        while ( index <= endIndex )
+        {
+            evictions[i++] = circle.removeHead();
+            index++;
+        }
+        endIndex = fromIndex - 1;
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/ConsecutiveInFlightCache.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/ConsecutiveInFlightCache.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.consensus.log.cache;
+
+import org.neo4j.causalclustering.core.consensus.log.RaftLogEntry;
+import org.neo4j.causalclustering.core.state.machines.tx.CoreReplicatedContent;
+
+/**
+ * A cache that keeps Raft log entries in memory, generally to bridge the gap
+ * between the time that a Raft log is being appended to the local Raft log and
+ * at a later time applied to the store. This cache optimises for the up-to-date
+ * case and does not cater specifically for lagging followers. It is better to let
+ * those catch up from entries read from disk where possible.
+ * <p>
+ * The cache relies on highly efficient underlying data structures (a circular
+ * buffer) and also allows on to specify a maximum bound on the number of entries
+ * as well as their total size where known, see {@link CoreReplicatedContent#hasSize()}.
+ */
+public class ConsecutiveInFlightCache implements InFlightCache
+{
+    private final ConsecutiveCache<RaftLogEntry> cache;
+    private final RaftLogEntry[] evictions;
+    private final InFlightCacheMonitor monitor;
+
+    private long totalBytes;
+    private long maxBytes;
+    private boolean enabled;
+
+    public ConsecutiveInFlightCache()
+    {
+        this( 1024, 8 * 1024 * 1024, InFlightCacheMonitor.VOID, true );
+    }
+
+    public ConsecutiveInFlightCache( int capacity, long maxBytes, InFlightCacheMonitor monitor, boolean enabled )
+    {
+        this.cache = new ConsecutiveCache<>( capacity );
+        this.evictions = new RaftLogEntry[capacity];
+
+        this.maxBytes = maxBytes;
+        this.monitor = monitor;
+        this.enabled = enabled;
+
+        monitor.setMaxBytes( maxBytes );
+        monitor.setMaxElements( capacity );
+    }
+
+    @Override
+    public synchronized void enable()
+    {
+        enabled = true;
+    }
+
+    @Override
+    public synchronized void put( long logIndex, RaftLogEntry entry )
+    {
+        if ( !enabled )
+        {
+            return;
+        }
+
+        totalBytes += sizeOf( entry );
+        cache.put( logIndex, entry, evictions );
+        processEvictions();
+
+        while ( totalBytes > maxBytes )
+        {
+            RaftLogEntry evicted = cache.remove();
+            totalBytes -= sizeOf( evicted );
+        }
+    }
+
+    @Override
+    public synchronized RaftLogEntry get( long logIndex )
+    {
+        if ( !enabled )
+        {
+            return null;
+        }
+
+        RaftLogEntry entry = cache.get( logIndex );
+
+        if ( entry == null )
+        {
+            monitor.miss();
+        }
+        else
+        {
+            monitor.hit();
+        }
+
+        return entry;
+    }
+
+    @Override
+    public synchronized void truncate( long fromIndex )
+    {
+        if ( !enabled )
+        {
+            return;
+        }
+
+        cache.truncate( fromIndex, evictions );
+        processEvictions();
+    }
+
+    @Override
+    public synchronized void prune( long upToIndex )
+    {
+        if ( !enabled )
+        {
+            return;
+        }
+
+        cache.prune( upToIndex, evictions );
+        processEvictions();
+    }
+
+    @Override
+    public synchronized long totalBytes()
+    {
+        return totalBytes;
+    }
+
+    @Override
+    public synchronized int elementCount()
+    {
+        return cache.size();
+    }
+
+    private long sizeOf( RaftLogEntry entry )
+    {
+        return entry.content().hasSize() ? entry.content().size() : 0;
+    }
+
+    private void processEvictions()
+    {
+        for ( int i = 0; i < evictions.length; i++ )
+        {
+            RaftLogEntry entry = evictions[i];
+            if ( entry == null )
+            {
+                break;
+            }
+            evictions[i] = null;
+            totalBytes -= sizeOf( entry );
+        }
+
+        monitor.setTotalBytes( totalBytes );
+        monitor.setElementCount( cache.size() );
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/InFlightCache.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/InFlightCache.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.consensus.log.cache;
+
+import org.neo4j.causalclustering.core.consensus.log.RaftLogEntry;
+
+/**
+ * A cache for in-flight entries which also tracks the size of the cache.
+ */
+public interface InFlightCache
+{
+    /**
+     * Enables the cache.
+     */
+    void enable();
+
+    /**
+     * Put item into the cache.
+     *
+     * @param logIndex the index of the log entry.
+     * @param entry the Raft log entry.
+     */
+    void put( long logIndex, RaftLogEntry entry );
+
+    /**
+     * Get item from the cache.
+     *
+     * @param logIndex the index of the log entry.
+     * @return the log entry.
+     */
+    RaftLogEntry get( long logIndex );
+
+    /**
+     * Disposes of a range of elements from the tail of the consecutive cache.
+     *
+     * @param fromIndex the index to start from (inclusive).
+     */
+    void truncate( long fromIndex );
+
+    /**
+     * Prunes items from the cache.
+     *
+     * @param upToIndex the last index to prune (inclusive).
+     */
+    void prune( long upToIndex );
+
+    /**
+     * @return the amount of data in the cache.
+     */
+    long totalBytes();
+
+    /**
+     * @return the number of log entries in the cache.
+     */
+    int elementCount();
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/InFlightCacheFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/InFlightCacheFactory.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.consensus.log.cache;
+
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.monitoring.Monitors;
+
+import static org.neo4j.causalclustering.core.CausalClusteringSettings.in_flight_cache_max_bytes;
+import static org.neo4j.causalclustering.core.CausalClusteringSettings.in_flight_cache_max_entries;
+
+public class InFlightCacheFactory
+{
+    public static InFlightCache create( Config config, Monitors monitors )
+    {
+        return config.get( CausalClusteringSettings.in_flight_cache_type ).create( config, monitors );
+    }
+
+    public enum Type
+    {
+        NONE
+                {
+                    @Override
+                    InFlightCache create( Config config, Monitors monitors )
+                    {
+                        return new VoidInFlightCache();
+                    }
+                },
+        CONSECUTIVE
+                {
+                    @Override
+                    InFlightCache create( Config config, Monitors monitors )
+                    {
+                        return new ConsecutiveInFlightCache( config.get( in_flight_cache_max_entries ), config.get( in_flight_cache_max_bytes ),
+                                monitors.newMonitor( InFlightCacheMonitor.class ), false );
+                    }
+                },
+        UNBOUNDED
+                {
+                    @Override
+                    InFlightCache create( Config config, Monitors monitors )
+                    {
+                        return new UnboundedInFlightCache();
+                    }
+                };
+
+        abstract InFlightCache create( Config config, Monitors monitors );
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/InFlightCacheMonitor.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/InFlightCacheMonitor.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.consensus.log.cache;
+
+public interface InFlightCacheMonitor
+{
+    InFlightCacheMonitor VOID = new InFlightCacheMonitor()
+    {
+        @Override
+        public void miss()
+        {
+        }
+
+        @Override
+        public void hit()
+        {
+
+        }
+
+        @Override
+        public void setMaxBytes( long maxBytes )
+        {
+
+        }
+
+        @Override
+        public void setTotalBytes( long totalBytes )
+        {
+
+        }
+
+        @Override
+        public void setMaxElements( int maxElements )
+        {
+
+        }
+
+        @Override
+        public void setElementCount( int elementCount )
+        {
+
+        }
+    };
+
+    void miss();
+
+    void hit();
+
+    void setMaxBytes( long maxBytes );
+
+    void setTotalBytes( long totalBytes );
+
+    void setMaxElements( int maxElements );
+
+    void setElementCount( int elementCount );
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/UnboundedInFlightCache.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/UnboundedInFlightCache.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.consensus.log.cache;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.neo4j.causalclustering.core.consensus.log.RaftLogEntry;
+
+/**
+ * This cache is not meant for production use, but it can be useful
+ * in various investigative circumstances.
+ */
+public class UnboundedInFlightCache implements InFlightCache
+{
+    private Map<Long,RaftLogEntry> map = new HashMap<>();
+    private boolean enabled;
+
+    @Override
+    public synchronized void enable()
+    {
+        enabled = true;
+    }
+
+    @Override
+    public synchronized void put( long logIndex, RaftLogEntry entry )
+    {
+        if ( !enabled )
+        {
+            return;
+        }
+
+        map.put( logIndex, entry );
+    }
+
+    @Override
+    public synchronized RaftLogEntry get( long logIndex )
+    {
+        if ( !enabled )
+        {
+            return null;
+        }
+
+        return map.get( logIndex );
+    }
+
+    @Override
+    public synchronized void truncate( long fromIndex )
+    {
+        if ( !enabled )
+        {
+            return;
+        }
+
+        map.keySet().removeIf( idx -> idx >= fromIndex );
+    }
+
+    @Override
+    public synchronized void prune( long upToIndex )
+    {
+        if ( !enabled )
+        {
+            return;
+        }
+
+        map.keySet().removeIf( idx -> idx <= upToIndex );
+    }
+
+    @Override
+    public synchronized long totalBytes()
+    {
+        // not updated correctly
+        return 0;
+    }
+
+    @Override
+    public synchronized int elementCount()
+    {
+        // not updated correctly
+        return 0;
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/VoidInFlightCache.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/log/cache/VoidInFlightCache.java
@@ -17,27 +17,53 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.causalclustering.core.consensus.outcome;
+package org.neo4j.causalclustering.core.consensus.log.cache;
 
-import java.io.IOException;
-
-import org.neo4j.causalclustering.core.consensus.log.cache.InFlightCache;
-import org.neo4j.causalclustering.core.consensus.log.RaftLog;
 import org.neo4j.causalclustering.core.consensus.log.RaftLogEntry;
-import org.neo4j.logging.Log;
 
-public interface RaftLogCommand
+/**
+ * A cache which caches nothing. This means that all lookups
+ * will go to the on-disk Raft log, which might be quite good
+ * anyway since recently written items will be in OS page cache
+ * memory generally. But it will incur an unmarshalling overhead.
+ */
+public class VoidInFlightCache implements InFlightCache
 {
-    interface Handler
+    @Override
+    public void enable()
     {
-        void append( long baseIndex, RaftLogEntry... entries ) throws IOException;
-        void truncate( long fromIndex ) throws IOException;
-        void prune( long pruneIndex );
     }
 
-    void dispatch( Handler handler ) throws IOException;
+    @Override
+    public void put( long logIndex, RaftLogEntry entry )
+    {
+    }
 
-    void applyTo( RaftLog raftLog, Log log ) throws IOException;
+    @Override
+    public RaftLogEntry get( long logIndex )
+    {
+        return null;
+    }
 
-    void applyTo( InFlightCache inFlightCache, Log log ) throws IOException;
+    @Override
+    public void truncate( long fromIndex )
+    {
+    }
+
+    @Override
+    public void prune( long upToIndex )
+    {
+    }
+
+    @Override
+    public long totalBytes()
+    {
+        return 0;
+    }
+
+    @Override
+    public int elementCount()
+    {
+        return 0;
+    }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/AppendLogEntry.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/AppendLogEntry.java
@@ -22,9 +22,9 @@ package org.neo4j.causalclustering.core.consensus.outcome;
 import java.io.IOException;
 import java.util.Objects;
 
+import org.neo4j.causalclustering.core.consensus.log.cache.InFlightCache;
 import org.neo4j.causalclustering.core.consensus.log.RaftLog;
 import org.neo4j.causalclustering.core.consensus.log.RaftLogEntry;
-import org.neo4j.causalclustering.core.consensus.log.segmented.InFlightMap;
 import org.neo4j.logging.Log;
 
 public class AppendLogEntry implements RaftLogCommand
@@ -49,9 +49,9 @@ public class AppendLogEntry implements RaftLogCommand
     }
 
     @Override
-    public void applyTo( InFlightMap<RaftLogEntry> inFlightMap, Log log ) throws IOException
+    public void applyTo( InFlightCache inFlightCache, Log log ) throws IOException
     {
-        inFlightMap.put( index, entry );
+        inFlightCache.put( index, entry );
     }
 
     @Override

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/BatchAppendLogEntries.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/BatchAppendLogEntries.java
@@ -23,9 +23,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Objects;
 
+import org.neo4j.causalclustering.core.consensus.log.cache.InFlightCache;
 import org.neo4j.causalclustering.core.consensus.log.RaftLog;
 import org.neo4j.causalclustering.core.consensus.log.RaftLogEntry;
-import org.neo4j.causalclustering.core.consensus.log.segmented.InFlightMap;
 import org.neo4j.logging.Log;
 
 import static java.lang.String.format;
@@ -62,11 +62,11 @@ public class BatchAppendLogEntries implements RaftLogCommand
     }
 
     @Override
-    public void applyTo( InFlightMap<RaftLogEntry> inFlightMap, Log log )
+    public void applyTo( InFlightCache inFlightCache, Log log )
     {
         for ( int i = offset; i < entries.length; i++ )
         {
-            inFlightMap.put( baseIndex + i , entries[i]);
+            inFlightCache.put( baseIndex + i , entries[i]);
         }
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/PruneLogCommand.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/PruneLogCommand.java
@@ -22,9 +22,8 @@ package org.neo4j.causalclustering.core.consensus.outcome;
 import java.io.IOException;
 import java.util.Objects;
 
+import org.neo4j.causalclustering.core.consensus.log.cache.InFlightCache;
 import org.neo4j.causalclustering.core.consensus.log.RaftLog;
-import org.neo4j.causalclustering.core.consensus.log.RaftLogEntry;
-import org.neo4j.causalclustering.core.consensus.log.segmented.InFlightMap;
 import org.neo4j.logging.Log;
 
 public class PruneLogCommand implements RaftLogCommand
@@ -49,7 +48,7 @@ public class PruneLogCommand implements RaftLogCommand
     }
 
     @Override
-    public void applyTo( InFlightMap<RaftLogEntry> inFlightMap, Log log ) throws IOException
+    public void applyTo( InFlightCache inFlightCache, Log log ) throws IOException
     {
         // only the actual log prunes
     }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/TruncateLogCommand.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/outcome/TruncateLogCommand.java
@@ -22,9 +22,8 @@ package org.neo4j.causalclustering.core.consensus.outcome;
 import java.io.IOException;
 import java.util.Objects;
 
+import org.neo4j.causalclustering.core.consensus.log.cache.InFlightCache;
 import org.neo4j.causalclustering.core.consensus.log.RaftLog;
-import org.neo4j.causalclustering.core.consensus.log.RaftLogEntry;
-import org.neo4j.causalclustering.core.consensus.log.segmented.InFlightMap;
 import org.neo4j.logging.Log;
 
 public class TruncateLogCommand implements RaftLogCommand
@@ -49,10 +48,10 @@ public class TruncateLogCommand implements RaftLogCommand
     }
 
     @Override
-    public void applyTo( InFlightMap<RaftLogEntry> inFlightMap, Log log ) throws IOException
+    public void applyTo( InFlightCache inFlightCache, Log log ) throws IOException
     {
-        log.debug( "Start truncating in-flight-map from index %d. Current map:%n%s", fromIndex, inFlightMap );
-        inFlightMap.truncate( fromIndex );
+        log.debug( "Start truncating in-flight-map from index %d. Current map:%n%s", fromIndex, inFlightCache );
+        inFlightCache.truncate( fromIndex );
     }
 
     @Override

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/state/RaftState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/state/RaftState.java
@@ -23,10 +23,9 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.neo4j.causalclustering.core.consensus.log.cache.InFlightCache;
 import org.neo4j.causalclustering.core.consensus.log.RaftLog;
-import org.neo4j.causalclustering.core.consensus.log.RaftLogEntry;
 import org.neo4j.causalclustering.core.consensus.log.ReadableRaftLog;
-import org.neo4j.causalclustering.core.consensus.log.segmented.InFlightMap;
 import org.neo4j.causalclustering.core.consensus.membership.RaftMembership;
 import org.neo4j.causalclustering.core.consensus.outcome.Outcome;
 import org.neo4j.causalclustering.core.consensus.outcome.RaftLogCommand;
@@ -46,7 +45,7 @@ public class RaftState implements ReadableRaftState
     private final RaftMembership membership;
     private final Log log;
     private final RaftLog entryLog;
-    private final InFlightMap<RaftLogEntry> inFlightMap;
+    private final InFlightCache inFlightCache;
 
     private TermState termState;
     private VoteState voteState;
@@ -64,14 +63,14 @@ public class RaftState implements ReadableRaftState
                       RaftMembership membership,
                       RaftLog entryLog,
                       StateStorage<VoteState> voteStorage,
-                      InFlightMap<RaftLogEntry> inFlightMap, LogProvider logProvider )
+                      InFlightCache inFlightCache, LogProvider logProvider )
     {
         this.myself = myself;
         this.termStorage = termStorage;
         this.voteStorage = voteStorage;
         this.membership = membership;
         this.entryLog = entryLog;
-        this.inFlightMap = inFlightMap;
+        this.inFlightCache = inFlightCache;
         log = logProvider.getLog( getClass() );
     }
 
@@ -194,7 +193,7 @@ public class RaftState implements ReadableRaftState
         for ( RaftLogCommand logCommand : outcome.getLogCommands() )
         {
             logCommand.applyTo( entryLog, log );
-            logCommand.applyTo( inFlightMap, log );
+            logCommand.applyTo( inFlightCache, log );
         }
         commitIndex = outcome.getCommitIndex();
     }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/DistributedOperation.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/replication/DistributedOperation.java
@@ -61,6 +61,18 @@ public class  DistributedOperation implements ReplicatedContent
         return content;
     }
 
+    @Override
+    public boolean hasSize()
+    {
+        return content.hasSize();
+    }
+
+    @Override
+    public long size()
+    {
+        return content.size();
+    }
+
     public void serialize( WritableChannel channel ) throws IOException
     {
         channel.putLong( globalSession().sessionId().getMostSignificantBits() );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
@@ -167,7 +167,7 @@ public class CoreServerModule
                 config.get( CausalClusteringSettings.state_machine_apply_max_batch_size ),
                 config.get( CausalClusteringSettings.state_machine_flush_window_size ), databaseHealthSupplier,
                 logProvider, replicationModule.getProgressTracker(),
-                replicationModule.getSessionTracker(), coreState, consensusModule.inFlightMap(),
+                replicationModule.getSessionTracker(), coreState, consensusModule.inFlightCache(),
                 platformModule.monitors );
         dependencies.satisfyDependency( commandApplicationProcess ); // lastApplied() for CC-robustness
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/ComparableRaftStateTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/ComparableRaftStateTest.java
@@ -21,8 +21,8 @@ package org.neo4j.causalclustering.core.consensus.explorer;
 
 import org.junit.Test;
 
+import org.neo4j.causalclustering.core.consensus.log.cache.ConsecutiveInFlightCache;
 import org.neo4j.causalclustering.core.consensus.log.InMemoryRaftLog;
-import org.neo4j.causalclustering.core.consensus.log.segmented.InFlightMap;
 import org.neo4j.logging.NullLogProvider;
 
 import static org.junit.Assert.assertEquals;
@@ -39,12 +39,12 @@ public class ComparableRaftStateTest
         ComparableRaftState state1 = new ComparableRaftState( member( 0 ),
                 asSet( member( 0 ), member( 1 ), member( 2 ) ),
                 asSet( member( 0 ), member( 1 ), member( 2 ) ),
-                new InMemoryRaftLog(), new InFlightMap<>(), logProvider );
+                new InMemoryRaftLog(), new ConsecutiveInFlightCache(), logProvider );
 
         ComparableRaftState state2 = new ComparableRaftState( member( 0 ),
                 asSet( member( 0 ), member( 1 ), member( 2 ) ),
                 asSet( member( 0 ), member( 1 ), member( 2 ) ),
-                new InMemoryRaftLog(), new InFlightMap<>(), logProvider );
+                new InMemoryRaftLog(), new ConsecutiveInFlightCache(), logProvider );
 
         // then
         assertEquals(state1, state2);

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/cache/CircularBufferTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/cache/CircularBufferTest.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.consensus.log.cache;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class CircularBufferTest
+{
+    private final ThreadLocalRandom tlr = ThreadLocalRandom.current();
+
+    @Test
+    public void shouldBeInitiallyEmpty() throws Exception
+    {
+        // when
+        CircularBuffer<Object> buffer = new CircularBuffer<>( 3 );
+
+        // then
+        assertEquals( 0, buffer.size() );
+        assertEquals( null, buffer.remove() );
+        assertEquals( null, buffer.read( 0 ) );
+
+        // again for idempotency check
+        assertEquals( 0, buffer.size() );
+        assertEquals( null, buffer.remove() );
+        assertEquals( null, buffer.read( 0 ) );
+    }
+
+    @Test
+    public void removeShouldReturnNullWhenEmpty() throws Exception
+    {
+        // given
+        CircularBuffer<Object> buffer = new CircularBuffer<>( 3 );
+
+        buffer.append( 1L );
+        buffer.append( 2L );
+        buffer.append( 3L );
+
+        // when
+        buffer.remove();
+        buffer.remove();
+        buffer.remove();
+
+        // then
+        assertEquals( null, buffer.remove() );
+    }
+
+    @Test
+    public void shouldEvictElementsWhenClearing() throws Exception
+    {
+        // given
+        CircularBuffer<Integer> buffer = new CircularBuffer<>( 3 );
+        Integer[] evictions = new Integer[3];
+        buffer.append( 1 );
+        buffer.append( 2 );
+
+        // when
+        buffer.clear( evictions );
+
+        // then
+        assertEquals( 0, buffer.size() );
+        assertArrayEquals( evictions, new Integer[]{1, 2, null} );
+    }
+
+    @Test
+    public void shouldNullRemovedElements() throws Exception
+    {
+        // given
+        CircularBuffer<Integer> buffer = new CircularBuffer<>( 3 );
+        Integer[] evictions = new Integer[3];
+        buffer.append( 1 );
+        buffer.append( 2 );
+        buffer.append( 3 );
+
+        // when
+        buffer.remove();
+        buffer.remove();
+        buffer.remove();
+
+        // then
+        assertNull( buffer.read( 0 ) );
+        assertNull( buffer.read( 1 ) );
+        assertNull( buffer.read( 2 ) );
+    }
+
+    @Test
+    public void shouldNullClearedElements() throws Exception
+    {
+        // given
+        CircularBuffer<Integer> buffer = new CircularBuffer<>( 3 );
+        Integer[] evictions = new Integer[3];
+        buffer.append( 1 );
+        buffer.append( 2 );
+        buffer.append( 3 );
+
+        // when
+        buffer.clear( evictions );
+
+        // then
+        assertNull( buffer.read( 0 ) );
+        assertNull( buffer.read( 1 ) );
+        assertNull( buffer.read( 2 ) );
+    }
+
+    @Test
+    public void comprehensivelyTestAppendRemove() throws Exception
+    {
+        for ( int capacity = 1; capacity <= 128; capacity++ )
+        {
+            for ( int operations = 1; operations < capacity * 3; operations++ )
+            {
+                comprehensivelyTestAppendRemove( capacity, operations, new CircularBuffer<>( capacity ) );
+            }
+        }
+    }
+
+    @Test
+    public void comprehensivelyTestAppendRemoveHead() throws Exception
+    {
+        for ( int capacity = 1; capacity <= 128; capacity++ )
+        {
+            for ( int operations = 1; operations < capacity * 3; operations++ )
+            {
+                comprehensivelyTestAppendRemoveHead( capacity, operations, new CircularBuffer<>( capacity ) );
+            }
+        }
+    }
+
+    @Test
+    public void comprehensivelyTestAppendRemoveReusingBuffer() throws Exception
+    {
+        for ( int capacity = 1; capacity <= 128; capacity++ )
+        {
+            CircularBuffer<Integer> buffer = new CircularBuffer<>( capacity );
+            for ( int operations = 1; operations <= capacity * 3; operations++ )
+            {
+                comprehensivelyTestAppendRemove( capacity, operations, buffer );
+            }
+        }
+    }
+
+    private void comprehensivelyTestAppendRemove( int capacity, int operations, CircularBuffer<Integer> buffer ) throws Exception
+    {
+        ArrayList<Integer> numbers = new ArrayList<>( operations );
+
+        // when: adding a bunch of random numbers
+        for ( int i = 0; i < operations; i++ )
+        {
+            int number = tlr.nextInt();
+            numbers.add( number );
+            buffer.append( number );
+        }
+
+        // then: these should have been knocked out
+        for ( int i = 0; i < operations - capacity; i++ )
+        {
+            numbers.remove( 0 );
+        }
+
+        // and these should remain
+        while ( !numbers.isEmpty() )
+        {
+            assertEquals( numbers.remove( 0 ), buffer.remove() );
+        }
+
+        assertEquals( 0, buffer.size() );
+    }
+
+    private void comprehensivelyTestAppendRemoveHead( int capacity, int operations, CircularBuffer<Integer> buffer ) throws Exception
+    {
+        ArrayList<Integer> numbers = new ArrayList<>( operations );
+
+        // when: adding a bunch of random numbers
+        for ( int i = 0; i < operations; i++ )
+        {
+            int number = tlr.nextInt();
+            numbers.add( number );
+            buffer.append( number );
+        }
+
+        // then: these should have been knocked out
+        for ( int i = 0; i < operations - capacity; i++ )
+        {
+            numbers.remove( 0 );
+        }
+
+        // and these should remain
+        while ( !numbers.isEmpty() )
+        {
+            assertEquals( numbers.remove( numbers.size() - 1 ), buffer.removeHead() );
+        }
+
+        assertEquals( 0, buffer.size() );
+    }
+
+    @Test
+    public void comprehensivelyTestAppendRead() throws Exception
+    {
+        for ( int capacity = 1; capacity <= 128; capacity++ )
+        {
+            for ( int operations = 1; operations < capacity * 3; operations++ )
+            {
+                comprehensivelyTestAppendRead( capacity, operations );
+            }
+        }
+    }
+
+    private void comprehensivelyTestAppendRead( int capacity, int operations ) throws Exception
+    {
+        CircularBuffer<Integer> buffer = new CircularBuffer<>( capacity );
+        ArrayList<Integer> numbers = new ArrayList<>( operations );
+
+        // when: adding a bunch of random numbers
+        for ( int i = 0; i < operations; i++ )
+        {
+            int number = tlr.nextInt();
+            numbers.add( number );
+            buffer.append( number );
+        }
+
+        // then: these should have been knocked out
+        for ( int i = 0; i < operations - capacity; i++ )
+        {
+            numbers.remove( 0 );
+        }
+
+        // and these should remain
+        int i = 0;
+        while ( !numbers.isEmpty() )
+        {
+            assertEquals( numbers.remove( 0 ), buffer.read( i++ ) );
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/cache/ConsecutiveCacheTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/cache/ConsecutiveCacheTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.consensus.log.cache;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith( Parameterized.class )
+public class ConsecutiveCacheTest
+{
+    private final int capacity;
+    private ConsecutiveCache<Integer> cache;
+    private Integer[] evictions;
+
+    public ConsecutiveCacheTest( int capacity )
+    {
+        this.capacity = capacity;
+        this.evictions = new Integer[capacity];
+    }
+
+    @Parameterized.Parameters( name = "capacity={0}" )
+    public static Collection<Object[]> data()
+    {
+        return Arrays.asList( new Object[][]{{1}, {2}, {3}, {4}, {8}, {1024}} );
+    }
+
+    @Before
+    public void setup() throws Exception
+    {
+        cache = new ConsecutiveCache<>( capacity );
+    }
+
+    @Test
+    public void testEmptyInvariants()
+    {
+        assertEquals( 0, cache.size() );
+        for ( int i = 0; i < capacity; i++ )
+        {
+            assertNull( cache.get( i ) );
+        }
+    }
+
+    @Test
+    public void testCacheFill()
+    {
+        for ( int i = 0; i < capacity; i++ )
+        {
+            // when
+            cache.put( i, i, evictions );
+            assertTrue( Stream.of( evictions ).allMatch( Objects::isNull ) );
+
+            // then
+            assertEquals( i + 1, cache.size() );
+        }
+
+        // then
+        for ( int i = 0; i < capacity; i++ )
+        {
+            assertEquals( i, cache.get( i ).intValue() );
+        }
+    }
+
+    @Test
+    public void testCacheMultipleFills()
+    {
+        // given
+        for ( int i = 0; i < capacity; i++ )
+        {
+            cache.put( i, i, evictions );
+        }
+
+        for ( int i = capacity; i < 10 * capacity; i++ )
+        {
+            // when
+            cache.put( i, i, evictions );
+
+            // then
+            assertEquals( i - capacity, evictions[0].intValue() );
+            assertTrue( Stream.of( evictions ).skip( 1 ).allMatch( Objects::isNull ) );
+            assertEquals( capacity, cache.size() );
+        }
+    }
+
+    @Test
+    public void testCacheClearing() throws Exception
+    {
+        // given
+        for ( int i = 0; i < capacity; i++ )
+        {
+            cache.put( i, i, evictions );
+        }
+
+        // when
+        cache.clear( evictions );
+
+        // then
+        for ( int i = 0; i < capacity; i++ )
+        {
+            assertEquals( i, evictions[i].intValue() );
+            assertEquals( null, cache.get( i ) );
+        }
+
+        assertEquals( 0, cache.size() );
+    }
+
+    @Test
+    public void testEntryOverride() throws Exception
+    {
+        // given
+        for ( int i = 0; i < capacity; i++ )
+        {
+            cache.put( i, i, evictions );
+        }
+
+        // when
+        cache.put( capacity / 2, 10000, evictions );
+
+        // then
+        for ( int i = 0; i < capacity; i++ )
+        {
+            if ( i == capacity / 2 )
+            {
+                continue;
+            }
+
+            assertEquals( i, evictions[i].intValue() );
+            assertEquals( null, cache.get( i ) );
+        }
+
+        assertEquals( 10000, cache.get( capacity / 2 ).intValue() );
+    }
+
+    @Test
+    public void testEntrySkip() throws Exception
+    {
+        // given
+        for ( int i = 0; i < capacity; i++ )
+        {
+            cache.put( i, i, evictions );
+        }
+
+        // when
+        cache.put( capacity + 1, 10000, evictions );
+
+        // then
+        for ( int i = 0; i < capacity; i++ )
+        {
+            assertEquals( i, evictions[i].intValue() );
+            assertEquals( null, cache.get( i ) );
+        }
+
+        assertEquals( 10000, cache.get( capacity + 1 ).intValue() );
+    }
+
+    @Test
+    public void testPruning() throws Exception
+    {
+        // given
+        for ( int i = 0; i < capacity; i++ )
+        {
+            cache.put( i, i, evictions );
+        }
+
+        // when
+        int upToIndex = capacity / 2;
+        cache.prune( upToIndex, evictions );
+
+        // then
+        for ( int i = 0; i <= upToIndex; i++ )
+        {
+            assertEquals( null, cache.get( i ) );
+            assertEquals( i, evictions[i].intValue() );
+        }
+
+        for ( int i = upToIndex + 1; i < capacity; i++ )
+        {
+            assertEquals( i, cache.get( i ).intValue() );
+        }
+    }
+
+    @Test
+    public void testRemoval() throws Exception
+    {
+        // given
+        for ( int i = 0; i < capacity; i++ )
+        {
+            cache.put( i, i, evictions );
+        }
+
+        // then
+        for ( int i = 0; i < capacity; i++ )
+        {
+            // when
+            Integer removed = cache.remove();
+
+            // then
+            assertEquals( i, removed.intValue() );
+        }
+
+        assertNull( cache.remove() );
+    }
+
+    @Test
+    public void testTruncation() throws Exception
+    {
+        // given
+        for ( int i = 0; i < capacity; i++ )
+        {
+            cache.put( i, i, evictions );
+        }
+
+        // when
+        int fromIndex = capacity / 2;
+        cache.truncate( fromIndex, evictions );
+
+        // then
+        for ( int i = 0; i < fromIndex; i++ )
+        {
+            assertEquals( i, cache.get( i ).intValue() );
+        }
+
+        for ( int i = fromIndex; i < capacity; i++ )
+        {
+            assertEquals( null, cache.get( i ) );
+            assertEquals( i, evictions[capacity - i - 1].intValue() );
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/cache/ConsecutiveInFlightCacheTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/log/cache/ConsecutiveInFlightCacheTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.consensus.log.cache;
+
+import org.junit.Test;
+
+import org.neo4j.causalclustering.core.consensus.log.RaftLogEntry;
+import org.neo4j.causalclustering.core.state.machines.dummy.DummyRequest;
+
+import static org.junit.Assert.assertEquals;
+
+public class ConsecutiveInFlightCacheTest
+{
+    @Test
+    public void shouldTrackUsedMemory() throws Exception
+    {
+        int capacity = 4;
+        ConsecutiveInFlightCache cache = new ConsecutiveInFlightCache( capacity, 1000, InFlightCacheMonitor.VOID, true );
+
+        for ( int i = 0; i < capacity; i++ )
+        {
+            // when
+            cache.put( i, content( 100 ) );
+
+            // then
+            assertEquals( (i + 1) * 100, cache.totalBytes() );
+        }
+
+        // when
+        cache.put( capacity, content( 100 ) );
+
+        // then
+        assertEquals( capacity, cache.elementCount() );
+        assertEquals( capacity * 100, cache.totalBytes() );
+
+        // when
+        cache.put( capacity + 1, content( 500 ) );
+        assertEquals( capacity, cache.elementCount() );
+        assertEquals( 800, cache.totalBytes() );
+
+        // when
+        cache.put( capacity + 2, content( 500 ) );
+        assertEquals( 2, cache.elementCount() );
+        assertEquals( 1000, cache.totalBytes() );
+    }
+
+    @Test
+    public void shouldReturnLatestItems() throws Exception
+    {
+        // given
+        int capacity = 4;
+        ConsecutiveInFlightCache cache = new ConsecutiveInFlightCache( capacity, 1000, InFlightCacheMonitor.VOID, true );
+
+        // when
+        for ( int i = 0; i < 3 * capacity; i++ )
+        {
+            cache.put( i, content( i ) );
+        }
+
+        // then
+        for ( int i = 0; i < 3 * capacity; i++ )
+        {
+            if ( i < 2 * capacity )
+            {
+                assertEquals( null, cache.get( i ) );
+            }
+            else
+            {
+                assertEquals( i, cache.get( i ).content().size() );
+            }
+        }
+    }
+
+    @Test
+    public void shouldRemovePrunedItems() throws Exception
+    {
+        // given
+        int capacity = 20;
+        ConsecutiveInFlightCache cache = new ConsecutiveInFlightCache( capacity, 1000, InFlightCacheMonitor.VOID, true );
+
+        for ( int i = 0; i < capacity; i++ )
+        {
+            cache.put( i, content( i ) );
+        }
+
+        // when
+        int upToIndex = capacity / 2 - 1;
+        cache.prune( upToIndex );
+
+        // then
+        assertEquals( capacity / 2, cache.elementCount() );
+
+        for ( int i = 0; i < capacity; i++ )
+        {
+            if ( i <= upToIndex )
+            {
+                assertEquals( null, cache.get( i ) );
+            }
+            else
+            {
+                assertEquals( i, cache.get( i ).content().size() );
+            }
+        }
+    }
+
+    @Test
+    public void shouldRemoveTruncatedItems() throws Exception
+    {
+        // given
+        int capacity = 20;
+        ConsecutiveInFlightCache cache = new ConsecutiveInFlightCache( capacity, 1000, InFlightCacheMonitor.VOID, true );
+
+        for ( int i = 0; i < capacity; i++ )
+        {
+            cache.put( i, content( i ) );
+        }
+
+        // when
+        int fromIndex = capacity / 2;
+        cache.truncate( fromIndex );
+
+        // then
+        assertEquals( fromIndex, cache.elementCount() );
+        assertEquals( (fromIndex * (fromIndex - 1)) / 2, cache.totalBytes() );
+
+        for ( int i = fromIndex; i < capacity; i++ )
+        {
+            assertEquals( null, cache.get( i ) );
+        }
+    }
+
+    private RaftLogEntry content( int size )
+    {
+        return new RaftLogEntry( 0, new DummyRequest( new byte[size] ) );
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/outcome/BatchAppendLogEntriesTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/outcome/BatchAppendLogEntriesTest.java
@@ -21,9 +21,10 @@ package org.neo4j.causalclustering.core.consensus.outcome;
 
 import org.junit.Test;
 
+import org.neo4j.causalclustering.core.consensus.log.cache.ConsecutiveInFlightCache;
+import org.neo4j.causalclustering.core.consensus.log.cache.InFlightCache;
 import org.neo4j.causalclustering.core.consensus.log.InMemoryRaftLog;
 import org.neo4j.causalclustering.core.consensus.log.RaftLogEntry;
-import org.neo4j.causalclustering.core.consensus.log.segmented.InFlightMap;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.NullLog;
 
@@ -90,7 +91,7 @@ public class BatchAppendLogEntriesTest
 
         BatchAppendLogEntries batchAppend = new BatchAppendLogEntries( baseIndex, offset, entries );
 
-        InFlightMap<RaftLogEntry> cache = new InFlightMap<>( true );
+        InFlightCache cache = new ConsecutiveInFlightCache();
 
         //when
         batchAppend.applyTo( cache, log );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/shipping/RaftLogShipperTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/shipping/RaftLogShipperTest.java
@@ -34,10 +34,11 @@ import org.neo4j.causalclustering.core.consensus.RaftMessages;
 import org.neo4j.causalclustering.core.consensus.RaftMessages.AppendEntries;
 import org.neo4j.causalclustering.core.consensus.ReplicatedInteger;
 import org.neo4j.causalclustering.core.consensus.ReplicatedString;
+import org.neo4j.causalclustering.core.consensus.log.cache.ConsecutiveInFlightCache;
 import org.neo4j.causalclustering.core.consensus.log.InMemoryRaftLog;
 import org.neo4j.causalclustering.core.consensus.log.RaftLog;
 import org.neo4j.causalclustering.core.consensus.log.RaftLogEntry;
-import org.neo4j.causalclustering.core.consensus.log.segmented.InFlightMap;
+
 import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.logging.Log;
@@ -107,7 +108,7 @@ public class RaftLogShipperTest
     private void startLogShipper()
     {
         logShipper = new RaftLogShipper( outbound, logProvider, raftLog, clock, leader, follower, leaderTerm, leaderCommit,
-                        retryTimeMillis, catchupBatchSize, maxAllowedShippingLag, new InFlightMap<>() );
+                        retryTimeMillis, catchupBatchSize, maxAllowedShippingLag, new ConsecutiveInFlightCache() );
         logShipper.start();
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/state/RaftStateBuilder.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/state/RaftStateBuilder.java
@@ -25,12 +25,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import org.neo4j.causalclustering.core.consensus.log.cache.ConsecutiveInFlightCache;
 import org.neo4j.causalclustering.core.state.storage.InMemoryStateStorage;
 import org.neo4j.causalclustering.core.state.storage.StateStorage;
 import org.neo4j.causalclustering.core.consensus.RaftMessages;
 import org.neo4j.causalclustering.core.consensus.log.InMemoryRaftLog;
 import org.neo4j.causalclustering.core.consensus.log.RaftLog;
-import org.neo4j.causalclustering.core.consensus.log.segmented.InFlightMap;
 import org.neo4j.causalclustering.core.consensus.membership.RaftMembership;
 import org.neo4j.causalclustering.core.consensus.outcome.RaftLogCommand;
 import org.neo4j.causalclustering.core.consensus.outcome.Outcome;
@@ -136,7 +136,7 @@ public class RaftStateBuilder
         StubMembership membership = new StubMembership( votingMembers, replicationMembers );
 
         RaftState state = new RaftState( myself, termStore, membership, entryLog,
-                voteStore, new InFlightMap<>(), NullLogProvider.getInstance() );
+                voteStore, new ConsecutiveInFlightCache(), NullLogProvider.getInstance() );
 
         Collection<RaftMessages.Directed> noMessages = Collections.emptyList();
         List<RaftLogCommand> noLogCommands = Collections.emptyList();

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/state/RaftStateTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/state/RaftStateTest.java
@@ -28,11 +28,12 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
+import org.neo4j.causalclustering.core.consensus.log.cache.ConsecutiveInFlightCache;
+import org.neo4j.causalclustering.core.consensus.log.cache.InFlightCache;
 import org.neo4j.causalclustering.core.state.storage.InMemoryStateStorage;
 import org.neo4j.causalclustering.core.consensus.RaftMessages;
 import org.neo4j.causalclustering.core.consensus.log.InMemoryRaftLog;
 import org.neo4j.causalclustering.core.consensus.log.RaftLogEntry;
-import org.neo4j.causalclustering.core.consensus.log.segmented.InFlightMap;
 import org.neo4j.causalclustering.core.consensus.membership.RaftMembership;
 import org.neo4j.causalclustering.core.consensus.outcome.AppendLogEntry;
 import org.neo4j.causalclustering.core.consensus.outcome.RaftLogCommand;
@@ -59,10 +60,10 @@ public class RaftStateTest
     @Test
     public void shouldUpdateCacheState() throws Exception
     {
-        //Test that updates applied to the raft state will be refelcted in the entry cache.
+        //Test that updates applied to the raft state will be reflected in the entry cache.
 
         //given
-        InFlightMap<RaftLogEntry> cache = new InFlightMap<>( true );
+        InFlightCache cache = new ConsecutiveInFlightCache();
         RaftState raftState = new RaftState( member( 0 ),
                 new InMemoryStateStorage<>( new TermState() ), new FakeMembership(), new InMemoryRaftLog(),
                 new InMemoryStateStorage<>( new VoteState() ), cache, NullLogProvider.getInstance() );
@@ -100,7 +101,7 @@ public class RaftStateTest
                 new InMemoryStateStorage<>( new TermState() ),
                 new FakeMembership(), new InMemoryRaftLog(),
                 new InMemoryStateStorage<>( new VoteState( ) ),
-                new InFlightMap<>(), NullLogProvider.getInstance() );
+                new ConsecutiveInFlightCache(), NullLogProvider.getInstance() );
 
         raftState.update( new Outcome( CANDIDATE, 1, null, -1, null, emptySet(), -1, initialFollowerStates(), true, emptyLogCommands(),
                 emptyOutgoingMessages(), emptySet(), -1, emptySet() ) );

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/InFlightCacheMetric.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/causalclustering/InFlightCacheMetric.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.metrics.source.causalclustering;
+
+import org.neo4j.causalclustering.core.consensus.log.cache.InFlightCacheMonitor;
+
+public class InFlightCacheMetric implements InFlightCacheMonitor
+{
+    private volatile long misses;
+    private volatile long hits;
+    private volatile long totalBytes;
+    private volatile long maxBytes;
+    private volatile int elementCount;
+    private volatile int maxElements;
+
+    @Override
+    public void miss()
+    {
+        misses++;
+    }
+
+    @Override
+    public void hit()
+    {
+        hits++;
+    }
+
+    public long getMisses()
+    {
+        return misses;
+    }
+
+    public long getHits()
+    {
+        return hits;
+    }
+
+    public long getMaxBytes()
+    {
+        return maxBytes;
+    }
+
+    public long getTotalBytes()
+    {
+        return totalBytes;
+    }
+
+    public long getMaxElements()
+    {
+        return maxElements;
+    }
+
+    public long getElementCount()
+    {
+        return elementCount;
+    }
+
+    @Override
+    public void setMaxBytes( long maxBytes )
+    {
+        this.maxBytes = maxBytes;
+    }
+
+    @Override
+    public void setTotalBytes( long totalBytes )
+    {
+        this.totalBytes = totalBytes;
+    }
+
+    @Override
+    public void setMaxElements( int maxElements )
+    {
+        this.maxElements = maxElements;
+    }
+
+    @Override
+    public void setElementCount( int elementCount )
+    {
+        this.elementCount = elementCount;
+    }
+}


### PR DESCRIPTION
A highly efficient cache which only can keep a consecutive range of raft log entries
cached, allowing for a very simple and efficient circular buffer to be used. The cache
also allows putting a maximum bound on the amount of entries as well as their total combined
size.

The cache also exposes metrics so that cache hits, misses and total data can be observed.