### PR TITLE
Fix bugs in neo4j-shell CALL and trav commands

### DIFF
--- a/community/shell/src/main/resources/META-INF/services/org.neo4j.shell.App
+++ b/community/shell/src/main/resources/META-INF/services/org.neo4j.shell.App
@@ -6,6 +6,7 @@ org.neo4j.shell.apps.Man
 org.neo4j.shell.kernel.apps.Begin
 org.neo4j.shell.kernel.apps.Cd
 org.neo4j.shell.kernel.apps.Commit
+org.neo4j.shell.kernel.apps.cypher.Call
 org.neo4j.shell.kernel.apps.cypher.Create
 org.neo4j.shell.kernel.apps.cypher.Cypher
 org.neo4j.shell.kernel.apps.cypher.Drop

--- a/community/shell/src/test/java/org/neo4j/shell/AppsIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/AppsIT.java
@@ -1234,6 +1234,76 @@ public class AppsIT extends AbstractShellIT
     }
 
     @Test
+    public void travMustListAllPathsWithinDistance() throws Exception
+    {
+        long me;
+        RelationshipType type;
+        long firstOut;
+        long firstOutOut;
+        long secondOut;
+        long secondOutOut;
+        try ( Transaction tx = db.beginTx() )
+        {
+            Relationship[] firstChain = createRelationshipChain( 2 );
+            Node startNode = firstChain[0].getStartNode();
+            type = firstChain[0].getType();
+            Relationship[] secondChain = createRelationshipChain( startNode, type, 3 );
+            me = startNode.getId();
+            firstOut = firstChain[0].getEndNodeId();
+            firstOutOut = firstChain[1].getEndNodeId();
+            secondOut = secondChain[0].getEndNodeId();
+            secondOutOut = secondChain[1].getEndNodeId();
+            tx.success();
+        }
+        String pb = "\\(";
+        String pe = "\\)";
+        String rel = pe + "-\\[:" + type + "\\]->" + pb;
+        executeCommand( "cd " + me );
+        executeCommand( "trav -d 2",
+                pb + "me" + pe,
+                pb + "me" + rel + firstOut + pe,
+                pb + "me" + rel + firstOut + rel + firstOutOut + pe,
+                pb + "me" + rel + secondOut + pe,
+                pb + "me" + rel + secondOut + rel + secondOutOut + pe );
+    }
+
+    @Test
+    public void travMustRunCommandForAllPaths() throws Exception
+    {
+        long me;
+        RelationshipType type;
+        long firstOut;
+        long firstOutOut;
+        long secondOut;
+        long secondOutOut;
+        long secondOutOutOut;
+        try ( Transaction tx = db.beginTx() )
+        {
+            Relationship[] firstChain = createRelationshipChain( 2 );
+            Node startNode = firstChain[0].getStartNode();
+            type = firstChain[0].getType();
+            Relationship[] secondChain = createRelationshipChain( startNode, type, 3 );
+            me = startNode.getId();
+            firstOut = firstChain[0].getEndNodeId();
+            firstOutOut = firstChain[1].getEndNodeId();
+            secondOut = secondChain[0].getEndNodeId();
+            secondOutOut = secondChain[1].getEndNodeId();
+            secondOutOutOut = secondChain[2].getEndNodeId();
+            tx.success();
+        }
+        String pb = "\\(";
+        String pe = "\\)";
+        String rel = pe + "-\\[:" + type + "\\]->" + pb;
+        executeCommand( "cd " + me );
+        executeCommand( "trav -d 2 -c \"ls $i\" ",
+                pb + "me" + rel + firstOut + pe,
+                pb + firstOut + rel + firstOutOut + pe,
+                pb + "me" + rel + secondOut + pe,
+                pb + secondOut + rel + secondOutOut + pe,
+                pb + secondOutOut + rel + secondOutOutOut + pe );
+    }
+
+    @Test
     public void shouldSupportUsingPeriodicCommitInSession() throws Exception
     {
         long fileSize = 120;

--- a/community/shell/src/test/java/org/neo4j/shell/AppsIT.java
+++ b/community/shell/src/test/java/org/neo4j/shell/AppsIT.java
@@ -537,7 +537,7 @@ public class AppsIT extends AbstractShellIT
     }
 
     @Test
-    public void use_cypher_periodic_commit() throws Exception
+    public void useCypherPeriodicCommit() throws Exception
     {
         File file = File.createTempFile( "file", "csv", null );
         try ( PrintWriter writer = new PrintWriter( file ) )


### PR DESCRIPTION
This makes `CALL` work where it previously did not, because the service loader couldn't find the CallApp. Also included is allowing commands to execute sub-commands within their transactional context, which fixes #5880.