### PR TITLE
Align the code and user output around naming of Argument

### DIFF
--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Argument.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Argument.scala
@@ -19,19 +19,19 @@
  */
 package org.neo4j.cypher.internal.v3_4.logical.plans
 
-import org.neo4j.cypher.internal.util.v3_4.symbols._
 import org.neo4j.cypher.internal.ir.v3_4.{CardinalityEstimation, IdName, PlannerQuery}
+import org.neo4j.cypher.internal.util.v3_4.symbols._
 
 /**
   * Produce a single row with the contents of argument
   */
-case class SingleRow(argumentIds: Set[IdName] = Set.empty)(val solved: PlannerQuery with CardinalityEstimation)
+case class Argument(argumentIds: Set[IdName] = Set.empty)(val solved: PlannerQuery with CardinalityEstimation)
                    (val typeInfo: Map[String, CypherType] = argumentIds.map( id => id.name -> CTNode).toMap)
   extends LogicalLeafPlan {
 
   def availableSymbols: Set[IdName] = argumentIds
 
-  override def updateSolved(newSolved: PlannerQuery with CardinalityEstimation): SingleRow =
+  override def updateSolved(newSolved: PlannerQuery with CardinalityEstimation): Argument =
     copy(argumentIds)(newSolved)(typeInfo)
 
   override def copyPlan(): LogicalPlan = this.copy(argumentIds)(solved)(typeInfo).asInstanceOf[this.type]

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/CardinalityCostModel.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/CardinalityCostModel.scala
@@ -20,10 +20,10 @@
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical
 
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.Metrics._
-import org.neo4j.cypher.internal.v3_4.logical.plans._
 import org.neo4j.cypher.internal.ir.v3_4._
 import org.neo4j.cypher.internal.util.v3_4.{Cardinality, Cost, CostPerRow, Multiplier}
 import org.neo4j.cypher.internal.v3_4.expressions.{HasLabels, Property}
+import org.neo4j.cypher.internal.v3_4.logical.plans._
 
 object CardinalityCostModel extends CostModel {
   def VERBOSE = java.lang.Boolean.getBoolean("CardinalityCostModel.VERBOSE")
@@ -78,7 +78,7 @@ object CardinalityCostModel extends CostModel {
          _: AbstractLetSemiApply |
          _: Limit |
          _: Optional |
-         _: SingleRow |
+         _: Argument |
          _: OuterHashJoin |
          _: AbstractSemiApply |
          _: Skip |

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/Eagerness.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/Eagerness.scala
@@ -19,9 +19,9 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical
 
-import org.neo4j.cypher.internal.util.v3_4.{Rewriter, bottomUp}
 import org.neo4j.cypher.internal.frontend.v3_4.helpers.fixedPoint
 import org.neo4j.cypher.internal.ir.v3_4.{IdName, PlannerQuery, QueryGraph}
+import org.neo4j.cypher.internal.util.v3_4.{Rewriter, bottomUp}
 import org.neo4j.cypher.internal.v3_4.logical.plans._
 
 import scala.annotation.tailrec
@@ -288,7 +288,6 @@ object Eagerness {
     Glossary:
       Ax : Apply
       L,R: Arbitrary operator, named Left and Right
-      SR : SingleRow - operator that produces single row with no columns
       CN : CreateNode
       Dn : Delete node
       Dr : Delete relationship

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PlanUpdates.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PlanUpdates.scala
@@ -19,11 +19,11 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical
 
-import org.neo4j.cypher.internal.util.v3_4.InternalException
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps.{LogicalPlanProducer, mergeUniqueIndexSeekLeafPlanner}
 import org.neo4j.cypher.internal.ir.v3_4._
-import org.neo4j.cypher.internal.v3_4.logical.plans.{LockNodes, LogicalPlan}
+import org.neo4j.cypher.internal.util.v3_4.InternalException
 import org.neo4j.cypher.internal.v3_4.expressions.{ContainerIndex, PathExpression, Variable}
+import org.neo4j.cypher.internal.v3_4.logical.plans.{LockNodes, LogicalPlan}
 
 /*
  * This coordinates PlannerQuery planning of updates.
@@ -64,7 +64,7 @@ case object PlanUpdates
       //FOREACH
       case foreach: ForeachPattern =>
         val innerLeaf = context.logicalPlanProducer
-          .planSingleRow(Set.empty, Set.empty, source.availableSymbols + foreach.variable)
+          .planArgument(Set.empty, Set.empty, source.availableSymbols + foreach.variable)
         val innerUpdatePlan = planAllUpdatesRecursively(foreach.innerUpdates, innerLeaf)
         context.logicalPlanProducer.planForeachApply(source, innerUpdatePlan, foreach)
 
@@ -176,7 +176,7 @@ case object PlanUpdates
     //          apply  onMatch
     val condApply = if (onMatchPatterns.nonEmpty) {
       val qgWithAllNeededArguments = matchGraph.addArgumentIds(matchGraph.allCoveredIds.toIndexedSeq)
-      val onMatch = onMatchPatterns.foldLeft[LogicalPlan](producer.planQuerySingleRow(qgWithAllNeededArguments)) {
+      val onMatch = onMatchPatterns.foldLeft[LogicalPlan](producer.planQueryArgument(qgWithAllNeededArguments)) {
         case (src, current) => planUpdate(src, current, first)
       }
       producer.planConditionalApply(mergeMatch, onMatch, ids)(innerContext)
@@ -188,7 +188,7 @@ case object PlanUpdates
     //       /         \
     //      /     mergeCreatePart
     // condApply
-    val createNodes = createNodePatterns.foldLeft(producer.planQuerySingleRow(matchGraph): LogicalPlan) {
+    val createNodes = createNodePatterns.foldLeft(producer.planQueryArgument(matchGraph): LogicalPlan) {
       case (acc, current) => producer.planMergeCreateNode(acc, current)
     }
     val mergeCreatePart = createRelationshipPatterns.foldLeft(createNodes) {

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPQueryGraphSolver.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPQueryGraphSolver.scala
@@ -82,10 +82,7 @@ case class IDPQueryGraphSolver(singleComponentSolver: SingleComponentPlannerTrai
     }
 
   private def planEmptyComponent(queryGraph: QueryGraph)(implicit context: LogicalPlanningContext, kit: QueryPlannerKit): Seq[PlannedComponent] = {
-    val plan = if (queryGraph.argumentIds.isEmpty)
-      context.logicalPlanProducer.planSingleRow()
-    else
-      context.logicalPlanProducer.planQuerySingleRow(queryGraph)
+    val plan = context.logicalPlanProducer.planQueryArgument(queryGraph)
     val result: LogicalPlan = kit.select(plan, queryGraph)
     monitor.emptyComponentPlanned(queryGraph, result)
     Seq(PlannedComponent(queryGraph, result))

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/unnestOptional.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/unnestOptional.scala
@@ -19,9 +19,9 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical.plans.rewriter
 
+import org.neo4j.cypher.internal.ir.v3_4.{CardinalityEstimation, PlannerQuery}
 import org.neo4j.cypher.internal.util.v3_4.{Rewriter, bottomUp}
 import org.neo4j.cypher.internal.v3_4.expressions.Expression
-import org.neo4j.cypher.internal.ir.v3_4.{CardinalityEstimation, PlannerQuery}
 import org.neo4j.cypher.internal.v3_4.logical.plans._
 
 case object unnestOptional extends Rewriter {
@@ -45,13 +45,13 @@ case object unnestOptional extends Rewriter {
 
     case apply@Apply(lhs,
       Optional(
-      e@Expand(_: SingleRow, _, _, _, _, _, _), _)) =>
+      e@Expand(_: Argument, _, _, _, _, _, _), _)) =>
         optionalExpand(e, lhs)(Seq.empty)(apply.solved)
 
     case apply@Apply(lhs,
       Optional(
       Selection(predicates,
-      e@Expand(_: SingleRow, _, _, _, _, _, _)), _)) =>
+      e@Expand(_: Argument, _, _, _, _, _, _)), _)) =>
         optionalExpand(e, lhs)(predicates)(apply.solved)
   })
 

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/argumentLeafPlanner.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/argumentLeafPlanner.scala
@@ -29,6 +29,6 @@ object argumentLeafPlanner extends LeafPlanner {
     if ((qg.argumentIds intersect ids).isEmpty)
       Seq.empty
     else
-      Seq(context.logicalPlanProducer.planQuerySingleRow(qg))
+      Seq(context.logicalPlanProducer.planQueryArgument(qg))
   }
 }

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/planShortestPaths.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/planShortestPaths.scala
@@ -20,14 +20,14 @@
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps
 
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.LogicalPlanningContext
-import org.neo4j.cypher.internal.util.v3_4.{ExhaustiveShortestPathForbiddenException, FreshIdNameGenerator, InternalException}
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.idp.expandSolverStep
 import org.neo4j.cypher.internal.frontend.v3_4.ast.rewriters.projectNamedPaths
 import org.neo4j.cypher.internal.frontend.v3_4.notification.ExhaustiveShortestPathForbiddenNotification
 import org.neo4j.cypher.internal.ir.v3_4.{IdName, Predicate, ShortestPathPattern, _}
-import org.neo4j.cypher.internal.v3_4.logical.plans.{Ascending, DoNotIncludeTies, IncludeTies, LogicalPlan}
+import org.neo4j.cypher.internal.util.v3_4.{ExhaustiveShortestPathForbiddenException, FreshIdNameGenerator, InternalException}
 import org.neo4j.cypher.internal.v3_4.expressions._
 import org.neo4j.cypher.internal.v3_4.functions.{Length, Nodes}
+import org.neo4j.cypher.internal.v3_4.logical.plans.{Ascending, DoNotIncludeTies, IncludeTies, LogicalPlan}
 
 case object planShortestPaths {
 
@@ -87,13 +87,13 @@ case object planShortestPaths {
 
     // Plan FindShortestPaths within an Apply with an Optional so we get null rows when
     // the graph algorithm does not find anything (left-hand-side)
-    val lhsArgument = lpp.planSingleRowFrom(inner)
+    val lhsArgument = lpp.planArgumentFrom(inner)
     val lhsSp = lpp.planShortestPath(lhsArgument, shortestPath, predicates, withFallBack = true,
                                      disallowSameNode = context.errorIfShortestPathHasCommonNodesAtRuntime)
     val lhsOption = lpp.planOptional(lhsSp, Set.empty)
     val lhs = lpp.planApply(inner, lhsOption)
 
-    val rhsArgument = lpp.planSingleRowFrom(lhs)
+    val rhsArgument = lpp.planArgumentFrom(lhs)
 
     val rhs = if (context.errorIfShortestPathFallbackUsedAtRuntime) {
       lpp.planError(rhsArgument, new ExhaustiveShortestPathForbiddenException)

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/triadicSelectionFinder.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/triadicSelectionFinder.scala
@@ -21,8 +21,8 @@ package org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps
 
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.{CandidateGenerator, LogicalPlanningContext}
 import org.neo4j.cypher.internal.ir.v3_4.{IdName, QueryGraph}
-import org.neo4j.cypher.internal.v3_4.logical.plans.{Expand, ExpandAll, LogicalPlan, Selection}
 import org.neo4j.cypher.internal.v3_4.expressions._
+import org.neo4j.cypher.internal.v3_4.logical.plans.{Expand, ExpandAll, LogicalPlan, Selection}
 
 object triadicSelectionFinder extends CandidateGenerator[LogicalPlan] {
 
@@ -81,7 +81,7 @@ object triadicSelectionFinder extends CandidateGenerator[LogicalPlan] {
       else
         exp1
 
-      val argument = context.logicalPlanProducer.planSingleRowFrom(left)
+      val argument = context.logicalPlanProducer.planArgumentFrom(left)
       val newExpand2 = Expand(argument, exp2.from, exp2.dir, exp2.types, exp2.to, exp2.relName, ExpandAll)(exp2.solved)
       val right = if (incomingPredicates.nonEmpty)
         context.logicalPlanProducer.planSelection(newExpand2, incomingPredicates, incomingPredicates)

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/ArgumentPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/ArgumentPlanningIntegrationTest.scala
@@ -19,16 +19,16 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical
 
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport2
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.v3_4.expressions.SignedDecimalIntegerLiteral
-import org.neo4j.cypher.internal.v3_4.logical.plans.{Projection, SingleRow}
+import org.neo4j.cypher.internal.v3_4.logical.plans.{Argument, Projection}
 
-class SingleRowPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
+class ArgumentPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
   test("should build plans containing single row") {
     planFor("RETURN 42")._2 should equal(
       Projection(
-        SingleRow()(solved)(), expressions = Map("42" -> SignedDecimalIntegerLiteral("42")_)
+        Argument()(solved)(), expressions = Map("42" -> SignedDecimalIntegerLiteral("42")_)
       )(solved)
     )
   }

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/CardinalityCostModelTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/CardinalityCostModelTest.scala
@@ -19,12 +19,12 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical
 
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.Metrics.QueryGraphSolverInput
 import org.neo4j.cypher.internal.frontend.v3_4.ast.AstConstructionTestSupport
 import org.neo4j.cypher.internal.ir.v3_4.LazyMode
 import org.neo4j.cypher.internal.util.v3_4.Cost
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.v3_4.expressions.{HasLabels, LabelName, SemanticDirection}
 import org.neo4j.cypher.internal.v3_4.logical.plans._
 
@@ -36,7 +36,7 @@ class CardinalityCostModelTest extends CypherFunSuite with LogicalPlanningTestSu
         Expand(
           Selection(List(HasLabels(varFor("a"), Seq(LabelName("Awesome") _)) _),
             Expand(
-              SingleRow(Set("a"))(solvedWithEstimation(10.0))(),
+              Argument(Set("a"))(solvedWithEstimation(10.0))(),
               "a", SemanticDirection.OUTGOING, Seq.empty, "b", "r1")(solvedWithEstimation(100.0))
           )(solvedWithEstimation(10.0)), "a", SemanticDirection.OUTGOING, Seq.empty, "b", "r1")(solvedWithEstimation(100.0))
       )(solvedWithEstimation(10.0))
@@ -99,7 +99,7 @@ class CardinalityCostModelTest extends CypherFunSuite with LogicalPlanningTestSu
     val card10 = solvedWithEstimation(cardinality)
     val plan =
       Selection(List(propEquality("a", "prop1", 42), propEquality("a", "prop1", 42), propEquality("a", "prop1", 42)),
-        SingleRow(Set("a"))(card10)())(card10)
+        Argument(Set("a"))(card10)())(card10)
 
     val numberOfPredicates = 3
     val costForSelection = cardinality * numberOfPredicates

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/CreateNodePlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/CreateNodePlanningIntegrationTest.scala
@@ -19,9 +19,9 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical
 
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport2
 import org.neo4j.cypher.internal.ir.v3_4.IdName
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.v3_4.expressions.{MapExpression, PropertyKeyName, SignedDecimalIntegerLiteral}
 import org.neo4j.cypher.internal.v3_4.logical.plans._
 
@@ -30,7 +30,7 @@ class CreateNodePlanningIntegrationTest extends CypherFunSuite with LogicalPlann
   test("should plan single create") {
     planFor("CREATE (a)")._2 should equal(
       EmptyResult(
-        CreateNode(SingleRow()(solved)(), IdName("a"), Seq.empty, None)(solved))(solved)
+        CreateNode(Argument()(solved)(), IdName("a"), Seq.empty, None)(solved))(solved)
     )
   }
 
@@ -39,7 +39,7 @@ class CreateNodePlanningIntegrationTest extends CypherFunSuite with LogicalPlann
       EmptyResult(
         CreateNode(
           CreateNode(
-            CreateNode(SingleRow()(solved)(), IdName("a"), Seq.empty, None)(solved),
+            CreateNode(Argument()(solved)(), IdName("a"), Seq.empty, None)(solved),
             IdName("b"), Seq.empty, None)(solved),
           IdName("c"), Seq.empty, None)(solved))
         (solved)
@@ -51,7 +51,7 @@ class CreateNodePlanningIntegrationTest extends CypherFunSuite with LogicalPlann
       EmptyResult(
         CreateNode(
           CreateNode(
-            CreateNode(SingleRow()(solved)(), IdName("a"), Seq.empty, None)(solved),
+            CreateNode(Argument()(solved)(), IdName("a"), Seq.empty, None)(solved),
             IdName("b"), Seq.empty, None)(solved),
           IdName("c"), Seq.empty, None)(solved))
         (solved)
@@ -60,14 +60,14 @@ class CreateNodePlanningIntegrationTest extends CypherFunSuite with LogicalPlann
 
   test("should plan single create with return") {
     planFor("CREATE (a) return a")._2 should equal(
-        CreateNode(SingleRow()(solved)(), IdName("a"), Seq.empty, None)(solved)
+        CreateNode(Argument()(solved)(), IdName("a"), Seq.empty, None)(solved)
     )
   }
 
   test("should plan create with labels") {
     planFor("CREATE (a:A:B)")._2 should equal(
       EmptyResult(
-        CreateNode(SingleRow()(solved)(), IdName("a"), Seq(lblName("A"), lblName("B")), None)(solved))(solved)
+        CreateNode(Argument()(solved)(), IdName("a"), Seq(lblName("A"), lblName("B")), None)(solved))(solved)
     )
   }
 
@@ -75,7 +75,7 @@ class CreateNodePlanningIntegrationTest extends CypherFunSuite with LogicalPlann
 
     planFor("CREATE (a {prop: 42})")._2 should equal(
       EmptyResult(
-        CreateNode(SingleRow()(solved)(), IdName("a"), Seq.empty,
+        CreateNode(Argument()(solved)(), IdName("a"), Seq.empty,
           Some(
             MapExpression(Seq((PropertyKeyName("prop")(pos), SignedDecimalIntegerLiteral("42")(pos))))(pos)
           )

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/CreateRelationshipPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/CreateRelationshipPlanningIntegrationTest.scala
@@ -19,9 +19,9 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical
 
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport2
 import org.neo4j.cypher.internal.ir.v3_4.IdName
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.v3_4.expressions.{RelTypeName, Variable}
 import org.neo4j.cypher.internal.v3_4.logical.plans._
 
@@ -32,7 +32,7 @@ class CreateRelationshipPlanningIntegrationTest extends CypherFunSuite with Logi
       EmptyResult(
         CreateRelationship(
           CreateNode(
-            CreateNode(SingleRow()(solved)(), IdName("a"), Seq.empty, None)(solved),
+            CreateNode(Argument()(solved)(), IdName("a"), Seq.empty, None)(solved),
             IdName("b"), Seq.empty, None)(solved),
           IdName("r"), IdName("a"), relType("R"), IdName("b"), None)(solved)
       )(solved)
@@ -48,7 +48,7 @@ class CreateRelationshipPlanningIntegrationTest extends CypherFunSuite with Logi
               CreateNode(
                 CreateNode(
                   CreateNode(
-                    CreateNode(SingleRow()(solved)(),IdName("a"),Seq.empty,None)(solved),
+                    CreateNode(Argument()(solved)(),IdName("a"),Seq.empty,None)(solved),
                     IdName("b"),Seq.empty,None)(solved),
                   IdName("c"),Seq.empty,None)(solved),
                 IdName("d"),Seq.empty,None)(solved),
@@ -66,7 +66,7 @@ class CreateRelationshipPlanningIntegrationTest extends CypherFunSuite with Logi
           CreateRelationship(
             CreateNode(
               CreateNode(
-                CreateNode(SingleRow()(solved)(),IdName("a"),Seq.empty,None)(solved),
+                CreateNode(Argument()(solved)(),IdName("a"),Seq.empty,None)(solved),
                 IdName("b"),Seq.empty,None)(solved),
               IdName("c"),Seq.empty,None)(solved),
             IdName("r1"),IdName("b"),relType("R1"),IdName("a"),None)(solved),

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/DefaultQueryPlannerTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/DefaultQueryPlannerTest.scala
@@ -21,8 +21,6 @@ package org.neo4j.cypher.internal.compiler.v3_4.planner.logical
 
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify, when}
-import org.neo4j.cypher.internal.util.v3_4.symbols._
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v3_4.planner._
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.Metrics.QueryGraphSolverInput
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps.LogicalPlanProducer
@@ -31,8 +29,10 @@ import org.neo4j.cypher.internal.frontend.v3_4.phases.devNullLogger
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.{ExpressionTypeInfo, SemanticTable}
 import org.neo4j.cypher.internal.ir.v3_4._
 import org.neo4j.cypher.internal.planner.v3_4.spi.PlanContext
-import org.neo4j.cypher.internal.v3_4.logical.plans.{LogicalPlan, ProduceResult, Projection, SingleRow}
+import org.neo4j.cypher.internal.util.v3_4.symbols._
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.v3_4.expressions._
+import org.neo4j.cypher.internal.v3_4.logical.plans.{Argument, LogicalPlan, ProduceResult, Projection}
 
 class DefaultQueryPlannerTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
 
@@ -88,7 +88,7 @@ class DefaultQueryPlannerTest extends CypherFunSuite with LogicalPlanningTestSup
     when(plannerQuery.allHints).thenReturn(Set[Hint]())
 
     val lp = {
-      val plan = SingleRow()(plannerQuery)()
+      val plan = Argument()(plannerQuery)()
       Projection(plan, Map.empty)(plannerQuery)
     }
 

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/LeafPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/LeafPlanningIntegrationTest.scala
@@ -19,16 +19,16 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical
 
-import org.neo4j.cypher.internal.util.v3_4._
-import org.neo4j.cypher.internal.util.v3_4.symbols._
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v3_4.planner.BeLikeMatcher._
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport2
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.Metrics.QueryGraphSolverInput
 import org.neo4j.cypher.internal.frontend.v3_4.ast._
 import org.neo4j.cypher.internal.ir.v3_4.IdName
-import org.neo4j.cypher.internal.v3_4.logical.plans.{Union, _}
+import org.neo4j.cypher.internal.util.v3_4._
+import org.neo4j.cypher.internal.util.v3_4.symbols._
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.v3_4.expressions._
+import org.neo4j.cypher.internal.v3_4.logical.plans.{Union, _}
 
 class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTestSupport2 with AstConstructionTestSupport {
 
@@ -642,7 +642,7 @@ class LeafPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
     plan._2 should equal(
       Aggregation(
         Apply(
-          Projection(SingleRow()(solved)(),Map("arr" -> ListLiteral(List(SignedDecimalIntegerLiteral("0")_, SignedDecimalIntegerLiteral("1")_, SignedDecimalIntegerLiteral("3")_))_))(solved),
+          Projection(Argument()(solved)(),Map("arr" -> ListLiteral(List(SignedDecimalIntegerLiteral("0")_, SignedDecimalIntegerLiteral("1")_, SignedDecimalIntegerLiteral("3")_))_))(solved),
           NodeByIdSeek(IdName("n"), ManySeekableArgs(Variable("arr")_),Set(IdName("arr")))(solved)
         )(solved),
         Map(), Map("count(*)" -> CountStar()_)

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/MergeNodePlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/MergeNodePlanningIntegrationTest.scala
@@ -19,9 +19,9 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical
 
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport2
 import org.neo4j.cypher.internal.ir.v3_4.IdName
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.v3_4.expressions._
 import org.neo4j.cypher.internal.v3_4.logical.plans._
 
@@ -33,7 +33,7 @@ class MergeNodePlanningIntegrationTest extends CypherFunSuite with LogicalPlanni
   test("should plan single merge node") {
     val allNodesScan = AllNodesScan(aId, Set.empty)(solved)
     val optional = Optional(allNodesScan)(solved)
-    val onCreate = MergeCreateNode(SingleRow()(solved)(), aId, Seq.empty, None)(solved)
+    val onCreate = MergeCreateNode(Argument()(solved)(), aId, Seq.empty, None)(solved)
 
     val mergeNode = AntiConditionalApply(optional, onCreate, Seq(aId))(solved)
     val emptyResult = EmptyResult(mergeNode)(solved)
@@ -45,7 +45,7 @@ class MergeNodePlanningIntegrationTest extends CypherFunSuite with LogicalPlanni
 
     val labelScan = NodeByLabelScan(aId, lblName("X"), Set.empty)(solved)
     val optional = Optional(labelScan)(solved)
-    val onCreate = MergeCreateNode(SingleRow()(solved)(), aId, Seq(lblName("X")), None)(solved)
+    val onCreate = MergeCreateNode(Argument()(solved)(), aId, Seq(lblName("X")), None)(solved)
 
     val mergeNode = AntiConditionalApply(optional, onCreate, Seq(aId))(solved)
     val emptyResult = EmptyResult(mergeNode)(solved)
@@ -66,7 +66,7 @@ class MergeNodePlanningIntegrationTest extends CypherFunSuite with LogicalPlanni
                                      ListLiteral(Seq(propertyValue))(pos))(pos)), allNodesScan)(solved)
     val optional = Optional(selection)(solved)
 
-    val onCreate = MergeCreateNode(SingleRow()(solved)(), aId, Seq.empty,
+    val onCreate = MergeCreateNode(Argument()(solved)(), aId, Seq.empty,
       Some(MapExpression(List((PropertyKeyName("prop")(pos),
         SignedDecimalIntegerLiteral("42")(pos))))(pos)))(solved)
 
@@ -77,10 +77,10 @@ class MergeNodePlanningIntegrationTest extends CypherFunSuite with LogicalPlanni
   }
 
   test("should plan create followed by merge") {
-    val createNode = CreateNode(SingleRow()(solved)(), aId, Seq.empty, None)(solved)
+    val createNode = CreateNode(Argument()(solved)(), aId, Seq.empty, None)(solved)
     val allNodesScan = AllNodesScan(bId, Set.empty)(solved)
     val optional = Optional(allNodesScan)(solved)
-    val onCreate = MergeCreateNode(SingleRow()(solved)(), bId, Seq.empty, None)(solved)
+    val onCreate = MergeCreateNode(Argument()(solved)(), bId, Seq.empty, None)(solved)
     val mergeNode = AntiConditionalApply(optional, onCreate, Seq(bId))(solved)
     val apply = Apply(createNode, mergeNode)(solved)
     val emptyResult = EmptyResult(apply)(solved)
@@ -91,7 +91,7 @@ class MergeNodePlanningIntegrationTest extends CypherFunSuite with LogicalPlanni
   test("should plan merge followed by create") {
     val allNodesScan = AllNodesScan(aId, Set.empty)(solved)
     val optional = Optional(allNodesScan)(solved)
-    val onCreate = MergeCreateNode(SingleRow()(solved)(), aId, Seq.empty, None)(solved)
+    val onCreate = MergeCreateNode(Argument()(solved)(), aId, Seq.empty, None)(solved)
     val mergeNode = AntiConditionalApply(optional, onCreate, Seq(aId))(solved)
     val eager = Eager(mergeNode)(solved)
     val createNode = CreateNode(eager, bId, Seq.empty, None)(solved)
@@ -127,20 +127,20 @@ class MergeNodePlanningIntegrationTest extends CypherFunSuite with LogicalPlanni
    *                /       \
    *               /    merge create node
    *         condApply       \
-   *            /    \       arg
+   *            /    \       arg2
    *       optional  set label
-   *         /
-   *    allnodes
+   *         /        \
+   *    allnodes     arg1
    */
   test("should plan merge node with on create and on match ") {
     val allNodesScan = AllNodesScan(aId, Set.empty)(solved)
     val optional = Optional(allNodesScan)(solved)
-    val argument = SingleRow(Set(aId))(solved)(Map.empty)
-    val setLabels = SetLabels(argument, aId, Seq(lblName("L")))(solved)
+    val argument1 = Argument(Set(aId))(solved)(Map.empty)
+    val setLabels = SetLabels(argument1, aId, Seq(lblName("L")))(solved)
     val onMatch = ConditionalApply(optional, setLabels, Seq(aId))(solved)
 
-    val singleRow = SingleRow()(solved)()
-    val mergeCreateNode = MergeCreateNode(singleRow, aId, Seq.empty, None)(solved)
+    val argument2 = Argument()(solved)()
+    val mergeCreateNode = MergeCreateNode(argument2, aId, Seq.empty, None)(solved)
     val createAndOnCreate = SetNodeProperty(mergeCreateNode, aId, PropertyKeyName("prop")(pos), SignedDecimalIntegerLiteral("1")(pos))(solved)
     val mergeNode = AntiConditionalApply(onMatch, createAndOnCreate, Seq(aId))(solved)
     val emptyResult = EmptyResult(mergeNode)(solved)

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/OptionalMatchPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/OptionalMatchPlanningIntegrationTest.scala
@@ -19,12 +19,12 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical
 
-import org.neo4j.cypher.internal.util.v3_4.Foldable._
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport2
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.plans.rewriter.unnestOptional
 import org.neo4j.cypher.internal.ir.v3_4.{IdName, SimplePatternLength}
 import org.neo4j.cypher.internal.util.v3_4.Cardinality
+import org.neo4j.cypher.internal.util.v3_4.Foldable._
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.v3_4.expressions._
 import org.neo4j.cypher.internal.v3_4.logical.plans.{Limit, _}
 import org.neo4j.kernel.impl.util.dbstructure.DbStructureLargeOptionalMatchStructure
@@ -39,7 +39,7 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
         case (p: Expand, _) if p.findByAllClass[CartesianProduct].nonEmpty => Double.MaxValue
         case (_: Expand, _) => 10.0
         case (_: OuterHashJoin, _) => 20.0
-        case (_: SingleRow, _) => 1.0
+        case (_: Argument, _) => 1.0
         case _ => Double.MaxValue
       }
     } getLogicalPlanFor "MATCH (a:X)-[r1]->(b) OPTIONAL MATCH (b)-[r2]->(c:Y) RETURN b")._2 should equal(
@@ -79,7 +79,7 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
         AllNodesScan(IdName("b1"), _), _, _, _, _, _, _), _, _),
         Optional(
         ProjectEndpoints(
-        SingleRow(args), IdName("r"), IdName("b2"), false, IdName("a1"), true, None, true, SimplePatternLength
+        Argument(args), IdName("r"), IdName("b2"), false, IdName("a1"), true, None, true, SimplePatternLength
         ), _
         )
         ) =>
