### PR TITLE
Fix security logging with multiple auth providers

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/Neo4jWithSocket.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/Neo4jWithSocket.java
@@ -77,6 +77,16 @@ public class Neo4jWithSocket extends ExternalResource
         this.configure = configure;
     }
 
+    public FileSystemAbstraction getFileSystem()
+    {
+        return this.graphDatabaseFactory.getFileSystem();
+    }
+
+    public File getWorkingDirectory()
+    {
+        return workingDirectory;
+    }
+
     @Override
     public Statement apply( final Statement statement, final Description description )
     {

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
@@ -163,22 +163,16 @@ public class LdapRealm extends DefaultLdapRealm implements RealmLifecycle, Shiro
                 }
                 catch ( Exception e )
                 {
-                    securityLog.error( withRealm( "Failed to authenticate user '%s' against %s: %s", token.getPrincipal(),
-                            serverString, e.getMessage() ) );
-
                     if ( isExceptionAnLdapConnectionTimeout( e ) )
                     {
-                        securityLog.error( withRealm( "LDAP connection to %s timed out.", serverString ) );
                         throw new AuthProviderTimeoutException( LDAP_CONNECTION_TIMEOUT_CLIENT_MESSAGE, e );
                     }
                     else if ( isExceptionAnLdapReadTimeout( e ) )
                     {
-                        securityLog.error( withRealm( "LDAP response from %s timed out.", serverString ) );
                         throw new AuthProviderTimeoutException( LDAP_READ_TIMEOUT_CLIENT_MESSAGE, e );
                     }
                     else if ( isExceptionConnectionRefused( e ) )
                     {
-                        securityLog.error( withRealm( "LDAP connection to %s was refused.", serverString ) );
                         throw new AuthProviderFailedException( LDAP_CONNECTION_REFUSED_CLIENT_MESSAGE, e );
                     }
                     // This exception will be caught and rethrown by Shiro, and then by us, so we do not need to wrap it here
@@ -560,7 +554,6 @@ public class LdapRealm extends DefaultLdapRealm implements RealmLifecycle, Shiro
                     }
                     catch ( Exception ex )
                     {
-                        securityLog.warn( "Error in authentication for user " + loginUser, ex );
                         // We have to rethrow the exception, to indicate invalid login
                         throw ex;
                     }
@@ -568,16 +561,9 @@ public class LdapRealm extends DefaultLdapRealm implements RealmLifecycle, Shiro
             }
             else
             {
-                securityLog.warn( "No user matching: " + principal );
                 throw new AuthenticationException( "No user matching: " + principal );
             }
             return createAuthenticationInfo( token, principal, credentials, ctx );
