### PR TITLE
Edit on new configuration setting descriptions in 3.3

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
@@ -83,7 +83,7 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
 {
     public static class Settings implements LoadableConfig
     {
-        @Description( "SSL policy to use" )
+        @Description( "Specify the SSL policy to use" )
         public static Setting<String> ssl_policy = setting( "bolt.ssl_policy", STRING, LEGACY_POLICY_NAME );
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
@@ -143,7 +143,7 @@ public class CausalClusteringSettings implements LoadableConfig
     public static final Setting<Boolean> disable_middleware_logging =
             setting( "causal_clustering.disable_middleware_logging", BOOLEAN, TRUE );
 
-    @Description( "Logging level of middleware logging" )
+    @Description( "The level of middleware logging" )
     public static final Setting<Integer> middleware_logging_level =
             setting( "causal_clustering.middleware_logging.level", INTEGER, Integer.toString( Level.FINE.intValue() ) );
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
@@ -234,7 +234,7 @@ public class CausalClusteringSettings implements LoadableConfig
     @Description( "Interval of pulling updates from cores." )
     public static final Setting<Duration> pull_interval = setting( "causal_clustering.pull_interval", DURATION, "1s" );
 
-    @Description( "The catch up protocol times out if the given duration elapses with not network activity. " +
+    @Description( "The catch up protocol times out if the given duration elapses with no network activity. " +
             "Every message received by the client from the server extends the time out duration." )
     public static final Setting<Duration> catch_up_client_inactivity_timeout =
             setting( "causal_clustering.catch_up_client_inactivity_timeout", DURATION, "20s" );


### PR DESCRIPTION
https://trello.com/c/qcVsm0ij/1434-edit-descriptions-on-new-configuration-settings

Following a review of the new configuration settings that went into 3.3, we flagged that the descriptions for `bolt.ssl_policy`, `causal_clustering.catch_up_client_inactivity_timeout`, and `causal_clustering.middleware_logging.level` needed some small amendments. 

This PR covers the minor editorial changes to the descriptions, including fixing a typo.