### PR TITLE
Turn off sort and top after stand-alone limit in compiled runtime.

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -157,6 +157,9 @@ Accessing a map with null should return null
 //SkipLimitAcceptance.feature
 Combining LIMIT and aggregation
 Using a optional match after aggregation and before an aggregation
+Limit before sort should work except in compiled
+Limit before top should work except in compiled
+Limit before distinct should work except in compiled
 
 //MatchAcceptance.feature
 difficult to plan query number 1

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -157,9 +157,9 @@ Accessing a map with null should return null
 //SkipLimitAcceptance.feature
 Combining LIMIT and aggregation
 Using a optional match after aggregation and before an aggregation
-Limit before sort should work except in compiled
-Limit before top should work except in compiled
-Limit before distinct should work except in compiled
+Limit before sort
+Limit before top
+Limit before distinct
 
 //MatchAcceptance.feature
 difficult to plan query number 1

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/SkipLimitAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/SkipLimitAcceptance.feature
@@ -71,7 +71,7 @@ Feature: SkipLimitAcceptance
       |   1   |
     And no side effects
 
-  Scenario: Normal limit in the end should work
+  Scenario: Stand alone limit in the return clause
     And having executed:
       """
       CREATE (:A {id:0})-[:REL]->(:B {id:1})
@@ -88,7 +88,7 @@ Feature: SkipLimitAcceptance
       | 1  |
     And no side effects
 
-  Scenario: Order by followed by limit in the end should work
+  Scenario: Order by followed by limit in return clause
     And having executed:
       """
       CREATE (:A {id:0})-[:REL]->(:B {id:1})
@@ -105,7 +105,7 @@ Feature: SkipLimitAcceptance
       | 1  |
     And no side effects
 
-  Scenario: Limit in with should work
+  Scenario: Limit in with clause
       And having executed:
       """
       CREATE (:A {id:0})-[:REL]->(:B {id:1})
@@ -121,7 +121,7 @@ Feature: SkipLimitAcceptance
         | 1  |
       And no side effects
 
-  Scenario: Limit before sort should work except in compiled
+  Scenario: Limit before sort
     And having executed:
       """
       CREATE (:A {id:0})-[:REL]->(:B {id:1})
@@ -138,7 +138,7 @@ Feature: SkipLimitAcceptance
       | 1  |
     And no side effects
 
-  Scenario: Limit before top should work except in compiled
+  Scenario: Limit before top
     And having executed:
       """
       CREATE (:A {id:0})-[:REL]->(:B {id:1})
@@ -155,7 +155,7 @@ Feature: SkipLimitAcceptance
       | 1  |
     And no side effects
 
-  Scenario: Limit before distinct should work except in compiled
+  Scenario: Limit before distinct
     And having executed:
       """
       CREATE (:A {id:0})-[:REL]->(:B {id:1})

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/SkipLimitAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/SkipLimitAcceptance.feature
@@ -70,3 +70,103 @@ Feature: SkipLimitAcceptance
       | count |
       |   1   |
     And no side effects
+
+  Scenario: Normal limit in the end should work
+    And having executed:
+      """
+      CREATE (:A {id:0})-[:REL]->(:B {id:1})
+      """
+    When executing query:
+      """
+      MATCH (n:A) WITH n
+      MATCH (n)-[:REL]->(m)
+      RETURN m.id AS id
+      LIMIT 1
+      """
+    Then the result should be, in order:
+      | id |
+      | 1  |
+    And no side effects
+
+  Scenario: Order by followed by limit in the end should work
+    And having executed:
+      """
+      CREATE (:A {id:0})-[:REL]->(:B {id:1})
+      """
+    When executing query:
+      """
+      MATCH (n:A) WITH n
+      MATCH (n)-[:REL]->(m)
+      RETURN m.id AS id
+      ORDER BY id LIMIT 1
+      """
+    Then the result should be, in order:
+      | id |
+      | 1  |
+    And no side effects
+
+  Scenario: Limit in with should work
+      And having executed:
+      """
+      CREATE (:A {id:0})-[:REL]->(:B {id:1})
+      """
+      When executing query:
+      """
+      MATCH (n:A) WITH n LIMIT 1
+      MATCH (n)-[:REL]->(m)
+      RETURN m.id AS id
+      """
+      Then the result should be, in order:
+        | id |
+        | 1  |
+      And no side effects
+
+  Scenario: Limit before sort should work except in compiled
+    And having executed:
+      """
+      CREATE (:A {id:0})-[:REL]->(:B {id:1})
+      """
+    When executing query:
+      """
+      MATCH (n:A) WITH n LIMIT 1
+      MATCH (n)-[:REL]->(m)
+      RETURN m.id AS id
+      ORDER BY id
+      """
+    Then the result should be, in order:
+      | id |
+      | 1  |
+    And no side effects
+
+  Scenario: Limit before top should work except in compiled
+    And having executed:
+      """
+      CREATE (:A {id:0})-[:REL]->(:B {id:1})
+      """
+    When executing query:
+      """
+      MATCH (n:A) WITH n LIMIT 1
+      MATCH (n)-[:REL]->(m)
+      RETURN m.id AS id
+      ORDER BY id LIMIT 1
+      """
+    Then the result should be, in order:
+      | id |
+      | 1  |
+    And no side effects
+
+  Scenario: Limit before distinct should work except in compiled
+    And having executed:
+      """
+      CREATE (:A {id:0})-[:REL]->(:B {id:1})
+      """
+    When executing query:
+      """
+      MATCH (n:A) WITH n LIMIT 1
+      MATCH (n)-[:REL]->(m)
+      RETURN DISTINCT m.id AS id
+      """
+    Then the result should be, in order:
+      | id |
+      | 1  |
+    And no side effects


### PR DESCRIPTION
Executed, but with the wrong result before. 
Same behaviour in 3.3 confirmed, should be forward merged all the way to 3.4