### PR TITLE
Refresh raft timeouts on message recieve

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/ConsensusModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/ConsensusModule.java
@@ -20,6 +20,7 @@
 package org.neo4j.causalclustering.core.consensus;
 
 import java.io.File;
+import java.time.Duration;
 
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.core.EnterpriseCoreEditionModule;
@@ -35,6 +36,7 @@ import org.neo4j.causalclustering.core.consensus.membership.MemberIdSetBuilder;
 import org.neo4j.causalclustering.core.consensus.membership.RaftMembershipManager;
 import org.neo4j.causalclustering.core.consensus.membership.RaftMembershipState;
 import org.neo4j.causalclustering.core.consensus.schedule.DelayedRenewableTimeoutService;
+import org.neo4j.causalclustering.core.consensus.schedule.RenewableTimeoutService;
 import org.neo4j.causalclustering.core.consensus.shipping.RaftLogShippingManager;
 import org.neo4j.causalclustering.core.consensus.term.MonitoredTermStateStorage;
 import org.neo4j.causalclustering.core.consensus.term.TermState;
@@ -75,6 +77,8 @@ public class ConsensusModule
     private final RaftMembershipManager raftMembershipManager;
     private final InFlightCache inFlightCache;
 
+    private final LeaderAvailabilityTimers leaderAvailabilityTimers;
+
     public ConsensusModule( MemberId myself, final PlatformModule platformModule,
             Outbound<MemberId,RaftMessages.RaftMessage> outbound, File clusterStateDirectory,
             CoreTopologyService coreTopologyService )
@@ -112,8 +116,9 @@ public class ConsensusModule
                         new RaftMembershipState.Marshal(),
                         config.get( CausalClusteringSettings.raft_membership_state_size ), logProvider ) );
 
-        long electionTimeout = config.get( CausalClusteringSettings.leader_election_timeout ).toMillis();
-        long heartbeatInterval = electionTimeout / 3;
+        raftTimeoutService = new DelayedRenewableTimeoutService( systemClock(), logProvider );
+
+        leaderAvailabilityTimers = createElectionTiming( config, raftTimeoutService, logProvider );
 
         Integer expectedClusterSize = config.get( CausalClusteringSettings.expected_core_cluster_size );
 
@@ -122,7 +127,7 @@ public class ConsensusModule
         SendToMyself leaderOnlyReplicator = new SendToMyself( myself, outbound );
 
         raftMembershipManager = new RaftMembershipManager( leaderOnlyReplicator, memberSetBuilder, raftLog, logProvider,
-                expectedClusterSize, electionTimeout, systemClock(), config.get( join_catch_up_timeout ).toMillis(),
+                expectedClusterSize, leaderAvailabilityTimers.getElectionTimeout(), systemClock(), config.get( join_catch_up_timeout ).toMillis(),
                 raftMembershipStorage );
 
         life.add( raftMembershipManager );
@@ -131,21 +136,25 @@ public class ConsensusModule
 
         RaftLogShippingManager logShipping =
                 new RaftLogShippingManager( outbound, logProvider, raftLog, systemClock(), myself,
-                        raftMembershipManager, electionTimeout, config.get( catchup_batch_size ),
+                        raftMembershipManager, leaderAvailabilityTimers.getElectionTimeout(), config.get( catchup_batch_size ),
                         config.get( log_shipping_max_lag ), inFlightCache );
-
-        raftTimeoutService = new DelayedRenewableTimeoutService( systemClock(), logProvider );
 
         boolean supportsPreVoting = config.get( CausalClusteringSettings.enable_pre_voting );
 
