### PR TITLE
Fixed bug in calculating the cardinality of non-existing labels

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/HardcodedGraphStatistics.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/HardcodedGraphStatistics.scala
@@ -41,8 +41,10 @@ class HardcodedGraphStatisticsValues extends GraphStatistics {
     Some(INDEX_PROPERTY_EXISTS_SELECTIVITY * Selectivity.of(index.properties.length).get)
 
   def nodesWithLabelCardinality(labelId: Option[LabelId]): Cardinality =
-    labelId.map(_ => NODES_WITH_LABEL_CARDINALITY).getOrElse(NODES_CARDINALITY)
+    labelId.map(_ => NODES_WITH_LABEL_CARDINALITY).getOrElse(Cardinality.SINGLE)
 
   def cardinalityByLabelsAndRelationshipType(fromLabel: Option[LabelId], relTypeId: Option[RelTypeId], toLabel: Option[LabelId]): Cardinality =
     RELATIONSHIPS_CARDINALITY
+
+  override def nodesAllCardinality(): Cardinality = NODES_CARDINALITY
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/cardinality/ExpressionSelectivityCalculator.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/cardinality/ExpressionSelectivityCalculator.scala
@@ -100,7 +100,7 @@ case class ExpressionSelectivityCalculator(stats: GraphStatistics, combiner: Sel
 
     // WHERE id(x) =/IN [...]
     case AsIdSeekable(seekable) =>
-      (seekable.args.sizeHint.map(Cardinality(_)).getOrElse(DEFAULT_NUMBER_OF_ID_LOOKUPS) / stats.nodesWithLabelCardinality(None)) getOrElse Selectivity.ONE
+      (seekable.args.sizeHint.map(Cardinality(_)).getOrElse(DEFAULT_NUMBER_OF_ID_LOOKUPS) / stats.nodesAllCardinality()) getOrElse Selectivity.ONE
 
     // WHERE <expr> = <expr>
     case _: Equals =>
@@ -121,8 +121,13 @@ case class ExpressionSelectivityCalculator(stats: GraphStatistics, combiner: Sel
   }
 
   private def calculateSelectivityForLabel(label: Option[LabelId]): Selectivity = {
-    val labelCardinality = label.map(l => stats.nodesWithLabelCardinality(Some(l))).getOrElse(Cardinality.SINGLE)
-    labelCardinality / stats.nodesWithLabelCardinality(None) getOrElse Selectivity.ONE
+    val labelCardinality =
+    if(label.isEmpty){
+      Cardinality.SINGLE
+    } else {
+      label.map(l => stats.nodesWithLabelCardinality(Some(l))).getOrElse(Cardinality.SINGLE)
+    }
+    labelCardinality / stats.nodesAllCardinality() getOrElse Selectivity.ONE
   }
 
   private def calculateSelectivityForPropertyEquality(variable: String,

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/cardinality/TokenSpec.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/cardinality/TokenSpec.scala
@@ -35,7 +35,7 @@ object TokenSpec {
 
   def mapFrom[T <: SymbolicNameWithId[ID], ID <: NameId](input: Set[T])(implicit semanticTable: SemanticTable): Set[TokenSpec[ID]] =
     if (input.isEmpty)
-      Set(Unspecified())
+      Set(Unspecified)
     else
       input.map {
         case label =>
@@ -52,7 +52,7 @@ case class SpecifiedButUnknown() extends TokenSpec[Nothing] {
   override def map[T](f: Option[Nothing] => T): Option[T] = None
 }
 
-case class Unspecified() extends TokenSpec[Nothing] {
+case object Unspecified extends TokenSpec[Nothing] {
   def id = None
 
   override def map[T](f: Option[Nothing] => T): Option[T] = Some(f(None))

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/cardinality/assumeIndependence/AssumeIndependenceQueryGraphCardinalityModel.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/cardinality/assumeIndependence/AssumeIndependenceQueryGraphCardinalityModel.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v3_2.planner.logical.cardinality.assu
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.Metrics.{QueryGraphCardinalityModel, QueryGraphSolverInput}
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.cardinality.{ExpressionSelectivityCalculator, SelectivityCombiner}
 import org.neo4j.cypher.internal.compiler.v3_2.spi.GraphStatistics
-import org.neo4j.cypher.internal.frontend.v3_2.SemanticTable
+import org.neo4j.cypher.internal.frontend.v3_2.{LabelId, SemanticTable}
 import org.neo4j.cypher.internal.frontend.v3_2.ast.LabelName
 import org.neo4j.cypher.internal.ir.v3_2.{QueryGraph, _}
 
@@ -74,7 +74,7 @@ case class AssumeIndependenceQueryGraphCardinalityModel(stats: GraphStatistics, 
                                       (implicit semanticTable: SemanticTable): Cardinality = {
     val (selectivity, numberOfZeroZeroRels) = calculateSelectivity(qg, input.labelInfo)
     val numberOfPatternNodes = calculateNumberOfPatternNodes(qg) - numberOfZeroZeroRels
-    val numberOfGraphNodes = stats.nodesWithLabelCardinality(None)
+    val numberOfGraphNodes = stats.nodesAllCardinality()
 
     val c = if (qg.argumentIds.nonEmpty) {
       if ((qg.argumentIds intersect qg.patternNodes).isEmpty) {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/cardinality/assumeIndependence/PatternSelectivityCalculator.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/cardinality/assumeIndependence/PatternSelectivityCalculator.scala
@@ -40,7 +40,7 @@ case class PatternSelectivityCalculator(stats: GraphStatistics, combiner: Select
 
   def apply(pattern: PatternRelationship, labels: Map[IdName, Set[LabelName]])
            (implicit semanticTable: SemanticTable, selections: Selections): Selectivity = {
-    val nbrOfNodesInGraph = stats.nodesWithLabelCardinality(None)
+    val nbrOfNodesInGraph = stats.nodesAllCardinality()
     val (lhs, rhs) = pattern.nodes
     val labelsOnLhs: Seq[TokenSpec[LabelId]] = mapToLabelTokenSpecs(selections.labelsOnNode(lhs) ++ labels.getOrElse(lhs, Set.empty))
     val labelsOnRhs: Seq[TokenSpec[LabelId]] = mapToLabelTokenSpecs(selections.labelsOnNode(rhs) ++ labels.getOrElse(rhs, Set.empty))
@@ -137,8 +137,9 @@ case class PatternSelectivityCalculator(stats: GraphStatistics, combiner: Select
   private def calculateLabelSelectivity(specs: Seq[TokenSpec[LabelId]], totalNbrOfNodes: Cardinality): Selectivity = {
     val selectivities = specs map {
       case SpecifiedButUnknown() => Selectivity.ZERO
-      case spec: TokenSpec[LabelId] =>
-        stats.nodesWithLabelCardinality(spec.id) / totalNbrOfNodes getOrElse Selectivity.ZERO
+      case Unspecified() => Selectivity.ONE
+      case SpecifiedAndKnown(spec: LabelId) =>  // Specified labels have ids
+          stats.nodesWithLabelCardinality(Some(spec)) / totalNbrOfNodes getOrElse Selectivity.ZERO
     }
 
     combiner.andTogetherSelectivities(selectivities).getOrElse(Selectivity.ONE)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/cardinality/assumeIndependence/PatternSelectivityCalculator.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/cardinality/assumeIndependence/PatternSelectivityCalculator.scala
@@ -80,8 +80,8 @@ case class PatternSelectivityCalculator(stats: GraphStatistics, combiner: Select
               yield {
                 for (i <- 1 to length)
                   yield {
-                    val labelsOnL: Seq[TokenSpec[LabelId]] = if (i == 1) labelsOnLhs else Seq(Unspecified())
-                    val labelsOnR: Seq[TokenSpec[LabelId]] = if (i == length) labelsOnRhs else Seq(Unspecified())
+                    val labelsOnL: Seq[TokenSpec[LabelId]] = if (i == 1) labelsOnLhs else Seq(Unspecified)
+                    val labelsOnR: Seq[TokenSpec[LabelId]] = if (i == length) labelsOnRhs else Seq(Unspecified)
                     calculateSelectivityForSingleRelHop(types, labelsOnL, labelsOnR, pattern.dir, estimatedMaxCardForPatternBasedOnLabels)
                   }
               }
@@ -137,7 +137,7 @@ case class PatternSelectivityCalculator(stats: GraphStatistics, combiner: Select
   private def calculateLabelSelectivity(specs: Seq[TokenSpec[LabelId]], totalNbrOfNodes: Cardinality): Selectivity = {
     val selectivities = specs map {
       case SpecifiedButUnknown() => Selectivity.ZERO
-      case Unspecified() => Selectivity.ONE
+      case Unspecified => Selectivity.ONE
       case SpecifiedAndKnown(spec: LabelId) =>  // Specified labels have ids
           stats.nodesWithLabelCardinality(Some(spec)) / totalNbrOfNodes getOrElse Selectivity.ZERO
     }
@@ -148,7 +148,7 @@ case class PatternSelectivityCalculator(stats: GraphStatistics, combiner: Select
   // These two methods should be one, but I failed to conjure up the proper Scala type magic to make it work
   private def mapToLabelTokenSpecs(input: Set[LabelName])(implicit semanticTable: SemanticTable): Seq[TokenSpec[LabelId]] =
     if (input.isEmpty)
-      Seq(Unspecified())
+      Seq(Unspecified)
     else
       input.toIndexedSeq.map {
         case label =>
@@ -158,7 +158,7 @@ case class PatternSelectivityCalculator(stats: GraphStatistics, combiner: Select
 
   private def mapToRelTokenSpecs(input: Set[RelTypeName])(implicit semanticTable: SemanticTable): Seq[TokenSpec[RelTypeId]] =
     if (input.isEmpty)
-      Seq(Unspecified())
+      Seq(Unspecified)
     else
       input.toIndexedSeq.map {
         case rel =>

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/GraphStatistics.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/GraphStatistics.scala
@@ -37,7 +37,17 @@ object GraphStatistics {
 }
 
 trait GraphStatistics {
+
+  /**
+    * Gets the Cardinality for given LabelId
+    *
+    * Attention: This method does NOT return the number of nodes anymore!
+    * @param labelId Either some labelId for which the Cardinality should be retrieved or None
+    * @return returns the Cardinality for the given LabelId or Cardinality(1) for a non-existing label
+    */
   def nodesWithLabelCardinality(labelId: Option[LabelId]): Cardinality
+
+  def nodesAllCardinality(): Cardinality
 
   def cardinalityByLabelsAndRelationshipType(fromLabel: Option[LabelId], relTypeId: Option[RelTypeId], toLabel: Option[LabelId]): Cardinality
 
@@ -68,6 +78,8 @@ class DelegatingGraphStatistics(delegate: GraphStatistics) extends GraphStatisti
 
   override def indexPropertyExistsSelectivity(index: IndexDescriptor): Option[Selectivity] =
     delegate.indexPropertyExistsSelectivity(index)
+
+  override def nodesAllCardinality(): Cardinality = delegate.nodesAllCardinality()
 }
 
 class StatisticsCompletingGraphStatistics(delegate: GraphStatistics)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/InstrumentedGraphStatistics.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/InstrumentedGraphStatistics.scala
@@ -29,7 +29,7 @@ import scala.collection.mutable
 
 sealed trait StatisticsKey
 case class NodesWithLabelCardinality(labelId: Option[LabelId]) extends StatisticsKey
-case class NodesAllCardinality() extends StatisticsKey
+case object NodesAllCardinality extends StatisticsKey
 case class CardinalityByLabelsAndRelationshipType(lhs: Option[LabelId], relType: Option[RelTypeId], rhs: Option[LabelId]) extends StatisticsKey
 case class IndexSelectivity(index: IndexDescriptor) extends StatisticsKey
 case class IndexPropertyExistsSelectivity(index: IndexDescriptor) extends StatisticsKey
@@ -45,9 +45,9 @@ case class GraphStatisticsSnapshot(statsValues: Map[StatisticsKey, Double] = Map
     statsValues.keys.foreach {
       case NodesWithLabelCardinality(labelId) =>
         instrumented.nodesWithLabelCardinality(labelId)
-      case NodesAllCardinality() =>
-        val value = statsValues.get(NodesAllCardinality()).getOrElse(1.0)
-        snapshot.map.put(NodesAllCardinality(), value) // Copy the old value, otherwise every create would lead to a diverged cache if we update this
+      case NodesAllCardinality =>
+        val value = statsValues.getOrElse(NodesAllCardinality, 1.0)
+        snapshot.map.put(NodesAllCardinality, value) // Copy the old value, otherwise every create would lead to a diverged cache if we update this
       case CardinalityByLabelsAndRelationshipType(lhs, relType, rhs) =>
         instrumented.cardinalityByLabelsAndRelationshipType(lhs, relType, rhs)
       case IndexSelectivity(index) =>
@@ -98,5 +98,5 @@ case class InstrumentedGraphStatistics(inner: GraphStatistics, snapshot: Mutable
     selectivity
   }
 
-  override def nodesAllCardinality(): Cardinality = snapshot.map.getOrElseUpdate(NodesAllCardinality(), inner.nodesAllCardinality().amount)
+  override def nodesAllCardinality(): Cardinality = snapshot.map.getOrElseUpdate(NodesAllCardinality, inner.nodesAllCardinality().amount)
 }

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/DbStructureGraphStatistics.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/DbStructureGraphStatistics.scala
@@ -54,4 +54,6 @@ class DbStructureGraphStatistics(lookup: DbStructureLookup) extends GraphStatist
     val result = lookup.indexPropertyExistsSelectivity( index.label.id, index.property.id )
     if (result.isNaN) None else Some(Selectivity.of(result).get)
   }
+
+  override def nodesAllCardinality(): Cardinality = Cardinality(lookup.nodesAllCardinality())
 }

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/cardinality/CardinalityTestHelper.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/cardinality/CardinalityTestHelper.scala
@@ -207,6 +207,8 @@ trait CardinalityTestHelper extends QueryGraphProducer with CardinalityCustomMat
         private def getPropertyName(propertyId: PropertyKeyId) = propertyIds.collectFirst {
           case (name, id) if id == propertyId.id => name
         }
+
+        override def nodesAllCardinality(): Cardinality = nodesCardinality
       }
 
       val semanticTable: SemanticTable = {

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/cardinality/ExpressionSelectivityCalculatorTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/cardinality/ExpressionSelectivityCalculatorTest.scala
@@ -41,7 +41,7 @@ class ExpressionSelectivityCalculatorTest extends CypherFunSuite with AstConstru
     implicit val selections = Selections(Set(Predicate(Set(IdName("n")), HasLabels(varFor("n"), Seq(LabelName("Page")_))_)))
 
     val stats = mock[GraphStatistics]
-    when(stats.nodesWithLabelCardinality(None)).thenReturn(1000.0)
+    when(stats.nodesAllCardinality()).thenReturn(1000.0)
     when(stats.indexSelectivity(index)).thenReturn(Some(Selectivity.of(0.1d).get))
 
     val calculator = ExpressionSelectivityCalculator(stats, IndependenceCombiner)
@@ -58,7 +58,7 @@ class ExpressionSelectivityCalculatorTest extends CypherFunSuite with AstConstru
     implicit val selections = Selections(Set(Predicate(Set(IdName("n")), HasLabels(varFor("n"), Seq(LabelName("Page")_))_)))
 
     val stats = mock[GraphStatistics]
-    when(stats.nodesWithLabelCardinality(None)).thenReturn(2000.0)
+    when(stats.nodesAllCardinality()).thenReturn(2000.0)
     when(stats.nodesWithLabelCardinality(Some(index.label))).thenReturn(1000.0)
     val calculator = ExpressionSelectivityCalculator(stats, IndependenceCombiner)
 
@@ -81,7 +81,7 @@ class ExpressionSelectivityCalculatorTest extends CypherFunSuite with AstConstru
     implicit val selections = Selections(Set(n_is_Person, n_gt_3_and_lt_4))
 
     val stats = mock[GraphStatistics]
-    when(stats.nodesWithLabelCardinality(None)).thenReturn(2000.0)
+    when(stats.nodesAllCardinality()).thenReturn(2000.0)
     when(stats.nodesWithLabelCardinality(Some(index.label))).thenReturn(1000.0)
     val calculator = ExpressionSelectivityCalculator(stats, IndependenceCombiner)
 
@@ -147,7 +147,7 @@ class ExpressionSelectivityCalculatorTest extends CypherFunSuite with AstConstru
 
   test("should default to single cardinality for HasLabels with previously unknown label") {
     val stats = mock[GraphStatistics]
-    when(stats.nodesWithLabelCardinality(None)).thenReturn(Cardinality(10))
+    when(stats.nodesAllCardinality()).thenReturn(Cardinality(10))
     val calculator = ExpressionSelectivityCalculator(stats, IndependenceCombiner)
     implicit val semanticTable = SemanticTable()
     implicit val selections = mock[Selections]

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/cardinality/assumeIndependence/PatternSelectivityCalculatorTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/cardinality/assumeIndependence/PatternSelectivityCalculatorTest.scala
@@ -38,6 +38,7 @@ class PatternSelectivityCalculatorTest extends CypherFunSuite with LogicalPlanCo
   test("should return zero if there are no nodes with the given labels") {
     val stats: GraphStatistics = mock[GraphStatistics]
     when(stats.nodesWithLabelCardinality(any())).thenReturn(Cardinality(0))
+    when(stats.nodesAllCardinality()).thenReturn(Cardinality.EMPTY)
     when(stats.cardinalityByLabelsAndRelationshipType(any(), any(), any())).thenReturn(Cardinality(42))
 
     val calculator = PatternSelectivityCalculator(stats, IndependenceCombiner)
@@ -55,6 +56,7 @@ class PatternSelectivityCalculatorTest extends CypherFunSuite with LogicalPlanCo
   test("should not consider label selectivity twice") {
     val stats: GraphStatistics = mock[GraphStatistics]
     when(stats.nodesWithLabelCardinality(any())).thenReturn(Cardinality(1))
+    when(stats.nodesAllCardinality()).thenReturn(Cardinality.SINGLE)
     when(stats.cardinalityByLabelsAndRelationshipType(any(), any(), any())).thenReturn(Cardinality(42))
 
     val calculator = PatternSelectivityCalculator(stats, IndependenceCombiner)
@@ -72,6 +74,7 @@ class PatternSelectivityCalculatorTest extends CypherFunSuite with LogicalPlanCo
   test("handles variable length paths over 32 in length") {
     val stats: GraphStatistics = mock[GraphStatistics]
     when(stats.nodesWithLabelCardinality(any())).thenReturn(Cardinality(1))
+    when(stats.nodesAllCardinality()).thenReturn(Cardinality.SINGLE)
     when(stats.cardinalityByLabelsAndRelationshipType(any(), any(), any())).thenReturn(Cardinality(3))
 
     val calculator = PatternSelectivityCalculator(stats, IndependenceCombiner)
@@ -92,11 +95,12 @@ class PatternSelectivityCalculatorTest extends CypherFunSuite with LogicalPlanCo
       override def answer(invocationOnMock: InvocationOnMock): Cardinality = {
         val arg = invocationOnMock.getArguments()(0).asInstanceOf[Option[LabelId]]
         arg match {
-          case None => Cardinality(10)
+          case None => Cardinality(1)
           case Some(_) => Cardinality(1)
         }
       }
     })
+    when(stats.nodesAllCardinality()).thenReturn(Cardinality(10))
     when(stats.cardinalityByLabelsAndRelationshipType(any(), any(), any())).thenReturn(Cardinality(42))
 
     val calculator = PatternSelectivityCalculator(stats, IndependenceCombiner)

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/GraphStatisticsSnapshotTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/GraphStatisticsSnapshotTest.scala
@@ -43,13 +43,13 @@ class GraphStatisticsSnapshotTest extends CypherFunSuite {
     val statistics = graphStatistics(allNodes = allNodes, idxSelectivity = indexSelectivity,
       relCardinality = relationships, labeledNodes = nodesWithLabel)
     val instrumentedStatistics = InstrumentedGraphStatistics(statistics, snapshot)
-    instrumentedStatistics.nodesWithLabelCardinality(None)
+    instrumentedStatistics.nodesAllCardinality()
     instrumentedStatistics.indexSelectivity(index)
     instrumentedStatistics.nodesWithLabelCardinality(Some(label4))
     instrumentedStatistics.cardinalityByLabelsAndRelationshipType(Some(label2), None, None)
 
     snapshot.freeze.statsValues should equal(Map(
-      NodesWithLabelCardinality(None) -> allNodes,
+      NodesAllCardinality() -> allNodes,
       IndexSelectivity(index) -> indexSelectivity,
       NodesWithLabelCardinality(Some(label4)) -> nodesWithLabel,
       CardinalityByLabelsAndRelationshipType(Some(label2), None, None) -> relationships
@@ -59,7 +59,7 @@ class GraphStatisticsSnapshotTest extends CypherFunSuite {
   test("a snapshot shouldn't diverge from equal values") {
     val snapshot = new MutableGraphStatisticsSnapshot()
     val instrumentedStatistics = InstrumentedGraphStatistics(graphStatistics(), snapshot)
-    instrumentedStatistics.nodesWithLabelCardinality(None)
+    instrumentedStatistics.nodesAllCardinality()
     instrumentedStatistics.indexSelectivity(index)
     instrumentedStatistics.nodesWithLabelCardinality(Some(label4))
     instrumentedStatistics.cardinalityByLabelsAndRelationshipType(Some(label2), None, None)
@@ -72,7 +72,7 @@ class GraphStatisticsSnapshotTest extends CypherFunSuite {
     instrumentedStatistics2.cardinalityByLabelsAndRelationshipType(None, Some(RelTypeId(1)), Some(label2))
     instrumentedStatistics2.cardinalityByLabelsAndRelationshipType(Some(label2), None, None)
     instrumentedStatistics2.indexSelectivity(index)
-    instrumentedStatistics2.nodesWithLabelCardinality(None)
+    instrumentedStatistics2.nodesAllCardinality()
     instrumentedStatistics2.nodesWithLabelCardinality(Some(label4))
 
     val frozen1 = snapshot.freeze
@@ -84,11 +84,11 @@ class GraphStatisticsSnapshotTest extends CypherFunSuite {
   test("a snapshot shouldn't diverge from small differences") {
     val snapshot = new MutableGraphStatisticsSnapshot()
     val instrumentedStatistics = InstrumentedGraphStatistics(graphStatistics(allNodes = 1000), snapshot)
-    instrumentedStatistics.nodesWithLabelCardinality(None)
+    instrumentedStatistics.nodesAllCardinality()
 
     val snapshot2 = new MutableGraphStatisticsSnapshot()
     val instrumentedStatistics2 = InstrumentedGraphStatistics(graphStatistics(allNodes = 1010), snapshot2)
-    instrumentedStatistics2.nodesWithLabelCardinality(None)
+    instrumentedStatistics2.nodesAllCardinality()
 
     val frozen1 = snapshot.freeze
     frozen1.diverges(snapshot2.freeze, minThreshold = 0.01) should equal(false)
@@ -99,13 +99,13 @@ class GraphStatisticsSnapshotTest extends CypherFunSuite {
     val snapshot1 = new MutableGraphStatisticsSnapshot()
     val statistics = graphStatistics()
     val instrumentedStatistics1 = InstrumentedGraphStatistics(statistics, snapshot1)
-    instrumentedStatistics1.nodesWithLabelCardinality(None)
+    instrumentedStatistics1.nodesAllCardinality()
     instrumentedStatistics1.indexSelectivity(index)
     instrumentedStatistics1.nodesWithLabelCardinality(Some(label4))
 
     val snapshot2 = new MutableGraphStatisticsSnapshot()
     val instrumentedStatistics2 = InstrumentedGraphStatistics(statistics, snapshot2)
-    instrumentedStatistics2.nodesWithLabelCardinality(None)
+    instrumentedStatistics2.nodesAllCardinality()
     instrumentedStatistics2.nodesWithLabelCardinality(Some(label4))
 
     statistics.factor(2)
@@ -124,13 +124,13 @@ class GraphStatisticsSnapshotTest extends CypherFunSuite {
     val snapshot1 = new MutableGraphStatisticsSnapshot()
     val statistics = graphStatistics()
     val instrumentedStatistics1 = InstrumentedGraphStatistics(statistics, snapshot1)
-    instrumentedStatistics1.nodesWithLabelCardinality(None)
+    instrumentedStatistics1.nodesAllCardinality()
     instrumentedStatistics1.indexSelectivity(index)
     instrumentedStatistics1.nodesWithLabelCardinality(Some(label4))
 
     val snapshot2 = new MutableGraphStatisticsSnapshot()
     val instrumentedStatistics2 = InstrumentedGraphStatistics(statistics, snapshot2)
-    instrumentedStatistics2.nodesWithLabelCardinality(None)
+    instrumentedStatistics2.nodesAllCardinality()
     instrumentedStatistics2.nodesWithLabelCardinality(Some(label4))
 
     statistics.factor(Long.MaxValue)
@@ -150,7 +150,7 @@ class GraphStatisticsSnapshotTest extends CypherFunSuite {
     private var _factor: Double = 1L
 
     def nodesWithLabelCardinality(labelId: Option[LabelId]): Cardinality = labelId match {
-      case None => Cardinality(allNodes * _factor)
+      case None => Cardinality.SINGLE
       case Some(id) => Cardinality(labeledNodes * _factor)
     }
 
@@ -167,5 +167,7 @@ class GraphStatisticsSnapshotTest extends CypherFunSuite {
     def factor(factor: Double): Unit = {
       _factor = factor
     }
+
+    override def nodesAllCardinality(): Cardinality = Cardinality(allNodes * _factor)
   }
 }

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/GraphStatisticsSnapshotTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/GraphStatisticsSnapshotTest.scala
@@ -49,7 +49,7 @@ class GraphStatisticsSnapshotTest extends CypherFunSuite {
     instrumentedStatistics.cardinalityByLabelsAndRelationshipType(Some(label2), None, None)
 
     snapshot.freeze.statsValues should equal(Map(
-      NodesAllCardinality() -> allNodes,
+      NodesAllCardinality -> allNodes,
       IndexSelectivity(index) -> indexSelectivity,
       NodesWithLabelCardinality(Some(label4)) -> nodesWithLabel,
       CardinalityByLabelsAndRelationshipType(Some(label2), None, None) -> relationships

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundGraphStatistics.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundGraphStatistics.scala
@@ -79,6 +79,8 @@ object TransactionBoundGraphStatistics {
       else
         Cardinality(count)
     }
+
+    override def nodesAllCardinality(): Cardinality =  atLeastOne(operations.nodesGetCount())
   }
 }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompilerAstCacheAcceptanceTest.scala
@@ -177,6 +177,28 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
     counter.counts should equal(CacheCounts(hits = 1, misses = 2, flushes = 1, evicted = 1))
   }
 
+  test("should not evict query because of unrelated statistics change") {
+    // given
+    val clock: Clock = Clock.fixed(Instant.ofEpochMilli(1000L), ZoneOffset.UTC)
+    counter = new CacheCounter()
+    compiler = createCompiler(queryPlanTTL = 0, clock = clock)
+    compiler.monitors.addMonitorListener(counter)
+    val query: String = "match (n:Person) return n"
+
+    // when
+    runQuery(query)
+
+    // then
+    counter.counts should equal(CacheCounts(hits = 0, misses = 1, flushes = 1, evicted = 0))
+
+    // when
+    (0 until 5).foreach { _ => createLabeledNode("Dog") }
+    runQuery(query)
+
+    // then
+    counter.counts should equal(CacheCounts(hits = 1, misses = 1, flushes = 1, evicted = 0))
+  }
+
   test("should log on cache remove") {
     // given
     val logProvider = new AssertableLogProvider()

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundPlanContextTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundPlanContextTest.scala
@@ -49,7 +49,7 @@ class TransactionBoundPlanContextTest extends CypherFunSuite {
 
     // label stats
     statistics.nodesWithLabelCardinality(Some(LabelId(0))) should equal(Cardinality.SINGLE)
-    statistics.nodesWithLabelCardinality(None) should equal(Cardinality.SINGLE)
+    statistics.nodesAllCardinality() should equal(Cardinality.SINGLE)
 
     // pattern stats
     Set(Some(LabelId(0)), None).foreach { label1 =>
@@ -74,7 +74,7 @@ class TransactionBoundPlanContextTest extends CypherFunSuite {
     // label stats
     statistics.nodesWithLabelCardinality(Some(LabelId(0))) should equal(Cardinality(100))
     statistics.nodesWithLabelCardinality(Some(LabelId(1))) should equal(Cardinality.SINGLE)
-    statistics.nodesWithLabelCardinality(None) should equal(Cardinality(200))
+    statistics.nodesAllCardinality() should equal(Cardinality(200))
 
     // pattern stats
     statistics.cardinalityByLabelsAndRelationshipType(

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureCollector.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureCollector.java
@@ -107,6 +107,12 @@ public class DbStructureCollector implements DbStructureVisitor
             }
 
             @Override
+            public long nodesAllCardinality()
+            {
+                return allNodesCount;
+            }
+
+            @Override
             public Iterator<Pair<String,String[]>> knownRelationshipPropertyExistenceConstraints()
             {
                 return Iterators.map( relConstraint ->
@@ -121,7 +127,7 @@ public class DbStructureCollector implements DbStructureVisitor
             @Override
             public long nodesWithLabelCardinality( int labelId )
             {
-                Long result = labelId == -1 ? allNodesCount : nodeCounts.get( labelId );
+                Long result = nodeCounts.get( labelId );
                 return result == null ? 0L : result;
             }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureLookup.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureLookup.java
@@ -36,6 +36,7 @@ public interface DbStructureLookup
     Iterator<Pair<String, String[]>> knownRelationshipPropertyExistenceConstraints();
     Iterator<Pair<String, String[]>> knownNodeKeyConstraints();
 
+    long nodesAllCardinality();
     long nodesWithLabelCardinality( int labelId );
     long cardinalityByLabelsAndRelationshipType( int fromLabelId, int relTypeId, int toLabelId );
     double indexSelectivity( int labelId, int... propertyKeyIds );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureCollectorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/dbstructure/DbStructureCollectorTest.java
@@ -76,7 +76,7 @@ public class DbStructureCollectorTest
         assertEquals( asList( "City" ), Iterators.asList( Iterators.map( Pair::first, lookup.knownIndices() ) ) );
         assertArrayEquals( new String[]{"income"}, lookup.knownIndices().next().other() );
 
-        assertEquals( 50, lookup.nodesWithLabelCardinality( -1 ) );
+        assertEquals( 50, lookup.nodesAllCardinality() );
         assertEquals( 20, lookup.nodesWithLabelCardinality( 1 ) );
         assertEquals( 30, lookup.nodesWithLabelCardinality( 2 ) );
         assertEquals( 500, lookup.cardinalityByLabelsAndRelationshipType( 1, 2, -1 ) );
@@ -126,7 +126,7 @@ public class DbStructureCollectorTest
         assertEquals( asList( "City" ), Iterators.asList( Iterators.map( Pair::first, lookup.knownIndices() ) ) );
         assertArrayEquals( new String[]{"income", "tax"}, lookup.knownIndices().next().other() );
 
-        assertEquals( 50, lookup.nodesWithLabelCardinality( -1 ) );
+        assertEquals( 50, lookup.nodesAllCardinality() );
         assertEquals( 20, lookup.nodesWithLabelCardinality( 1 ) );
         assertEquals( 30, lookup.nodesWithLabelCardinality( 2 ) );
         assertEquals( 500, lookup.cardinalityByLabelsAndRelationshipType( 1, 2, -1 ) );


### PR DESCRIPTION
This mainly meant to change the behavior of "nodesWithLabelCardinality(labelId: Option[LabelId])" in GraphStatistics.scala to assume that labelId == None means there is no label in the db for this yet. Prior to this, labelId == None meant giving out the Cardinality of all nodes in the DB. This functionality is now separated into nodesAllCardinality()