### PR TITLE
Do not use primitive equals on refs

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcAcceptanceTest.scala
@@ -22,6 +22,7 @@ package org.neo4j.internal.cypher.acceptance
 import org.neo4j.cypher.ExecutionEngineFunSuite
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.planDescription.InternalPlanDescription.Arguments.EstimatedRows
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
 
 /**
   * Runs the 14 LDBC queries and checks so that the result is what is expected.
@@ -70,6 +71,34 @@ class LdbcAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSu
     // no precision loss resulting in insane numbers
     all(collectEstimations(result.executionPlanDescription())) should be > 0.0
     all(collectEstimations(result.executionPlanDescription())) should be < 10.0
+  }
+
+  test("This LDBC query should work") {
+    // given
+    val ldbcQuery = """MATCH (knownTag:Tag {name:{2}})
+                      |MATCH (person:Person {id:{1}})-[:KNOWS*1..2]-(friend)
+                      |WHERE NOT person=friend
+                      |WITH DISTINCT friend, knownTag
+                      |MATCH (friend)<-[:POST_HAS_CREATOR]-(post)
+                      |WHERE (post)-[:POST_HAS_TAG]->(knownTag)
+                      |WITH post, knownTag
+                      |MATCH (post)-[:POST_HAS_TAG]->(commonTag)
+                      |WHERE NOT commonTag=knownTag
+                      |WITH commonTag, count(post) AS postCount
+                      |RETURN commonTag.name AS tagName, postCount
+                      |ORDER BY postCount DESC, tagName ASC
+                      |LIMIT {3}""".stripMargin
+    eengine.execute(LdbcQueries.Query4.createQuery, LdbcQueries.Query4.createParams)
+
+
+    val params: Map[String, Any] = Map("1" -> 1, "2" ->  "tag1-ᚠさ丵פش", "3" -> 10)
+
+    val result =
+    // when
+      executeWith(Configs.CommunityInterpreted, ldbcQuery, params = params)
+
+    // then
+    result should not be empty
   }
 
   private def collectEstimations(plan: InternalPlanDescription): Seq[Double] = {

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/SlottedRewriter.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/SlottedRewriter.scala
@@ -146,8 +146,7 @@ class SlottedRewriter(tokenContext: TokenContext) {
       case e@Equals(Variable(k1), Variable(k2)) => // TODO: Handle nullability
         val slot1 = pipelineInformation(k1)
         val slot2 = pipelineInformation(k2)
-        if (slot1.typ == slot2.typ && PipelineInformation.isLongSlot(slot1)) {
-          assert(PipelineInformation.isLongSlot(slot2))
+        if (slot1.typ == slot2.typ && PipelineInformation.isLongSlot(slot1) && PipelineInformation.isLongSlot(slot2)) {
           PrimitiveEquals(IdFromSlot(slot1.offset), IdFromSlot(slot2.offset))
         }
         else


### PR DESCRIPTION
In some case we end up with an `Equals` where one of the variables is
a longslot and one is a projected refslot. Comparing these using
`PrimitiveEquals` will not work, and what actually happened is that we
failed on a scala assert before doing the actual comparison.

changelog: Fixed an error in slotted runtime where a runtime failure happened when a reference node was being compared to a primitive node