### PR TITLE
Verbose page cache flush tracer

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/ByteUnit.java
+++ b/community/io/src/main/java/org/neo4j/io/ByteUnit.java
@@ -19,6 +19,10 @@
  */
 package org.neo4j.io;
 
+import java.util.Locale;
+
+import static java.lang.String.format;
+
 /**
  * A ByteUnit is a unit for a quantity of bytes.
  * <p>
@@ -43,7 +47,11 @@ public enum ByteUnit
     GibiByte( 3, "GiB" ),
     TebiByte( 4, "TiB" ),
     PebiByte( 5, "PiB" ),
-    ExbiByte( 6, "EiB" ),;
+    ExbiByte( 6, "EiB" );
+
+    public static final long ONE_KIBI_BYTE = ByteUnit.KibiByte.toBytes( 1 );
+    public static final long ONE_MEBI_BYTE = ByteUnit.MebiByte.toBytes( 1 );
+    public static final long ONE_GIBI_BYTE = ByteUnit.GibiByte.toBytes( 1 );
 
     private static final long EIC_MULTIPLIER = 1024;
 
@@ -165,5 +173,25 @@ public enum ByteUnit
     public static long exbiBytes( long exbibytes )
     {
         return ExbiByte.toBytes( exbibytes );
+    }
+
+    public static String bytesToString( long bytes )
+    {
+        if ( bytes > ONE_GIBI_BYTE )
+        {
+            return format( Locale.ROOT, "%.4g%s", bytes / (double) ONE_GIBI_BYTE, GibiByte.shortName );
+        }
+        else if ( bytes > ONE_MEBI_BYTE )
+        {
+            return format( Locale.ROOT, "%.4g%s", bytes / (double) ONE_MEBI_BYTE, MebiByte.shortName );
+        }
+        else if ( bytes > ONE_KIBI_BYTE )
+        {
+            return format( Locale.ROOT, "%.4g%s", bytes / (double) ONE_KIBI_BYTE, KibiByte.shortName );
+        }
+        else
+        {
+            return bytes + Byte.shortName;
+        }
     }
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -589,11 +589,14 @@ public class MuninnPageCache implements PageCache
     {
         try ( MajorFlushEvent cacheFlush = pageCacheTracer.beginCacheFlush() )
         {
-            FlushEventOpportunity flushOpportunity = cacheFlush.flushEventOpportunity();
             FileMapping fileMapping = mappedFiles;
             while ( fileMapping != null )
             {
-                fileMapping.pagedFile.flushAndForceInternal( flushOpportunity, false, limiter );
+                try ( MajorFlushEvent fileFlush = pageCacheTracer.beginFileFlush( fileMapping.pagedFile.swapper ) )
+                {
+                    FlushEventOpportunity flushOpportunity = fileFlush.flushEventOpportunity();
+                    fileMapping.pagedFile.flushAndForceInternal( flushOpportunity, false, limiter );
+                }
                 fileMapping = fileMapping.next;
             }
             syncDevice();

--- a/community/io/src/test/java/org/neo4j/io/ByteUnitTest.java
+++ b/community/io/src/test/java/org/neo4j/io/ByteUnitTest.java
@@ -22,6 +22,7 @@ package org.neo4j.io;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class ByteUnitTest
@@ -148,5 +149,21 @@ public class ByteUnitTest
         assertThat( ByteUnit.tebiBytes( 1 ), is( 1099511627776L ) );
         assertThat( ByteUnit.pebiBytes( 1 ), is( 1125899906842624L ) );
         assertThat( ByteUnit.exbiBytes( 1 ), is( 1152921504606846976L ) );
+    }
+
+    @Test
+    public void bytesToString()
+    {
+        assertEquals( "1B", ByteUnit.bytesToString( 1 ) );
+        assertEquals( "10B", ByteUnit.bytesToString( 10 ) );
+        assertEquals( "1000B", ByteUnit.bytesToString( 1000 ) );
+        assertEquals( "1.001KiB", ByteUnit.bytesToString( 1025 ) );
+        assertEquals( "10.01KiB", ByteUnit.bytesToString( 10250 ) );
+        assertEquals( "100.1KiB", ByteUnit.bytesToString( 102500 ) );
+        assertEquals( "1001KiB", ByteUnit.bytesToString( 1025000 ) );
+        assertEquals( "9.775MiB", ByteUnit.bytesToString( 10250000 ) );
+        assertEquals( "97.75MiB", ByteUnit.bytesToString( 102500000 ) );
+        assertEquals( "977.5MiB", ByteUnit.bytesToString( 1025000000 ) );
+        assertEquals( "9.546GiB", ByteUnit.bytesToString( 10250000000L) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/helpers/TimeUtil.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/TimeUtil.java
@@ -22,6 +22,14 @@ package org.neo4j.helpers;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
+import static java.util.concurrent.TimeUnit.DAYS;
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 public final class TimeUtil
 {
     public static final TimeUnit DEFAULT_TIME_UNIT = TimeUnit.SECONDS;
@@ -70,6 +78,55 @@ public final class TimeUtil
             return timeUnit.toMillis( amount );
         }
     };
+
+    public static String nanosToString( long nanos )
+    {
+        assert nanos >= 0;
+        long nanoSeconds = nanos;
+        StringBuilder timeString = new StringBuilder();
+
+        long days = DAYS.convert( nanoSeconds, NANOSECONDS );
+        if ( days > 0 )
+        {
+            nanoSeconds -= DAYS.toNanos( days );
+            timeString.append( days ).append( "d" );
+        }
+        long hours = HOURS.convert( nanoSeconds, NANOSECONDS );
+        if ( hours > 0 )
+        {
+            nanoSeconds -= HOURS.toNanos( hours );
+            timeString.append( hours ).append( "h" );
+        }
+        long minutes = MINUTES.convert( nanoSeconds, NANOSECONDS );
+        if ( minutes > 0 )
+        {
+            nanoSeconds -= MINUTES.toNanos( minutes );
+            timeString.append( minutes ).append( "m" );
+        }
+        long seconds = SECONDS.convert( nanoSeconds, NANOSECONDS );
+        if ( seconds > 0 )
+        {
+            nanoSeconds -= SECONDS.toNanos( seconds );
+            timeString.append( seconds ).append( "s" );
+        }
+        long milliseconds = MILLISECONDS.convert( nanoSeconds, NANOSECONDS );
+        if ( milliseconds > 0 )
+        {
+            nanoSeconds -= MILLISECONDS.toNanos( milliseconds );
+            timeString.append( milliseconds ).append( "ms" );
+        }
+        long microseconds = MICROSECONDS.convert( nanoSeconds, NANOSECONDS );
+        if ( microseconds > 0 )
+        {
+            nanoSeconds -= MICROSECONDS.toNanos( microseconds );
+            timeString.append( microseconds ).append( "μs" );
+        }
+        if ( nanoSeconds > 0 || timeString.length() == 0 )
+        {
+            timeString.append( nanoSeconds ).append( "ns" );
+        }
+        return timeString.toString();
+    }
 
     private TimeUtil()
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.neo4j.configuration.Internal;
 import org.neo4j.configuration.LoadableConfig;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.security.URLAccessRule;
@@ -32,7 +33,6 @@ import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.configuration.Internal;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.coreapi.CoreAPIAvailabilityGuard;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -164,7 +164,7 @@ public class PlatformModule
 
         String desiredImplementationName = config.get( GraphDatabaseFacadeFactory.Configuration.tracer );
         tracers = dependencies.satisfyDependency( new Tracers( desiredImplementationName,
-                logging.getInternalLog( Tracers.class ), monitors, jobScheduler ) );
+                logging.getInternalLog( Tracers.class ), monitors, jobScheduler, clock ) );
         dependencies.satisfyDependency( tracers.pageCacheTracer );
         dependencies.satisfyDependency( firstImplementor(
                 LogRotationMonitor.class, tracers.transactionTracer, LogRotationMonitor.NULL ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/DefaultTracerFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/DefaultTracerFactory.java
@@ -27,6 +27,8 @@ import org.neo4j.kernel.impl.transaction.tracing.CheckPointTracer;
 import org.neo4j.kernel.impl.transaction.tracing.TransactionTracer;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.Log;
+import org.neo4j.time.SystemNanoClock;
 
 /**
  * The default TracerFactory, when nothing else is otherwise configured.
@@ -40,7 +42,8 @@ public class DefaultTracerFactory implements TracerFactory
     }
 
     @Override
-    public PageCacheTracer createPageCacheTracer( Monitors monitors, JobScheduler jobScheduler )
+    public PageCacheTracer createPageCacheTracer( Monitors monitors, JobScheduler jobScheduler, SystemNanoClock clock,
+            Log log )
     {
         return new DefaultPageCacheTracer();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/TracerFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/TracerFactory.java
@@ -27,6 +27,8 @@ import org.neo4j.kernel.impl.transaction.tracing.CheckPointTracer;
 import org.neo4j.kernel.impl.transaction.tracing.TransactionTracer;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.Log;
+import org.neo4j.time.SystemNanoClock;
 
 /**
  * A TracerFactory determines the implementation of the tracers, that a database should use. Each implementation has
@@ -46,9 +48,11 @@ public interface TracerFactory
      *
      * @param monitors the monitoring manager
      * @param jobScheduler a scheduler for async jobs
+     * @param clock system nano clock
+     * @param log log
      * @return The created instance.
      */
