### PR TITLE
Introduce network level write throttling

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/DefaultThrottleLock.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/DefaultThrottleLock.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.transport;
+
+import io.netty.channel.Channel;
+
+public class DefaultThrottleLock implements ThrottleLock
+{
+    private final Object syncObject = new Object();
+
+    @Override
+    public void lock( Channel channel, long timeout )
+    {
+        synchronized ( syncObject )
+        {
+            try
+            {
+                syncObject.wait( timeout );
+            }
+            catch ( InterruptedException e )
+            {
+                // do nothing
+            }
+        }
+    }
+
+    @Override
+    public void unlock( Channel channel )
+    {
+        synchronized ( syncObject )
+        {
+            syncObject.notifyAll();
+        }
+    }
+}

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/DefaultThrottleLock.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/DefaultThrottleLock.java
@@ -26,18 +26,11 @@ public class DefaultThrottleLock implements ThrottleLock
     private final Object syncObject = new Object();
 
     @Override
-    public void lock( Channel channel, long timeout )
+    public void lock( Channel channel, long timeout ) throws InterruptedException
     {
         synchronized ( syncObject )
         {
-            try
-            {
-                syncObject.wait( timeout );
-            }
-            catch ( InterruptedException e )
-            {
-                // do nothing
-            }
+            syncObject.wait( timeout );
         }
     }
 

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/ThrottleLock.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/ThrottleLock.java
@@ -24,7 +24,7 @@ import io.netty.channel.Channel;
 public interface ThrottleLock
 {
 
-    void lock( Channel channel, long timeout );
+    void lock( Channel channel, long timeout ) throws InterruptedException;
 
     void unlock( Channel channel );
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/ThrottleLock.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/ThrottleLock.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.transport;
+
+import io.netty.channel.Channel;
+
+public interface ThrottleLock
+{
+
+    void lock( Channel channel, long timeout );
+
+    void unlock( Channel channel );
+}

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportThrottle.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportThrottle.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.transport;
+
+import io.netty.channel.Channel;
+
+public interface TransportThrottle
+{
+
+    /**
+     * Installs the throttle to the given channel.
+     *
+     * @param channel the netty channel to which this throttle should be installed
+     */
+    void install( Channel channel );
+
+    /**
+     * Apply throttling logic for the given channel..
+     *
+     * @param channel the netty channel to which this throttling logic should be applied
+     */
+    void acquire( Channel channel );
+
+    /**
+     * Release throttling for the given channel (if applied)..
+     *
+     * @param channel the netty channel from which this throttling logic should be released
+     */
+    void release( Channel channel );
+
+    /**
+     * Uninstalls the throttle from the given channel.
+     *
+     * @param channel the netty channel from which this throttle should be uninstalled
+     */
+    void uninstall( Channel channel );
+}

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportThrottleGroup.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportThrottleGroup.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.transport;
+
+import io.netty.channel.Channel;
+import io.netty.util.AttributeKey;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.configuration.Config;
+
+/**
+ * Serves as an entry point for throttling of transport related resources. Currently only
+ * write operations are throttled based on pending buffered data. If there will be new types
+ * of throttles (number of active channels, reads, etc.) they should be added and registered
+ * through this class.
+ */
+public class TransportThrottleGroup
+{
+    public static final TransportThrottleGroup NO_THROTTLE = new TransportThrottleGroup();
+
+    private final TransportThrottle writeThrottle;
+
+    private TransportThrottleGroup()
+    {
+        this.writeThrottle = NoOpTransportThrottle.INSTANCE;
+    }
+
+    public TransportThrottleGroup( Config config )
+    {
+        this.writeThrottle = createWriteThrottle( config );
+    }
+
+    public TransportThrottle writeThrottle()
+    {
+        return writeThrottle;
+    }
+
+    public void install( Channel channel )
+    {
+        writeThrottle.install( channel );
+    }
+
+    public void uninstall( Channel channel )
+    {
+        writeThrottle.uninstall( channel );
+    }
+
+    private static TransportThrottle createWriteThrottle( Config config )
+    {
+        if ( config.get( GraphDatabaseSettings.bolt_write_throttle ) )
+        {
+            return new TransportWriteThrottle( config.get( GraphDatabaseSettings.bolt_write_buffer_low_water_mark ),
+                    config.get( GraphDatabaseSettings.bolt_write_buffer_high_water_mark ) );
+        }
+
+        return NoOpTransportThrottle.INSTANCE;
+    }
+
+    private static class NoOpTransportThrottle implements TransportThrottle
+    {
+        private static final TransportThrottle INSTANCE = new NoOpTransportThrottle();
+
+        @Override
+        public void install( Channel channel )
+        {
+
+        }
+
+        @Override
+        public void acquire( Channel channel )
+        {
+
+        }
+
+        @Override
+        public void release( Channel channel )
+        {
+
+        }
+
+        @Override
+        public void uninstall( Channel channel )
+        {
+
+        }
+    }
+}

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportWriteThrottle.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportWriteThrottle.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.transport;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.WriteBufferWaterMark;
+import io.netty.util.AttributeKey;
+
+import java.util.function.Supplier;
+
+/**
+ * Throttle that blocks write operations to the channel based on channel's isWritable
+ * property. Buffer sizes based on which the channel will change its isWritable property
+ * and whether to apply this throttle are configurable through GraphDatabaseSettings.
+ */
+public class TransportWriteThrottle implements TransportThrottle
+{
+    private static final AttributeKey<ThrottleLock> LOCK_KEY = AttributeKey.valueOf( "BOLT.WRITE_THROTTLE.LOCK" );
+    private final int lowWaterMark;
+    private final int highWaterMark;
+    private final Supplier<ThrottleLock> lockSupplier;
+    private final ChannelInboundHandler listener;
+
+    public TransportWriteThrottle( int lowWaterMark, int highWaterMark )
+    {
+        this( lowWaterMark, highWaterMark, () -> new DefaultThrottleLock() );
+    }
+
+    public TransportWriteThrottle( int lowWaterMark, int highWaterMark, Supplier<ThrottleLock> lockSupplier )
+    {
+        this.lowWaterMark = lowWaterMark;
+        this.highWaterMark = highWaterMark;
+        this.lockSupplier = lockSupplier;
+        this.listener = new ChannelStatusListener();
+    }
+
+    @Override
+    public void install( Channel channel )
+    {
+        ThrottleLock lock = lockSupplier.get();
+
+        channel.attr( LOCK_KEY ).set( lock );
+        channel.config().setWriteBufferWaterMark( new WriteBufferWaterMark( lowWaterMark, highWaterMark ) );
+        channel.pipeline().addLast( listener );
+    }
+
+    @Override
+    public void acquire( Channel channel )
+    {
+        ThrottleLock lock = channel.attr( LOCK_KEY ).get();
+
+        while ( channel.isOpen() && !channel.isWritable() )
+        {
+            lock.lock( channel, 1000 );
+        }
+    }
+
+    @Override
+    public void release( Channel channel )
+    {
+        if ( channel.isWritable() )
+        {
+            ThrottleLock lock = channel.attr( LOCK_KEY ).get();
+
+            lock.unlock( channel );
+        }
+    }
+
+    @Override
+    public void uninstall( Channel channel )
+    {
+        channel.attr( LOCK_KEY ).set( null );
+    }
+
+    @ChannelHandler.Sharable
+    private class ChannelStatusListener extends ChannelInboundHandlerAdapter
+    {
+
+        @Override
+        public void channelWritabilityChanged( ChannelHandlerContext ctx ) throws Exception
+        {
+            release( ctx.channel() );
+        }
+    }
+}

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportWriteThrottle.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportWriteThrottle.java
@@ -72,7 +72,14 @@ public class TransportWriteThrottle implements TransportThrottle
 
         while ( channel.isOpen() && !channel.isWritable() )
         {
-            lock.lock( channel, 1000 );
+            try
+            {
+                lock.lock( channel, 1000 );
+            }
+            catch ( InterruptedException ex )
+            {
+                Thread.currentThread().interrupt();
+            }
         }
     }
 

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/transport/BoltMessagingProtocolV1Handler.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/transport/BoltMessagingProtocolV1Handler.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.neo4j.bolt.BoltChannel;
 import org.neo4j.bolt.transport.BoltMessagingProtocolHandler;