@@ -95,7 +95,7 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
       Selection(
       predicates,
       ProjectEndpoints(
-      SingleRow(args),
+      Argument(args),
       IdName("r"), IdName("b2"), false, IdName("a2"), false, None, true, SimplePatternLength
       )
       ), _
@@ -113,7 +113,7 @@ class OptionalMatchPlanningIntegrationTest extends CypherFunSuite with LogicalPl
       Limit(Expand(AllNodesScan(IdName("b1"), _), _, _, _, _, _, _), _, _),
       Optional(
       ProjectEndpoints(
-      SingleRow(args),
+      Argument(args),
       IdName("r"), IdName("a2"), false, IdName("b2"), false, None, true, SimplePatternLength
       ), _
       )

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PatternPredicatePlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PatternPredicatePlanningIntegrationTest.scala
@@ -19,10 +19,10 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical
 
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v3_4.planner.BeLikeMatcher._
 import org.neo4j.cypher.internal.compiler.v3_4.planner._
 import org.neo4j.cypher.internal.ir.v3_4.{QueryGraph, RegularPlannerQuery}
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection.OUTGOING
 import org.neo4j.cypher.internal.v3_4.expressions._
 import org.neo4j.cypher.internal.v3_4.logical.plans.{NestedPlanExpression, _}
