### PR TITLE
Split should return list not array

### DIFF
--- a/community/values/src/main/java/org/neo4j/values/storable/CharValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/CharValue.java
@@ -19,7 +19,11 @@
  */
 package org.neo4j.values.storable;
 
+import org.neo4j.values.virtual.ListValue;
+
 import static java.lang.String.format;
+import static org.neo4j.values.virtual.VirtualValues.EMPTY_LIST;
+import static org.neo4j.values.virtual.VirtualValues.list;
 
 public final class CharValue extends TextValue
 {
@@ -146,15 +150,15 @@ public final class CharValue extends TextValue
     }
 
     @Override
-    public TextArray split( String separator )
+    public ListValue split( String separator )
     {
         if ( separator.equals( stringValue() ) )
         {
-            return Values.EMPTY_TEXT_ARRAY;
+            return EMPTY_LIST;
         }
         else
         {
-            return Values.stringArray( stringValue() );
+            return list( Values.stringValue( stringValue() ) );
         }
     }
 

--- a/community/values/src/main/java/org/neo4j/values/storable/CharValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/CharValue.java
@@ -22,7 +22,6 @@ package org.neo4j.values.storable;
 import org.neo4j.values.virtual.ListValue;
 
 import static java.lang.String.format;
-import static org.neo4j.values.virtual.VirtualValues.EMPTY_LIST;
 import static org.neo4j.values.virtual.VirtualValues.list;
 
 public final class CharValue extends TextValue
