### PR TITLE
Add unified causal clustering REST endpoint

### DIFF
--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/CoreDatabaseAvailabilityService.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/CoreDatabaseAvailabilityService.java
@@ -37,6 +37,9 @@ import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.status;
 
+/**
+ * To be deprecated by {@link org.neo4j.server.rest.causalclustering.CausalClusteringService}.
+ */
 @Path(CoreDatabaseAvailabilityService.BASE_PATH)
 public class CoreDatabaseAvailabilityService implements AdvertisableService
 {

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/DatabaseRoleInfoServerModule.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/DatabaseRoleInfoServerModule.java
@@ -27,6 +27,7 @@ import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.server.configuration.ServerSettings;
 import org.neo4j.server.modules.ServerModule;
+import org.neo4j.server.rest.causalclustering.CausalClusteringService;
 import org.neo4j.server.web.WebServer;
 
 import static java.util.Arrays.asList;
@@ -65,7 +66,8 @@ public class DatabaseRoleInfoServerModule implements ServerModule
         return asList(
                 MasterInfoService.class.getName(),
                 CoreDatabaseAvailabilityService.class.getName(),
-                ReadReplicaDatabaseAvailabilityService.class.getName()
+                ReadReplicaDatabaseAvailabilityService.class.getName(),
+                CausalClusteringService.class.getName()
         );
     }
 

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/ReadReplicaDatabaseAvailabilityService.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/ReadReplicaDatabaseAvailabilityService.java
@@ -31,10 +31,12 @@ import org.neo4j.server.rest.repr.OutputFormat;
 
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
 import static javax.ws.rs.core.Response.Status.FORBIDDEN;
-import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.OK;
 import static javax.ws.rs.core.Response.status;
 