+import org.neo4j.bolt.transport.TransportThrottleGroup;
 import org.neo4j.bolt.v1.messaging.BoltMessageRouter;
 import org.neo4j.bolt.v1.messaging.BoltResponseMessageWriter;
 import org.neo4j.bolt.v1.messaging.Neo4jPack;
@@ -56,9 +57,9 @@ public class BoltMessagingProtocolV1Handler implements BoltMessagingProtocolHand
 
     private final Log internalLog;
 
-    public BoltMessagingProtocolV1Handler( BoltChannel boltChannel, BoltWorker worker, LogService logging )
+    public BoltMessagingProtocolV1Handler( BoltChannel boltChannel, BoltWorker worker, TransportThrottleGroup throttleGroup, LogService logging )
     {
-        this.chunkedOutput = new ChunkedOutput( boltChannel.rawChannel(), DEFAULT_OUTPUT_BUFFER_SIZE );
+        this.chunkedOutput = new ChunkedOutput( boltChannel.rawChannel(), DEFAULT_OUTPUT_BUFFER_SIZE, throttleGroup );
         this.packer = new BoltResponseMessageWriter(
                 new Neo4jPack.Packer( chunkedOutput ), chunkedOutput, boltChannel.log() );
         this.worker = worker;

--- a/community/bolt/src/test/java/org/neo4j/bolt/transport/TransportWriteThrottleTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/transport/TransportWriteThrottleTest.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.transport;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.WriteBufferWaterMark;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.SocketChannelConfig;
+import io.netty.util.Attribute;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TransportWriteThrottleTest
+{
+    private ChannelHandlerContext context;
+    private Channel channel;
+    private SocketChannelConfig config;
+    private ThrottleLock lock;
+
+    @Before
+    public void setup() throws Exception
+    {
+        lock = mock( ThrottleLock.class );
+        config = mock( SocketChannelConfig.class );
+
+        Attribute lockAttribute = mock( Attribute.class );
+        when( lockAttribute.get() ).thenReturn( lock );
+
+        channel = mock( SocketChannel.class, Answers.RETURNS_MOCKS );
+        when( channel.config() ).thenReturn( config );
+        when( channel.isOpen() ).thenReturn( true );
+        when( channel.attr( any() ) ).thenReturn( lockAttribute );
+
+        ChannelPipeline pipeline = channel.pipeline();
+        when( channel.pipeline() ).thenReturn( pipeline );
+
+        context = mock( ChannelHandlerContext.class, Answers.RETURNS_MOCKS );
+        when( context.channel() ).thenReturn( channel );
+    }
+
+    @Test
+    public void shouldSetWriteBufferWatermarkOnChannelConfigWhenInstalled()
+    {
+        // given
+        TransportThrottle throttle = newThrottle();
+
+        // when
+        throttle.install( channel );
+
+        // expect
+        ArgumentCaptor<WriteBufferWaterMark> argument = ArgumentCaptor.forClass( WriteBufferWaterMark.class );
+        verify( config, times( 1 ) ).setWriteBufferWaterMark( argument.capture() );
+
+        assertEquals( 64, argument.getValue().low() );
+        assertEquals( 256, argument.getValue().high() );
+    }
+
+    @Test
+    public void shouldNotLockWhenWritable() throws Exception
+    {
+        // given
+        TransportThrottle throttle = newThrottleAndInstall( channel );
+        when( channel.isWritable() ).thenReturn( true );
+
+        // when
+        Future future = Executors.newSingleThreadExecutor().submit( () -> throttle.acquire( channel ) );
+
+        // expect
+        try
+        {
+            future.get( 2000, TimeUnit.MILLISECONDS );
+        }
+        catch ( Throwable t )
+        {
+            fail( "should not throw" );
+        }
+
+        assertTrue( future.isDone() );
+        verify( lock, never() ).lock( any(), anyLong() );
+    }
+
+    @Test
+    public void shouldLockWhenNotWritable() throws Exception
+    {
+        // given
+        TransportThrottle throttle = newThrottleAndInstall( channel );
+        when( channel.isWritable() ).thenReturn( false );
+
+        // when
+        Future future = Executors.newSingleThreadExecutor().submit( () -> throttle.acquire( channel ) );
+
+        // expect
+        try
+        {
+            future.get( 2000, TimeUnit.MILLISECONDS );
+
+            fail( "should timeout" );
+        }
+        catch ( TimeoutException t )
+        {
+            // expected
+        }
+        catch ( Throwable t )
+        {
+            fail( "should timeout" );
+        }
+
+        assertFalse( future.isDone() );
+        verify( lock, atLeastOnce() ).lock( any(), anyLong() );
+        verify( lock, never() ).unlock( any() );
+    }
+
+    @Test
+    public void shouldResumeWhenWritableOnceAgain() throws Exception
+    {
+        // given
+        TransportThrottle throttle = newThrottleAndInstall( channel );
+        when( channel.isWritable() ).thenReturn( false ).thenReturn( true );
+
+        // when
+        throttle.acquire( channel );
+
+        // expect
+        verify( lock, atLeastOnce() ).lock( any(), anyLong() );
+        verify( lock, never() ).unlock( any() );
+    }
+
+    @Test
+    public void shouldResumeWhenWritabilityChanged() throws Exception
+    {
+        // given
+        TransportThrottle throttle = newThrottleAndInstall( channel );
+        when( channel.isWritable() ).thenReturn( false );
+
+        Future future = Executors.newSingleThreadExecutor().submit( () -> throttle.acquire( channel ) );
+        Thread.sleep( 500 );
+
+        // when
+        when( channel.isWritable() ).thenReturn( true );
+        ArgumentCaptor<ChannelInboundHandler> captor = ArgumentCaptor.forClass( ChannelInboundHandler.class );
+        verify( channel.pipeline() ).addLast( captor.capture() );
+        captor.getValue().channelWritabilityChanged( context );
+
+        // expect
+        try
+        {
+            future.get( 2000, TimeUnit.MILLISECONDS );
+        }
+        catch ( Throwable t )
+        {
+            fail( "should not throw" );
+        }
+
+        verify( lock, atLeastOnce() ).lock( any(), anyLong() );
+        verify( lock, times( 1 ) ).unlock( any() );
+    }
+
+    private TransportThrottle newThrottle()
+    {
+        return new TransportWriteThrottle( 64, 256, () -> lock );
+    }
+
+    private TransportThrottle newThrottleAndInstall( Channel channel )
+    {
+        TransportThrottle throttle = newThrottle();
+
+        throttle.install( channel );
+
+        return throttle;
+    }
+
+}

--- a/community/bolt/src/test/java/org/neo4j/bolt/transport/TransportWriteThrottleTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/transport/TransportWriteThrottleTest.java
@@ -180,7 +180,7 @@ public class TransportWriteThrottleTest
         Future future = Executors.newSingleThreadExecutor().submit( () -> throttle.acquire( channel ) );
 
         // Wait until lock is acquired.
-        if (!lock.waitLocked( 1, TimeUnit.SECONDS ))
+        if ( !lock.waitLocked( 1, TimeUnit.SECONDS ) )
         {
             fail( "lock should be acquired" );
         }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/BoltMessagingProtocolV1HandlerTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/BoltMessagingProtocolV1HandlerTest.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.util.Objects;
 
 import org.neo4j.bolt.BoltChannel;
+import org.neo4j.bolt.transport.TransportThrottleGroup;
 import org.neo4j.bolt.v1.runtime.BoltStateMachine;
 import org.neo4j.bolt.v1.runtime.BoltWorker;
 import org.neo4j.bolt.v1.runtime.SynchronousBoltWorker;
@@ -61,7 +62,7 @@ public class BoltMessagingProtocolV1HandlerTest
 
         BoltStateMachine machine = mock( BoltStateMachine.class );
         BoltMessagingProtocolV1Handler protocol = new BoltMessagingProtocolV1Handler(
-                boltChannel, new SynchronousBoltWorker( machine ), NullLogService.getInstance() );
+                boltChannel, new SynchronousBoltWorker( machine ), TransportThrottleGroup.NO_THROTTLE, NullLogService.getInstance() );
         verify( outputChannel ).alloc();
 
         // And given inbound data that'll explode when the protocol tries to interpret it
