### PR TITLE
Fixes equality for lists in accordance with OpenCypher.

### DIFF
--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
@@ -191,12 +191,52 @@ public abstract class CompiledConversionUtils
             return null;
         }
 
+        boolean lhsIsSeq = lhs instanceof  List<?>;
+        boolean rhsIsSeq = rhs instanceof List<?>;
+
+        // Can't compare a literal to a list
+        if ( (lhsIsSeq && !rhsIsSeq) || (!lhsIsSeq && rhsIsSeq) )
+        {
+            return null;
+        }
+
+        if ( lhsIsSeq && rhsIsSeq )
+        {
+            List<?> lhsList = (List<?>) lhs;
+            List<?> rhsList = (List<?>) rhs;
+            boolean foundNull = false;
+
+            // Different length lists can't be equal
+            if (lhsList.size() != rhsList.size())
+            {
+                return false;
+            }
+
+            for ( int i = 0; i < lhsList.size(); i++ )
+            {
+                Object obj1 = lhsList.get( i );
+                Object obj2 = rhsList.get( i );
+
+                Boolean objEquality = equals( obj1, obj2 );
+                if( objEquality == null )
+                {
+                    foundNull = true;
+                } else if ( !objEquality ) {
+                    return false;
+
+                }
+            }
+            if (foundNull) {
+                return null;
+            }
+            return true;
+        }
+
         if ( (lhs instanceof NodeIdWrapper && !(rhs instanceof NodeIdWrapper)) ||
              (rhs instanceof NodeIdWrapper && !(lhs instanceof NodeIdWrapper)) ||
              (lhs instanceof RelationshipIdWrapper && !(rhs instanceof RelationshipIdWrapper)) ||
              (rhs instanceof RelationshipIdWrapper && !(lhs instanceof RelationshipIdWrapper)) )
         {
-
             throw new IncomparableValuesException( lhs.getClass().getSimpleName(), rhs.getClass().getSimpleName() );
         }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/predicates/Checker.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/predicates/Checker.scala
@@ -44,7 +44,6 @@ class BuildUp(list: ListValue) extends Checker {
   // else we return Some(false).
   private var falseResult: Option[Boolean] = Some(false)
 
-
   override def contains(value: AnyValue): (Option[Boolean], Checker) = {
     if (value == Values.NO_VALUE) (None, this)
     else {
@@ -56,7 +55,7 @@ class BuildUp(list: ListValue) extends Checker {
   }
 
   private def checkAndBuildUpCache(value: AnyValue): (Option[Boolean], Checker) = {
-    var foundMatch = false
+    var foundMatch: java.lang.Boolean = false
     while (iterator.hasNext && !foundMatch) {
       val nextValue = iterator.next()
 
@@ -65,9 +64,13 @@ class BuildUp(list: ListValue) extends Checker {
       } else {
         cachedSet.add(nextValue)
         foundMatch = (nextValue, value) match {
-          case (a: ArrayValue, b: ListValue) => VirtualValues.fromArray(a).equals(b)
-          case (a: ListValue, b: ArrayValue) => VirtualValues.fromArray(b).equals(a)
-          case (a, b) => a.equals(b)
+          case (a: ArrayValue, b: ListValue) => VirtualValues.fromArray(a).ternaryEquals(b)
+          case (a: ListValue, b: ArrayValue) => VirtualValues.fromArray(b).ternaryEquals(a)
+          case (a, b) => a.ternaryEquals(b)
+        }
+        if (foundMatch == null) {
+          falseResult = None
+          foundMatch = false
         }
       }
     }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/predicates/ComparablePredicate.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/predicates/ComparablePredicate.scala
@@ -22,8 +22,10 @@ package org.neo4j.cypher.internal.compatibility.v3_3.runtime.commands.predicates
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.ExecutionContext
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.commands.expressions.{Expression, Literal, Variable}
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes.QueryState
-import org.neo4j.values.AnyValues
+import org.neo4j.values.{AnyValue, AnyValues, SequenceValue}
 import org.neo4j.values.storable._
+
+import scala.runtime.Tuple2Zipped
 
 abstract sealed class ComparablePredicate(val left: Expression, val right: Expression) extends Predicate {
 
@@ -74,10 +76,47 @@ case class Equals(a: Expression, b: Expression) extends Predicate {
     val a1 = a(m, state)
     val b1 = b(m, state)
 
-    (a1, b1) match {
-      case (x, y) if x == Values.NO_VALUE || y == Values.NO_VALUE => None
-      case _ => Some(a1.equals(b1))
+    equality(a1, b1)
+  }
+
+  private def equality(a1: AnyValue, b1: AnyValue): Option[Boolean] = {
+
+    if (a1 == Values.NO_VALUE || b1 == Values.NO_VALUE) {
+      None
+    } else {
+      val a1IsSeq = a1.isInstanceOf[SequenceValue]
+      val b1IsSeq = b1.isInstanceOf[SequenceValue]
+
+      (a1IsSeq, b1IsSeq) match {
+        case (true, false) => None
+        case (false, true) => None
+        case (false, false) => Some(a1.equals(b1))
+        case (true, true) => compareLists(a1.asInstanceOf[SequenceValue], b1.asInstanceOf[SequenceValue])
+      }
+
     }
+  }
+  private def differentLength(a: SequenceValue, b: SequenceValue): Boolean = a.length() != b.length()
+
+  private def compareLists(seq1: SequenceValue, seq2: SequenceValue): Option[Boolean] = {
+    var foundNull = false
+
+    // Different length lists can't be equal
+    if (differentLength(seq1, seq2)) return Some(false)
+
+    val itr1 = seq1.iterator()
+    val itr2 = seq2.iterator()
+
+    while (itr1.hasNext) {
+      val (x, y) = (itr1.next(), itr2.next())
+      equality(x.asInstanceOf[AnyValue], y.asInstanceOf[AnyValue]) match {
+        case None => foundNull = true
+        case Some(false) => return Some(false)
+        case Some(true) => // continue
+      }
+    }
+
+    if (foundNull) None else Some(true)
   }
 
   override def toString = s"$a == $b"

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ValueUtils.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ValueUtils.java
@@ -315,6 +315,16 @@ public final class ValueUtils
         }
 
         @Override
+        public Boolean ternaryEquals( Object other )
+        {
+            if ( other == null )
+            {
+                return null;
+            }
+            return other.equals( object );
+        }
+
+        @Override
         protected int computeHash()
         {
             return object.hashCode();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ValueUtils.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ValueUtils.java
@@ -50,6 +50,7 @@ import org.neo4j.values.virtual.PointValue;
 import org.neo4j.values.virtual.VirtualValues;
 
 import static java.util.stream.StreamSupport.stream;
+import static org.neo4j.values.storable.Values.NO_VALUE;
 import static org.neo4j.values.virtual.VirtualValues.list;
 import static org.neo4j.values.virtual.VirtualValues.map;
 
@@ -315,9 +316,9 @@ public final class ValueUtils
         }
 
         @Override
-        public Boolean ternaryEquals( Object other )
+        public Boolean ternaryEquals( AnyValue other )
         {
-            if ( other == null )
+            if ( other == null || other == NO_VALUE )
             {
                 return null;
             }

--- a/community/values/src/main/java/org/neo4j/values/AnyValue.java
+++ b/community/values/src/main/java/org/neo4j/values/AnyValue.java
@@ -52,4 +52,6 @@ public abstract class AnyValue
     {
         return false; // per default Values are no SequenceValues
     }
+
+    public abstract Boolean ternaryEquals( Object other );
 }

--- a/community/values/src/main/java/org/neo4j/values/AnyValue.java
+++ b/community/values/src/main/java/org/neo4j/values/AnyValue.java
@@ -53,5 +53,5 @@ public abstract class AnyValue
         return false; // per default Values are no SequenceValues
     }
 
-    public abstract Boolean ternaryEquals( Object other );
+    public abstract Boolean ternaryEquals( AnyValue other );
 }

--- a/community/values/src/main/java/org/neo4j/values/SequenceValue.java
+++ b/community/values/src/main/java/org/neo4j/values/SequenceValue.java
@@ -84,6 +84,33 @@ public interface SequenceValue extends Iterable<AnyValue>
         return areEqual;
     }
 
+    static Boolean ternaryEqualsUsingRandomAccess( SequenceValue a, SequenceValue b )
+    {
+        if ( a.length() != b.length() )
+        {
+            return false;
+        }
+
+        int i = 0;
+        Boolean equivalenceResult = true;
+
+        while ( i < a.length() )
+        {
+            Boolean areEqual = a.value( i ).ternaryEquals( b.value( i ) );
+            if ( areEqual == null )
+            {
+                equivalenceResult = null;
+            }
+            else if ( !areEqual )
+            {
+                return false;
+            }
+            i++;
+        }
+
+        return equivalenceResult;
+    }
+
     static boolean equalsUsingIterators( SequenceValue a, SequenceValue b )
     {
         boolean areEqual = true;
@@ -96,6 +123,28 @@ public interface SequenceValue extends Iterable<AnyValue>
         }
 
         return areEqual && aIterator.hasNext() == bIterator.hasNext();
+    }
+
+    static Boolean ternaryEqualsUsingIterators( SequenceValue a, SequenceValue b )
+    {
+        Boolean equivalenceResult = true;
+        Iterator<AnyValue> aIterator = a.iterator();
+        Iterator<AnyValue> bIterator = b.iterator();
+
+        while ( aIterator.hasNext() && bIterator.hasNext() )
+        {
+            Boolean areEqual = aIterator.next().ternaryEquals( bIterator.next() );
+            if ( areEqual == null )
+            {
+                equivalenceResult = null;
+            }
+            else if ( !areEqual )
+            {
+                return false;
+            }
+        }
+
+        return aIterator.hasNext() == bIterator.hasNext() ? equivalenceResult : Boolean.FALSE;
     }
 
     default int compareToSequence( SequenceValue other, Comparator<AnyValue> comparator )
@@ -149,5 +198,19 @@ public interface SequenceValue extends Iterable<AnyValue>
         }
 
         return x;