@@ -154,7 +153,7 @@ public final class CharValue extends TextValue
     {
         if ( separator.equals( stringValue() ) )
         {
-            return EMPTY_LIST;
+            return EMPTY_SPLIT;
         }
         else
         {

--- a/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
@@ -27,8 +27,6 @@ import static org.neo4j.values.virtual.VirtualValues.fromArray;
 
 public abstract class StringValue extends TextValue
 {
-    private static final ListValue EMPTY_SPLIT = fromArray( stringArray( "", "" ) );
-
     abstract String value();
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
@@ -19,10 +19,16 @@
  */
 package org.neo4j.values.storable;
 
+import org.neo4j.values.virtual.ListValue;
+
 import static java.lang.String.format;
+import static org.neo4j.values.storable.Values.stringArray;
+import static org.neo4j.values.virtual.VirtualValues.fromArray;
 
 public abstract class StringValue extends TextValue
 {
+    private static final ListValue EMPTY_SPLIT = fromArray( stringArray( "", "" ) );
+
     abstract String value();
 
     @Override
@@ -68,7 +74,7 @@ public abstract class StringValue extends TextValue
     }
 
     @Override
-    public TextArray split( String separator )
+    public ListValue split( String separator )
     {
         assert separator != null;
         String asString = value();
@@ -77,10 +83,10 @@ public abstract class StringValue extends TextValue
         //where as java returns an empty array
         if ( separator.equals( asString ) )
         {
-            return Values.stringArray( "", "" );
+            return EMPTY_SPLIT;
         }
         String[] split = asString.split( separator );
-        return Values.stringArray( split );
+        return fromArray( stringArray( split ) );
     }
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/TextValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TextValue.java
@@ -21,8 +21,13 @@ package org.neo4j.values.storable;
 
 import org.neo4j.values.virtual.ListValue;
 
+import static org.neo4j.values.storable.Values.stringArray;
+import static org.neo4j.values.virtual.VirtualValues.fromArray;
+
 public abstract class TextValue extends ScalarValue
 {
+    protected static final ListValue EMPTY_SPLIT = fromArray( stringArray( "", "" ) );
+
     TextValue()
     {
     }

--- a/community/values/src/main/java/org/neo4j/values/storable/TextValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TextValue.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.values.storable;
 
+import org.neo4j.values.virtual.ListValue;
+
 public abstract class TextValue extends ScalarValue
 {
     TextValue()
@@ -51,7 +53,7 @@ public abstract class TextValue extends ScalarValue
 
     public abstract TextValue toUpper();
 
-    public abstract TextArray split( String separator );
+    public abstract ListValue split( String separator );
 
     public abstract TextValue replace( String find, String replace );
 

--- a/community/values/src/main/java/org/neo4j/values/storable/UTF8StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/UTF8StringValue.java
@@ -107,6 +107,8 @@ public final class UTF8StringValue extends StringValue
             if ( b >= 0 )
             {
                 i++;
+                count++;
+                continue;
             }
 
             //The number of high bits tells us how many bytes we use to store the value

--- a/community/values/src/test/java/org/neo4j/values/storable/CharValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/CharValueTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.storable;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.neo4j.values.storable.Values.EMPTY_STRING;
+import static org.neo4j.values.storable.Values.charValue;
+import static org.neo4j.values.storable.Values.stringValue;
+import static org.neo4j.values.virtual.VirtualValues.list;
+
+public class CharValueTest
+{
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    private char[] chars = {' ', '楡', 'a', '7', 'Ö'};
+
+    @Test
+    public void shouldHandleDifferentTypesOfChars()
+    {
+        for ( char c : chars )
+        {
+            TextValue charValue = charValue( c );
+            TextValue stringValue = stringValue( Character.toString( c ) );
+
+            assertThat( charValue, equalTo( stringValue ) );
+            assertThat( charValue.length(), equalTo( stringValue.length() ) );
+            assertThat( charValue.hashCode(), equalTo( stringValue.hashCode() ) );
+            assertThat( charValue.split( Character.toString( c ) ),
+                    equalTo( stringValue.split( Character.toString( c ) ) ) );
+            assertThat( charValue.toUpper(), equalTo( stringValue.toUpper() ) );
+            assertThat( charValue.toLower(), equalTo( stringValue.toLower() ) );
+        }
+    }
+
+    @Test
+    public void shouldSplit()
+    {
+        CharValue charValue = charValue( 'a' );
+        assertThat( charValue.split( "a" ), equalTo( list( EMPTY_STRING, EMPTY_STRING ) ) );
+        assertThat( charValue.split( "A" ), equalTo( list( charValue ) ) );
+    }
+
+    @Test
+    public void shouldTrim()
+    {
+        assertThat( charValue( 'a' ).trim(), equalTo( charValue( 'a' ) ) );
+        assertThat( charValue( ' ' ).trim(), equalTo( EMPTY_STRING ) );
+    }
+
+    @Test
+    public void shouldLTrim()
+    {
+        assertThat( charValue( 'a' ).ltrim(), equalTo( charValue( 'a' ) ) );
+        assertThat( charValue( ' ' ).ltrim(), equalTo( EMPTY_STRING ) );
+    }
+
+    @Test
+    public void shouldRTrim()
+    {
+        assertThat( charValue( 'a' ).rtrim(), equalTo( charValue( 'a' ) ) );
+        assertThat( charValue( ' ' ).rtrim(), equalTo( EMPTY_STRING ) );
+    }
+
+    @Test
+    public void shouldReverse()
+    {
+        for ( char c : chars )
+        {
+            CharValue charValue = charValue( c );
+            assertThat( charValue.reverse(), equalTo( charValue ) );
+        }
+    }
+
+    @Test
+    public void shouldReplace()
+    {
+        assertThat( charValue( 'a' ).replace( "a", "a long string" ), equalTo( stringValue( "a long string" ) ) );
+        assertThat( charValue( 'a' ).replace( "b", "a long string" ), equalTo( charValue( 'a' ) ) );
+    }
+
+    @Test
+    public void shouldSubstring()
+    {
+        assertThat( charValue( 'a' ).substring( 0, 1 ), equalTo( charValue( 'a' ) ) );
+        assertThat( charValue( 'a' ).substring( 1, 3 ), equalTo( EMPTY_STRING ) );
+    }
+}

--- a/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionResultTest.java
+++ b/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionResultTest.java
@@ -35,6 +35,7 @@ import org.neo4j.test.rule.EnterpriseDatabaseRule;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 public class ExecutionResultTest
@@ -264,6 +265,13 @@ public class ExecutionResultTest
         assertThat( arguments.get( "planner-impl" ), equalTo( "PROCEDURE" ) );
         assertThat( arguments.get( "runtime" ), equalTo( "PROCEDURE" ) );
         assertThat( arguments.get( "runtime-impl" ), equalTo( "PROCEDURE" ) );
+    }
+
+    @Test
+    public void shouldReturnListFromSplit()
+    {
+        assertThat(db.execute( "RETURN split('hello, world', ',') AS s" ).next().get("s"),
+                instanceOf(List.class));
     }
 
     private void createNode()


### PR DESCRIPTION
Accidentally made `split` return an array instead of a list in the embedded
API.