### PR TITLE
Make sure all instances are properly closed in Cluster test class

### DIFF
--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
@@ -174,21 +174,37 @@ public class Cluster
         return member;
     }
 
-    public void shutdown() throws ExecutionException, InterruptedException
+    public void shutdown()
     {
-        shutdownReadReplicas();
-        shutdownCoreMembers();
+        try ( ErrorHandler errorHandler = new ErrorHandler( "Error when trying to shutdown cluster" ) )
+        {
+            shutdownCoreMembers( errorHandler );
+            shutdownReadReplicas( errorHandler );
+        }
     }
 
-    public void shutdownCoreMembers() throws InterruptedException, ExecutionException
+    private void shutdownCoreMembers( ErrorHandler errorHandler )
+    {
+        shutdownMembers( coreMembers(), errorHandler );
+    }
+
+    public void shutdownCoreMembers()
+    {
+        try ( ErrorHandler errorHandler = new ErrorHandler( "Error when trying to shutdown core members" ) )
+        {
+            shutdownCoreMembers( errorHandler );
+        }
+    }
+
+    private void shutdownMembers( Collection<? extends ClusterMember> clusterMembers, ErrorHandler errorHandler )
     {
         ExecutorService executor = Executors.newCachedThreadPool();
         List<Callable<Object>> memberShutdownSuppliers = new ArrayList<>();
-        for ( final CoreClusterMember coreClusterMember : coreMembers.values() )
+        for ( final ClusterMember clusterMember : clusterMembers )
         {
             memberShutdownSuppliers.add( () ->
             {
-                coreClusterMember.shutdown();
+                clusterMember.shutdown();
                 return null;
             } );
         }
@@ -196,6 +212,10 @@ public class Cluster
         try
         {
             combine( executor.invokeAll( memberShutdownSuppliers ) ).get();
+        }
+        catch ( Exception e )
+        {
+            errorHandler.add( e );
         }
         finally
         {
@@ -462,9 +482,9 @@ public class Cluster
         }
     }
 
-    private void shutdownReadReplicas()
+    private void shutdownReadReplicas( ErrorHandler errorHandler )
     {
-        readReplicas.values().forEach( ReadReplica::shutdown );
+        shutdownMembers( readReplicas(), errorHandler );
     }
 
     /**

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ClusterTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ClusterTest.java
@@ -1,0 +1,57 @@
+package org.neo4j.causalclustering.discovery;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ClusterTest
+{
+    @Test
+    public void shouldShutdownAllMembersThenThrowException() throws Exception
+    {
+        // given
+        Cluster clusterMock = mock( Cluster.class );
+        CoreClusterMember unhealthyCore = mock( CoreClusterMember.class );
+        doThrow( IllegalStateException.class ).when( unhealthyCore ).shutdown();
+        CoreClusterMember healthyCore = mock( CoreClusterMember.class );
+        ReadReplica unhealthyReadReplica = mock( ReadReplica.class );
+        doThrow( IllegalStateException.class ).when( unhealthyReadReplica ).shutdown();
+        ReadReplica healthyReadReplica = mock( ReadReplica.class );
+
+        doCallRealMethod().when( clusterMock ).shutdown();
+        when( clusterMock.coreMembers() ).thenReturn( Arrays.asList( unhealthyCore, healthyCore ) );
+        when( clusterMock.readReplicas() ).thenReturn( Arrays.asList( unhealthyReadReplica, healthyReadReplica ) );
+
+
+        // when
+        RuntimeException exception = null;
+        try
+        {
+            clusterMock.shutdown();
+        }
+        catch ( RuntimeException e )
+        {
+            exception = e;
+        }
+
+        // then
+        assertNotNull( exception );
+        verify( healthyCore, only() ).shutdown();
+        verify( unhealthyCore, only() ).shutdown();
+        verify( healthyReadReplica, only() ).shutdown();
+        verify( unhealthyReadReplica, only() ).shutdown();
+
+        assertEquals( IllegalStateException.class, exception.getCause().getCause().getClass() );
+        assertEquals( 1, exception.getSuppressed().length );
+        assertEquals( IllegalStateException.class, exception.getSuppressed()[0].getCause().getClass() );
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ErrorHandler.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ErrorHandler.java
@@ -1,0 +1,52 @@
+package org.neo4j.causalclustering.discovery;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ErrorHandler implements AutoCloseable
+{
+    private final List<Throwable> throwables = new ArrayList<>();
+    private final String message;
+
+    public ErrorHandler( String message )
+    {
+        this.message = message;
+    }
+
+    public void add( Throwable throwable )
+    {
+        throwables.add( throwable );
+    }
+
+    public List<Throwable> throwables()
+    {
+        return Collections.unmodifiableList( throwables );
+    }
+
+    @Override
+    public void close() throws RuntimeException
+    {
+        throwIfException();
+    }
+
+    private void throwIfException()
+    {
+        if ( !throwables.isEmpty() )
+        {
+            RuntimeException runtimeException = null;
+            for ( Throwable throwable : throwables )
+            {
+                if ( runtimeException == null )
+                {
+                    runtimeException = new RuntimeException( message, throwable );
+                }
+                else
+                {
+                    runtimeException.addSuppressed( throwable );
+                }
+            }
+            throw runtimeException;
+        }
+    }
+}


### PR DESCRIPTION
This adds an error handler to avoid instance shutdown to be aborted
if any exception is thrown. The error handler will collect any
exceptions caught during instance shutdown and then throw after
shutdowns are completed. The thrown exception will be a RuntimeException
with any additional exceptions added as suppressed.