### PR TITLE
Consistent import of neo4j 2.3.X (to be 2.3.11)

### DIFF
--- a/enterprise/cypher/cypher/pom.xml
+++ b/enterprise/cypher/cypher/pom.xml
@@ -164,7 +164,7 @@
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-cypher-compiler-2.3</artifactId>
-      <version>2.3.10</version>
+      <version>2.3.11</version>
       <exclusions>
         <exclusion>
           <groupId>org.neo4j</groupId>

--- a/enterprise/cypher/physical-planning/pom.xml
+++ b/enterprise/cypher/physical-planning/pom.xml
@@ -144,7 +144,7 @@
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-cypher-compiler-2.3</artifactId>
-      <version>2.3.10</version>
+      <version>2.3.11</version>
       <exclusions>
         <exclusion>
           <groupId>org.neo4j</groupId>

--- a/enterprise/cypher/slotted-runtime/pom.xml
+++ b/enterprise/cypher/slotted-runtime/pom.xml
@@ -159,7 +159,7 @@
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-cypher-compiler-2.3</artifactId>
-      <version>2.3.10</version>
+      <version>2.3.11</version>
       <exclusions>
         <exclusion>
           <groupId>org.neo4j</groupId>


### PR DESCRIPTION
There was 2.3.11 in one location and 2.3.10 in three locations.