### PR TITLE
Asynchronously terminated transactions now immediately release their locks, so others can make progress

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitor.java
@@ -45,7 +45,7 @@ public class KernelTransactionTimeoutMonitor implements Runnable
     }
 
     @Override
-    public void run()
+    public synchronized void run()
     {
         Set<KernelTransactionHandle> activeTransactions = kernelTransactions.activeTransactions();
         long now = clock.millis();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StackingQueryRegistrationOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StackingQueryRegistrationOperations.java
@@ -73,7 +73,7 @@ public class StackingQueryRegistrationOperations implements QueryRegistrationOpe
         String threadName = thread.getName();
         ExecutingQuery executingQuery =
                 new ExecutingQuery( queryId, clientConnection, statement.username(), queryText, queryParameters,
-                        statement.getTransaction().getMetaData(), statement.locks()::activeLockCount,
+                        statement.getTransaction().getMetaData(), () -> statement.locks().activeLockCount(),
                         statement.getPageCursorTracer(),
                         threadId, threadName, clock, cpuClock, heapAllocation );
         registerExecutingQuery( statement, executingQuery );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/Locks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/Locks.java
@@ -105,9 +105,21 @@ public interface Locks
         void releaseExclusive( ResourceType resourceType, long... resourceIds );
 
         /**
-         * Stop all active lock waiters and release them. All already held locks remains.
+         * Start preparing this transaction for committing. In two-phase locking palace, we will in principle no longer
+         * be acquiring any new locks - though we still allow it because it is useful in certain technical situations -
+         * but when we are ready, we will start releasing them. This also means that we will no longer accept being
+         * {@link #stop() asynchronously stopped}. From this point on, only the commit process can decide if the
+         * transaction lives or dies, and in either case, the lock client will end up releasing all locks via the
+         * {@link #close()} method.
+         */
+        void prepare();
+
+        /**
+         * Stop all active lock waiters and release them.
          * All new attempts to acquire any locks will cause exceptions.
          * This client can and should only be {@link #close() closed} afterwards.
+         * If this client has been {@link #prepare() prepared}, then all currently acquired locks will remain held,
+         * otherwise they will be released immediately.
          */
         void stop();
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/NoOpClient.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/NoOpClient.java
@@ -71,6 +71,11 @@ public class NoOpClient implements Locks.Client
     }
 
     @Override
+    public void prepare()
+    {
+    }
+
+    @Override
     public void stop()
     {
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/SimpleStatementLocks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/SimpleStatementLocks.java
@@ -50,6 +50,7 @@ public class SimpleStatementLocks implements StatementLocks
     public void prepareForCommit( LockTracer lockTracer )
     {
         // Locks where grabbed eagerly by client so no need to prepare
+        client.prepare();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/StatementLocks.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/locking/StatementLocks.java
@@ -46,7 +46,8 @@ public interface StatementLocks extends AutoCloseable
 
     /**
      * Prepare the underlying {@link Locks.Client client}(s) for commit. This will grab all locks that have
-     * previously been taken {@link #optimistic() optimistically}.
+     * previously been taken {@link #optimistic() optimistically}, and tell the underlying lock client to enter the
+     * <em>prepare</em> state.
      * @param lockTracer lock tracer
      */
     void prepareForCommit( LockTracer lockTracer );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitorIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitorIT.java
@@ -123,8 +123,10 @@ public class KernelTransactionTimeoutMonitorIT
         }
         while ( !proceed );
 
-        Thread.sleep( 150 ); // locker should be stopped by now
-        assertFalse( lockerDone.get() ); // but still blocked on the latch
+        Thread.sleep( 150 ); // locker transaction is definitely past its allocated time now
+        // make sure it's terminated; we call this explicitly so we don't have to wait for the scheduler to run
+        database.resolveDependency( KernelTransactionTimeoutMonitor.class ).run();
+        assertFalse( lockerDone.get() ); // but the thread should still be blocked on the latch
         // Yet we should be able to proceed and grab the locks they once held
         try ( Transaction tx = database.beginTx() )
         {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitorIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitorIT.java
@@ -27,8 +27,11 @@ import org.junit.rules.ExpectedException;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.neo4j.concurrent.BinaryLatch;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
@@ -38,16 +41,25 @@ import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.test.rule.DatabaseRule;
 import org.neo4j.test.rule.EmbeddedDatabaseRule;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 public class KernelTransactionTimeoutMonitorIT
 {
     @Rule
-    public DatabaseRule database = new EmbeddedDatabaseRule()
-            .withSetting( GraphDatabaseSettings.transaction_monitor_check_interval, "100ms" );
+    public DatabaseRule database = createDatabaseRule();
+
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
 
     private static final int NODE_ID = 0;
     private ExecutorService executor;
+
+    protected DatabaseRule createDatabaseRule()
+    {
+        return new EmbeddedDatabaseRule()
+                .withSetting( GraphDatabaseSettings.transaction_monitor_check_interval, "100ms" );
+    }
 
     @Before
     public void setUp() throws Exception
@@ -78,6 +90,52 @@ public class KernelTransactionTimeoutMonitorIT
             nodeById.setProperty( "a", "b" );
             executor.submit( startAnotherTransaction() ).get();
         }
+    }
+
+    @Test( timeout = 30_000 )
+    public void terminatingTransactionMustEagerlyReleaseTheirLocks() throws Exception
+    {
+        AtomicBoolean nodeLockAcquired = new AtomicBoolean();
+        AtomicBoolean lockerDone = new AtomicBoolean();
+        BinaryLatch lockerPause = new BinaryLatch();
+        long nodeId;
+        try ( Transaction tx = database.beginTx() )
+        {
+            nodeId = database.createNode().getId();
+            tx.success();
+        }
+        Future<?> locker = executor.submit( () ->
+        {
+            try ( Transaction tx = database.beginTx( 100, TimeUnit.MILLISECONDS ) )
+            {
+                Node node = database.getNodeById( nodeId );
+                tx.acquireReadLock( node );
+                nodeLockAcquired.set( true );
+                lockerPause.await();
+            }
+            lockerDone.set( true );
+        } );
+
+        boolean proceed;
+        do
+        {
+            proceed = nodeLockAcquired.get();
+        }
+        while ( !proceed );
+
+        Thread.sleep( 150 ); // locker should be stopped by now
+        assertFalse( lockerDone.get() ); // but still blocked on the latch
+        // Yet we should be able to proceed and grab the locks they once held
+        try ( Transaction tx = database.beginTx() )
+        {
+            // Write-locking is only possible if their shared lock was released
+            tx.acquireWriteLock( database.getNodeById( nodeId ) );
+            tx.success();
+        }
+        // No exception from our lock client being stopped (e.g. we ended up blocked for too long) or from timeout
+        lockerPause.release();
+        locker.get();
+        assertTrue( lockerDone.get() );
     }
 
     private Runnable startAnotherTransaction()

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManager.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/machines/locks/LeaderOnlyLockManager.java
@@ -260,6 +260,12 @@ public class LeaderOnlyLockManager implements Locks
         }
 
         @Override