@@ -48,7 +48,7 @@ class PatternPredicatePlanningIntegrationTest extends CypherFunSuite with Logica
               Selection(
                 Seq(HasLabels(varFor("  UNNAMED116"), Seq(LabelName("ComedyClub")_))_),
                 Expand(
-                  SingleRow(Set("f"))(solved)(),
+                  Argument(Set("f"))(solved)(),
                   "f", SemanticDirection.OUTGOING, Seq(RelTypeName("WORKS_AT")_), "  UNNAMED116", "  UNNAMED102", ExpandAll
                 )(solved)
               )(solved)

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PlanEventHorizonTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PlanEventHorizonTest.scala
@@ -19,16 +19,16 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical
 
-import org.neo4j.cypher.internal.util.v3_4.{Cardinality, DummyPosition}
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v3_4.planner.ProcedureCallProjection
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps.LogicalPlanProducer
 import org.neo4j.cypher.internal.frontend.v3_4.phases.InternalNotificationLogger
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.SemanticTable
 import org.neo4j.cypher.internal.ir.v3_4.{CardinalityEstimation, RegularPlannerQuery, RegularQueryProjection}
 import org.neo4j.cypher.internal.planner.v3_4.spi.PlanContext
-import org.neo4j.cypher.internal.v3_4.logical.plans.{ProcedureCall, Projection, ResolvedCall, SingleRow}
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.util.v3_4.{Cardinality, DummyPosition}
 import org.neo4j.cypher.internal.v3_4.expressions.SignedDecimalIntegerLiteral
