### PR TITLE
Deprecate the Service.Implementation annotation

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/helpers/Service.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Service.java
@@ -131,11 +131,14 @@ public abstract class Service
      * the implementation class to the services listings file. But it serves as
      * a handle for an Annotation Processing Tool to utilize for performing that
      * task.
+     * <p>
+     * This annotation is deprecated and will be removed in a future release.
      *
      * @author Tobias Ivarsson
      */
     @Target( ElementType.TYPE )
     @Retention( RetentionPolicy.SOURCE )
+    @Deprecated
     public @interface Implementation
     {
         /**


### PR DESCRIPTION
We used to have an annotation processor that would find these annotated classes and write META-INF/services files for us.
Due to problems with getting that to work with our day-to-day development tools, the annotation processor was removed.
However, this annotation remained.
Unfortunately, it is public API, so we cannot just remove it. Hence it has been deprecated.