### PR TITLE
Remove cancelAndAwait method from RobustJobSchedulerWrapper

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClient.java
@@ -106,8 +106,8 @@ class HazelcastClient extends LifecycleAdapter implements TopologyService
     @Override
     public void stop() throws Throwable
     {
-        scheduler.cancelAndWaitTermination( keepAliveJob );
-        scheduler.cancelAndWaitTermination( refreshTopologyJob );
+        keepAliveJob.cancel( true );
+        refreshTopologyJob.cancel( true );
         disconnectFromCore();
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
@@ -122,7 +122,7 @@ class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopol
         log.info( String.format( "HazelcastCoreTopologyService stopping and unbinding from %s",
                 config.get( discovery_listen_address ) ) );
 
-        scheduler.cancelAndWaitTermination( refreshJob );
+        refreshJob.cancel( true );
 
         try
         {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/RobustJobSchedulerWrapper.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/RobustJobSchedulerWrapper.java
@@ -77,32 +77,4 @@ public class RobustJobSchedulerWrapper
             throw t;
         }
     }
-
-    /**
-     * Note that because of the cancellation, the effects of the job
-     * are not necessarily visible after this call, which is different
-     * from a pure waitForTermination call.
-     *
-     * @param job The job to terminate.
-     */
-    public void cancelAndWaitTermination( JobScheduler.JobHandle job )
-    {
-        try
-        {
-            job.cancel( true );
-
-            try
-            {
-                job.waitTermination();
-            }
-            catch ( CancellationException e )
-            {
-                // expected sometimes because of cancellation above
-            }
-        }
-        catch ( Throwable e )
-        {
-            log.warn( "Termination experienced exception", e );
-        }
-    }
 }


### PR DESCRIPTION
This method practiced an illegal usage of future and caused flaky test result.
Calling .get() after .cancel() will throw a CancallationException and is not a
valid sequence of method calls.