### PR TITLE
3.4 disable double[] and float[] bit-compaction

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicArrayStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicArrayStore.java
@@ -93,7 +93,7 @@ public class DynamicArrayStore extends AbstractDynamicStore
         }
     }
 
-    private static byte[] createBitCompactedArray(ShortArray type, Object array )
+    private static byte[] createBitCompactedArray( ShortArray type, Object array )
     {
         Class<?> componentType = array.getClass().getComponentType();
         boolean isPrimitiveByteArray = componentType.equals( Byte.TYPE );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicArrayStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicArrayStore.java
@@ -112,6 +112,15 @@ public class DynamicArrayStore extends AbstractDynamicStore
                 }
             }
         }
+        else if ( type == ShortArray.DOUBLE )
+        {
+            // Skip array compaction for floating point numbers where compaction makes very little difference
+            bytes = new byte[NUMBER_HEADER_SIZE + 8 * arrayLength];
+            bytes[0] = (byte) type.intValue();
+            bytes[1] = (byte) 8;
+            bytes[2] = (byte) 64;
+            ShortArray.DOUBLE.writeAll( array, bytes, NUMBER_HEADER_SIZE );
+        }
         else
         {
             Bits bits = Bits.bits( numberOfBytes );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicArrayStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/DynamicArrayStore.java
@@ -76,61 +76,83 @@ public class DynamicArrayStore extends AbstractDynamicStore
     public static void allocateFromNumbers( Collection<DynamicRecord> target, Object array,
             DynamicRecordAllocator recordAllocator )
     {
-        Class<?> componentType = array.getClass().getComponentType();
-        boolean isPrimitiveByteArray = componentType.equals( Byte.TYPE );
-        boolean isByteArray = componentType.equals( Byte.class ) || isPrimitiveByteArray;
         ShortArray type = ShortArray.typeOf( array );
         if ( type == null )
         {
             throw new IllegalArgumentException( array + " not a valid array type." );
         }
 
-        int arrayLength = Array.getLength( array );
-        int requiredBits = isByteArray ? Byte.SIZE : type.calculateRequiredBitsForArray( array, arrayLength );
-        int totalBits = requiredBits * arrayLength;
-        int numberOfBytes = (totalBits - 1) / 8 + 1;
-        int bitsUsedInLastByte = totalBits % 8;
-        bitsUsedInLastByte = bitsUsedInLastByte == 0 ? 8 : bitsUsedInLastByte;
-        numberOfBytes += NUMBER_HEADER_SIZE; // type + rest + requiredBits header. TODO no need to use full bytes
-        byte[] bytes;
-        if ( isByteArray )
-        {
-            bytes = new byte[NUMBER_HEADER_SIZE + arrayLength];
-            bytes[0] = (byte) type.intValue();
-            bytes[1] = (byte) bitsUsedInLastByte;
-            bytes[2] = (byte) requiredBits;
-            if ( isPrimitiveByteArray )
-            {
-                arraycopy( array, 0, bytes, NUMBER_HEADER_SIZE, arrayLength );
-            }
-            else
-            {
-                Byte[] source = (Byte[]) array;
-                for ( int i = 0; i < source.length; i++ )
-                {
-                    bytes[NUMBER_HEADER_SIZE + i] = source[i];
-                }
-            }
-        }
-        else if ( type == ShortArray.DOUBLE )
+        if ( type == ShortArray.DOUBLE || type == ShortArray.FLOAT )
         {
             // Skip array compaction for floating point numbers where compaction makes very little difference
-            bytes = new byte[NUMBER_HEADER_SIZE + 8 * arrayLength];
-            bytes[0] = (byte) type.intValue();
-            bytes[1] = (byte) 8;
-            bytes[2] = (byte) 64;
-            ShortArray.DOUBLE.writeAll( array, bytes, NUMBER_HEADER_SIZE );
+            allocateRecordsFromBytes( target, createUncompactedArray( type, array ), recordAllocator );
         }
         else
         {
+            allocateRecordsFromBytes( target, createBitCompactedArray( type, array ), recordAllocator );
+        }
+    }
+
+    private static byte[] createBitCompactedArray(ShortArray type, Object array )
+    {
+        Class<?> componentType = array.getClass().getComponentType();
+        boolean isPrimitiveByteArray = componentType.equals( Byte.TYPE );
+        boolean isByteArray = componentType.equals( Byte.class ) || isPrimitiveByteArray;
+        int arrayLength = Array.getLength( array );
+        int requiredBits = isByteArray ? Byte.SIZE : type.calculateRequiredBitsForArray( array, arrayLength );
+        int totalBits = requiredBits * arrayLength;
+        int bitsUsedInLastByte = totalBits % 8;
+        bitsUsedInLastByte = bitsUsedInLastByte == 0 ? 8 : bitsUsedInLastByte;
+        if ( isByteArray )
+        {
+            return createBitCompactedByteArray( type, isPrimitiveByteArray, array, bitsUsedInLastByte, requiredBits );
+        }
+        else
+        {
+            int numberOfBytes = (totalBits - 1) / 8 + 1;
+            numberOfBytes += NUMBER_HEADER_SIZE; // type + rest + requiredBits header. TODO no need to use full bytes
             Bits bits = Bits.bits( numberOfBytes );
             bits.put( (byte) type.intValue() );
             bits.put( (byte) bitsUsedInLastByte );
             bits.put( (byte) requiredBits );
             type.writeAll( array, arrayLength, requiredBits, bits );
-            bytes = bits.asBytes();
+            return bits.asBytes();
         }
-        allocateRecordsFromBytes( target, bytes, recordAllocator );
+    }
+
+    private static byte[] createBitCompactedByteArray( ShortArray type, boolean isPrimitiveByteArray, Object array,
+            int bitsUsedInLastByte, int requiredBits )
+    {
+        int arrayLength = Array.getLength( array );
+        byte[] bytes = new byte[NUMBER_HEADER_SIZE + arrayLength];
+        bytes[0] = (byte) type.intValue();
+        bytes[1] = (byte) bitsUsedInLastByte;
+        bytes[2] = (byte) requiredBits;
+        if ( isPrimitiveByteArray )
+        {
+            arraycopy( array, 0, bytes, NUMBER_HEADER_SIZE, arrayLength );
+        }
+        else
+        {
+            Byte[] source = (Byte[]) array;
+            for ( int i = 0; i < source.length; i++ )
+            {
+                bytes[NUMBER_HEADER_SIZE + i] = source[i];
+            }
+        }
+        return bytes;
+    }
+
+    private static byte[] createUncompactedArray( ShortArray type, Object array )
+    {
+        int arrayLength = Array.getLength( array );
+        int bytesPerElement = type.maxBits / 8;
+        byte[] bytes = new byte[NUMBER_HEADER_SIZE + bytesPerElement * arrayLength];
+        bytes[0] = (byte) type.intValue();
+        bytes[1] = (byte) 8;
+        bytes[2] = (byte) type.maxBits;
+        type.writeAll( array, bytes, NUMBER_HEADER_SIZE );
+        return bytes;
     }
 
     private static void allocateFromString( Collection<DynamicRecord> target, String[] array,

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/ShortArray.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/ShortArray.java
@@ -579,6 +579,35 @@ public enum ShortArray
             }
         }
 
