### PR TITLE
Slotted argument mapping

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
@@ -359,7 +359,7 @@ class PatternComprehensionAcceptanceTest extends ExecutionEngineFunSuite with Cy
 
     val query = "RETURN size([(:Start)-->() | 1]) AS size"
 
-    val result = executeWith(expectedToSucceedRestricted, query)
+    val result = executeWith(expectedToSucceedIncludingSlottedRestricted, query)
     result.toList should equal(List(Map("size" -> 3)))
   }
 

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildSlottedExecutionPlan.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildSlottedExecutionPlan.scala
@@ -55,9 +55,9 @@ object BuildSlottedExecutionPlan extends Phase[EnterpriseRuntimeContext, Logical
   private def createSlottedRuntimeExecPlan(from: LogicalPlanState, context: EnterpriseRuntimeContext) = {
     val runtimeSuccessRateMonitor = context.monitors.newMonitor[NewRuntimeSuccessRateMonitor]()
     try {
-      val (logicalPlan, pipelines) = rewritePlan(context, from.logicalPlan)
+      val (logicalPlan, physicalPlan) = rewritePlan(context, from.logicalPlan)
       val converters = new ExpressionConverters(SlottedExpressionConverters, CommunityExpressionConverter)
-      val pipeBuilderFactory = EnterprisePipeBuilderFactory(pipelines)
+      val pipeBuilderFactory = EnterprisePipeBuilderFactory(physicalPlan)
       val executionPlanBuilder = new PipeExecutionPlanBuilder(context.clock, context.monitors,
                                                               expressionConverters = converters,
                                                               pipeBuilderFactory = pipeBuilderFactory)
@@ -84,11 +84,11 @@ object BuildSlottedExecutionPlan extends Phase[EnterpriseRuntimeContext, Logical
     }
   }
 
-  private def rewritePlan(context: EnterpriseRuntimeContext, beforeRewrite: LogicalPlan) = {
+  private def rewritePlan(context: EnterpriseRuntimeContext, beforeRewrite: LogicalPlan): (LogicalPlan, PhysicalPlan) = {
     val physicalPlan: PhysicalPlan = SlotAllocation.allocateSlots(beforeRewrite)
     val slottedRewriter = new SlottedRewriter(context.planContext)
     val logicalPlan = slottedRewriter(beforeRewrite, physicalPlan.slotConfigurations)
-    (logicalPlan, physicalPlan.slotConfigurations)
+    (logicalPlan, physicalPlan)
   }
 
   case class SlottedExecutionPlan(fingerprint: PlanFingerprintReference,
@@ -112,7 +112,7 @@ object BuildSlottedExecutionPlan extends Phase[EnterpriseRuntimeContext, Logical
       BuildInterpretedExecutionPlan.checkForNotifications(pipe, planContext, config)
   }
 
-  case class EnterprisePipeBuilderFactory(slotConfigurations: Map[LogicalPlanId, SlotConfiguration])
+  case class EnterprisePipeBuilderFactory(physicalPlan: PhysicalPlan)
     extends PipeBuilderFactory {
     def apply(monitors: Monitors, recurse: LogicalPlan => Pipe, readOnly: Boolean,
               expressionConverters: ExpressionConverters)
@@ -122,8 +122,7 @@ object BuildSlottedExecutionPlan extends Phase[EnterpriseRuntimeContext, Logical
 
       val fallback = CommunityPipeBuilder(monitors, recurse, readOnly, expressionConverters, expressionToExpression)
 
-      new SlottedPipeBuilder(fallback, expressionConverters, monitors, slotConfigurations, readOnly,
-        expressionToExpression)
+      new SlottedPipeBuilder(fallback, expressionConverters, monitors, physicalPlan, readOnly, expressionToExpression)
     }
   }
 

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildSlottedExecutionPlan.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildSlottedExecutionPlan.scala
@@ -19,6 +19,7 @@
  */
 package org.neo4j.cypher.internal
 
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotAllocation.PhysicalPlan
 import org.neo4j.cypher.internal.util.v3_4.CypherException
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime._
 import org.neo4j.cypher.internal.runtime.interpreted.commands.convert.{CommunityExpressionConverter, ExpressionConverters}
@@ -84,10 +85,10 @@ object BuildSlottedExecutionPlan extends Phase[EnterpriseRuntimeContext, Logical
   }
 
   private def rewritePlan(context: EnterpriseRuntimeContext, beforeRewrite: LogicalPlan) = {
-    val slotConfigurations: Map[LogicalPlanId, SlotConfiguration] = SlotAllocation.allocateSlots(beforeRewrite)
+    val physicalPlan: PhysicalPlan = SlotAllocation.allocateSlots(beforeRewrite)
     val slottedRewriter = new SlottedRewriter(context.planContext)
-    val logicalPlan = slottedRewriter(beforeRewrite, slotConfigurations)
-    (logicalPlan, slotConfigurations)
+    val logicalPlan = slottedRewriter(beforeRewrite, physicalPlan.slotConfigurations)
+    (logicalPlan, physicalPlan.slotConfigurations)
   }
 
   case class SlottedExecutionPlan(fingerprint: PlanFingerprintReference,

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildVectorizedExecutionPlan.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildVectorizedExecutionPlan.scala
@@ -20,6 +20,7 @@
 package org.neo4j.cypher.internal
 
 
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotAllocation.PhysicalPlan
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.EnterpriseRuntimeContext
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan.StandardInternalExecutionResult.IterateByAccepting
@@ -79,10 +80,10 @@ object BuildVectorizedExecutionPlan extends Phase[EnterpriseRuntimeContext, Logi
   }
 
   private def rewritePlan(context: EnterpriseRuntimeContext, beforeRewrite: LogicalPlan) = {
-    val slotConfigurations: Map[LogicalPlanId, SlotConfiguration] = SlotAllocation.allocateSlots(beforeRewrite)
+    val physicalPlan: PhysicalPlan = SlotAllocation.allocateSlots(beforeRewrite)
     val slottedRewriter = new SlottedRewriter(context.planContext)
-    val logicalPlan = slottedRewriter(beforeRewrite, slotConfigurations)
-    (logicalPlan, slotConfigurations)
+    val logicalPlan = slottedRewriter(beforeRewrite, physicalPlan.slotConfigurations)
+    (logicalPlan, physicalPlan.slotConfigurations)
   }
 
   override def postConditions: Set[Condition] = Set.empty

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildVectorizedExecutionPlan.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildVectorizedExecutionPlan.scala
@@ -79,17 +79,17 @@ object BuildVectorizedExecutionPlan extends Phase[EnterpriseRuntimeContext, Logi
   }
 
   private def rewritePlan(context: EnterpriseRuntimeContext, beforeRewrite: LogicalPlan) = {
-    val pipelines: Map[LogicalPlanId, PipelineInformation] = SlotAllocation.allocateSlots(beforeRewrite)
+    val slotConfigurations: Map[LogicalPlanId, SlotConfiguration] = SlotAllocation.allocateSlots(beforeRewrite)
     val slottedRewriter = new SlottedRewriter(context.planContext)
-    val logicalPlan = slottedRewriter(beforeRewrite, pipelines)
-    (logicalPlan, pipelines)
+    val logicalPlan = slottedRewriter(beforeRewrite, slotConfigurations)
+    (logicalPlan, slotConfigurations)
   }
 
   override def postConditions: Set[Condition] = Set.empty
 
   case class VectorizedExecutionPlan(plannerUsed: PlannerName,
                                      operators: Pipeline,
-                                     pipelineInformation: Map[LogicalPlanId, PipelineInformation],
+                                     slots: Map[LogicalPlanId, SlotConfiguration],
                                      physicalPlan: LogicalPlan,
                                      fieldNames: Array[String],
                                      dispatcher: Dispatcher,

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilderTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilderTest.scala
@@ -22,6 +22,7 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.BuildSlottedExecutionPlan.EnterprisePipeBuilderFactory
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotAllocation.PhysicalPlan
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration.Size
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.EnterpriseRuntimeContext
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.expressions._
@@ -61,7 +62,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
     val logicalPlan = slottedRewriter(beforeRewrite, physicalPlan.slotConfigurations)
     val converters = new ExpressionConverters(CommunityExpressionConverter, SlottedExpressionConverters)
     val executionPlanBuilder = new PipeExecutionPlanBuilder(context.clock, context.monitors,
-      expressionConverters = converters, pipeBuilderFactory = EnterprisePipeBuilderFactory(physicalPlan.slotConfigurations))
+      expressionConverters = converters, pipeBuilderFactory = EnterprisePipeBuilderFactory(physicalPlan))
     val pipeBuildContext = PipeExecutionBuilderContext(context.metrics.cardinality, table, IDPPlannerName)
     executionPlanBuilder.build(None, logicalPlan)(pipeBuildContext, context.planContext).pipe
   }
@@ -70,6 +71,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
   private val z = IdName("z")
   private val r = IdName("r")
   private val LABEL = LabelName("label1")(pos)
+  private val X_NODE_SLOTS = SlotConfiguration.empty.newLong("x", false, CTNode)
 
   test("only single allnodes scan") {
     // given
@@ -80,7 +82,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
 
     // then
     pipe should equal(
-      AllNodesScanSlottedPipe("x", SlotConfiguration(Map("x" -> LongSlot(0, nullable = false, CTNode)), 1, 0))()
+      AllNodesScanSlottedPipe("x", X_NODE_SLOTS, Size.zero)()
     )
   }
 
@@ -94,7 +96,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
     // then
     pipe should equal(
       LimitPipe(
-        AllNodesScanSlottedPipe("x", SlotConfiguration(Map("x" -> LongSlot(0, nullable = false, CTNode)), 1, 0))(),
+        AllNodesScanSlottedPipe("x", X_NODE_SLOTS, Size.zero)(),
         Literal(1)
       )()
     )
@@ -121,7 +123,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
     pipe should equal(
       CreateNodeSlottedPipe(
         EagerSlottedPipe(
-          AllNodesScanSlottedPipe("x", beforeEagerSlots)(),
+          AllNodesScanSlottedPipe("x", beforeEagerSlots, Size.zero)(),
           afterEagerSlots)(),
         "z", afterEagerSlots, Seq(LazyLabel(label)), None)()
     )
@@ -139,7 +141,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
     // then
     pipe should equal(
       CreateNodeSlottedPipe(
-        ArgumentSlottedPipe(SlotConfiguration(Map("z" -> LongSlot(0, nullable = false, CTNode)), 1, 0))(),
+        ArgumentSlottedPipe(SlotConfiguration.empty.newLong("z", false, CTNode), Size.zero)(),
         "z",
         SlotConfiguration(Map("z" -> LongSlot(0, nullable = false, CTNode)), 1, 0),
         Seq(LazyLabel(label)),
@@ -158,7 +160,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
 
     // then
     pipe should equal(
-      NodesByLabelScanSlottedPipe("x", LazyLabel(label), SlotConfiguration(Map("x" -> LongSlot(0, nullable = false, CTNode)), 1, 0))()
+      NodesByLabelScanSlottedPipe("x", LazyLabel(label), X_NODE_SLOTS, Size.zero)()
     )
   }
 
@@ -174,7 +176,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
     // then
     pipe should equal(
       FilterPipe(
-        NodesByLabelScanSlottedPipe("x", LazyLabel(label), SlotConfiguration(Map("x" -> LongSlot(0, nullable = false, CTNode)), 1, 0))(),
+        NodesByLabelScanSlottedPipe("x", LazyLabel(label), X_NODE_SLOTS, Size.zero)(),
         predicates.True()
       )()
     )
@@ -193,7 +195,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
     val rRelSlot = LongSlot(1, nullable = false, CTRelationship)
     val zNodeSlot = LongSlot(2, nullable = false, CTNode)
     pipe should equal(ExpandAllSlottedPipe(
-      AllNodesScanSlottedPipe("x", SlotConfiguration(Map("x" -> xNodeSlot), numberOfLongs = 1, numberOfReferences = 0))(),
+      AllNodesScanSlottedPipe("x", X_NODE_SLOTS, Size.zero)(),
       xNodeSlot.offset, rRelSlot.offset, zNodeSlot.offset,
       SemanticDirection.INCOMING,
       LazyTypes.empty,
@@ -216,7 +218,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
     val nodeSlot = LongSlot(0, nullable = false, CTNode)
     val relSlot = LongSlot(1, nullable = false, CTRelationship)
     pipe should equal(ExpandIntoSlottedPipe(
-      AllNodesScanSlottedPipe("x", SlotConfiguration(Map("x" -> nodeSlot), numberOfLongs = 1, numberOfReferences = 0))(),
+      AllNodesScanSlottedPipe("x", X_NODE_SLOTS, Size.zero)(),
       nodeSlot.offset, relSlot.offset, nodeSlot.offset, SemanticDirection.INCOMING, LazyTypes.empty,
       SlotConfiguration(Map("x" -> nodeSlot, "r" -> relSlot), numberOfLongs = 2, numberOfReferences = 0)
     )())
@@ -244,9 +246,10 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
     pipe should equal(
       ExpandAllSlottedPipe(
         OptionalSlottedPipe(
-          AllNodesScanSlottedPipe("x", allNodeScanSlots)(),
+          AllNodesScanSlottedPipe("x", allNodeScanSlots, Size.zero)(),
           Seq(0),
-          allNodeScanSlots
+          allNodeScanSlots,
+          Size.zero
         )(),
         xNodeSlot.offset, rRelSlot.offset, zNodeSlot.offset,
         SemanticDirection.INCOMING,
@@ -273,9 +276,10 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
     pipe should equal(
       ExpandIntoSlottedPipe(
         OptionalSlottedPipe(
-          AllNodesScanSlottedPipe("x", allNodeScanSlots)(),
+          AllNodesScanSlottedPipe("x", allNodeScanSlots, Size.zero)(),
           Seq(0),
-          allNodeScanSlots
+          allNodeScanSlots,
+          Size.zero
         )(),
         nodeSlot.offset, relSlot.offset, nodeSlot.offset, SemanticDirection.INCOMING, LazyTypes.empty,
         expandSlots)()
@@ -293,9 +297,10 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
     // then
     val expectedSlots = SlotConfiguration(Map("x" -> LongSlot(0, nullable = true, CTNode)), numberOfLongs = 1, numberOfReferences = 0)
     pipe should equal(OptionalSlottedPipe(
-      AllNodesScanSlottedPipe("x", expectedSlots)(),
+      AllNodesScanSlottedPipe("x", expectedSlots, Size.zero)(),
       Seq(0),
-      expectedSlots
+      expectedSlots,
+      Size.zero
     )())
   }
 
@@ -309,8 +314,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
 
     // then
     pipe should equal(OptionalExpandAllSlottedPipe(
-      AllNodesScanSlottedPipe("x",
-        SlotConfiguration(Map("x" -> LongSlot(0, nullable = false, CTNode)), numberOfLongs = 1, numberOfReferences = 0))(),
+      AllNodesScanSlottedPipe("x", X_NODE_SLOTS, Size.zero)(),
       0, 1, 2, SemanticDirection.INCOMING, LazyTypes.empty, predicates.True(),
       SlotConfiguration(Map(
         "x" -> LongSlot(0, nullable = false, CTNode),
@@ -329,8 +333,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
 
     // then
     pipe should equal(OptionalExpandIntoSlottedPipe(
-      AllNodesScanSlottedPipe("x",
-        SlotConfiguration(Map("x" -> LongSlot(0, nullable = false, CTNode)), numberOfLongs = 1, numberOfReferences = 0))(),
+      AllNodesScanSlottedPipe("x", X_NODE_SLOTS, Size.zero)(),
       0, 1, 0, SemanticDirection.INCOMING, LazyTypes.empty, predicates.True(),
       SlotConfiguration(Map(
         "x" -> LongSlot(0, nullable = false, CTNode),
@@ -368,13 +371,13 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
       "z" -> zNodeSlot), numberOfLongs = 2, numberOfReferences = 1)
 
     pipe should equal(VarLengthExpandSlottedPipe(
-      AllNodesScanSlottedPipe("x", allNodeScanSlots)(),
+      AllNodesScanSlottedPipe("x", allNodeScanSlots, Size.zero)(),
       xNodeSlot.offset, rRelSlot.offset, zNodeSlot.offset,
       SemanticDirection.INCOMING, SemanticDirection.INCOMING,
       LazyTypes.empty, varLength.min, varLength.max, shouldExpandAll = true,
       varExpandSlots,
       tempNodeSlot.offset, tempRelSlot.offset,
-      commands.predicates.True(), commands.predicates.True(), 1
+      commands.predicates.True(), commands.predicates.True(), Size(1, 0)
     )())
   }
 
@@ -411,7 +414,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
       "z" -> zNodeSlot), numberOfLongs = 2, numberOfReferences = 1)
 
     pipe should equal(VarLengthExpandSlottedPipe(
-      AllNodesScanSlottedPipe("x", allNodeScanSlots)(),
+      AllNodesScanSlottedPipe("x", allNodeScanSlots, Size.zero)(),
       xNodeSlot.offset, rRelSlot.offset, zNodeSlot.offset,
       SemanticDirection.INCOMING, SemanticDirection.INCOMING,
       LazyTypes.empty, varLength.min, varLength.max, shouldExpandAll = true,
@@ -419,7 +422,9 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
       tempNodeSlot.offset, tempRelSlot.offset,
       commands.predicates.Equals(NodeProperty(1, 0), Literal(4)),
       commands.predicates.Not(
-        commands.predicates.LessThan(RelationshipProperty(2, 0), Literal(4))), 1
+        commands.predicates.LessThan(RelationshipProperty(2, 0), Literal(4))
+      ),
+      Size(1, 0)
     )())
   }
 
@@ -433,8 +438,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
 
     // then
     pipe should equal(SkipPipe(
-      AllNodesScanSlottedPipe("x",
-        SlotConfiguration(Map("x" -> LongSlot(0, nullable = false, CTNode)), numberOfLongs = 1, numberOfReferences = 0))(),
+      AllNodesScanSlottedPipe("x", X_NODE_SLOTS, Size.zero)(),
       commands.expressions.Literal(42)
     )())
   }
@@ -452,15 +456,12 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
 
     // then
     pipe should equal(ApplySlottedPipe(
-      NodesByLabelScanSlottedPipe("x", LazyLabel("label"),
-        SlotConfiguration(Map(
-          "x" -> LongSlot(0, nullable = false, CTNode)),
-          numberOfLongs = 1, numberOfReferences = 0))(),
+      NodesByLabelScanSlottedPipe("x", LazyLabel("label"), X_NODE_SLOTS, Size.zero)(),
       NodeIndexSeekSlottedPipe("z", label, Seq.empty, SingleQueryExpression(commands.expressions.Literal(42)), IndexSeek,
-        SlotConfiguration(Map(
-          "x" -> LongSlot(0, nullable = false, CTNode),
-          "z" -> LongSlot(1, nullable = false, CTNode)
-        ), numberOfLongs = 2, numberOfReferences = 0))()
+        SlotConfiguration.empty
+          .newLong("x", false, CTNode)
+          .newLong("z", false, CTNode),
+        Size(1, 0))()
     )())
   }
 
@@ -474,8 +475,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
 
     // then
     pipe should equal(DistinctPipe(
-      NodesByLabelScanSlottedPipe("x", LazyLabel("label"),
-        SlotConfiguration(Map("x" -> LongSlot(0, nullable = false, CTNode)), numberOfLongs = 1, numberOfReferences = 0))(),
+      NodesByLabelScanSlottedPipe("x", LazyLabel("label"), X_NODE_SLOTS, Size.zero)(),
       Map("x" -> commands.expressions.Variable("x"))
     )())
   }
@@ -490,11 +490,10 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
 
     // when
     val pipe = build(distinct)
-    val slots = SlotConfiguration(Map("x" -> LongSlot(0, nullable = true, CTNode)), numberOfLongs = 1, numberOfReferences = 0)
 
     // then
-    val labelScan = NodesByLabelScanSlottedPipe("x", LazyLabel("label"), slots)()
-    val optionalPipe = OptionalSlottedPipe(labelScan, Seq(0), slots)()
+    val labelScan = NodesByLabelScanSlottedPipe("x", LazyLabel("label"), X_NODE_SLOTS, Size.zero)()
+    val optionalPipe = OptionalSlottedPipe(labelScan, Seq(0), X_NODE_SLOTS, Size.zero)()
     pipe should equal(DistinctPipe(
       optionalPipe,
       Map("x" -> Variable("x"), "x.propertyKey" -> Property(Variable("x"), KeyToken.Resolved("propertyKey", 0, PropertyKey)))
@@ -511,16 +510,15 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
 
     // when
     val pipe = build(distinct)
-    val slots = SlotConfiguration(Map("x" -> LongSlot(0, nullable = true, CTNode)), numberOfLongs = 1, numberOfReferences = 0)
 
     // then
-    val nodeByLabelScan = NodesByLabelScanSlottedPipe("x", LazyLabel("label"), slots)()
+    val nodeByLabelScan = NodesByLabelScanSlottedPipe("x", LazyLabel("label"), X_NODE_SLOTS, Size.zero)()
     val grouping = Map(
       "x" -> Variable("x"),
       "x.propertyKey" -> Property(Variable("x"), KeyToken.Resolved("propertyKey", 0, PropertyKey))
     )
     pipe should equal(EagerAggregationPipe(
-      OptionalSlottedPipe(nodeByLabelScan, Seq(0), slots)(),
+      OptionalSlottedPipe(nodeByLabelScan, Seq(0), X_NODE_SLOTS, Size.zero)(),
       keyExpressions = grouping,
       aggregations = Map("count" -> commands.expressions.CountStar())
     )())
@@ -535,12 +533,12 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
     val pipe = build(projection)
 
     // then
-    val slots = SlotConfiguration(numberOfLongs = 1, numberOfReferences = 1,
-      slots = Map(
-        "x" -> LongSlot(0, nullable = false, CTNode),
-        "x.propertyKey" -> RefSlot(0, nullable = true, CTAny)))
+    val slots = SlotConfiguration.empty
+      .newLong("x", false, CTNode)
+      .newReference("x.propertyKey", true, CTAny)
+
     pipe should equal(ProjectionSlottedPipe(
-      NodesByLabelScanSlottedPipe("x", LazyLabel("label"), slots)(),
+      NodesByLabelScanSlottedPipe("x", LazyLabel("label"), slots, Size.zero)(),
       Map(0 -> NodeProperty(slots("x.propertyKey").offset, 0))
     )())
   }
@@ -554,13 +552,13 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
     val pipe = build(projection)
 
     // then
-    val slots = SlotConfiguration(numberOfLongs = 1, numberOfReferences = 1,
-      slots = Map(
-        "x" -> LongSlot(0, nullable = false, CTNode),
-        "A" -> LongSlot(0, nullable = false, CTNode),
-        "x.propertyKey" -> RefSlot(0, nullable = true, CTAny)))
+    val slots = SlotConfiguration.empty
+      .newLong("x", false, CTNode)
+      .addAlias("A", "x")
+      .newReference("x.propertyKey", true, CTAny)
+
     pipe should equal(ProjectionSlottedPipe(
-      NodesByLabelScanSlottedPipe("x", LazyLabel("label"), slots)(),
+      NodesByLabelScanSlottedPipe("x", LazyLabel("label"), slots, Size.zero)(),
       Map(0 -> NodeProperty(slots("x.propertyKey").offset, 0))
     )())
   }
@@ -583,8 +581,8 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
 
     // then
     pipe should equal(CartesianProductSlottedPipe(
-      NodesByLabelScanSlottedPipe("x", LazyLabel("label1"), lhsSlots)(),
-      NodesByLabelScanSlottedPipe("y", LazyLabel("label2"), rhsSlots)(),
+      NodesByLabelScanSlottedPipe("x", LazyLabel("label1"), lhsSlots, Size.zero)(),
+      NodesByLabelScanSlottedPipe("y", LazyLabel("label2"), rhsSlots, Size.zero)(),
       lhsLongCount = 1, lhsRefCount = 0, xProdSlots)()
     )
   }
@@ -601,21 +599,20 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
     val pipe = build(apply)
 
     // then
-    val lhsSlots = SlotConfiguration(Map(
-      "x" -> LongSlot(0, nullable = false, CTNode)),
-      numberOfLongs = 1, numberOfReferences = 0)
+    val lhsSlots = SlotConfiguration.empty.newLong("x", false, CTNode)
 
-    val rhsSlots = SlotConfiguration(Map(
-      "x" -> LongSlot(0, nullable = false, CTNode),
-      "z" -> LongSlot(2, nullable = false, CTNode),
-      "r" -> LongSlot(1, nullable = false, CTRelationship)
-    ), numberOfLongs = 3, numberOfReferences = 0)
-
+    val rhsSlots = SlotConfiguration.empty
+      .newLong("x", false, CTNode)
+      .newLong("r", false, CTRelationship)
+      .newLong("z", false, CTNode)
 
     pipe should equal(ApplySlottedPipe(
-      NodesByLabelScanSlottedPipe("x", LazyLabel(LABEL), lhsSlots)(),
+      NodesByLabelScanSlottedPipe("x", LazyLabel(LABEL), lhsSlots, Size.zero)(),
       ExpandAllSlottedPipe(
-        ArgumentSlottedPipe(lhsSlots)(), 0, 1, 2, SemanticDirection.INCOMING, LazyTypes.empty, rhsSlots)())())
+        ArgumentSlottedPipe(lhsSlots, Size(1, 0))(),
+        0, 1, 2, SemanticDirection.INCOMING, LazyTypes.empty, rhsSlots
+      )()
+    )())
   }
 
   test("NodeIndexScan should yield a NodeIndexScanSlottedPipe") {
@@ -636,7 +633,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
         "n",
         LabelToken("Awesome", LabelId(0)),
         PropertyKeyToken("prop", PropertyKeyId(0)),
-        SlotConfiguration(Map("n" -> LongSlot(0, nullable = false, CTNode)), 1, 0))())
+        SlotConfiguration.empty.newLong("n", false, CTNode), Size.zero)())
   }
 
   test("Should use NodeIndexUniqueSeek") {
@@ -651,9 +648,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
     // then
     pipe should equal(
       NodeIndexSeekSlottedPipe("z", label, Seq.empty, SingleQueryExpression(commands.expressions.Literal(42)), UniqueIndexSeek,
-        SlotConfiguration(Map(
-          "z" -> LongSlot(0, nullable = false, CTNode)
-        ), numberOfLongs = 1, numberOfReferences = 0))()
+        SlotConfiguration.empty.newLong("z", false, CTNode), Size.zero)()
     )
   }
 