-        raftMachine = new RaftMachine( myself, termState, voteState, raftLog, electionTimeout, heartbeatInterval,
-                raftTimeoutService, outbound, logProvider, raftMembershipManager, logShipping, inFlightCache,
+        raftMachine = new RaftMachine( myself, termState, voteState, raftLog, leaderAvailabilityTimers,
+                outbound, logProvider, raftMembershipManager, logShipping, inFlightCache,
                 RefuseToBeLeaderStrategy.shouldRefuseToBeLeader( config, logProvider.getLog( getClass() ) ),
-               supportsPreVoting, platformModule.monitors, systemClock() );
+                supportsPreVoting, platformModule.monitors );
 
         life.add( new RaftCoreTopologyConnector( coreTopologyService, raftMachine ) );
 
         life.add( logShipping );
+    }
+
+    private LeaderAvailabilityTimers createElectionTiming( Config config, RenewableTimeoutService renewableTimeoutService, LogProvider logProvider )
+    {
+        Duration electionTimeout = config.get( CausalClusteringSettings.leader_election_timeout );
+        return new LeaderAvailabilityTimers( electionTimeout, electionTimeout.dividedBy( 3 ), systemClock(), renewableTimeoutService, logProvider );
     }
 
     private RaftLog createRaftLog( Config config, LifeSupport life, FileSystemAbstraction fileSystem,
@@ -202,5 +211,10 @@ public class ConsensusModule
     public InFlightCache inFlightCache()
     {
         return inFlightCache;
+    }
+
+    public LeaderAvailabilityTimers getLeaderAvailabilityTimers()
+    {
+        return leaderAvailabilityTimers;
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderAvailabilityHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderAvailabilityHandler.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.consensus;
+
+import java.util.Objects;
+import java.util.function.LongSupplier;
+
+import org.neo4j.causalclustering.identity.ClusterId;
+import org.neo4j.causalclustering.messaging.Inbound;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+public class LeaderAvailabilityHandler implements Inbound.MessageHandler<RaftMessages.ClusterIdAwareMessage>
+{
+    private final Inbound.MessageHandler<RaftMessages.ClusterIdAwareMessage> delegateHandler;
+    private final LeaderAvailabilityTimers leaderAvailabilityTimers;
+    private final LongSupplier term;
+    private final Log log;
+    private volatile ClusterId boundClusterId;
+
+    public LeaderAvailabilityHandler( Inbound.MessageHandler<RaftMessages.ClusterIdAwareMessage> delegateHandler, LeaderAvailabilityTimers leaderAvailabilityTimers,
+            LongSupplier term, LogProvider logProvider )
+    {
+        this.delegateHandler = delegateHandler;
+        this.leaderAvailabilityTimers = leaderAvailabilityTimers;
+        this.term = term;
+        this.log = logProvider.getLog( getClass() );
+    }
+
+    public synchronized void start( ClusterId clusterId )
+    {
+        boundClusterId = clusterId;
+    }
+
+    public synchronized void stop()
+    {
+        boundClusterId = null;
+    }
+
+    @Override
+    public void handle( RaftMessages.ClusterIdAwareMessage message )
+    {
+        if ( Objects.isNull( boundClusterId ) )
+        {
+            log.debug( "This pre handler has been stopped, dropping the message: %s", message.message() );
+        }
+        else if ( !Objects.equals( message.clusterId(), boundClusterId ) )
+        {
+            log.info( "Discarding message[%s] owing to mismatched clusterId. Expected: %s, Encountered: %s",
+                    message.message(), boundClusterId, message.clusterId() );
+        }
+        else
+        {
+            handleTimeouts( message );
+
+            delegateHandler.handle( message );
+        }
+    }
+
+    private void handleTimeouts( RaftMessages.ClusterIdAwareMessage message )
+    {
+        if ( shouldRenewElectionTimeout( message.message() ) )
+        {
+            leaderAvailabilityTimers.renewElection();
+        }
+    }
+
+    // TODO replace with visitor pattern
+    private boolean shouldRenewElectionTimeout( RaftMessages.RaftMessage message )
+    {
+        switch ( message.type() )
+        {
+        case HEARTBEAT:
+            RaftMessages.Heartbeat heartbeat = (RaftMessages.Heartbeat) message;
+            return heartbeat.leaderTerm() >= term.getAsLong();
+        case APPEND_ENTRIES_REQUEST:
+            RaftMessages.AppendEntries.Request request = (RaftMessages.AppendEntries.Request) message;
+            return request.leaderTerm() >= term.getAsLong();
+        default:
+            return false;
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderAvailabilityTimers.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderAvailabilityTimers.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.consensus;
+
+import java.time.Clock;
+import java.time.Duration;
+
+import org.neo4j.causalclustering.core.consensus.schedule.RenewableTimeoutService;
+import org.neo4j.function.ThrowingAction;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+class LeaderAvailabilityTimers
+{
+    private final long electionTimeout;
+    private final long heartbeatInterval;
+    private final Clock clock;
+    private final RenewableTimeoutService renewableTimeoutService;
+    private final Log log;
+
+    private volatile long lastElectionRenewalMillis;
+
+    private RenewableTimeoutService.RenewableTimeout heartbeatTimer;
+    private RenewableTimeoutService.RenewableTimeout electionTimer;
+
+    LeaderAvailabilityTimers( Duration electionTimeout, Duration heartbeatInterval, Clock clock, RenewableTimeoutService renewableTimeoutService,
+            LogProvider logProvider )
+    {
+        this.electionTimeout = electionTimeout.toMillis();
+        this.heartbeatInterval = heartbeatInterval.toMillis();
+        this.clock = clock;
+        this.renewableTimeoutService = renewableTimeoutService;
+        this.log = logProvider.getLog( getClass() );
+
+        if ( this.electionTimeout < this.heartbeatInterval )
+        {
+            throw new IllegalArgumentException( String.format(
+                            "Election timeout %s should not be shorter than heartbeat interval %s", this.electionTimeout, this.heartbeatInterval
+            ) );
+        }
+    }
+
+    synchronized void start( ThrowingAction<Exception> electionAction, ThrowingAction<Exception> heartbeatAction )
+    {
+        this.electionTimer = renewableTimeoutService.create( RaftMachine.Timeouts.ELECTION, getElectionTimeout(), randomTimeoutRange(),
+                renewing( electionAction ) );
+        this.heartbeatTimer = renewableTimeoutService.create( RaftMachine.Timeouts.HEARTBEAT, getHeartbeatInterval(), 0,
+                renewing( heartbeatAction ) );
+        lastElectionRenewalMillis = clock.millis();
+    }
+
+    synchronized void stop()
+    {
+        if ( electionTimer != null )
+        {
+            electionTimer.cancel();
+        }
+        if ( heartbeatTimer != null )
+        {
+            heartbeatTimer.cancel();
+        }
+
+    }
+
+    synchronized void renewElection()
+    {
+        lastElectionRenewalMillis = clock.millis();
+        if ( electionTimer != null )
+        {
+            electionTimer.renew();
+        }
+    }
+
+    synchronized boolean isElectionTimedOut()
+    {
+        return clock.millis() - lastElectionRenewalMillis >= electionTimeout;
+    }
+
+    // Getters for immutable values
+    long getElectionTimeout()
+    {
+        return electionTimeout;
+    }
+
+    long getHeartbeatInterval()
+    {
+        return heartbeatInterval;
+    }
+
+    private long randomTimeoutRange()
+    {
+        return getElectionTimeout();
+    }
+
+    private RenewableTimeoutService.TimeoutHandler renewing( ThrowingAction<Exception> action )
+    {
+        return timeout ->
+        {
+            try
+            {
+                action.apply();
+            }
+            catch ( Exception e )
+            {
+                log.error( "Failed to process timeout.", e );
+            }
+            timeout.renew();
+        };
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Appending.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Appending.java
@@ -49,7 +49,6 @@ class Appending
             return;
         }
 
-        outcome.renewElectionTimeout();
         outcome.setPreElection( false );
         outcome.setNextTerm( request.leaderTerm() );
         outcome.setLeader( request.from() );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Heart.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Heart.java
@@ -36,7 +36,6 @@ class Heart
             return;
         }
 
-        outcome.renewElectionTimeout();
         outcome.setPreElection( false );
         outcome.setNextTerm( request.leaderTerm() );
         outcome.setLeader( request.from() );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Voting.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Voting.java
@@ -30,7 +30,7 @@ import org.neo4j.logging.Log;
 
 public class Voting
 {
-    static  void handleVoteRequest( ReadableRaftState state, Outcome outcome,
+    static void handleVoteRequest( ReadableRaftState state, Outcome outcome,
             RaftMessages.Vote.Request voteRequest, Log log ) throws IOException
     {
         if ( voteRequest.term() > state.term() )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/term/TermState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/term/TermState.java
@@ -27,7 +27,7 @@ import org.neo4j.storageengine.api.WritableChannel;
 
 public class TermState
 {
-    private long term = 0;
+    private volatile long term = 0;
 
     public TermState()
     {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
@@ -40,6 +40,7 @@ import org.neo4j.causalclustering.core.IdentityModule;
 import org.neo4j.causalclustering.core.consensus.ConsensusModule;
 import org.neo4j.causalclustering.core.consensus.ContinuousJob;
 import org.neo4j.causalclustering.core.consensus.RaftMessages;
+import org.neo4j.causalclustering.core.consensus.LeaderAvailabilityHandler;
 import org.neo4j.causalclustering.core.consensus.RaftServer;
 import org.neo4j.causalclustering.core.consensus.log.pruning.PruningScheduler;
 import org.neo4j.causalclustering.core.consensus.membership.MembershipWaiter;
@@ -181,21 +182,20 @@ public class CoreServerModule
         RaftMessageHandler messageHandler = new RaftMessageHandler( localDatabase, logProvider,
                 consensusModule.raftMachine(), downloader, commandApplicationProcess );
 
-        CoreLife coreLife = new CoreLife( consensusModule.raftMachine(), localDatabase,
-                clusteringModule.clusterBinder(), commandApplicationProcess,
-                coreStateMachinesModule.coreStateMachines, messageHandler, snapshotService );
-
-        RaftLogPruner raftLogPruner = new RaftLogPruner( consensusModule.raftMachine(), commandApplicationProcess );
-        dependencies.satisfyDependency( raftLogPruner );
-
-        life.add( new PruningScheduler( raftLogPruner, jobScheduler,
-                config.get( CausalClusteringSettings.raft_log_pruning_frequency ).toMillis(), logProvider ) );
-
         int queueSize = config.get( CausalClusteringSettings.raft_in_queue_size );
         int maxBatch = config.get( CausalClusteringSettings.raft_in_queue_max_batch );
 
         BatchingMessageHandler batchingMessageHandler = new BatchingMessageHandler( messageHandler, queueSize, maxBatch,
                 logProvider );
+
+        LeaderAvailabilityHandler leaderAvailabilityHandler = new LeaderAvailabilityHandler( batchingMessageHandler, consensusModule.getLeaderAvailabilityTimers(),
+                consensusModule.raftMachine()::term, logProvider );
+
+        CoreLife coreLife = new CoreLife( consensusModule.raftMachine(), localDatabase,
+                clusteringModule.clusterBinder(), commandApplicationProcess,
+                coreStateMachinesModule.coreStateMachines, messageHandler, leaderAvailabilityHandler, snapshotService );
+
+        loggingRaftInbound.registerHandler( leaderAvailabilityHandler );
 
         long electionTimeout = config.get( CausalClusteringSettings.leader_election_timeout ).toMillis();
 
@@ -205,14 +205,18 @@ public class CoreServerModule
         membershipWaiterLifecycle = new MembershipWaiterLifecycle( membershipWaiter, joinCatchupTimeout,
                 consensusModule.raftMachine(), logProvider );
 
-        loggingRaftInbound.registerHandler( batchingMessageHandler );
-
         CatchupServer catchupServer = new CatchupServer( logProvider, userLogProvider, localDatabase::storeId,
                 platformModule.dependencies.provideDependency( TransactionIdStore.class ),
                 platformModule.dependencies.provideDependency( LogicalTransactionStore.class ),
                 localDatabase::dataSource, localDatabase::isAvailable, snapshotService, config, platformModule.monitors,
                 new CheckpointerSupplier( platformModule.dependencies ), fileSystem, platformModule.pageCache,
                 platformModule.storeCopyCheckPointMutex, sslPolicy );
+
+        RaftLogPruner raftLogPruner = new RaftLogPruner( consensusModule.raftMachine(), commandApplicationProcess );
+        dependencies.satisfyDependency( raftLogPruner );
+
+        life.add( new PruningScheduler( raftLogPruner, jobScheduler,
+                config.get( CausalClusteringSettings.raft_log_pruning_frequency ).toMillis(), logProvider ) );
 
         // Exposes this so that tests can start/stop the catchup server
         dependencies.satisfyDependency( catchupServer );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/LeaderAvailabilityHandlerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/LeaderAvailabilityHandlerTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.consensus;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.UUID;
+import java.util.function.LongSupplier;
+
+import org.neo4j.causalclustering.core.consensus.log.RaftLogEntry;
+import org.neo4j.causalclustering.identity.ClusterId;
+import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.causalclustering.messaging.Inbound;
+import org.neo4j.logging.NullLogProvider;
+
+public class LeaderAvailabilityHandlerTest
+{
+    @SuppressWarnings( "unchecked" )
+    private Inbound.MessageHandler<RaftMessages.ClusterIdAwareMessage> delegate = Mockito.mock( Inbound.MessageHandler.class );
+    private LeaderAvailabilityTimers leaderAvailabilityTimers = Mockito.mock( LeaderAvailabilityTimers.class );
+    private ClusterId clusterId = new ClusterId( UUID.randomUUID() );
+    private LongSupplier term = () -> 3;
+
+    private LeaderAvailabilityHandler handler = new LeaderAvailabilityHandler( delegate, leaderAvailabilityTimers, term, NullLogProvider.getInstance() );
+
+    private MemberId leader = new MemberId( UUID.randomUUID() );
+    private RaftMessages.ClusterIdAwareMessage heartbeat =
+            new RaftMessages.ClusterIdAwareMessage( clusterId, new RaftMessages.Heartbeat( leader, term.getAsLong(), 0, 0 ) );
+    private RaftMessages.ClusterIdAwareMessage appendEntries =
+            new RaftMessages.ClusterIdAwareMessage( clusterId,
+                    new RaftMessages.AppendEntries.Request( leader, term.getAsLong(), 0, 0, RaftLogEntry.empty, 0 )
+            );
+    private RaftMessages.ClusterIdAwareMessage voteResponse =
+            new RaftMessages.ClusterIdAwareMessage( clusterId, new RaftMessages.Vote.Response( leader, term.getAsLong(), false ) );
+
+    @Test
+    public void shouldDropMessagesIfHasNotBeenStarted() throws Exception
+    {
+        // when
+        handler.handle( heartbeat );
+
+        // then
+        Mockito.verify( delegate, Mockito.never() ).handle( heartbeat );
+    }
+
+    @Test
+    public void shouldDropMessagesIfHasBeenStopped() throws Exception
+    {
+        // given
+        handler.start( clusterId );
+        handler.stop();
+
+        // when
+        handler.handle( heartbeat );
+
+        // then
+        Mockito.verify( delegate, Mockito.never() ).handle( heartbeat );
+    }
+
+    @Test
+    public void shouldDropMessagesIfForDifferentClusterId() throws Exception
+    {
+        // given
+        handler.start( clusterId );
+
+        // when
+        handler.handle( new RaftMessages.ClusterIdAwareMessage(
+                new ClusterId( UUID.randomUUID() ), new RaftMessages.Heartbeat( leader, term.getAsLong(), 0, 0 )
+        ) );
+
+        // then
+        Mockito.verify( delegate, Mockito.never() ).handle( heartbeat );
+    }
+
+    @Test
+    public void shouldDelegateMessages() throws Exception
+    {
+        // given
+        handler.start( clusterId );
+
+        // when
+        handler.handle( heartbeat );
+
+        // then
+        Mockito.verify( delegate ).handle( heartbeat );
+    }
+
+    @Test
+    public void shouldRenewElectionForHeartbeats() throws Exception
+    {
+        // given
+        handler.start( clusterId );
+
+        // when
+        handler.handle( heartbeat );
+
+        // then
+        Mockito.verify( leaderAvailabilityTimers ).renewElection();
+    }
+
+    @Test
+    public void shouldRenewElectionForAppendEntriesRequests() throws Exception
+    {
+        // given
+        handler.start( clusterId );
+
+        // when
+        handler.handle( appendEntries );
+
+        // then
+        Mockito.verify( leaderAvailabilityTimers ).renewElection();
+    }
+
+    @Test
+    public void shouldNotRenewElectionForOtherMessages() throws Exception
+    {
+        // given
+        handler.start( clusterId );
+
+        // when
+        handler.handle( voteResponse );
+
+        // then
+        Mockito.verify( leaderAvailabilityTimers, Mockito.never() ).renewElection();
+    }
+
+    @Test
+    public void shouldNotRenewElectionTimeoutsForHeartbeatsFromEarlierTerm() throws Exception
+    {
+        // given
+        RaftMessages.ClusterIdAwareMessage heartbeat =
+                new RaftMessages.ClusterIdAwareMessage( clusterId, new RaftMessages.Heartbeat( leader, term.getAsLong() - 1, 0, 0 ) );
+
+        handler.start( clusterId );
+
+        // when
+        handler.handle( heartbeat );
+
+        // then
+        Mockito.verify( leaderAvailabilityTimers, Mockito.never() ).renewElection();
+    }
+
+    @Test
+    public void shouldNotRenewElectionTimeoutsForAppendEntriesRequestsFromEarlierTerms() throws Exception
+    {
+        RaftMessages.ClusterIdAwareMessage appendEntries =
+                new RaftMessages.ClusterIdAwareMessage( clusterId,
+                        new RaftMessages.AppendEntries.Request( leader, term.getAsLong() - 1, 0, 0, RaftLogEntry.empty, 0 )
+                );
+
+        handler.start( clusterId );
+
+        // when
+        handler.handle( appendEntries );
+
+        // then
+        Mockito.verify( leaderAvailabilityTimers, Mockito.never() ).renewElection();
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftMachineBuilder.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftMachineBuilder.java
@@ -21,6 +21,7 @@ package org.neo4j.causalclustering.core.consensus;
 
 import java.io.IOException;
 import java.time.Clock;
+import java.time.Duration;
 
 import org.neo4j.causalclustering.core.consensus.log.cache.ConsecutiveInFlightCache;
 import org.neo4j.causalclustering.core.consensus.log.cache.InFlightCache;
@@ -55,8 +56,9 @@ public class RaftMachineBuilder
     private int expectedClusterSize;
     private RaftGroup.Builder memberSetBuilder;
 
-    private StateStorage<TermState> termState = new InMemoryStateStorage<>( new TermState() );
-    private StateStorage<VoteState> voteState = new InMemoryStateStorage<>( new VoteState() );
+    private TermState termState = new TermState();
+    private StateStorage<TermState> termStateStorage = new InMemoryStateStorage<>( termState );
+    private StateStorage<VoteState> voteStateStorage = new InMemoryStateStorage<>( new VoteState() );
     private RaftLog raftLog = new InMemoryRaftLog();
     private RenewableTimeoutService renewableTimeoutService = new DelayedRenewableTimeoutService( Clocks.systemClock(),
             getInstance() );
@@ -68,8 +70,11 @@ public class RaftMachineBuilder
     private Clock clock = Clocks.systemClock();
     private Clock shippingClock = Clocks.systemClock();
 
+    private long term = termState.currentTerm();
+
     private long electionTimeout = 500;
     private long heartbeatInterval = 150;
+
     private long catchupTimeout = 30000;
     private long retryTimeMillis = electionTimeout / 2;
     private int catchupBatchSize = 64;
@@ -89,17 +94,20 @@ public class RaftMachineBuilder
 
     public RaftMachine build()
     {
+        termState.update( term );
+        LeaderAvailabilityTimers
+                leaderAvailabilityTimers = new LeaderAvailabilityTimers( Duration.ofMillis( electionTimeout ), Duration.ofMillis( heartbeatInterval ), clock,
+                renewableTimeoutService, logProvider );
         SendToMyself leaderOnlyReplicator = new SendToMyself( member, outbound );
         RaftMembershipManager membershipManager = new RaftMembershipManager( leaderOnlyReplicator,
-                memberSetBuilder, raftLog, logProvider, expectedClusterSize, electionTimeout, clock, catchupTimeout,
+                memberSetBuilder, raftLog, logProvider, expectedClusterSize, leaderAvailabilityTimers.getElectionTimeout(), clock, catchupTimeout,
                 raftMembership );
         membershipManager.setRecoverFromIndexSupplier( () -> 0 );
         RaftLogShippingManager logShipping =
                 new RaftLogShippingManager( outbound, logProvider, raftLog, shippingClock, member, membershipManager,
                         retryTimeMillis, catchupBatchSize, maxAllowedShippingLag, inFlightCache );
-        RaftMachine raft = new RaftMachine( member, termState, voteState, raftLog, electionTimeout,
-                heartbeatInterval, renewableTimeoutService, outbound, logProvider,
-                membershipManager, logShipping, inFlightCache, false, false, monitors, clock );
+        RaftMachine raft = new RaftMachine( member, termStateStorage, voteStateStorage, raftLog, leaderAvailabilityTimers, outbound, logProvider,
+                membershipManager, logShipping, inFlightCache, false, false, monitors );
         inbound.registerHandler( ( incomingMessage ) ->
         {
             try
@@ -182,6 +190,12 @@ public class RaftMachineBuilder
     RaftMachineBuilder monitors( Monitors monitors )
     {
         this.monitors = monitors;
+        return this;
+    }
+
+    public RaftMachineBuilder term( long term )
+    {
+        this.term = term;
         return this;
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/FollowerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/FollowerTest.java
@@ -234,24 +234,6 @@ public class FollowerTest
     }
 
     @Test
-    public void shouldRenewElectionTimeoutOnReceiptOfHeartbeatInCurrentOrHigherTerm() throws Exception
-    {
-        // given
-        RaftState state = raftState()
-                .myself( myself )
-                .term(0)
-                .build();
-
-        Follower follower = new Follower();
-
-        Outcome outcome = follower.handle( new RaftMessages.Heartbeat( myself, 1, 1, 1 ),
-                state, log() );
-
-        // then
-        assertTrue( outcome.electionTimeoutRenewed() );
-    }
-
-    @Test
     public void shouldNotRenewElectionTimeoutOnReceiptOfHeartbeatInLowerTerm() throws Exception
     {
         // given


### PR DESCRIPTION
Introduce pre handling for raft messages that will refresh election timeouts on heartbeat and append entries requests.

This is not on the same thread as the main raft message handling, which may block to download a snapshot and thus fail to process heartbeats.

changelog: Raft heartbeat messages refresh election timeouts on receive rather than on process.
This addresses unnecessary elections caused by the raft message processing being delayed and failing to reset election timeouts in a timely manner.