### PR TITLE
Allow logs truncator to do its work on windows in CorruptedLogsTruncatorTest

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/recovery/CorruptedLogsTruncatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/recovery/CorruptedLogsTruncatorTest.java
@@ -146,9 +146,11 @@ public class CorruptedLogsTruncatorTest
         int bytesToPrune = 7;
         long byteOffset = fileSizeBeforePrune - bytesToPrune;
         LogPosition prunePosition = new LogPosition( highestCorrectLogFileIndex, byteOffset );
+        life.shutdown();
 
         logPruner.truncate( prunePosition );
 
+        life.start();
         assertEquals( 6, logFiles.logFiles().length );
         assertEquals( byteOffset, highestCorrectLogFile.length() );
 


### PR DESCRIPTION
Shutdown life to allow transaction log file deletion.