+    }
+
+    default Boolean ternaryEquals( SequenceValue other )
+    {
+        IterationPreference pref = iterationPreference();
+        IterationPreference otherPref = other.iterationPreference();
+        if ( pref == RANDOM_ACCESS && otherPref == RANDOM_ACCESS )
+        {
+            return ternaryEqualsUsingRandomAccess(this, other );
+        }
+        else
+        {
+            return ternaryEqualsUsingIterators( this, other );
+        }
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/SequenceValue.java
+++ b/community/values/src/main/java/org/neo4j/values/SequenceValue.java
@@ -200,7 +200,7 @@ public interface SequenceValue extends Iterable<AnyValue>
         return x;
     }
 
-    default Boolean ternaryEquals( SequenceValue other )
+    default Boolean ternaryEquality( SequenceValue other )
     {
         IterationPreference pref = iterationPreference();
         IterationPreference otherPref = other.iterationPreference();

--- a/community/values/src/main/java/org/neo4j/values/VirtualValue.java
+++ b/community/values/src/main/java/org/neo4j/values/VirtualValue.java
@@ -46,6 +46,23 @@ public abstract class VirtualValue extends AnyValue
 
     public abstract boolean equals( VirtualValue other );
 
+    public Boolean ternaryEquals( Object other )
+    {
+        if ( other == null )
+        {
+            return null;
+        }
+        if ( other instanceof SequenceValue && this.isSequenceValue() )
+        {
+            return ((SequenceValue) this).ternaryEquals( (SequenceValue) other );
+        }
+        if ( other instanceof VirtualValue && ((VirtualValue) other).valueGroup() == valueGroup() )
+        {
+            return equals( (VirtualValue) other );
+        }
+        return null;
+    }
+
     public abstract VirtualValueGroup valueGroup();
 
     public abstract int compareTo( VirtualValue other, Comparator<AnyValue> comparator );

--- a/community/values/src/main/java/org/neo4j/values/VirtualValue.java
+++ b/community/values/src/main/java/org/neo4j/values/VirtualValue.java
@@ -23,6 +23,8 @@ import java.util.Comparator;
 
 import org.neo4j.values.virtual.VirtualValueGroup;
 
+import static org.neo4j.values.storable.Values.NO_VALUE;
+
 /**
  * Value that can exist transiently during computations, but that cannot be stored as a property value. A Virtual
  * Value could be a NodeReference for example.
@@ -48,7 +50,7 @@ public abstract class VirtualValue extends AnyValue
 
     public Boolean ternaryEquals( Object other )
     {
-        if ( other == null )
+        if ( other == null || other == NO_VALUE )
         {
             return null;
         }
@@ -60,7 +62,7 @@ public abstract class VirtualValue extends AnyValue
         {
             return equals( (VirtualValue) other );
         }
-        return null;
+        return false;
     }
 
     public abstract VirtualValueGroup valueGroup();

--- a/community/values/src/main/java/org/neo4j/values/VirtualValue.java
+++ b/community/values/src/main/java/org/neo4j/values/VirtualValue.java
@@ -48,6 +48,7 @@ public abstract class VirtualValue extends AnyValue
 
     public abstract boolean equals( VirtualValue other );
 
+    @Override
     public Boolean ternaryEquals( AnyValue other )
     {
         if ( other == null || other == NO_VALUE )

--- a/community/values/src/main/java/org/neo4j/values/VirtualValue.java
+++ b/community/values/src/main/java/org/neo4j/values/VirtualValue.java
@@ -48,7 +48,7 @@ public abstract class VirtualValue extends AnyValue
 
     public abstract boolean equals( VirtualValue other );
 
-    public Boolean ternaryEquals( Object other )
+    public Boolean ternaryEquals( AnyValue other )
     {
         if ( other == null || other == NO_VALUE )
         {
@@ -56,7 +56,7 @@ public abstract class VirtualValue extends AnyValue
         }
         if ( other instanceof SequenceValue && this.isSequenceValue() )
         {
-            return ((SequenceValue) this).ternaryEquals( (SequenceValue) other );
+            return ((SequenceValue) this).ternaryEquality( (SequenceValue) other );
         }
         if ( other instanceof VirtualValue && ((VirtualValue) other).valueGroup() == valueGroup() )
         {

--- a/community/values/src/main/java/org/neo4j/values/storable/ArrayValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ArrayValue.java
@@ -20,6 +20,7 @@
 package org.neo4j.values.storable;
 
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.SequenceValue;
@@ -51,7 +52,11 @@ public abstract class ArrayValue extends Value implements SequenceValue
             @Override
             public AnyValue next()
             {
-                return value( offset );
+                if ( !hasNext() )
+                {
+                    throw new NoSuchElementException();
+                }
+                return value( offset++ );
             }
         };
     }

--- a/community/values/src/main/java/org/neo4j/values/storable/CharValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/CharValue.java
@@ -43,12 +43,6 @@ public final class CharValue extends TextValue
     }
 
     @Override
-    public boolean equals( boolean x )
-    {
-        return false;
-    }
-
-    @Override
     public boolean equals( char x )
     {
         return value == x;

--- a/community/values/src/main/java/org/neo4j/values/storable/FloatingPointValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/FloatingPointValue.java
@@ -69,6 +69,12 @@ public abstract class FloatingPointValue extends NumberValue
     }
 
     @Override
+    public boolean isNaN()
+    {
+        return this.doubleValue() != this.doubleValue();
+    }
+
+    @Override
     public long longValue()
     {
         return (long) doubleValue();

--- a/community/values/src/main/java/org/neo4j/values/storable/FloatingPointValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/FloatingPointValue.java
@@ -71,7 +71,7 @@ public abstract class FloatingPointValue extends NumberValue
     @Override
     public boolean isNaN()
     {
-        return this.doubleValue() != this.doubleValue();
+        return Double.isNaN( this.doubleValue() );
     }
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/NoValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/NoValue.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.values.storable;
 
+import org.neo4j.values.AnyValue;
+
 /**
  * Not a value.
  *
@@ -41,7 +43,7 @@ final class NoValue extends Value
     }
 
     @Override
-    public Boolean ternaryEquals( Object other )
+    public Boolean ternaryEquals( AnyValue other )
     {
         return null;
     }

--- a/community/values/src/main/java/org/neo4j/values/storable/NoValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/NoValue.java
@@ -41,6 +41,12 @@ final class NoValue extends Value
     }
 
     @Override
+    public Boolean ternaryEquals( Object other )
+    {
+        return null;
+    }
+
+    @Override
     public int computeHash()
     {
         return System.identityHashCode( this );

--- a/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
@@ -28,12 +28,6 @@ public abstract class StringValue extends TextValue
     abstract String value();
 
     @Override
-    public boolean eq( Object other )
-    {
-        return other != null && other instanceof Value && equals( (Value) other );
-    }
-
-    @Override
     public boolean equals( Value value )
     {
         return value.equals( value() );

--- a/community/values/src/main/java/org/neo4j/values/storable/Value.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Value.java
@@ -66,7 +66,7 @@ public abstract class Value extends AnyValue
         {
             return null;
         }
-        if ( other instanceof SequenceValue && this.isSequenceValue() )
+        if ( other.isSequenceValue() && this.isSequenceValue() )
         {
             return ((SequenceValue) this).ternaryEquality( (SequenceValue) other );
         }

--- a/community/values/src/main/java/org/neo4j/values/storable/Value.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Value.java
@@ -23,6 +23,8 @@ import org.neo4j.values.AnyValue;
 import org.neo4j.values.AnyValueWriter;
 import org.neo4j.values.SequenceValue;
 
+import static org.neo4j.values.storable.Values.NO_VALUE;
+
 public abstract class Value extends AnyValue
 {
     @Override
@@ -59,7 +61,7 @@ public abstract class Value extends AnyValue
 
     public Boolean ternaryEquals( Object other )
     {
-        if ( other == null )
+        if ( other == null || other == NO_VALUE )
         {
             return null;
         }
@@ -76,7 +78,7 @@ public abstract class Value extends AnyValue
             }
             return equals( otherValue );
         }
-        return null;
+        return false;
     }
 
     public <E extends Exception> void writeTo( AnyValueWriter<E> writer ) throws E

--- a/community/values/src/main/java/org/neo4j/values/storable/Value.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Value.java
@@ -21,9 +21,16 @@ package org.neo4j.values.storable;
 
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.AnyValueWriter;
+import org.neo4j.values.SequenceValue;
 
 public abstract class Value extends AnyValue
 {
+    @Override
+    public boolean eq( Object other )
+    {
+        return other != null && other instanceof Value && equals( (Value) other );
+    }
+
     public abstract boolean equals( Value other );
 
     public abstract boolean equals( byte[] x );
@@ -49,6 +56,28 @@ public abstract class Value extends AnyValue
     public abstract boolean equals( char[] x );
 
     public abstract boolean equals( String[] x );
+
+    public Boolean ternaryEquals( Object other )
+    {
+        if ( other == null )
+        {
+            return null;
+        }
+        if ( other instanceof SequenceValue && this.isSequenceValue() )
+        {
+            return ((SequenceValue) this).ternaryEquals( (SequenceValue) other );
+        }
+        if ( other instanceof Value && ((Value) other).valueGroup() == valueGroup() )
+        {
+            Value otherValue = (Value) other;
+            if ( this.isNaN() || otherValue.isNaN() )
+            {
+                return null;
+            }
+            return equals( otherValue );
+        }
+        return null;
+    }
 
     public <E extends Exception> void writeTo( AnyValueWriter<E> writer ) throws E
     {
@@ -84,4 +113,9 @@ public abstract class Value extends AnyValue
     public abstract ValueGroup valueGroup();
 
     public abstract NumberType numberType();
+
+    public boolean isNaN()
+    {
+        return false;
+    }
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/Value.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Value.java
@@ -59,6 +59,7 @@ public abstract class Value extends AnyValue
 
     public abstract boolean equals( String[] x );
 
+    @Override
     public Boolean ternaryEquals( AnyValue other )
     {
         if ( other == null || other == NO_VALUE )
@@ -81,6 +82,7 @@ public abstract class Value extends AnyValue
         return false;
     }
 
+    @Override
     public <E extends Exception> void writeTo( AnyValueWriter<E> writer ) throws E
     {
         writeTo( (ValueWriter<E>)writer );

--- a/community/values/src/main/java/org/neo4j/values/storable/Value.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Value.java
@@ -59,7 +59,7 @@ public abstract class Value extends AnyValue
 
     public abstract boolean equals( String[] x );
 
-    public Boolean ternaryEquals( Object other )
+    public Boolean ternaryEquals( AnyValue other )
     {
         if ( other == null || other == NO_VALUE )
         {
@@ -67,7 +67,7 @@ public abstract class Value extends AnyValue
         }
         if ( other instanceof SequenceValue && this.isSequenceValue() )
         {
-            return ((SequenceValue) this).ternaryEquals( (SequenceValue) other );
+            return ((SequenceValue) this).ternaryEquality( (SequenceValue) other );
         }
         if ( other instanceof Value && ((Value) other).valueGroup() == valueGroup() )
         {

--- a/community/values/src/main/java/org/neo4j/values/virtual/MapValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/MapValue.java
@@ -118,6 +118,48 @@ public final class MapValue extends VirtualValue
         return compare;
     }
 
+    @Override
+    public Boolean ternaryEquals( Object other )
+    {
+        if ( other == null || !(other instanceof MapValue) )
+        {
+            return null;
+        }
+        Map<String,AnyValue> otherMap = ((MapValue) other).map;
+        int size = map.size();
+        if (size != otherMap.size())
+        {
+            return false;
+        }
+        String[] thisKeys = map.keySet().toArray( new String[size] );
+        Arrays.sort( thisKeys, String::compareTo );
+        String[] thatKeys = otherMap.keySet().toArray( new String[size] );
+        Arrays.sort( thatKeys, String::compareTo );
+        for ( int i = 0; i < size; i++ )
+        {
+            if ( thisKeys[i].compareTo( thatKeys[i] ) != 0 )
+            {
+                return false;
+            }
+        }
+        Boolean equalityResult = true;
+
+        for ( int i = 0; i < size; i++ )
+        {
+            String key = thisKeys[i];
+            Boolean s = map.get( key ).ternaryEquals( otherMap.get( key ) );
+            if (s == null)
+            {
+                equalityResult = null;
+            }
+            else if ( !s )
+            {
+                return false;
+            }
+        }
+        return equalityResult;
+    }
+
     public void foreach( BiConsumer<String,AnyValue> f )
     {
         map.forEach( f );

--- a/community/values/src/main/java/org/neo4j/values/virtual/MapValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/MapValue.java
@@ -127,7 +127,7 @@ public final class MapValue extends VirtualValue
         }
         Map<String,AnyValue> otherMap = ((MapValue) other).map;
         int size = map.size();
-        if (size != otherMap.size())
+        if ( size != otherMap.size() )
         {
             return false;
         }
@@ -148,7 +148,7 @@ public final class MapValue extends VirtualValue
         {
             String key = thisKeys[i];
             Boolean s = map.get( key ).ternaryEquals( otherMap.get( key ) );
-            if (s == null)
+            if ( s == null )
             {
                 equalityResult = null;
             }

--- a/community/values/src/main/java/org/neo4j/values/virtual/MapValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/MapValue.java
@@ -30,6 +30,8 @@ import org.neo4j.values.AnyValueWriter;
 import org.neo4j.values.VirtualValue;
 import org.neo4j.values.storable.Values;
 
+import static org.neo4j.values.storable.Values.NO_VALUE;
+
 public final class MapValue extends VirtualValue
 {
     private final Map<String,AnyValue> map;
@@ -119,11 +121,15 @@ public final class MapValue extends VirtualValue
     }
 
     @Override
-    public Boolean ternaryEquals( Object other )
+    public Boolean ternaryEquals( AnyValue other )
     {
-        if ( other == null || !(other instanceof MapValue) )
+        if ( other == null || other == NO_VALUE )
         {
             return null;
+        }
+        else if ( !(other instanceof MapValue) )
+        {
+            return false;
         }
         Map<String,AnyValue> otherMap = ((MapValue) other).map;
         int size = map.size();
@@ -177,7 +183,7 @@ public final class MapValue extends VirtualValue
 
     public AnyValue get( String key )
     {
-      return map.getOrDefault( key, Values.NO_VALUE );
+      return map.getOrDefault( key, NO_VALUE );
     }
 
     @Override

--- a/community/values/src/test/java/org/neo4j/values/AnyValuesTest.java
+++ b/community/values/src/test/java/org/neo4j/values/AnyValuesTest.java
@@ -21,7 +21,6 @@ package org.neo4j.values;
 
 import org.junit.Test;
 
-import static junit.framework.TestCase.assertFalse;
 import static org.neo4j.values.storable.Values.booleanValue;
 import static org.neo4j.values.storable.Values.byteValue;
 import static org.neo4j.values.storable.Values.doubleValue;
@@ -30,6 +29,7 @@ import static org.neo4j.values.storable.Values.intValue;
 import static org.neo4j.values.storable.Values.longValue;
 import static org.neo4j.values.storable.Values.shortValue;
 import static org.neo4j.values.storable.Values.stringValue;
+import static org.neo4j.values.utils.AnyValueTestUtil.assertIncomparable;
 
 public class AnyValuesTest
 {
@@ -39,19 +39,13 @@ public class AnyValuesTest
     {
         VirtualValue virtual = new MyVirtualValue( 42 );
 
-        assertNotEqual( booleanValue( false ), virtual );
-        assertNotEqual( byteValue( (byte)0 ), virtual );
-        assertNotEqual( shortValue( (short)0 ), virtual );
-        assertNotEqual( intValue( 0 ), virtual );
-        assertNotEqual( longValue( 0 ), virtual );
-        assertNotEqual( floatValue( 0.0f ), virtual );
-        assertNotEqual( doubleValue( 0.0 ), virtual );
-        assertNotEqual( stringValue( "" ), virtual );
-    }
-
-    private void assertNotEqual( AnyValue a, AnyValue b )
-    {
-        assertFalse( "should not be equal", a.equals( b ) );
-        assertFalse( "should not be equal", b.equals( a ) );
+        assertIncomparable( booleanValue( false ), virtual );
+        assertIncomparable( byteValue( (byte)0 ), virtual );
+        assertIncomparable( shortValue( (short)0 ), virtual );
+        assertIncomparable( intValue( 0 ), virtual );
+        assertIncomparable( longValue( 0 ), virtual );
+        assertIncomparable( floatValue( 0.0f ), virtual );
+        assertIncomparable( doubleValue( 0.0 ), virtual );
+        assertIncomparable( stringValue( "" ), virtual );
     }
 }

--- a/community/values/src/test/java/org/neo4j/values/AnyValuesTest.java
+++ b/community/values/src/test/java/org/neo4j/values/AnyValuesTest.java
@@ -29,7 +29,7 @@ import static org.neo4j.values.storable.Values.intValue;
 import static org.neo4j.values.storable.Values.longValue;
 import static org.neo4j.values.storable.Values.shortValue;
 import static org.neo4j.values.storable.Values.stringValue;
-import static org.neo4j.values.utils.AnyValueTestUtil.assertIncomparable;
+import static org.neo4j.values.utils.AnyValueTestUtil.assertNotEqual;
 
 public class AnyValuesTest
 {
@@ -39,13 +39,13 @@ public class AnyValuesTest
     {
         VirtualValue virtual = new MyVirtualValue( 42 );
 
-        assertIncomparable( booleanValue( false ), virtual );
-        assertIncomparable( byteValue( (byte)0 ), virtual );
-        assertIncomparable( shortValue( (short)0 ), virtual );
-        assertIncomparable( intValue( 0 ), virtual );
-        assertIncomparable( longValue( 0 ), virtual );
-        assertIncomparable( floatValue( 0.0f ), virtual );
-        assertIncomparable( doubleValue( 0.0 ), virtual );
-        assertIncomparable( stringValue( "" ), virtual );
+        assertNotEqual( booleanValue( false ), virtual );
+        assertNotEqual( byteValue( (byte)0 ), virtual );
+        assertNotEqual( shortValue( (short)0 ), virtual );
+        assertNotEqual( intValue( 0 ), virtual );
+        assertNotEqual( longValue( 0 ), virtual );
+        assertNotEqual( floatValue( 0.0f ), virtual );
+        assertNotEqual( doubleValue( 0.0 ), virtual );
+        assertNotEqual( stringValue( "" ), virtual );
     }
 }

--- a/community/values/src/test/java/org/neo4j/values/storable/NumberValuesTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/NumberValuesTest.java
@@ -27,6 +27,8 @@ import java.util.concurrent.ThreadLocalRandom;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.neo4j.values.storable.NumberValues.hash;
+import static org.neo4j.values.utils.AnyValueTestUtil.assertIncomparable;
+import static org.neo4j.values.virtual.VirtualValueTestUtil.toAnyValue;
 
 public class NumberValuesTest
 {
@@ -42,6 +44,14 @@ public class NumberValuesTest
     {
         assertThat( hash( Double.NEGATIVE_INFINITY ), equalTo( hash( Float.NEGATIVE_INFINITY ) ) );
         assertThat( hash( Double.POSITIVE_INFINITY ), equalTo( hash( Float.POSITIVE_INFINITY ) ) );
+    }
+
+    @Test
+    public void shouldHandleNaNCorrectly()
+    {
+        assertIncomparable( toAnyValue(Double.NaN), toAnyValue( Double.NaN ) );
+        assertIncomparable( toAnyValue( 1 ), toAnyValue( Double.NaN ) );
+        assertIncomparable( toAnyValue( Double.NaN ), toAnyValue( 1 ) );
     }
 
     @Test

--- a/community/values/src/test/java/org/neo4j/values/storable/UTF8StringValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/UTF8StringValueTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.neo4j.values.storable.Values.stringValue;
 import static org.neo4j.values.storable.Values.utf8Value;
+import static org.neo4j.values.utils.AnyValueTestUtil.assertEqual;
 
 public class UTF8StringValueTest
 {
@@ -40,7 +41,8 @@ public class UTF8StringValueTest
             TextValue stringValue = stringValue( string );
             byte[] bytes = string.getBytes( StandardCharsets.UTF_8 );
             TextValue utf8 = utf8Value( bytes );
-            assertSame( stringValue, utf8 );
+            assertEqual( stringValue, utf8 );
+            assertThat( stringValue.length(), equalTo( utf8.length() ) );
         }
     }
 
@@ -54,14 +56,7 @@ public class UTF8StringValueTest
         TextValue textValue = utf8Value( bytes, 3, 2 );
 
         // Then
-        assertSame( textValue, stringValue( "de" ) );
-    }
-
-    private void assertSame( TextValue lhs, TextValue rhs )
-    {
-        assertThat( lhs.length(), equalTo( rhs.length() ) );
-        assertThat( lhs, equalTo( rhs ) );
-        assertThat( rhs, equalTo( lhs ) );
-        assertThat( lhs.hashCode(), equalTo( rhs.hashCode() ) );
+        assertEqual( textValue, stringValue( "de" ) );
+        assertThat( textValue.length(), equalTo( stringValue( "de" ).length() ) );
     }
 }

--- a/community/values/src/test/java/org/neo4j/values/storable/ValueEqualityTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/ValueEqualityTest.java
@@ -43,12 +43,12 @@ public class ValueEqualityTest
                 shouldMatch( false, false ),
                 shouldNotMatch( true, false ),
                 shouldNotMatch( false, true ),
-                shouldBeIncomparable( true, 0 ),
-                shouldBeIncomparable( false, 0 ),
-                shouldBeIncomparable( true, 1 ),
-                shouldBeIncomparable( false, 1 ),
-                shouldBeIncomparable( false, "false" ),
-                shouldBeIncomparable( true, "true" ),
+                shouldNotMatch( true, 0 ),
+                shouldNotMatch( false, 0 ),
+                shouldNotMatch( true, 1 ),
+                shouldNotMatch( false, 1 ),
+                shouldNotMatch( false, "false" ),
+                shouldNotMatch( true, "true" ),
 
                 //byte properties
                 shouldMatch( (byte) 42, (byte) 42 ),
@@ -126,8 +126,8 @@ public class ValueEqualityTest
                 shouldNotMatch( "AA", 'A' ),
                 shouldNotMatch( "a", "A" ),
                 shouldNotMatch( "A", "a" ),
-                shouldBeIncomparable( "0", 0 ),
-                shouldBeIncomparable( '0', 0 ),
+                shouldNotMatch( "0", 0 ),
+                shouldNotMatch( '0', 0 ),
 
                 // arrays
                 shouldMatch( new int[]{1, 2, 3}, new int[]{1, 2, 3} ),
@@ -158,127 +158,112 @@ public class ValueEqualityTest
 
     public static Test shouldMatch( boolean propertyValue, Object value )
     {
-        return new Test( Values.booleanValue( propertyValue ), value, true, false );
+        return new Test( Values.booleanValue( propertyValue ), value, true );
     }
 
     public static Test shouldNotMatch( boolean propertyValue, Object value )
     {
-        return new Test( Values.booleanValue( propertyValue ), value, false, false );
-    }
-
-    private static Test shouldBeIncomparable( boolean propertyValue, Object value )
-    {
-        return new Test(Values.booleanValue( propertyValue ), value, false, true );
+        return new Test( Values.booleanValue( propertyValue ), value, false );
     }
 
     public static Test shouldMatch( byte propertyValue, Object value )
     {
-        return new Test( Values.byteValue( propertyValue ), value, true, false );
+        return new Test( Values.byteValue( propertyValue ), value, true );
     }
 
     public static Test shouldNotMatch( byte propertyValue, Object value )
     {
-        return new Test( Values.byteValue( propertyValue ), value, false, false );
+        return new Test( Values.byteValue( propertyValue ), value, false );
     }
 
     public static Test shouldMatch( short propertyValue, Object value )
     {
-        return new Test( Values.shortValue( propertyValue ), value, true, false );
+        return new Test( Values.shortValue( propertyValue ), value, true );
     }
 
     public static Test shouldNotMatch( short propertyValue, Object value )
     {
-        return new Test( Values.shortValue( propertyValue ), value, false, false );
+        return new Test( Values.shortValue( propertyValue ), value, false );
     }
 
     public static Test shouldMatch( float propertyValue, Object value )
     {
-        return new Test( Values.floatValue( propertyValue ), value, true, false );
+        return new Test( Values.floatValue( propertyValue ), value, true );
     }
 
     public static Test shouldNotMatch( float propertyValue, Object value )
     {
-        return new Test( Values.floatValue( propertyValue ), value, false, false );
+        return new Test( Values.floatValue( propertyValue ), value, false );
     }
 
     public static Test shouldMatch( long propertyValue, Object value )
     {
-        return new Test( Values.longValue( propertyValue ), value, true, false );
+        return new Test( Values.longValue( propertyValue ), value, true );
     }
 
     public static Test shouldNotMatch( long propertyValue, Object value )
     {
-        return new Test( Values.longValue( propertyValue ), value, false, false );
+        return new Test( Values.longValue( propertyValue ), value, false );
     }
 
     public static Test shouldMatch( double propertyValue, Object value )
     {
-        return new Test( Values.doubleValue( propertyValue ), value, true, false );
+        return new Test( Values.doubleValue( propertyValue ), value, true );
     }
 
     public static Test shouldNotMatch( double propertyValue, Object value )
     {
-        return new Test( Values.doubleValue( propertyValue ), value, false, false );
+        return new Test( Values.doubleValue( propertyValue ), value, false );
     }
 
     public static Test shouldMatch( String propertyValue, Object value )
     {
-        return new Test( Values.stringValue( propertyValue ), value, true, false );
+        return new Test( Values.stringValue( propertyValue ), value, true );
     }
 
     public static Test shouldNotMatch( String propertyValue, Object value )
     {
-        return new Test( Values.stringValue( propertyValue ), value, false, false );
-    }
-
-    public static Test shouldBeIncomparable( String propertyValue, Object value )
-    {
-        return new Test( Values.stringValue( propertyValue ), value, false, true );
+        return new Test( Values.stringValue( propertyValue ), value, false );
     }
 
     public static Test shouldMatch( char propertyValue, Object value )
     {
-        return new Test( Values.charValue( propertyValue ), value, true, false );
+        return new Test( Values.charValue( propertyValue ), value, true );
     }
 
     public static Test shouldNotMatch( char propertyValue, Object value )
     {
-        return new Test( Values.charValue( propertyValue ), value, false, false );
-    }
-
-    public static Test shouldBeIncomparable( char propertyValue, Object value )
-    {
-        return new Test( Values.charValue( propertyValue ), value, false, true );
+        return new Test( Values.charValue( propertyValue ), value, false );
     }
 
     public static Test shouldMatch( int[] propertyValue, Object value )
     {
-        return new Test( Values.intArray( propertyValue ), value, true, false );
+        return new Test( Values.intArray( propertyValue ), value, true );
     }
 
     public static Test shouldNotMatch( int[] propertyValue, Object value )
     {
-        return new Test( Values.intArray( propertyValue ), value, false, false );
+        return new Test( Values.intArray( propertyValue ), value, false );
     }
 
     public static Test shouldMatch( char[] propertyValue, Object value )
     {
-        return new Test( Values.charArray( propertyValue ), value, true, false );
+        return new Test( Values.charArray( propertyValue ), value, true );
     }
 
     public static Test shouldNotMatch( char[] propertyValue, Object value )
     {
-        return new Test( Values.charArray( propertyValue ), value, false, false );
+        return new Test( Values.charArray( propertyValue ), value, false );
     }
 
     public static Test shouldMatch( String[] propertyValue, Object value )
     {
-        return new Test( Values.stringArray( propertyValue ), value, true, false );
+        return new Test( Values.stringArray( propertyValue ), value, true );
     }
 
     public static Test shouldNotMatch( String[] propertyValue, Object value )
     {
-        return new Test( Values.stringArray( propertyValue ), value, false, false );
+        return new Test( Values.stringArray( propertyValue ), value, false );
     }
 
     private static class Test
@@ -286,14 +271,12 @@ public class ValueEqualityTest
         final Value a;
         final Value b;
         final boolean shouldMatch;
-        final boolean incomparable;
 
-        private Test( Value a, Object b, boolean shouldMatch, boolean incomparable )
+        private Test( Value a, Object b, boolean shouldMatch )
         {
             this.a = a;
             this.b = Values.of( b );
             this.shouldMatch = shouldMatch;
-            this.incomparable = incomparable;
         }
 
         @Override
@@ -307,10 +290,6 @@ public class ValueEqualityTest
             if ( shouldMatch )
             {
                 assertEqual( a, b );
-            }
-            else if ( incomparable )
-            {
-                assertIncomparable( a, b );
             }
             else
             {

--- a/community/values/src/test/java/org/neo4j/values/storable/ValueEqualityTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/ValueEqualityTest.java
@@ -24,8 +24,9 @@ import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.neo4j.values.utils.AnyValueTestUtil.assertEqual;
+import static org.neo4j.values.utils.AnyValueTestUtil.assertIncomparable;
+import static org.neo4j.values.utils.AnyValueTestUtil.assertNotEqual;
 
 /**
  * This test was faithfully converted (including personal remarks) from PropertyEqualityTest.
@@ -42,12 +43,12 @@ public class ValueEqualityTest
                 shouldMatch( false, false ),
                 shouldNotMatch( true, false ),
                 shouldNotMatch( false, true ),
-                shouldNotMatch( true, 0 ),
-                shouldNotMatch( false, 0 ),
-                shouldNotMatch( true, 1 ),
-                shouldNotMatch( false, 1 ),
-                shouldNotMatch( false, "false" ),
-                shouldNotMatch( true, "true" ),
+                shouldBeIncomparable( true, 0 ),
+                shouldBeIncomparable( false, 0 ),
+                shouldBeIncomparable( true, 1 ),
+                shouldBeIncomparable( false, 1 ),
+                shouldBeIncomparable( false, "false" ),
+                shouldBeIncomparable( true, "true" ),
 
                 //byte properties
                 shouldMatch( (byte) 42, (byte) 42 ),
@@ -125,8 +126,8 @@ public class ValueEqualityTest
                 shouldNotMatch( "AA", 'A' ),
                 shouldNotMatch( "a", "A" ),
                 shouldNotMatch( "A", "a" ),
-                shouldNotMatch( "0", 0 ),
-                shouldNotMatch( '0', 0 ),
+                shouldBeIncomparable( "0", 0 ),
+                shouldBeIncomparable( '0', 0 ),
 
                 // arrays
                 shouldMatch( new int[]{1, 2, 3}, new int[]{1, 2, 3} ),
@@ -157,112 +158,127 @@ public class ValueEqualityTest
 
     public static Test shouldMatch( boolean propertyValue, Object value )
     {
-        return new Test( Values.booleanValue( propertyValue ), value, true );
+        return new Test( Values.booleanValue( propertyValue ), value, true, false );
     }
 
     public static Test shouldNotMatch( boolean propertyValue, Object value )
     {
-        return new Test( Values.booleanValue( propertyValue ), value, false );
+        return new Test( Values.booleanValue( propertyValue ), value, false, false );
+    }
+
+    private static Test shouldBeIncomparable( boolean propertyValue, Object value )
+    {
+        return new Test(Values.booleanValue( propertyValue ), value, false, true );
     }
 
     public static Test shouldMatch( byte propertyValue, Object value )
     {
-        return new Test( Values.byteValue( propertyValue ), value, true );
+        return new Test( Values.byteValue( propertyValue ), value, true, false );
     }
 
     public static Test shouldNotMatch( byte propertyValue, Object value )
     {
-        return new Test( Values.byteValue( propertyValue ), value, false );
+        return new Test( Values.byteValue( propertyValue ), value, false, false );
     }
 
     public static Test shouldMatch( short propertyValue, Object value )
     {
-        return new Test( Values.shortValue( propertyValue ), value, true );
+        return new Test( Values.shortValue( propertyValue ), value, true, false );
     }
 
     public static Test shouldNotMatch( short propertyValue, Object value )
     {
-        return new Test( Values.shortValue( propertyValue ), value, false );
+        return new Test( Values.shortValue( propertyValue ), value, false, false );
     }
 
     public static Test shouldMatch( float propertyValue, Object value )
     {
-        return new Test( Values.floatValue( propertyValue ), value, true );
+        return new Test( Values.floatValue( propertyValue ), value, true, false );
     }
 
     public static Test shouldNotMatch( float propertyValue, Object value )
     {
-        return new Test( Values.floatValue( propertyValue ), value, false );
+        return new Test( Values.floatValue( propertyValue ), value, false, false );
     }
 
     public static Test shouldMatch( long propertyValue, Object value )
     {
-        return new Test( Values.longValue( propertyValue ), value, true );
+        return new Test( Values.longValue( propertyValue ), value, true, false );
     }
 
     public static Test shouldNotMatch( long propertyValue, Object value )
     {
-        return new Test( Values.longValue( propertyValue ), value, false );
+        return new Test( Values.longValue( propertyValue ), value, false, false );
     }
 
     public static Test shouldMatch( double propertyValue, Object value )
     {
-        return new Test( Values.doubleValue( propertyValue ), value, true );
+        return new Test( Values.doubleValue( propertyValue ), value, true, false );
     }
 
     public static Test shouldNotMatch( double propertyValue, Object value )
     {
-        return new Test( Values.doubleValue( propertyValue ), value, false );
+        return new Test( Values.doubleValue( propertyValue ), value, false, false );
     }
 
     public static Test shouldMatch( String propertyValue, Object value )
     {
-        return new Test( Values.stringValue( propertyValue ), value, true );
+        return new Test( Values.stringValue( propertyValue ), value, true, false );
     }
 
     public static Test shouldNotMatch( String propertyValue, Object value )
     {
-        return new Test( Values.stringValue( propertyValue ), value, false );
+        return new Test( Values.stringValue( propertyValue ), value, false, false );
+    }
+
+    public static Test shouldBeIncomparable( String propertyValue, Object value )
+    {
+        return new Test( Values.stringValue( propertyValue ), value, false, true );
     }
 
     public static Test shouldMatch( char propertyValue, Object value )
     {
-        return new Test( Values.charValue( propertyValue ), value, true );
+        return new Test( Values.charValue( propertyValue ), value, true, false );
     }
 
     public static Test shouldNotMatch( char propertyValue, Object value )
     {
-        return new Test( Values.charValue( propertyValue ), value, false );
+        return new Test( Values.charValue( propertyValue ), value, false, false );
+    }
+
+    public static Test shouldBeIncomparable( char propertyValue, Object value )
+    {
+        return new Test( Values.charValue( propertyValue ), value, false, true );
     }
 
     public static Test shouldMatch( int[] propertyValue, Object value )
     {
-        return new Test( Values.intArray( propertyValue ), value, true );
+        return new Test( Values.intArray( propertyValue ), value, true, false );
     }
 
     public static Test shouldNotMatch( int[] propertyValue, Object value )
     {
-        return new Test( Values.intArray( propertyValue ), value, false );
+        return new Test( Values.intArray( propertyValue ), value, false, false );
     }
 
     public static Test shouldMatch( char[] propertyValue, Object value )
     {
-        return new Test( Values.charArray( propertyValue ), value, true );
+        return new Test( Values.charArray( propertyValue ), value, true, false );
     }
 
     public static Test shouldNotMatch( char[] propertyValue, Object value )
     {
-        return new Test( Values.charArray( propertyValue ), value, false );
+        return new Test( Values.charArray( propertyValue ), value, false, false );
     }
 
     public static Test shouldMatch( String[] propertyValue, Object value )
     {
-        return new Test( Values.stringArray( propertyValue ), value, true );
+        return new Test( Values.stringArray( propertyValue ), value, true, false );
     }
 
     public static Test shouldNotMatch( String[] propertyValue, Object value )
     {
-        return new Test( Values.stringArray( propertyValue ), value, false );
+        return new Test( Values.stringArray( propertyValue ), value, false, false );
     }
 
     private static class Test
@@ -270,12 +286,14 @@ public class ValueEqualityTest
         final Value a;
         final Value b;
         final boolean shouldMatch;
+        final boolean incomparable;
 
-        private Test( Value a, Object b, boolean shouldMatch )
+        private Test( Value a, Object b, boolean shouldMatch, boolean incomparable )
         {
             this.a = a;
             this.b = Values.of( b );
             this.shouldMatch = shouldMatch;
+            this.incomparable = incomparable;
         }
 
         @Override
@@ -288,24 +306,16 @@ public class ValueEqualityTest
         {
             if ( shouldMatch )
             {
-                assertEquality( a, b );
+                assertEqual( a, b );
+            }
+            else if ( incomparable )
+            {
+                assertIncomparable( a, b );
             }
             else
             {
-                assertNonEquality( a, b );
+                assertNotEqual( a, b );
             }
-        }
-
-        void assertEquality( Value a, Value b )
-        {
-            assertTrue( String.format( "Expected %s to be equal to %s but it wasn't.", a, b ), a.equals( b ) );
-            assertTrue( String.format( "Expected %s and %s to share hash, but they didn't.", a, b ),
-                    a.hashCode() == b.hashCode() );
-        }
-
-        void assertNonEquality( Value a, Value b )
-        {
-            assertFalse( String.format( "Expected %s to not be equal to %s but it was.", a, b ), a.equals( b ) );
         }
     }
 }

--- a/community/values/src/test/java/org/neo4j/values/storable/ValuesTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/ValuesTest.java
@@ -21,8 +21,6 @@ package org.neo4j.values.storable;
 
 import org.junit.Test;
 
-import static junit.framework.TestCase.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.neo4j.values.storable.Values.booleanArray;
 import static org.neo4j.values.storable.Values.booleanValue;
 import static org.neo4j.values.storable.Values.byteArray;
@@ -41,6 +39,7 @@ import static org.neo4j.values.storable.Values.shortArray;
 import static org.neo4j.values.storable.Values.shortValue;
 import static org.neo4j.values.storable.Values.stringArray;
 import static org.neo4j.values.storable.Values.stringValue;
+import static org.neo4j.values.utils.AnyValueTestUtil.assertEqual;
 
 public class ValuesTest
 {
@@ -85,12 +84,5 @@ public class ValuesTest
         assertEqual( doubleArray( new double[]{1.0} ), doubleArray( new double[]{1.0} ) );
         assertEqual( charArray( new char[]{'x'} ), charArray( new char[]{'x'} ) );
         assertEqual( stringArray( new String[]{"hi"} ), stringArray( new String[]{"hi"} ) );
-    }
-
-    private void assertEqual( Value a, Value b )
-    {
-        assertTrue( "should be equal", a.equals( b ) );
-        assertTrue( "should be equal", b.equals( a ) );
-        assertTrue( "should have same has", a.hashCode() == b.hashCode() );
     }
 }

--- a/community/values/src/test/java/org/neo4j/values/utils/AnyValueTestUtil.java
+++ b/community/values/src/test/java/org/neo4j/values/utils/AnyValueTestUtil.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.utils;
+
+import org.neo4j.values.AnyValue;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class AnyValueTestUtil
+{
+    public static void assertEqual( AnyValue a, AnyValue b )
+    {
+        assertTrue(
+                String.format( "%s should be equivalent to %s", a.getClass().getSimpleName(), b.getClass().getSimpleName() ),
+                a.equals( b ) );
+        assertTrue(
+                String.format( "%s should be equivalent to %s", a.getClass().getSimpleName(), b.getClass().getSimpleName() ),
+                b.equals( a ) );
+        assertTrue(
+                String.format( "%s should be equal %s", a.getClass().getSimpleName(), b.getClass().getSimpleName() ),
+                a.ternaryEquals( b ) );
+        assertTrue(
+                String.format( "%s should be equal %s", a.getClass().getSimpleName(), b.getClass().getSimpleName() ),
+                b.ternaryEquals( a ) );
+        assertTrue( String.format( "%s should have same hashcode as %s", a.getClass().getSimpleName(),
+                b.getClass().getSimpleName() ), a.hashCode() == b.hashCode() );
+    }
+
+    public static void assertEqualValues( AnyValue a, AnyValue b )
+    {
+        assertTrue( a + " should be equivalent to " + b, a.equals( b ) );
+        assertTrue( a + " should be equivalent to " + b, b.equals( a ) );
+        assertTrue( a + " should be equal to " + b, a.ternaryEquals( b ) );
+        assertTrue( a + " should be equal to " + b, b.ternaryEquals( a ) );
+    }
+
+    public static void assertNotEqual( AnyValue a, AnyValue b )
+    {
+        assertFalse( a + " should not be equivalent to " + b, a.equals( b ) );
+        assertFalse( b + " should not be equivalent to " + a, b.equals( a ) );
+        assertFalse( a + " should not equal " + b, a.ternaryEquals( b ) );
+        assertFalse( b + " should not equal " + a, b.ternaryEquals( a ) );
+    }
+
+    public static void assertIncomparable( AnyValue a, AnyValue b )
+    {
+        assertFalse( a + " should not be equivalent to " + b, a.equals( b ) );
+        assertFalse( b + " should not be equivalent to " + a, b.equals( a ) );
+        assertNull( a + " should be incomparable to " + b, a.ternaryEquals( b ) );
+        assertNull( b + " should be incomparable to " + a, b.ternaryEquals( a ) );
+    }
+}

--- a/community/values/src/test/java/org/neo4j/values/virtual/GraphElementValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/virtual/GraphElementValueTest.java
@@ -22,8 +22,8 @@ package org.neo4j.values.virtual;
 import org.junit.Test;
 
 import static org.junit.Assert.fail;
-import static org.neo4j.values.virtual.VirtualValueTestUtil.assertEqual;
-import static org.neo4j.values.virtual.VirtualValueTestUtil.assertNotEqual;
+import static org.neo4j.values.utils.AnyValueTestUtil.assertEqual;
+import static org.neo4j.values.utils.AnyValueTestUtil.assertNotEqual;
 import static org.neo4j.values.virtual.VirtualValueTestUtil.edge;
 import static org.neo4j.values.virtual.VirtualValueTestUtil.edges;
 import static org.neo4j.values.virtual.VirtualValueTestUtil.node;

--- a/community/values/src/test/java/org/neo4j/values/virtual/ListTest.java
+++ b/community/values/src/test/java/org/neo4j/values/virtual/ListTest.java
@@ -103,9 +103,9 @@ public class ListTest
         assertNotEqual( list( 1 ), list( 1, 2 ) );
         assertNotEqual( list( 1, 1 ), list( 1, 2 ) );
         assertNotEqual( list( 1, "d" ), list( 1, "f" ) );
-        assertIncomparable( list( 1, "d" ), list( "d", 1 ) );
-        assertIncomparable( list( "d" ), list( false ) );
-        assertIncomparable(
+        assertNotEqual( list( 1, "d" ), list( "d", 1 ) );
+        assertNotEqual( list( "d" ), list( false ) );
+        assertNotEqual(
                 list( Values.stringArray( new String[]{"d"} ) ),
                 list( "d" ) );
 
@@ -114,14 +114,14 @@ public class ListTest
                 list( intArray( new int[]{3, 4, 50} ) ) );
 
         // different value types
-        assertIncomparable( list( true, true ), intArray( new int[]{0, 0} ) );
-        assertIncomparable( list( true, true ), longArray( new long[]{0L, 0L} ) );
-        assertIncomparable( list( true, true ), shortArray( new short[]{(short) 0, (short) 0} ) );
-        assertIncomparable( list( true, true ), floatArray( new float[]{0.0f, 0.0f} ) );
-        assertIncomparable( list( true, true ), doubleArray( new double[]{0.0, 0.0} ) );
-        assertIncomparable( list( true, true ), charArray( new char[]{'T', 'T'} ) );
-        assertIncomparable( list( true, true ), stringArray( new String[]{"True", "True"} ) );
-        assertIncomparable( list( true, true ), byteArray( new byte[]{(byte) 0, (byte) 0} ) );
+        assertNotEqual( list( true, true ), intArray( new int[]{0, 0} ) );
+        assertNotEqual( list( true, true ), longArray( new long[]{0L, 0L} ) );
+        assertNotEqual( list( true, true ), shortArray( new short[]{(short) 0, (short) 0} ) );
+        assertNotEqual( list( true, true ), floatArray( new float[]{0.0f, 0.0f} ) );
+        assertNotEqual( list( true, true ), doubleArray( new double[]{0.0, 0.0} ) );
+        assertNotEqual( list( true, true ), charArray( new char[]{'T', 'T'} ) );
+        assertNotEqual( list( true, true ), stringArray( new String[]{"True", "True"} ) );
+        assertNotEqual( list( true, true ), byteArray( new byte[]{(byte) 0, (byte) 0} ) );
 
         // wrong or missing items
         assertNotEqual( list( true ), booleanArray( new boolean[]{true, false} ) );
@@ -143,7 +143,14 @@ public class ListTest
         assertNotEqual( list( "hi", "hello" ), stringArray( new String[]{"hi"} ) );
         assertNotEqual( list( "hello" ), stringArray( new String[]{"hi"} ) );
 
-        assertIncomparable( list( 1, 'b' ), charArray( new char[]{'a', 'b'} ) );
+        assertNotEqual( list( 1, 'b' ), charArray( new char[]{'a', 'b'} ) );
+    }
+
+    @Test
+    public void shouldHandleNullInList()
+    {
+        assertIncomparable( list( 1, null ), list( 1, 2 ) );
+        assertNotEqual( list( 1, null ), list( 2, 3 ) );
     }
 
     @Test
@@ -187,7 +194,7 @@ public class ListTest
                         intArray( new int[]{1, 2} ),
                         stringArray( new String[]{"Hello", "World"} ) ) );
 
-        assertIncomparable(
+        assertNotEqual(
                 list(
                         intArray( new int[]{1, 2} ),
                         booleanArray( new boolean[]{true, false} ),

--- a/community/values/src/test/java/org/neo4j/values/virtual/ListTest.java
+++ b/community/values/src/test/java/org/neo4j/values/virtual/ListTest.java
@@ -38,10 +38,10 @@ import static org.neo4j.values.storable.Values.intArray;
 import static org.neo4j.values.storable.Values.longArray;
 import static org.neo4j.values.storable.Values.shortArray;
 import static org.neo4j.values.storable.Values.stringArray;
-import static org.neo4j.values.virtual.VirtualValueTestUtil.assertEqual;
-import static org.neo4j.values.virtual.VirtualValueTestUtil.assertEqualValues;
-import static org.neo4j.values.virtual.VirtualValueTestUtil.assertNotEqual;
-import static org.neo4j.values.virtual.VirtualValueTestUtil.assertNotEqualValues;
+import static org.neo4j.values.utils.AnyValueTestUtil.assertEqual;
+import static org.neo4j.values.utils.AnyValueTestUtil.assertEqualValues;
+import static org.neo4j.values.utils.AnyValueTestUtil.assertIncomparable;
+import static org.neo4j.values.utils.AnyValueTestUtil.assertNotEqual;
 import static org.neo4j.values.virtual.VirtualValueTestUtil.list;
 import static org.neo4j.values.virtual.VirtualValues.range;
 
@@ -103,9 +103,9 @@ public class ListTest
         assertNotEqual( list( 1 ), list( 1, 2 ) );
         assertNotEqual( list( 1, 1 ), list( 1, 2 ) );
         assertNotEqual( list( 1, "d" ), list( 1, "f" ) );
-        assertNotEqual( list( 1, "d" ), list( "d", 1 ) );
-        assertNotEqual( list( "d" ), list( false ) );
-        assertNotEqual(
+        assertIncomparable( list( 1, "d" ), list( "d", 1 ) );
+        assertIncomparable( list( "d" ), list( false ) );
+        assertIncomparable(
                 list( Values.stringArray( new String[]{"d"} ) ),
                 list( "d" ) );
 
@@ -114,36 +114,36 @@ public class ListTest
                 list( intArray( new int[]{3, 4, 50} ) ) );
 
         // different value types
-        assertNotEqualValues( list( true, true ), intArray( new int[]{0, 0} ) );
-        assertNotEqualValues( list( true, true ), longArray( new long[]{0L, 0L} ) );
-        assertNotEqualValues( list( true, true ), shortArray( new short[]{(short) 0, (short) 0} ) );
-        assertNotEqualValues( list( true, true ), floatArray( new float[]{0.0f, 0.0f} ) );
-        assertNotEqualValues( list( true, true ), doubleArray( new double[]{0.0, 0.0} ) );
-        assertNotEqualValues( list( true, true ), charArray( new char[]{'T', 'T'} ) );
-        assertNotEqualValues( list( true, true ), stringArray( new String[]{"True", "True"} ) );
-        assertNotEqualValues( list( true, true ), byteArray( new byte[]{(byte) 0, (byte) 0} ) );
+        assertIncomparable( list( true, true ), intArray( new int[]{0, 0} ) );
+        assertIncomparable( list( true, true ), longArray( new long[]{0L, 0L} ) );
+        assertIncomparable( list( true, true ), shortArray( new short[]{(short) 0, (short) 0} ) );
+        assertIncomparable( list( true, true ), floatArray( new float[]{0.0f, 0.0f} ) );
+        assertIncomparable( list( true, true ), doubleArray( new double[]{0.0, 0.0} ) );
+        assertIncomparable( list( true, true ), charArray( new char[]{'T', 'T'} ) );
+        assertIncomparable( list( true, true ), stringArray( new String[]{"True", "True"} ) );
+        assertIncomparable( list( true, true ), byteArray( new byte[]{(byte) 0, (byte) 0} ) );
 
         // wrong or missing items
-        assertNotEqualValues( list( true ), booleanArray( new boolean[]{true, false} ) );
-        assertNotEqualValues( list( true, true ), booleanArray( new boolean[]{true, false} ) );
-        assertNotEqualValues( list( 84, 104, 32, 105, 115, 32, 106, 117, 115, 116, 32, 97, 32, 116, 101, 115, 116 ),
+        assertNotEqual( list( true ), booleanArray( new boolean[]{true, false} ) );
+        assertNotEqual( list( true, true ), booleanArray( new boolean[]{true, false} ) );
+        assertNotEqual( list( 84, 104, 32, 105, 115, 32, 106, 117, 115, 116, 32, 97, 32, 116, 101, 115, 116 ),
                 byteArray( "This is just a test".getBytes() ) );
-        assertNotEqualValues( list( 'h' ), charArray( new char[]{'h', 'i'} ) );
-        assertNotEqualValues( list( 'h', 'o' ), charArray( new char[]{'h', 'i'} ) );
-        assertNotEqualValues( list( 9.0, 2.0 ), doubleArray( new double[]{1.0, 2.0} ) );
-        assertNotEqualValues( list( 1.0 ), doubleArray( new double[]{1.0, 2.0} ) );
-        assertNotEqualValues( list( 1.5f ), floatArray( new float[]{1.5f, -5f} ) );
-        assertNotEqualValues( list( 1.5f, 5f ), floatArray( new float[]{1.5f, -5f} ) );
-        assertNotEqualValues( list( 1, 3 ), intArray( new int[]{1, -3} ) );
-        assertNotEqualValues( list( -3 ), intArray( new int[]{1, -3} ) );
-        assertNotEqualValues( list( 2L, 3L ), longArray( new long[]{2L, -3L} ) );
-        assertNotEqualValues( list( 2L ), longArray( new long[]{2L, -3L} ) );
-        assertNotEqualValues( list( (short) 2, (short) 3 ), shortArray( new short[]{(short) 2, (short) -3} ) );
-        assertNotEqualValues( list( (short) 2 ), shortArray( new short[]{(short) 2, (short) -3} ) );
-        assertNotEqualValues( list( "hi", "hello" ), stringArray( new String[]{"hi"} ) );
-        assertNotEqualValues( list( "hello" ), stringArray( new String[]{"hi"} ) );
+        assertNotEqual( list( 'h' ), charArray( new char[]{'h', 'i'} ) );
+        assertNotEqual( list( 'h', 'o' ), charArray( new char[]{'h', 'i'} ) );
+        assertNotEqual( list( 9.0, 2.0 ), doubleArray( new double[]{1.0, 2.0} ) );
+        assertNotEqual( list( 1.0 ), doubleArray( new double[]{1.0, 2.0} ) );
+        assertNotEqual( list( 1.5f ), floatArray( new float[]{1.5f, -5f} ) );
+        assertNotEqual( list( 1.5f, 5f ), floatArray( new float[]{1.5f, -5f} ) );
+        assertNotEqual( list( 1, 3 ), intArray( new int[]{1, -3} ) );
+        assertNotEqual( list( -3 ), intArray( new int[]{1, -3} ) );
+        assertNotEqual( list( 2L, 3L ), longArray( new long[]{2L, -3L} ) );
+        assertNotEqual( list( 2L ), longArray( new long[]{2L, -3L} ) );
+        assertNotEqual( list( (short) 2, (short) 3 ), shortArray( new short[]{(short) 2, (short) -3} ) );
+        assertNotEqual( list( (short) 2 ), shortArray( new short[]{(short) 2, (short) -3} ) );
+        assertNotEqual( list( "hi", "hello" ), stringArray( new String[]{"hi"} ) );
+        assertNotEqual( list( "hello" ), stringArray( new String[]{"hi"} ) );
 
-        assertNotEqualValues( list( 1, 'b' ), charArray( new char[]{'a', 'b'} ) );
+        assertIncomparable( list( 1, 'b' ), charArray( new char[]{'a', 'b'} ) );
     }
 
     @Test
@@ -187,7 +187,7 @@ public class ListTest
                         intArray( new int[]{1, 2} ),
                         stringArray( new String[]{"Hello", "World"} ) ) );
 
-        assertNotEqual(
+        assertIncomparable(
                 list(
                         intArray( new int[]{1, 2} ),
                         booleanArray( new boolean[]{true, false} ),

--- a/community/values/src/test/java/org/neo4j/values/virtual/MapTest.java
+++ b/community/values/src/test/java/org/neo4j/values/virtual/MapTest.java
@@ -21,7 +21,7 @@ package org.neo4j.values.virtual;
 
 import org.junit.Test;
 
-import static org.neo4j.values.virtual.VirtualValueTestUtil.assertEqual;
+import static org.neo4j.values.utils.AnyValueTestUtil.assertEqual;
 import static org.neo4j.values.virtual.VirtualValueTestUtil.map;
 
 public class MapTest

--- a/community/values/src/test/java/org/neo4j/values/virtual/PointTest.java
+++ b/community/values/src/test/java/org/neo4j/values/virtual/PointTest.java
@@ -22,8 +22,8 @@ package org.neo4j.values.virtual;
 import org.junit.Test;
 
 import static org.junit.Assert.assertTrue;
-import static org.neo4j.values.virtual.VirtualValueTestUtil.assertEqual;
-import static org.neo4j.values.virtual.VirtualValueTestUtil.assertNotEqual;
+import static org.neo4j.values.utils.AnyValueTestUtil.assertEqual;
+import static org.neo4j.values.utils.AnyValueTestUtil.assertNotEqual;
 import static org.neo4j.values.virtual.VirtualValues.pointCartesian;
 import static org.neo4j.values.virtual.VirtualValues.pointGeographic;
 

--- a/community/values/src/test/java/org/neo4j/values/virtual/VirtualValueTestUtil.java
+++ b/community/values/src/test/java/org/neo4j/values/virtual/VirtualValueTestUtil.java
@@ -24,11 +24,8 @@ import java.util.Arrays;
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.VirtualValue;
 import org.neo4j.values.storable.TextValue;
-import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import static org.neo4j.values.storable.Values.stringArray;
 import static org.neo4j.values.storable.Values.stringValue;
 import static org.neo4j.values.virtual.VirtualValues.edgeValue;
@@ -100,36 +97,6 @@ public class VirtualValueTestUtil
             values[i / 2] = toAnyValue( keyOrVal[i + 1] );
         }
         return VirtualValues.map( keys, values );
-    }
-
-    public static void assertEqual( VirtualValue a, VirtualValue b )
-    {
-        assertTrue(
-                String.format( "%s should be equal %s", a.getClass().getSimpleName(), b.getClass().getSimpleName() ),
-                a.equals( b ) );
-        assertTrue(
-                String.format( "%s should be equal %s", a.getClass().getSimpleName(), b.getClass().getSimpleName() ),
-                b.equals( a ) );
-        assertTrue( String.format( "%s should have same hashcode as %s", a.getClass().getSimpleName(),
-                b.getClass().getSimpleName() ), a.hashCode() == b.hashCode() );
-    }
-
-    public static void assertNotEqual( VirtualValue a, VirtualValue b )
-    {
-        assertFalse( a + " should not equal " + b, a.equals( b ) );
-        assertFalse( b + "should not equal " + a, b.equals( a ) );
-    }
-
-    public static void assertEqualValues( VirtualValue a, Value b )
-    {
-        assertTrue( "should be equal values", a.equals( b ) );
-        assertTrue( "should be equal values", b.equals( a ) );
-    }
-
-    public static void assertNotEqualValues( VirtualValue a, Value b )
-    {
-        assertFalse( "should not equal values", a.equals( b ) );
-        assertFalse( "should not equal values", b.equals( a ) );
     }
 
     public static NodeValue[] nodes( long... ids )

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExpressionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExpressionAcceptanceTest.scala
@@ -20,7 +20,7 @@
 package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher._
-import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
 
 class ExpressionAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NaNAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NaNAcceptanceTest.scala
@@ -86,6 +86,6 @@ class NaNAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTest
     val result = execute("MATCH (n) RETURN n.x = n.x AS eq, n.x <> n.x as ne")
 
     // Then
-    result.toList should equal(List(Map("eq" -> false, "ne" -> true)))
+    result.toList should equal(List(Map("eq" -> null, "ne" -> null)))
   }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NullListAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NullListAcceptanceTest.scala
@@ -147,26 +147,19 @@ class NullListAcceptanceTest extends ExecutionEngineFunSuite with CypherComparis
     //result.toList should equal(List(Map("res" -> null)))
   }
 
-  // To be uncomment after PR #xxx (which fixes this) is merged
-
-  //  test("comparing equal length lists with null should return null") {
-  //    val query = "WITH [1, 2] AS l1, [null, 2] AS l2 RETURN l1 < l2 AS res"
-  //
-  //    val result = executeWith(Configs.Interpreted - Configs.AllRulePlanners, query)
-  //
-  //    println(result.executionPlanDescription())
-  //
-  //    result.toList should equal(List(Map("res" -> null)))
-  //  }
-  //
-  //  test("comparing different length lists with null should be ok") {
-  //    val query = "WITH [1] AS l1, [null, 2] AS l2 RETURN l1 < l2 AS res"
-  //
-  //    val result = executeWith(Configs.All, query)
-  //
-  //    println(result.executionPlanDescription())
-  //
-  //    result.toList should equal(List(Map("res" -> "true")))
-  //  }
-
+//  test("comparing equal length lists with null should return null") {
+//    val query = "WITH [1, 2] AS l1, [null, 2] AS l2 RETURN l1 < l2 AS res"
+//
+//    val result = executeWith(Configs.Version3_3 - Configs.AllRulePlanners - Configs.Compiled, query)
+//
+//    result.toList should equal(List(Map("res" -> null)))
+//  }
+//
+//  test("comparing different length lists with null should be ok") {
+//    val query = "WITH [1] AS l1, [null, 2] AS l2 RETURN l1 < l2 AS res"
+//
+//    val result = executeWith(Configs.Version3_3 - Configs.AllRulePlanners - Configs.Compiled, query)
+//
+//    result.toList should equal(List(Map("res" -> true)))
+//  }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NullListAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NullListAcceptanceTest.scala
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import org.neo4j.cypher._
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Versions.{V2_3, V3_2}
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
+
+class NullListAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
+
+  // Changed behaviour to comply with opencypher in 3.3
+  val nullInListConfigOld: TestConfiguration = TestConfiguration(V2_3 -> V3_2, Planners.all, Runtimes.all) + Configs.AllRulePlanners
+
+  // Comparison between lists and non-lists
+
+  test("equality between list and literal should return null") {
+    val query = "WITH [1, 2] AS l1, 'foo' AS l2 RETURN l1 = l2 AS res"
+
+    val result = executeWith(Configs.All, query, expectedDifferentResults = nullInListConfigOld)
+
+    result.toList should equal(List(Map("res" -> null)))
+  }
+
+  // Equality between lists with null
+
+  test("equality of lists of different length should return false despite nulls") {
+    val query = "WITH [1] AS l1, [1, null] AS l2 RETURN l1 = l2 AS res"
+
+    val result = executeWith(Configs.All, query)
+
+    result.toList should equal(List(Map("res" -> false)))
+  }
+
+  test("equality between different lists with null should return false") {
+    val query = "WITH [1, 2] AS l1, [null, 'foo'] AS l2 RETURN l1 = l2 AS res"
+
+    val result = executeWith(Configs.All, query)
+
+    result.toList should equal(List(Map("res" -> false)))
+  }
+
+  test("equality between almost equal lists with null should return null") {
+    val query = "WITH [1, 2] AS l1, [null, 2] AS l2 RETURN l1 = l2 AS res"
+
+    val result = executeWith(Configs.All, query, expectedDifferentResults = nullInListConfigOld)
+
+    result.toList should equal(List(Map("res" -> null)))
+  }
+
+  // Nested Lists
+  test("equality ofnested  lists of different length should return false despite nulls") {
+    val query = "WITH [[1]] AS l1, [[1], [null]] AS l2 RETURN l1 = l2 AS res"
+
+    val result = executeWith(Configs.All, query)
+
+    result.toList should equal(List(Map("res" -> false)))
+  }
+
+  test("equality between different nested lists with null should return false") {
+    val query = "WITH [[1, 2], [1, 3]] AS l1, [[1, 2], [null, 'foo']] AS l2 RETURN l1 = l2 AS res"
+
+    val result = executeWith(Configs.All, query)
+
+    result.toList should equal(List(Map("res" -> false)))
+  }
+
+  test("equality between almost equal nested lists with null should return null") {
+    val query = "WITH [[1, 2], ['foo', 'bar']] AS l1, [[1, 2], [null, 'bar']] AS l2 RETURN l1 = l2 AS res"
+
+    val result = executeWith(Configs.Interpreted, query, expectedDifferentResults = nullInListConfigOld)
+
+    result.toList should equal(List(Map("res" -> null)))
+  }
+
+  // IN with null
+
+  test("IN with different length lists should return false despite nulls") {
+    val query = "WITH [1] AS l1, [1, null] AS l2 RETURN l1 IN [l2] AS res"
+
+    val result = executeWith(Configs.All, query)
+
+    result.toList should equal(List(Map("res" -> false)))
+  }
+
+  test("IN should return true if match despite nulls") {
+    val query = "WITH 3 AS l1, [1, null, 3] AS l2 RETURN l1 IN l2 AS res"
+
+    val result = executeWith(Configs.Interpreted, query)
+
+    result.toList should equal(List(Map("res" -> true)))
+  }
+
+  test("IN should return null if comparison with null is required") {
+    val query = "WITH 4 AS l1, [1, null, 3] AS l2 RETURN l1 IN l2 AS res"
+
+    val result = executeWith(Configs.Interpreted, query)
+
+    result.toList should equal(List(Map("res" -> null)))
+  }
+
+
+  // IN with null, list version
+
+  test("IN should return true if correct list found despite other lists having nulls") {
+    val query = "WITH [1, 2] AS l1, [[null, 'foo'], [1, 2]] AS l2 RETURN l1 IN l2 AS res"
+
+    val result = executeWith(Configs.Interpreted, query)
+
+    result.toList should equal(List(Map("res" -> true)))
+  }
+
+  test("IN should return false if no match can be found, despite nulls") {
+    val query = "WITH [1,2] AS l1, [[null, 'foo']] AS l2 RETURN l1 IN l2 as res"
+
+    val result = executeWith(Configs.Interpreted, query)
+
+    result.toList should equal(List(Map("res" -> false)))
+  }
+
+  // TODO: This one is using some other code, needs to be fixed
+  test("IN should return null if comparison with null is required, list version") {
+    val query = "WITH [1,2] AS l1, [[null, 2]] AS l2 RETURN l1 IN l2 as res"
+
+    val result = executeWith(Configs.Interpreted, query)
+
+    result.toList should equal(List(Map("res" -> false)))
+
+    //val result = executeWith(Configs.Interpreted, query, expectedDifferentResults = nullInListConfigOld)
+
+    //result.toList should equal(List(Map("res" -> null)))
+  }
+
+  // To be uncomment after PR #xxx (which fixes this) is merged
+
+  //  test("comparing equal length lists with null should return null") {
+  //    val query = "WITH [1, 2] AS l1, [null, 2] AS l2 RETURN l1 < l2 AS res"
+  //
+  //    val result = executeWith(Configs.Interpreted - Configs.AllRulePlanners, query)
+  //
+  //    println(result.executionPlanDescription())
+  //
+  //    result.toList should equal(List(Map("res" -> null)))
+  //  }
+  //
+  //  test("comparing different length lists with null should be ok") {
+  //    val query = "WITH [1] AS l1, [null, 2] AS l2 RETURN l1 < l2 AS res"
+  //
+  //    val result = executeWith(Configs.All, query)
+  //
+  //    println(result.executionPlanDescription())
+  //
+  //    result.toList should equal(List(Map("res" -> "true")))
+  //  }
+
+}

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NullListAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NullListAcceptanceTest.scala
@@ -30,12 +30,12 @@ class NullListAcceptanceTest extends ExecutionEngineFunSuite with CypherComparis
 
   // Comparison between lists and non-lists
 
-  test("equality between list and literal should return null") {
+  test("equality between list and literal should return false") {
     val query = "WITH [1, 2] AS l1, 'foo' AS l2 RETURN l1 = l2 AS res"
 
-    val result = executeWith(Configs.All, query, expectedDifferentResults = nullInListConfigOld)
+    val result = executeWith(Configs.All, query)
 
-    result.toList should equal(List(Map("res" -> null)))
+    result.toList should equal(List(Map("res" -> false)))
   }
 
   // Equality between lists with null
@@ -65,7 +65,7 @@ class NullListAcceptanceTest extends ExecutionEngineFunSuite with CypherComparis
   }
 
   // Nested Lists
-  test("equality ofnested  lists of different length should return false despite nulls") {
+  test("equality of nested lists of different length should return false despite nulls") {
     val query = "WITH [[1]] AS l1, [[1], [null]] AS l2 RETURN l1 = l2 AS res"
 
     val result = executeWith(Configs.All, query)
@@ -84,7 +84,7 @@ class NullListAcceptanceTest extends ExecutionEngineFunSuite with CypherComparis
   test("equality between almost equal nested lists with null should return null") {
     val query = "WITH [[1, 2], ['foo', 'bar']] AS l1, [[1, 2], [null, 'bar']] AS l2 RETURN l1 = l2 AS res"
 
-    val result = executeWith(Configs.Interpreted, query, expectedDifferentResults = nullInListConfigOld)
+    val result = executeWith(Configs.All, query, expectedDifferentResults = nullInListConfigOld)
 
     result.toList should equal(List(Map("res" -> null)))
   }
@@ -115,7 +115,6 @@ class NullListAcceptanceTest extends ExecutionEngineFunSuite with CypherComparis
     result.toList should equal(List(Map("res" -> null)))
   }
 
-
   // IN with null, list version
 
   test("IN should return true if correct list found despite other lists having nulls") {
@@ -134,32 +133,27 @@ class NullListAcceptanceTest extends ExecutionEngineFunSuite with CypherComparis
     result.toList should equal(List(Map("res" -> false)))
   }
 
-  // TODO: This one is using some other code, needs to be fixed
   test("IN should return null if comparison with null is required, list version") {
     val query = "WITH [1,2] AS l1, [[null, 2]] AS l2 RETURN l1 IN l2 as res"
 
-    val result = executeWith(Configs.Interpreted, query)
+    val result = executeWith(Configs.Interpreted, query, expectedDifferentResults = nullInListConfigOld)
 
-    result.toList should equal(List(Map("res" -> false)))
-
-    //val result = executeWith(Configs.Interpreted, query, expectedDifferentResults = nullInListConfigOld)
-
-    //result.toList should equal(List(Map("res" -> null)))
+    result.toList should equal(List(Map("res" -> null)))
   }
 
-//  test("comparing equal length lists with null should return null") {
-//    val query = "WITH [1, 2] AS l1, [null, 2] AS l2 RETURN l1 < l2 AS res"
-//
-//    val result = executeWith(Configs.Version3_3 - Configs.AllRulePlanners - Configs.Compiled, query)
-//
-//    result.toList should equal(List(Map("res" -> null)))
-//  }
-//
-//  test("comparing different length lists with null should be ok") {
-//    val query = "WITH [1] AS l1, [null, 2] AS l2 RETURN l1 < l2 AS res"
-//
-//    val result = executeWith(Configs.Version3_3 - Configs.AllRulePlanners - Configs.Compiled, query)
-//
-//    result.toList should equal(List(Map("res" -> true)))
-//  }
+  test("IN should return true with previous null match, list version") {
+    val query = "WITH [1,2] AS l1, [[null, 2], [1, 2]] AS l2 RETURN l1 IN l2 as res"
+
+    val result = executeWith(Configs.Interpreted, query)
+
+    result.toList should equal(List(Map("res" -> true)))
+  }
+
+  test("IN should return null if comparison with null is required, list version 2") {
+    val query = "WITH [1,2] AS l1, [[null, 2], [1, 3]] AS l2 RETURN l1 IN l2 as res"
+
+    val result = executeWith(Configs.Interpreted, query, expectedDifferentResults = nullInListConfigOld)
+
+    result.toList should equal(List(Map("res" -> null)))
+  }
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/compiled/codegen/ir/expressions/Equals.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/compiled/codegen/ir/expressions/Equals.scala
@@ -21,12 +21,13 @@ package org.neo4j.cypher.internal.compatibility.v3_3.runtime.compiled.codegen.ir
 
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.compiled.codegen.CodeGenContext
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.compiled.codegen.spi.MethodStructure
-import org.neo4j.cypher.internal.frontend.v3_3.symbols.CTBoolean
+import org.neo4j.cypher.internal.frontend.v3_3.symbols.{CTBoolean, CTMap, ListType}
 import org.neo4j.cypher.internal.frontend.v3_3.{IncomparableValuesException, symbols}
 
 case class Equals(lhs: CodeGenExpression, rhs: CodeGenExpression) extends CodeGenExpression {
 
-  override def nullable(implicit context: CodeGenContext) = lhs.nullable || rhs.nullable
+  override def nullable(implicit context: CodeGenContext) = lhs.nullable || rhs.nullable ||
+    isCollectionOfNonPrimitives(lhs) || isCollectionOfNonPrimitives(rhs)
 
   override def codeGenType(implicit context: CodeGenContext) =
     if (nullable) CypherCodeGenType(CTBoolean, ReferenceType)
@@ -95,4 +96,14 @@ case class Equals(lhs: CodeGenExpression, rhs: CodeGenExpression) extends CodeGe
           CypherCodeGenType(CTBoolean, ReferenceType))
       }
   }
+
+  private def isCollectionOfNonPrimitives(e: CodeGenExpression)(implicit context: CodeGenContext) =
+    e.codeGenType match {
+      case CypherCodeGenType(ListType(_), ListReferenceType(inner)) if !RepresentationType.isPrimitive(inner) =>
+        true
+      case CypherCodeGenType(CTMap, _) =>
+        true
+      case _ =>
+        false
+    }
 }


### PR DESCRIPTION
changelog: Fixes equality for lists in accordance with OpenCypher.

Before this change, `[1,2,3] = [1,2,null]` returned `false`. Now, this comparison will return `null` which makes equality more consistent in it's behaviour.