### PR TITLE
Introduce wait for getting Leader in RaftReplicator.

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMachine.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMachine.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.time.Clock;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
@@ -202,7 +203,7 @@ public class RaftMachine implements LeaderLocator, CoreMetaData
     @Override
     public MemberId getLeader() throws NoLeaderFoundException
     {
-        return waitForLeader( 0, member -> member != null );
+        return waitForLeader( 0, Objects::nonNull );
     }
 
     private MemberId waitForLeader( long timeoutMillis, Predicate<MemberId> predicate ) throws NoLeaderFoundException

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/replication/RaftReplicatorTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/replication/RaftReplicatorTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.neo4j.causalclustering.core.consensus.NoLeaderFoundException;
 import org.neo4j.causalclustering.messaging.Message;
@@ -57,7 +58,7 @@ public class RaftReplicatorTest
     private MemberId leader = new MemberId( UUID.randomUUID() );
     private GlobalSession session = new GlobalSession( UUID.randomUUID(), myself );
     private LocalSessionPool sessionPool = new LocalSessionPool( session );
-    private RetryStrategy retryStrategy = new ConstantTimeRetryStrategy( 0, MILLISECONDS );
+    private RetryStrategy noWaitRetryStrategy = new ConstantTimeRetryStrategy( 0, MILLISECONDS );
 
     @Test
     public void shouldSendReplicatedContentToLeader() throws Exception
@@ -69,7 +70,7 @@ public class RaftReplicatorTest
 
         RaftReplicator replicator =
                 new RaftReplicator( leaderLocator, myself, outbound, sessionPool,
-                        capturedProgress, retryStrategy, NullLogProvider.getInstance() );
+                        capturedProgress, noWaitRetryStrategy, noWaitRetryStrategy, NullLogProvider.getInstance() );
 
         ReplicatedInteger content = ReplicatedInteger.valueOf( 5 );
         Thread replicatingThread = replicatingThread( replicator, content, false );
@@ -93,10 +94,10 @@ public class RaftReplicatorTest
         // given
         when( leaderLocator.getLeader() ).thenReturn( leader );
         CapturingProgressTracker capturedProgress = new CapturingProgressTracker();
-        CapturingOutbound outbound = new CapturingOutbound();
+        CapturingOutbound<RaftMessages.RaftMessage> outbound = new CapturingOutbound<>();
 
         RaftReplicator replicator = new RaftReplicator( leaderLocator, myself, outbound,
-                sessionPool, capturedProgress, retryStrategy, NullLogProvider.getInstance() );
+                sessionPool, capturedProgress, noWaitRetryStrategy, noWaitRetryStrategy, NullLogProvider.getInstance() );
 
         ReplicatedInteger content = ReplicatedInteger.valueOf( 5 );
         Thread replicatingThread = replicatingThread( replicator, content, false );
@@ -112,15 +113,45 @@ public class RaftReplicatorTest
     }
 
     @Test
+    public void shouldRetryGettingLeader() throws Exception
+    {
+        // given
+        AtomicInteger leaderRetries = new AtomicInteger( 0 );
+
+        when( leaderLocator.getLeader() )
+                .thenThrow( new NoLeaderFoundException( ) )
+                .thenReturn( leader );
+        CapturingProgressTracker capturedProgress = new CapturingProgressTracker();
+        CapturingOutbound<RaftMessages.RaftMessage> outbound = new CapturingOutbound<>();
+
+        RaftReplicator replicator =
+                new RaftReplicator( leaderLocator, myself, outbound, sessionPool,
+                        capturedProgress, noWaitRetryStrategy, new SpyRetryStrategy( leaderRetries ), NullLogProvider.getInstance() );
+
+        ReplicatedInteger content = ReplicatedInteger.valueOf( 5 );
+        Thread replicatingThread = replicatingThread( replicator, content, false );
+
+        // when
+        replicatingThread.start();
+        // then
+        assertEventually( "send count", () -> outbound.count, greaterThan( 2 ), DEFAULT_TIMEOUT_MS, MILLISECONDS );
+        assertEquals( 1, leaderRetries.get() );
+
+        // cleanup
+        capturedProgress.last.setReplicated();
+        replicatingThread.join( DEFAULT_TIMEOUT_MS );
+    }
+
+    @Test
     public void shouldReleaseSessionWhenFinished() throws Exception
     {
         // given
         when( leaderLocator.getLeader() ).thenReturn( leader );
         CapturingProgressTracker capturedProgress = new CapturingProgressTracker();
-        CapturingOutbound outbound = new CapturingOutbound();
+        CapturingOutbound<RaftMessages.RaftMessage> outbound = new CapturingOutbound<>();
 
         RaftReplicator replicator = new RaftReplicator( leaderLocator, myself, outbound,
-                sessionPool, capturedProgress, retryStrategy, NullLogProvider.getInstance() );
+                sessionPool, capturedProgress, noWaitRetryStrategy, noWaitRetryStrategy, NullLogProvider.getInstance() );
 
         ReplicatedInteger content = ReplicatedInteger.valueOf( 5 );
         Thread replicatingThread = replicatingThread( replicator, content, true );
@@ -160,7 +191,7 @@ public class RaftReplicatorTest
                     }
                 }
             }
-            catch ( InterruptedException | NoLeaderFoundException e )
+            catch ( InterruptedException  e )
             {
                 throw new IllegalStateException();
             }
@@ -209,7 +240,7 @@ public class RaftReplicatorTest
         }
     }
 
-    private class CapturingOutbound<MESSAGE extends Message> implements Outbound<MemberId, MESSAGE>
+    private static class CapturingOutbound<MESSAGE extends Message> implements Outbound<MemberId, MESSAGE>
     {
         private MemberId lastTo;
         private int count;
@@ -221,5 +252,34 @@ public class RaftReplicatorTest
             this.count++;
         }
 
+    }
+
+    private static class SpyRetryStrategy implements RetryStrategy
+    {
+        private final AtomicInteger increments;
+
+        SpyRetryStrategy( AtomicInteger increments )
+        {
+            this.increments = increments;
+        }
+
+        @Override
+        public RetryStrategy.Timeout newTimeout()
+        {
+            return new RetryStrategy.Timeout()
+            {
+                @Override
+                public long getMillis()
+                {
+                    return 0;
+                }
+
+                @Override
+                public void increment()
+                {
+                    increments.incrementAndGet();
+                }
+            };
+        }
     }
 }


### PR DESCRIPTION
Without a wait new TimeoutException and NoLeaderFoundException would be
generated constantly until a Leader has been elected.

Suggestions for an appropriate RetryStrategy welcomed. As is, will retry every half second.

This isn't an easy thing to test.