+import org.neo4j.cypher.internal.v3_4.logical.plans.{Argument, ProcedureCall, Projection, ResolvedCall}
 
 class PlanEventHorizonTest extends CypherFunSuite {
 
@@ -40,7 +40,7 @@ class PlanEventHorizonTest extends CypherFunSuite {
     // Given
     val literal = SignedDecimalIntegerLiteral("42")(pos)
     val pq = RegularPlannerQuery(horizon = RegularQueryProjection(Map("a" -> literal)))
-    val inputPlan = SingleRow()(CardinalityEstimation.lift(RegularPlannerQuery(), Cardinality(1)))()
+    val inputPlan = Argument()(CardinalityEstimation.lift(RegularPlannerQuery(), Cardinality(1)))()
 
     // When
     val producedPlan = PlanEventHorizon(pq, inputPlan)
@@ -54,7 +54,7 @@ class PlanEventHorizonTest extends CypherFunSuite {
     val literal = SignedDecimalIntegerLiteral("42")(pos)
     val call = mock[ResolvedCall]
     val pq = RegularPlannerQuery(horizon = ProcedureCallProjection(call))
-    val inputPlan = SingleRow()(CardinalityEstimation.lift(RegularPlannerQuery(), Cardinality(1)))()
+    val inputPlan = Argument()(CardinalityEstimation.lift(RegularPlannerQuery(), Cardinality(1)))()
 
     // When
     val producedPlan = PlanEventHorizon(pq, inputPlan)

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PriorityLeafPlannerListTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/PriorityLeafPlannerListTest.scala
@@ -22,13 +22,13 @@ package org.neo4j.cypher.internal.compiler.v3_4.planner.logical
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{verify, verifyZeroInteractions, when}
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport2
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.ir.v3_4.QueryGraph
-import org.neo4j.cypher.internal.v3_4.logical.plans.SingleRow
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.v3_4.logical.plans.Argument
 
 class PriorityLeafPlannerListTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
   private val queryGraph = QueryGraph.empty
-  private val candidates = Seq(Seq(SingleRow()(solved)()))
+  private val candidates = Seq(Seq(Argument()(solved)()))
   private implicit val context = mock[LogicalPlanningContext]
 
   test("should use the priority list if that contains result") {

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/WithPlanningIntegrationTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/WithPlanningIntegrationTest.scala
@@ -19,8 +19,8 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical
 
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.{CypherFunSuite, WindowsStringSafe}
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport2
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.{CypherFunSuite, WindowsStringSafe}
 import org.neo4j.cypher.internal.v3_4.expressions.{Expression, SignedDecimalIntegerLiteral}
 import org.neo4j.cypher.internal.v3_4.logical.plans.{AllNodesScan, DoNotIncludeTies, Limit, Projection}
 
@@ -90,7 +90,7 @@ class WithPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
         |    }
         |  }
         |  RHS -> ProjectEndpoints(IdName(r), IdName(u), false, IdName(v), false, None, true, SimplePatternLength) {
-        |    LHS -> SingleRow(Set(IdName(r))) {}
+        |    LHS -> Argument(Set(IdName(r))) {}
         |  }
         |}""".stripMargin)
   }
@@ -106,7 +106,7 @@ class WithPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
         |    }
         |  }
         |  RHS -> ProjectEndpoints(IdName(r), IdName(a), true, IdName(b2), false, None, true, SimplePatternLength) {
-        |    LHS -> SingleRow(Set(IdName(a), IdName(r))) {}
+        |    LHS -> Argument(Set(IdName(a), IdName(r))) {}
         |  }
         |}""".stripMargin)
   }
@@ -122,7 +122,7 @@ class WithPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
         |    }
         |  }
         |  RHS -> ProjectEndpoints(IdName(r), IdName(a), true, IdName(b), true, None, true, SimplePatternLength) {
-        |    LHS -> SingleRow(Set(IdName(a), IdName(b), IdName(r))) {}
+        |    LHS -> Argument(Set(IdName(a), IdName(b), IdName(r))) {}
         |  }
         |}""".stripMargin)
   }
@@ -138,7 +138,7 @@ class WithPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
         |    }
         |  }
         |  RHS -> ProjectEndpoints(IdName(r), IdName(a), true, IdName(b2), false, None, true, SimplePatternLength) {
-        |    LHS -> SingleRow(Set(IdName(a), IdName(r))) {}
+        |    LHS -> Argument(Set(IdName(a), IdName(r))) {}
         |  }
         |}""".stripMargin)
   }
@@ -154,7 +154,7 @@ class WithPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
         |    }
         |  }
         |  RHS -> ProjectEndpoints(IdName(r), IdName(a), true, IdName(b2), false, None, false, SimplePatternLength) {
-        |    LHS -> SingleRow(Set(IdName(a), IdName(r))) {}
+        |    LHS -> Argument(Set(IdName(a), IdName(r))) {}
         |  }
         |}""".stripMargin)
   }
@@ -170,7 +170,7 @@ class WithPlanningIntegrationTest extends CypherFunSuite with LogicalPlanningTes
         |    }
         |  }
         |  RHS -> ProjectEndpoints(IdName(r), IdName(a), true, IdName(b2), false, None, true, VarPatternLength(1,None)) {
-        |    LHS -> SingleRow(Set(IdName(a), IdName(r))) {}
+        |    LHS -> Argument(Set(IdName(a), IdName(r))) {}
         |  }
         |}""".stripMargin)
   }

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPQueryGraphSolverTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/IDPQueryGraphSolverTest.scala
@@ -20,13 +20,13 @@
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical.idp
 
 import org.mockito.Mockito.{times, verify, verifyNoMoreInteractions}
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport2
-import org.neo4j.cypher.internal.v3_4.logical.plans._
 import org.neo4j.cypher.internal.ir.v3_4._
 import org.neo4j.cypher.internal.util.v3_4.Cardinality
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection.OUTGOING
 import org.neo4j.cypher.internal.v3_4.expressions._
+import org.neo4j.cypher.internal.v3_4.logical.plans._
 import org.scalatest.exceptions.TestFailedException
 
 import scala.collection.immutable
@@ -336,7 +336,7 @@ class IDPQueryGraphSolverTest extends CypherFunSuite with LogicalPlanningTestSup
     }
   }
 
