### PR TITLE
NodeIndexScanSlottedPipe copied more than it should

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -856,4 +856,22 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
 
     result.toList should equal(List(Map("req.eid" -> null, "y.eid" -> null)))
   }
+
+  test("Problem with index seek gh #10387") {
+    graph.createIndex("ROLE", "id")
+    graph.createIndex("REALM", "id")
+
+    createLabeledNode(Map("id" -> "abc"), "ROLE")
+    val realm = createLabeledNode(Map("id" -> "def"), "REALM")
+    val q = """MATCH (role:ROLE)
+              |WHERE role.id = "abc"
+              |WITH role
+              |UNWIND [{realmId: "def", rights: ["read"]}] AS permission
+              |MATCH (realm:REALM)
+              |WHERE realm.id = permission.realmId
+              |RETURN realm""".stripMargin
+
+    val res = executeWith(Configs.Interpreted, q)
+    res.toList should equal(List(Map("realm" -> realm)))
+  }
 }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/pipes/NodeIndexScanSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/pipes/NodeIndexScanSlottedPipe.scala
@@ -24,8 +24,8 @@ import org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes._
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.{ExecutionContext, PipelineInformation}
 import org.neo4j.cypher.internal.compiler.v3_3.IndexDescriptor
-import org.neo4j.cypher.internal.v3_3.logical.plans.LogicalPlanId
 import org.neo4j.cypher.internal.frontend.v3_3.ast.{LabelToken, PropertyKeyToken}
+import org.neo4j.cypher.internal.v3_3.logical.plans.LogicalPlanId
 
 
 case class NodeIndexScanSlottedPipe(ident: String,
@@ -43,7 +43,7 @@ case class NodeIndexScanSlottedPipe(ident: String,
     val nodes = state.query.indexScanPrimitive(descriptor)
     PrimitiveLongHelper.map(nodes, { node =>
       val context = PrimitiveExecutionContext(pipelineInformation)
-      state.copyArgumentStateTo(context, pipelineInformation.numberOfLongs, pipelineInformation.numberOfReferences)
+      state.copyArgumentStateTo(context, pipelineInformation.initialNumberOfLongs, pipelineInformation.initialNumberOfReferences)
       context.setLongAt(offset, node)
       context
     })


### PR DESCRIPTION
`NodeIndexScanSlottedPipe` was trying to copy more data than it should
leading to `ArrayIndexOutOfBoundsException` for some queries.

Changelog: Fixes #10387, `ArrayIndexOutOfBoundsException` for index scans in the slotted runtime for some queries.