### PR TITLE
Add possibility to generate test coverage reports with jacoco

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/state/NeoStoreFileListingTest.java
@@ -155,9 +155,7 @@ public class NeoStoreFileListingTest
     {
         assertTrue( neoStoreDataSource.listStoreFiles( false ).stream()
                 .reduce( ( a, b ) -> b )
-                .map( toStoreType )
-                .filter( Optional::isPresent )
-                .map( Optional::get )
+                .flatMap( toStoreType )
                 .filter( StoreType.META_DATA::equals )
                 .isPresent() );
     }
@@ -167,9 +165,7 @@ public class NeoStoreFileListingTest
     {
         assertTrue( neoStoreDataSource.listStoreFiles( true ).stream()
                 .reduce( ( a, b ) -> b )
-                .map( toStoreType )
-                .filter( Optional::isPresent )
-                .map( Optional::get )
+                .flatMap( toStoreType )
                 .filter( StoreType.META_DATA::equals )
                 .isPresent() );
     }

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <lucene.version>5.5.0</lucene.version>
     <bouncycastle.version>1.53</bouncycastle.version>
     <generate-config-docs-phase>prepare-package</generate-config-docs-phase>
-    <test.runner.jvm.settings.additional></test.runner.jvm.settings.additional>
+    <test.runner.jvm.settings.additional/>
     <test.runner.jvm.settings>-Xmx2G -XX:+UseG1GC -XX:-OmitStackTraceInFastThrow -XX:+HeapDumpOnOutOfMemoryError
       -XX:HeapDumpPath=target/test-data -Dorg.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.DIRTY_MEMORY=true
       -Dorg.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.CHECK_NATIVE_ACCESS=true
@@ -684,6 +684,77 @@
       <properties>
         <forkCounts>1C</forkCounts>
       </properties>
+    </profile>
+
+    <profile>
+      <id>testCoverage</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <property>
+          <name>testCoverage</name>
+        </property>
+      </activation>
+      <properties>
+        <test.runner.jvm.settings.additional>@{argLine}</test.runner.jvm.settings.additional>
+      </properties>
+        <build>
+            <plugins>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.7.9</version>
+                    <executions>
+                        <execution>
+                            <id>default-prepare-agent</id>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>default-prepare-agent-integration</id>
+                            <goals>
+                                <goal>prepare-agent-integration</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>merge</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>merge</goal>
+                            </goals>
+                            <configuration>
+                                <destFile>${project.build.directory}/jacoco-aggregated.exec</destFile>
+                                <fileSets>
+                                    <fileSet implementation="org.apache.maven.shared.model.fileset.FileSet">
+                                        <directory>${project.build.directory}</directory>
+                                        <includes>
+                                            <include>*.exec</include>
+                                        </includes>
+                                    </fileSet>
+                                </fileSets>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>default-report</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                          <configuration>
+                            <dataFile>${project.build.directory}/jacoco-aggregated.exec</dataFile>
+                          </configuration>
+                        </execution>
+                        <execution>
+                            <id>report-aggregate</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>report-aggregate</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </build>
     </profile>
 
     <!--


### PR DESCRIPTION
Introduce new "testCoverage" maven profile that will allow to generate
separate and aggregated test coverage and reports for each module.
Small cleanup.