### PR TITLE
Fixes problem around equality and lists with single values

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/commands/predicates/Equivalent.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/commands/predicates/Equivalent.scala
@@ -113,7 +113,7 @@ object Equivalent {
     val it = x.toIterator
     if (it.isEmpty) return None
     val e1 = eager(it.next())
-    if (it.isEmpty) return e1
+    if (it.isEmpty) return Some(e1)
     val e2 = eager(it.next())
     if (it.isEmpty) return (e1, e2)
     val e3 = eager(it.next())

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/RuntimeValueEqualityTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/RuntimeValueEqualityTest.scala
@@ -26,9 +26,7 @@ import java.util.Collections.singletonMap
 import org.neo4j.cypher.internal.codegen.CompiledEquivalenceUtils
 import org.neo4j.cypher.internal.compiler.v3_2.commands.predicates.Equivalent
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
-import org.neo4j.graphdb.spatial.{Coordinate => JavaCoordinate}
-import org.neo4j.graphdb.spatial.{CRS => JavaCRS}
-import org.neo4j.graphdb.spatial. {Point => JavaPoint}
+import org.neo4j.graphdb.spatial.{CRS => JavaCRS, Coordinate => JavaCoordinate, Point => JavaPoint}
 
 import scala.collection.JavaConverters._
 
@@ -163,6 +161,11 @@ class RuntimeValueEqualityTest extends CypherFunSuite {
   shouldMatch(Array[String]("A", "B", "C"), asList('A', 'B', 'C'))
   shouldMatch(Array[Char]('A', 'B', 'C'), asList("A", "B", "C"))
   shouldMatch(new util.ArrayList[AnyRef](), Array.empty)
+  shouldNotMatch(false, Array(false))
+  shouldNotMatch(Array(false), false)
+  shouldNotMatch(1, Array(1))
+  shouldNotMatch("apa", Array("apa"))
+  shouldNotMatch(Array(1), Array(Array(1)))
 
   // Maps
   shouldMatch(Map("a" -> 42).asJava, Map("a" -> 42).asJava)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/java/cypher/AcceptanceSpecSuiteTest.java
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/java/cypher/AcceptanceSpecSuiteTest.java
@@ -34,7 +34,7 @@ public class AcceptanceSpecSuiteTest
     // If you want to run only a single feature, put the name of the feature file in `FEATURE_TO_RUN` (including .feature)
     // If you want to run only a single scenario, put (part of) its name in the `SCENARIO_NAME_REQUIRED` constant
     // Do not forget to clear these strings to empty strings before you commit!!
-    public static final String FEATURE_TO_RUN = "OptionalMatchAcceptance.feature";
+    public static final String FEATURE_TO_RUN = "";
     public static final String SCENARIO_NAME_REQUIRED = "";
 
     @RunWith( Cucumber.class )

--- a/enterprise/cypher/acceptance-spec-suite/src/test/java/cypher/AcceptanceSpecSuiteTest.java
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/java/cypher/AcceptanceSpecSuiteTest.java
@@ -34,7 +34,7 @@ public class AcceptanceSpecSuiteTest
     // If you want to run only a single feature, put the name of the feature file in `FEATURE_TO_RUN` (including .feature)
     // If you want to run only a single scenario, put (part of) its name in the `SCENARIO_NAME_REQUIRED` constant
     // Do not forget to clear these strings to empty strings before you commit!!
-    public static final String FEATURE_TO_RUN = "";
+    public static final String FEATURE_TO_RUN = "OptionalMatchAcceptance.feature";
     public static final String SCENARIO_NAME_REQUIRED = "";
 
     @RunWith( Cucumber.class )

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-31.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-31.txt
@@ -7,3 +7,5 @@ Ordering for lists, ascending
 Ordering for lists, descending
 
 Shorthand case with filter should work as expected
+equality with boolean lists
+optional equality with boolean lists

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -135,7 +135,6 @@ LIMIT 0 should stop side effects
 Id on null
 type on null
 Shorthand case with filter should work as expected
-equality with boolean lists
 optional equality with boolean lists
 
 //OrderByAcceptance.feature - Unsupported orderability

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -135,6 +135,8 @@ LIMIT 0 should stop side effects
 Id on null
 type on null
 Shorthand case with filter should work as expected
+equality with boolean lists
+optional equality with boolean lists
 
 //OrderByAcceptance.feature - Unsupported orderability
 ORDER BY nodes should return null results last in ascending order

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/MatchAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/MatchAcceptance.feature
@@ -186,3 +186,16 @@ Feature: MatchAcceptance
       | a.id | b.id |
       | 1    | 2    |
     And no side effects
+
+  Scenario: equality with boolean lists
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ({prop: [false]})
+      """
+    When executing query:
+      """
+      MATCH (n {prop: false}) RETURN n
+      """
+    Then the result should be empty
+    And no side effects

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/OptionalMatchAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/OptionalMatchAcceptance.feature
@@ -49,3 +49,18 @@ Feature: OptionalMatchAcceptance
       | type(r) |
       | null    |
     And no side effects
+
+  Scenario: optional equality with boolean lists
+    Given an empty graph
+    And having executed:
+      """
+      CREATE ({prop: [false]})
+      """
+    When executing query:
+      """
+      OPTIONAL MATCH (n {prop: false}) RETURN n
+      """
+    Then the result should be:
+      | n    |
+      | null |
+    And no side effects


### PR DESCRIPTION
When a predicate was being evaluated at runtime using filtering
and not through index queries, single element lists where being treated
as equivalent to the single element without the list.