-  test("should solve empty graph with SingleRow") {
+  test("should solve empty graph with Argument") {
     val monitor = mock[IDPQueryGraphSolverMonitor]
 
     new given {
@@ -347,7 +347,7 @@ class IDPQueryGraphSolverTest extends CypherFunSuite with LogicalPlanningTestSup
 
       val plan = queryGraphSolver.plan(cfg.qg)
       plan should equal(
-        SingleRow()(solved)()
+        Argument()(solved)()
       )
 
       verify(monitor).emptyComponentPlanned(cfg.qg, plan)
@@ -369,7 +369,7 @@ class IDPQueryGraphSolverTest extends CypherFunSuite with LogicalPlanningTestSup
 
       val plan: LogicalPlan = queryGraphSolver.plan(cfg.qg)
       plan should equal(
-        SingleRow(Set("a"))(solved)()
+        Argument(Set("a"))(solved)()
       )
 
       verify(monitor).emptyComponentPlanned(cfg.qg, plan)
@@ -394,7 +394,7 @@ class IDPQueryGraphSolverTest extends CypherFunSuite with LogicalPlanningTestSup
 
       val plan: LogicalPlan = queryGraphSolver.plan(cfg.qg)
       plan should equal(
-        ProjectEndpoints(SingleRow(Set("r"))(solved)(), "r", "a", startInScope = false, "b", endInScope = false, None, directed = true, SimplePatternLength)(solved)
+        ProjectEndpoints(Argument(Set("r"))(solved)(), "r", "a", startInScope = false, "b", endInScope = false, None, directed = true, SimplePatternLength)(solved)
       )
 
       verify(monitor).initTableFor(cfg.qg)
@@ -436,7 +436,7 @@ class IDPQueryGraphSolverTest extends CypherFunSuite with LogicalPlanningTestSup
       val plan: LogicalPlan = queryGraphSolver.plan(cfg.qg)
       plan should equal(
         Expand(
-          ProjectEndpoints(SingleRow(Set("r1"))(solved)(), "r1", "a", startInScope = false, "b", endInScope = false, None, directed = true, SimplePatternLength)(solved),
+          ProjectEndpoints(Argument(Set("r1"))(solved)(), "r1", "a", startInScope = false, "b", endInScope = false, None, directed = true, SimplePatternLength)(solved),
           "b", SemanticDirection.OUTGOING, Seq.empty, "c", "r2", ExpandAll
         )(solved)
       )
@@ -469,7 +469,7 @@ class IDPQueryGraphSolverTest extends CypherFunSuite with LogicalPlanningTestSup
 
       val plan = queryGraphSolver.plan(cfg.qg)
       plan should equal(
-        Expand(SingleRow(Set("a"))(solved)(), "a", SemanticDirection.OUTGOING, Seq.empty, "b", "r", ExpandAll)(solved)
+        Expand(Argument(Set("a"))(solved)(), "a", SemanticDirection.OUTGOING, Seq.empty, "b", "r", ExpandAll)(solved)
       )
 
       verify(monitor).initTableFor(cfg.qg)
@@ -614,7 +614,7 @@ class IDPQueryGraphSolverTest extends CypherFunSuite with LogicalPlanningTestSup
 
       val plan = queryGraphSolver.plan(cfg.qg)
       plan should equal(
-        SingleRow(Set("a"))(solved)()
+        Argument(Set("a"))(solved)()
       )
 
       verify(monitor).noIDPIterationFor(cfg.qg, plan)
@@ -708,7 +708,7 @@ class IDPQueryGraphSolverTest extends CypherFunSuite with LogicalPlanningTestSup
 
       val qgs = cfg.qg.connectedComponents
       val allNodeScanA: AllNodesScan = AllNodesScan("a", Set.empty)(solved)
-      val expandAtoB = Expand(SingleRow(Set("a"))(solved)(), "a", SemanticDirection.OUTGOING, Seq.empty, "b", "r")(solved)
+      val expandAtoB = Expand(Argument(Set("a"))(solved)(), "a", SemanticDirection.OUTGOING, Seq.empty, "b", "r")(solved)
       val expandBtoA = Expand(AllNodesScan("b", Set.empty)(solved), "b", SemanticDirection.INCOMING, Seq.empty, "a", "r")(solved)
       val plan = queryGraphSolver.plan(cfg.qg)
       plan should equal(
@@ -813,7 +813,7 @@ class IDPQueryGraphSolverTest extends CypherFunSuite with LogicalPlanningTestSup
 
       queryGraphSolver.plan(cfg.qg) should equal(
         Apply(
-          SingleRow()(solved)(),
+          Argument()(solved)(),
           Optional(
             Expand(
               AllNodesScan("b", Set.empty)(solved),
@@ -874,7 +874,7 @@ class IDPQueryGraphSolverTest extends CypherFunSuite with LogicalPlanningTestSup
       queryGraphSolver.plan(cfg.qg) should equal(
         ProjectEndpoints(
           ProjectEndpoints(
-            SingleRow(Set("r1", "r2"))(solved)(),
+            Argument(Set("r1", "r2"))(solved)(),
             "r2", "b", startInScope = false, "c", endInScope = false, None, directed = true, SimplePatternLength)(solved),
           "r1", "a", startInScope = false, "b", endInScope = true, None, directed = true, SimplePatternLength)(solved))
     }
@@ -903,7 +903,7 @@ class IDPQueryGraphSolverTest extends CypherFunSuite with LogicalPlanningTestSup
         Expand(
           ProjectEndpoints(
             ProjectEndpoints(
-              SingleRow(Set("r2", "r1", "a", "d", "b", "c"))(solved)(),
+              Argument(Set("r2", "r1", "a", "d", "b", "c"))(solved)(),
               "r2", "c", startInScope = true, "d", endInScope = true, None, directed = true, SimplePatternLength)(solved),
             "r1", "a" , startInScope = true, "b", endInScope = true, None, directed = true, SimplePatternLength)(solved),
           "a", OUTGOING, List(), "d", "r3", ExpandInto)(solved))
@@ -923,7 +923,7 @@ class IDPQueryGraphSolverTest extends CypherFunSuite with LogicalPlanningTestSup
       implicit val x = ctx
 
       queryGraphSolver.plan(cfg.qg) should equal(
-        SingleRow(Set("a", "b"))(solved)()
+        Argument(Set("a", "b"))(solved)()
       )
     }
   }

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/ArgumentLeafPlannerTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/ArgumentLeafPlannerTest.scala
@@ -19,12 +19,12 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical.plans
 
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps.argumentLeafPlanner
 import org.neo4j.cypher.internal.ir.v3_4.QueryGraph
-import org.neo4j.cypher.internal.v3_4.logical.plans.SingleRow
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.v3_4.expressions.PatternExpression
+import org.neo4j.cypher.internal.v3_4.logical.plans.Argument
 
 class ArgumentLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
@@ -61,7 +61,7 @@ class ArgumentLeafPlannerTest extends CypherFunSuite with LogicalPlanningTestSup
     )
 
     argumentLeafPlanner(qg) should equal(
-      Seq(SingleRow(Set("a", "b","c"))(solved)())
+      Seq(Argument(Set("a", "b","c"))(solved)())
     )
   }
 }

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/LogicalPlanAssignedIdTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/LogicalPlanAssignedIdTest.scala
@@ -21,18 +21,18 @@ package org.neo4j.cypher.internal.compiler.v3_4.planner.logical.plans
 
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport2
 import org.neo4j.cypher.internal.ir.v3_4.IdName
-import org.neo4j.cypher.internal.v3_4.logical.plans.{NestedPlanExpression, _}
-import org.neo4j.cypher.internal.util.v3_4.{CypherException, Rewriter, topDown}
 import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.util.v3_4.{CypherException, Rewriter, topDown}
+import org.neo4j.cypher.internal.v3_4.logical.plans.{NestedPlanExpression, _}
 
 class LogicalPlanAssignedIdTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
   test("assignedId survives rewriting") {
-    val sr1 = SingleRow()(solved)()
+    val sr1 = Argument()(solved)()
     val pr = Projection(sr1, Map.empty)(solved)
     pr.assignIds()
 
     val prPrim = pr.endoRewrite(topDown(Rewriter.lift {
-      case sr: SingleRow => SingleRow()(solved)()
+      case sr: Argument => Argument()(solved)()
     }))
 
     pr.assignedId should equal(prPrim.assignedId)
@@ -40,8 +40,8 @@ class LogicalPlanAssignedIdTest extends CypherFunSuite with LogicalPlanningTestS
   }
 
   test("assignedIds are different between plans") {
-    val sr1 = SingleRow()(solved)()
-    val sr2 = SingleRow()(solved)()
+    val sr1 = Argument()(solved)()
+    val sr2 = Argument()(solved)()
     val apply = Apply(sr1, sr2)(solved)
     apply.assignIds()
 
@@ -54,11 +54,11 @@ class LogicalPlanAssignedIdTest extends CypherFunSuite with LogicalPlanningTestS
         ApplyA(5)         ApplyB(2)
     SR1A(4)  SR2A(3)   SR1B(1) SR2B(0)
      */
-    val sr1A = SingleRow()(solved)()
-    val sr2A = SingleRow()(solved)()
+    val sr1A = Argument()(solved)()
+    val sr2A = Argument()(solved)()
     val applyA = Apply(sr1A, sr2A)(solved)
-    val sr1B = SingleRow()(solved)()
-    val sr2B = SingleRow()(solved)()
+    val sr1B = Argument()(solved)()
+    val sr2B = Argument()(solved)()
     val applyB = Apply(sr1B, sr2B)(solved)
     val applyAll = Apply(applyA, applyB)(solved) // I heard you guys like Apply, so we applied an Apply in your Apply
 
@@ -74,16 +74,16 @@ class LogicalPlanAssignedIdTest extends CypherFunSuite with LogicalPlanningTestS
   }
 
   test("cant assign ids twice") {
-    val sr1 = SingleRow()(solved)()
+    val sr1 = Argument()(solved)()
     val pr = Projection(sr1, Map.empty)(solved)
     pr.assignIds()
     intercept[CypherException](pr.assignIds())
   }
 
   test("can assign inside expressions as well") {
-    val singleRow = SingleRow()(solved)()
+    val argument = Argument()(solved)()
     val inner = AllNodesScan(IdName("x"), Set.empty)(solved)
-    val filter = Selection(Seq(NestedPlanExpression(inner, literalInt(42))(pos)), singleRow)(solved)
+    val filter = Selection(Seq(NestedPlanExpression(inner, literalInt(42))(pos)), argument)(solved)
 
     filter.assignIds()
 

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/LogicalPlanTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/LogicalPlanTest.scala
@@ -20,9 +20,9 @@
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical.plans
 
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.ir.v3_4.{CardinalityEstimation, IdName, PlannerQuery}
-import org.neo4j.cypher.internal.v3_4.logical.plans.{Apply, LogicalPlan, SingleRow}
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.v3_4.logical.plans.{Apply, Argument, LogicalPlan}
 
 class LogicalPlanTest extends CypherFunSuite with LogicalPlanningTestSupport  {
   case class TestPlan()(val solved: PlannerQuery with CardinalityEstimation) extends LogicalPlan {
@@ -43,33 +43,33 @@ class LogicalPlanTest extends CypherFunSuite with LogicalPlanningTestSupport  {
   }
 
   test("single row returns itself as the leafs") {
-    val singleRow = SingleRow(Set(IdName("a")))(solved)()
+    val argument = Argument(Set(IdName("a")))(solved)()
 
-    singleRow.leaves should equal(Seq(singleRow))
+    argument.leaves should equal(Seq(argument))
   }
 
-  test("apply with two singlerows should return them both") {
-    val singleRow1 = SingleRow(Set(IdName("a")))(solved)()
-    val singleRow2 = SingleRow()(solved)()
-    val apply = Apply(singleRow1, singleRow2)(solved)
+  test("apply with two arguments should return them both") {
+    val argument1 = Argument(Set(IdName("a")))(solved)()
+    val argument2 = Argument()(solved)()
+    val apply = Apply(argument1, argument2)(solved)
 
-    apply.leaves should equal(Seq(singleRow1, singleRow2))
+    apply.leaves should equal(Seq(argument1, argument2))
   }
 
   test("apply pyramid should work multiple levels deep") {
-    val singleRow1 = SingleRow(Set(IdName("a")))(solved)()
-    val singleRow2 = SingleRow()(solved)()
-    val singleRow3 = SingleRow(Set(IdName("b")))(solved)()
-    val singleRow4 = SingleRow()(solved)()
-    val apply1 = Apply(singleRow1, singleRow2)(solved)
-    val apply2 = Apply(singleRow3, singleRow4)(solved)
+    val argument1 = Argument(Set(IdName("a")))(solved)()
+    val argument2 = Argument()(solved)()
+    val argument3 = Argument(Set(IdName("b")))(solved)()
+    val argument4 = Argument()(solved)()
+    val apply1 = Apply(argument1, argument2)(solved)
+    val apply2 = Apply(argument3, argument4)(solved)
     val metaApply = Apply(apply1, apply2)(solved)
 
-    metaApply.leaves should equal(Seq(singleRow1, singleRow2, singleRow3, singleRow4))
+    metaApply.leaves should equal(Seq(argument1, argument2, argument3, argument4))
   }
 
   test("calling updateSolved on argument should work") {
-    val argument = SingleRow(Set(IdName("a")))(solved)()
+    val argument = Argument(Set(IdName("a")))(solved)()
     val updatedPlannerQuery = CardinalityEstimation.lift(PlannerQuery.empty.amendQueryGraph(_.addPatternNodes(IdName("a"))), 0.0)
     val newPlan = argument.updateSolved(updatedPlannerQuery)
     newPlan.solved should equal(updatedPlannerQuery)

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/FuseSelectionsTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/FuseSelectionsTest.scala
@@ -21,15 +21,15 @@ package org.neo4j.cypher.internal.compiler.v3_4.planner.logical.plans.rewriter
 
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport
 import org.neo4j.cypher.internal.frontend.v3_4.ast.AstConstructionTestSupport
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.ir.v3_4.IdName
-import org.neo4j.cypher.internal.v3_4.logical.plans.{Selection, SingleRow}
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.v3_4.logical.plans.{Argument, Selection}
 
 class FuseSelectionsTest extends CypherFunSuite with LogicalPlanningTestSupport with AstConstructionTestSupport {
   test("merges two selections into one") {
     val p1 = propEquality("a", "foo", 12)
     val p2 = propEquality("a", "bar", 33)
-    val lhs = SingleRow(Set(IdName("a")))(solved)()
+    val lhs = Argument(Set(IdName("a")))(solved)()
 
     Selection(Seq(p1),
       Selection(Seq(p2), lhs)(solved))(solved).
@@ -42,7 +42,7 @@ class FuseSelectionsTest extends CypherFunSuite with LogicalPlanningTestSupport 
     val p1 = propEquality("a", "foo", 12)
     val p2 = propEquality("a", "bar", 33)
     val p3 = propEquality("a", "baz", 42)
-    val lhs = SingleRow(Set(IdName("a")))(solved)()
+    val lhs = Argument(Set(IdName("a")))(solved)()
 
     Selection(Seq(p1),
       Selection(Seq(p2),

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/PruningVarExpanderTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/PruningVarExpanderTest.scala
@@ -19,10 +19,10 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical.plans.rewriter
 
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport
 import org.neo4j.cypher.internal.frontend.v3_4.ast._
 import org.neo4j.cypher.internal.ir.v3_4.{IdName, VarPatternLength}
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.v3_4.expressions._
 import org.neo4j.cypher.internal.v3_4.logical.plans._
 
@@ -174,7 +174,7 @@ class PruningVarExpanderTest extends CypherFunSuite with LogicalPlanningTestSupp
     val length = VarPatternLength(1, Some(3))
 
     val allNodes = AllNodesScan(aId, Set.empty)(solved)
-    val argument = SingleRow(Set(aId))(solved)()
+    val argument = Argument(Set(aId))(solved)()
     val originalExpand = VarExpand(argument, aId, dir, dir, Seq(RelTypeName("R")(pos)), bId, relRId, length, ExpandAll, IdName("tempNode"), IdName("tempEdge"), TRUE, TRUE, Seq.empty)(solved)
     val optional1 = Optional(originalExpand, Set(aId))(solved)
     val apply1 = Apply(allNodes, optional1)(solved)
@@ -276,7 +276,7 @@ class PruningVarExpanderTest extends CypherFunSuite with LogicalPlanningTestSupp
   }
 
   test("should handle insanely long logical plans without running out of stack") {
-    val leafPlan: LogicalPlan = SingleRow(Set(IdName("x")))(solved)()
+    val leafPlan: LogicalPlan = Argument(Set(IdName("x")))(solved)()
     var plan = leafPlan
     (1 until 10000) foreach { i =>
       plan = Selection(Seq(True()(pos)), plan)(solved)

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/UnnestApplyTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/rewriter/UnnestApplyTest.scala
@@ -21,31 +21,31 @@ package org.neo4j.cypher.internal.compiler.v3_4.planner.logical.plans.rewriter
 
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport
 import org.neo4j.cypher.internal.frontend.v3_4.helpers.fixedPoint
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.ir.v3_4.{IdName, VarPatternLength}
-import org.neo4j.cypher.internal.v3_4.logical.plans._
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection
+import org.neo4j.cypher.internal.v3_4.logical.plans._
 
 class UnnestApplyTest extends CypherFunSuite with LogicalPlanningTestSupport {
-  test("should unnest apply with a single SingleRow on the lhs") {
+  test("should unnest apply with a single Argument on the lhs") {
     val rhs = newMockedLogicalPlan()
-    val singleRow = SingleRow()(solved)()
-    val input = Apply(singleRow, rhs)(solved)
+    val argument = Argument()(solved)()
+    val input = Apply(argument, rhs)(solved)
 
     rewrite(input) should equal(rhs)
   }
 
-  test("should unnest apply with a single SingleRow on the rhs") {
+  test("should unnest apply with a single Argument on the rhs") {
     val lhs = newMockedLogicalPlan()
-    val singleRow = SingleRow(Set.empty)(solved)()
-    val input = Apply(lhs, singleRow)(solved)
+    val argument = Argument(Set.empty)(solved)()
+    val input = Apply(lhs, argument)(solved)
 
     rewrite(input) should equal(lhs)
   }
 
   test("should unnest also when deeper in the structure") {
     val lhs = newMockedLogicalPlan()
-    val argument = SingleRow(Set.empty)(solved)()
+    val argument = Argument(Set.empty)(solved)()
     val apply = Apply(lhs, argument)(solved)
     val optional = Optional(apply)(solved)
 
@@ -58,7 +58,7 @@ class UnnestApplyTest extends CypherFunSuite with LogicalPlanningTestSupport {
          LHS  OuterJoin
               Arg   RHS
      */
-    val argPlan = SingleRow(Set(IdName("a")))(solved)()
+    val argPlan = Argument(Set(IdName("a")))(solved)()
     val lhs = newMockedLogicalPlan("a")
     val rhs = newMockedLogicalPlan("a")
 
@@ -76,7 +76,7 @@ class UnnestApplyTest extends CypherFunSuite with LogicalPlanningTestSupport {
   }
 
   test("should not cross OPTIONAL boundaries") {
-    val argPlan = SingleRow(Set(IdName("a")))(solved)()
+    val argPlan = Argument(Set(IdName("a")))(solved)()
     val lhs = newMockedLogicalPlan("a")
     val rhs = Selection(Seq(propEquality("a", "prop", 42)), argPlan)(solved)
     val optional = Optional(rhs)(solved)
@@ -96,8 +96,8 @@ class UnnestApplyTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
     // Given
     val lhs = newMockedLogicalPlan("a")
-    val arg1 = SingleRow(Set(IdName("a")))(solved)()
-    val arg2 = SingleRow(Set(IdName("a")))(solved)()
+    val arg1 = Argument(Set(IdName("a")))(solved)()
+    val arg2 = Argument(Set(IdName("a")))(solved)()
     val expand = Expand(arg2, IdName("a"), SemanticDirection.OUTGOING, Seq.empty, IdName("b"), IdName("r"), ExpandAll)(solved)
     val apply2 = Apply(arg1, expand)(solved)
     val apply = Apply(lhs, apply2)(solved)
@@ -175,7 +175,7 @@ class UnnestApplyTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
     // Given
     val lhs = newMockedLogicalPlan("a")
-    val arg = SingleRow(Set(IdName("a")))(solved)()
+    val arg = Argument(Set(IdName("a")))(solved)()
     val expand = VarExpand(arg, IdName("a"), SemanticDirection.OUTGOING, SemanticDirection.OUTGOING, Seq.empty, IdName("b"), IdName("r"), VarPatternLength(1, None), ExpandAll, IdName("tempNode"), IdName("tempEdge"), TRUE, TRUE, Seq.empty)(solved)
     val apply = Apply(lhs, expand)(solved)
 
@@ -197,8 +197,8 @@ class UnnestApplyTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
     // Given
     val lhs = newMockedLogicalPlan("a")
-    val arg1 = SingleRow(Set(IdName("a")))(solved)()
-    val arg2 = SingleRow(Set(IdName("a")))(solved)()
+    val arg1 = Argument(Set(IdName("a")))(solved)()
+    val arg2 = Argument(Set(IdName("a")))(solved)()
     val expand = Expand(arg2, IdName("a"), SemanticDirection.OUTGOING, Seq.empty, IdName("b"), IdName("r"), ExpandAll)(solved)
     val optional = Optional(expand)(solved)
     val apply2 = Apply(arg1, optional)(solved)
@@ -226,8 +226,8 @@ class UnnestApplyTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
     // Given
     val lhs = newMockedLogicalPlan("a")
-    val arg1 = SingleRow(Set(IdName("a")))(solved)()
-    val arg2 = SingleRow(Set(IdName("a")))(solved)()
+    val arg1 = Argument(Set(IdName("a")))(solved)()
+    val arg2 = Argument(Set(IdName("a")))(solved)()
     val expand = Expand(arg2, IdName("a"), SemanticDirection.OUTGOING, Seq.empty, IdName("b"), IdName("r"), ExpandAll)(solved)
     val optional = Optional(expand)(solved)
     val apply2 = Apply(arg1, optional)(solved)

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/SelectPatternPredicatesTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/SelectPatternPredicatesTest.scala
@@ -21,15 +21,14 @@ package org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps
 
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v3_4.planner._
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.Metrics.QueryGraphSolverInput
-import org.neo4j.cypher.internal.frontend.v3_4.ast._
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.SemanticTable
 import org.neo4j.cypher.internal.ir.v3_4._
 import org.neo4j.cypher.internal.util.v3_4.Cardinality
-import org.neo4j.cypher.internal.v3_4.logical.plans._
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.v3_4.expressions._
+import org.neo4j.cypher.internal.v3_4.logical.plans._
 
 class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTestSupport {
 
@@ -74,7 +73,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     )
 
     val aPlan = newMockedLogicalPlan("a")
-    val inner = Expand(SingleRow(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
+    val inner = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
 
     // When
     val result = selectPatternPredicates(aPlan, qg)
@@ -106,7 +105,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     )
 
     val aPlan = newMockedLogicalPlan("a")
-    val inner = Expand(SingleRow(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
+    val inner = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
 
     // When
     val result = selectPatternPredicates(aPlan, qg)
@@ -172,8 +171,8 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     )
 
     val aPlan = newMockedLogicalPlan("a")
-    val singleRow = SingleRow(Set(IdName("a")))(solved)()
-    val inner = Expand(singleRow, IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
+    val argument = Argument(Set(IdName("a")))(solved)()
+    val inner = Expand(argument, IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
 
     // When
     val result = selectPatternPredicates(aPlan, qg)
@@ -209,7 +208,7 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     )
 
     val aPlan = newMockedLogicalPlan("a")
-    val inner = Expand(SingleRow(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
+    val inner = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
 
     // When
     val result = selectPatternPredicates(aPlan, qg)
@@ -255,8 +254,8 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     )
 
     val aPlan = newMockedLogicalPlan("a")
-    val inner = Expand(SingleRow(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
-    val inner2 = Expand(SingleRow(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName("  UNNAMED4"), patternRel2.name, ExpandAll)(solved)
+    val inner = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
+    val inner2 = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName("  UNNAMED4"), patternRel2.name, ExpandAll)(solved)
 
     // When
     val result = selectPatternPredicates(aPlan, qg)
@@ -301,8 +300,8 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     )
 
     val aPlan = newMockedLogicalPlan("a")
-    val inner = Expand(SingleRow(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
-    val inner2 = Expand(SingleRow(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName("  UNNAMED4"), patternRel2.name, ExpandAll)(solved)
+    val inner = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
+    val inner2 = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName("  UNNAMED4"), patternRel2.name, ExpandAll)(solved)
 
     // When
     val result = selectPatternPredicates(aPlan, qg)
@@ -347,8 +346,8 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     )
 
     val aPlan = newMockedLogicalPlan("a")
-    val inner = Expand(SingleRow(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
-    val inner2 = Expand(SingleRow(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName("  UNNAMED4"), patternRel2.name, ExpandAll)(solved)
+    val inner = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
+    val inner2 = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName("  UNNAMED4"), patternRel2.name, ExpandAll)(solved)
 
     // When
     val result = selectPatternPredicates(aPlan, qg)
@@ -398,8 +397,8 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     )
 
     val aPlan = newMockedLogicalPlan("a")
-    val inner = Expand(SingleRow(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
-    val inner2 = Expand(SingleRow(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName("  UNNAMED4"), patternRel2.name, ExpandAll)(solved)
+    val inner = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
+    val inner2 = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName("  UNNAMED4"), patternRel2.name, ExpandAll)(solved)
 
     // When
     val result = selectPatternPredicates(aPlan, qg)
@@ -449,8 +448,8 @@ class SelectPatternPredicatesTest extends CypherFunSuite with LogicalPlanningTes
     )
 
     val aPlan = newMockedLogicalPlan("a")
-    val inner = Expand(SingleRow(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
-    val inner2 = Expand(SingleRow(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName("  UNNAMED4"), patternRel2.name, ExpandAll)(solved)
+    val inner = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName(nodeName), patternRel.name, ExpandAll)(solved)
+    val inner2 = Expand(Argument(Set(IdName("a")))(solved)(), IdName("a"), dir, types, IdName("  UNNAMED4"), patternRel2.name, ExpandAll)(solved)
 
     // When
     val result = selectPatternPredicates(aPlan, qg)

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/TriadicSelectionFinderTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/TriadicSelectionFinderTest.scala
@@ -19,14 +19,14 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.planner.logical.steps
 
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.QueryGraphProducer
 import org.neo4j.cypher.internal.ir.v3_4.{IdName, QueryGraph}
 import org.neo4j.cypher.internal.planner.v3_4.spi.PlanContext
-import org.neo4j.cypher.internal.v3_4.logical.plans._
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection.{INCOMING, OUTGOING}
 import org.neo4j.cypher.internal.v3_4.expressions._
+import org.neo4j.cypher.internal.v3_4.logical.plans._
 
 class TriadicSelectionFinderTest extends CypherFunSuite with LogicalPlanningTestSupport with QueryGraphProducer {
 
@@ -234,7 +234,7 @@ class TriadicSelectionFinderTest extends CypherFunSuite with LogicalPlanningTest
   private def produceTriadicTestPlan(expand1: Expand, predicateExpressionCase: Boolean = false,
                                      r1Types: Seq[String] = Seq.empty, r1Direction: SemanticDirection = OUTGOING, bLabels: Seq[String] = Seq.empty,
                                      r2Types: Seq[String] = Seq.empty, r2Direction: SemanticDirection = OUTGOING, cLabels: Seq[String] = Seq.empty) = {
-    val argument = SingleRow(expand1.availableSymbols)(solved)()
+    val argument = Argument(expand1.availableSymbols)(solved)()
     val expand2B = Expand(argument, IdName("b"), r2Direction, r2Types.map(RelTypeName(_)(pos)), IdName("c"), IdName("r2"), ExpandAll)(solved)
     val relationshipUniqueness = Not(Equals(Variable("r1")(pos), Variable("r2")(pos))(pos))(pos)
     val labelPredicates = cLabels.map(lbl => HasLabels(Variable("c")(pos), Seq(LabelName(lbl)(pos)))(pos))

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/CommunityPipeBuilder.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/CommunityPipeBuilder.scala
@@ -19,12 +19,10 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime
 
-import org.neo4j.cypher.internal.util.v3_4.{Eagerly, InternalException}
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan.builders.prepare.KeyTokenResolver
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.pipes.DropResultPipe
 import org.neo4j.cypher.internal.frontend.v3_4.phases.Monitors
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.SemanticTable
-import org.neo4j.cypher.internal.v3_4.expressions.{Equals => ASTEquals, Expression => ASTExpression, _}
 import org.neo4j.cypher.internal.ir.v3_4.{IdName, VarPatternLength}
 import org.neo4j.cypher.internal.planner.v3_4.spi.PlanContext
 import org.neo4j.cypher.internal.runtime.ProcedureCallMode
@@ -34,6 +32,8 @@ import org.neo4j.cypher.internal.runtime.interpreted.commands.convert.PatternCon
 import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.{AggregationExpression, Literal}
 import org.neo4j.cypher.internal.runtime.interpreted.commands.predicates.{Predicate, True}
 import org.neo4j.cypher.internal.runtime.interpreted.pipes._
+import org.neo4j.cypher.internal.util.v3_4.{Eagerly, InternalException}
+import org.neo4j.cypher.internal.v3_4.expressions.{Equals => ASTEquals, Expression => ASTExpression, _}
 import org.neo4j.cypher.internal.v3_4.logical.plans
 import org.neo4j.cypher.internal.v3_4.logical.plans.{ColumnOrder, Limit => LimitPlan, LoadCSV => LoadCSVPlan, Skip => SkipPlan, _}
 import org.neo4j.values.AnyValue
@@ -58,8 +58,8 @@ case class CommunityPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe
   def build(plan: LogicalPlan): Pipe = {
     val id = plan.assignedId
     plan match {
-      case SingleRow(_) =>
-        SingleRowPipe()(id)
+      case Argument(_) =>
+        ArgumentPipe()(id)
 
       case AllNodesScan(IdName(ident), _) =>
         AllNodesScanPipe(ident)(id = id)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/PipeExecutionPlanBuilderIT.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/PipeExecutionPlanBuilderIT.scala
@@ -22,24 +22,24 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime
 import java.time.Clock
 
 import org.mockito.Mockito.{atLeastOnce, verify, when}
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
-import org.neo4j.cypher.internal.runtime.interpreted.commands.convert.{CommunityExpressionConverter, ExpressionConverters}
-import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Literal
-import org.neo4j.cypher.internal.runtime.interpreted.commands.predicates.True
-import org.neo4j.cypher.internal.runtime.interpreted.commands.values.KeyToken.Resolved
-import org.neo4j.cypher.internal.runtime.interpreted.commands.values.TokenType
-import org.neo4j.cypher.internal.runtime.interpreted.commands.{expressions => legacy}
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan.PipeInfo
-import org.neo4j.cypher.internal.runtime.interpreted.pipes._
 import org.neo4j.cypher.internal.compiler.v3_4.planner._
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.Metrics
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.Metrics.QueryGraphSolverInput
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.SemanticTable
 import org.neo4j.cypher.internal.ir.v3_4._
 import org.neo4j.cypher.internal.planner.v3_4.spi.PlanContext
+import org.neo4j.cypher.internal.runtime.interpreted.commands.convert.{CommunityExpressionConverter, ExpressionConverters}
+import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Literal
+import org.neo4j.cypher.internal.runtime.interpreted.commands.predicates.True
+import org.neo4j.cypher.internal.runtime.interpreted.commands.values.KeyToken.Resolved
+import org.neo4j.cypher.internal.runtime.interpreted.commands.values.TokenType
+import org.neo4j.cypher.internal.runtime.interpreted.commands.{expressions => legacy}
+import org.neo4j.cypher.internal.runtime.interpreted.pipes._
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.util.v3_4.{Cardinality, RelTypeId}
-import org.neo4j.cypher.internal.v3_4.logical.plans._
 import org.neo4j.cypher.internal.v3_4.expressions._
+import org.neo4j.cypher.internal.v3_4.logical.plans._
 
 import scala.collection.mutable
 
@@ -64,12 +64,12 @@ class PipeExecutionPlanBuilderIT extends CypherFunSuite with LogicalPlanningTest
 
   test("projection only query") {
     val logicalPlan = Projection(
-      SingleRow()(solvedWithEstimation(1.0))(), Map("42" -> SignedDecimalIntegerLiteral("42")(pos)))_
+      Argument()(solvedWithEstimation(1.0))(), Map("42" -> SignedDecimalIntegerLiteral("42")(pos)))_
     val pipeInfo = build(logicalPlan)
 
     pipeInfo should not be 'updating
     pipeInfo.periodicCommit should equal(None)
-    pipeInfo.pipe should equal(ProjectionPipe(SingleRowPipe()(), Map("42" -> legacy.Literal(42)))())
+    pipeInfo.pipe should equal(ProjectionPipe(ArgumentPipe()(), Map("42" -> legacy.Literal(42)))())
   }
 
   test("simple pattern query") {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/CheckForLoadCsvAndMatchOnLargeLabelTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/CheckForLoadCsvAndMatchOnLargeLabelTest.scala
@@ -23,12 +23,12 @@ import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Literal
-import org.neo4j.cypher.internal.runtime.interpreted.pipes._
 import org.neo4j.cypher.internal.frontend.v3_4.notification.LargeLabelWithLoadCsvNotification
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.ir.v3_4.HasHeaders
 import org.neo4j.cypher.internal.planner.v3_4.spi.{GraphStatistics, PlanContext}
+import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Literal
+import org.neo4j.cypher.internal.runtime.interpreted.pipes._
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.util.v3_4.{Cardinality, LabelId}
 
 class CheckForLoadCsvAndMatchOnLargeLabelTest extends CypherFunSuite {
@@ -51,14 +51,14 @@ class CheckForLoadCsvAndMatchOnLargeLabelTest extends CypherFunSuite {
   private val checker = CheckForLoadCsvAndMatchOnLargeLabel(planContext, THRESHOLD)
 
   test("should notify when doing LoadCsv on top of large label scan") {
-    val loadCsvPipe = LoadCSVPipe(SingleRowPipe()(), HasHeaders, Literal("foo"), "bar", None, false)()
+    val loadCsvPipe = LoadCSVPipe(ArgumentPipe()(), HasHeaders, Literal("foo"), "bar", None, false)()
     val pipe = CartesianProductPipe(loadCsvPipe, NodeByLabelScanPipe("bar", LazyLabel(labelOverThreshold))())()
 
     checker(pipe) should equal(Some(LargeLabelWithLoadCsvNotification))
   }
 
   test("should not notify when doing LoadCsv on top of a small label scan") {
-    val loadCsvPipe = LoadCSVPipe(SingleRowPipe()(), HasHeaders, Literal("foo"), "bar", None, false)()
+    val loadCsvPipe = LoadCSVPipe(ArgumentPipe()(), HasHeaders, Literal("foo"), "bar", None, false)()
     val pipe = CartesianProductPipe(loadCsvPipe, NodeByLabelScanPipe("bar", LazyLabel(labelUnderThreshold))())()
 
     checker(pipe) should equal(None)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/ExecutionWorkflowBuilderTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/ExecutionWorkflowBuilderTest.scala
@@ -21,23 +21,22 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan
 
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.neo4j.cypher.internal.runtime.interpreted.pipes.Pipe
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.{EagerResultIterator, _}
-import org.neo4j.cypher.internal.compiler.v3_4._
 import org.neo4j.cypher.internal.frontend.v3_4.phases.devNullLogger
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.ir.v3_4.{CardinalityEstimation, PlannerQuery}
 import org.neo4j.cypher.internal.planner.v3_4.spi.IDPPlannerName
+import org.neo4j.cypher.internal.runtime.interpreted.pipes.Pipe
 import org.neo4j.cypher.internal.runtime.{ExplainMode, NormalMode, QueryContext, QueryTransactionalContext}
 import org.neo4j.cypher.internal.util.v3_4.Cardinality
-import org.neo4j.cypher.internal.v3_4.logical.plans.SingleRow
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.v3_4.logical.plans.Argument
 import org.neo4j.values.virtual.VirtualValues.EMPTY_MAP
 
 class ExecutionWorkflowBuilderTest extends CypherFunSuite {
   val PlannerName = IDPPlannerName
   val solved = CardinalityEstimation.lift(PlannerQuery.empty, Cardinality(1))
   val logicalPlan = {
-    val x = SingleRow()(solved)()
+    val x = Argument()(solved)()
     x.assignIds()
     x
   }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/Pipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/Pipe.scala
@@ -48,7 +48,7 @@ trait Pipe {
   def id: LogicalPlanId
 }
 
-case class SingleRowPipe()(val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends Pipe {
+case class ArgumentPipe()(val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends Pipe {
 
   def internalCreateResults(state: QueryState) =
     Iterator(state.createOrGetInitialContext())

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/planDescription/InternalPlanDescription.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/planDescription/InternalPlanDescription.scala
@@ -351,9 +351,9 @@ final case class CompactedPlanDescription(similar: Seq[InternalPlanDescription])
 
 }
 
-final case class SingleRowPlanDescription(id: LogicalPlanId,
-                                          arguments: Seq[Argument] = Seq.empty,
-                                          variables: Set[String])
+final case class ArgumentPlanDescription(id: LogicalPlanId,
+                                         arguments: Seq[Argument] = Seq.empty,
+                                         variables: Set[String])
   extends InternalPlanDescription {
 
   def children = NoChildren

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/planDescription/LogicalPlan2PlanDescription.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/planDescription/LogicalPlan2PlanDescription.scala
@@ -69,11 +69,11 @@ case class LogicalPlan2PlanDescription(readOnly: Boolean)
       case ProduceResult(_, _) =>
         PlanDescriptionImpl(id, "ProduceResults", NoChildren, Seq(), variables)
 
-      case _: SingleRow if variables.size > 0 =>
+      case _: plans.Argument if variables.nonEmpty =>
         PlanDescriptionImpl(id, "Argument", NoChildren, Seq.empty, variables)
 
-      case _: SingleRow =>
-        SingleRowPlanDescription(id, Seq.empty, variables)
+      case _: plans.Argument =>
+        ArgumentPlanDescription(id, Seq.empty, variables)
 
       case DirectedRelationshipByIdSeek(_, relIds, _, _, _) =>
         val entityByIdRhs = EntityByIdRhs(relIds)
@@ -121,7 +121,7 @@ case class LogicalPlan2PlanDescription(readOnly: Boolean)
 
     val id = plan.assignedId
     val variables = plan.availableSymbols.map(_.name)
-    val children = if (source.isInstanceOf[SingleRowPlanDescription]) NoChildren else SingleChild(source)
+    val children = if (source.isInstanceOf[ArgumentPlanDescription]) NoChildren else SingleChild(source)
 
     val result: InternalPlanDescription = plan match {
       case Aggregation(_, groupingExpressions, aggregationExpressions) if aggregationExpressions.isEmpty =>
@@ -329,8 +329,8 @@ case class LogicalPlan2PlanDescription(readOnly: Boolean)
       case LetSelectOrSemiApply(_, _, _, predicate) =>
         PlanDescriptionImpl(id, "LetSelectOrSemiApply", children, Seq(Expression(predicate)), variables)
 
-      case row: SingleRow =>
-        SingleRowPlanDescription(id = plan.assignedId, Seq.empty, row.argumentIds.map(_.name))
+      case row: plans.Argument =>
+        ArgumentPlanDescription(id = plan.assignedId, Seq.empty, row.argumentIds.map(_.name))
 
       case LetSelectOrAntiSemiApply(_, _, _, predicate) =>
         PlanDescriptionImpl(id, "LetSelectOrSemiApply", children, Seq(Expression(predicate)), variables)

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/planDescription/PlanDescriptionArgumentSerializerTests.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/planDescription/PlanDescriptionArgumentSerializerTests.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.util.v3_4.symbols.{CTBoolean, CTList, CTNode, C
 import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.util.v3_4.{Cardinality, DummyPosition}
 import org.neo4j.cypher.internal.v3_4.expressions.{DummyExpression, SemanticDirection, SignedDecimalIntegerLiteral}
-import org.neo4j.cypher.internal.v3_4.logical.plans.{LogicalPlan, NestedPlanExpression, SingleRow}
+import org.neo4j.cypher.internal.v3_4.logical.plans.{Argument, LogicalPlan, NestedPlanExpression}
 
 class PlanDescriptionArgumentSerializerTests extends CypherFunSuite {
   val solved = CardinalityEstimation.lift(PlannerQuery.empty, Cardinality(1))
@@ -52,12 +52,12 @@ class PlanDescriptionArgumentSerializerTests extends CypherFunSuite {
   }
 
   test("serialize nested plan expression") {
-    val argument: LogicalPlan = SingleRow(Set.empty)(solved)(Map.empty)
+    val argument: LogicalPlan = Argument(Set.empty)(solved)(Map.empty)
     val expression = DummyExpression(CTList(CTNode) | CTBoolean | CTList(CTString), DummyPosition(5))
 
     val nested = NestedPlanExpression(argument, expression)(pos)
 
-    serialize(Expression(nested)) should equal("NestedPlanExpression(SingleRow)")
+    serialize(Expression(nested)) should equal("NestedPlanExpression(Argument)")
   }
 
   test("projection should show multiple expressions") {

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/planDescription/RenderTreeTableTest.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/internal/runtime/planDescription/RenderTreeTableTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.runtime.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.util.v3_4.test_helpers.{CypherFunSuite, WindowsStringSafe}
 import org.neo4j.cypher.internal.util.v3_4.{Cardinality, DummyPosition}
 import org.neo4j.cypher.internal.v3_4.expressions.{Expression => ASTExpression, LabelName => ASTLabelName, Range => ASTRange, _}
-import org.neo4j.cypher.internal.v3_4.logical.plans.{Expand, ExpandAll, LogicalPlanId, SingleRow}
+import org.neo4j.cypher.internal.v3_4.logical.plans.{Argument, Expand, ExpandAll, LogicalPlanId}
 import org.scalatest.BeforeAndAfterAll
 
 class RenderTreeTableTest extends CypherFunSuite with BeforeAndAfterAll {
@@ -217,7 +217,7 @@ class RenderTreeTableTest extends CypherFunSuite with BeforeAndAfterAll {
   }
 
   val solved = CardinalityEstimation.lift(PlannerQuery.empty, Cardinality(1))
-  val singleRow = SingleRow()(solved)()
+  val argument = Argument()(solved)()
 
   test("single node is represented nicely") {
     val arguments = Seq(
@@ -321,7 +321,7 @@ class RenderTreeTableTest extends CypherFunSuite with BeforeAndAfterAll {
   }
 
   test("Expand contains information about its relations") {
-    val expandPlan = Expand(singleRow, IdName("from"), SemanticDirection.INCOMING, Seq.empty, IdName("to"), IdName("rel"), ExpandAll)(solved)
+    val expandPlan = Expand(argument, IdName("from"), SemanticDirection.INCOMING, Seq.empty, IdName("to"), IdName("rel"), ExpandAll)(solved)
     expandPlan.assignIds()
     val description = LogicalPlan2PlanDescription(true)
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExplainAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExplainAcceptanceTest.scala
@@ -72,6 +72,6 @@ class ExplainAcceptanceTest extends ExecutionEngineFunSuite with CypherCompariso
     val plan = result.executionPlanDescription().toString
     result.close()
 
-    plan.toString should include("NestedPlanExpression(VarExpand-SingleRow)")
+    plan.toString should include("NestedPlanExpression(VarExpand-Argument)")
   }
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/LogicalPlanConverter.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/LogicalPlanConverter.scala
@@ -19,7 +19,6 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.codegen
 
-import org.neo4j.cypher.internal.util.v3_4.{InternalException, One, ZeroOneOrMany, symbols}
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.codegen.ir._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.codegen.ir.aggregation.AggregationConverter.aggregateExpressionConverter
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.codegen.ir.aggregation.Distinct
@@ -27,19 +26,19 @@ import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.codegen.ir.
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.codegen.ir.expressions._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.codegen.spi.SortItem
 import org.neo4j.cypher.internal.compiler.v3_4.planner.CantCompileQueryException
-import org.neo4j.cypher.internal.util.v3_4.Foldable._
-import org.neo4j.cypher.internal.v3_4.expressions.{Expression, FunctionInvocation}
-import org.neo4j.cypher.internal.v3_4.{functions => ast_functions}
-import org.neo4j.cypher.internal.util.v3_4.Eagerly.immutableMapValues
-import org.neo4j.cypher.internal.v3_4.{expressions => ast}
 import org.neo4j.cypher.internal.ir.v3_4.IdName
+import org.neo4j.cypher.internal.util.v3_4.Eagerly.immutableMapValues
+import org.neo4j.cypher.internal.util.v3_4.Foldable._
+import org.neo4j.cypher.internal.util.v3_4.{InternalException, One, ZeroOneOrMany, symbols}
+import org.neo4j.cypher.internal.v3_4.expressions.{Expression, FunctionInvocation}
 import org.neo4j.cypher.internal.v3_4.logical.plans
 import org.neo4j.cypher.internal.v3_4.logical.plans.ColumnOrder
+import org.neo4j.cypher.internal.v3_4.{expressions => ast, functions => ast_functions}
 
 object LogicalPlanConverter {
 
   def asCodeGenPlan(logicalPlan: plans.LogicalPlan): CodeGenPlan = logicalPlan match {
-    case p: plans.SingleRow => singleRowAsCodeGenPlan(p)
+    case p: plans.Argument => argumentAsCodeGenPlan(p)
     case p: plans.AllNodesScan => allNodesScanAsCodeGenPlan(p)
     case p: plans.NodeByLabelScan => nodeByLabelScanAsCodeGenPlan(p)
     case p: plans.NodeIndexSeek => nodeIndexSeekAsCodeGenPlan(p)
@@ -70,13 +69,13 @@ object LogicalPlanConverter {
       throw new CantCompileQueryException(s"This logicalPlan is not yet supported: $logicalPlan")
   }
 
-  private def singleRowAsCodeGenPlan(singleRow: plans.SingleRow) = new CodeGenPlan with LeafCodeGenPlan {
+  private def argumentAsCodeGenPlan(argument: plans.Argument) = new CodeGenPlan with LeafCodeGenPlan {
     override def produce(context: CodeGenContext): (Option[JoinTableMethod], List[Instruction]) = {
       val (methodHandle, actions) = context.popParent().consume(context, this)
       (methodHandle, actions)
     }
 
-    override val logicalPlan: plans.LogicalPlan = singleRow
+    override val logicalPlan: plans.LogicalPlan = argument
   }
 
   private def aggregationNotSupported(p: plans.Aggregation) = {

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/BuildCompiledExecutionPlanTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/BuildCompiledExecutionPlanTest.scala
@@ -22,15 +22,15 @@ package org.neo4j.cypher.internal.compiled_runtime.v3_4
 import org.neo4j.cypher.internal.compatibility.v3_4.WrappedMonitors
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.BuildCompiledExecutionPlan
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan.NewRuntimeSuccessRateMonitor
+import org.neo4j.cypher.internal.compiler.v3_4.NotImplementedPlanContext
 import org.neo4j.cypher.internal.compiler.v3_4.phases.LogicalPlanState
 import org.neo4j.cypher.internal.compiler.v3_4.planner.{CantCompileQueryException, HardcodedGraphStatistics}
-import org.neo4j.cypher.internal.compiler.v3_4.NotImplementedPlanContext
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.SemanticTable
 import org.neo4j.cypher.internal.ir.v3_4.{CardinalityEstimation, QueryGraph, RegularPlannerQuery}
 import org.neo4j.cypher.internal.planner.v3_4.spi.{CostBasedPlannerName, GraphStatistics}
 import org.neo4j.cypher.internal.spi.v3_4.codegen.GeneratedQueryStructure
-import org.neo4j.cypher.internal.v3_4.logical.plans.{LogicalPlan, ProduceResult, SingleRow}
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.v3_4.logical.plans.{Argument, LogicalPlan, ProduceResult}
 import org.neo4j.kernel.monitoring.Monitors
 
 class BuildCompiledExecutionPlanTest extends CypherFunSuite {
@@ -44,7 +44,7 @@ class BuildCompiledExecutionPlanTest extends CypherFunSuite {
     monitors.addMonitorListener(monitor)
 
     // When
-    process(monitors, ProduceResult(SingleRow()(solved)(), Seq.empty))
+    process(monitors, ProduceResult(Argument()(solved)(), Seq.empty))
 
     // Then
     monitor.successfullyPlanned should equal(true)
@@ -56,7 +56,7 @@ class BuildCompiledExecutionPlanTest extends CypherFunSuite {
     val monitor = new SpyingMonitor
     monitors.addMonitorListener(monitor)
 
-    process(monitors, SingleRow()(solved)())
+    process(monitors, Argument()(solved)())
 
     // Then
     monitor.failedToPlan should equal(true)

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
@@ -119,7 +119,7 @@ object SlotAllocation {
         pipeline.newLong(leaf.idName.name, nullable, CTNode)
         pipeline
 
-      case _:SingleRow =>
+      case _:Argument =>
         argument.getOrElse(PipelineInformation.empty)
 
       case p => throw new SlotAllocationFailed(s"Don't know how to handle $p")

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriterTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriterTest.scala
@@ -68,7 +68,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val node3 = IdName("c")
     val rel1 = IdName("r1")
     val rel2 = IdName("r2")
-    val argument = SingleRow(Set(node1, node2, node3, rel1, rel2))(solved)()
+    val argument = Argument(Set(node1, node2, node3, rel1, rel2))(solved)()
     val predicate = Not(Equals(varFor("r1"), varFor("r2"))(pos))(pos)
     val selection = Selection(Seq(predicate), argument)(solved)
     selection.assignIds()
@@ -154,7 +154,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val node1 = IdName("a")
     val node2 = IdName("b")
     val edge = IdName("r")
-    val argument = SingleRow(Set(node1, node2, edge))(solved)()
+    val argument = Argument(Set(node1, node2, edge))(solved)()
     val predicate = Equals(prop("r", "prop"), literalInt(42))(pos)
     val selection = Selection(Seq(predicate), argument)(solved)
     selection.assignIds()
@@ -261,9 +261,9 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     )
   }
 
-  test("singlerow on two sides of Apply") {
-    val sr1 = SingleRow()(solved)()
-    val sr2 = SingleRow()(solved)()
+  test("argument on two sides of Apply") {
+    val sr1 = Argument()(solved)()
+    val sr2 = Argument()(solved)()
     val pr1A = Projection(sr1, Map("x" -> literalInt(42)))(solved)
     val pr1B = Projection(pr1A, Map("xx" -> varFor("x")))(solved)
     val pr2 = Projection(sr2, Map("y" -> literalInt(666)))(solved)

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilder.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilder.scala
@@ -80,8 +80,8 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
       case NodeByLabelScan(IdName(column), label, _) =>
         NodesByLabelScanSlottedPipe(column, LazyLabel(label), pipelineInformation)(id)
 
-      case _:SingleRow =>
-        SingleRowSlottedPipe(pipelineInformation)(id)
+      case _:Argument =>
+        ArgumentSlottedPipe(pipelineInformation)(id)
 
       case _ =>
         throw new CantCompileQueryException(s"Unsupported logical plan operator: $plan")

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ArgumentSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ArgumentSlottedPipe.scala
@@ -24,9 +24,9 @@ import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExe
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.{Pipe, QueryState}
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 
-case class SingleRowSlottedPipe(pipelineInformation: PipelineInformation)(val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends Pipe {
+case class ArgumentSlottedPipe(pipelineInformation: PipelineInformation)(val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends Pipe {
 
-  def internalCreateResults(state: QueryState) = {
+  def internalCreateResults(state: QueryState): Iterator[PrimitiveExecutionContext] = {
     val context = PrimitiveExecutionContext(pipelineInformation)
     state.copyArgumentStateTo(context,
       pipelineInformation.initialNumberOfLongs, pipelineInformation.initialNumberOfReferences)


### PR DESCRIPTION
We have recently changed the code so we don't have both Argument and
SingleRow. The code and what the user was seeing was not aligned. This
commit changes the class names and variables used in the code to reflect
what plan descriptions will show users.