### PR TITLE
Prevent ExplicitIndexProxy from closing statment multiple times

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/explicitindex/AbstractIndexHits.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/explicitindex/AbstractIndexHits.java
@@ -40,13 +40,7 @@ public abstract class AbstractIndexHits<T> extends PrefetchingIterator<T> implem
     @Override
     public T getSingle()
     {
-        try
-        {
-            return Iterators.singleOrNull( this );
-        }
-        finally
-        {
-            close();
-        }
+        // This instance will be closed by this call
+        return Iterators.singleOrNull( this );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/ExplicitIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/coreapi/ExplicitIndexProxy.java
@@ -505,6 +505,7 @@ public class ExplicitIndexProxy<T extends PropertyContainer> implements Index<T>
     {
         private final ExplicitIndexHits ids;
         private final KernelStatement statement;
+        private volatile boolean closed;
 
         ExplicitIndexWrapHits( ExplicitIndexHits ids )
         {
@@ -560,8 +561,12 @@ public class ExplicitIndexProxy<T extends PropertyContainer> implements Index<T>
         @Override
         public void close()
         {
-            ids.close();
-            statement.close();
+            if ( !closed )
+            {
+                closed = true;
+                ids.close();
+                statement.close();
+            }
         }
     }
 }

--- a/community/lucene-index/src/test/java/org/neo4j/index/ExplicitIndexTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/index/ExplicitIndexTest.java
@@ -283,6 +283,45 @@ public class ExplicitIndexTest
         }
     }
 
+    @Test
+    public void getSingleMustNotCloseStatementTwice() throws Exception
+    {
+        // given
+        String indexName = "index";
+        long expected1;
+        long expected2;
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node1 = db.createNode();
+            Node node2 = db.createNode();
+            Index<Node> nodeIndex = db.index().forNodes( indexName );
+            nodeIndex.add( node1, "key", "hej" );
+            nodeIndex.add( node2, "key", "hejhej" );
+
+            expected1 = node1.getId();
+            expected2 = node2.getId();
+            tx.success();
+        }
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Index<Node> nodeIndex = db.index().forNodes( indexName );
+
+            // when using getSingle this should not close statement for outer loop
+            IndexHits<Node> hits = nodeIndex.query( "key", "hej" );
+            while ( hits.hasNext() )
+            {
+                Node actual1 = hits.next();
+                assertEquals( expected1, actual1.getId() );
+
+                IndexHits<Node> hits2 = nodeIndex.query( "key", "hejhej" );
+                Node actual2 = hits2.getSingle();
+                assertEquals( expected2, actual2.getId() );
+            }
+            tx.success();
+        }
+    }
+
     private static void createNodeExplicitIndexWithSingleNode( GraphDatabaseService db, String indexName )
     {
         try ( Transaction tx = db.beginTx() )


### PR DESCRIPTION
When using getSingle in ExplicitIndexWrapHits statement would be
closed twice because of Iterators.singleOrNull closing provided
iterator if it is a resource, which ExplicitIndexWrapHits is.

We now keep track of close state to prevent it being closed
multiple times and thereby closing statement for others that
might be using it.