+        public void prepare()
+        {
+            localClient.prepare();
+        }
+
+        @Override
         public void stop()
         {
             localClient.stop();

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/ReadReplicaLockManager.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/ReadReplicaLockManager.java
@@ -95,6 +95,11 @@ public class ReadReplicaLockManager implements Locks
         }
 
         @Override
+        public void prepare()
+        {
+        }
+
+        @Override
         public void stop()
         {
         }

--- a/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringLockClient.java
+++ b/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringLockClient.java
@@ -158,6 +158,12 @@ public class DeferringLockClient implements Locks.Client
     }
 
     @Override
+    public void prepare()
+    {
+        clientDelegate.prepare();
+    }
+
+    @Override
     public void stop()
     {
         stopped = true;

--- a/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringStatementLocks.java
+++ b/enterprise/deferred-locks/src/main/java/org/neo4j/kernel/impl/locking/DeferringStatementLocks.java
@@ -52,6 +52,7 @@ public class DeferringStatementLocks implements StatementLocks
     public void prepareForCommit( LockTracer lockTracer )
     {
         implicit.acquireDeferredLocks( lockTracer );
+        explicit.prepare();
     }
 
     @Override

--- a/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLockClientTest.java
+++ b/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringLockClientTest.java
@@ -137,6 +137,20 @@ public class DeferringLockClientTest
     }
 
     @Test
+    public void shouldPrepareUnderlyingClient() throws Exception
+    {
+        // GIVEN
+        Locks.Client actualClient = mock( Locks.Client.class );
+        DeferringLockClient client = new DeferringLockClient( actualClient );
+
+        // WHEN
+        client.prepare();
+
+        // THEN
+        verify( actualClient ).prepare();
+    }
+
+    @Test
     public void shouldCloseUnderlyingClient() throws Exception
     {
         // GIVEN
@@ -463,6 +477,11 @@ public class DeferringLockClientTest
 
         @Override
         public void releaseExclusive( ResourceType resourceType, long... resourceIds )
+        {
+        }
+
+        @Override
+        public void prepare()
         {
         }
 

--- a/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringStatementLocksTest.java
+++ b/enterprise/deferred-locks/src/test/java/org/neo4j/kernel/impl/locking/DeferringStatementLocksTest.java
@@ -59,6 +59,7 @@ public class DeferringStatementLocksTest
         statementLocks.prepareForCommit( LockTracer.NONE );
 
         // THEN
+        verify( client ).prepare();
         verifyNoMoreInteractions( client );
     }
 
@@ -76,6 +77,7 @@ public class DeferringStatementLocksTest
         statementLocks.prepareForCommit( LockTracer.NONE );
 
         // THEN
+        verify( client ).prepare();
         verify( client ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 1 );
         verify( client ).acquireExclusive( LockTracer.NONE, ResourceTypes.RELATIONSHIP, 42 );
         verifyNoMoreInteractions( client );

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/lock/SlaveLocksClient.java
@@ -187,6 +187,12 @@ class SlaveLocksClient implements Locks.Client
     }
 
     @Override
