### PR TITLE
Bump timeout on flaky tests

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/AwaitIndexProcedureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/AwaitIndexProcedureTest.java
@@ -167,7 +167,7 @@ public class AwaitIndexProcedureTest
         {
             try
             {
-                procedure.awaitIndex( ":Person(name)", TIMEOUT, TimeUnit.MILLISECONDS );
+                procedure.awaitIndex( ":Person(name)", TIMEOUT, TIME_UNIT );
             }
             catch ( ProcedureException e )
             {
@@ -180,7 +180,7 @@ public class AwaitIndexProcedureTest
 
         state.set( ONLINE );
         assertEventually( "Procedure did not return after index was online",
-                done::get, is( true ), TIMEOUT, TimeUnit.SECONDS );
+                done::get, is( true ), TIMEOUT, TIME_UNIT );
     }
 
     @Test
@@ -197,7 +197,8 @@ public class AwaitIndexProcedureTest
         {
             try
             {
-                procedure.awaitIndex( ":Person(name)", TIMEOUT, TimeUnit.MILLISECONDS );
+                // We wait here, because we expect timeout
+                procedure.awaitIndex( ":Person(name)", 0, TIME_UNIT );
             }
             catch ( ProcedureException e )
             {

--- a/community/kernel/src/test/java/org/neo4j/test/mockito/matcher/Neo4jMatchers.java
+++ b/community/kernel/src/test/java/org/neo4j/test/mockito/matcher/Neo4jMatchers.java
@@ -651,7 +651,7 @@ public class Neo4jMatchers
     {
         try ( Transaction ignored = beansAPI.beginTx() )
         {
-            beansAPI.schema().awaitIndexOnline( indexDef, 10, SECONDS );
+            beansAPI.schema().awaitIndexOnline( indexDef, 30, SECONDS );
         }
     }
 
@@ -659,7 +659,7 @@ public class Neo4jMatchers
     {
         try ( Transaction ignored = beansAPI.beginTx() )
         {
-            beansAPI.schema().awaitIndexesOnline( 10, SECONDS );
+            beansAPI.schema().awaitIndexesOnline( 30, SECONDS );
         }
     }
 

--- a/community/neo4j/src/test/java/schema/IndexPopulationIT.java
+++ b/community/neo4j/src/test/java/schema/IndexPopulationIT.java
@@ -50,7 +50,7 @@ public class IndexPopulationIT
     @ClassRule
     public static final TestDirectory directory = TestDirectory.testDirectory();
 
-    private static final int TEST_TIMEOUT = 30_000;
+    private static final int TEST_TIMEOUT = 120_000;
     private static GraphDatabaseService database;
     private static ExecutorService executorService;
 


### PR DESCRIPTION
Specifically addressing tests:
`AwaitIndexProcedureTest.shouldBlockUntilTheIndexIsOnline`
`IndexPopulationIT.indexCreationDoNotBlockQueryExecutions`
`IndexingAcceptanceTest.shouldAddIndexedPropertyToNodeWithDynamicLabels`
`SchemaAcceptanceTest.awaitingIndexComingOnlineWorks`