### PR TITLE
Fixed windows service installation issue when JVM memory settings are present

### DIFF
--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jPrunsrv.ps1
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/Neo4j-Management/Get-Neo4jPrunsrv.ps1
@@ -135,17 +135,18 @@ Function Get-Neo4jPrunsrv
         )
 
         # Check if Java invocation includes Java memory sizing
-        $JvmMs = ''
-        $JvmMx = ''
         $JavaCMD.args | ForEach-Object -Process {
           if ($Matches -ne $null) { $Matches.Clear() }
           if ($_ -match '^-Xms([\d]+)m$') {
-            $PrunArgs += "`"--JvmMs $($matches[1])`""
+            $PrunArgs += "`"--JvmMs`""
+            $PrunArgs += "`"$($matches[1])`""
             Write-Verbose "Use JVM Start Memory of $($matches[1]) MB"
           }
           if ($Matches -ne $null) { $Matches.Clear() }
           if ($_ -match '^-Xmx([\d]+)m$') {
-            $PrunArgs += "`"--JvmMx $($matches[1])`""
+            $PrunArgs += "`"--JvmMx`""
+            $PrunArgs += "`"$($matches[1])`""
+
             Write-Verbose "Use JVM Max Memory of $($matches[1]) MB"
           }
         }

--- a/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Neo4jPrunsrv.Tests.ps1
+++ b/packaging/standalone/src/tests/Neo4j-Management/unit/Get-Neo4jPrunsrv.Tests.ps1
@@ -164,11 +164,11 @@ InModuleScope Neo4j-Management {
       # http://commons.apache.org/proper/commons-daemon/procrun.html
 
       It "should specify --JvmMs if dbms.memory.heap.initial_size is set" {
-        $prunArgs | Should Match ([regex]::Escape("--JvmMs $mockJvmMs"))
+        $prunArgs | Should Match ([regex]::Escape("`"--JvmMs`" `"$mockJvmMs`""))
       }
 
       It "should specify --JvmMx if dbms.memory.heap.max_size is set" {
-        $prunArgs | Should Match ([regex]::Escape("--JvmMx $mockJvmMx"))
+        $prunArgs | Should Match ([regex]::Escape("`"--JvmMx`" `"$mockJvmMx`""))
       }
     }
 


### PR DESCRIPTION
As part of #10407, all arguments were changed to be quoted by default. However, `--JvmMs` and `--JvmMx` arguments of `procrun` were incorrectly quoted to also include its parameters, which is fixed with this PR.