-        }
-        catch ( NamingException ne )
-        {
-            securityLog.error( "Error in ldap name resolving", ne );
-            // We have to rethrow the exception, to indicate invalid login
-            throw ne;
         }
         finally
         {

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManager.java
@@ -101,10 +101,26 @@ class MultiRealmAuthManager implements EnterpriseAuthAndUserManager
         {
             securityContext = new StandardEnterpriseSecurityContext(
                     this, (ShiroSubject) securityManager.login( null, token ) );
-            if ( logSuccessfulLogin )
+            AuthenticationResult authenticationResult = securityContext.subject().getAuthenticationResult();
+            if ( authenticationResult == AuthenticationResult.SUCCESS )
             {
-                securityLog.info( securityContext, "logged in" );
+                if ( logSuccessfulLogin )
+                {
+                    securityLog.info( securityContext, "logged in" );
+                }
             }
+            else if ( authenticationResult == AuthenticationResult.PASSWORD_CHANGE_REQUIRED )
+            {
+                securityLog.info( securityContext, "logged in (password change required)" );
+            }
+            else
+            {
+                String errorMessage = ((StandardEnterpriseSecurityContext.NeoShiroSubject) securityContext.subject())
+                        .getAuthenticationFailureMessage();
+                securityLog.error( "[%s]: failed to log in: %s", escape( token.getPrincipal().toString() ), errorMessage );
+            }
+            // No need to keep full Shiro authentication info around on the subject
+            ((StandardEnterpriseSecurityContext.NeoShiroSubject) securityContext.subject()).clearAuthenticationInfo();
         }
         catch ( UnsupportedTokenException e )
         {
@@ -128,20 +144,28 @@ class MultiRealmAuthManager implements EnterpriseAuthAndUserManager
         {
             if ( e.getCause() != null && e.getCause() instanceof AuthProviderTimeoutException )
             {
-                securityLog.error( "[%s]: failed to log in: auth server timeout",
-                        escape( token.getPrincipal().toString() ) );
+                Throwable cause = e.getCause().getCause();
+                securityLog.error( "[%s]: failed to log in: auth server timeout%s",
+                        escape( token.getPrincipal().toString() ),
+                        cause != null && cause.getMessage() != null ? " (" + cause.getMessage() + ")" : "" );
                 throw new AuthProviderTimeoutException( e.getCause().getMessage(), e.getCause() );
             }
             else if ( e.getCause() != null && e.getCause() instanceof AuthProviderFailedException )
             {
-                securityLog.error( "[%s]: failed to log in: auth server connection refused",
-                        escape( token.getPrincipal().toString() ) );
+                Throwable cause = e.getCause().getCause();
+                securityLog.error( "[%s]: failed to log in: auth server connection refused%s",
+                        escape( token.getPrincipal().toString() ),
+                        cause != null && cause.getMessage() != null ? " (" + cause.getMessage() + ")" : "" );
                 throw new AuthProviderFailedException( e.getCause().getMessage(), e.getCause() );
             }
             securityContext = new StandardEnterpriseSecurityContext( this,
                     new ShiroSubject( securityManager, AuthenticationResult.FAILURE ) );
-            securityLog.error( "[%s]: failed to log in: invalid principal or credentials",
-                    escape( token.getPrincipal().toString() ) );
+            Throwable cause = e.getCause();
+            Throwable causeCause = e.getCause() != null ? e.getCause().getCause() : null;
+            securityLog.error( "[%s]: failed to log in: invalid principal or credentials%s%s",
+                    escape( token.getPrincipal().toString() ),
+                    cause != null && cause.getMessage() != null ? " (" + cause.getMessage() + ")" : "",
+                    causeCause != null && causeCause.getMessage() != null ? " (" + causeCause.getMessage() + ")" : "" );
         }
 
         return securityContext;

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthenticationInfo.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthenticationInfo.java
@@ -23,6 +23,9 @@ import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.SimpleAuthenticationInfo;
 import org.apache.shiro.util.ByteSource;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.neo4j.kernel.api.security.AuthenticationResult;
 
 import static org.neo4j.kernel.api.security.AuthenticationResult.FAILURE;
@@ -33,11 +36,13 @@ import static org.neo4j.kernel.api.security.AuthenticationResult.TOO_MANY_ATTEMP
 public class ShiroAuthenticationInfo extends SimpleAuthenticationInfo
 {
     private AuthenticationResult authenticationResult;
+    private List<Throwable> throwables;
 
     public ShiroAuthenticationInfo()
     {
         super();
         this.authenticationResult = AuthenticationResult.FAILURE;
+        this.throwables = new ArrayList<>( 1 );
     }
 
     public ShiroAuthenticationInfo( Object principal, String realmName, AuthenticationResult authenticationResult )
@@ -56,6 +61,16 @@ public class ShiroAuthenticationInfo extends SimpleAuthenticationInfo
     public AuthenticationResult getAuthenticationResult()
     {
         return authenticationResult;
+    }
+
+    public void addThrowable( Throwable t )
+    {
+        throwables.add( t );
+    }
+
+    public List<Throwable> getThrowables()
+    {
+        return throwables;
     }
 
     @Override

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthenticationStrategy.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthenticationStrategy.java
@@ -35,4 +35,17 @@ public class ShiroAuthenticationStrategy extends AbstractAuthenticationStrategy
     {
         return new ShiroAuthenticationInfo();
     }
+
+    @Override
+    public AuthenticationInfo afterAttempt( Realm realm, AuthenticationToken token, AuthenticationInfo singleRealmInfo,
+            AuthenticationInfo aggregateInfo, Throwable t ) throws AuthenticationException
+    {
+        AuthenticationInfo info = super.afterAttempt( realm, token, singleRealmInfo, aggregateInfo, t );
+        if ( t != null && info instanceof ShiroAuthenticationInfo )
+        {
+            // Save the throwable so we can use it for correct log messages later
+            ((ShiroAuthenticationInfo) info).addThrowable( t );
+        }
+        return info;
+    }
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroSubject.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroSubject.java
@@ -29,6 +29,7 @@ import org.neo4j.kernel.api.security.AuthenticationResult;
 public class ShiroSubject extends DelegatingSubject
 {
     private AuthenticationResult authenticationResult;
+    private ShiroAuthenticationInfo authenticationInfo;
 
     public ShiroSubject( SecurityManager securityManager, AuthenticationResult authenticationResult )
     {
@@ -37,10 +38,12 @@ public class ShiroSubject extends DelegatingSubject
     }
 
     public ShiroSubject( PrincipalCollection principals, boolean authenticated, String host, Session session,
-            boolean sessionCreationEnabled, SecurityManager securityManager, AuthenticationResult authenticationResult )
+            boolean sessionCreationEnabled, SecurityManager securityManager, AuthenticationResult authenticationResult,
+            ShiroAuthenticationInfo authenticationInfo )
     {
         super( principals, authenticated, host, session, sessionCreationEnabled, securityManager );
         this.authenticationResult = authenticationResult;
+        this.authenticationInfo = authenticationInfo;
     }
 
     public AuthenticationResult getAuthenticationResult()
@@ -51,5 +54,15 @@ public class ShiroSubject extends DelegatingSubject
     void setAuthenticationResult( AuthenticationResult authenticationResult )
     {
         this.authenticationResult = authenticationResult;
+    }
+
+    public ShiroAuthenticationInfo getAuthenticationInfo()
+    {
+        return authenticationInfo;
+    }
+
+    public void clearAuthenticationInfo()
+    {
+        this.authenticationInfo = null;
     }
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroSubjectFactory.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroSubjectFactory.java
@@ -40,6 +40,6 @@ public class ShiroSubjectFactory implements SubjectFactory
         ShiroAuthenticationInfo authcInfo = (ShiroAuthenticationInfo) context.getAuthenticationInfo();
 
         return new ShiroSubject( principals, authenticated, host, session, sessionCreationEnabled, securityManager,
-                authcInfo.getAuthenticationResult() );
+                authcInfo.getAuthenticationResult(), authcInfo );
     }
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseSecurityContext.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseSecurityContext.java
@@ -266,6 +266,7 @@ class StandardEnterpriseSecurityContext implements EnterpriseSecurityContext
                     message = buildMessageFromThrowables( "password change required", throwables );
                 }
                 break;