@@ -669,17 +664,16 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
     val pipe = build(sort)
 
     // then
-    val expectedSlots1 = SlotConfiguration(Map.empty, 0, 0)
+    val expectedSlots1 = SlotConfiguration.empty
     val xSlot = RefSlot(0, nullable = true, CTAny)
-    val expectedSlots2 = SlotConfiguration(numberOfLongs = 0, numberOfReferences = 1, slots = Map(
-      "x" -> xSlot
-    ))
+    val expectedSlots2 =
+      SlotConfiguration(numberOfLongs = 0, numberOfReferences = 1, slots = Map("x" -> xSlot))
 
     pipe should equal(
       SortSlottedPipe(orderBy = Seq(slottedPipes.Ascending(xSlot)), slots = expectedSlots2,
         source = UnwindSlottedPipe(collection = commands.expressions.ListLiteral(commands.expressions.Literal(1),
           commands.expressions.Literal(2), commands.expressions.Literal(3)), offset = 0, slots = expectedSlots2,
-          source = ArgumentSlottedPipe(expectedSlots1)()
+          source = ArgumentSlottedPipe(expectedSlots1, Size.zero)()
         )()
       )()
     )

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/Morsel.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/Morsel.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.runtime.vectorized
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.values.AnyValue
 
 /*
@@ -31,9 +31,9 @@ class Morsel(val longs: Array[Long], val refs: Array[AnyValue], var validRows: I
 }
 
 object Morsel {
-  def create(slotInformation: PipelineInformation, size: Int): Morsel = {
-    val longs = new Array[Long](slotInformation.numberOfLongs * size)
-    val refs = new Array[AnyValue](slotInformation.numberOfReferences * size)
+  def create(slots: SlotConfiguration, size: Int): Morsel = {
+    val longs = new Array[Long](slots.numberOfLongs * size)
+    val refs = new Array[AnyValue](slots.numberOfReferences * size)
     new Morsel(longs, refs, size)
   }
 }

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/Operator.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/Operator.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.runtime.vectorized
 
 import java.util
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.runtime.QueryContext
 import org.neo4j.cypher.result.QueryResult.QueryResultVisitor
 import org.neo4j.values.virtual.MapValue
@@ -75,7 +75,7 @@ case class QueryState(params: MapValue, visitor: QueryResultVisitor[_])
 
 case class Pipeline(start: Operator,
                     operators: Seq[MiddleOperator],
-                    slotInformation: PipelineInformation,
+                    slots: SlotConfiguration,
                     dependency: Dependency)
                    (var parent: Option[Pipeline] = None) {
 
@@ -95,7 +95,7 @@ case class Pipeline(start: Operator,
       println(s"Pipeline: $this")
 
 
-      val longCount = slotInformation.numberOfLongs
+      val longCount = slots.numberOfLongs
       val rows = for (i <- 0 until(data.validRows * longCount, longCount)) yield {
         util.Arrays.toString(data.longs.slice(i, i + longCount))
       }

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/dispatcher/ParallelDispatcher.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/dispatcher/ParallelDispatcher.scala
@@ -97,7 +97,7 @@ class ParallelDispatcher(morselSize: Int, workers: Int, executor: Executor) exte
   }
 
   private def execute(query: Query, pipeline: Pipeline, message: Message, queryContext: QueryContext, state: QueryState) = {
-    val data = Morsel.create(pipeline.slotInformation, morselSize)
+    val data = Morsel.create(pipeline.slots, morselSize)
     val continuation = pipeline.operate(message, data, queryContext, state)
 
     pipeline.parent match {

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/dispatcher/SingleThreadedExecutor.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/dispatcher/SingleThreadedExecutor.scala
@@ -54,7 +54,7 @@ class SingleThreadedExecutor(morselSize: Int = 100000) extends Dispatcher {
 
       while (jobStack.nonEmpty) {
         val (message, pipeline) = jobStack.pop()
-        val data = Morsel.create(pipeline.slotInformation, morselSize)
+        val data = Morsel.create(pipeline.slots, morselSize)
         val continuation = pipeline.operate(message, data, queryContext, state)
         if (continuation != EndOfLoop(iteration)) {
           jobStack.push((ContinueLoopWith(continuation), pipeline))

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/ExpandAllOperator.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/ExpandAllOperator.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.runtime.vectorized.operators
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker.nodeIsNull
 import org.neo4j.cypher.internal.runtime.QueryContext
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.LazyTypes
@@ -29,8 +29,8 @@ import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection
 import org.neo4j.kernel.impl.api.RelationshipVisitor
 import org.neo4j.kernel.impl.api.store.RelationshipIterator
 
-class ExpandAllOperator(toPipeline: PipelineInformation,
-                        fromPipeline: PipelineInformation,
+class ExpandAllOperator(toSlots: SlotConfiguration,
+                        fromSlots: SlotConfiguration,
                         fromOffset: Int,
                         relOffset: Int,
                         toOffset: Int,
@@ -70,10 +70,10 @@ class ExpandAllOperator(toPipeline: PipelineInformation,
         throw new InternalException("Unknown continuation received")
     }
 
-    val inputLongCount = fromPipeline.numberOfLongs
-    val inputRefCount = fromPipeline.numberOfReferences
-    val outputLongCount = toPipeline.numberOfLongs
-    val outputRefCount = toPipeline.numberOfReferences
+    val inputLongCount = fromSlots.numberOfLongs
+    val inputRefCount = fromSlots.numberOfReferences
+    val outputLongCount = toSlots.numberOfLongs
+    val outputRefCount = toSlots.numberOfReferences
 
     while (readPos < input.validRows && writePos < output.validRows) {
 

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/FilterOperator.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/FilterOperator.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.runtime.vectorized.operators
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.runtime.QueryContext
 import org.neo4j.cypher.internal.runtime.interpreted.commands.predicates.Predicate
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.{QueryState => OldQueryState}
@@ -27,7 +27,7 @@ import org.neo4j.cypher.internal.runtime.vectorized._
 /*
 Takes an input morsel and compacts all rows to the beginning of it, only keeping the rows that match a predicate
  */
