### PR TITLE
Fix an integer overflow bug that prevented allocation of 512 GiB or more for the page cache.

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/PageList.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/PageList.java
@@ -100,7 +100,7 @@ class PageList
         this.memoryManager = memoryManager;
         this.swappers = swappers;
         this.victimPageAddress = victimPageAddress;
-        long bytes = pageCount * META_DATA_BYTES_PER_PAGE;
+        long bytes = ((long) pageCount) * META_DATA_BYTES_PER_PAGE;
         this.baseAddress = memoryManager.allocateAligned( bytes );
         clearMemory( baseAddress, pageCount );
     }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/PageList.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/PageList.java
@@ -31,6 +31,7 @@ import org.neo4j.unsafe.impl.internal.dragons.MemoryManager;
 import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
 import static java.lang.String.format;
+import static org.neo4j.unsafe.impl.internal.dragons.FeatureToggles.flag;
 
 /**
  * The PageList maintains the off-heap meta-data for the individual memory pages.
@@ -49,6 +50,8 @@ import static java.lang.String.format;
  */
 class PageList
 {
+    private static final boolean forceSlowMemoryClear = flag( PageList.class, "forceSlowMemoryClear", false );
+
     private static final int META_DATA_BYTES_PER_PAGE = 32;
     private static final int OFFSET_LOCK_WORD = 0; // 8 bytes
     private static final int OFFSET_ADDRESS = 8; // 8 bytes
@@ -124,6 +127,21 @@ class PageList
 
     private void clearMemory( long baseAddress, long pageCount )
     {
+        long memcpyChunkSize = UnsafeUtil.pageSize();
+        long metaDataEntriesPerChunk = memcpyChunkSize / META_DATA_BYTES_PER_PAGE;
+        if ( pageCount < metaDataEntriesPerChunk || forceSlowMemoryClear )
+        {
+            clearMemorySimple( baseAddress, pageCount );
+        }
+        else
+        {
+            clearMemoryFast( baseAddress, pageCount, memcpyChunkSize, metaDataEntriesPerChunk );
+        }
+        UnsafeUtil.fullFence(); // Guarantee the visibility of the cleared memory.
+    }
+
+    private void clearMemorySimple( long baseAddress, long pageCount )
+    {
         long address = baseAddress - 8;
         for ( long i = 0; i < pageCount; i++ )
         {
@@ -132,7 +150,23 @@ class PageList
             UnsafeUtil.putLong( address += 8, PageCursor.UNBOUND_PAGE_ID ); // file page id
             UnsafeUtil.putLong( address += 8, 0 ); // rest
         }
-        UnsafeUtil.fullFence(); // Guarantee the visibility of the cleared memory
+    }
+
+    private void clearMemoryFast( long baseAddress, long pageCount, long memcpyChunkSize, long metaDataEntriesPerChunk )
+    {
+        // Initialise one chunk worth of data.
+        clearMemorySimple( baseAddress, metaDataEntriesPerChunk );
+        // Since all entries contain the same data, we can now copy this chunk over and over.
+        long chunkCopies = pageCount / metaDataEntriesPerChunk - 1;
+        long address = baseAddress + memcpyChunkSize;
+        for ( int i = 0; i < chunkCopies; i++ )
+        {
+            UnsafeUtil.copyMemory( baseAddress, address, memcpyChunkSize );
+            address += memcpyChunkSize;
+        }
+        // Finally fill in the tail.
+        long tailCount = pageCount % metaDataEntriesPerChunk;
+        clearMemorySimple( address, tailCount );
     }
 
     /**

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/LargePageListTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/LargePageListTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.io.pagecache.impl.muninn;
+
+import org.junit.Test;
+
+import org.neo4j.io.ByteUnit;
+import org.neo4j.unsafe.impl.internal.dragons.MemoryManager;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class LargePageListTest
+{
+    private static final long ALIGNMENT = 8;
+
+    @Test
+    public void veryLargePageListsMustBeFullyAccessible() throws Exception
+    {
+        long pageCacheSize = ByteUnit.tebiBytes( 1 );
+        int pageSize = (int) ByteUnit.kibiBytes( 8 );
+        int pages = Math.toIntExact( pageCacheSize / pageSize );
+
+        MemoryManager mman = new MemoryManager( ByteUnit.mebiBytes( 1 ), ALIGNMENT );
+        SwapperSet swappers = new SwapperSet();
+        long victimPage = VictimPageReference.getVictimPage( pageSize );
+
+        PageList pageList = new PageList( pages, pageSize, mman, swappers, victimPage );
+        assertThat( pageList.getPageCount(), is( pages ) );
+        long ref = pageList.deref( pages - 1 );
+        pageList.incrementUsage( ref );
+        pageList.incrementUsage( ref );
+        assertFalse( pageList.decrementUsage( ref ) );
+        assertTrue( pageList.decrementUsage( ref ) );
+        System.out.println( "mman.sumUsedMemory() = " + mman.sumUsedMemory() );
+    }
+}


### PR DESCRIPTION
Also, initialisation of large page lists has been made significantly faster.

This fixes #10468.