+    public void prepare()
+    {
+        client.prepare();
+    }
+
+    @Override
     public void stop()
     {
         client.stop();

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiClient.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiClient.java
@@ -717,6 +717,7 @@ public class ForsetiClient implements Locks.Client
         stateHolder.closeClient();
         waitForAllClientsToLeave();
         releaseAllLocks();
+        clientPool.release( this );
     }
 
     private void releaseAllLocks()

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiClient.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/lock/forseti/ForsetiClient.java
@@ -679,11 +679,25 @@ public class ForsetiClient implements Locks.Client
     }
 
     @Override
+    public void prepare()
+    {
+        stateHolder.prepare( this );
+    }
+
+    @Override
     public void stop()
     {
         // marking client as closed
-        stateHolder.stopClient();
-        // waiting for all operations to be completed
+        if ( stateHolder.stopClient() )
+        {
+            // waiting for all operations to be completed
+            waitForAllClientsToLeave();
+            releaseAllLocks();
+        }
+    }
+
+    private void waitForAllClientsToLeave()
+    {
         while ( stateHolder.hasActiveClients() )
         {
             try
@@ -700,14 +714,19 @@ public class ForsetiClient implements Locks.Client
     @Override
     public void close()
     {
-        stop();
+        stateHolder.closeClient();
+        waitForAllClientsToLeave();
+        releaseAllLocks();
+    }
+
+    private void releaseAllLocks()
+    {
         if ( hasLocks )
         {
             releaseAllClientLocks();
             clearWaitList();
             hasLocks = false;
         }
-        clientPool.release( this );
     }
 
     @Override

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitorWithForsetiIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitorWithForsetiIT.java
@@ -17,29 +17,18 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.impl.enterprise.lock.forseti;
+package org.neo4j.kernel.impl.api;
 
-import java.time.Clock;
+import org.neo4j.kernel.impl.enterprise.lock.forseti.ForsetiLocksFactory;
+import org.neo4j.test.rule.DatabaseRule;
 
-import org.neo4j.helpers.Service;
-import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.locking.Locks;
-import org.neo4j.kernel.impl.locking.ResourceTypes;
-import org.neo4j.storageengine.api.lock.ResourceType;
+import static org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory.Configuration.lock_manager;
 
-@Service.Implementation( Locks.Factory.class )
-public class ForsetiLocksFactory extends Locks.Factory
+public class KernelTransactionTimeoutMonitorWithForsetiIT extends KernelTransactionTimeoutMonitorIT
 {
-    public static final String KEY = "forseti";
-
-    public ForsetiLocksFactory()
-    {
-        super( KEY );
-    }
-
     @Override
-    public Locks newInstance( Config config, Clock clock, ResourceType[] resourceTypes )
+    protected DatabaseRule createDatabaseRule()
     {
-        return new ForsetiLockManager( config, clock, ResourceTypes.values() );
+        return super.createDatabaseRule().withSetting( lock_manager, ForsetiLocksFactory.KEY );
     }
 }


### PR DESCRIPTION
Previously, asynchronously terminated transactions would only release their locks after checking the termination flag,
realising that the transaction had been asynchronously terminated, and then closing their transaction.
This process required that the terminated threads would cooperate and clean up the resources they are holding.
One such resource, a particularly precious one, is the locks acquired by the given transaction.
If a transaction never went into the kernel, it would never discover that it had been terminated, and thus could hold
on to their locks practically indefinitely, in turn blocking other transactions stuck on those locks from making
process.

The reason we did it this way, is because transactions might need to also grab locks during commit, and we cannot allow
asynchronous termination of transactions that have already started their commit process. Transactions that have started
committing will presumably relinquish their resource pretty soon anyway.

So to do this differently, to solve both the problem of letting killed transactions relinquish their locks sooner, and
to avoid killing transactions during commit, a new lock client state called "PREPARE" is introduced.
The lock client is moved to the PREPARE state when the transaction enters the PREPARE phase. Once the lock client is
in PREPARE, it can no longer be moved to the STOPPED state via asynchronous termination.
In the PREPARE state, the lock client will still allow new locks to be taken and released, and the client will move to
the STOPPED state when it is closed.

This mechanism protects the lock client and the commit process, and it allows us to release all locks held by a lock
client, when we asynchronously terminate with the stop() method it before the prepare phase.
This means that transaction timeout is now also effective on transactions that are stuck waiting for network traffic,
or other resources external to the database itself, for instance.
And it means that terminating a transaction will now immediately allow any other transactions, that are otherwise stuck
waiting for locks held by the terminated transaction, to make progress.

In this process, a bug has also been fixed in the listQueries procedure, where the lock count would come from whichever
lock client was used to *plan* the query, and not the lock client associated with the running transaction. The reason
this bug happened, is that the `StackingQueryRegistrationOperations` eagerly grabbed the lock client from the current
statement locks, when creating a lambda for getting the current lock count. The fix for that is to make the lambda
capture the `statement` reference, instead of the reference coming out of the `statement.locks()` call.