### PR TITLE
Backported improved error logging in bolt server from 3.3

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/MessageProcessingHandler.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/MessageProcessingHandler.java
@@ -138,8 +138,7 @@ class MessageProcessingHandler implements BoltResponseHandler
         {
             // we tried to write error back to the client and realized that the underlying channel is closed
             // log a warning, client driver might have just been stopped and closed all socket connections
-            log.warn( "Unable to send error back to the client. " +
-                      "Communication channel is closed. Client has probably been stopped.", error.cause() );
+            log.warn( "Unable to send error back to the client. " + e.getMessage(), error.cause() );
         }
         catch ( Throwable t )
         {

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackOutputClosedException.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/packstream/PackOutputClosedException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.v1.packstream;
+
+import java.io.IOException;
+
+public class PackOutputClosedException extends IOException
+{
+    public PackOutputClosedException( String message )
+    {
+        super( message );
+    }
+}

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/transport/ChunkedOutput.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/transport/ChunkedOutput.java
@@ -161,7 +161,8 @@ public class ChunkedOutput implements PackOutput, BoltResponseMessageBoundaryHoo
         assert size <= maxChunkSize : size + " > " + maxChunkSize;
         if ( closed.get() )
         {
-            throw new PackOutputClosedException( "Unable to write to the closed output channel" );
+            throw new PackOutputClosedException( "Network channel towards " + channel.remoteAddress() + " is closed. " +
+                                                 "Client has probably been stopped." );
         }
         int toWriteSize = chunkOpen ? size : size + CHUNK_HEADER_SIZE;
         synchronized ( this )

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/transport/ChunkedOutput.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/transport/ChunkedOutput.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.neo4j.bolt.v1.messaging.BoltResponseMessageBoundaryHook;
 import org.neo4j.bolt.v1.packstream.PackOutput;
+import org.neo4j.bolt.v1.packstream.PackOutputClosedException;
 import org.neo4j.bolt.v1.packstream.PackStream;
 
 import static java.lang.Math.max;
@@ -160,7 +161,7 @@ public class ChunkedOutput implements PackOutput, BoltResponseMessageBoundaryHoo
         assert size <= maxChunkSize : size + " > " + maxChunkSize;
         if ( closed.get() )
         {
-            throw new IOException( "Cannot write to buffer when closed" );
+            throw new PackOutputClosedException( "Unable to write to the closed output channel" );
         }
         int toWriteSize = chunkOpen ? size : size + CHUNK_HEADER_SIZE;
         synchronized ( this )

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/MessageProcessingHandlerTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/messaging/MessageProcessingHandlerTest.java
@@ -21,27 +21,37 @@ package org.neo4j.bolt.v1.messaging;
 
 import org.junit.Test;
 
-import java.util.Map;
+import java.io.IOException;
 
+import org.neo4j.bolt.v1.packstream.PackOutputClosedException;
 import org.neo4j.bolt.v1.runtime.BoltWorker;
+import org.neo4j.bolt.v1.runtime.Neo4jError;
+import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.logging.Log;
 
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyMapOf;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.neo4j.logging.AssertableLogProvider.inLog;
+import static org.neo4j.test.matchers.CommonMatchers.hasSuppressed;
 
-@SuppressWarnings( "unchecked" )
 public class MessageProcessingHandlerTest
 {
     @Test
     public void shouldCallHaltOnUnexpectedFailures() throws Exception
     {
         // Given
-        BoltResponseMessageHandler msgHandler = mock( BoltResponseMessageHandler.class );
+        BoltResponseMessageHandler<IOException> msgHandler = newResponseHandlerMock();
         doThrow( new RuntimeException( "Something went horribly wrong" ) )
                 .when( msgHandler )
-                .onSuccess( any(Map.class) );
+                .onSuccess( anyMapOf( String.class, Object.class ) );
 
         BoltWorker worker = mock( BoltWorker.class );
         MessageProcessingHandler handler =
@@ -52,6 +62,96 @@ public class MessageProcessingHandlerTest
         handler.onFinish();
 
         // Then
-        verify( worker  ).halt();
+        verify( worker ).halt();
+    }
+
+    @Test
+    public void shouldLogOriginalErrorWhenOutputIsClosed() throws Exception
+    {
+        testLoggingOfOriginalErrorWhenOutputIsClosed( false );
+    }
+
+    @Test
+    public void shouldLogOriginalFatalErrorWhenOutputIsClosed() throws Exception
+    {
+        testLoggingOfOriginalErrorWhenOutputIsClosed( true );
+    }
+
+    @Test
+    public void shouldLogWriteErrorAndOriginalErrorWhenUnknownFailure() throws Exception
+    {
+        testLoggingOfWriteErrorAndOriginalErrorWhenUnknownFailure( false );
+    }
+
+    @Test
+    public void shouldLogWriteErrorAndOriginalFatalErrorWhenUnknownFailure() throws Exception
+    {
+        testLoggingOfWriteErrorAndOriginalErrorWhenUnknownFailure( true );
+    }
+
+    private static void testLoggingOfOriginalErrorWhenOutputIsClosed( boolean fatalError ) throws Exception
+    {
+        AssertableLogProvider logProvider = new AssertableLogProvider();
+        Log log = logProvider.getLog( "Test" );
+
+        PackOutputClosedException outputClosed = new PackOutputClosedException( "Output closed" );
+        BoltResponseMessageHandler<IOException> responseHandler = newResponseHandlerMock( fatalError, outputClosed );
+
+        MessageProcessingHandler handler = new MessageProcessingHandler( responseHandler, mock( Runnable.class ),
+                mock( BoltWorker.class ), log );
+
+        RuntimeException originalError = new RuntimeException( "Hi, I'm the original error" );
+        markFailed( handler, fatalError, originalError );
+
+        logProvider.assertExactly( inLog( "Test" ).warn(
+                startsWith( "Unable to send error back to the client" ),
+                equalTo( originalError ) ) );
+    }
+
+    private static void testLoggingOfWriteErrorAndOriginalErrorWhenUnknownFailure( boolean fatalError ) throws Exception
+    {
+        AssertableLogProvider logProvider = new AssertableLogProvider();
+        Log log = logProvider.getLog( "Test" );
+
+        RuntimeException outputError = new RuntimeException( "Output failed" );
+        BoltResponseMessageHandler<IOException> responseHandler = newResponseHandlerMock( fatalError, outputError );
+
+        MessageProcessingHandler handler = new MessageProcessingHandler( responseHandler, mock( Runnable.class ),
+                mock( BoltWorker.class ), log );
+
+        RuntimeException originalError = new RuntimeException( "Hi, I'm the original error" );
+        markFailed( handler, fatalError, originalError );
+
+        logProvider.assertExactly( inLog( "Test" ).error(
+                startsWith( "Unable to send error back to the client" ),
+                both( equalTo( outputError ) ).and( hasSuppressed( originalError ) ) ) );
+    }
+
+    private static void markFailed( MessageProcessingHandler handler, boolean fatalError, Throwable error )
+    {
+        Neo4jError neo4jError = fatalError ? Neo4jError.fatalFrom( error ) : Neo4jError.from( error );
+        handler.markFailed( neo4jError );
+        handler.onFinish();
+    }
+
+    private static BoltResponseMessageHandler<IOException> newResponseHandlerMock( boolean fatalError, Throwable error )
+            throws Exception
+    {
+        BoltResponseMessageHandler<IOException> handler = newResponseHandlerMock();
+        if ( fatalError )
+        {
+            doThrow( error ).when( handler ).onFatal( any( Status.class ), anyString() );
+        }
+        else
+        {
+            doThrow( error ).when( handler ).onFailure( any( Status.class ), anyString() );
+        }
+        return handler;
+    }
+
+    @SuppressWarnings( "unchecked" )
+    private static BoltResponseMessageHandler<IOException> newResponseHandlerMock()
+    {
+        return mock( BoltResponseMessageHandler.class );
     }
 }

--- a/community/logging/src/test/java/org/neo4j/logging/AssertableLogProvider.java
+++ b/community/logging/src/test/java/org/neo4j/logging/AssertableLogProvider.java
@@ -28,12 +28,12 @@ import org.junit.runners.model.Statement;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.IllegalFormatException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
@@ -52,7 +52,7 @@ import static org.junit.Assert.fail;
 public class AssertableLogProvider extends AbstractLogProvider<Log> implements TestRule
 {
     private final boolean debugEnabled;
-    private final List<LogCall> logCalls = Collections.synchronizedList( new ArrayList<LogCall>() );
+    private final List<LogCall> logCalls = new CopyOnWriteArrayList<>();
 
     public AssertableLogProvider()
     {

--- a/integrationtests/src/test/java/org/neo4j/bolt/BoltFailuresIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/BoltFailuresIT.java
@@ -19,32 +19,46 @@
  */
 package org.neo4j.bolt;
 
-import java.time.Clock;
-import java.util.function.Consumer;
-
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.time.Clock;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+
 import org.neo4j.bolt.v1.runtime.BoltFactory;
 import org.neo4j.bolt.v1.runtime.MonitoredWorkerFactory.SessionMonitor;
 import org.neo4j.bolt.v1.runtime.WorkerFactory;
+import org.neo4j.bolt.v1.transport.BoltProtocolV1;
 import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
+import org.neo4j.function.Predicates;
 import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.TransactionTerminatedException;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.IOUtils;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.AssertableLogProvider;
+import org.neo4j.logging.LogProvider;
+import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
 import org.neo4j.test.rule.TestDirectory;
 
+import static java.util.concurrent.CompletableFuture.runAsync;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -52,11 +66,14 @@ import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
-
+import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.Connector.ConnectorType.BOLT;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.boltConnector;
+import static org.neo4j.helpers.collection.Iterators.count;
+import static org.neo4j.helpers.collection.Iterators.single;
 import static org.neo4j.kernel.configuration.Settings.FALSE;
 import static org.neo4j.kernel.configuration.Settings.TRUE;
+import static org.neo4j.logging.AssertableLogProvider.inLog;
 
 public class BoltFailuresIT
 {
@@ -157,6 +174,42 @@ public class BoltFailuresIT
         throwsWhenRunMessageFails( ThrowingSessionMonitor::throwInProcessingDone );
     }
 
+    @Test
+    public void boltServerLogsRealErrorWhenDriverIsClosedWithRunningTransactions() throws Exception
+    {
+        AssertableLogProvider internalLogProvider = new AssertableLogProvider();
+        db = startTestDb( internalLogProvider );
+
+        // create a dummy node
+        db.execute( "CREATE (:Node)" ).close();
+
+        // lock that dummy node to make all subsequent writes wait on an exclusive lock
+        org.neo4j.graphdb.Transaction tx = db.beginTx();
+        Node node = single( db.findNodes( label( "Node" ) ) );
+        tx.acquireWriteLock( node );
+
+        Driver driver = createDriver();
+
+        // try to execute write query for the same node through the driver
+        Future<?> writeThroughDriverFuture = updateAllNodesAsync( driver );
+        // make sure this query is executing and visible in query listing
+        awaitNumberOfActiveQueriesToBe( 1 );
+
+        // close driver while it has ongoing transaction, it should get terminated
+        driver.close();
+
+        // driver transaction should fail
+        expectFailure( writeThroughDriverFuture );
+
+        // make sure there are no active queries
+        awaitNumberOfActiveQueriesToBe( 0 );
+
+        // verify that closing of the driver resulted in transaction termination on the server and correct log message
+        internalLogProvider.assertAtLeastOnce( inLog( BoltProtocolV1.class ).warn(
+                startsWith( "Unable to send error back to the client" ),
+                instanceOf( TransactionTerminatedException.class ) ) );
+    }
+
     private void throwsWhenInitMessageFails( Consumer<ThrowingSessionMonitor> monitorSetup,
             boolean shouldBeAbleToBeginTransaction )
     {
@@ -219,7 +272,12 @@ public class BoltFailuresIT
 
     private GraphDatabaseService startTestDb( Monitors monitors )
     {
-        return startDbWithBolt( new GraphDatabaseFactory().setMonitors( monitors ) );
+        return startDbWithBolt( newDbFactory().setMonitors( monitors ) );
+    }
+
+    private GraphDatabaseService startTestDb( LogProvider internalLogProvider )
+    {
+        return startDbWithBolt( newDbFactory().setInternalLogProvider( internalLogProvider ) );
     }
 
     private GraphDatabaseService startDbWithBolt( GraphDatabaseFactory dbFactory )
@@ -229,6 +287,44 @@ public class BoltFailuresIT
                 .setConfig( boltConnector( "0" ).enabled, TRUE )
                 .setConfig( GraphDatabaseSettings.auth_enabled, FALSE )
                 .newGraphDatabase();
+    }
+
+    private void awaitNumberOfActiveQueriesToBe( int value ) throws TimeoutException
+    {
+        Predicates.await( () ->
+        {
+            Result listQueriesResult = db.execute( "CALL dbms.listQueries()" );
+            return count( listQueriesResult ) == value + 1; // procedure call itself is also listed
+        }, 1, MINUTES );
+    }
+
+    private Future<?> updateAllNodesAsync( Driver driver )
+    {
+        return runAsync( () ->
+        {
+            try ( Session session = driver.session() )
+            {
+                session.run( "MATCH (n) SET n.prop = 42" ).consume();
+            }
+        } );
+    }
+
+    private static void expectFailure( Future<?> future ) throws TimeoutException, InterruptedException
+    {
+        try
+        {
+            future.get( 1, MINUTES );
+            fail( "Exception expected" );
+        }
+        catch ( ExecutionException e )
+        {
+            // expected
+        }
+    }
+
+    private static TestEnterpriseGraphDatabaseFactory newDbFactory()
+    {
+        return new TestEnterpriseGraphDatabaseFactory();
     }
 
     private static Driver createDriver()

--- a/integrationtests/src/test/java/org/neo4j/bolt/BoltFailuresIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/BoltFailuresIT.java
@@ -24,41 +24,29 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.time.Clock;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 import org.neo4j.bolt.v1.runtime.BoltFactory;
 import org.neo4j.bolt.v1.runtime.MonitoredWorkerFactory.SessionMonitor;
 import org.neo4j.bolt.v1.runtime.WorkerFactory;
-import org.neo4j.bolt.v1.transport.BoltProtocolV1;
 import org.neo4j.driver.v1.Config;
 import org.neo4j.driver.v1.Driver;
 import org.neo4j.driver.v1.GraphDatabase;
 import org.neo4j.driver.v1.Session;
 import org.neo4j.driver.v1.Transaction;
 import org.neo4j.driver.v1.exceptions.ServiceUnavailableException;
-import org.neo4j.function.Predicates;
 import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.Result;
-import org.neo4j.graphdb.TransactionTerminatedException;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.IOUtils;
+import org.neo4j.kernel.configuration.BoltConnector;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.monitoring.Monitors;
-import org.neo4j.logging.AssertableLogProvider;
-import org.neo4j.logging.LogProvider;
 import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
 import org.neo4j.test.rule.TestDirectory;
 
-import static java.util.concurrent.CompletableFuture.runAsync;
-import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.startsWith;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -66,14 +54,9 @@ import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
-import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.Connector.ConnectorType.BOLT;
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.boltConnector;
-import static org.neo4j.helpers.collection.Iterators.count;
-import static org.neo4j.helpers.collection.Iterators.single;
 import static org.neo4j.kernel.configuration.Settings.FALSE;
 import static org.neo4j.kernel.configuration.Settings.TRUE;
-import static org.neo4j.logging.AssertableLogProvider.inLog;
 
 public class BoltFailuresIT
 {
@@ -84,7 +67,6 @@ public class BoltFailuresIT
 
     private GraphDatabaseService db;
     private Driver driver;
-    private Session session;
 
     @After
     public void shutdownDb()
@@ -93,7 +75,7 @@ public class BoltFailuresIT
         {
             db.shutdown();
         }
-        IOUtils.closeAllSilently( session, driver );
+        IOUtils.closeAllSilently( driver );
     }
 
     @Test( timeout = TEST_TIMEOUT )
@@ -174,42 +156,6 @@ public class BoltFailuresIT
         throwsWhenRunMessageFails( ThrowingSessionMonitor::throwInProcessingDone );
     }
 
-    @Test
-    public void boltServerLogsRealErrorWhenDriverIsClosedWithRunningTransactions() throws Exception
-    {
-        AssertableLogProvider internalLogProvider = new AssertableLogProvider();
-        db = startTestDb( internalLogProvider );
-
-        // create a dummy node
-        db.execute( "CREATE (:Node)" ).close();
-
-        // lock that dummy node to make all subsequent writes wait on an exclusive lock
-        org.neo4j.graphdb.Transaction tx = db.beginTx();
-        Node node = single( db.findNodes( label( "Node" ) ) );
-        tx.acquireWriteLock( node );
-
-        Driver driver = createDriver();
-
-        // try to execute write query for the same node through the driver
-        Future<?> writeThroughDriverFuture = updateAllNodesAsync( driver );
-        // make sure this query is executing and visible in query listing
-        awaitNumberOfActiveQueriesToBe( 1 );
-
-        // close driver while it has ongoing transaction, it should get terminated
-        driver.close();
-
-        // driver transaction should fail
-        expectFailure( writeThroughDriverFuture );
-
-        // make sure there are no active queries
-        awaitNumberOfActiveQueriesToBe( 0 );
-
-        // verify that closing of the driver resulted in transaction termination on the server and correct log message
-        internalLogProvider.assertAtLeastOnce( inLog( BoltProtocolV1.class ).warn(
-                startsWith( "Unable to send error back to the client" ),
-                instanceOf( TransactionTerminatedException.class ) ) );
-    }
-
     private void throwsWhenInitMessageFails( Consumer<ThrowingSessionMonitor> monitorSetup,
             boolean shouldBeAbleToBeginTransaction )
     {
@@ -275,51 +221,13 @@ public class BoltFailuresIT
         return startDbWithBolt( newDbFactory().setMonitors( monitors ) );
     }
 
-    private GraphDatabaseService startTestDb( LogProvider internalLogProvider )
-    {
-        return startDbWithBolt( newDbFactory().setInternalLogProvider( internalLogProvider ) );
-    }
-
     private GraphDatabaseService startDbWithBolt( GraphDatabaseFactory dbFactory )
     {
         return dbFactory.newEmbeddedDatabaseBuilder( dir.graphDbDir() )
-                .setConfig( boltConnector( "0" ).type, BOLT.name() )
-                .setConfig( boltConnector( "0" ).enabled, TRUE )
+                .setConfig( new BoltConnector( "0" ).type, BOLT.name() )
+                .setConfig( new BoltConnector( "0" ).enabled, TRUE )
                 .setConfig( GraphDatabaseSettings.auth_enabled, FALSE )
                 .newGraphDatabase();
-    }
-
-    private void awaitNumberOfActiveQueriesToBe( int value ) throws TimeoutException
-    {
-        Predicates.await( () ->
-        {
-            Result listQueriesResult = db.execute( "CALL dbms.listQueries()" );
-            return count( listQueriesResult ) == value + 1; // procedure call itself is also listed
-        }, 1, MINUTES );
-    }
-
-    private Future<?> updateAllNodesAsync( Driver driver )
-    {
-        return runAsync( () ->
-        {
-            try ( Session session = driver.session() )
-            {
-                session.run( "MATCH (n) SET n.prop = 42" ).consume();
-            }
-        } );
-    }
-
-    private static void expectFailure( Future<?> future ) throws TimeoutException, InterruptedException
-    {
-        try
-        {
-            future.get( 1, MINUTES );
-            fail( "Exception expected" );
-        }
-        catch ( ExecutionException e )
-        {
-            // expected
-        }
     }
 
     private static TestEnterpriseGraphDatabaseFactory newDbFactory()


### PR DESCRIPTION
This is a backport of two commits from 3.3. Change should improve error messages from bolt server.

**Null-merge forward is required.**