+/**
+ * To be deprecated by {@link org.neo4j.server.rest.causalclustering.CausalClusteringService}.
+ */
 @Path( ReadReplicaDatabaseAvailabilityService.BASE_PATH)
 public class ReadReplicaDatabaseAvailabilityService implements AdvertisableService
 {

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/BaseStatus.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/BaseStatus.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.causalclustering;
+
+import javax.ws.rs.core.Response;
+
+import org.neo4j.server.rest.repr.OutputFormat;
+
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
+import static javax.ws.rs.core.Response.status;
+import static org.neo4j.server.rest.causalclustering.CausalClusteringService.BASE_PATH;
+
+abstract class BaseStatus implements CausalClusteringStatus
+{
+    private final OutputFormat output;
+
+    BaseStatus( OutputFormat output )
+    {
+        this.output = output;
+    }
+
+    @Override
+    public Response discover()
+    {
+        return output.ok( new CausalClusteringDiscovery( BASE_PATH ) );
+    }
+
+    Response positiveResponse()
+    {
+        return plainTextResponse( OK, "true" );
+    }
+
+    Response negativeResponse()
+    {
+        return plainTextResponse( NOT_FOUND, "false" );
+    }
+
+    private Response plainTextResponse( Response.Status status, String entityBody )
+    {
+        return status( status ).type( TEXT_PLAIN_TYPE ).entity( entityBody ).build();
+    }
+}

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/CausalClusteringDiscovery.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/CausalClusteringDiscovery.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.causalclustering;
+
+import org.neo4j.server.rest.repr.MappingRepresentation;
+import org.neo4j.server.rest.repr.MappingSerializer;
+
+import static org.neo4j.server.rest.causalclustering.CausalClusteringService.AVAILABLE;
+import static org.neo4j.server.rest.causalclustering.CausalClusteringService.READ_ONLY;
+import static org.neo4j.server.rest.causalclustering.CausalClusteringService.WRITABLE;
+
+public class CausalClusteringDiscovery extends MappingRepresentation
+{
+    private static final String DISCOVERY_REPRESENTATION_TYPE = "discovery";
+
+    private final String basePath;
+
+    CausalClusteringDiscovery( String basePath )
+    {
+        super( DISCOVERY_REPRESENTATION_TYPE );
+        this.basePath = basePath;
+    }
+
+    @Override
+    protected void serialize( MappingSerializer serializer )
+    {
+        serializer.putRelativeUri( AVAILABLE, basePath + "/" + AVAILABLE );
+        serializer.putRelativeUri( READ_ONLY, basePath + "/" + READ_ONLY );
+        serializer.putRelativeUri( WRITABLE, basePath + "/" + WRITABLE );
+    }
+}

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/CausalClusteringService.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/CausalClusteringService.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.causalclustering;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.server.rest.management.AdvertisableService;
+import org.neo4j.server.rest.repr.BadInputException;
+import org.neo4j.server.rest.repr.OutputFormat;
+
+@Path( CausalClusteringService.BASE_PATH )
+public class CausalClusteringService implements AdvertisableService
+{
+    static final String BASE_PATH = "server/causalclustering/";
+
+    static final String AVAILABLE = "available";
+    static final String WRITABLE = "writable";
+    static final String READ_ONLY = "read-only";
+
+    private final CausalClusteringStatus status;
+
+    public CausalClusteringService( @Context OutputFormat output, @Context GraphDatabaseService db )
+    {
+        this.status = CausalClusteringStatusFactory.build( output, db );
+    }
+
+    @GET
+    public Response discover() throws BadInputException
+    {
+        return status.discover();
+    }
+
+    @GET
+    @Path( WRITABLE )
+    public Response isWritable() throws BadInputException
+    {
+        return status.writable();
+    }
+
+    @GET
+    @Path( READ_ONLY )
+    public Response isReadOnly() throws BadInputException
+    {
+        return status.readonly();
+    }
+
+    @GET
+    @Path( AVAILABLE )
+    public Response isAvailable()
+    {
+        return status.available();
+    }
+
+    @Override
+    public String getName()
+    {
+        return "causalclustering";
+    }
+
+    @Override
+    public String getServerPath()
+    {
+        return BASE_PATH;
+    }
+}

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/CausalClusteringStatus.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/CausalClusteringStatus.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.causalclustering;
+
+import javax.ws.rs.core.Response;
+
+interface CausalClusteringStatus
+{
+    Response discover();
+
+    Response available();
+
+    Response readonly();
+
+    Response writable();
+}

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/CausalClusteringStatusFactory.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/CausalClusteringStatusFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.causalclustering;
+
+import org.neo4j.causalclustering.core.CoreGraphDatabase;
+import org.neo4j.causalclustering.readreplica.ReadReplicaGraphDatabase;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.server.rest.repr.OutputFormat;
+
+public class CausalClusteringStatusFactory
+{
+    public static CausalClusteringStatus build( OutputFormat output, GraphDatabaseService db )
+    {
+        if ( db instanceof CoreGraphDatabase )
+        {
+            return new CoreStatus( output, (CoreGraphDatabase) db );
+        }
+        else if ( db instanceof ReadReplicaGraphDatabase )
+        {
+            return new ReadReplicaStatus( output );
+        }
+        else
+        {
+            return new NotCausalClustering( output );
+        }
+    }
+}

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/CoreStatus.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/CoreStatus.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.causalclustering;
+
+import java.util.stream.Stream;
+import javax.ws.rs.core.Response;
+
+import org.neo4j.causalclustering.core.CoreGraphDatabase;
+import org.neo4j.causalclustering.core.consensus.roles.Role;
+import org.neo4j.server.rest.repr.OutputFormat;
+
+import static org.neo4j.server.rest.causalclustering.CausalClusteringService.BASE_PATH;
+
+class CoreStatus extends BaseStatus
+{
+    private final OutputFormat output;
+    private final CoreGraphDatabase db;
+
+    CoreStatus( OutputFormat output, CoreGraphDatabase db )
+    {
+        super( output );
+        this.output = output;
+        this.db = db;
+    }
+
+    @Override
+    public Response discover()
+    {
+        return output.ok( new CausalClusteringDiscovery( BASE_PATH ) );
+    }
+
+    @Override
+    public Response available()
+    {
+        return positiveResponse();
+    }
+
+    @Override
+    public Response readonly()
+    {
+        Role role = db.getRole();
+        return Stream.of( Role.FOLLOWER, Role.CANDIDATE ).anyMatch( r -> r.equals( role ) ) ? positiveResponse() : negativeResponse();
+    }
+
+    @Override
+    public Response writable()
+    {
+        return db.getRole() == Role.LEADER ? positiveResponse() : negativeResponse();
+    }
+}

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/NotCausalClustering.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/NotCausalClustering.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.causalclustering;
+
+import javax.ws.rs.core.Response;
+
+import org.neo4j.server.rest.repr.OutputFormat;
+
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+import static javax.ws.rs.core.Response.status;
+
+class NotCausalClustering extends BaseStatus
+{
+    NotCausalClustering( OutputFormat output )
+    {
+        super( output );
+    }
+
+    @Override
+    public Response discover()
+    {
+        return status( FORBIDDEN ).build();
+    }
+
+    @Override
+    public Response available()
+    {
+        return status( FORBIDDEN ).build();
+    }
+
+    @Override
+    public Response readonly()
+    {
+        return status( FORBIDDEN ).build();
+    }
+
+    @Override
+    public Response writable()
+    {
+        return status( FORBIDDEN ).build();
+    }
+}

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/ReadReplicaStatus.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/causalclustering/ReadReplicaStatus.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.causalclustering;
+
+import javax.ws.rs.core.Response;
+
+import org.neo4j.server.rest.repr.OutputFormat;
+
+import static org.neo4j.server.rest.causalclustering.CausalClusteringService.BASE_PATH;
+
+class ReadReplicaStatus extends BaseStatus
+{
+    private final OutputFormat output;
+
+    ReadReplicaStatus( OutputFormat output )
+    {
+        super( output );
+        this.output = output;
+    }
+
+    @Override
+    public Response discover()
+    {
+        return output.ok( new CausalClusteringDiscovery( BASE_PATH ) );
+    }
+
+    @Override
+    public Response available()
+    {
+        return positiveResponse();
+    }
+
+    @Override
+    public Response readonly()
+    {
+        return positiveResponse();
+    }
+
+    @Override
+    public Response writable()
+    {
+        return negativeResponse();
+    }
+}

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/causalclustering/CoreStatusTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/causalclustering/CoreStatusTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.causalclustering;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+import javax.ws.rs.core.Response;
+
+import org.neo4j.causalclustering.core.CoreGraphDatabase;
+import org.neo4j.causalclustering.core.consensus.roles.Role;
+import org.neo4j.server.rest.repr.OutputFormat;
+import org.neo4j.server.rest.repr.formats.JsonFormat;
+
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CoreStatusTest
+{
+    private CoreGraphDatabase db;
+    private CausalClusteringStatus status;
+
+    @Before
+    public void setup() throws Exception
+    {
+        OutputFormat output = new OutputFormat( new JsonFormat(), new URI( "http://base.local:1234/" ), null );
+        db = mock( CoreGraphDatabase.class );
+        status = CausalClusteringStatusFactory.build( output, db );
+    }
+
+    @Test
+    public void testAnswersWhenLeader() throws Exception
+    {
+        // given
+        when( db.getRole() ).thenReturn( Role.LEADER );
+
+        // when
+        Response available = status.available();
+        Response readonly = status.readonly();
+        Response writable = status.writable();
+
+        // then
+        assertEquals( OK.getStatusCode(), available.getStatus() );
+        assertEquals( "true", available.getEntity() );
+
+        assertEquals( NOT_FOUND.getStatusCode(), readonly.getStatus() );
+        assertEquals( "false", readonly.getEntity() );
+
+        assertEquals( OK.getStatusCode(), writable.getStatus() );
+        assertEquals( "true", writable.getEntity() );
+    }
+
+    @Test
+    public void testAnswersWhenCandidate() throws Exception
+    {
+        // given
+        when( db.getRole() ).thenReturn( Role.CANDIDATE );
+
+        // when
+        Response available = status.available();
+        Response readonly = status.readonly();
+        Response writable = status.writable();
+
+        // then
+        assertEquals( OK.getStatusCode(), available.getStatus() );
+        assertEquals( "true", available.getEntity() );
+
+        assertEquals( OK.getStatusCode(), readonly.getStatus() );
+        assertEquals( "true", readonly.getEntity() );
+
+        assertEquals( NOT_FOUND.getStatusCode(), writable.getStatus() );
+        assertEquals( "false", writable.getEntity() );
+    }
+
+    @Test
+    public void testAnswersWhenFollower() throws Exception
+    {
+        // given
+        when( db.getRole() ).thenReturn( Role.FOLLOWER );
+
+        // when
+        Response available = status.available();
+        Response readonly = status.readonly();
+        Response writable = status.writable();
+
+        // then
+        assertEquals( OK.getStatusCode(), available.getStatus() );
+        assertEquals( "true", available.getEntity() );
+
+        assertEquals( OK.getStatusCode(), readonly.getStatus() );
+        assertEquals( "true", readonly.getEntity() );
+
+        assertEquals( NOT_FOUND.getStatusCode(), writable.getStatus() );
+        assertEquals( "false", writable.getEntity() );
+    }
+}

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/causalclustering/ReadReplicaStatusTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/causalclustering/ReadReplicaStatusTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.rest.causalclustering;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+import javax.ws.rs.core.Response;
+
+import org.neo4j.causalclustering.readreplica.ReadReplicaGraphDatabase;
+import org.neo4j.server.rest.repr.OutputFormat;
+import org.neo4j.server.rest.repr.formats.JsonFormat;
+
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class ReadReplicaStatusTest
+{
+    private CausalClusteringStatus status;
+
+    @Before
+    public void setup() throws Exception
+    {
+        OutputFormat output = new OutputFormat( new JsonFormat(), new URI( "http://base.local:1234/" ), null );
+        status = CausalClusteringStatusFactory.build( output, mock( ReadReplicaGraphDatabase.class ) );
+    }
+
+    @Test
+    public void testAnswers() throws Exception
+    {
+        // when
+        Response available = status.available();
+        Response readonly = status.readonly();
+        Response writable = status.writable();
+
+        // then
+        assertEquals( OK.getStatusCode(), available.getStatus() );
+        assertEquals( "true", available.getEntity() );
+
+        assertEquals( OK.getStatusCode(), readonly.getStatus() );
+        assertEquals( "true", readonly.getEntity() );
+
+        assertEquals( NOT_FOUND.getStatusCode(), writable.getStatus() );
+        assertEquals( "false", writable.getEntity() );
+    }
+}


### PR DESCRIPTION
/db/manage/server/causalclustering/available
/db/manage/server/causalclustering/read-only
/db/manage/server/causalclustering/writable

which return 200 OK "true" or 404 "false"
respectively as appropriate.

This behaviour of the actual endpoint is inherited
from the previously split REST endpoints.