### PR TITLE
Abandoned and timed out transactions are not released by bolt server

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltStateMachine.java
@@ -260,6 +260,16 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
         ctx.statementProcessor.markCurrentTransactionForTermination();
     }
 
+    /**
+     * When this is invoked, the machine will check whether the related transaction is
+     * marked for termination and will reset the TransactionStateMachine to AUTO_COMMIT mode
+     * while releasing the related transactional resources.
+     */
+    public void validateTransaction() throws KernelException
+    {
+        ctx.statementProcessor.validateTransaction();
+    }
+
     public void externalError( Neo4jError error, BoltResponseHandler handler ) throws BoltConnectionFatality
     {
         before( handler );
@@ -820,6 +830,12 @@ public class BoltStateMachine implements AutoCloseable, ManagedBoltStateMachine
         public void markCurrentTransactionForTermination()
         {
             // nothing to mark
+        }
+
+        @Override
+        public void validateTransaction() throws KernelException
+        {
+            // nothing to validate
         }
 
         @Override

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/StatementProcessor.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/StatementProcessor.java
@@ -38,5 +38,7 @@ public interface StatementProcessor
 
     boolean hasTransaction();
 
+    void validateTransaction() throws KernelException;
+
     void setQuerySource( BoltQuerySource querySource );
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachine.java
@@ -137,13 +137,13 @@ public class TransactionStateMachine implements StatementProcessor
 
         if ( tx != null )
         {
-            Optional<Status> status = tx.getReasonIfTerminated();
+            Optional<Status> statusOpt = tx.getReasonIfTerminated();
 
-            if ( status.isPresent() )
+            if ( statusOpt.isPresent() )
             {
-                if ( status.get().code().classification().rollbackTransaction() )
+                if ( statusOpt.get().code().classification().rollbackTransaction() )
                 {
-                    ctx.pendingTerminationNotice = status;
+                    ctx.pendingTerminationNotice = statusOpt.get();
 
                     reset();
                 }
@@ -153,11 +153,11 @@ public class TransactionStateMachine implements StatementProcessor
 
     private void ensureNoPendingTerminationNotice()
     {
-        if ( ctx.pendingTerminationNotice.isPresent() )
+        if ( ctx.pendingTerminationNotice != null )
         {
-            Status status = ctx.pendingTerminationNotice.get();
+            Status status = ctx.pendingTerminationNotice;
 
-            ctx.pendingTerminationNotice = Optional.empty();
+            ctx.pendingTerminationNotice = null;
 
             throw new TransactionTerminatedException( status );
         }
@@ -422,7 +422,7 @@ public class TransactionStateMachine implements StatementProcessor
         /** The current transaction, if present */
         KernelTransaction currentTransaction;
 
-        Optional<Status> pendingTerminationNotice = Optional.empty();
+        Status pendingTerminationNotice;
 
         /** Last Cypher statement executed */
         String lastStatement = "";

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachine.java
@@ -21,6 +21,7 @@ package org.neo4j.bolt.v1.runtime;
 
 import java.time.Clock;
 import java.util.Map;
+import java.util.Optional;
 
 import org.neo4j.bolt.security.auth.AuthenticationResult;
 import org.neo4j.bolt.v1.runtime.bookmarking.Bookmark;
@@ -29,6 +30,7 @@ import org.neo4j.bolt.v1.runtime.spi.BookmarkResult;
 import org.neo4j.cypher.InvalidSemanticsException;
 import org.neo4j.function.ThrowingAction;
 import org.neo4j.function.ThrowingConsumer;
+import org.neo4j.graphdb.TransactionTerminatedException;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.Status;
@@ -71,6 +73,8 @@ public class TransactionStateMachine implements StatementProcessor
         before();
         try
         {
+            ensureNoPendingTerminationNotice();
+
             state = state.run( ctx, spi, statement, params );
 
             return ctx.currentStatementMetadata;
@@ -87,6 +91,8 @@ public class TransactionStateMachine implements StatementProcessor
         before();
         try
         {
+            ensureNoPendingTerminationNotice();
+
             state.streamResult( ctx, resultConsumer );
         }
         finally
@@ -112,10 +118,7 @@ public class TransactionStateMachine implements StatementProcessor
 
     private void after()
     {
-        if ( ctx.currentTransaction != null )
-        {
-            spi.unbindTransactionFromCurrentThread();
-        }
+        spi.unbindTransactionFromCurrentThread();
     }
 
     public void markCurrentTransactionForTermination()
@@ -124,6 +127,39 @@ public class TransactionStateMachine implements StatementProcessor
         if ( tx != null )
         {
             tx.markForTermination( Status.Transaction.Terminated );
+        }
+    }
+
+    @Override
+    public void validateTransaction() throws KernelException
+    {
+        KernelTransaction tx = ctx.currentTransaction;
+
+        if ( tx != null )
+        {
+            Optional<Status> status = tx.getReasonIfTerminated();
+
+            if ( status.isPresent() )
+            {
+                if ( status.get().code().classification().rollbackTransaction() )
+                {
+                    ctx.pendingTerminationNotice = status;
+
+                    reset();
+                }
+            }
+        }
+    }
+
+    private void ensureNoPendingTerminationNotice()
+    {
+        if ( ctx.pendingTerminationNotice.isPresent() )
+        {
+            Status status = ctx.pendingTerminationNotice.get();
+
+            ctx.pendingTerminationNotice = Optional.empty();
+
+            throw new TransactionTerminatedException( status );
         }
     }
 
@@ -385,6 +421,8 @@ public class TransactionStateMachine implements StatementProcessor
 
         /** The current transaction, if present */
         KernelTransaction currentTransaction;
+
+        Optional<Status> pendingTerminationNotice = Optional.empty();
 
         /** Last Cypher statement executed */
         String lastStatement = "";

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachine.java
@@ -208,8 +208,8 @@ public class TransactionStateMachine implements StatementProcessor
                         }
                         else if ( statement.equalsIgnoreCase( ROLLBACK ) )
                         {
-                            throw new QueryExecutionKernelException(
-                                    new InvalidSemanticsException( "No current transaction to rollback." ) );
+                            ctx.currentResult = BoltResult.EMPTY;
+                            return AUTO_COMMIT;
                         }
                         else
                         {

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/concurrent/RunnableBoltWorker.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/concurrent/RunnableBoltWorker.java
@@ -40,6 +40,7 @@ import org.neo4j.logging.Log;
 class RunnableBoltWorker implements Runnable, BoltWorker
 {
     private static final int workQueueSize = Integer.getInteger( "org.neo4j.bolt.workQueueSize", 100 );
+    static final int workQueuePollDuration =  Integer.getInteger( "org.neo4j.bolt.workQueuePollDuration", 10 );
 
     private final BlockingQueue<Job> jobQueue = new ArrayBlockingQueue<>( workQueueSize );
     private final BoltStateMachine machine;
@@ -85,7 +86,7 @@ class RunnableBoltWorker implements Runnable, BoltWorker
         {
             while ( keepRunning )
             {
-                Job job = jobQueue.poll( 10, TimeUnit.SECONDS );
+                Job job = jobQueue.poll( workQueuePollDuration, TimeUnit.SECONDS );
                 if ( job != null )
                 {
                     execute( job );
@@ -95,6 +96,10 @@ class RunnableBoltWorker implements Runnable, BoltWorker
                     {
                         executeBatch( batch );
                     }
+                }
+                else
+                {
+                    machine.validateTransaction();
                 }
             }
         }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineTest.java
@@ -22,15 +22,32 @@ package org.neo4j.bolt.v1.runtime;
 import org.junit.Test;
 
 import java.util.Map;
+import java.util.Optional;
 
+import org.neo4j.bolt.v1.runtime.spi.BoltResult;
+import org.neo4j.graphdb.TransactionTerminatedException;
+import org.neo4j.kernel.api.KernelTransaction;
+import org.neo4j.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.time.FakeClock;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyMap;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.neo4j.bolt.security.auth.AuthenticationResult.AUTH_DISABLED;
 import static org.neo4j.helpers.collection.MapUtil.map;
 
@@ -87,8 +104,255 @@ public class TransactionStateMachineTest
         verify( stateMachineSPI ).awaitUpToDate( 67 );
     }
 
+    @Test
+    public void shouldStartWithAutoCommitState() throws Exception
+    {
+        TransactionStateMachineSPI stateMachineSPI = mock( TransactionStateMachineSPI.class );
+        TransactionStateMachine stateMachine = newTransactionStateMachine( stateMachineSPI );
+
+        assertThat( stateMachine.state, is( TransactionStateMachine.State.AUTO_COMMIT ) );
+        assertNull( stateMachine.ctx.currentTransaction );
+        assertNull( stateMachine.ctx.currentResultHandle );
+        assertNull( stateMachine.ctx.currentResult );
+    }
+
+    @Test
+    public void shouldDoNothingInAutoCommitTransactionUponInitialisationWhenValidated() throws Exception
+    {
+        KernelTransaction transaction = newTimedOutTransaction();
+        TransactionStateMachineSPI stateMachineSPI = newTransactionStateMachineSPI( transaction );
+        TransactionStateMachine stateMachine = newTransactionStateMachine( stateMachineSPI );
+
+        // We're in auto-commit state
+        assertThat( stateMachine.state, is( TransactionStateMachine.State.AUTO_COMMIT ) );
+        assertNull( stateMachine.ctx.currentTransaction );
+
+        // call validate transaction
+        stateMachine.validateTransaction();
+
+        assertThat( stateMachine.state, is( TransactionStateMachine.State.AUTO_COMMIT ) );
+        assertNull( stateMachine.ctx.currentTransaction );
+
+        verify( transaction, never() ).getReasonIfTerminated();
+        verify( transaction, never() ).failure();
+        verify( transaction, never() ).close();
+    }
+
+    @Test
+    public void shouldResetInAutoCommitTransactionWhileStatementIsRunningWhenValidated() throws Exception
+    {
+        KernelTransaction transaction = newTimedOutTransaction();
+        TransactionStateMachineSPI stateMachineSPI = newTransactionStateMachineSPI( transaction );
+        TransactionStateMachine stateMachine = newTransactionStateMachine( stateMachineSPI );
+
+        // We're in auto-commit state
+        assertThat( stateMachine.state, is( TransactionStateMachine.State.AUTO_COMMIT ) );
+        assertNull( stateMachine.ctx.currentTransaction );
+
+        stateMachine.run( "RETURN 1", null );
+
+        // We're in auto-commit state
+        assertThat( stateMachine.state, is( TransactionStateMachine.State.AUTO_COMMIT ) );
+        assertNotNull( stateMachine.ctx.currentTransaction );
+
+        // call validate transaction
+        stateMachine.validateTransaction();
+
+        assertThat( stateMachine.state, is( TransactionStateMachine.State.AUTO_COMMIT ) );
+        assertNull( stateMachine.ctx.currentTransaction );
+        assertNull( stateMachine.ctx.currentResult );
+        assertNull( stateMachine.ctx.currentResultHandle );
+
+        verify( transaction, times( 1 ) ).getReasonIfTerminated();
+        verify( transaction, times( 1 ) ).failure();
+        verify( transaction, times( 1 ) ).close();
+    }
+
+    @Test
+    public void shouldResetInExplicitTransactionUponTxBeginWhenValidated() throws Exception
+    {
+        KernelTransaction transaction = newTimedOutTransaction();
+        TransactionStateMachineSPI stateMachineSPI = newTransactionStateMachineSPI( transaction );
+        TransactionStateMachine stateMachine = newTransactionStateMachine( stateMachineSPI );
+
+        // start an explicit transaction
+        stateMachine.run( "BEGIN", map() );
+        assertThat( stateMachine.state, is( TransactionStateMachine.State.EXPLICIT_TRANSACTION ) );
+        assertNotNull( stateMachine.ctx.currentTransaction );
+
+        // verify transaction, which is timed out
+        stateMachine.validateTransaction();
+
+        assertThat( stateMachine.state, is( TransactionStateMachine.State.AUTO_COMMIT ) );
+        assertNull( stateMachine.ctx.currentTransaction );
+        assertNull( stateMachine.ctx.currentResult );
+        assertNull( stateMachine.ctx.currentResultHandle );
+
+        verify( transaction, times( 1 ) ).getReasonIfTerminated();
+        verify( transaction, times( 1 ) ).failure();
+        verify( transaction, times( 1 ) ).close();
+    }
+
+    @Test
+    public void shouldResetInExplicitTransactionWhileStatementIsRunningWhenValidated() throws Exception
+    {
+        KernelTransaction transaction = newTimedOutTransaction();
+        TransactionStateMachineSPI stateMachineSPI = newTransactionStateMachineSPI( transaction );
+        TransactionStateMachine stateMachine = newTransactionStateMachine( stateMachineSPI );
+
+        // start an explicit transaction
+        stateMachine.run( "BEGIN", map() );
+        assertThat( stateMachine.state, is( TransactionStateMachine.State.EXPLICIT_TRANSACTION ) );
+        assertNotNull( stateMachine.ctx.currentTransaction );
+
+        stateMachine.run( "RETURN 1", null );
+
+        // verify transaction, which is timed out
+        stateMachine.validateTransaction();
+
+        assertThat( stateMachine.state, is( TransactionStateMachine.State.AUTO_COMMIT ) );
+        assertNull( stateMachine.ctx.currentTransaction );
+        assertNull( stateMachine.ctx.currentResult );
+        assertNull( stateMachine.ctx.currentResultHandle );
+
+        verify( transaction, times( 1 ) ).getReasonIfTerminated();
+        verify( transaction, times( 1 ) ).failure();
+        verify( transaction, times( 1 ) ).close();
+    }
+
+    @Test
+    public void shouldUnbindTxAfterRun() throws Exception
+    {
+        KernelTransaction transaction = newTimedOutTransaction();
+        TransactionStateMachineSPI stateMachineSPI = newTransactionStateMachineSPI( transaction );
+        TransactionStateMachine stateMachine = newTransactionStateMachine( stateMachineSPI );
+
+        stateMachine.run( "SOME STATEMENT", null );
+
+        verify( stateMachineSPI, times( 1 ) ).unbindTransactionFromCurrentThread();
+    }
+
+    @Test
+    public void shouldUnbindTxAfterStreamResult() throws Exception
+    {
+        KernelTransaction transaction = newTimedOutTransaction();
+        TransactionStateMachineSPI stateMachineSPI = newTransactionStateMachineSPI( transaction );
+        TransactionStateMachine stateMachine = newTransactionStateMachine( stateMachineSPI );
+
+        stateMachine.run( "SOME STATEMENT", null );
+        stateMachine.streamResult( boltResult ->
+        {
+
+        } );
+
+        verify( stateMachineSPI, times( 2 ) ).unbindTransactionFromCurrentThread();
+    }
+
+    @Test
+    public void shouldThrowDuringRunIfPendingTerminationNoticeExists() throws Exception
+    {
+        KernelTransaction transaction = newTimedOutTransaction();
+        TransactionStateMachineSPI stateMachineSPI = newTransactionStateMachineSPI( transaction );
+        TransactionStateMachine stateMachine = newTransactionStateMachine( stateMachineSPI );
+
+        stateMachine.ctx.pendingTerminationNotice = Optional.of( Status.Transaction.TransactionTimedOut );
+
+        try
+        {
+            stateMachine.run( "SOME STATEMENT", null );
+            fail( "exception expected" );
+        }
+        catch ( TransactionTerminatedException t )
+        {
+            assertThat( t.status(), is( Status.Transaction.TransactionTimedOut ) );
+        }
+        catch ( Throwable t )
+        {
+            fail( "expected TransactionTerminated but got " + t.getMessage() );
+        }
+    }
+
+    @Test
+    public void shouldThrowDuringStreamResultIfPendingTerminationNoticeExists() throws Exception
+    {
+        KernelTransaction transaction = newTimedOutTransaction();
+        TransactionStateMachineSPI stateMachineSPI = newTransactionStateMachineSPI( transaction );
+        TransactionStateMachine stateMachine = newTransactionStateMachine( stateMachineSPI );
+
+        stateMachine.run( "SOME STATEMENT", null );
+        stateMachine.ctx.pendingTerminationNotice = Optional.of( Status.Transaction.TransactionTimedOut );
+
+        try
+        {
+            stateMachine.streamResult( boltResult ->
+            {
+
+            });
+
+            fail( "exception expected" );
+        }
+        catch ( TransactionTerminatedException t )
+        {
+            assertThat( t.status(), is( Status.Transaction.TransactionTimedOut ) );
+        }
+        catch ( Throwable t )
+        {
+            fail( "expected TransactionTerminated but got " + t.getMessage() );
+        }
+    }
+
+    private static KernelTransaction newTransaction()
+    {
+        KernelTransaction transaction = mock( KernelTransaction.class );
+
+        when( transaction.isOpen() ).thenReturn( true );
+
+        return transaction;
+    }
+
+    private static KernelTransaction newTimedOutTransaction()
+    {
+        KernelTransaction transaction = newTransaction();
+
+        when( transaction.getReasonIfTerminated() ).thenReturn( Optional.of( Status.Transaction.TransactionTimedOut ) );
+
+        return transaction;
+    }
+
     private static TransactionStateMachine newTransactionStateMachine( TransactionStateMachineSPI stateMachineSPI )
     {
         return new TransactionStateMachine( stateMachineSPI, AUTH_DISABLED, new FakeClock() );
+    }
+
+    private static TransactionStateMachineSPI newFailingTransactionStateMachineSPI( Status failureStatus ) throws KernelException
+    {
+        TransactionStateMachine.BoltResultHandle resultHandle = newResultHandle();
+        TransactionStateMachineSPI stateMachineSPI = mock( TransactionStateMachineSPI.class );
+
+        when( stateMachineSPI.beginTransaction( any() ) ).thenReturn( mock( KernelTransaction.class ) );
+        when( stateMachineSPI.executeQuery( any(), any(), anyString(), anyMap(), any() ) ).thenReturn( resultHandle );
+        when( stateMachineSPI.executeQuery( any(), any(), eq( "FAIL" ), anyMap(), any() ) ).thenThrow( new TransactionTerminatedException( failureStatus ) );
+
+        return stateMachineSPI;
+    }
+
+    private static TransactionStateMachineSPI newTransactionStateMachineSPI( KernelTransaction transaction ) throws KernelException
+    {
+        TransactionStateMachine.BoltResultHandle resultHandle = newResultHandle();
+        TransactionStateMachineSPI stateMachineSPI = mock( TransactionStateMachineSPI.class );
+
+        when( stateMachineSPI.beginTransaction( any() ) ).thenReturn( transaction );
+        when( stateMachineSPI.executeQuery( any(), any(), anyString(), anyMap(), any() ) ).thenReturn( resultHandle );
+
+        return stateMachineSPI;
+    }
+
+    private static TransactionStateMachine.BoltResultHandle newResultHandle() throws KernelException
+    {
+        TransactionStateMachine.BoltResultHandle resultHandle = mock( TransactionStateMachine.BoltResultHandle.class );
+
+        when( resultHandle.start() ).thenReturn( BoltResult.EMPTY );
+
+        return resultHandle;
     }
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineTest.java
@@ -255,7 +255,7 @@ public class TransactionStateMachineTest
         TransactionStateMachineSPI stateMachineSPI = newTransactionStateMachineSPI( transaction );
         TransactionStateMachine stateMachine = newTransactionStateMachine( stateMachineSPI );
 
-        stateMachine.ctx.pendingTerminationNotice = Optional.of( Status.Transaction.TransactionTimedOut );
+        stateMachine.ctx.pendingTerminationNotice = Status.Transaction.TransactionTimedOut;
 
         try
         {
@@ -280,7 +280,7 @@ public class TransactionStateMachineTest
         TransactionStateMachine stateMachine = newTransactionStateMachine( stateMachineSPI );
 
         stateMachine.run( "SOME STATEMENT", null );
-        stateMachine.ctx.pendingTerminationNotice = Optional.of( Status.Transaction.TransactionTimedOut );
+        stateMachine.ctx.pendingTerminationNotice = Status.Transaction.TransactionTimedOut;
 
         try
         {

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/TransactionIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/integration/TransactionIT.java
@@ -121,7 +121,7 @@ public class TransactionIT
     }
 
     @Test
-    public void shouldFailNicelyWhenOutOfOrderRollback() throws Throwable
+    public void shouldNotFailWhenOutOfOrderRollbackInAutoCommitMode() throws Throwable
     {
         // Given
         BoltResponseRecorder runRecorder = new BoltResponseRecorder();
@@ -134,8 +134,8 @@ public class TransactionIT
         machine.pullAll( pullAllRecorder );
 
         // Then
-        assertThat( runRecorder.nextResponse(), failedWithStatus( Status.Statement.SemanticError ) );
-        assertThat( pullAllRecorder.nextResponse(), wasIgnored() );
+        assertThat( runRecorder.nextResponse(), succeeded() );
+        assertThat( pullAllRecorder.nextResponse(), succeeded() );
     }
 
     @Test


### PR DESCRIPTION
When client transactions are not closed appropriately, bolt server continues to hold related transactions even if the server is configured to time out transactions. This PR addresses this problem and validates the transaction (if any) and releases it in case it is timed out. With releasing, the transaction state machine is reset - closing any open statement handles and transactions.

In case the client tries to interact with the server, the recorded termination status message is returned to the client as a failure message.