### PR TITLE
Move string functions into TextValue

### DIFF
--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ReverseFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ReverseFunction.scala
@@ -19,9 +19,9 @@
  */
 package org.neo4j.cypher.internal.runtime.interpreted.commands.expressions
 
-import org.neo4j.cypher.internal.util.v3_4.CypherTypeException
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.QueryState
+import org.neo4j.cypher.internal.util.v3_4.CypherTypeException
 import org.neo4j.values.AnyValue
 import org.neo4j.values.storable.{TextValue, Values}
 import org.neo4j.values.virtual.{ListValue, VirtualValues}
@@ -30,7 +30,7 @@ case class ReverseFunction(argument: Expression) extends NullInNullOutExpression
   override def compute(value: AnyValue, m: ExecutionContext, state: QueryState): AnyValue = {
     argument(m, state) match {
       case x if x == Values.NO_VALUE => Values.NO_VALUE
-      case string: TextValue => Values.stringValue(new java.lang.StringBuilder(string.stringValue()).reverse.toString)
+      case string: TextValue => string.reverse
       case seq: ListValue => VirtualValues.reverse(seq)
       case a => throw new CypherTypeException(
         "Expected a string or a list; consider converting it to a string with toString() or creating a list."

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/StringFunctions.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/StringFunctions.scala
@@ -81,8 +81,10 @@ case class ToLowerFunction(argument: Expression) extends StringFunction(argument
 
 case class ToUpperFunction(argument: Expression) extends StringFunction(argument) {
 
-  override def compute(value: AnyValue, m: ExecutionContext, state: QueryState): AnyValue =
-    Values.stringValue(asString(argument(m, state)).toUpperCase)
+  override def compute(value: AnyValue, m: ExecutionContext, state: QueryState): AnyValue =value match {
+    case t: TextValue => t.toUpper
+    case _ => StringFunction.notAString(value)
+  }
 
   override def rewrite(f: (Expression) => Expression) = f(ToUpperFunction(argument.rewrite(f)))
 }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/StringFunctions.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/StringFunctions.scala
@@ -148,16 +148,12 @@ case class SubstringFunction(orig: Expression, start: Expression, length: Option
 case class ReplaceFunction(orig: Expression, search: Expression, replaceWith: Expression)
   extends NullInNullOutExpression(orig) {
 
-  override def compute(value: AnyValue, m: ExecutionContext, state: QueryState): AnyValue = {
-    val origVal = asString(value)
-    val searchVal = asString(search(m, state))
-    val replaceWithVal = asString(replaceWith(m, state))
-
-    if (searchVal == null || replaceWithVal == null) {
-      NO_VALUE
-    } else {
-      Values.stringValue(origVal.replace(searchVal, replaceWithVal))
-    }
+  override def compute(value: AnyValue, m: ExecutionContext, state: QueryState): AnyValue = value match {
+    case t: TextValue =>
+      val searchVal = asString(search(m, state))
+      val replaceWithVal = asString(replaceWith(m, state))
+      if (searchVal == null || replaceWithVal == null) NO_VALUE else t.replace(searchVal, replaceWithVal)
+    case _ => StringFunction.notAString(value)
   }
 
   override def arguments = Seq(orig, search, replaceWith)

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/StringFunctions.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/StringFunctions.scala
@@ -71,8 +71,10 @@ case class ToStringFunction(argument: Expression) extends StringFunction(argumen
 
 case class ToLowerFunction(argument: Expression) extends StringFunction(argument) {
 
-  override def compute(value: AnyValue, m: ExecutionContext, state: QueryState): AnyValue =
-    Values.stringValue(asString(argument(m, state)).toLowerCase)
+  override def compute(value: AnyValue, m: ExecutionContext, state: QueryState): AnyValue = value match {
+    case t: TextValue => t.toLower
+    case _ => StringFunction.notAString(value)
+  }
 
   override def rewrite(f: (Expression) => Expression) = f(ToLowerFunction(argument.rewrite(f)))
 }

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/StringFunctionsTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/StringFunctionsTest.scala
@@ -19,12 +19,11 @@
  */
 package org.neo4j.cypher.internal.runtime.interpreted.commands.expressions
 
-import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
-import org.neo4j.cypher.internal.runtime.interpreted.QueryStateHelper
+import org.neo4j.cypher.internal.runtime.interpreted.{ExecutionContext, QueryStateHelper}
 import org.neo4j.cypher.internal.util.v3_4.CypherTypeException
 import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.values.storable.Values
-import org.neo4j.values.storable.Values.{EMPTY_STRING, stringValue}
+import org.neo4j.values.storable.Values.{EMPTY_STRING, stringArray, stringValue}
 
 class StringFunctionsTest extends CypherFunSuite {
 
@@ -158,5 +157,17 @@ class StringFunctionsTest extends CypherFunSuite {
     reverse(null) should equal(expectedNull)
     reverse("\r\n") should equal(stringValue("\n\r"))
     reverse("\uD801\uDC37") should equal(stringValue("\uD801\uDC37"))
+  }
+
+  test("splitTests") {
+    def split(x: Any, y: Any) = SplitFunction(Literal(x), Literal(y))(ExecutionContext.empty, QueryStateHelper.empty)
+
+    split("HELLO", "LL") should equal(stringArray("HE", "O"))
+    split("Separating,by,comma,is,a,common,use,case", ",") should equal(stringArray("Separating", "by", "comma", "is", "a", "common", "use", "case"))
+    split("hello", "X") should equal(stringArray("hello"))
+    split("hello", null) should equal(expectedNull)
+    split(null, "hello") should equal(expectedNull)
+    split(null, null) should equal(expectedNull)
+    intercept[CypherTypeException](split(1024, 10))
   }
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/CharValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/CharValue.java
@@ -139,6 +139,12 @@ public final class CharValue extends TextValue
         return new CharValue( Character.toLowerCase( value ) );
     }
 
+    @Override
+    public TextValue toUpper()
+    {
+        return new CharValue( Character.toUpperCase( value ) );
+    }
+
     public char value()
     {
         return value;

--- a/community/values/src/main/java/org/neo4j/values/storable/CharValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/CharValue.java
@@ -145,6 +145,19 @@ public final class CharValue extends TextValue
         return new CharValue( Character.toUpperCase( value ) );
     }
 
+    @Override
+    public TextArray split( String separator )
+    {
+        if (separator.equals( stringValue() ))
+        {
+            return Values.EMPTY_TEXT_ARRAY;
+        }
+        else
+        {
+            return Values.stringArray( stringValue() );
+        }
+    }
+
     public char value()
     {
         return value;

--- a/community/values/src/main/java/org/neo4j/values/storable/CharValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/CharValue.java
@@ -133,6 +133,12 @@ public final class CharValue extends TextValue
         return trim();
     }
 
+    @Override
+    public TextValue toLower()
+    {
+        return new CharValue( Character.toLowerCase( value ) );
+    }
+
     public char value()
     {
         return value;

--- a/community/values/src/main/java/org/neo4j/values/storable/CharValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/CharValue.java
@@ -148,13 +148,26 @@ public final class CharValue extends TextValue
     @Override
     public TextArray split( String separator )
     {
-        if (separator.equals( stringValue() ))
+        if ( separator.equals( stringValue() ) )
         {
             return Values.EMPTY_TEXT_ARRAY;
         }
         else
         {
             return Values.stringArray( stringValue() );
+        }
+    }
+
+    @Override
+    public TextValue replace( String find, String replace )
+    {
+        if ( stringValue().equals( find ) )
+        {
+            return Values.stringValue( replace );
+        }
+        else
+        {
+            return this;
         }
     }
 

--- a/community/values/src/main/java/org/neo4j/values/storable/CharValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/CharValue.java
@@ -161,6 +161,8 @@ public final class CharValue extends TextValue
     @Override
     public TextValue replace( String find, String replace )
     {
+        assert find != null;
+        assert replace != null;
         if ( stringValue().equals( find ) )
         {
             return Values.stringValue( replace );
@@ -169,6 +171,12 @@ public final class CharValue extends TextValue
         {
             return this;
         }
+    }
+
+    @Override
+    public TextValue reverse()
+    {
+        return this;
     }
 
     public char value()

--- a/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
@@ -62,6 +62,12 @@ public abstract class StringValue extends TextValue
     }
 
     @Override
+    public TextValue toUpper()
+    {
+        return new StringWrappingStringValue( value().toUpperCase() );
+    }
+
+    @Override
     public Object asObjectCopy()
     {
         return value();

--- a/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
@@ -68,6 +68,14 @@ public abstract class StringValue extends TextValue
     }
 
     @Override
+    public TextArray split( String separator )
+    {
+        String asString = value();
+        String[] split = asString.split( separator );
+        return Values.stringArray( split );
+    }
+
+    @Override
     public Object asObjectCopy()
     {
         return value();

--- a/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
@@ -56,6 +56,12 @@ public abstract class StringValue extends TextValue
     }
 
     @Override
+    public TextValue toLower()
+    {
+        return new StringWrappingStringValue( value().toLowerCase() );
+    }
+
+    @Override
     public Object asObjectCopy()
     {
         return value();

--- a/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
@@ -70,6 +70,7 @@ public abstract class StringValue extends TextValue
     @Override
     public TextArray split( String separator )
     {
+        assert separator != null;
         String asString = value();
         //Cypher has different semantics for the case where the separator
         //is exactly the value, in cypher we expect two empty arrays
@@ -85,7 +86,17 @@ public abstract class StringValue extends TextValue
     @Override
     public TextValue replace( String find, String replace )
     {
+        assert find != null;
+        assert replace != null;
+
         return Values.stringValue( value().replace( find, replace ) );
+    }
+
+    @Override
+    public TextValue reverse()
+    {
+        StringBuilder stringBuilder = new StringBuilder( value() );
+        return Values.stringValue( stringBuilder.reverse().toString() );
     }
 
     @Override
@@ -132,7 +143,7 @@ public abstract class StringValue extends TextValue
             }
             k += Character.charCount( c1 );
         }
-        return length() - other.length();
+        return len1 - len2;
     }
 
     static TextValue EMTPY = new StringValue()
@@ -176,7 +187,7 @@ public abstract class StringValue extends TextValue
         @Override
         public int compareTo( TextValue other )
         {
-            return Integer.compare( 0, other.length() );
+            return -other.length();
         }
 
         @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
@@ -76,6 +76,12 @@ public abstract class StringValue extends TextValue
     }
 
     @Override
+    public TextValue replace( String find, String replace )
+    {
+        return Values.stringValue( value().replace( find, replace ) );
+    }
+
+    @Override
     public Object asObjectCopy()
     {
         return value();

--- a/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
@@ -71,6 +71,13 @@ public abstract class StringValue extends TextValue
     public TextArray split( String separator )
     {
         String asString = value();
+        //Cypher has different semantics for the case where the separator
+        //is exactly the value, in cypher we expect two empty arrays
+        //where as java returns an empty array
+        if ( separator.equals( asString ) )
+        {
+            return Values.stringArray( "", "" );
+        }
         String[] split = asString.split( separator );
         return Values.stringArray( split );
     }

--- a/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
@@ -93,13 +93,6 @@ public abstract class StringValue extends TextValue
     }
 
     @Override
-    public TextValue reverse()
-    {
-        StringBuilder stringBuilder = new StringBuilder( value() );
-        return Values.stringValue( stringBuilder.reverse().toString() );
-    }
-
-    @Override
     public Object asObjectCopy()
     {
         return value();
@@ -182,6 +175,37 @@ public abstract class StringValue extends TextValue
         public TextValue rtrim()
         {
             return this;
+        }
+
+        @Override
+        public TextValue reverse()
+        {
+            return this;
+        }
+
+        @Override
+        public TextValue toLower()
+        {
+            return this;
+        }
+
+        @Override
+        public TextValue toUpper()
+        {
+            return this;
+        }
+
+        @Override
+        public TextValue replace( String find, String replace )
+        {
+            if ( find.isEmpty() )
+            {
+                return Values.stringValue( replace );
+            }
+            else
+            {
+                return this;
+            }
         }
 
         @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/StringWrappingStringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringWrappingStringValue.java
@@ -95,6 +95,13 @@ final class StringWrappingStringValue extends StringValue
         return Values.stringValue( value.substring( 0, end ) );
     }
 
+    @Override
+    public TextValue reverse()
+    {
+        StringBuilder stringBuilder = new StringBuilder( value() );
+        return Values.stringValue( stringBuilder.reverse().toString() );
+    }
+
     private int ltrimIndex( String value )
     {
         int start = 0, length = value.length();

--- a/community/values/src/main/java/org/neo4j/values/storable/TextValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TextValue.java
@@ -51,7 +51,9 @@ public abstract class TextValue extends ScalarValue
 
     public abstract TextValue toUpper();
 
-    public abstract TextArray split(String separator);
+    public abstract TextArray split( String separator );
+
+    public abstract TextValue replace( String find, String replace );
 
     public abstract int compareTo( TextValue other );
 

--- a/community/values/src/main/java/org/neo4j/values/storable/TextValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TextValue.java
@@ -55,6 +55,8 @@ public abstract class TextValue extends ScalarValue
 
     public abstract TextValue replace( String find, String replace );
 
+    public abstract TextValue reverse();
+
     public abstract int compareTo( TextValue other );
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/TextValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TextValue.java
@@ -49,6 +49,8 @@ public abstract class TextValue extends ScalarValue
 
     public abstract TextValue toLower();
 
+    public abstract TextValue toUpper();
+
     public abstract int compareTo( TextValue other );
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/TextValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TextValue.java
@@ -51,6 +51,8 @@ public abstract class TextValue extends ScalarValue
 
     public abstract TextValue toUpper();
 
+    public abstract TextArray split(String separator);
+
     public abstract int compareTo( TextValue other );
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/TextValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TextValue.java
@@ -47,6 +47,8 @@ public abstract class TextValue extends ScalarValue
 
     public abstract TextValue rtrim();
 
+    public abstract TextValue toLower();
+
     public abstract int compareTo( TextValue other );
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/UTF8StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/UTF8StringValue.java
@@ -20,7 +20,6 @@
 package org.neo4j.values.storable;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 
 /*
  * Just as a normal StringValue but is backed by a byte array and does string
@@ -39,7 +38,7 @@ public final class UTF8StringValue extends StringValue
     private final int offset;
     private final int byteLength;
 
-    public UTF8StringValue( byte[] bytes, int offset, int length )
+    UTF8StringValue( byte[] bytes, int offset, int length )
     {
         assert bytes != null;
         this.bytes = bytes;
@@ -58,7 +57,19 @@ public final class UTF8StringValue extends StringValue
     {
         if ( value instanceof UTF8StringValue )
         {
-            return Arrays.equals( bytes, ((org.neo4j.values.storable.UTF8StringValue) value).bytes );
+            UTF8StringValue other = (UTF8StringValue) value;
+            if ( byteLength != other.byteLength )
+            {
+                return false;
+            }
+            for ( int i = offset, j = other.offset; i < byteLength; i++, j++ )
+            {
+                if ( bytes[i] != other.bytes[j] )
+                {
+                    return false;
+                }
+            }
+            return true;
         }
         else
         {

--- a/community/values/src/main/java/org/neo4j/values/storable/UTF8StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/UTF8StringValue.java
@@ -284,7 +284,6 @@ public final class UTF8StringValue extends StringValue
 
         int i = offset, len = offset + byteLength;
         byte[] newValues = new byte[byteLength];
-        int newIndex = byteLength -1;
         while ( i < len )
         {
             byte b = values[i];
@@ -292,8 +291,9 @@ public final class UTF8StringValue extends StringValue
             //we are dealing with an ascii value and use a single byte for storing the value.
             if ( b >= 0 )
             {
-                newValues[newIndex] = b;
-                newIndex--;
+                //a single byte is trivial to reverse
+                //just put it at the opposite end of the new array
+                newValues[len - 1 - i] = b;
                 i++;
                 continue;
             }
@@ -310,9 +310,11 @@ public final class UTF8StringValue extends StringValue
                 bytesNeeded++;
                 b = (byte) (b << 1);
             }
-            System.arraycopy( values, i, newValues, newIndex - bytesNeeded + 1, bytesNeeded );
+            //reversing when multiple bytes are needed for the code point we cannot just reverse
+            //since we need to preserve the code point while moving it,
+            //e.g. [A, b1,b2, B] -> [B, b1,b2, A]
+            System.arraycopy( values, i, newValues, len - i - bytesNeeded, bytesNeeded );
             i += bytesNeeded;
-            newIndex -= bytesNeeded;
         }
 
         return new UTF8StringValue( newValues, 0, newValues.length );

--- a/community/values/src/main/java/org/neo4j/values/storable/UTF8StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/UTF8StringValue.java
@@ -39,7 +39,7 @@ public final class UTF8StringValue extends StringValue
     private final int offset;
     private final int byteLength;
 
-    UTF8StringValue( byte[] bytes, int offset, int length )
+    public UTF8StringValue( byte[] bytes, int offset, int length )
     {
         assert bytes != null;
         this.bytes = bytes;
@@ -161,6 +161,10 @@ public final class UTF8StringValue extends StringValue
         if ( start < 0 || length < 0 )
         {
             throw new IndexOutOfBoundsException( "Cannot handle negative start index nor negative length" );
+        }
+        if ( length == 0 )
+        {
+            return StringValue.EMTPY;
         }
 
         int end = start + length;

--- a/community/values/src/main/java/org/neo4j/values/storable/Values.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Values.java
@@ -44,7 +44,7 @@ public final class Values
     public static final Value MAX_NUMBER = Values.doubleValue( Double.NaN );
     public static final Value ZERO_FLOAT = Values.doubleValue( 0.0 );
     public static final Value ZERO_INT = Values.longValue( 0 );
-    public static final Value MIN_STRING = Values.stringValue( "" );
+    public static final Value MIN_STRING =  StringValue.EMTPY;
     public static final Value MAX_STRING = Values.booleanValue( false );
     public static final BooleanValue TRUE = Values.booleanValue( true );
     public static final BooleanValue FALSE = Values.booleanValue( false );
@@ -59,7 +59,7 @@ public final class Values
     public static final ArrayValue EMPTY_LONG_ARRAY = Values.longArray( new long[0] );
     public static final ArrayValue EMPTY_FLOAT_ARRAY = Values.floatArray( new float[0] );
     public static final ArrayValue EMPTY_DOUBLE_ARRAY = Values.doubleArray( new double[0] );
-    public static final TextArray EMPTY_TEXT_ARRAY = Values.stringArray(  );
+    public static final TextArray EMPTY_TEXT_ARRAY = Values.stringArray();
 
     private Values()
     {
@@ -108,18 +108,32 @@ public final class Values
 
     public static final Value NO_VALUE = NoValue.NO_VALUE;
 
-    public static UTF8StringValue utf8Value( byte[] bytes )
+    public static TextValue utf8Value( byte[] bytes )
     {
+        if ( bytes.length == 0 )
+        {
+            return EMPTY_STRING;
+        }
+
         return utf8Value( bytes, 0, bytes.length );
     }
 
-    public static UTF8StringValue utf8Value( byte[] bytes, int offset, int length )
+    public static TextValue utf8Value( byte[] bytes, int offset, int length )
     {
+        if ( length == 0 )
+        {
+            return EMPTY_STRING;
+        }
+
         return new UTF8StringValue( bytes, offset, length );
     }
 
     public static TextValue stringValue( String value )
     {
+        if ( value.isEmpty() )
+        {
+            return EMPTY_STRING;
+        }
         return new StringWrappingStringValue( value );
     }
 
@@ -131,7 +145,7 @@ public final class Values
         }
         else
         {
-            return new StringWrappingStringValue( value );
+            return stringValue( value );
         }
     }
 

--- a/community/values/src/main/java/org/neo4j/values/storable/Values.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Values.java
@@ -44,7 +44,7 @@ public final class Values
     public static final Value MAX_NUMBER = Values.doubleValue( Double.NaN );
     public static final Value ZERO_FLOAT = Values.doubleValue( 0.0 );
     public static final Value ZERO_INT = Values.longValue( 0 );
-    public static final Value MIN_STRING =  StringValue.EMTPY;
+    public static final Value MIN_STRING = StringValue.EMTPY;
     public static final Value MAX_STRING = Values.booleanValue( false );
     public static final BooleanValue TRUE = Values.booleanValue( true );
     public static final BooleanValue FALSE = Values.booleanValue( false );

--- a/community/values/src/main/java/org/neo4j/values/storable/Values.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Values.java
@@ -59,6 +59,7 @@ public final class Values
     public static final ArrayValue EMPTY_LONG_ARRAY = Values.longArray( new long[0] );
     public static final ArrayValue EMPTY_FLOAT_ARRAY = Values.floatArray( new float[0] );
     public static final ArrayValue EMPTY_DOUBLE_ARRAY = Values.doubleArray( new double[0] );
+    public static final TextArray EMPTY_TEXT_ARRAY = Values.stringArray(  );
 
     private Values()
     {

--- a/community/values/src/main/java/org/neo4j/values/utils/UTF8Utils.java
+++ b/community/values/src/main/java/org/neo4j/values/utils/UTF8Utils.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.values.utils;
 
+import org.neo4j.values.storable.TextValue;
 import org.neo4j.values.storable.UTF8StringValue;
 
 import static org.neo4j.values.storable.Values.utf8Value;
@@ -39,7 +40,7 @@ public final class UTF8Utils
      * @param b value to add
      * @return the value a + b
      */
-    public static UTF8StringValue add( UTF8StringValue a, UTF8StringValue b )
+    public static TextValue add( UTF8StringValue a, UTF8StringValue b )
     {
         byte[] bytesA = a.bytes();
         byte[] bytesB = b.bytes();
@@ -47,6 +48,6 @@ public final class UTF8Utils
         byte[] bytes = new byte[bytesA.length + bytesB.length];
         System.arraycopy( bytesA, 0, bytes, 0, bytesA.length );
         System.arraycopy( bytesB, 0, bytes, bytesA.length, bytesB.length );
-        return utf8Value(bytes);
+        return utf8Value( bytes );
     }
 }

--- a/community/values/src/test/java/org/neo4j/values/storable/TextValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/TextValueTest.java
@@ -124,10 +124,10 @@ public class TextValueTest
     @Test
     public void reverse()
     {
-        assertThat( value.apply( "Foo" ).reverse(), equalTo( value.apply( "ooF" ) ) );
-        assertThat( value.apply( "" ).reverse(), equalTo( StringValue.EMTPY ) );
-        assertThat( value.apply( " L" ).reverse(), equalTo( value.apply( "L " ) ) );
-        assertThat( value.apply( "\r\n" ).reverse(), equalTo( value.apply( "\n\r" ) ) );
+//        assertThat( value.apply( "Foo" ).reverse(), equalTo( value.apply( "ooF" ) ) );
+//        assertThat( value.apply( "" ).reverse(), equalTo( StringValue.EMTPY ) );
+//        assertThat( value.apply( " L" ).reverse(), equalTo( value.apply( "L " ) ) );
+//        assertThat( value.apply( "\r\n" ).reverse(), equalTo( value.apply( "\n\r" ) ) );
         assertThat( value.apply( "\uD801\uDC37" ).reverse(), equalTo( value.apply( "\uD801\uDC37" ) ) );
     }
 

--- a/community/values/src/test/java/org/neo4j/values/storable/TextValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/TextValueTest.java
@@ -56,6 +56,8 @@ public class TextValueTest
         assertThat( value.apply( "hello" ).replace( "l", "w" ), equalTo( value.apply( "hewwo" ) ) );
         assertThat( value.apply( "hello" ).replace( "ell", "ipp" ), equalTo( value.apply( "hippo" ) ) );
         assertThat( value.apply( "hello" ).replace( "a", "x" ), equalTo( value.apply( "hello" ) ) );
+        assertThat( value.apply( "hello" ).replace( "e", "" ), equalTo( value.apply( "hllo" ) ) );
+        assertThat( value.apply( "" ).replace( "", "⁻" ), equalTo( value.apply( "⁻" ) ) );
     }
 
     @Test
@@ -68,10 +70,10 @@ public class TextValueTest
         assertThat( value.apply( "0123456789" ).substring( 1 ), equalTo( value.apply( "123456789" ) ) );
         assertThat( value.apply( "0123456789" ).substring( 5 ), equalTo( value.apply( "56789" ) ) );
         assertThat( value.apply( "0123456789" ).substring( 15 ), equalTo( StringValue.EMTPY ) );
-        assertThat( value.apply( "\uD83D\uDE21\uD83D\uDE21\uD83D\uDE21" ).substring( 1, 1 ),
-                equalTo( value.apply( "\uD83D\uDE21" ) ) );
-        assertThat( value.apply( "\uD83D\uDE21\uD83D\uDE21\uD83D\uDE21" ).substring( 1, 2 ),
-                equalTo( value.apply( "\uD83D\uDE21\uD83D\uDE21" ) ) );
+        assertThat( value.apply( "\uD83D\uDE21\uD83D\uDCA9\uD83D\uDC7B" ).substring( 1, 1 ),
+                equalTo( value.apply( "\uD83D\uDCA9" ) ) );
+        assertThat( value.apply( "\uD83D\uDE21\uD83D\uDCA9\uD83D\uDC7B" ).substring( 1, 2 ),
+                equalTo( value.apply( "\uD83D\uDCA9\uD83D\uDC7B" ) ) );
 
         exception.expect( IndexOutOfBoundsException.class );
         value.apply( "hello" ).substring( -4, 2 );
@@ -83,6 +85,7 @@ public class TextValueTest
         assertThat( value.apply( "HELLO" ).toLower(), equalTo( value.apply( "hello" ) ) );
         assertThat( value.apply( "Hello" ).toLower(), equalTo( value.apply( "hello" ) ) );
         assertThat( value.apply( "hello" ).toLower(), equalTo( value.apply( "hello" ) ) );
+        assertThat( value.apply( "" ).toLower(), equalTo( value.apply( "" ) ) );
     }
 
     @Test
@@ -91,6 +94,7 @@ public class TextValueTest
         assertThat( value.apply( "HELLO" ).toUpper(), equalTo( value.apply( "HELLO" ) ) );
         assertThat( value.apply( "Hello" ).toUpper(), equalTo( value.apply( "HELLO" ) ) );
         assertThat( value.apply( "hello" ).toUpper(), equalTo( value.apply( "HELLO" ) ) );
+        assertThat( value.apply( "" ).toUpper(), equalTo( value.apply( "" ) ) );
     }
 
     @Test
@@ -124,11 +128,15 @@ public class TextValueTest
     @Test
     public void reverse()
     {
-//        assertThat( value.apply( "Foo" ).reverse(), equalTo( value.apply( "ooF" ) ) );
-//        assertThat( value.apply( "" ).reverse(), equalTo( StringValue.EMTPY ) );
-//        assertThat( value.apply( " L" ).reverse(), equalTo( value.apply( "L " ) ) );
-//        assertThat( value.apply( "\r\n" ).reverse(), equalTo( value.apply( "\n\r" ) ) );
+        assertThat( value.apply( "Foo" ).reverse(), equalTo( value.apply( "ooF" ) ) );
+        assertThat( value.apply( "" ).reverse(), equalTo( StringValue.EMTPY ) );
+        assertThat( value.apply( " L" ).reverse(), equalTo( value.apply( "L " ) ) );
+        assertThat( value.apply( "\r\n" ).reverse(), equalTo( value.apply( "\n\r" ) ) );
         assertThat( value.apply( "\uD801\uDC37" ).reverse(), equalTo( value.apply( "\uD801\uDC37" ) ) );
+        assertThat( value.apply( "This is literally a pile of crap \uD83D\uDCA9, it is fantastic" ).reverse(),
+                equalTo( value.apply( "citsatnaf si ti ,\uD83D\uDCA9 parc fo elip a yllaretil si sihT" ) ) );
+        assertThat( value.apply( "\uD83D\uDE21\uD83D\uDCA9\uD83D\uDC7B" ).reverse(), equalTo( value.apply(
+                "\uD83D\uDC7B\uD83D\uDCA9\uD83D\uDE21" ) ) );
     }
 
     @Test
@@ -137,5 +145,7 @@ public class TextValueTest
         assertThat( value.apply( "HELLO" ).split( "LL" ), equalTo( stringArray( "HE", "O" ) ) );
         assertThat( value.apply( "Separating,by,comma,is,a,common,use,case" ).split( "," ),
                 equalTo( stringArray( "Separating", "by", "comma", "is", "a", "common", "use", "case" ) ) );
+        assertThat( value.apply( "HELLO" ).split( "HELLO" ), equalTo( stringArray( "", "" ) ) );
+
     }
 }

--- a/community/values/src/test/java/org/neo4j/values/storable/TextValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/TextValueTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.storable;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.function.Function;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.neo4j.values.storable.Values.stringArray;
+import static org.neo4j.values.storable.Values.utf8Value;
+
+@RunWith( Parameterized.class )
+public class TextValueTest
+{
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Parameterized.Parameter
+    public Function<String,TextValue> value;
+
+    @Parameterized.Parameters
+    public static Collection<Function<String,TextValue>> functions()
+    {
+        return asList( Values::stringValue, s -> utf8Value( s.getBytes( StandardCharsets.UTF_8 ) ) );
+    }
+
+    @Test
+    public void replace()
+    {
+        assertThat( value.apply( "hello" ).replace( "l", "w" ), equalTo( value.apply( "hewwo" ) ) );
+        assertThat( value.apply( "hello" ).replace( "ell", "ipp" ), equalTo( value.apply( "hippo" ) ) );
+        assertThat( value.apply( "hello" ).replace( "a", "x" ), equalTo( value.apply( "hello" ) ) );
+    }
+
+    @Test
+    public void substring()
+    {
+        assertThat( value.apply( "hello" ).substring( 2, 5 ), equalTo( value.apply( "llo" ) ) );
+        assertThat( value.apply( "hello" ).substring( 4, 5 ), equalTo( value.apply( "o" ) ) );
+        assertThat( value.apply( "hello" ).substring( 1, 3 ), equalTo( value.apply( "ell" ) ) );
+        assertThat( value.apply( "hello" ).substring( 8, 5 ), equalTo( StringValue.EMTPY ) );
+        assertThat( value.apply( "0123456789" ).substring( 1 ), equalTo( value.apply( "123456789" ) ) );
+        assertThat( value.apply( "0123456789" ).substring( 5 ), equalTo( value.apply( "56789" ) ) );
+        assertThat( value.apply( "0123456789" ).substring( 15 ), equalTo( StringValue.EMTPY ) );
+        assertThat( value.apply( "\uD83D\uDE21\uD83D\uDE21\uD83D\uDE21" ).substring( 1, 1 ),
+                equalTo( value.apply( "\uD83D\uDE21" ) ) );
+        assertThat( value.apply( "\uD83D\uDE21\uD83D\uDE21\uD83D\uDE21" ).substring( 1, 2 ),
+                equalTo( value.apply( "\uD83D\uDE21\uD83D\uDE21" ) ) );
+
+        exception.expect( IndexOutOfBoundsException.class );
+        value.apply( "hello" ).substring( -4, 2 );
+    }
+
+    @Test
+    public void toLower()
+    {
+        assertThat( value.apply( "HELLO" ).toLower(), equalTo( value.apply( "hello" ) ) );
+        assertThat( value.apply( "Hello" ).toLower(), equalTo( value.apply( "hello" ) ) );
+        assertThat( value.apply( "hello" ).toLower(), equalTo( value.apply( "hello" ) ) );
+    }
+
+    @Test
+    public void toUpper()
+    {
+        assertThat( value.apply( "HELLO" ).toUpper(), equalTo( value.apply( "HELLO" ) ) );
+        assertThat( value.apply( "Hello" ).toUpper(), equalTo( value.apply( "HELLO" ) ) );
+        assertThat( value.apply( "hello" ).toUpper(), equalTo( value.apply( "HELLO" ) ) );
+    }
+
+    @Test
+    public void ltrim()
+    {
+        assertThat( value.apply( "  HELLO" ).ltrim(), equalTo( value.apply( "HELLO" ) ) );
+        assertThat( value.apply( " Hello" ).ltrim(), equalTo( value.apply( "Hello" ) ) );
+        assertThat( value.apply( "  hello  " ).ltrim(), equalTo( value.apply( "hello  " ) ) );
+        assertThat( value.apply( "\u2009㺂࿝鋦毠\u2009" ).ltrim(), equalTo( value.apply( "㺂࿝鋦毠\u2009" ) ) );
+    }
+
+    @Test
+    public void rtrim()
+    {
+        assertThat( value.apply( "HELLO  " ).rtrim(), equalTo( value.apply( "HELLO" ) ) );
+        assertThat( value.apply( "Hello  " ).rtrim(), equalTo( value.apply( "Hello" ) ) );
+        assertThat( value.apply( "  hello  " ).rtrim(), equalTo( value.apply( "  hello" ) ) );
+        assertThat( value.apply( "\u2009㺂࿝鋦毠\u2009" ).rtrim(), equalTo( value.apply( "\u2009㺂࿝鋦毠" ) ) );
+    }
+
+    @Test
+    public void trim()
+    {
+        assertThat( value.apply( "  hello  " ).trim(), equalTo( value.apply( "hello" ) ) );
+        assertThat( value.apply( "  hello " ).trim(), equalTo( value.apply( "hello" ) ) );
+        assertThat( value.apply( "hello " ).trim(), equalTo( value.apply( "hello" ) ) );
+        assertThat( value.apply( "  hello" ).trim(), equalTo( value.apply( "hello" ) ) );
+        assertThat( value.apply( "\u2009㺂࿝鋦毠\u2009" ).trim(), equalTo( value.apply( "㺂࿝鋦毠" ) ) );
+    }
+
+    @Test
+    public void reverse()
+    {
+        assertThat( value.apply( "Foo" ).reverse(), equalTo( value.apply( "ooF" ) ) );
+        assertThat( value.apply( "" ).reverse(), equalTo( StringValue.EMTPY ) );
+        assertThat( value.apply( " L" ).reverse(), equalTo( value.apply( "L " ) ) );
+        assertThat( value.apply( "\r\n" ).reverse(), equalTo( value.apply( "\n\r" ) ) );
+        assertThat( value.apply( "\uD801\uDC37" ).reverse(), equalTo( value.apply( "\uD801\uDC37" ) ) );
+    }
+
+    @Test
+    public void split()
+    {
+        assertThat( value.apply( "HELLO" ).split( "LL" ), equalTo( stringArray( "HE", "O" ) ) );
+        assertThat( value.apply( "Separating,by,comma,is,a,common,use,case" ).split( "," ),
+                equalTo( stringArray( "Separating", "by", "comma", "is", "a", "common", "use", "case" ) ) );
+    }
+}

--- a/community/values/src/test/java/org/neo4j/values/storable/UTF8StringValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/UTF8StringValueTest.java
@@ -127,6 +127,18 @@ public class UTF8StringValueTest
     }
 
     @Test
+    public void shouldReverse()
+    {
+        for ( String string : strings )
+        {
+            TextValue stringValue = stringValue( string );
+            byte[] bytes = string.getBytes( UTF_8 );
+            TextValue utf8 = utf8Value( bytes );
+            assertSame( stringValue.reverse(), utf8.reverse() );
+        }
+    }
+
+    @Test
     public void shouldHandleOffset()
     {
         // Given
@@ -137,6 +149,7 @@ public class UTF8StringValueTest
 
         // Then
         assertSame( textValue, stringValue( "de" ) );
+        assertSame( textValue.reverse(), stringValue( "ed" ) );
     }
 
     private void assertSame( TextValue lhs, TextValue rhs )

--- a/community/values/src/test/java/org/neo4j/values/storable/UTF8StringValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/UTF8StringValueTest.java
@@ -153,7 +153,7 @@ public class UTF8StringValueTest
     public void shouldHandleTooLargeStartPointInSubstring()
     {
         // Given
-        UTF8StringValue value = utf8Value( "hello".getBytes( UTF_8 ) );
+        TextValue value = utf8Value( "hello".getBytes( UTF_8 ) );
 
         // When
         TextValue substring = value.substring( 8, 5 );
@@ -166,7 +166,7 @@ public class UTF8StringValueTest
     public void shouldHandleTooLargeLengthInSubstring()
     {
         // Given
-        UTF8StringValue value = utf8Value( "hello".getBytes( UTF_8 ) );
+        TextValue value = utf8Value( "hello".getBytes( UTF_8 ) );
 
         // When
         TextValue substring = value.substring( 3, 76 );
@@ -179,7 +179,7 @@ public class UTF8StringValueTest
     public void shouldThrowOnNegativeStart()
     {
         // Given
-        UTF8StringValue value = utf8Value( "hello".getBytes( UTF_8 ) );
+        TextValue value = utf8Value( "hello".getBytes( UTF_8 ) );
 
         // Expect
         exception.expect( IndexOutOfBoundsException.class );
@@ -192,7 +192,7 @@ public class UTF8StringValueTest
     public void shouldThrowOnNegativeLength()
     {
         // Given
-        UTF8StringValue value = utf8Value( "hello".getBytes( UTF_8 ) );
+        TextValue value = utf8Value( "hello".getBytes( UTF_8 ) );
 
         // Expect
         exception.expect( IndexOutOfBoundsException.class );

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TextValueSpecification.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TextValueSpecification.scala
@@ -60,6 +60,12 @@ object TextValueSpecification extends Properties("TextValue") with Configuration
       equivalent(utf8StringValue.trim(), sValue.ltrim().rtrim())}
   }
 
+  property("reverse") = forAll { (x: String) =>
+    val sValue = stringValue(x)
+    val utf8StringValue = utf8Value(x.getBytes(StandardCharsets.UTF_8))
+    equivalent(sValue.reverse(), utf8StringValue.reverse())
+  }
+
   property("ltrim") = forAll { (x: String) =>
     equivalent(stringValue(x).ltrim(), utf8Value(x.getBytes(StandardCharsets.UTF_8)).ltrim())
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TextValueSpecification.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TextValueSpecification.scala
@@ -22,7 +22,7 @@ package org.neo4j.internal.cypher.acceptance
 import java.nio.charset.StandardCharsets
 
 import org.neo4j.values.storable.TextValue
-import org.neo4j.values.storable.Values.{stringValue, utf8Value}
+import org.neo4j.values.storable.Values.{stringArray, stringValue, utf8Value}
 import org.scalacheck.{Properties, _}
 import org.scalatest.prop.Configuration
 
@@ -67,6 +67,40 @@ object TextValueSpecification extends Properties("TextValue") with Configuration
   property("rtrim") = forAll { (x: String) =>
     equivalent(stringValue(x).rtrim(), utf8Value(x.getBytes(StandardCharsets.UTF_8)).rtrim())
   }
+
+  property("toLower") = forAll { (x: String) => {
+    val value = stringValue(x)
+    val utf8 = utf8Value(x.getBytes(StandardCharsets.UTF_8))
+    equivalent(stringValue(x.toLowerCase), value.toLower) &&
+      equivalent(value.toLower, utf8.toLower)
+  }}
+
+  property("toUpper") = forAll { (x: String) => {
+    val value = stringValue(x)
+    val utf8 = utf8Value(x.getBytes(StandardCharsets.UTF_8))
+    equivalent(stringValue(x.toUpperCase), value.toUpper) &&
+      equivalent(value.toUpper, utf8.toUpper)
+  }}
+
+  property("replace") = forAll { (x: String, find: String, replace: String) => {
+    val value = stringValue(x)
+    val utf8 = utf8Value(x.getBytes(StandardCharsets.UTF_8))
+    equivalent(stringValue(x.replace(find, replace)), value.replace(find, replace)) &&
+      equivalent(value.replace(find, replace), utf8.replace(find, replace))
+  }}
+
+  property("split") = forAll { (x: String, find: String) => {
+    val value = stringValue(x)
+    val utf8 = utf8Value(x.getBytes(StandardCharsets.UTF_8))
+    val split = x.split(find)
+    if (x != find) {
+      stringArray(split: _*) == value.split(find) &&
+        value.split(find) == utf8.split(find)
+    } else {
+      value.split(find) == utf8.split(find) && value.split(find) == stringArray("", "")
+    }
+
+  }}
 
   property("compareTo") = forAll { (x: String, y: String) =>
     val stringX = stringValue(x)


### PR DESCRIPTION
Instead of having `StringFunction.scala` implementing string functions we move the implementation of the rest of the string functions down to the `TextValue` implementation. All these methods currently require some form of regular expression support which is why these methods are added on the abstract class using the `value()` method which forces a string to be materialized.