+        public void writeAll( Object array, byte[] result, int offset )
+        {
+            if ( isPrimitive( array ) )
+            {
+                double[] values = (double[]) array;
+                for ( int i = 0; i < values.length; i++ )
+                {
+                    writeDouble( values[i], result, offset + i * 8 );
+                }
+            }
+            else
+            {
+                Double[] values = (Double[]) array;
+                for ( int i = 0; i < values.length; i++ )
+                {
+                    writeDouble( values[i], result, offset + i * 8 );
+                }
+            }
+        }
+
+        private void writeDouble( double doubleValue, byte[] result, int offset )
+        {
+            long value = Double.doubleToLongBits( doubleValue );
+            for ( int b = 0; b < 8; b++ )
+            {
+                result[offset + b] = (byte) ((value >> (b * 8)) & 0xFFL);
+            }
+        }
+
         @Override
         public ArrayValue createArray( int length, Bits bits, int requiredBits )
         {
@@ -786,6 +815,11 @@ public enum ShortArray
     }
 
     public abstract void writeAll( Object array, int length, int requiredBits, Bits result );
+
+    public void writeAll( Object array, byte[] result, int offset )
+    {
+        throw new IllegalStateException( "Types that skip bit compaction should implement this method" );
+    }
 
     public abstract ArrayValue createEmptyArray();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/ShortArray.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/ShortArray.java
@@ -550,37 +550,13 @@ public enum ShortArray
     {
         int getRequiredBits( double value )
         {
-            long v = Double.doubleToLongBits( value );
-            long mask = 1L << maxBits - 1;
-            for ( int i = maxBits; i > 0; i--, mask >>= 1 )
-            {
-                if ( (mask & v) != 0 )
-                {
-                    return i;
-                }
-            }
-            return 1;
+            return 64;
         }
 
         @Override
         int getRequiredBits( Object array, int arrayLength )
         {
-            int highest = 1;
-            if ( isPrimitive( array ) )
-            {
-                for ( double value : (double[]) array )
-                {
-                    highest = Math.max( getRequiredBits( value ), highest );
-                }
-            }
-            else
-            {
-                for ( double value : (Double[]) array )
-                {
-                    highest = Math.max( getRequiredBits( value ), highest );
-                }
-            }
-            return highest;
+            return 64;
         }
 
         @Override


### PR DESCRIPTION
The DynamicArrayStore bit-compacts all arrays by trimming leading 0's, down to the size of the least trimmable element in the array. However, in the case of double[] and float[] this is a lot of work for very little gain (often double trims from 64 bits to only 63 or 62). This change causes the DynamicArrayStore to skip bit-compaction entirely for double[] and float[], and instead byte align the values, which should be faster.

We have done benchmarks for adding properties using the jmh-benchmarks and see some performance improvements.