+            default:
             }
             return message;
         }
@@ -276,7 +277,7 @@ class StandardEnterpriseSecurityContext implements EnterpriseSecurityContext
         }
     }
 
-    static private String buildMessageFromThrowables( String baseMessage, List<Throwable> throwables )
+    private static String buildMessageFromThrowables( String baseMessage, List<Throwable> throwables )
     {
         if ( throwables == null )
         {

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseSecurityContext.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseSecurityContext.java
@@ -22,6 +22,7 @@ package org.neo4j.server.security.enterprise.auth;
 import org.apache.shiro.authz.AuthorizationInfo;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -199,7 +200,7 @@ class StandardEnterpriseSecurityContext implements EnterpriseSecurityContext
         }
     }
 
-    private class NeoShiroSubject implements AuthSubject
+    class NeoShiroSubject implements AuthSubject
     {
 
         @Override
@@ -243,5 +244,70 @@ class StandardEnterpriseSecurityContext implements EnterpriseSecurityContext
             Object principal = shiroSubject.getPrincipal();
             return principal != null && username != null && username.equals( principal );
         }
+
+        public String getAuthenticationFailureMessage()
+        {
+            String message = "";
+            List<Throwable> throwables = shiroSubject.getAuthenticationInfo().getThrowables();
+            switch ( shiroSubject.getAuthenticationResult() )
+            {
+            case FAILURE:
+                {
+                    message = buildMessageFromThrowables( "invalid principal or credentials", throwables );
+                }
+                break;
+            case TOO_MANY_ATTEMPTS:
+                {
+                    message = buildMessageFromThrowables( "too many failed attempts", throwables );
+                }
+                break;
+            case PASSWORD_CHANGE_REQUIRED:
+                {
+                    message = buildMessageFromThrowables( "password change required", throwables );
+                }
+                break;
+            }
+            return message;
+        }
+
+        public void clearAuthenticationInfo()
+        {
+            shiroSubject.clearAuthenticationInfo();
+        }
+    }
+
+    static private String buildMessageFromThrowables( String baseMessage, List<Throwable> throwables )
+    {
+        if ( throwables == null )
+        {
+            return baseMessage;
+        }
+
+        StringBuilder sb = new StringBuilder( baseMessage );
+
+        for ( Throwable t : throwables )
+        {
+            if ( t.getMessage() != null )
+            {
+                sb.append( " (" );
+                sb.append( t.getMessage() );
+                sb.append( ")" );
+            }
+            Throwable cause = t.getCause();
+            if ( cause != null && cause.getMessage() != null )
+            {
+                sb.append( " (" );
+                sb.append( cause.getMessage() );
+                sb.append( ")" );
+            }
+            Throwable causeCause = cause != null ? cause.getCause() : null;
+            if ( causeCause != null && causeCause.getMessage() != null )
+            {
+                sb.append( " (" );
+                sb.append( causeCause.getMessage() );
+                sb.append( ")" );
+            }
+        }
+        return sb.toString();
     }
 }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapRealmTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapRealmTest.java
