### PR TITLE
Keeps fewer transactions in memory during recovery

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/DefaultRecoverySPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/DefaultRecoverySPI.java
@@ -91,7 +91,7 @@ public class DefaultRecoverySPI implements Recovery.SPI
         // Go and read more at {@link CommonAbstractStore#deleteIdGenerator()}
         storageEngine.prepareForRecoveryRequired();
 
-        transactionsToApply = new TransactionQueue( 10_000, (first,last) -> storageEngine.apply( first, RECOVERY ) );
+        transactionsToApply = new TransactionQueue( 100, (first,last) -> storageEngine.apply( first, RECOVERY ) );
         recoveryVisitor = new RecoveryVisitor( transactionsToApply );
 
         return recoveryVisitor;


### PR DESCRIPTION
Because there's no performance gain in batching that many.
In fact there's barely any gain in batching at all since recovery
in 3.2 doesn't apply to indexes.