### PR TITLE
Log runtime used in query.log

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -566,6 +566,10 @@ public class GraphDatabaseSettings implements LoadableConfig
     public static final Setting<Boolean> log_queries_allocation_logging_enabled =
             setting( "dbms.logs.query.allocation_logging_enabled", BOOLEAN, FALSE );
 
+    @Description( "Logs which runtime that was used to run the query" )
+    public static final Setting<Boolean> log_queries_runtime_logging_enabled =
+            setting( "dbms.logs.query.runtime_logging_enabled", BOOLEAN, FALSE );
+
     @Description( "Log page hits and page faults for the executed queries being logged." )
     public static final Setting<Boolean> log_queries_page_detail_logging_enabled =
             setting( "dbms.logs.query.page_logging_enabled", BOOLEAN, FALSE );

--- a/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLogEntryContent.java
+++ b/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLogEntryContent.java
@@ -28,7 +28,8 @@ enum QueryLogEntryContent
     LOG_PARAMETERS( GraphDatabaseSettings.log_queries_parameter_logging_enabled ),
     LOG_DETAILED_TIME( GraphDatabaseSettings.log_queries_detailed_time_logging_enabled ),
     LOG_ALLOCATED_BYTES( GraphDatabaseSettings.log_queries_allocation_logging_enabled ),
-    LOG_PAGE_DETAILS( GraphDatabaseSettings.log_queries_page_detail_logging_enabled );
+    LOG_PAGE_DETAILS( GraphDatabaseSettings.log_queries_page_detail_logging_enabled ),
+    LOG_RUNTIME( GraphDatabaseSettings.log_queries_runtime_logging_enabled );
     private final Setting<Boolean> setting;
 
     QueryLogEntryContent( Setting<Boolean> setting )

--- a/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLogger.java
+++ b/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLogger.java
@@ -40,6 +40,7 @@ class QueryLogger implements QueryExecutionMonitor
     private final boolean logDetailedTime;
     private final boolean logAllocatedBytes;
     private final boolean logPageDetails;
+    private final boolean logRuntime;
     private final EnumSet<QueryLogEntryContent> flags;
 
     private static final Pattern PASSWORD_PATTERN = Pattern.compile(
@@ -59,6 +60,7 @@ class QueryLogger implements QueryExecutionMonitor
         this.logDetailedTime = flags.contains( QueryLogEntryContent.LOG_DETAILED_TIME );
         this.logAllocatedBytes = flags.contains( QueryLogEntryContent.LOG_ALLOCATED_BYTES );
         this.logPageDetails = flags.contains( QueryLogEntryContent.LOG_PAGE_DETAILS );
+        this.logRuntime = flags.contains( QueryLogEntryContent.LOG_RUNTIME );
         this.flags = flags;
     }
 
@@ -132,6 +134,10 @@ class QueryLogger implements QueryExecutionMonitor
         if ( logQueryParameters )
         {
             QueryLogFormatter.formatMapValue( result.append(" - "), query.queryParameters(), passwordParams );
+        }
+        if ( logRuntime )
+        {
+            result.append( " - runtime=" ).append( query.runtime() );
         }
         QueryLogFormatter.formatMap( result.append(" - "), query.transactionAnnotationData() );
         return result.toString();

--- a/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
+++ b/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
@@ -239,6 +239,25 @@ public class QueryLoggerIT
         assertThat( logLines.get( 0 ), containsString( AUTH_DISABLED.username() ) );
     }
 
+    @Test
+    public void shouldLogRuntime() throws Exception
+    {
+        GraphDatabaseService database = databaseBuilder.setConfig( GraphDatabaseSettings.log_queries, Settings.TRUE )
+                .setConfig( GraphDatabaseSettings.logs_directory, logsDirectory.getPath() )
+                .setConfig( GraphDatabaseSettings.log_queries_runtime_logging_enabled, Settings.TRUE )
+                .newGraphDatabase();
+
+        String query = "RETURN 42";
+        executeQueryAndShutdown( database, query, Collections.emptyMap() );
+
+        List<String> logLines = readAllLines( logFilename );
+        assertEquals( 1, logLines.size() );
+        assertThat( logLines.get( 0 ), endsWith( String.format(
+                " ms: %s - %s - {} - runtime=interpreted - {}",
+                clientConnectionInfo(),
+                query ) ) );
+    }
+
     private String clientConnectionInfo()
     {
         return ClientConnectionInfo.EMBEDDED_CONNECTION.withUsername( AUTH_DISABLED.username() ).asConnectionDetails();


### PR DESCRIPTION
Adds the option to be able to log the which runtime that was used in
`query.log`. Adds the configuration `dbms.logs.query.runtime_logging_enabled`
('false' by default) that allows you to see which runtime was used in the
query log.

changelog: Adds the ability to log which runtime that was used in query.log