@@ -405,9 +405,10 @@ public class LdapRealmTest
                 NamingException.class );
 
         // Then
-        verify( securityLog ).error( contains(
-                "{LdapRealm}: Failed to authenticate user 'olivia' against 'ldap://myserver.org:12345' using StartTLS: " +
-                        "Simulated failure" ) );
+        // Authentication failures are logged from MultiRealmAuthManager
+        //verify( securityLog ).error( contains(
+        //        "{LdapRealm}: Failed to authenticate user 'olivia' against 'ldap://myserver.org:12345' using StartTLS: " +
+        //                "Simulated failure" ) );
     }
 
     @Test

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerTest.java
@@ -254,7 +254,7 @@ public class MultiRealmAuthManagerTest extends InitialUserTest
 
         // Then
         assertThat( result, equalTo( AuthenticationResult.PASSWORD_CHANGE_REQUIRED ) );
-        logProvider.assertExactly( info( "[jake]: logged in" ) );
+        logProvider.assertExactly( info( "[jake]: logged in (password change required)" ) );
     }
 
     @Test
@@ -300,7 +300,7 @@ public class MultiRealmAuthManagerTest extends InitialUserTest
 
         // Then
         assertThat( result, equalTo( AuthenticationResult.FAILURE ) );
-        logProvider.assertExactly( error( "[%s]: failed to log in: invalid principal or credentials", "unknown" ) );
+        logProvider.assertExactly( error( "[%s]: failed to log in: invalid principal or credentials%s%s", "unknown", "", "" ) );
     }
 
     @Test
@@ -315,8 +315,8 @@ public class MultiRealmAuthManagerTest extends InitialUserTest
 
         // Then
         assertThat( result, equalTo( AuthenticationResult.FAILURE ) );
-        logProvider.assertExactly( error( "[%s]: failed to log in: invalid principal or credentials",
-                escape( "unknown\n\t\r\"haxx0r\"" ) ) );
+        logProvider.assertExactly( error( "[%s]: failed to log in: invalid principal or credentials%s%s",
+                escape( "unknown\n\t\r\"haxx0r\"" ), "", "" ) );
     }
 
     @Test

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/BoltInitChangePasswordTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/BoltInitChangePasswordTest.java
@@ -56,7 +56,7 @@ public class BoltInitChangePasswordTest
         authentication.authenticate( authToken( "neo4j", "123", "secret" ) );
 
         FullSecurityLog fullLog = authManagerRule.getFullSecurityLog();
-        fullLog.assertHasLine( "neo4j", "logged in" );
+        fullLog.assertHasLine( "neo4j", "logged in (password change required)" );
         fullLog.assertHasLine( "neo4j", "changed password" );
     }
 
@@ -67,7 +67,7 @@ public class BoltInitChangePasswordTest
                 AuthenticationException.class, "Old password and new password cannot be the same." );
 
         FullSecurityLog fullLog = authManagerRule.getFullSecurityLog();
-        fullLog.assertHasLine( "neo4j", "logged in" );
+        fullLog.assertHasLine( "neo4j", "logged in (password change required)" );
         fullLog.assertHasLine( "neo4j", "tried to change password: Old password and new password cannot be the same." );
     }
 

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/LdapAuthIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/LdapAuthIT.java
@@ -1034,7 +1034,8 @@ public class LdapAuthIT extends EnterpriseAuthenticationTestBase
     {
         // When
         restartNeo4jServerWithOverriddenSettings( ldapOnlyAuthSettings.andThen(
-                settings -> {
+                settings ->
+                {
                     settings.put( SecuritySettings.ldap_server, "ldap://" + NON_ROUTABLE_IP );
                     settings.put( SecuritySettings.ldap_connection_timeout, "1s" );
                 } ) );


### PR DESCRIPTION
Improves security logging when multiple auth providers are
configured.

If a user is successfully authenticated by one auth provider we now
do not log authentication error messages to the security log from
another auth provider.

Also fixes a bug where we could get successful login messages in the
security log upon authenentication failure with multiple auth providers
enabled.