-    PageCacheTracer createPageCacheTracer( Monitors monitors, JobScheduler jobScheduler );
+    PageCacheTracer createPageCacheTracer( Monitors monitors, JobScheduler jobScheduler, SystemNanoClock clock, Log log );
 
     /**
      * Create a new TransactionTracer instance.

--- a/community/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/Tracers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/Tracers.java
@@ -29,6 +29,7 @@ import org.neo4j.kernel.impl.transaction.tracing.TransactionTracer;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.Log;
+import org.neo4j.time.SystemNanoClock;
 
 /**
  * <h1>Tracers</h1>
@@ -115,7 +116,8 @@ public class Tracers
      * @param monitors the monitoring manager
      * @param jobScheduler a scheduler for async jobs
      */
-    public Tracers( String desiredImplementationName, Log msgLog, Monitors monitors, JobScheduler jobScheduler )
+    public Tracers( String desiredImplementationName, Log msgLog, Monitors monitors, JobScheduler jobScheduler,
+            SystemNanoClock clock )
     {
         if ( "null".equalsIgnoreCase( desiredImplementationName ) )
         {
@@ -153,7 +155,7 @@ public class Tracers
             }
 
             pageCursorTracerSupplier = foundFactory.createPageCursorTracerSupplier( monitors, jobScheduler );
-            pageCacheTracer = foundFactory.createPageCacheTracer( monitors, jobScheduler );
+            pageCacheTracer = foundFactory.createPageCacheTracer( monitors, jobScheduler, clock, msgLog );
             transactionTracer = foundFactory.createTransactionTracer( monitors, jobScheduler );
             checkPointTracer = foundFactory.createCheckPointTracer( monitors, jobScheduler );
             lockTracer = foundFactory.createLockTracer( monitors, jobScheduler );

--- a/community/kernel/src/test/java/org/neo4j/helpers/TimeUtilTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/TimeUtilTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.helpers;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.helpers.TimeUtil.nanosToString;
+
+public class TimeUtilTest
+{
+    @Test
+    public void formatNanosToString()
+    {
+        assertEquals( "1ns", nanosToString( 1 ) );
+        assertEquals( "10ns", nanosToString( 10 ) );
+        assertEquals( "100ns", nanosToString( 100 ) );
+        assertEquals( "1μs", nanosToString( 1000 ) );
+        assertEquals( "10μs100ns", nanosToString( 10100 ) );
+        assertEquals( "101μs10ns", nanosToString( 101010 ) );
+        assertEquals( "10ms101μs10ns", nanosToString( 10101010 ) );
+        assertEquals( "1s20ms304μs50ns", nanosToString( 1020304050 ) );
+        assertEquals( "1m42s30ms405μs60ns", nanosToString( 102030405060L ) );
+        assertEquals( "2h50m3s40ms506μs70ns", nanosToString( 10203040506070L ) );
+        assertEquals( "11d19h25m4s50ms607μs80ns", nanosToString( 1020304050607080L ) );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
@@ -72,6 +72,8 @@ import org.neo4j.storageengine.api.txstate.ReadableTransactionState;
 import org.neo4j.test.OtherThreadExecutor;
 import org.neo4j.test.Race;
 import org.neo4j.test.rule.concurrent.OtherThreadRule;
+import org.neo4j.time.Clocks;
+import org.neo4j.time.SystemNanoClock;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.locks.LockSupport.parkNanos;
@@ -107,7 +109,7 @@ public class KernelTransactionsTest
     @Rule
     public final ExpectedException expectedException = ExpectedException.none();
 
-    private static final Clock clock = Clock.systemUTC();
+    private static final SystemNanoClock clock = Clocks.nanoClock();
     private static AvailabilityGuard availabilityGuard;
 
     @Before
@@ -529,7 +531,8 @@ public class KernelTransactionsTest
         TransactionIdStore transactionIdStore = mock( TransactionIdStore.class );
         when( transactionIdStore.getLastCommittedTransaction() ).thenReturn( new TransactionId( 0, 0, 0 ) );
 
-        Tracers tracers = new Tracers( "null", NullLog.getInstance(), new Monitors(), mock( JobScheduler.class ) );
+        Tracers tracers = new Tracers( "null", NullLog.getInstance(), new Monitors(), mock( JobScheduler.class ),
+                clock );
         StatementLocksFactory statementLocksFactory = new SimpleStatementLocksFactory( locks );
 
         StatementOperationContainer statementOperationsContianer = new StatementOperationContainer( null, null );

--- a/community/kernel/src/test/java/org/neo4j/kernel/monitoring/tracing/TracersTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/monitoring/tracing/TracersTest.java
@@ -33,6 +33,8 @@ import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.logging.Log;
+import org.neo4j.time.Clocks;
+import org.neo4j.time.SystemNanoClock;
 
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -43,6 +45,7 @@ public class TracersTest
 {
     private final AssertableLogProvider logProvider = new AssertableLogProvider();
     private final JobScheduler jobScheduler = mock( JobScheduler.class );
+    private final SystemNanoClock clock = Clocks.nanoClock();
     private final Monitors monitors = new Monitors();
 
     private Log log;
@@ -57,7 +60,7 @@ public class TracersTest
     @Test
     public void mustProduceNullImplementationsWhenRequested() throws Exception
     {
-        Tracers tracers = new Tracers( "null", log, monitors, jobScheduler );
+        Tracers tracers = createTracers( "null" );
         assertThat( tracers.pageCacheTracer, is( PageCacheTracer.NULL ) );
         assertThat( tracers.pageCursorTracerSupplier, is( PageCursorTracerSupplier.NULL ) );
         assertThat( tracers.transactionTracer, is( TransactionTracer.NULL ) );
@@ -67,7 +70,7 @@ public class TracersTest
     @Test
     public void mustProduceNullImplementationsWhenRequestedIgnoringCase() throws Exception
     {
-        Tracers tracers = new Tracers( "NuLl", log, monitors, jobScheduler );
+        Tracers tracers = createTracers( "NuLl" );
         assertThat( tracers.pageCacheTracer, is( PageCacheTracer.NULL ) );
         assertThat( tracers.pageCursorTracerSupplier, is( PageCursorTracerSupplier.NULL ) );
         assertThat( tracers.transactionTracer, is( TransactionTracer.NULL ) );
@@ -77,7 +80,7 @@ public class TracersTest
     @Test
     public void mustProduceDefaultImplementationForNullConfiguration() throws Exception
     {
-        Tracers tracers = new Tracers( null, log, monitors, jobScheduler );
+        Tracers tracers = createTracers( null );
         assertDefaultImplementation( tracers );
         assertNoWarning();
     }
@@ -85,7 +88,7 @@ public class TracersTest
     @Test
     public void mustProduceDefaultImplementationWhenRequested() throws Exception
     {
-        Tracers tracers = new Tracers( "default", log, monitors, jobScheduler );
+        Tracers tracers = createTracers( "default" );
         assertDefaultImplementation( tracers );
         assertNoWarning();
     }
@@ -93,7 +96,7 @@ public class TracersTest
     @Test
     public void mustProduceDefaultImplementationWhenRequestedIgnoringCase() throws Exception
     {
-        Tracers tracers = new Tracers( "DeFaUlT", log, monitors, jobScheduler );
+        Tracers tracers = createTracers( "DeFaUlT" );
         assertDefaultImplementation( tracers );
         assertNoWarning();
     }
@@ -101,9 +104,14 @@ public class TracersTest
     @Test
     public void mustProduceDefaultImplementationWhenRequestingUnknownImplementation() throws Exception
     {
-        Tracers tracers = new Tracers( "there's nothing like this", log, monitors, jobScheduler );
+        Tracers tracers = createTracers( "there's nothing like this" );
         assertDefaultImplementation( tracers );
         assertWarning( "there's nothing like this" );
+    }
+
+    private Tracers createTracers( String s )
+    {
+        return new Tracers( s, log, monitors, jobScheduler, clock );
     }
 
     private void assertDefaultImplementation( Tracers tracers )

--- a/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoreDataSourceRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/NeoStoreDataSourceRule.java
@@ -138,7 +138,7 @@ public class NeoStoreDataSourceRule extends ExternalResource
                 new StartupStatisticsProvider(), null,
                 new CommunityCommitProcessFactory(), mock( InternalAutoIndexing.class ), pageCache,
                 new StandardConstraintSemantics(), monitors,
-                new Tracers( "null", NullLog.getInstance(), monitors, jobScheduler ),
+                new Tracers( "null", NullLog.getInstance(), monitors, jobScheduler, clock ),
                 mock( Procedures.class ),
                 IOLimiter.unlimited(),
                 availabilityGuard, clock,

--- a/community/logging/src/test/java/org/neo4j/logging/AssertableLogProvider.java
+++ b/community/logging/src/test/java/org/neo4j/logging/AssertableLogProvider.java
@@ -642,6 +642,23 @@ public class AssertableLogProvider extends AbstractLogProvider<Log> implements T
         }
     }
 
+    public void assertLogStringContains( String partOfMessage )
+    {
+        synchronized (logCalls)
+        {
+            for ( LogCall logCall : logCalls )
+            {
+                if ( logCall.toLogLikeString().contains( partOfMessage ) )
+                {
+                    return;
+                }
+            }
+        }
+        fail( format(
+                "Expected at least one log strings containing '%s', but none found. Actual log calls were:\n%s",
+                partOfMessage, serialize( logCalls.iterator() ) ) );
+    }
+
     public void assertContainsLogCallContaining( String partOfMessage )
     {
         if ( !containsLogCallContaining( partOfMessage ) )

--- a/enterprise/kernel/pom.xml
+++ b/enterprise/kernel/pom.xml
@@ -171,6 +171,13 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-logging</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/VerbosePageCacheTracer.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/VerbosePageCacheTracer.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.monitoring.tracing;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.neo4j.helpers.TimeUtil;
+import org.neo4j.io.ByteUnit;
+import org.neo4j.io.pagecache.PageSwapper;
+import org.neo4j.io.pagecache.tracing.DefaultPageCacheTracer;
+import org.neo4j.io.pagecache.tracing.FlushEvent;
+import org.neo4j.io.pagecache.tracing.FlushEventOpportunity;
+import org.neo4j.io.pagecache.tracing.MajorFlushEvent;
+import org.neo4j.logging.Log;
+import org.neo4j.time.SystemNanoClock;
+
+import static java.lang.String.format;
+import static org.neo4j.unsafe.impl.internal.dragons.FeatureToggles.flag;
+import static org.neo4j.unsafe.impl.internal.dragons.FeatureToggles.getInteger;
+
+public class VerbosePageCacheTracer extends DefaultPageCacheTracer
+{
+    private static final boolean USE_RAW_REPORTING_UNITS =
+            flag( VerbosePageCacheTracer.class, "reportInRawUnits", false );
+    private static final int SPEED_REPORTING_TIME_THRESHOLD = getInteger( VerbosePageCacheTracer.class,
+            "speedReportingThresholdSeconds", 10 );
+
+    private final Log log;
+    private final SystemNanoClock clock;
+    private final AtomicLong flushedPages = new AtomicLong();
+    private final AtomicLong flushBytesWritten = new AtomicLong();
+
+    VerbosePageCacheTracer( Log log, SystemNanoClock clock )
+    {
+        this.log = log;
+        this.clock = clock;
+    }
+
+    @Override
+    public void mappedFile( File file )
+    {
+        log.info( format( "Map file: '%s'.", file.getName() ) );
+        super.mappedFile( file );
+    }
+
+    @Override
+    public void unmappedFile( File file )
+    {
+        log.info( format( "Unmap file: '%s'.", file.getName() ) );
+        super.unmappedFile( file );
+    }
+
+    @Override
+    public MajorFlushEvent beginCacheFlush()
+    {
+        log.info( "Start whole page cache flush." );
+        return new PageCacheMajorFlushEvent( flushedPages.get(), flushBytesWritten.get(), clock.nanos() );
+    }
+
+    @Override
+    public MajorFlushEvent beginFileFlush( PageSwapper swapper )
+    {
+        String fileName = swapper.file().getName();
+        log.info( format( "Flushing file: '%s'.", fileName ) );
+        return new FileFlushEvent( fileName, flushedPages.get(), flushBytesWritten.get(), clock.nanos() );
+    }
+
+    private static String nanosToString( long nanos )
+    {
+        if ( USE_RAW_REPORTING_UNITS )
+        {
+            return nanos + "ns";
+        }
+        return TimeUtil.nanosToString( nanos );
+    }
+
+    private static String flushSpeed( long bytesWrittenInTotal, long flushTimeNanos )
+    {
+        if ( USE_RAW_REPORTING_UNITS )
+        {
+            return bytesInNanoSeconds( bytesWrittenInTotal, flushTimeNanos );
+        }
+        long seconds = TimeUnit.NANOSECONDS.toSeconds( flushTimeNanos );
+        if ( seconds > 0 )
+        {
+            return bytesToString( bytesWrittenInTotal / seconds ) + "/s";
+        }
+        else
+        {
+            return bytesInNanoSeconds( bytesWrittenInTotal, flushTimeNanos );
+        }
+    }
+
+    private static String bytesInNanoSeconds( long bytesWrittenInTotal, long flushTimeNanos )
+    {
+        long bytesInNanoSecond = flushTimeNanos > 0 ? (bytesWrittenInTotal / flushTimeNanos) : bytesWrittenInTotal;
+        return bytesInNanoSecond + "bytes/ns";
+    }
+
+    private static String bytesToString( long bytes )
+    {
+        if ( USE_RAW_REPORTING_UNITS )
+        {
+            return bytes + "bytes";
+        }
+        return ByteUnit.bytesToString( bytes );
+    }
+
+    private final FlushEvent flushEvent = new FlushEvent()
+    {
+        @Override
+        public void addBytesWritten( long bytes )
+        {
+            bytesWritten.add( bytes );
+            flushBytesWritten.getAndAdd( bytes );
+        }
+
+        @Override
+        public void done()
+        {
+            flushes.increment();
+        }
+
+        @Override
+        public void done( IOException exception )
+        {
+            done();
+        }
+
+        @Override
+        public void addPagesFlushed( int pageCount )
+        {
+            flushedPages.getAndAdd( pageCount );
+        }
+    };
+
+    private class FileFlushEvent implements MajorFlushEvent
+    {
+        private final long startTimeNanos;
+        private final String fileName;
+        private long flushesOnStart;
+        private long bytesWrittenOnStart;
+
+        FileFlushEvent( String fileName, long flushesOnStart, long bytesWrittenOnStart, long startTimeNanos )
+        {
+            this.fileName = fileName;
+            this.flushesOnStart = flushesOnStart;
+            this.bytesWrittenOnStart = bytesWrittenOnStart;
+            this.startTimeNanos = startTimeNanos;
+        }
+
+        @Override
+        public FlushEventOpportunity flushEventOpportunity()
+        {
+            return new VerboseFlushOpportunity( fileName, startTimeNanos, bytesWrittenOnStart );
+        }
+
+        @Override
+        public void close()
+        {
+            long fileFlushNanos = clock.nanos() - startTimeNanos;
+            long bytesWrittenInTotal = flushBytesWritten.get() - bytesWrittenOnStart;
+            long flushedPagesInTotal = flushedPages.get() - flushesOnStart;
+            log.info( "'%s' flush completed. Flushed %s in %d pages. Flush took: %s. Average speed: %s.",
+                    fileName,
+                    bytesToString( bytesWrittenInTotal ), flushedPagesInTotal,
+                    nanosToString( fileFlushNanos ), flushSpeed( bytesWrittenInTotal, fileFlushNanos ) );
+        }
+    }
+
+    private class PageCacheMajorFlushEvent implements MajorFlushEvent
+    {
+        private final long flushesOnStart;
+        private final long bytesWrittenOnStart;
+        private final long startTimeNanos;
+
+        PageCacheMajorFlushEvent( long flushesOnStart, long bytesWrittenOnStart, long startTimeNanos )
+        {
+            this.flushesOnStart = flushesOnStart;
+            this.bytesWrittenOnStart = bytesWrittenOnStart;
+            this.startTimeNanos = startTimeNanos;
+        }
+
+        @Override
+        public FlushEventOpportunity flushEventOpportunity()
+        {
+            return new VerboseFlushOpportunity( "Page Cache", startTimeNanos, bytesWrittenOnStart );
+        }
+
+        @Override
+        public void close()
+        {
+            long pageCacheFlushNanos = clock.nanos() - startTimeNanos;
+            long bytesWrittenInTotal = flushBytesWritten.get() - bytesWrittenOnStart;
+            long flushedPagesInTotal = flushedPages.get() - flushesOnStart;
+            log.info( "Page cache flush completed. Flushed %s in %d pages. Flush took: %s. Average speed: %s.",
+                    bytesToString( bytesWrittenInTotal ), flushedPagesInTotal,
+                    nanosToString(pageCacheFlushNanos),
+                    flushSpeed( bytesWrittenInTotal, pageCacheFlushNanos ) );
+        }
+    }
+
+    private class VerboseFlushOpportunity implements FlushEventOpportunity
+    {
+        private final String fileName;
+        private long lastReportingTime;
+        private long lastReportedBytesWritten;
+
+        VerboseFlushOpportunity( String fileName, long nanoStartTime, long bytesWrittenOnStart )
+        {
+            this.fileName = fileName;
+            this.lastReportingTime = nanoStartTime;
+            this.lastReportedBytesWritten = bytesWrittenOnStart;
+        }
+
+        @Override
+        public FlushEvent beginFlush( long filePageId, int cachePageId, PageSwapper swapper )
+        {
+            long now = clock.nanos();
+            long opportunityIntervalNanos = now - lastReportingTime;
+            if ( TimeUnit.NANOSECONDS.toSeconds( opportunityIntervalNanos ) > SPEED_REPORTING_TIME_THRESHOLD )
+            {
+                long writtenBytes = flushBytesWritten.get();
+                log.info( format("'%s' flushing speed: %s.", fileName,
+                        flushSpeed( writtenBytes - lastReportedBytesWritten, opportunityIntervalNanos ) ) );
+                lastReportingTime = now;
+                lastReportedBytesWritten = writtenBytes;
+            }
+            return flushEvent;
+        }
+    }
+}

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/VerboseTracerFactory.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/monitoring/tracing/VerboseTracerFactory.java
@@ -17,43 +17,28 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.kernel.stresstests.transaction.checkpoint.tracers;
+package org.neo4j.kernel.monitoring.tracing;
 
+import org.neo4j.helpers.Service;
 import org.neo4j.io.pagecache.tracing.PageCacheTracer;
-import org.neo4j.kernel.impl.transaction.tracing.CheckPointTracer;
-import org.neo4j.kernel.impl.transaction.tracing.TransactionTracer;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.monitoring.Monitors;
-import org.neo4j.kernel.monitoring.tracing.TracerFactory;
 import org.neo4j.logging.Log;
 import org.neo4j.time.SystemNanoClock;
 
-public class TimerTracerFactory implements TracerFactory
+@Service.Implementation( TracerFactory.class )
+public class VerboseTracerFactory extends DefaultTracerFactory
 {
-    private TimerTransactionTracer timerTransactionTracer = new TimerTransactionTracer();
-
     @Override
     public String getImplementationName()
     {
-        return "timer";
+        return "verbose";
     }
 
     @Override
     public PageCacheTracer createPageCacheTracer( Monitors monitors, JobScheduler jobScheduler, SystemNanoClock clock,
-            Log log )
+            Log msgLog )
     {
-        return PageCacheTracer.NULL;
-    }
-
-    @Override
-    public TransactionTracer createTransactionTracer( Monitors monitors, JobScheduler jobScheduler )
-    {
-        return timerTransactionTracer;
-    }
-
-    @Override
-    public CheckPointTracer createCheckPointTracer( Monitors monitors, JobScheduler jobScheduler )
-    {
-        return timerTransactionTracer;
+        return new VerbosePageCacheTracer( msgLog, clock );
     }
 }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/monitoring/tracing/VerbosePageCacheTracerTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/monitoring/tracing/VerbosePageCacheTracerTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.monitoring.tracing;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.io.ByteUnit;
+import org.neo4j.io.pagecache.tracing.DummyPageSwapper;
+import org.neo4j.io.pagecache.tracing.EvictionEvent;
+import org.neo4j.io.pagecache.tracing.EvictionRunEvent;
+import org.neo4j.io.pagecache.tracing.FlushEvent;
+import org.neo4j.io.pagecache.tracing.FlushEventOpportunity;
+import org.neo4j.io.pagecache.tracing.MajorFlushEvent;
+import org.neo4j.logging.AssertableLogProvider;
+import org.neo4j.logging.Log;
+import org.neo4j.time.Clocks;
+import org.neo4j.time.FakeClock;
+
+public class VerbosePageCacheTracerTest
+{
+    private AssertableLogProvider logProvider = new AssertableLogProvider( true );
+    private Log log = logProvider.getLog( getClass() );
+    private FakeClock clock = Clocks.fakeClock();
+
+    @Test
+    public void traceFileMap()
+    {
+        VerbosePageCacheTracer tracer = createTracer();
+        tracer.mappedFile( new File( "mapFile" ) );
+        logProvider.assertContainsMessageContaining( "Map file: 'mapFile'." );
+    }
+
+    @Test
+    public void traceUnmapFile()
+    {
+        VerbosePageCacheTracer tracer = createTracer();
+        tracer.unmappedFile( new File( "unmapFile" ) );
+        logProvider.assertContainsMessageContaining( "Unmap file: 'unmapFile'." );
+    }
+
+    @Test
+    public void traceSinglePageCacheFlush()
+    {
+        VerbosePageCacheTracer tracer = createTracer();
+        try ( MajorFlushEvent majorFlushEvent = tracer.beginCacheFlush() )
+        {
+            FlushEventOpportunity flushEventOpportunity = majorFlushEvent.flushEventOpportunity();
+            FlushEvent flushEvent = flushEventOpportunity.beginFlush( 1, 2, new DummyPageSwapper( "testFile" ) );
+            flushEvent.addBytesWritten( 2 );
+            flushEvent.addPagesFlushed( 7 );
+            flushEvent.done();
+        }
+        logProvider.assertContainsMessageContaining( "Start whole page cache flush." );
+        logProvider.assertLogStringContains( "Page cache flush completed. Flushed 2B in 7 pages. Flush took: 0ns. " +
+                "Average speed: 2bytes/ns." );
+    }
+
+    @Test
+    public void evictionDoesNotInfluenceFlushNumbers()
+    {
+        VerbosePageCacheTracer tracer = createTracer();
+        try ( MajorFlushEvent majorFlushEvent = tracer.beginCacheFlush() )
+        {
+            FlushEventOpportunity flushEventOpportunity = majorFlushEvent.flushEventOpportunity();
+            FlushEvent flushEvent = flushEventOpportunity.beginFlush( 1, 2, new DummyPageSwapper( "testFile" ) );
+            clock.forward( 2, TimeUnit.MILLISECONDS );
+
+            try ( EvictionRunEvent evictionRunEvent = tracer.beginPageEvictions( 5 ) )
+            {
+                try ( EvictionEvent evictionEvent = evictionRunEvent.beginEviction() )
+                {
+                    FlushEventOpportunity evictionEventOpportunity = evictionEvent.flushEventOpportunity();
+                    FlushEvent evictionFlush = evictionEventOpportunity.beginFlush( 2, 3, new DummyPageSwapper( "evictionFile" ) );
+                    evictionFlush.addPagesFlushed( 10 );
+                    evictionFlush.addPagesFlushed( 100 );
+                }
+            }
+            flushEvent.addBytesWritten( 2 );
+            flushEvent.addPagesFlushed( 7 );
+            flushEvent.done();
+        }
+        logProvider.assertContainsMessageContaining( "Start whole page cache flush." );
+        logProvider.assertLogStringContains( "Page cache flush completed. Flushed 2B in 7 pages. Flush took: 2ms. " +
+                "Average speed: 0bytes/ns." );
+    }
+
+    @Test
+    public void traceFileFlush()
+    {
+        VerbosePageCacheTracer tracer = createTracer();
+        DummyPageSwapper swapper = new DummyPageSwapper( "fileToFlush" );
+        try ( MajorFlushEvent fileToFlush = tracer.beginFileFlush( swapper ) )
+        {
+            FlushEventOpportunity flushEventOpportunity = fileToFlush.flushEventOpportunity();
+            FlushEvent flushEvent = flushEventOpportunity.beginFlush( 1, 2, swapper );
+            flushEvent.addPagesFlushed( 100 );
+            flushEvent.addBytesWritten( ByteUnit.ONE_MEBI_BYTE );
+            flushEvent.done();
+            clock.forward( 1, TimeUnit.SECONDS );
+            FlushEvent flushEvent2 = flushEventOpportunity.beginFlush( 1, 2, swapper );
+            flushEvent2.addPagesFlushed( 10 );
+            flushEvent2.addBytesWritten( ByteUnit.ONE_MEBI_BYTE );
+            flushEvent2.done();
+        }
+        logProvider.assertContainsMessageContaining( "Flushing file: 'fileToFlush'." );
+        logProvider.assertLogStringContains( "'fileToFlush' flush completed. Flushed 2.000MiB in 110 pages. Flush took: 1s. Average speed: 2.000MiB/s." );
+    }
+
+    private VerbosePageCacheTracer createTracer()
+    {
+        return new VerbosePageCacheTracer( log, clock );
+    }
+}

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/monitoring/tracing/VerboseTracerFactoryTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/monitoring/tracing/VerboseTracerFactoryTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.monitoring.tracing;
+
+import org.junit.Test;
+
+import org.neo4j.io.pagecache.tracing.PageCacheTracer;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.BufferingLog;
+import org.neo4j.test.OnDemandJobScheduler;
+import org.neo4j.time.Clocks;
+
+import static org.junit.Assert.assertEquals;
+
+public class VerboseTracerFactoryTest
+{
+
+    @Test
+    public void verboseTracerFactoryRegisterTracerWithCodeNameVerbose()
+    {
+        assertEquals( "verbose", tracerFactory().getImplementationName() );
+    }
+
+    @Test
+    public void verboseFactoryCreateVerboseTracer()
+    {
+        BufferingLog msgLog = new BufferingLog();
+        PageCacheTracer pageCacheTracer = tracerFactory().createPageCacheTracer( new Monitors(),
+                new OnDemandJobScheduler(), Clocks.nanoClock(), msgLog );
+        pageCacheTracer.beginCacheFlush();
+        assertEquals( "Start whole page cache flush.", msgLog.toString().trim() );
+    }
+
+    private VerboseTracerFactory tracerFactory()
+    {
+        return new VerboseTracerFactory();
+    }
+}

--- a/integrationtests/src/test/java/org/neo4j/kernel/PageCacheFlushTracingTest.java
+++ b/integrationtests/src/test/java/org/neo4j/kernel/PageCacheFlushTracingTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory;
+import org.neo4j.logging.AssertableLogProvider;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.test.rule.TestDirectory;
+
+public class PageCacheFlushTracingTest
+{
+    @Rule
+    public final TestDirectory testDirectory = TestDirectory.testDirectory();
+
+    @Test
+    public void tracePageCacheFlushProgress()
+    {
+        AssertableLogProvider logProvider = new AssertableLogProvider( true );
+        GraphDatabaseService database = new TestGraphDatabaseFactory().setInternalLogProvider( logProvider )
+                                            .newEmbeddedDatabaseBuilder( testDirectory.directory() )
+                                            .setConfig( GraphDatabaseFacadeFactory.Configuration.tracer, "verbose" )
+                                            .newGraphDatabase();
+        try ( Transaction transaction = database.beginTx() )
+        {
+            database.createNode();
+            transaction.success();
+        }
+        database.shutdown();
+        logProvider.assertContainsMessageContaining( "Flushing file" );
+        logProvider.assertContainsMessageContaining( "Page cache flush completed. Flushed " );
+    }
+}


### PR DESCRIPTION
Introduce verbose page cache flush tracer that will
log page cache events that happen during page cache flush together with
some additional information: flush speed, number of pages affected by flush
etc.
Useful for investigation purposes when there is a need to see how much pages
affected, how much data is flushed, how fast flush is actually progress.