@@ -94,7 +95,7 @@ public class BoltMessagingProtocolV1HandlerTest
         when( boltChannel.rawChannel() ).thenReturn( outputChannel );
 
         BoltMessagingProtocolV1Handler protocol = new BoltMessagingProtocolV1Handler(
-                boltChannel, new SynchronousBoltWorker( machine ), NullLogService.getInstance() );
+                boltChannel, new SynchronousBoltWorker( machine ), TransportThrottleGroup.NO_THROTTLE, NullLogService.getInstance() );
         protocol.close();
 
         verify( machine ).close();
@@ -115,7 +116,7 @@ public class BoltMessagingProtocolV1HandlerTest
         when( boltChannel.rawChannel() ).thenReturn( outputChannel );
 
         BoltMessagingProtocolV1Handler protocol = new BoltMessagingProtocolV1Handler(
-                boltChannel, mock( BoltWorker.class ), logService );
+                boltChannel, mock( BoltWorker.class ), TransportThrottleGroup.NO_THROTTLE, logService );
 
         protocol.handle( mock( ChannelHandlerContext.class ), data );
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/FragmentedMessageDeliveryTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/FragmentedMessageDeliveryTest.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 
 import org.neo4j.bolt.BoltChannel;
 import org.neo4j.bolt.logging.NullBoltMessageLogger;
