### PR TITLE
Forwarding message in constructor calls of internal CypherException

### DIFF
--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/CypherException.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/CypherException.scala
@@ -150,7 +150,7 @@ class LoadExternalResourceException(message: String, cause: Throwable = null)
 }
 
 class LoadCsvStatusWrapCypherException(extraInfo: String, cause: CypherException)
-    extends CypherException(cause) {
+    extends CypherException(extraInfo,  cause) {
   override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
     // the mapper will map the cause here, so we cannot pass 'this' in as the cause...
     mapper.loadCsvStatusWrapCypherException(extraInfo, cause)

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/CypherException.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/CypherException.scala
@@ -29,7 +29,7 @@ abstract class CypherException(protected val message: String, cause: Throwable)
   def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]): T
 }
 
-class UniquePathNotUniqueException(message: String) extends CypherException {
+class UniquePathNotUniqueException(message: String) extends CypherException(message) {
   override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]): T =
     mapper.uniquePathNotUniqueException(message, this)
 }
@@ -40,7 +40,7 @@ class FailedIndexException(indexName: String) extends CypherException {
 }
 
 class EntityNotFoundException(message: String, cause: Throwable = null)
-    extends CypherException(cause) {
+    extends CypherException(message, cause) {
   override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
     mapper.entityNotFoundException(message, this)
 }
@@ -51,7 +51,7 @@ class CypherTypeException(message: String, cause: Throwable = null)
     mapper.cypherTypeException(message, this)
 }
 
-class ParameterNotFoundException(message: String, cause: Throwable) extends CypherException(cause) {
+class ParameterNotFoundException(message: String, cause: Throwable) extends CypherException(message, cause) {
   def this(message: String) = this(message, null)
 
   override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
@@ -93,12 +93,12 @@ class ProfilerStatisticsNotReadyException extends CypherException {
 }
 
 class IndexHintException(variable: String, label: String, properties: Seq[String], message: String)
-    extends CypherException {
+    extends CypherException(message) {
   def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
     mapper.indexHintException(variable, label, properties, message, this)
 }
 
-class JoinHintException(variable: String, message: String) extends CypherException {
+class JoinHintException(variable: String, message: String) extends CypherException(message) {
   override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
     mapper.joinHintException(variable, message, this)
 }
@@ -120,7 +120,7 @@ class MergeConstraintConflictException(message: String, cause: Throwable = null)
     mapper.mergeConstraintConflictException(message, this)
 }
 
-class ArithmeticException(message: String, cause: Throwable = null) extends CypherException(cause) {
+class ArithmeticException(message: String, cause: Throwable = null) extends CypherException(message, cause) {
   override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
     mapper.arithmeticException(message, this)
 }
@@ -144,7 +144,7 @@ class PeriodicCommitInOpenTransactionException extends CypherException {
 }
 
 class LoadExternalResourceException(message: String, cause: Throwable = null)
-    extends CypherException(cause) {
+    extends CypherException(message, cause) {
   override def mapToPublic[T <: Throwable](mapper: MapToPublicExceptions[T]) =
     mapper.loadExternalResourceException(message, this)
 }


### PR DESCRIPTION
For some subclasses of the version specific CypherException, the
message was not forwarded to the super constructor.