### PR TITLE
Windows service does not start when in a directory with spaces in name

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jPrunsrv.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jPrunsrv.ps1
@@ -93,7 +93,7 @@ Function Get-Neo4jPrunsrv
     # Build the PRUNSRV command line
     switch ($PsCmdlet.ParameterSetName) {
       "ServerInstallInvoke"   {
-        $PrunArgs += @("//IS//$($Name)")
+        $PrunArgs += @("`"//IS//$($Name)`"")
 
         $JvmOptions = @()
 
@@ -140,12 +140,12 @@ Function Get-Neo4jPrunsrv
         $JavaCMD.args | ForEach-Object -Process {
           if ($Matches -ne $null) { $Matches.Clear() }
           if ($_ -match '^-Xms([\d]+)m$') {
-            $PrunArgs += "--JvmMs $($matches[1])"
+            $PrunArgs += "`"--JvmMs $($matches[1])`""
             Write-Verbose "Use JVM Start Memory of $($matches[1]) MB"
           }
           if ($Matches -ne $null) { $Matches.Clear() }
           if ($_ -match '^-Xmx([\d]+)m$') {
-            $PrunArgs += "--JvmMx $($matches[1])"
+            $PrunArgs += "`"--JvmMx $($matches[1])`""
             Write-Verbose "Use JVM Max Memory of $($matches[1]) MB"
           }
         }
@@ -154,11 +154,11 @@ Function Get-Neo4jPrunsrv
         if ($Neo4jServer.ServerType -eq 'Community') { $serverMainClass = 'org.neo4j.server.CommunityEntryPoint' }
         if ($Neo4jServer.DatabaseMode.ToUpper() -eq 'ARBITER') { $serverMainClass = 'org.neo4j.server.enterprise.ArbiterEntryPoint' }
         if ($serverMainClass -eq '') { Write-Error "Unable to determine the Server Main Class from the server information"; return $null }
-        $PrunArgs += @("--StopClass=$($serverMainClass)",
-                       "--StartClass=$($serverMainClass)")
+        $PrunArgs += @("`"--StopClass=$($serverMainClass)`"",
+                       "`"--StartClass=$($serverMainClass)`"")
       }
-      "ServerUninstallInvoke" { $PrunArgs += @("//DS//$($Name)") }
-      "ConsoleInvoke"         { $PrunArgs += @("//TS//$($Name)") }
+      "ServerUninstallInvoke" { $PrunArgs += @("`"//DS//$($Name)`"") }
+      "ConsoleInvoke"         { $PrunArgs += @("`"//TS//$($Name)`"") }
       default {
         throw "Unknown ParameterSerName $($PsCmdlet.ParameterSetName)"
         return $null

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jPrunsrv.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jPrunsrv.ps1
@@ -114,24 +114,24 @@ Function Get-Neo4jPrunsrv
         Write-Verbose "Reading JVM settings from console java invocation"
         $JvmOptions = [array](Merge-Neo4jJavaSettings -Source $JvmOptions -Add ($JavaCMD.args | Where-Object { $_ -match '(^-D|^-X)' }))
 
-        $PrunArgs += @('--StartMode=jvm',
-          '--StartMethod=start',
+        $PrunArgs += @("`"--StartMode=jvm`"",
+          "`"--StartMethod=start`"",
           "`"--StartPath=$($Neo4jServer.Home)`"",
           "`"--StartParams=--config-dir=$($Neo4jServer.ConfDir)`"",
           "`"++StartParams=--home-dir=$($Neo4jServer.Home)`"",
-          '--StopMode=jvm',
-          '--StopMethod=stop',
+          "`"--StopMode=jvm`"",
+          "`"--StopMethod=stop`"",
           "`"--StopPath=$($Neo4jServer.Home)`"",
           "`"--Description=Neo4j Graph Database - $($Neo4jServer.Home)`"",
           "`"--DisplayName=Neo4j Graph Database - $Name`"",
           "`"--Jvm=$($JvmDLL)`"",
-          "--LogPath=$($Neo4jServer.LogDir)",
-          "--StdOutput=$(Join-Path -Path $Neo4jServer.LogDir -ChildPath 'neo4j.log')",
-          "--StdError=$(Join-Path -Path $Neo4jServer.LogDir -ChildPath 'service-error.log')",
-          '--LogPrefix=neo4j-service',
-          '--Classpath=lib/*;plugins/*',
+          "`"--LogPath=$($Neo4jServer.LogDir)`"",
+          "`"--StdOutput=$(Join-Path -Path $Neo4jServer.LogDir -ChildPath 'neo4j.log')`"",
+          "`"--StdError=$(Join-Path -Path $Neo4jServer.LogDir -ChildPath 'service-error.log')`"",
+          "`"--LogPrefix=neo4j-service`"",
+          "`"--Classpath=lib/*;plugins/*`"",
           "`"--JvmOptions=$($JvmOptions -join ';')`"",
-          '--Startup=auto'
+          "`"--Startup=auto`""
         )
 
         # Check if Java invocation includes Java memory sizing

--- a/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Neo4jPrunsrv.Tests.ps1
+++ b/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Neo4jPrunsrv.Tests.ps1
@@ -78,6 +78,30 @@ InModuleScope Neo4j-Management {
       }
     }
 
+    Context "PRUNSRV arguments are quoted" {
+      $quotedStringRegex = ([regex]::New("^"".*""$"))
+      $serverObject = global:New-MockNeo4jInstall -RootDir "TestDrive:\Neo4j Install With Space"
+
+      It "on service install" {
+        $prunsrv = Get-Neo4jPrunsrv -Neo4jServer $serverObject -ForServerInstall
+
+        $prunsrv.args | Should Match ($quotedStringRegex)
+      }
+
+      It "on service uninstall" {
+        $prunsrv = Get-Neo4jPrunsrv -Neo4jServer $serverObject -ForServerUninstall
+
+        $prunsrv.args | Should Match ($quotedStringRegex)
+      }
+
+      It "on console" {
+        $prunsrv = Get-Neo4jPrunsrv -Neo4jServer $serverObject -ForConsole
+
+        $prunsrv.args | Should Match ($quotedStringRegex)
+      }
+    }
+
+
     Context "Server Invoke - Community v3.0" {
       $serverObject = global:New-MockNeo4jInstall -ServerVersion '3.0' -ServerType 'Community'
 


### PR DESCRIPTION
If neo4j is installed in a directory with space(s) in name (like C:\Program Files\neo4j), although service is reported to be installed successfully it does not start. With this fix, scripts are updated to quote all arguments passed to prunsrv.

changelog: Fixed broken service installation for paths with spaces on Windows