+import org.neo4j.bolt.transport.TransportThrottleGroup;
 import org.neo4j.bolt.v1.messaging.BoltRequestMessageWriter;
 import org.neo4j.bolt.v1.messaging.Neo4jPack;
 import org.neo4j.bolt.v1.messaging.RecordingByteChannel;
@@ -124,7 +125,7 @@ public class FragmentedMessageDeliveryTest
         when( boltChannel.log() ).thenReturn( NullBoltMessageLogger.getInstance() );
 
         BoltMessagingProtocolV1Handler protocol = new BoltMessagingProtocolV1Handler(
-                boltChannel, new SynchronousBoltWorker( machine ), NullLogService.getInstance() );
+                boltChannel, new SynchronousBoltWorker( machine ), TransportThrottleGroup.NO_THROTTLE, NullLogService.getInstance() );
 
         // When data arrives split up according to the current permutation
         for ( ByteBuf fragment : fragments )

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/SocketTransportHandlerTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/SocketTransportHandlerTest.java
@@ -34,6 +34,7 @@ import org.neo4j.bolt.logging.BoltMessageLogging;
 import org.neo4j.bolt.transport.BoltHandshakeProtocolHandler;
 import org.neo4j.bolt.transport.BoltMessagingProtocolHandler;
 import org.neo4j.bolt.transport.SocketTransportHandler;
