### PR TITLE
Avoid migrating "Nothing" during database upgrade.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
@@ -95,7 +95,10 @@ public class StoreUpgrader
     public void addParticipant( StoreMigrationParticipant participant )
     {
         assert participant != null;
-        this.participants.add( participant );
+        if ( !StoreMigrationParticipant.NOT_PARTICIPATING.equals( participant ) )
+        {
+            this.participants.add( participant );
+        }
     }
 
     public void migrateIfNeeded( File storeDirectory )
@@ -144,6 +147,11 @@ public class StoreUpgrader
         cleanup( participants, migrationDirectory );
 
         progressMonitor.completed();
+    }
+
+    List<StoreMigrationParticipant> getParticipants()
+    {
+        return participants;
     }
 
     private boolean isUpgradeAllowed()

--- a/community/neo4j/src/test/java/org/neo4j/kernel/impl/storemigration/StoreUpgraderTest.java
+++ b/community/neo4j/src/test/java/org/neo4j/kernel/impl/storemigration/StoreUpgraderTest.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package upgrade;
+package org.neo4j.kernel.impl.storemigration;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -49,13 +49,7 @@ import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.format.standard.Standard;
 import org.neo4j.kernel.impl.store.format.standard.StandardV2_3;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
-import org.neo4j.kernel.impl.storemigration.MigrationTestUtils;
-import org.neo4j.kernel.impl.storemigration.StoreMigrationParticipant;
-import org.neo4j.kernel.impl.storemigration.StoreUpgrader;
 import org.neo4j.kernel.impl.storemigration.StoreUpgrader.UnableToUpgradeException;
-import org.neo4j.kernel.impl.storemigration.StoreVersionCheck;
-import org.neo4j.kernel.impl.storemigration.UpgradableDatabase;
-import org.neo4j.kernel.impl.storemigration.UpgradeNotAllowedByConfigurationException;
 import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
 import org.neo4j.kernel.impl.storemigration.monitoring.SilentMigrationProgressMonitor;
 import org.neo4j.kernel.impl.storemigration.monitoring.VisibleMigrationProgressMonitor;
@@ -76,6 +70,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.hamcrest.Matchers.emptyCollectionOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
@@ -328,6 +323,15 @@ public class StoreUpgraderTest
         assertThat( migrationHelperDirs(), is( emptyCollectionOf( File.class ) ) );
     }
 
+    @Test
+    public void notParticipatingParticipantsAreNotPartOfMigration() throws IOException
+    {
+        PageCache pageCache = pageCacheRule.getPageCache( fileSystem );
+        UpgradableDatabase upgradableDatabase = getUpgradableDatabase( pageCache );
+        StoreUpgrader storeUpgrader = newUpgrader( upgradableDatabase, pageCache );
+        assertThat( storeUpgrader.getParticipants(), hasSize( 3 ) );
+    }
+
     protected void prepareSampleDatabase( String version, FileSystemAbstraction fileSystem, File dbDirectory,
             File databaseDirectory ) throws IOException
     {
@@ -385,6 +389,10 @@ public class StoreUpgraderTest
         StoreUpgrader upgrader = new StoreUpgrader( upgradableDatabase, progressMonitor, config, fileSystem, pageCache,
                 NullLogProvider.getInstance() );
         upgrader.addParticipant( indexMigrator );
+        upgrader.addParticipant( AbstractStoreMigrationParticipant.NOT_PARTICIPATING );
+        upgrader.addParticipant( AbstractStoreMigrationParticipant.NOT_PARTICIPATING );
+        upgrader.addParticipant( AbstractStoreMigrationParticipant.NOT_PARTICIPATING );
+        upgrader.addParticipant( AbstractStoreMigrationParticipant.NOT_PARTICIPATING );
         upgrader.addParticipant( defaultMigrator );
         upgrader.addParticipant( countsMigrator );
         return upgrader;

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/upgrade/EnterpriseStoreUpgraderTest.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/upgrade/EnterpriseStoreUpgraderTest.java
@@ -20,7 +20,6 @@
 package org.neo4j.upgrade;
 
 import org.junit.runners.Parameterized;
-import upgrade.StoreUpgraderTest;
 
 import java.io.File;
 import java.io.IOException;
@@ -30,6 +29,7 @@ import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.format.highlimit.HighLimit;
 import org.neo4j.kernel.impl.store.format.highlimit.v300.HighLimitV3_0_0;
+import org.neo4j.kernel.impl.storemigration.StoreUpgraderTest;
 import org.neo4j.test.Unzip;
 
 import static java.util.Collections.singletonList;

--- a/enterprise/neo4j-enterprise/src/test/java/org/neo4j/upgrade/StandardToEnterpriseStoreUpgraderTest.java
+++ b/enterprise/neo4j-enterprise/src/test/java/org/neo4j/upgrade/StandardToEnterpriseStoreUpgraderTest.java
@@ -19,10 +19,9 @@
  */
 package org.neo4j.upgrade;
 
-import upgrade.StoreUpgraderTest;
-
 import org.neo4j.kernel.impl.store.format.RecordFormats;
 import org.neo4j.kernel.impl.store.format.highlimit.HighLimit;
+import org.neo4j.kernel.impl.storemigration.StoreUpgraderTest;
 
 /**
  * Runs the store upgrader tests from older versions, migrating to the current enterprise version.


### PR DESCRIPTION
Previously in case if NOT_PARTICIPATING participant in anyway was added
into a list of database upgrade participants it took part in database
migration and was reporting its progress as "Migrate Nothing" thingy.
This PR changes that and simply ignores NOT_PARTICIPATING participants
that added into StoreUpgrader during its constructions.