-class FilterOperator(pipeline: PipelineInformation, predicate: Predicate) extends MiddleOperator {
+class FilterOperator(slots: SlotConfiguration, predicate: Predicate) extends MiddleOperator {
   override def operate(iterationState: Iteration,
                        data: Morsel,
                        context: QueryContext,
@@ -35,8 +35,8 @@ class FilterOperator(pipeline: PipelineInformation, predicate: Predicate) extend
 
     var readingPos = 0
     var writingPos = 0
-    val longCount = pipeline.numberOfLongs
-    val refCount = pipeline.numberOfReferences
+    val longCount = slots.numberOfLongs
+    val refCount = slots.numberOfReferences
     val currentRow = new MorselExecutionContext(data, longCount, refCount, currentRow = readingPos)
     val queryState = new OldQueryState(context, resources = null, params = state.params)
 

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/ProjectOperator.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/ProjectOperator.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Expres
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.{QueryState => OldQueryState}
 import org.neo4j.cypher.internal.runtime.vectorized._
 
-class ProjectOperator(val projectionOps: Map[Slot, Expression], pipeline: PipelineInformation) extends MiddleOperator {
+class ProjectOperator(val projectionOps: Map[Slot, Expression], slots: SlotConfiguration) extends MiddleOperator {
 
   private val project = projectionOps.map {
     case (LongSlot(_, _, _),_) =>
@@ -41,8 +41,8 @@ class ProjectOperator(val projectionOps: Map[Slot, Expression], pipeline: Pipeli
 
   override def operate(iterationState: Iteration, data: Morsel, context: QueryContext, state: QueryState): Unit = {
     var currentRow = 0
-    val longCount = pipeline.numberOfLongs
-    val refCount = pipeline.numberOfReferences
+    val longCount = slots.numberOfLongs
+    val refCount = slots.numberOfReferences
     val executionContext = new MorselExecutionContext(data, longCount, refCount, currentRow = currentRow)
     val queryState = new OldQueryState(context, resources = null, params = state.params)
 

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/UnwindOperator.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/UnwindOperator.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.runtime.vectorized.operators
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.runtime.QueryContext
 import org.neo4j.cypher.internal.runtime.interpreted.ListSupport
 import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Expression
@@ -29,8 +29,8 @@ import org.neo4j.values.AnyValue
 
 class UnwindOperator(collection: Expression,
                      offset: Int,
-                     fromPipeline: PipelineInformation,
-                     toPipeline: PipelineInformation)
+                     fromSlots: SlotConfiguration,
+                     toSlots: SlotConfiguration)
   extends Operator with ListSupport {
 
   override def operate(source: Message,
@@ -43,10 +43,10 @@ class UnwindOperator(collection: Expression,
     var iterationState: Iteration = null
     var currentRow: MorselExecutionContext = null
 
-    val inputLongCount = fromPipeline.numberOfLongs
-    val inputRefCount = fromPipeline.numberOfReferences
-    val outputLongCount = toPipeline.numberOfLongs
-    val outputRefCount = toPipeline.numberOfReferences
+    val inputLongCount = fromSlots.numberOfLongs
+    val inputRefCount = fromSlots.numberOfReferences
+    val outputLongCount = toSlots.numberOfLongs
+    val outputRefCount = toSlots.numberOfReferences
     val queryState = new OldQueryState(context, resources = null, params = state.params)
 
     source match {

--- a/enterprise/cypher/morsel-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/MergeSortOperatorTest.scala
+++ b/enterprise/cypher/morsel-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/MergeSortOperatorTest.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.runtime.vectorized.operators
 
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes.Ascending
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.{LongSlot, PipelineInformation}
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.{LongSlot, SlotConfiguration}
 import org.neo4j.cypher.internal.runtime.vectorized._
 import org.neo4j.cypher.internal.util.v3_4.symbols.CTNode
 import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
@@ -33,7 +33,7 @@ class MergeSortOperatorTest extends CypherFunSuite {
   test("sort a single morsel") {
     val slot = LongSlot(0, nullable = false, CTNode)
     val columnOrdering = Seq(Ascending(slot))
-    val info = new PipelineInformation(mutable.Map("apa" -> slot), 1, 0)
+    val info = new SlotConfiguration(mutable.Map("apa" -> slot), 1, 0)
 
     val longs = Array[Long](1, 2, 3, 4, 5, 6, 7, 8, 9)
     val in = new Morsel(longs, Array[AnyValue](), longs.length)
@@ -49,7 +49,7 @@ class MergeSortOperatorTest extends CypherFunSuite {
   test("sort two morsels") {
     val slot = LongSlot(0, nullable = false, CTNode)
     val columnOrdering = Seq(Ascending(slot))
-    val info = new PipelineInformation(mutable.Map("apa" -> slot), 1, 0)
+    val info = new SlotConfiguration(mutable.Map("apa" -> slot), 1, 0)
 
     val long1 = Array[Long](1, 2, 3, 4, 5, 6, 7, 8, 9)
     val long2 = Array[Long](5, 7, 9, 14, 86, 92)
@@ -75,7 +75,7 @@ class MergeSortOperatorTest extends CypherFunSuite {
   test("sort two morsels with one empty array") {
     val slot = LongSlot(0, nullable = false, CTNode)
     val columnOrdering = Seq(Ascending(slot))
-    val info = new PipelineInformation(mutable.Map("apa" -> slot), 1, 0)
+    val info = new SlotConfiguration(mutable.Map("apa" -> slot), 1, 0)
 
     val long1 = Array[Long](1, 2, 3, 4, 5, 6, 7, 8, 9)
     val long2 = Array.empty[Long]
@@ -93,7 +93,7 @@ class MergeSortOperatorTest extends CypherFunSuite {
   test("sort with too many output slots") {
     val slot = LongSlot(0, nullable = false, CTNode)
     val columnOrdering = Seq(Ascending(slot))
-    val info = new PipelineInformation(mutable.Map("apa" -> slot), 1, 0)
+    val info = new SlotConfiguration(mutable.Map("apa" -> slot), 1, 0)
 
     val longs = Array[Long](1, 2, 3, 4, 5, 6, 7, 8, 9)
     val in = new Morsel(longs, Array[AnyValue](), longs.length)

--- a/enterprise/cypher/morsel-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/PreSortOperatorTest.scala
+++ b/enterprise/cypher/morsel-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/PreSortOperatorTest.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.runtime.vectorized.operators
 
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes.Ascending
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.{LongSlot, PipelineInformation, RefSlot}
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.{LongSlot, SlotConfiguration, RefSlot}
 import org.neo4j.cypher.internal.runtime.vectorized.{Iteration, Morsel}
 import org.neo4j.cypher.internal.util.v3_4.symbols._
 import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
@@ -34,7 +34,7 @@ class PreSortOperatorTest extends CypherFunSuite {
   test("sort a morsel with a single long column") {
     val slot = LongSlot(0, nullable = false, CTNode)
     val columnOrdering = Seq(Ascending(slot))
-    val info = new PipelineInformation(mutable.Map("apa" -> slot), 1, 0)
+    val info = new SlotConfiguration(mutable.Map("apa" -> slot), 1, 0)
     val sortOperator = new PreSortOperator(columnOrdering, info)
 
     val longs = Array[Long](9, 8, 7, 6, 5, 4, 3, 2, 1)
@@ -49,7 +49,7 @@ class PreSortOperatorTest extends CypherFunSuite {
     val slot1 = LongSlot(0, nullable = false, CTNode)
     val slot2 = RefSlot(0, nullable = false, CTNumber)
     val columnOrdering = Seq(Ascending(slot2))
-    val info = new PipelineInformation(mutable.Map("apa1" -> slot1, "apa2" -> slot2), 1, 1)
+    val info = new SlotConfiguration(mutable.Map("apa1" -> slot1, "apa2" -> slot2), 1, 1)
     val sortOperator = new PreSortOperator(columnOrdering, info)
 
     val longs = Array[Long](
@@ -80,7 +80,7 @@ class PreSortOperatorTest extends CypherFunSuite {
     val slot1 = LongSlot(0, nullable = false, CTNode)
     val slot2 = LongSlot(1, nullable = false, CTNode)
     val columnOrdering = Seq(Ascending(slot1))
-    val info = new PipelineInformation(mutable.Map("apa1" -> slot1, "apa2" -> slot2), 2, 0)
+    val info = new SlotConfiguration(mutable.Map("apa1" -> slot1, "apa2" -> slot2), 2, 0)
     val sortOperator = new PreSortOperator(columnOrdering, info)
 
     val longs = Array[Long](
@@ -114,7 +114,7 @@ class PreSortOperatorTest extends CypherFunSuite {
   test("sort a morsel with no valid data") {
     val slot = LongSlot(0, nullable = false, CTNode)
     val columnOrdering = Seq(Ascending(slot))
-    val info = new PipelineInformation(mutable.Map("apa" -> slot), 1, 0)
+    val info = new SlotConfiguration(mutable.Map("apa" -> slot), 1, 0)
     val sortOperator = new PreSortOperator(columnOrdering, info)
 
     val longs = new Array[Long](10)
@@ -128,7 +128,7 @@ class PreSortOperatorTest extends CypherFunSuite {
   test("sort a morsel with empty array") {
     val slot = LongSlot(0, nullable = false, CTNode)
     val columnOrdering = Seq(Ascending(slot))
-    val info = new PipelineInformation(mutable.Map("apa" -> slot), 1, 0)
+    val info = new SlotConfiguration(mutable.Map("apa" -> slot), 1, 0)
     val sortOperator = new PreSortOperator(columnOrdering, info)
 
     val data = new Morsel(Array.empty, Array[AnyValue](), 0)

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
@@ -216,10 +216,8 @@ object SlotAllocation {
           case (key, parserAst.Variable(ident)) if key == ident =>
           // it's already there. no need to add a new slot for it
 
-          case (key, parserAst.Variable(ident)) if key != ident =>
-            val slot = source.get(ident).getOrElse(
-              throw new SlotAllocationFailed(s"Tried to lookup key $key that should be in slot configuration but wasn't"))
-            source.addAliasFor(slot, key)
+          case (newKey, parserAst.Variable(ident)) if newKey != ident =>
+            source.addAlias(newKey, ident)
 
           case (key, _) =>
             source.newReference(key, nullable = true, CTAny)

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
@@ -19,6 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime
 
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration.Size
 import org.neo4j.cypher.internal.ir.v3_4.IdName
 import org.neo4j.cypher.internal.util.v3_4.InternalException
 import org.neo4j.cypher.internal.util.v3_4.symbols._
@@ -41,20 +42,32 @@ import scala.collection.mutable
   **/
 object SlotAllocation {
 
+  private def NO_ARGUMENT() = SlotsAndArgument(SlotConfiguration.empty, Size.zero)
+
+  case class SlotsAndArgument(slotConfiguration: SlotConfiguration, argumentSize: Size)
+
+  case class PhysicalPlan(slotConfigurations: Map[LogicalPlanId, SlotConfiguration],
+                          argumentSizes: Map[LogicalPlanId, Size])
+
   /**
     * Allocate slot for every operator in the logical plan tree {@code lp}.
     *
     * @param lp the logical plan to process.
     * @return the slot configurations of every operator.
     */
-  def allocateSlots(lp: LogicalPlan): Map[LogicalPlanId, SlotConfiguration] = {
+  def allocateSlots(lp: LogicalPlan): PhysicalPlan = {
 
     val allocations = new mutable.OpenHashMap[LogicalPlanId, SlotConfiguration]()
+    val arguments = new mutable.OpenHashMap[LogicalPlanId, Size]()
 
     val planStack = new mutable.Stack[(Boolean, LogicalPlan)]()
     val resultStack = new mutable.Stack[SlotConfiguration]()
-    val argumentStack = new mutable.Stack[SlotConfiguration]()
+    val argumentStack = new mutable.Stack[SlotsAndArgument]()
     var comingFrom = lp
+
+    def recordArgument(plan:LogicalPlan, argument: SlotsAndArgument) = {
+      arguments += plan.assignedId -> argument.argumentSize
+    }
 
     /**
       * Eagerly populate the stack using all the lhs children.
@@ -81,21 +94,25 @@ object SlotAllocation {
 
       (current.lhs, current.rhs) match {
         case (None, None) =>
-          val argumentSlots = if (argumentStack.isEmpty) None else Some(argumentStack.top)
-          val result = allocate(current, nullable, argumentSlots)
+          val argument = if (argumentStack.isEmpty) NO_ARGUMENT()
+                         else argumentStack.top
+          recordArgument(current, argument)
+          val result = allocate(current, nullable, argument.slotConfiguration)
           allocations += (current.assignedId -> result)
           resultStack.push(result)
 
         case (Some(_), None) =>
           val sourceSlots = resultStack.pop()
-          val result = allocate(current, nullable, sourceSlots)
+          val argument = if (argumentStack.isEmpty) NO_ARGUMENT()
+                         else argumentStack.top
+          val result = allocate(current, nullable, sourceSlots, recordArgument(_, argument))
           allocations += (current.assignedId -> result)
           resultStack.push(result)
 
         case (Some(left), Some(right)) if (comingFrom eq left) && isAnApplyPlan(current) =>
           planStack.push((nullable, current))
           val argumentSlots = resultStack.top
-          argumentStack.push(argumentSlots.copy())
+          argumentStack.push(SlotsAndArgument(argumentSlots.copy(), argumentSlots.size()))
           populate(right, nullable)
 
         case (Some(left), Some(right)) if comingFrom eq left =>
@@ -115,7 +132,7 @@ object SlotAllocation {
       comingFrom = current
     }
 
-    allocations.toMap
+    PhysicalPlan(allocations.toMap, arguments.toMap)
   }
 
 
@@ -127,15 +144,15 @@ object SlotAllocation {
     * @param argument the logical plan argument slot configuration.
     * @return the slot configuration of lp
     */
-  private def allocate(lp: LogicalPlan, nullable: Boolean, argument: Option[SlotConfiguration]): SlotConfiguration =
+  private def allocate(lp: LogicalPlan, nullable: Boolean, argument: SlotConfiguration): SlotConfiguration =
     lp match {
       case leaf: NodeLogicalLeafPlan =>
-        val result = argument.getOrElse(SlotConfiguration.empty)
+        val result = argument
         result.newLong(leaf.idName.name, nullable, CTNode)
         result
 
       case _:Argument =>
-        argument.getOrElse(SlotConfiguration.empty)
+        argument
 
       case p => throw new SlotAllocationFailed(s"Don't know how to handle $p")
     }
@@ -146,9 +163,13 @@ object SlotAllocation {
     * @param lp the operator to compute slots for.
     * @param nullable
     * @param source the slot configuration of the source operator.
+    * @param recordArgument function which records the argument size for the given operator
     * @return the slot configuration of lp
     */
-  private def allocate(lp: LogicalPlan, nullable: Boolean, source: SlotConfiguration): SlotConfiguration =
+  private def allocate(lp: LogicalPlan,
+                       nullable: Boolean,
+                       source: SlotConfiguration,
+                       recordArgument: LogicalPlan => Unit): SlotConfiguration =
     lp match {
 
       case Distinct(_, groupingExpressions) =>
@@ -178,6 +199,7 @@ object SlotAllocation {
         result
 
       case Optional(_, _) =>
+        recordArgument(lp)
         source
 
       case _: ProduceResult |
@@ -205,12 +227,16 @@ object SlotAllocation {
         source
 
       case OptionalExpand(_, _, _, _, IdName(to), IdName(rel), ExpandAll, _) =>
+        // Note that OptionExpand only is optional on the expand and not on incoming rows, so
+        // we do not need to record the argument here.
         val result = source.copy()
         result.newLong(rel, nullable = true, CTRelationship)
         result.newLong(to, nullable = true, CTNode)
         result
 
       case OptionalExpand(_, _, _, _, _, IdName(rel), ExpandInto, _) =>
+        // Note that OptionExpand only is optional on the expand and not on incoming rows, so
+        // we do not need to record the argument here.
         val result = source.copy()
         result.newLong(rel, nullable = true, CTRelationship)
         result

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotConfiguration.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotConfiguration.scala
@@ -147,26 +147,25 @@ object SlotConfiguration {
   * store nodes and relationships, represented by their ids, and in RefSlots everything else, represented as AnyValues.
   *
   * @param slots the slots of the configuration.
-  * @param initialNumberOfLongs the initial number of long slots.
-  * @param initialNumberOfReferences the initial number of ref slots.
+  * @param numberOfLongs the number of long slots.
+  * @param numberOfReferences the number of ref slots.
   */
 class SlotConfiguration(private val slots: mutable.Map[String, Slot],
-                        val initialNumberOfLongs: Int,
-                        val initialNumberOfReferences: Int) {
-
-  var numberOfLongs: Int = initialNumberOfLongs
-  var numberOfReferences: Int = initialNumberOfReferences
+                        var numberOfLongs: Int,
+                        var numberOfReferences: Int) {
 
   private val aliases: mutable.Set[String] = mutable.Set()
   private val slotAliases = new mutable.HashMap[Slot, mutable.Set[String]] with mutable.MultiMap[Slot, String]
 
   def size() = SlotConfiguration.Size(numberOfLongs, numberOfReferences)
 
-  def addAliasFor(slot: Slot, key: String): SlotConfiguration = {
-    checkNotAlreadyTaken(key, slot)
-    slots.put(key, slot)
-    aliases.add(key)
-    slotAliases.addBinding(slot, key)
+  def addAlias(newKey: String, existingKey: String): SlotConfiguration = {
+    val slot = slots.getOrElse(existingKey,
+      throw new SlotAllocationFailed(s"Tried to alias non-existing slot '$existingKey'  with alias '$newKey'"))
+    checkNotAlreadyTaken(newKey, slot)
+    slots.put(newKey, slot)
+    aliases.add(newKey)
+    slotAliases.addBinding(slot, newKey)
     this
   }
 
@@ -247,7 +246,7 @@ class SlotConfiguration(private val slots: mutable.Map[String, Slot],
     state.map(_.hashCode()).foldLeft(0)((a, b) => 31 * a + b)
   }
 
-  override def toString = s"SlotConfiguration(longs=$numberOfLongs, objs=$numberOfReferences, slots=$slots)"
+  override def toString = s"SlotConfiguration(longs=$numberOfLongs, refs=$numberOfReferences, slots=$slots)"
 
   private def checkNotAlreadyTaken(key: String, slot: Slot): Unit =
     if (slots.contains(key))

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotConfiguration.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotConfiguration.scala
@@ -135,6 +135,11 @@ object SlotConfiguration {
     case _: LongSlot => true
     case _ => false
   }
+
+  case class Size(nLongs: Int, nReferences: Int)
+  object Size {
+    val zero = Size(nLongs = 0, nReferences = 0)
+  }
 }
 
 /**
@@ -154,6 +159,8 @@ class SlotConfiguration(private val slots: mutable.Map[String, Slot],
 
   private val aliases: mutable.Set[String] = mutable.Set()
   private val slotAliases = new mutable.HashMap[Slot, mutable.Set[String]] with mutable.MultiMap[Slot, String]
+
+  def size() = SlotConfiguration.Size(numberOfLongs, numberOfReferences)
 
   def addAliasFor(slot: Slot, key: String): SlotConfiguration = {
     checkNotAlreadyTaken(key, slot)

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/PipelineInformationTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/PipelineInformationTest.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 class PipelineInformationTest extends CypherFunSuite {
   test("can't overwrite variable name by mistake1") {
     // given
-    val pipeline = PipelineInformation.empty
+    val pipeline = SlotConfiguration.empty
     pipeline.newLong("x", nullable = false, CTNode)
 
     // when && then
@@ -35,7 +35,7 @@ class PipelineInformationTest extends CypherFunSuite {
 
   test("can't overwrite variable name by mistake2") {
     // given
-    val pipeline = PipelineInformation.empty
+    val pipeline = SlotConfiguration.empty
     pipeline.newLong("x", nullable = false, CTNode)
 
     // when && then
@@ -44,7 +44,7 @@ class PipelineInformationTest extends CypherFunSuite {
 
   test("can't overwrite variable name by mistake3") {
     // given
-    val pipeline = PipelineInformation.empty
+    val pipeline = SlotConfiguration.empty
     pipeline.newReference("x", nullable = false, CTNode)
 
     // when && then
@@ -53,7 +53,7 @@ class PipelineInformationTest extends CypherFunSuite {
 
   test("can't overwrite variable name by mistake4") {
     // given
-    val pipeline = PipelineInformation.empty
+    val pipeline = SlotConfiguration.empty
     pipeline.newReference("x", nullable = false, CTNode)
 
     // when && then
@@ -62,11 +62,11 @@ class PipelineInformationTest extends CypherFunSuite {
 
   test("deepClone creates an immutable copy") {
     // given
-    val pipeline = PipelineInformation(Map(
+    val pipeline = SlotConfiguration(Map(
       "x" -> LongSlot(0, nullable = false, CTNode),
       "y" -> LongSlot(1, nullable = false, CTNode)),
       numberOfLongs = 2, numberOfReferences = 0)
-    val clone: PipelineInformation = pipeline.breakPipelineAndClone()
+    val clone: SlotConfiguration = pipeline.copy()
     pipeline should equal(clone)
 
     // when

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocationArgumentsTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocationArgumentsTest.scala
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compatibility.v3_4.runtime
+
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration.Size
+import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport2
+import org.neo4j.cypher.internal.ir.v3_4.IdName
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.v3_4.expressions._
+import org.neo4j.cypher.internal.v3_4.logical.plans._
+
+class SlotAllocationArgumentsTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
+
+  private val x = IdName("x")
+  private val y = IdName("y")
+  private val z = IdName("z")
+  private val LABEL = LabelName("label")(pos)
+  private val r = IdName("r")
+
+  test("zero size argument for single all nodes scan") {
+    // given
+    val plan = AllNodesScan(x, Set.empty)(solved)
+    plan.assignIds()
+
+    // when
+    val arguments = SlotAllocation.allocateSlots(plan).argumentSizes
+
+    // then
+    arguments should have size 1
+    arguments(plan.assignedId) should equal(Size(0, 0))
+  }
+
+  test("zero size argument for only leaf operator") {
+    // given
+    val leaf = AllNodesScan(x, Set.empty)(solved)
+    val expand = Expand(leaf, x, SemanticDirection.INCOMING, Seq.empty, z, r, ExpandAll)(solved)
+    expand.assignIds()
+
+    // when
+    val arguments = SlotAllocation.allocateSlots(expand).argumentSizes
+
+    // then
+    arguments should have size 1
+    arguments(leaf.assignedId) should equal(Size(0, 0))
+  }
+
+  test("zero size argument for argument operator") {
+    val argument = Argument(Set.empty)(solved)()
+    argument.assignIds()
+
+    // when
+    val arguments = SlotAllocation.allocateSlots(argument).argumentSizes
+
+    // then
+    arguments should have size 1
+    arguments(argument.assignedId) should equal(Size(0, 0))
+  }
+
+  test("correct long size argument for rhs leaf") {
+    // given
+    val lhs = leaf()
+    val rhs = leaf()
+    val plan = applyRight(pipe(lhs, 1, 0), rhs)
+    plan.assignIds()
+
+    // when
+    val arguments = SlotAllocation.allocateSlots(plan).argumentSizes
+
+    // then
+    arguments should have size 2
+    arguments(lhs.assignedId) should equal(Size(0, 0))
+    arguments(rhs.assignedId) should equal(Size(1, 0))
+  }
+
+  test("correct ref size argument for rhs leaf") {
+    // given
+    val lhs = leaf()
+    val rhs = leaf()
+    val plan = applyRight(pipe(lhs, 0, 1), rhs)
+    plan.assignIds()
+
+    // when
+    val arguments = SlotAllocation.allocateSlots(plan).argumentSizes
+
+    // then
+    arguments should have size 2
+    arguments(lhs.assignedId) should equal(Size(0, 0))
+    arguments(rhs.assignedId) should equal(Size(0, 1))
+  }
+
+  test("correct size argument for more slots") {
+    // given
+    val lhs = leaf()
+    val rhs = leaf()
+    val plan = applyRight(pipe(lhs, 17, 11), rhs)
+    plan.assignIds()
+
+    // when
+    val arguments = SlotAllocation.allocateSlots(plan).argumentSizes
+
+    // then
+    arguments should have size 2
+    arguments(lhs.assignedId) should equal(Size(0, 0))
+    arguments(rhs.assignedId) should equal(Size(17, 11))
+  }
+
+  test("apply right keeps rhs slots") {
+    // given
+    //        applyRight
+    //         \        \
+    //    applyRight    leaf3
+    //    /        \
+    // +1 long   +1 ref
+    //    |         |
+    //  leaf1     leaf2
+
+    val leaf1 = leaf()
+    val leaf2 = leaf()
+    val leaf3 = leaf()
+    val plan = applyRight(applyRight(pipe(leaf1, 1, 0), pipe(leaf2, 0, 1)), leaf3)
+    plan.assignIds()
+
+    // when
+    val arguments = SlotAllocation.allocateSlots(plan).argumentSizes
+
+    // then
+    arguments should have size 3
+    arguments(leaf1.assignedId) should equal(Size(0, 0))
+    arguments(leaf2.assignedId) should equal(Size(1, 0))
+    arguments(leaf3.assignedId) should equal(Size(1, 1))
+  }
+
+  test("apply left ignores rhs slots") {
+    // given
+    //          applyRight
+    //         /          \
+    //     applyLeft     leaf3
+    //    /        \
+    // +1 long   +1 ref
+    //    |         |
+    //  leaf1     leaf2
+
+    val leaf1 = leaf()
+    val leaf2 = leaf()
+    val leaf3 = leaf()
+    val plan = applyRight(applyLeft(pipe(leaf1, 1, 0), pipe(leaf2, 0, 1)), leaf3)
+    plan.assignIds()
+
+    // when
+    val arguments = SlotAllocation.allocateSlots(plan).argumentSizes
+
+    // then
+    arguments should have size 3
+    arguments(leaf1.assignedId) should equal(Size(0, 0))
+    arguments(leaf2.assignedId) should equal(Size(1, 0))
+    arguments(leaf3.assignedId) should equal(Size(1, 0))
+  }
+
+  test("apply left argument does not leak downstream slots") {
+    // given
+    //       +1 ref
+    //         /
+    //     applyLeft
+    //    /        \
+    // +1 long   leaf2
+    //    |
+    //  leaf1
+
+    val leaf1 = leaf()
+    val leaf2 = leaf()
+    val plan = pipe(applyLeft(pipe(leaf1, 1, 0), leaf2), 0, 1)
+    plan.assignIds()
+
+    // when
+    val arguments = SlotAllocation.allocateSlots(plan).argumentSizes
+
+    // then
+    arguments should have size 2
+    arguments(leaf1.assignedId) should equal(Size(0, 0))
+    arguments(leaf2.assignedId) should equal(Size(1, 0))
+  }
+
+  test("argument is passed over pipeline break") {
+    // given
+    //     applyRight
+    //    /        \
+    // +1 long   +1 ref
+    //    |       --|--
+    //  leaf1     breaker
+    //              |
+    //            leaf2
+
+    val leaf1 = leaf()
+    val leaf2 = leaf()
+    val plan = applyRight(pipe(leaf1, 1, 0), pipe(break(leaf2), 0, 1))
+    plan.assignIds()
+
+    // when
+    val arguments = SlotAllocation.allocateSlots(plan).argumentSizes
+
+    // then
+    arguments should have size 2
+    arguments(leaf1.assignedId) should equal(Size(0, 0))
+    arguments(leaf2.assignedId) should equal(Size(1, 0))
+  }
+
+  test("Optional should record argument size") {
+    // given
+    //     applyRight
+    //    /        \
+    // +1 long   optional
+    //    |         |
+    //  leaf1     leaf2
+
+    val leaf1 = leaf()
+    val leaf2 = leaf()
+    val optional = Optional(leaf2, Set.empty)(solved)
+    val plan = applyRight(pipe(leaf1, 1, 0), optional)
+    plan.assignIds()
+
+    // when
+    val arguments = SlotAllocation.allocateSlots(plan).argumentSizes
+
+    // then
+    arguments should have size 3
+    arguments(leaf1.assignedId) should equal(Size(0, 0))
+    arguments(leaf2.assignedId) should equal(Size(1, 0))
+    arguments(optional.assignedId) should equal(Size(1, 0))
+  }
+
+  private def leaf() = Argument(Set.empty)(solved)()
+  private def applyRight(lhs:LogicalPlan, rhs:LogicalPlan) = Apply(lhs, rhs)(solved)
+  private def applyLeft(lhs:LogicalPlan, rhs:LogicalPlan) = SemiApply(lhs, rhs)(solved)
+  private def break(source:LogicalPlan) = Eager(source)(solved)
+  private def pipe(source:LogicalPlan, nLongs:Int, nRefs:Int) = {
+    var curr = source
+    for ( i <- 0 until nLongs ) {
+      curr = CreateNode(curr, IdName("long"+i), Nil, None)(solved)
+    }
+    for ( i <- 0 until nRefs ) {
+      curr = UnwindCollection(curr, IdName("ref"+i), listOf(literalInt(1)))(solved)
+    }
+    curr
+  }
+}

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocationTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocationTest.scala
@@ -42,7 +42,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     plan.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(plan)
+    val allocations = SlotAllocation.allocateSlots(plan).slotConfigurations
 
     // then
     allocations should have size 1
@@ -56,7 +56,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     plan.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(plan)
+    val allocations = SlotAllocation.allocateSlots(plan).slotConfigurations
 
     // then
     allocations should have size 2
@@ -70,7 +70,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     plan.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(plan)
+    val allocations = SlotAllocation.allocateSlots(plan).slotConfigurations
 
     // then
     allocations should have size 1
@@ -84,7 +84,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     filter.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(filter)
+    val allocations = SlotAllocation.allocateSlots(filter).slotConfigurations
 
     // then
     allocations should have size 2
@@ -99,7 +99,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     expand.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(expand)
+    val allocations = SlotAllocation.allocateSlots(expand).slotConfigurations
 
     // then we'll end up with two pipelines
     allocations should have size 2
@@ -122,7 +122,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     expand.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(expand)
+    val allocations = SlotAllocation.allocateSlots(expand).slotConfigurations
 
     // then we'll end up with two pipelines
     allocations should have size 2
@@ -143,7 +143,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     plan.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(plan)
+    val allocations = SlotAllocation.allocateSlots(plan).slotConfigurations
 
     // then
     allocations should have size 2
@@ -157,7 +157,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     expand.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(expand)
+    val allocations = SlotAllocation.allocateSlots(expand).slotConfigurations
 
     // then we'll end up with two pipelines
     allocations should have size 2
@@ -182,7 +182,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     expand.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(expand)
+    val allocations = SlotAllocation.allocateSlots(expand).slotConfigurations
 
     // then we'll end up with two pipelines
     allocations should have size 2
@@ -209,7 +209,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     expand.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(expand)
+    val allocations = SlotAllocation.allocateSlots(expand).slotConfigurations
 
     // then we'll end up with two pipelines
     allocations should have size 2
@@ -236,7 +236,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     skip.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(skip)
+    val allocations = SlotAllocation.allocateSlots(skip).slotConfigurations
 
     // then
     allocations should have size 2
@@ -258,7 +258,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     apply.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(apply)
+    val allocations = SlotAllocation.allocateSlots(apply).slotConfigurations
 
     // then
     allocations should have size 3
@@ -283,7 +283,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     distinct.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(distinct)
+    val allocations = SlotAllocation.allocateSlots(distinct).slotConfigurations
 
     // then
     allocations should have size 2
@@ -302,7 +302,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     distinct.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(distinct)
+    val allocations = SlotAllocation.allocateSlots(distinct).slotConfigurations
 
     // then
     allocations should have size 3
@@ -327,7 +327,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     countStar.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(countStar)
+    val allocations = SlotAllocation.allocateSlots(countStar).slotConfigurations
 
     // then
     allocations should have size 3
@@ -350,7 +350,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     projection.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(projection)
+    val allocations = SlotAllocation.allocateSlots(projection).slotConfigurations
 
     // then
     allocations should have size 2
@@ -369,7 +369,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     Xproduct.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(Xproduct)
+    val allocations = SlotAllocation.allocateSlots(Xproduct).slotConfigurations
 
     // then
     allocations should have size 3
@@ -394,7 +394,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     hashJoin.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(hashJoin)
+    val allocations = SlotAllocation.allocateSlots(hashJoin).slotConfigurations
 
     // then
     allocations should have size 3
@@ -422,7 +422,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     hashJoin.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(hashJoin)
+    val allocations = SlotAllocation.allocateSlots(hashJoin).slotConfigurations
 
     // then
     allocations should have size 5
@@ -458,7 +458,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     hashJoin.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(hashJoin)
+    val allocations = SlotAllocation.allocateSlots(hashJoin).slotConfigurations
 
     // then
     allocations should have size 5 // One for each label-scan and expand, and one after the join
@@ -491,7 +491,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     apply.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(apply)
+    val allocations = SlotAllocation.allocateSlots(apply).slotConfigurations
 
     // then
     val lhsPipeline = SlotConfiguration(Map(
@@ -519,7 +519,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     produceResult.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(produceResult)
+    val allocations = SlotAllocation.allocateSlots(produceResult).slotConfigurations
 
     // then
     allocations should have size 3
@@ -543,7 +543,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     produceResult.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(produceResult)
+    val allocations = SlotAllocation.allocateSlots(produceResult).slotConfigurations
 
     // then
     allocations should have size 4
@@ -577,7 +577,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     val rhs = Expand(arg, x, SemanticDirection.INCOMING, Seq.empty, y, r, ExpandAll)(solved)
     val semiApply = semiApplyBuilder(lhs, rhs)(solved)
     semiApply.assignIds()
-    val allocations = SlotAllocation.allocateSlots(semiApply)
+    val allocations = SlotAllocation.allocateSlots(semiApply).slotConfigurations
 
     val lhsPipeline = SlotConfiguration(Map(
       "x" -> LongSlot(0, nullable = false, CTNode)),
@@ -607,7 +607,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     apply.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(apply)
+    val allocations = SlotAllocation.allocateSlots(apply).slotConfigurations
 
     // then
     allocations should have size 5
@@ -636,7 +636,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     aggregation.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(aggregation)
+    val allocations = SlotAllocation.allocateSlots(aggregation).slotConfigurations
 
     allocations should have size 3
     allocations(expand.assignedId) should equal(
@@ -677,7 +677,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     rollUp.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(rollUp)
+    val allocations = SlotAllocation.allocateSlots(rollUp).slotConfigurations
 
     // then
     allocations should have size 5
@@ -696,7 +696,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     plan.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(plan)
+    val allocations = SlotAllocation.allocateSlots(plan).slotConfigurations
 
     // then
     allocations should have size 3
@@ -713,7 +713,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     plan.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(plan)
+    val allocations = SlotAllocation.allocateSlots(plan).slotConfigurations
 
     // then
     allocations should have size 4
@@ -729,7 +729,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     plan.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(plan)
+    val allocations = SlotAllocation.allocateSlots(plan).slotConfigurations
 
     // then
     allocations should have size 5

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocationTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocationTest.scala
@@ -47,7 +47,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     // then
     allocations should have size 1
     allocations(plan.assignedId) should equal(
-      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode)), 1, 0))
+      SlotConfiguration(Map("x" -> LongSlot(0, nullable = false, CTNode)), 1, 0))
   }
 
   test("limit should not introduce slots") {
@@ -61,7 +61,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     // then
     allocations should have size 2
     allocations(plan.assignedId) should equal(
-      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode)), 1, 0))
+      SlotConfiguration(Map("x" -> LongSlot(0, nullable = false, CTNode)), 1, 0))
   }
 
   test("single labelscan scan") {
@@ -74,7 +74,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
 
     // then
     allocations should have size 1
-    allocations(plan.assignedId) should equal(PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode)), 1, 0))
+    allocations(plan.assignedId) should equal(SlotConfiguration(Map("x" -> LongSlot(0, nullable = false, CTNode)), 1, 0))
   }
 
   test("labelscan with filtering") {
@@ -88,7 +88,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
 
     // then
     allocations should have size 2
-    allocations(leaf.assignedId) should equal(PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode)), 1, 0))
+    allocations(leaf.assignedId) should equal(SlotConfiguration(Map("x" -> LongSlot(0, nullable = false, CTNode)), 1, 0))
     allocations(filter.assignedId) shouldBe theSameInstanceAs(allocations(leaf.assignedId))
   }
 
@@ -105,11 +105,11 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     allocations should have size 2
     val labelScanAllocations = allocations(allNodesScan.assignedId)
     labelScanAllocations should equal(
-      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode)), numberOfLongs = 1, numberOfReferences = 0))
+      SlotConfiguration(Map("x" -> LongSlot(0, nullable = false, CTNode)), numberOfLongs = 1, numberOfReferences = 0))
 
     val expandAllocations = allocations(expand.assignedId)
     expandAllocations should equal(
-      PipelineInformation(Map(
+      SlotConfiguration(Map(
         "x" -> LongSlot(0, nullable = false, CTNode),
         "r" -> LongSlot(1, nullable = false, CTRelationship),
         "z" -> LongSlot(2, nullable = false, CTNode)), numberOfLongs = 3, numberOfReferences = 0))
@@ -128,11 +128,11 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     allocations should have size 2
     val labelScanAllocations = allocations(allNodesScan.assignedId)
     labelScanAllocations should equal(
-      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode)), numberOfLongs = 1, numberOfReferences = 0))
+      SlotConfiguration(Map("x" -> LongSlot(0, nullable = false, CTNode)), numberOfLongs = 1, numberOfReferences = 0))
 
     val expandAllocations = allocations(expand.assignedId)
     expandAllocations should equal(
-      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode), "r" -> LongSlot(1, nullable = false,
+      SlotConfiguration(Map("x" -> LongSlot(0, nullable = false, CTNode), "r" -> LongSlot(1, nullable = false,
         CTRelationship)), numberOfLongs = 2, numberOfReferences = 0))
   }
 
@@ -147,7 +147,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
 
     // then
     allocations should have size 2
-    allocations(plan.assignedId) should equal(PipelineInformation(Map("x" -> LongSlot(0, nullable = true, CTNode)), 1, 0))
+    allocations(plan.assignedId) should equal(SlotConfiguration(Map("x" -> LongSlot(0, nullable = true, CTNode)), 1, 0))
   }
 
   test("single node with optionalExpand ExpandAll") {
@@ -163,12 +163,12 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     allocations should have size 2
     val labelScanAllocations = allocations(allNodesScan.assignedId)
     labelScanAllocations should equal(
-      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode)), numberOfLongs = 1, numberOfReferences =
+      SlotConfiguration(Map("x" -> LongSlot(0, nullable = false, CTNode)), numberOfLongs = 1, numberOfReferences =
         0))
 
     val expandAllocations = allocations(expand.assignedId)
     expandAllocations should equal(
-      PipelineInformation(Map(
+      SlotConfiguration(Map(
         "x" -> LongSlot(0, nullable = false, CTNode),
         "r" -> LongSlot(1, nullable = true, CTRelationship),
         "z" -> LongSlot(2, nullable = true, CTNode)
@@ -188,11 +188,11 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     allocations should have size 2
     val labelScanAllocations = allocations(allNodesScan.assignedId)
     labelScanAllocations should equal(
-      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode)), numberOfLongs = 1, numberOfReferences = 0))
+      SlotConfiguration(Map("x" -> LongSlot(0, nullable = false, CTNode)), numberOfLongs = 1, numberOfReferences = 0))
 
     val expandAllocations = allocations(expand.assignedId)
     expandAllocations should equal(
-      PipelineInformation(Map(
+      SlotConfiguration(Map(
         "x" -> LongSlot(0, nullable = false, CTNode),
         "r" -> LongSlot(1, nullable = true, CTRelationship)
       ), numberOfLongs = 2, numberOfReferences = 0))
@@ -215,7 +215,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     allocations should have size 2
     val labelScanAllocations = allocations(allNodesScan.assignedId)
     labelScanAllocations should equal(
-      PipelineInformation(Map(
+      SlotConfiguration(Map(
         "x" -> LongSlot(0, nullable = false, CTNode),
         "r_NODES" -> LongSlot(1, nullable = false, CTNode),
         "r_EDGES" -> LongSlot(2, nullable = false, CTRelationship)),
@@ -223,7 +223,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
 
     val expandAllocations = allocations(expand.assignedId)
     expandAllocations should equal(
-      PipelineInformation(Map(
+      SlotConfiguration(Map(
         "x" -> LongSlot(0, nullable = false, CTNode),
         "r" -> RefSlot(0, nullable = false, CTList(CTRelationship)),
         "z" -> LongSlot(1, nullable = false, CTNode)), numberOfLongs = 2, numberOfReferences = 1))
@@ -242,7 +242,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     allocations should have size 2
     val labelScanAllocations = allocations(allNodesScan.assignedId)
     labelScanAllocations should equal(
-      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode)), numberOfLongs = 1, numberOfReferences = 0))
+      SlotConfiguration(Map("x" -> LongSlot(0, nullable = false, CTNode)), numberOfLongs = 1, numberOfReferences = 0))
 
     val expandAllocations = allocations(skip.assignedId)
     expandAllocations shouldBe theSameInstanceAs(labelScanAllocations)
@@ -263,12 +263,12 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     // then
     allocations should have size 3
     allocations(lhs.assignedId) should equal(
-      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode)), numberOfLongs = 1, numberOfReferences = 0))
+      SlotConfiguration(Map("x" -> LongSlot(0, nullable = false, CTNode)), numberOfLongs = 1, numberOfReferences = 0))
 
     val rhsPipeline = allocations(rhs.assignedId)
 
     rhsPipeline should equal(
-      PipelineInformation(Map(
+      SlotConfiguration(Map(
         "x" -> LongSlot(0, nullable = false, CTNode),
         "z" -> LongSlot(1, nullable = false, CTNode)
       ), numberOfLongs = 2, numberOfReferences = 0))
@@ -288,10 +288,10 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     // then
     allocations should have size 2
     allocations(leaf.assignedId) should equal(
-      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode)), numberOfLongs = 1, numberOfReferences = 0))
+      SlotConfiguration(Map("x" -> LongSlot(0, nullable = false, CTNode)), numberOfLongs = 1, numberOfReferences = 0))
 
     allocations(distinct.assignedId) should equal(
-      PipelineInformation(Map("x" -> RefSlot(0, nullable = false, CTNode)), numberOfLongs = 0, numberOfReferences = 1))
+      SlotConfiguration(Map("x" -> RefSlot(0, nullable = false, CTNode)), numberOfLongs = 0, numberOfReferences = 1))
   }
 
   test("optional travels through aggregation used for distinct") {
@@ -307,10 +307,10 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     // then
     allocations should have size 3
     allocations(leaf.assignedId) should equal(
-      PipelineInformation(Map("x" -> LongSlot(0, nullable = true, CTNode)), numberOfLongs = 1, numberOfReferences = 0))
+      SlotConfiguration(Map("x" -> LongSlot(0, nullable = true, CTNode)), numberOfLongs = 1, numberOfReferences = 0))
 
     allocations(optional.assignedId) should be theSameInstanceAs allocations(leaf.assignedId)
-    allocations(distinct.assignedId) should equal(PipelineInformation(numberOfLongs = 0, numberOfReferences = 2, slots = Map(
+    allocations(distinct.assignedId) should equal(SlotConfiguration(numberOfLongs = 0, numberOfReferences = 2, slots = Map(
       "x" -> RefSlot(0, nullable = true, CTNode),
       "x.propertyKey" -> RefSlot(1, nullable = true, CTAny)
     )))
@@ -332,11 +332,11 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     // then
     allocations should have size 3
     allocations(leaf.assignedId) should equal(
-      PipelineInformation(Map("x" -> LongSlot(0, nullable = true, CTNode)), numberOfLongs = 1, numberOfReferences = 0))
+      SlotConfiguration(Map("x" -> LongSlot(0, nullable = true, CTNode)), numberOfLongs = 1, numberOfReferences = 0))
 
     allocations(optional.assignedId) should be theSameInstanceAs allocations(leaf.assignedId)
     allocations(countStar.assignedId) should equal(
-      PipelineInformation(numberOfLongs = 0, numberOfReferences = 3, slots = Map(
+      SlotConfiguration(numberOfLongs = 0, numberOfReferences = 3, slots = Map(
         "x" -> RefSlot(0, nullable = true, CTNode),
         "x.propertyKey" -> RefSlot(1, nullable = true, CTAny),
         "count(*)" -> RefSlot(2, nullable = true, CTAny)
@@ -354,7 +354,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
 
     // then
     allocations should have size 2
-    allocations(leaf.assignedId) should equal(PipelineInformation(numberOfLongs = 1, numberOfReferences = 1, slots = Map(
+    allocations(leaf.assignedId) should equal(SlotConfiguration(numberOfLongs = 1, numberOfReferences = 1, slots = Map(
       "x" -> LongSlot(0, nullable = false, CTNode),
       "x.propertyKey" -> RefSlot(0, nullable = true, CTAny)
     )))
@@ -373,13 +373,13 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
 
     // then
     allocations should have size 3
-    allocations(lhs.assignedId) should equal(PipelineInformation(numberOfLongs = 1, numberOfReferences = 0, slots = Map(
+    allocations(lhs.assignedId) should equal(SlotConfiguration(numberOfLongs = 1, numberOfReferences = 0, slots = Map(
       "x" -> LongSlot(0, nullable = false, CTNode)
     )))
-    allocations(rhs.assignedId) should equal(PipelineInformation(numberOfLongs = 1, numberOfReferences = 0, slots = Map(
+    allocations(rhs.assignedId) should equal(SlotConfiguration(numberOfLongs = 1, numberOfReferences = 0, slots = Map(
       "y" -> LongSlot(0, nullable = false, CTNode)
     )))
-    allocations(Xproduct.assignedId) should equal(PipelineInformation(numberOfLongs = 2, numberOfReferences = 0, slots = Map(
+    allocations(Xproduct.assignedId) should equal(SlotConfiguration(numberOfLongs = 2, numberOfReferences = 0, slots = Map(
       "x" -> LongSlot(0, nullable = false, CTNode),
       "y" -> LongSlot(1, nullable = false, CTNode)
     )))
@@ -398,13 +398,13 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
 
     // then
     allocations should have size 3
-    allocations(lhs.assignedId) should equal(PipelineInformation(numberOfLongs = 1, numberOfReferences = 0, slots = Map(
+    allocations(lhs.assignedId) should equal(SlotConfiguration(numberOfLongs = 1, numberOfReferences = 0, slots = Map(
       "x" -> LongSlot(0, nullable = false, CTNode)
     )))
-    allocations(rhs.assignedId) should equal(PipelineInformation(numberOfLongs = 1, numberOfReferences = 0, slots = Map(
+    allocations(rhs.assignedId) should equal(SlotConfiguration(numberOfLongs = 1, numberOfReferences = 0, slots = Map(
       "x" -> LongSlot(0, nullable = false, CTNode)
     )))
-    allocations(hashJoin.assignedId) should equal(PipelineInformation(numberOfLongs = 1, numberOfReferences = 0, slots = Map(
+    allocations(hashJoin.assignedId) should equal(SlotConfiguration(numberOfLongs = 1, numberOfReferences = 0, slots = Map(
       "x" -> LongSlot(0, nullable = false, CTNode)
     )))
   }
@@ -426,17 +426,17 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
 
     // then
     allocations should have size 5
-    allocations(lhsE.assignedId) should equal(PipelineInformation(numberOfLongs = 3, numberOfReferences = 0, slots = Map(
+    allocations(lhsE.assignedId) should equal(SlotConfiguration(numberOfLongs = 3, numberOfReferences = 0, slots = Map(
       "x" -> LongSlot(0, nullable = false, CTNode),
       "r" -> LongSlot(1, nullable = false, CTRelationship),
       "y" -> LongSlot(2, nullable = false, CTNode)
     )))
-    allocations(rhsE.assignedId) should equal(PipelineInformation(numberOfLongs = 3, numberOfReferences = 0, slots = Map(
+    allocations(rhsE.assignedId) should equal(SlotConfiguration(numberOfLongs = 3, numberOfReferences = 0, slots = Map(
       "x" -> LongSlot(0, nullable = false, CTNode),
       "r2" -> LongSlot(1, nullable = false, CTRelationship),
       "z" -> LongSlot(2, nullable = false, CTNode)
     )))
-    allocations(hashJoin.assignedId) should equal(PipelineInformation(numberOfLongs = 5, numberOfReferences = 0, slots = Map(
+    allocations(hashJoin.assignedId) should equal(SlotConfiguration(numberOfLongs = 5, numberOfReferences = 0, slots = Map(
       "x" -> LongSlot(0, nullable = false, CTNode),
       "r" -> LongSlot(1, nullable = false, CTRelationship),
       "y" -> LongSlot(2, nullable = false, CTNode),
@@ -462,17 +462,18 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
 
     // then
     allocations should have size 5 // One for each label-scan and expand, and one after the join
-    allocations(lhsE.assignedId) should equal(PipelineInformation(numberOfLongs = 3, numberOfReferences = 0, slots = Map(
+    allocations(lhsE.assignedId) should equal(SlotConfiguration(numberOfLongs = 3, numberOfReferences = 0, slots = Map(
       "x" -> LongSlot(0, nullable = false, CTNode),
       "r" -> LongSlot(1, nullable = false, CTRelationship),
       "y" -> LongSlot(2, nullable = false, CTNode)
     )))
-    allocations(rhsE.assignedId) should equal(PipelineInformation(numberOfLongs = 3, numberOfReferences = 0, slots = Map(
+    allocations(rhsE.assignedId) should equal(SlotConfiguration(numberOfLongs = 3, numberOfReferences = 0, slots = Map(
       "x" -> LongSlot(0, nullable = false, CTNode),
       "r2" -> LongSlot(1, nullable = false, CTRelationship),
       "y" -> LongSlot(2, nullable = false, CTNode)
     )))
-    allocations(hashJoin.assignedId) should equal(PipelineInformation(numberOfLongs = 4, numberOfReferences = 0, slots = Map(
+    allocations(hashJoin.assignedId) should equal(SlotConfiguration(numberOfLongs = 4, numberOfReferences = 0, slots =
+      Map(
       "x" -> LongSlot(0, nullable = false, CTNode),
       "r" -> LongSlot(1, nullable = false, CTRelationship),
       "y" -> LongSlot(2, nullable = false, CTNode),
@@ -493,11 +494,11 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     val allocations = SlotAllocation.allocateSlots(apply)
 
     // then
-    val lhsPipeline = PipelineInformation(Map(
+    val lhsPipeline = SlotConfiguration(Map(
       "x" -> LongSlot(0, nullable = false, CTNode)),
       numberOfLongs = 1, numberOfReferences = 0)
 
-    val rhsPipeline = PipelineInformation(Map(
+    val rhsPipeline = SlotConfiguration(Map(
       "x" -> LongSlot(0, nullable = false, CTNode),
       "y" -> LongSlot(2, nullable = false, CTNode),
       "r" -> LongSlot(1, nullable = false, CTRelationship)
@@ -522,10 +523,10 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
 
     // then
     allocations should have size 3
-    allocations(leaf.assignedId) should equal(PipelineInformation(Map.empty, 0, 0))
+    allocations(leaf.assignedId) should equal(SlotConfiguration(Map.empty, 0, 0))
 
 
-    allocations(unwind.assignedId) should equal(PipelineInformation(numberOfLongs = 0, numberOfReferences = 1, slots = Map(
+    allocations(unwind.assignedId) should equal(SlotConfiguration(numberOfLongs = 0, numberOfReferences = 1, slots = Map(
       "x" -> RefSlot(0, nullable = true, CTAny)
     )))
     allocations(produceResult.assignedId) shouldBe theSameInstanceAs(allocations(unwind.assignedId))
@@ -546,10 +547,10 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
 
     // then
     allocations should have size 4
-    allocations(leaf.assignedId) should equal(PipelineInformation(Map.empty, 0, 0))
+    allocations(leaf.assignedId) should equal(SlotConfiguration(Map.empty, 0, 0))
 
 
-    val expectedPipeline = PipelineInformation(numberOfLongs = 0, numberOfReferences = 1, slots = Map(
+    val expectedPipeline = SlotConfiguration(numberOfLongs = 0, numberOfReferences = 1, slots = Map(
       "x" -> RefSlot(0, nullable = true, CTAny)
     ))
     allocations(unwind.assignedId) should equal(expectedPipeline)
@@ -578,13 +579,13 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     semiApply.assignIds()
     val allocations = SlotAllocation.allocateSlots(semiApply)
 
-    val lhsPipeline = PipelineInformation(Map(
+    val lhsPipeline = SlotConfiguration(Map(
       "x" -> LongSlot(0, nullable = false, CTNode)),
       numberOfLongs = 1, numberOfReferences = 0)
 
     val argumentSide = lhsPipeline
 
-    val rhsPipeline = PipelineInformation(Map(
+    val rhsPipeline = SlotConfiguration(Map(
       "x" -> LongSlot(0, nullable = false, CTNode),
       "y" -> LongSlot(2, nullable = false, CTNode),
       "r" -> LongSlot(1, nullable = false, CTRelationship)
@@ -610,8 +611,8 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
 
     // then
     allocations should have size 5
-    val lhsPipeline = PipelineInformation(Map("x" -> RefSlot(0, nullable = true, CTAny)), 0, 1)
-    val rhsPipeline = PipelineInformation(Map("x" -> RefSlot(0, nullable = true, CTAny), "y" -> RefSlot(1, nullable = true, CTAny)), 0, 2)
+    val lhsPipeline = SlotConfiguration(Map("x" -> RefSlot(0, nullable = true, CTAny)), 0, 1)
+    val rhsPipeline = SlotConfiguration(Map("x" -> RefSlot(0, nullable = true, CTAny), "y" -> RefSlot(1, nullable = true, CTAny)), 0, 2)
     allocations(arg1.assignedId) should equal(lhsPipeline)
     allocations(pr1.assignedId) should equal(lhsPipeline)
     allocations(arg2.assignedId) should equal(rhsPipeline)
@@ -639,14 +640,14 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
 
     allocations should have size 3
     allocations(expand.assignedId) should equal(
-      PipelineInformation(Map(
+      SlotConfiguration(Map(
         "x" -> LongSlot(0, nullable = false, CTNode),
         "r" -> LongSlot(1, nullable = false, CTRelationship),
         "y" -> LongSlot(2, nullable = false, CTNode)
       ), numberOfLongs = 3, numberOfReferences = 0)
     )
     allocations(aggregation.assignedId) should equal(
-      PipelineInformation(Map(
+      SlotConfiguration(Map(
         "x" -> RefSlot(0, nullable = false, CTNode),
         "x.prop" -> RefSlot(1, nullable = true, CTAny),
         "count(r.prop)" -> RefSlot(2, nullable = true, CTAny)
@@ -681,7 +682,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     // then
     allocations should have size 5
     allocations(rollUp.assignedId) should equal(
-      PipelineInformation(Map(
+      SlotConfiguration(Map(
         "c" -> RefSlot(0, nullable = false, CTList(CTAny))
       ), numberOfLongs = 0, numberOfReferences = 1)
     )
@@ -700,7 +701,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     // then
     allocations should have size 3
     allocations(plan.assignedId) should equal(
-      PipelineInformation(Map("x" -> LongSlot(0, nullable = false, CTNode)), 1, 0))
+      SlotConfiguration(Map("x" -> LongSlot(0, nullable = false, CTNode)), 1, 0))
   }
 
   test("should handle UNION of one primitive relationship and one node") {
@@ -717,7 +718,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     // then
     allocations should have size 4
     allocations(plan.assignedId) should equal(
-      PipelineInformation(Map("x" -> RefSlot(0, nullable = false, CTAny)), 0, 1))
+      SlotConfiguration(Map("x" -> RefSlot(0, nullable = false, CTAny)), 0, 1))
   }
 
   test("should handle UNION of projected variables") {
@@ -733,6 +734,6 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     // then
     allocations should have size 5
     allocations(plan.assignedId) should equal(
-      PipelineInformation(Map("A" -> RefSlot(0, nullable = true, CTAny)), 0, 1))
+      SlotConfiguration(Map("A" -> RefSlot(0, nullable = true, CTAny)), 0, 1))
   }
 }

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriterTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriterTest.scala
@@ -43,8 +43,8 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val produceResult = ProduceResult(selection, Seq("x"))
     produceResult.assignIds()
     val offset = 0
-    val pipeline = PipelineInformation(Map("x" -> LongSlot(offset, nullable = false, typ = CTNode)), 1, 0)
-    val lookup: Map[LogicalPlanId, PipelineInformation] = Map(
+    val pipeline = SlotConfiguration(Map("x" -> LongSlot(offset, nullable = false, typ = CTNode)), 1, 0)
+    val lookup: Map[LogicalPlanId, SlotConfiguration] = Map(
       allNodes.assignedId -> pipeline,
       selection.assignedId -> pipeline,
       produceResult.assignedId -> pipeline)
@@ -72,7 +72,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val predicate = Not(Equals(varFor("r1"), varFor("r2"))(pos))(pos)
     val selection = Selection(Seq(predicate), argument)(solved)
     selection.assignIds()
-    val pipelineInformation = PipelineInformation(Map(
+    val pipelineInformation = SlotConfiguration(Map(
       "a" -> nodeAt(0, "a"),
       "b" -> nodeAt(1, "b"),
       "r1" -> edgeAt(2, "r1"),
@@ -80,7 +80,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
       "r2" -> edgeAt(4, "r2")
     ), numberOfLongs = 5, numberOfReferences = 0)
 
-    val lookup: Map[LogicalPlanId, PipelineInformation] = Map(
+    val lookup: Map[LogicalPlanId, SlotConfiguration] = Map(
       argument.assignedId -> pipelineInformation,
       selection.assignedId -> pipelineInformation
     )
@@ -103,11 +103,11 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val predicate = Equals(prop("a", "prop"), literalInt(42))(pos)
     val selection = Selection(Seq(predicate), argument)(solved)
     selection.assignIds()
-    val pipelineInformation = PipelineInformation(Map(
+    val pipelineInformation = SlotConfiguration(Map(
       "a" -> LongSlot(0, nullable = true, typ = CTNode)
     ), numberOfLongs = 1, numberOfReferences = 0)
 
-    val lookup: Map[LogicalPlanId, PipelineInformation] = Map(
+    val lookup: Map[LogicalPlanId, SlotConfiguration] = Map(
       argument.assignedId -> pipelineInformation,
       selection.assignedId -> pipelineInformation
     )
@@ -132,8 +132,8 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val produceResult = ProduceResult(selection, Seq("x"))
     produceResult.assignIds()
     val offset = 0
-    val pipeline = PipelineInformation(Map("x" -> LongSlot(offset, nullable = false, typ = CTNode)), 1, 0)
-    val lookup: Map[LogicalPlanId, PipelineInformation] = Map(
+    val pipeline = SlotConfiguration(Map("x" -> LongSlot(offset, nullable = false, typ = CTNode)), 1, 0)
+    val lookup: Map[LogicalPlanId, SlotConfiguration] = Map(
       allNodes.assignedId -> pipeline,
       selection.assignedId -> pipeline,
       produceResult.assignedId -> pipeline)
@@ -158,13 +158,13 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val predicate = Equals(prop("r", "prop"), literalInt(42))(pos)
     val selection = Selection(Seq(predicate), argument)(solved)
     selection.assignIds()
-    val pipelineInformation = PipelineInformation(Map(
+    val pipelineInformation = SlotConfiguration(Map(
       "a" -> nodeAt(0, "a"),
       "b" -> nodeAt(1, "b"),
       "r" -> edgeAt(2, "r")
     ), numberOfLongs = 3, numberOfReferences = 0)
 
-    val lookup: Map[LogicalPlanId, PipelineInformation] = Map(
+    val lookup: Map[LogicalPlanId, SlotConfiguration] = Map(
       argument.assignedId -> pipelineInformation,
       selection.assignedId -> pipelineInformation
     )
@@ -188,11 +188,11 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     produceResult.assignIds()
     val nodeOffset = 0
     val propOffset = 0
-    val pipeline = PipelineInformation(Map(
+    val pipeline = SlotConfiguration(Map(
       "n" -> LongSlot(nodeOffset, nullable = false, typ = CTNode),
       "n.prop" -> RefSlot(propOffset, nullable = true, typ = CTAny)),
       1, 1)
-    val lookup: Map[LogicalPlanId, PipelineInformation] = Map(
+    val lookup: Map[LogicalPlanId, SlotConfiguration] = Map(
       allNodes.assignedId -> pipeline,
       projection.assignedId -> pipeline,
       produceResult.assignedId -> pipeline)
@@ -218,7 +218,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val tokenContext = mock[TokenContext]
     val tokenId = 2
     when(tokenContext.getOptPropertyKeyId("propertyKey")).thenReturn(Some(tokenId))
-    val pipeline = PipelineInformation.empty.
+    val pipeline = SlotConfiguration.empty.
       newLong("x", nullable = false, CTNode).
       newReference("x.propertyKey", nullable = true, CTAny)
 
@@ -243,7 +243,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val tokenContext = mock[TokenContext]
     val tokenId = 2
     when(tokenContext.getOptPropertyKeyId("propertyKey")).thenReturn(Some(tokenId))
-    val pipeline = PipelineInformation.empty.
+    val pipeline = SlotConfiguration.empty.
       newLong("x", nullable = true, CTNode).
       newReference("x.propertyKey", nullable = true, CTAny)
 
@@ -270,11 +270,11 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val apply = Apply(pr1B, pr2)(solved)
     apply.assignIds()
 
-    val lhsPipeline = PipelineInformation.empty.
+    val lhsPipeline = SlotConfiguration.empty.
       newReference("x", nullable = true, CTAny).
       newReference("xx", nullable = true, CTAny)
 
-    val rhsPipeline = PipelineInformation.empty.
+    val rhsPipeline = SlotConfiguration.empty.
       newReference("y", nullable = true, CTAny)
 
     // when

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/AllNodesScanSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/AllNodesScanSlottedPipe.scala
@@ -20,13 +20,14 @@
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration.Size
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.helpers.PrimitiveLongHelper
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.{Pipe, QueryState}
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 
-case class AllNodesScanSlottedPipe(ident: String, slots: SlotConfiguration)
+case class AllNodesScanSlottedPipe(ident: String, slots: SlotConfiguration, argumentSize: Size)
                                   (val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends Pipe {
 
   private val offset = slots.getLongOffsetFor(ident)
@@ -34,7 +35,7 @@ case class AllNodesScanSlottedPipe(ident: String, slots: SlotConfiguration)
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
     PrimitiveLongHelper.map(state.query.nodeOps.allPrimitive, { nodeId =>
       val context = PrimitiveExecutionContext(slots)
-      state.copyArgumentStateTo(context, slots.initialNumberOfLongs, slots.initialNumberOfReferences)
+      state.copyArgumentStateTo(context, argumentSize.nLongs, argumentSize.nReferences)
       context.setLongAt(offset, nodeId)
       context
     })

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/AllNodesScanSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/AllNodesScanSlottedPipe.scala
@@ -19,22 +19,22 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.helpers.PrimitiveLongHelper
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.{Pipe, QueryState}
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 
-case class AllNodesScanSlottedPipe(ident: String, pipelineInformation: PipelineInformation)
+case class AllNodesScanSlottedPipe(ident: String, slots: SlotConfiguration)
                                   (val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends Pipe {
 
-  private val offset = pipelineInformation.getLongOffsetFor(ident)
+  private val offset = slots.getLongOffsetFor(ident)
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
     PrimitiveLongHelper.map(state.query.nodeOps.allPrimitive, { nodeId =>
-      val context = PrimitiveExecutionContext(pipelineInformation)
-      state.copyArgumentStateTo(context, pipelineInformation.initialNumberOfLongs, pipelineInformation.initialNumberOfReferences)
+      val context = PrimitiveExecutionContext(slots)
+      state.copyArgumentStateTo(context, slots.initialNumberOfLongs, slots.initialNumberOfReferences)
       context.setLongAt(offset, nodeId)
       context
     })

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ArgumentSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ArgumentSlottedPipe.scala
@@ -19,17 +19,16 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.{Pipe, QueryState}
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 
-case class ArgumentSlottedPipe(pipelineInformation: PipelineInformation)(val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends Pipe {
+case class ArgumentSlottedPipe(slots: SlotConfiguration)(val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends Pipe {
 
   def internalCreateResults(state: QueryState): Iterator[PrimitiveExecutionContext] = {
-    val context = PrimitiveExecutionContext(pipelineInformation)
-    state.copyArgumentStateTo(context,
-      pipelineInformation.initialNumberOfLongs, pipelineInformation.initialNumberOfReferences)
+    val context = PrimitiveExecutionContext(slots)
+    state.copyArgumentStateTo(context, slots.initialNumberOfLongs, slots.initialNumberOfReferences)
     Iterator(context)
   }
 }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ArgumentSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ArgumentSlottedPipe.scala
@@ -20,15 +20,19 @@
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration.Size
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.{Pipe, QueryState}
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 
-case class ArgumentSlottedPipe(slots: SlotConfiguration)(val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends Pipe {
+case class ArgumentSlottedPipe(slots: SlotConfiguration,
+                               argumentSize:Size)
+                              (val id: LogicalPlanId = LogicalPlanId.DEFAULT)
+  extends Pipe {
 
   def internalCreateResults(state: QueryState): Iterator[PrimitiveExecutionContext] = {
     val context = PrimitiveExecutionContext(slots)
-    state.copyArgumentStateTo(context, slots.initialNumberOfLongs, slots.initialNumberOfReferences)
+    state.copyArgumentStateTo(context, argumentSize.nLongs, argumentSize.nReferences)
     Iterator(context)
   }
 }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/BaseRelationshipSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/BaseRelationshipSlottedPipe.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
 import java.util.function.BiConsumer
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.runtime.QueryContext
 import org.neo4j.cypher.internal.util.v3_4.{CypherTypeException, InvalidSemanticsException}
 import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Expression
@@ -32,12 +32,15 @@ import org.neo4j.graphdb.{Node, Relationship}
 import org.neo4j.values.AnyValue
 import org.neo4j.values.virtual.MapValue
 
-abstract class BaseRelationshipSlottedPipe(src: Pipe, RelationshipKey: String, startNode: Int, typ: LazyType, endNode: Int,
-                                           pipelineInformation: PipelineInformation,
-                                           properties: Option[Expression])
-  extends PipeWithSource(src) {
+abstract class BaseRelationshipSlottedPipe(src: Pipe,
+                                           RelationshipKey: String,
+                                           startNode: Int,
+                                           typ: LazyType,
+                                           endNode: Int,
+                                           slots: SlotConfiguration,
+                                           properties: Option[Expression]) extends PipeWithSource(src) {
 
-  private val offset = pipelineInformation.getLongOffsetFor(RelationshipKey)
+  private val offset = slots.getLongOffsetFor(RelationshipKey)
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] =
     input.map {
@@ -92,21 +95,29 @@ abstract class BaseRelationshipSlottedPipe(src: Pipe, RelationshipKey: String, s
   protected def handleNull(key: String): Unit
 }
 
-case class CreateRelationshipSlottedPipe(src: Pipe, RelationshipKey: String, startNode: Int, typ: LazyType, endNode: Int,
-                                         pipelineInformation: PipelineInformation,
+case class CreateRelationshipSlottedPipe(src: Pipe,
+                                         RelationshipKey: String,
+                                         startNode: Int,
+                                         typ: LazyType,
+                                         endNode: Int,
+                                         slots: SlotConfiguration,
                                          properties: Option[Expression])
                                         (val id: LogicalPlanId = LogicalPlanId.DEFAULT)
-  extends BaseRelationshipSlottedPipe(src, RelationshipKey, startNode, typ: LazyType, endNode, pipelineInformation, properties) {
+  extends BaseRelationshipSlottedPipe(src, RelationshipKey, startNode, typ: LazyType, endNode, slots, properties) {
   override protected def handleNull(key: String) {
     //do nothing
   }
 }
 
-case class MergeCreateRelationshipSlottedPipe(src: Pipe, RelationshipKey: String, startNode: Int, typ: LazyType, endNode: Int,
-                                              pipelineInformation: PipelineInformation,
+case class MergeCreateRelationshipSlottedPipe(src: Pipe,
+                                              RelationshipKey: String,
+                                              startNode: Int,
+                                              typ: LazyType,
+                                              endNode: Int,
+                                              slots: SlotConfiguration,
                                               properties: Option[Expression])
                                              (val id: LogicalPlanId = LogicalPlanId.DEFAULT)
-  extends BaseRelationshipSlottedPipe(src, RelationshipKey, startNode, typ: LazyType, endNode, pipelineInformation, properties) {
+  extends BaseRelationshipSlottedPipe(src, RelationshipKey, startNode, typ: LazyType, endNode, slots, properties) {
 
   override protected def handleNull(key: String) {
     //merge cannot use null properties, since in that case the match part will not find the result of the create

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/CartesianProductSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/CartesianProductSlottedPipe.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.{Pipe, QueryState}
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
@@ -27,7 +27,7 @@ import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 
 case class CartesianProductSlottedPipe(lhs: Pipe, rhs: Pipe,
                                        lhsLongCount: Int, lhsRefCount: Int,
-                                       pipelineInformation: PipelineInformation)
+                                       slots: SlotConfiguration)
                                       (val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends Pipe {
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
@@ -35,7 +35,7 @@ case class CartesianProductSlottedPipe(lhs: Pipe, rhs: Pipe,
       lhsCtx =>
         rhs.createResults(state) map {
           rhsCtx =>
-            val context = PrimitiveExecutionContext(pipelineInformation)
+            val context = PrimitiveExecutionContext(slots)
             lhsCtx.copyTo(context)
             rhsCtx.copyTo(context, lhsLongCount, lhsRefCount)
             context

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ConditionalApplySlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ConditionalApplySlottedPipe.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.{Pipe, PipeWithSource, QueryState}
@@ -27,8 +27,12 @@ import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 import org.neo4j.values.storable.Values
 
-case class ConditionalApplySlottedPipe(lhs: Pipe, rhs: Pipe, longOffsets: Seq[Int], refOffsets: Seq[Int], negated: Boolean,
-                                       pipelineInformation: PipelineInformation)
+case class ConditionalApplySlottedPipe(lhs: Pipe,
+                                       rhs: Pipe,
+                                       longOffsets: Seq[Int],
+                                       refOffsets: Seq[Int],
+                                       negated: Boolean,
+                                       slots: SlotConfiguration)
                                       (val id: LogicalPlanId = LogicalPlanId.DEFAULT)
   extends PipeWithSource(lhs) with Pipe {
 
@@ -41,8 +45,8 @@ case class ConditionalApplySlottedPipe(lhs: Pipe, rhs: Pipe, longOffsets: Seq[In
           rhs.createResults(rhsState)
         }
         else {
-          val output = PrimitiveExecutionContext(pipelineInformation)
-          output.copyFrom(lhsContext, pipelineInformation.initialNumberOfLongs, pipelineInformation.initialNumberOfReferences)
+          val output = PrimitiveExecutionContext(slots)
+          output.copyFrom(lhsContext, slots.initialNumberOfLongs, slots.initialNumberOfReferences)
           Iterator.single(output)
         }
     }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ConditionalApplySlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ConditionalApplySlottedPipe.scala
@@ -46,7 +46,7 @@ case class ConditionalApplySlottedPipe(lhs: Pipe,
         }
         else {
           val output = PrimitiveExecutionContext(slots)
-          output.copyFrom(lhsContext, slots.initialNumberOfLongs, slots.initialNumberOfReferences)
+          lhsContext.copyTo(output)
           Iterator.single(output)
         }
     }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/CreateNodeSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/CreateNodeSlottedPipe.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
 import java.util.function.BiConsumer
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.runtime.QueryContext
 import org.neo4j.cypher.internal.util.v3_4.{CypherTypeException, InvalidSemanticsException}
 import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Expression
@@ -32,11 +32,14 @@ import org.neo4j.graphdb.{Node, Relationship}
 import org.neo4j.values.AnyValue
 import org.neo4j.values.storable.Values
 
-abstract class BaseCreateNodeSlottedPipe(source: Pipe, ident: String, pipelineInformation: PipelineInformation,
-                                         labels: Seq[LazyLabel], properties: Option[Expression])
+abstract class BaseCreateNodeSlottedPipe(source: Pipe,
+                                         ident: String,
+                                         slots: SlotConfiguration,
+                                         labels: Seq[LazyLabel],
+                                         properties: Option[Expression])
   extends PipeWithSource(source) with Pipe {
 
-  private val offset = pipelineInformation.getLongOffsetFor(ident)
+  private val offset = slots.getLongOffsetFor(ident)
 
   override protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     input.map {
@@ -82,20 +85,26 @@ abstract class BaseCreateNodeSlottedPipe(source: Pipe, ident: String, pipelineIn
   }
 }
 
-case class CreateNodeSlottedPipe(source: Pipe, ident: String, pipelineInformation: PipelineInformation,
-                                 labels: Seq[LazyLabel], properties: Option[Expression])
+case class CreateNodeSlottedPipe(source: Pipe,
+                                 ident: String,
+                                 slots: SlotConfiguration,
+                                 labels: Seq[LazyLabel],
+                                 properties: Option[Expression])
                                 (val id: LogicalPlanId = LogicalPlanId.DEFAULT)
-  extends BaseCreateNodeSlottedPipe(source, ident, pipelineInformation, labels, properties) {
+  extends BaseCreateNodeSlottedPipe(source, ident, slots, labels, properties) {
 
   override protected def handleNull(key: String) {
     // do nothing
   }
 }
 
-case class MergeCreateNodeSlottedPipe(source: Pipe, ident: String, pipelineInformation: PipelineInformation,
-                                      labels: Seq[LazyLabel], properties: Option[Expression])
+case class MergeCreateNodeSlottedPipe(source: Pipe,
+                                      ident: String,
+                                      slots: SlotConfiguration,
+                                      labels: Seq[LazyLabel],
+                                      properties: Option[Expression])
                                      (val id: LogicalPlanId = LogicalPlanId.DEFAULT)
-  extends BaseCreateNodeSlottedPipe(source, ident, pipelineInformation, labels, properties) {
+  extends BaseCreateNodeSlottedPipe(source, ident, slots, labels, properties) {
 
   override protected def handleNull(key: String) {
     //merge cannot use null properties, since in that case the match part will not find the result of the create

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/DistinctSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/DistinctSlottedPipe.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Expression
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.{Pipe, PipeWithSource, QueryState}
@@ -31,8 +31,9 @@ import org.neo4j.values.virtual.VirtualValues
 import scala.collection.mutable
 
 case class DistinctSlottedPipe(source: Pipe,
-                               pipelineInformation: PipelineInformation,
-                               groupingExpressions: Map[Int, Expression])(val id: LogicalPlanId = LogicalPlanId.DEFAULT)
+                               slots: SlotConfiguration,
+                               groupingExpressions: Map[Int, Expression])
+                              (val id: LogicalPlanId = LogicalPlanId.DEFAULT)
   extends PipeWithSource(source) {
 
   private val keyOffsets: Array[Int] = groupingExpressions.keys.toArray
@@ -43,7 +44,7 @@ case class DistinctSlottedPipe(source: Pipe,
                                       state: QueryState): Iterator[ExecutionContext] = {
     // For each incoming row, run expression and put it into the correct slot in the context
     val result = input.map(incoming => {
-      val outgoing = PrimitiveExecutionContext(pipelineInformation)
+      val outgoing = PrimitiveExecutionContext(slots)
       groupingExpressions.foreach {
         case (offset, expression) => outgoing.setRefAt(offset, expression(incoming, state))
       }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/EagerAggregationWithoutGroupingSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/EagerAggregationWithoutGroupingSlottedPipe.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.AggregationExpression
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.aggregation.AggregationFunction
@@ -31,8 +31,9 @@ import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 This pipe can be used whenever we are aggregating and not grouping on anything
  */
 case class EagerAggregationWithoutGroupingSlottedPipe(source: Pipe,
-                                                      pipelineInformation: PipelineInformation,
-                                                      aggregations: Map[Int, AggregationExpression])(val id: LogicalPlanId = LogicalPlanId.DEFAULT)
+                                                      slots: SlotConfiguration,
+                                                      aggregations: Map[Int, AggregationExpression])
+                                                     (val id: LogicalPlanId = LogicalPlanId.DEFAULT)
   extends PipeWithSource(source) {
 
   aggregations.values.foreach(_.registerOwningPipe(this))
@@ -56,7 +57,7 @@ case class EagerAggregationWithoutGroupingSlottedPipe(source: Pipe,
       }
 
       // Present result
-      val context = PrimitiveExecutionContext(pipelineInformation)
+      val context = PrimitiveExecutionContext(slots)
       (aggregationOffsets zip aggregationAccumulators).foreach {
         case (offset, value) => context.setRefAt(offset, value.result(state))
       }
@@ -66,7 +67,7 @@ case class EagerAggregationWithoutGroupingSlottedPipe(source: Pipe,
 
   // Used when we have no input and no grouping expressions. In this case, we'll return a single row
   def createEmptyResult(state: QueryState): Iterator[ExecutionContext] = {
-    val context = PrimitiveExecutionContext(pipelineInformation)
+    val context = PrimitiveExecutionContext(slots)
     val aggregationOffsetsAndFunctions = aggregationOffsets zip aggregations
       .map(_._2.createAggregationFunction.result(state))
 

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/EagerSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/EagerSlottedPipe.scala
@@ -19,19 +19,19 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.{Pipe, PipeWithSource, QueryState}
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 
-case class EagerSlottedPipe(source: Pipe, pipelineInformation: PipelineInformation)(val id: LogicalPlanId = LogicalPlanId.DEFAULT)
+case class EagerSlottedPipe(source: Pipe, slots: SlotConfiguration)(val id: LogicalPlanId = LogicalPlanId.DEFAULT)
   extends PipeWithSource(source) {
 
   override protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     input.map { inputRow =>
       // this is necessary because Eager is the beginning of a new pipeline
-      val outputRow = PrimitiveExecutionContext(pipelineInformation)
+      val outputRow = PrimitiveExecutionContext(slots)
       inputRow.copyTo(outputRow)
       outputRow
     }.toIndexedSeq.iterator

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ExpandAllSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ExpandAllSlottedPipe.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.helpers.PrimitiveLongHelper
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker
@@ -37,7 +37,7 @@ case class ExpandAllSlottedPipe(source: Pipe,
                                 toOffset: Int,
                                 dir: SemanticDirection,
                                 types: LazyTypes,
-                                pipelineInformation: PipelineInformation)
+                                slots: SlotConfiguration)
                                (val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends PipeWithSource(source) with Pipe {
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
@@ -61,7 +61,7 @@ case class ExpandAllSlottedPipe(source: Pipe,
 
           PrimitiveLongHelper.map(relationships, relId => {
             relationships.relationshipVisit(relId, relVisitor)
-            val outputRow = PrimitiveExecutionContext(pipelineInformation)
+            val outputRow = PrimitiveExecutionContext(slots)
             inputRow.copyTo(outputRow)
             outputRow.setLongAt(relOffset, relId)
             outputRow.setLongAt(toOffset, otherSide)

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ExpandIntoSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ExpandIntoSlottedPipe.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
 import org.neo4j.collection.primitive.PrimitiveLongIterator
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.helpers.PrimitiveLongHelper
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker.nodeIsNull
@@ -44,7 +44,7 @@ case class ExpandIntoSlottedPipe(source: Pipe,
                                  toOffset: Int,
                                  dir: SemanticDirection,
                                  lazyTypes: LazyTypes,
-                                 pipelineInformation: PipelineInformation)
+                                 slots: SlotConfiguration)
                                 (val id: LogicalPlanId = LogicalPlanId.DEFAULT)
   extends PipeWithSource(source) with PrimitiveCachingExpandInto {
   self =>
@@ -66,7 +66,7 @@ case class ExpandIntoSlottedPipe(source: Pipe,
             .getOrElse(findRelationships(state.query, fromNode, toNode, relCache, dir, lazyTypes.types(state.query)))
 
           PrimitiveLongHelper.map(relationships, (relId: Long) => {
-            val outputRow = PrimitiveExecutionContext(pipelineInformation)
+            val outputRow = PrimitiveExecutionContext(slots)
             inputRow.copyTo(outputRow)
             outputRow.setLongAt(relOffset, relId)
             outputRow

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/NodeHashJoinSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/NodeHashJoinSlottedPipe.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
 import java.util
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker.nodeIsNull
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
@@ -34,7 +34,7 @@ case class NodeHashJoinSlottedPipe(leftNodes: Array[Int],
                                    rightNodes: Array[Int],
                                    left: Pipe,
                                    right: Pipe,
-                                   pipelineInformation: PipelineInformation,
+                                   slots: SlotConfiguration,
                                    longsToCopy: Array[(Int, Int)],
                                    refsToCopy: Array[(Int, Int)])
                                   (val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends PipeWithSource(left) {
@@ -60,7 +60,7 @@ case class NodeHashJoinSlottedPipe(leftNodes: Array[Int],
         val matchesFromLhs: mutable.Seq[ExecutionContext] = table.getOrElse(joinKey, mutable.MutableList.empty)
 
         matchesFromLhs.map{ lhs =>
-          val newRow = PrimitiveExecutionContext(pipelineInformation)
+          val newRow = PrimitiveExecutionContext(slots)
           lhs.copyTo(newRow)
           longsToCopy foreach {
             case (from, to) => newRow.setLongAt(to, rhs.getLongAt(from))

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/NodeIndexScanSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/NodeIndexScanSlottedPipe.scala
@@ -31,7 +31,8 @@ import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 case class NodeIndexScanSlottedPipe(ident: String,
                                     label: LabelToken,
                                     propertyKey: PropertyKeyToken,
-                                    slots: SlotConfiguration)
+                                    slots: SlotConfiguration,
+                                    argumentSize: SlotConfiguration.Size)
                                    (val id: LogicalPlanId = LogicalPlanId.DEFAULT)
   extends Pipe {
 
@@ -43,7 +44,7 @@ case class NodeIndexScanSlottedPipe(ident: String,
     val nodes = state.query.indexScanPrimitive(descriptor)
     PrimitiveLongHelper.map(nodes, { node =>
       val context = PrimitiveExecutionContext(slots)
-      state.copyArgumentStateTo(context, slots.initialNumberOfLongs, slots.initialNumberOfReferences)
+      state.copyArgumentStateTo(context, argumentSize.nLongs, argumentSize.nReferences)
       context.setLongAt(offset, node)
       context
     })

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/NodeIndexScanSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/NodeIndexScanSlottedPipe.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.helpers.PrimitiveLongHelper
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.planner.v3_4.spi.IndexDescriptor
@@ -31,19 +31,19 @@ import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 case class NodeIndexScanSlottedPipe(ident: String,
                                     label: LabelToken,
                                     propertyKey: PropertyKeyToken,
-                                    pipelineInformation: PipelineInformation)
+                                    slots: SlotConfiguration)
                                    (val id: LogicalPlanId = LogicalPlanId.DEFAULT)
   extends Pipe {
 
-  private val offset = pipelineInformation.getLongOffsetFor(ident)
+  private val offset = slots.getLongOffsetFor(ident)
 
   private val descriptor = IndexDescriptor(label.nameId.id, propertyKey.nameId.id)
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
     val nodes = state.query.indexScanPrimitive(descriptor)
     PrimitiveLongHelper.map(nodes, { node =>
-      val context = PrimitiveExecutionContext(pipelineInformation)
-      state.copyArgumentStateTo(context, pipelineInformation.initialNumberOfLongs, pipelineInformation.initialNumberOfReferences)
+      val context = PrimitiveExecutionContext(slots)
+      state.copyArgumentStateTo(context, slots.initialNumberOfLongs, slots.initialNumberOfReferences)
       context.setLongAt(offset, node)
       context
     })

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/NodeIndexSeekSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/NodeIndexSeekSlottedPipe.scala
@@ -34,7 +34,8 @@ case class NodeIndexSeekSlottedPipe(ident: String,
                                     propertyKeys: Seq[PropertyKeyToken],
                                     valueExpr: QueryExpression[Expression],
                                     indexMode: IndexSeekMode = IndexSeek,
-                                    slots: SlotConfiguration)
+                                    slots: SlotConfiguration,
+                                    argumentSize: SlotConfiguration.Size)
                                    (val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends Pipe {
 
   private val offset = slots.getLongOffsetFor(ident)
@@ -53,7 +54,7 @@ case class NodeIndexSeekSlottedPipe(ident: String,
     val resultNodes = indexQuery(valueExpr, baseContext, state, index, label.name, propertyKeys.map(_.name))
     resultNodes.map { node =>
       val context = PrimitiveExecutionContext(slots)
-      state.copyArgumentStateTo(context, slots.initialNumberOfLongs, slots.initialNumberOfReferences)
+      state.copyArgumentStateTo(context, argumentSize.nLongs, argumentSize.nReferences)
       context.setLongAt(offset, node.getId)
       context
     }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/NodeIndexSeekSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/NodeIndexSeekSlottedPipe.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.planner.v3_4.spi.IndexDescriptor
 import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Expression
@@ -34,10 +34,10 @@ case class NodeIndexSeekSlottedPipe(ident: String,
                                     propertyKeys: Seq[PropertyKeyToken],
                                     valueExpr: QueryExpression[Expression],
                                     indexMode: IndexSeekMode = IndexSeek,
-                                    pipelineInformation: PipelineInformation)
+                                    slots: SlotConfiguration)
                                    (val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends Pipe {
 
-  private val offset = pipelineInformation.getLongOffsetFor(ident)
+  private val offset = slots.getLongOffsetFor(ident)
 
   private val propertyIds: Array[Int] = propertyKeys.map(_.nameId.id).toArray
 
@@ -52,8 +52,8 @@ case class NodeIndexSeekSlottedPipe(ident: String,
     val baseContext = state.initialContext.getOrElse(PrimitiveExecutionContext.empty)
     val resultNodes = indexQuery(valueExpr, baseContext, state, index, label.name, propertyKeys.map(_.name))
     resultNodes.map { node =>
-      val context = PrimitiveExecutionContext(pipelineInformation)
-      state.copyArgumentStateTo(context, pipelineInformation.initialNumberOfLongs, pipelineInformation.initialNumberOfReferences)
+      val context = PrimitiveExecutionContext(slots)
+      state.copyArgumentStateTo(context, slots.initialNumberOfLongs, slots.initialNumberOfReferences)
       context.setLongAt(offset, node.getId)
       context
     }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/NodesByLabelScanSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/NodesByLabelScanSlottedPipe.scala
@@ -19,23 +19,23 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.helpers.PrimitiveLongHelper
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.{LazyLabel, Pipe, QueryState}
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 
-case class NodesByLabelScanSlottedPipe(ident: String, label: LazyLabel, pipelineInformation: PipelineInformation)
+case class NodesByLabelScanSlottedPipe(ident: String, label: LazyLabel, slots: SlotConfiguration)
                                       (val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends Pipe {
 
-  private val offset = pipelineInformation.getLongOffsetFor(ident)
+  private val offset = slots.getLongOffsetFor(ident)
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
     label.getOptId(state.query) match {
       case Some(labelId) =>
         PrimitiveLongHelper.map(state.query.getNodesByLabelPrimitive(labelId.id), { nodeId =>
-          val context = PrimitiveExecutionContext(pipelineInformation)
+          val context = PrimitiveExecutionContext(slots)
           state.copyArgumentStateTo(context)
           context.setLongAt(offset, nodeId)
           context

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/NodesByLabelScanSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/NodesByLabelScanSlottedPipe.scala
@@ -26,7 +26,10 @@ import org.neo4j.cypher.internal.runtime.interpreted.pipes.{LazyLabel, Pipe, Que
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 
-case class NodesByLabelScanSlottedPipe(ident: String, label: LazyLabel, slots: SlotConfiguration)
+case class NodesByLabelScanSlottedPipe(ident: String,
+                                       label: LazyLabel,
+                                       slots: SlotConfiguration,
+                                       argumentSize: SlotConfiguration.Size)
                                       (val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends Pipe {
 
   private val offset = slots.getLongOffsetFor(ident)
@@ -36,7 +39,7 @@ case class NodesByLabelScanSlottedPipe(ident: String, label: LazyLabel, slots: S
       case Some(labelId) =>
         PrimitiveLongHelper.map(state.query.getNodesByLabelPrimitive(labelId.id), { nodeId =>
           val context = PrimitiveExecutionContext(slots)
-          state.copyArgumentStateTo(context)
+          state.copyArgumentStateTo(context, argumentSize.nLongs, argumentSize.nReferences)
           context.setLongAt(offset, nodeId)
           context
         })

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalExpandAllSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalExpandAllSlottedPipe.scala
@@ -64,7 +64,7 @@ case class OptionalExpandAllSlottedPipe(source: Pipe,
           val matchIterator = PrimitiveLongHelper.map(relationships, relId => {
             relationships.relationshipVisit(relId, relVisitor)
             val outputRow = PrimitiveExecutionContext(slots)
-            outputRow.copyFrom(inputRow, slots.initialNumberOfLongs, slots.initialNumberOfReferences)
+            inputRow.copyTo(outputRow)
             outputRow.setLongAt(relOffset, relId)
             outputRow.setLongAt(toOffset, otherSide)
             outputRow
@@ -80,7 +80,7 @@ case class OptionalExpandAllSlottedPipe(source: Pipe,
 
   private def withNulls(inputRow: ExecutionContext) = {
     val outputRow = PrimitiveExecutionContext(slots)
-    outputRow.copyFrom(inputRow, slots.initialNumberOfLongs, slots.initialNumberOfReferences)
+    inputRow.copyTo(outputRow)
     outputRow.setLongAt(relOffset, -1)
     outputRow.setLongAt(toOffset, -1)
     outputRow

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalExpandAllSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalExpandAllSlottedPipe.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.helpers.PrimitiveLongHelper
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker
@@ -39,7 +39,7 @@ case class OptionalExpandAllSlottedPipe(source: Pipe,
                                         dir: SemanticDirection,
                                         types: LazyTypes,
                                         predicate: Predicate,
-                                        pipelineInformation: PipelineInformation)
+                                        slots: SlotConfiguration)
                                        (val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends PipeWithSource(source) with Pipe {
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
@@ -63,8 +63,8 @@ case class OptionalExpandAllSlottedPipe(source: Pipe,
 
           val matchIterator = PrimitiveLongHelper.map(relationships, relId => {
             relationships.relationshipVisit(relId, relVisitor)
-            val outputRow = PrimitiveExecutionContext(pipelineInformation)
-            outputRow.copyFrom(inputRow, pipelineInformation.initialNumberOfLongs, pipelineInformation.initialNumberOfReferences)
+            val outputRow = PrimitiveExecutionContext(slots)
+            outputRow.copyFrom(inputRow, slots.initialNumberOfLongs, slots.initialNumberOfReferences)
             outputRow.setLongAt(relOffset, relId)
             outputRow.setLongAt(toOffset, otherSide)
             outputRow
@@ -79,8 +79,8 @@ case class OptionalExpandAllSlottedPipe(source: Pipe,
   }
 
   private def withNulls(inputRow: ExecutionContext) = {
-    val outputRow = PrimitiveExecutionContext(pipelineInformation)
-    outputRow.copyFrom(inputRow, pipelineInformation.initialNumberOfLongs, pipelineInformation.initialNumberOfReferences)
+    val outputRow = PrimitiveExecutionContext(slots)
+    outputRow.copyFrom(inputRow, slots.initialNumberOfLongs, slots.initialNumberOfReferences)
     outputRow.setLongAt(relOffset, -1)
     outputRow.setLongAt(toOffset, -1)
     outputRow

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalExpandIntoSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalExpandIntoSlottedPipe.scala
@@ -60,7 +60,7 @@ case class OptionalExpandIntoSlottedPipe(source: Pipe,
 
           val matchIterator = PrimitiveLongHelper.map(relationships, relId => {
             val outputRow = PrimitiveExecutionContext(slots)
-            outputRow.copyFrom(inputRow, slots.initialNumberOfLongs, slots.initialNumberOfReferences)
+            inputRow.copyTo(outputRow)
             outputRow.setLongAt(relOffset, relId)
             outputRow
           }).filter(ctx => predicate.isTrue(ctx, state))
@@ -75,7 +75,7 @@ case class OptionalExpandIntoSlottedPipe(source: Pipe,
 
   private def withNulls(inputRow: ExecutionContext) = {
     val outputRow = PrimitiveExecutionContext(slots)
-    outputRow.copyFrom(inputRow, slots.initialNumberOfLongs, slots.initialNumberOfReferences)
+    inputRow.copyTo(outputRow)
     outputRow.setLongAt(relOffset, -1)
     outputRow
   }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalExpandIntoSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalExpandIntoSlottedPipe.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
 import org.neo4j.collection.primitive.PrimitiveLongIterator
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.helpers.PrimitiveLongHelper
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.commands.predicates.Predicate
@@ -37,7 +37,7 @@ case class OptionalExpandIntoSlottedPipe(source: Pipe,
                                          dir: SemanticDirection,
                                          lazyTypes: LazyTypes,
                                          predicate: Predicate,
-                                         pipelineInformation: PipelineInformation)
+                                         slots: SlotConfiguration)
                                         (val id: LogicalPlanId = LogicalPlanId.DEFAULT)
   extends PipeWithSource(source) with PrimitiveCachingExpandInto {
   self =>
@@ -59,8 +59,8 @@ case class OptionalExpandIntoSlottedPipe(source: Pipe,
             .getOrElse(findRelationships(state.query, fromNode, toNode, relCache, dir, lazyTypes.types(state.query)))
 
           val matchIterator = PrimitiveLongHelper.map(relationships, relId => {
-            val outputRow = PrimitiveExecutionContext(pipelineInformation)
-            outputRow.copyFrom(inputRow, pipelineInformation.initialNumberOfLongs, pipelineInformation.initialNumberOfReferences)
+            val outputRow = PrimitiveExecutionContext(slots)
+            outputRow.copyFrom(inputRow, slots.initialNumberOfLongs, slots.initialNumberOfReferences)
             outputRow.setLongAt(relOffset, relId)
             outputRow
           }).filter(ctx => predicate.isTrue(ctx, state))
@@ -74,8 +74,8 @@ case class OptionalExpandIntoSlottedPipe(source: Pipe,
   }
 
   private def withNulls(inputRow: ExecutionContext) = {
-    val outputRow = PrimitiveExecutionContext(pipelineInformation)
-    outputRow.copyFrom(inputRow, pipelineInformation.initialNumberOfLongs, pipelineInformation.initialNumberOfReferences)
+    val outputRow = PrimitiveExecutionContext(slots)
+    outputRow.copyFrom(inputRow, slots.initialNumberOfLongs, slots.initialNumberOfReferences)
     outputRow.setLongAt(relOffset, -1)
     outputRow
   }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalSlottedPipe.scala
@@ -25,14 +25,16 @@ import org.neo4j.cypher.internal.runtime.interpreted.pipes.{Pipe, PipeWithSource
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 
-case class OptionalSlottedPipe(source: Pipe, nullableOffsets: Seq[Int],
-                               slots: SlotConfiguration)
+case class OptionalSlottedPipe(source: Pipe,
+                               nullableOffsets: Seq[Int],
+                               slots: SlotConfiguration,
+                               argumentSize: SlotConfiguration.Size)
                               (val id: LogicalPlanId = LogicalPlanId.DEFAULT)
   extends PipeWithSource(source) with Pipe {
 
   private def notFoundExecutionContext(state: QueryState): ExecutionContext = {
     val context = PrimitiveExecutionContext(slots)
-    state.copyArgumentStateTo(context)
+    state.copyArgumentStateTo(context, argumentSize.nLongs, argumentSize.nReferences)
     // TODO: This can probably be done with java.util.Arrays.fill knowing the first offset
     nullableOffsets.foreach(offset => context.setLongAt(offset, -1))
     context

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalSlottedPipe.scala
@@ -19,19 +19,19 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.{Pipe, PipeWithSource, QueryState}
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 
 case class OptionalSlottedPipe(source: Pipe, nullableOffsets: Seq[Int],
-                               pipelineInformation: PipelineInformation)
+                               slots: SlotConfiguration)
                               (val id: LogicalPlanId = LogicalPlanId.DEFAULT)
   extends PipeWithSource(source) with Pipe {
 
   private def notFoundExecutionContext(state: QueryState): ExecutionContext = {
-    val context = PrimitiveExecutionContext(pipelineInformation)
+    val context = PrimitiveExecutionContext(slots)
     state.copyArgumentStateTo(context)
     // TODO: This can probably be done with java.util.Arrays.fill knowing the first offset
     nullableOffsets.foreach(offset => context.setLongAt(offset, -1))

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/RollUpApplySlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/RollUpApplySlottedPipe.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.{LongSlot, PipelineInformation, RefSlot}
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.{LongSlot, SlotConfiguration, RefSlot}
 import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Expression
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.{Pipe, PipeWithSource, QueryState}
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
@@ -31,7 +31,7 @@ case class RollUpApplySlottedPipe(lhs: Pipe, rhs: Pipe,
                                   collectionRefSlotOffset: Int,
                                   identifierToCollect: (String, Expression),
                                   nullableIdentifiers: Set[String],
-                                  pipelineInformation: PipelineInformation)
+                                  slots: SlotConfiguration)
                                  (val id: LogicalPlanId = LogicalPlanId.DEFAULT)
   extends PipeWithSource(lhs) {
 
@@ -42,7 +42,7 @@ case class RollUpApplySlottedPipe(lhs: Pipe, rhs: Pipe,
 
   private val hasNullValuePredicates: Seq[(ExecutionContext) => Boolean] =
     nullableIdentifiers.toSeq.map { elem =>
-      val elemSlot = pipelineInformation.get(elem)
+      val elemSlot = slots.get(elem)
       elemSlot match {
         case Some(LongSlot(offset, true, _)) => { (ctx: ExecutionContext) => ctx.getLongAt(offset) == -1 }
         case Some(RefSlot(offset, true, _)) => { (ctx: ExecutionContext) => ctx.getRefAt(offset) == NO_VALUE }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/SortSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/SortSlottedPipe.scala
@@ -21,13 +21,16 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
 import java.util.Comparator
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.{LongSlot, PipelineInformation, RefSlot, Slot}
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.{LongSlot, SlotConfiguration, RefSlot, Slot}
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.{Pipe, PipeWithSource, QueryState}
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 import org.neo4j.values.{AnyValue, AnyValues}
 
-case class SortSlottedPipe(source: Pipe, orderBy: Seq[ColumnOrder], pipelineInformation: PipelineInformation)(val id: LogicalPlanId = LogicalPlanId.DEFAULT)
+case class SortSlottedPipe(source: Pipe,
+                           orderBy: Seq[ColumnOrder],
+                           slots: SlotConfiguration)
+                          (val id: LogicalPlanId = LogicalPlanId.DEFAULT)
   extends PipeWithSource(source) {
   assert(orderBy.nonEmpty)
 

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/UnwindSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/UnwindSlottedPipe.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Expression
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.{Pipe, PipeWithSource, QueryState}
@@ -30,7 +30,10 @@ import org.neo4j.values.AnyValue
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 
-case class UnwindSlottedPipe(source: Pipe, collection: Expression, offset: Int, pipeline: PipelineInformation)
+case class UnwindSlottedPipe(source: Pipe,
+                             collection: Expression,
+                             offset: Int,
+                             slots: SlotConfiguration)
                             (val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends PipeWithSource(source) with ListSupport {
   override protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] =
     new UnwindIterator(input, state)
@@ -57,7 +60,7 @@ case class UnwindSlottedPipe(source: Pipe, collection: Expression, offset: Int, 
     private def prefetch() {
       nextItem = null
       if (unwindIterator != null && unwindIterator.hasNext) {
-        nextItem = PrimitiveExecutionContext(pipeline)
+        nextItem = PrimitiveExecutionContext(slots)
         currentInputRow.copyTo(nextItem)
         nextItem.setRefAt(offset, unwindIterator.next())
       } else {

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/VarLengthExpandSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/VarLengthExpandSlottedPipe.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.commands.predicates.Predicate
@@ -44,7 +44,7 @@ case class VarLengthExpandSlottedPipe(source: Pipe,
                                       min: Int,
                                       maxDepth: Option[Int],
                                       shouldExpandAll: Boolean,
-                                      pipeline: PipelineInformation,
+                                      slots: SlotConfiguration,
                                       tempNodeOffset: Int,
                                       tempEdgeOffset: Int,
                                       nodePredicate: Predicate,
@@ -121,8 +121,8 @@ case class VarLengthExpandSlottedPipe(source: Pipe,
           paths collect {
             case (toNode: LNode, rels: Seq[Relationship])
               if rels.length >= min && isToNodeValid(inputRowWithFromNode, toNode) =>
-              val resultRow = PrimitiveExecutionContext(pipeline)
-              resultRow.copyFrom(inputRowWithFromNode, longsToCopy, pipeline .initialNumberOfReferences)
+              val resultRow = PrimitiveExecutionContext(slots)
+              resultRow.copyFrom(inputRowWithFromNode, longsToCopy, slots.initialNumberOfReferences)
               resultRow.setLongAt(toOffset, toNode)
               resultRow.setRefAt(relOffset, ValueUtils.asListOfEdges(rels.toArray))
               resultRow

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/PrimitiveExecutionContextTest.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/PrimitiveExecutionContextTest.scala
@@ -19,18 +19,18 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.util.v3_4.InternalException
 import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.values.storable.Values.stringValue
 
 class PrimitiveExecutionContextTest extends CypherFunSuite {
 
-  private def pipeline(longs: Int, refs: Int) = PipelineInformation(Map.empty, longs, refs)
+  private def slots(longs: Int, refs: Int) = SlotConfiguration(Map.empty, longs, refs)
 
   test("copy fills upp the first few elements") {
-    val input = PrimitiveExecutionContext(pipeline(2, 1))
-    val result = PrimitiveExecutionContext(pipeline(3, 2))
+    val input = PrimitiveExecutionContext(slots(2, 1))
+    val result = PrimitiveExecutionContext(slots(3, 2))
 
     input.setLongAt(0, 42)
     input.setLongAt(1, 666)
@@ -44,15 +44,15 @@ class PrimitiveExecutionContextTest extends CypherFunSuite {
   }
 
   test("copy fails if copy from larger") {
-    val input = PrimitiveExecutionContext(pipeline(4, 0))
-    val result = PrimitiveExecutionContext(pipeline(2, 0))
+    val input = PrimitiveExecutionContext(slots(4, 0))
+    val result = PrimitiveExecutionContext(slots(2, 0))
 
     intercept[InternalException](result.copyFrom(input, 4, 0))
   }
 
   test("copy fails if copy from larger 2") {
-    val input = PrimitiveExecutionContext(pipeline(0, 4))
-    val result = PrimitiveExecutionContext(pipeline(0, 2))
+    val input = PrimitiveExecutionContext(slots(0, 4))
+    val result = PrimitiveExecutionContext(slots(0, 2))
 
     intercept[InternalException](result.copyFrom(input, 0, 4))
   }

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/FakeSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/FakeSlottedPipe.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.{LongSlot, PipelineInformation, RefSlot}
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.{LongSlot, SlotConfiguration, RefSlot}
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.ValueConversion.asValue
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.{Pipe, QueryState}
@@ -27,16 +27,16 @@ import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 import org.scalatest.mock.MockitoSugar
 
-case class FakeSlottedPipe(data: Iterator[Map[String, Any]], pipeline: PipelineInformation)
+case class FakeSlottedPipe(data: Iterator[Map[String, Any]], slots: SlotConfiguration)
   extends Pipe with MockitoSugar {
 
   def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
     data.map { values =>
-      val result = PrimitiveExecutionContext(pipeline)
+      val result = PrimitiveExecutionContext(slots)
 
       values foreach {
         case (key, value) =>
-          pipeline(key) match {
+          slots(key) match {
             case LongSlot(offset, _, _) if value == null =>
               result.setLongAt(offset, -1)
 

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/TopSlottedPipeTest.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/TopSlottedPipeTest.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 import org.neo4j.cypher.InternalException
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes.TopSlottedPipeTestSupport._
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.{LongSlot, PipelineInformation, RefSlot}
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.{LongSlot, SlotConfiguration, RefSlot}
 import org.neo4j.cypher.internal.runtime.interpreted.QueryStateHelper
 import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Literal
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.Pipe
@@ -218,12 +218,12 @@ object TopSlottedPipeTestSupport {
   }
 
   def singleColumnTopWithInput(data: Traversable[Any], orderBy: TestColumnOrder, limit: Int, withTies: Boolean = false) = {
-    val pipeline = PipelineInformation.empty
+    val slots = SlotConfiguration.empty
       .newReference("a", nullable = true, CTAny)
 
-    val slot = pipeline("a")
+    val slot = slots("a")
 
-    val source = FakeSlottedPipe(data.map(v => Map("a" -> v)).toIterator, pipeline)
+    val source = FakeSlottedPipe(data.map(v => Map("a" -> v)).toIterator, slots)
 
     val topOrderBy = orderBy match {
       case AscendingOrder => List(Ascending(slot))
@@ -245,13 +245,13 @@ object TopSlottedPipeTestSupport {
   }
 
   def twoColumnTopWithInput(data: Traversable[(Any, Any)], orderBy: Seq[TestColumnOrder], limit: Int, withTies: Boolean = false) = {
-    val pipeline = PipelineInformation.empty
+    val slotConfiguration = SlotConfiguration.empty
       .newReference("a", nullable = true, CTAny)
       .newReference("b", nullable = true, CTAny)
 
-    val slots = Seq(pipeline("a"), pipeline("b"))
+    val slots = Seq(slotConfiguration("a"), slotConfiguration("b"))
 
-    val source = FakeSlottedPipe(data.map { case (v1, v2) => Map("a" -> v1, "b" -> v2) }.toIterator, pipeline)
+    val source = FakeSlottedPipe(data.map { case (v1, v2) => Map("a" -> v1, "b" -> v2) }.toIterator, slotConfiguration)
 
     val topOrderBy = orderBy.zip(slots).map {
       case (AscendingOrder, slot) => Ascending(slot)

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/UnwindSlottedPipeTest.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/UnwindSlottedPipeTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.PipelineInformation
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.expressions.ReferenceFromSlot
 import org.neo4j.cypher.internal.runtime.interpreted.QueryStateHelper
@@ -34,12 +34,12 @@ import scala.collection.JavaConverters._
 class UnwindSlottedPipeTest extends CypherFunSuite {
 
   private def unwindWithInput(data: Traversable[Map[String, Any]]) = {
-    val inputPipeline = PipelineInformation
+    val inputPipeline = SlotConfiguration
       .empty
       .newReference("x", nullable = false, CTAny)
 
     val outputPipeline = inputPipeline
-      .breakPipelineAndClone()
+      .copy()
       .newReference("y", nullable = true, CTAny)
 
     val x = inputPipeline.getReferenceOffsetFor("x")


### PR DESCRIPTION
This PR changes how argument copying is performed, to support more complicated plans.

During the slot allocation tree walk, all operators which require an argument (all leaf operators + all optional operators) get assigned an slot argument size that they need for copying the argument.

Builds on top of https://github.com/neo4j/neo4j/pull/10450.