+import org.neo4j.bolt.transport.TransportThrottleGroup;
 import org.neo4j.bolt.v1.runtime.BoltStateMachine;
 import org.neo4j.bolt.v1.runtime.SynchronousBoltWorker;
 import org.neo4j.bolt.v1.transport.BoltMessagingProtocolV1Handler;
@@ -205,7 +206,7 @@ public class SocketTransportHandlerTest
         Map<Long,Function<BoltChannel, BoltMessagingProtocolHandler>> availableVersions = new HashMap<>();
         availableVersions.put( (long) BoltMessagingProtocolV1Handler.VERSION,
                 boltChannel -> new BoltMessagingProtocolV1Handler( boltChannel, new SynchronousBoltWorker( machine ),
-                        NullLogService.getInstance() )
+                        TransportThrottleGroup.NO_THROTTLE, NullLogService.getInstance() )
         );
 
         return new BoltHandshakeProtocolHandler( availableVersions, false, true );

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.graphdb.factory;
 
+import com.sun.org.apache.xpath.internal.operations.Bool;
+
 import java.io.File;
 import java.time.Duration;
 import java.util.List;
@@ -752,6 +754,25 @@ public class GraphDatabaseSettings implements LoadableConfig
     @Internal
     public static final Setting<File> bolt_log_filename = derivedSetting( "unsupported.dbms.logs.bolt.path",
             GraphDatabaseSettings.logs_directory, logsDir -> new File( logsDir, "bolt.log" ), PATH );
+
+    @Description( "Whether to apply network level write throttling" )
+    @Internal
+    public static final Setting<Boolean> bolt_write_throttle = setting( "unsupported.dbms.bolt.write_throttle", BOOLEAN, TRUE );
+
+    @Description( "When the size (in bytes) of write buffers, used by bolt's network layer, " +
+            "grows beyond this value bolt channel will advertise itself as unwritable and bolt worker " +
+            "threads will block until it becomes writable again." )
+    @Internal
+    public static final Setting<Integer> bolt_write_buffer_high_water_mark =
+            buildSetting( "unsupported.dbms.bolt.write_throttle.high_watermark", INTEGER, String.valueOf( ByteUnit.kibiBytes( 512 ) ) ).constraint(
+                    range( (int) ByteUnit.kibiBytes( 64 ), Integer.MAX_VALUE ) ).build();
+
+    @Description( "When the size (in bytes) of write buffers, previously advertised as unwritable, " +
+            "gets below this value bolt channel will re-advertise itself as writable and blocked bolt worker " + "threads will resume execution." )
+    @Internal
+    public static final Setting<Integer> bolt_write_buffer_low_water_mark =
+            buildSetting( "unsupported.dbms.bolt.write_throttle.low_watermark", INTEGER, String.valueOf( ByteUnit.kibiBytes( 128 ) ) ).constraint(
+                    range( (int) ByteUnit.kibiBytes( 16 ), Integer.MAX_VALUE ) ).build();
 
     @Description( "Create an archive of an index before re-creating it if failing to load on startup." )
     @Internal

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.graphdb.factory;
 
-import com.sun.org.apache.xpath.internal.operations.Bool;
-
 import java.io.File;
 import java.time.Duration;
 import java.util.List;


### PR DESCRIPTION
This PR creates a network level back pressure where bolt worker threads are blocked based on related channel's buffer length.

changelog: Introduce network level write throttling for better use of memory in bolt server.