### PR TITLE
Faster ValueUtils.of

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ValueUtils.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ValueUtils.java
@@ -172,7 +172,7 @@ public final class ValueUtils
 
     public static ListValue asListValue( List<?> collection )
     {
-        ArrayList<AnyValue> values = new ArrayList<>(collection.size());
+        ArrayList<AnyValue> values = new ArrayList<>( collection.size() );
         for ( Object o : collection )
         {
             values.add( of( o ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ValueUtils.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ValueUtils.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import org.neo4j.graphdb.Entity;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.PropertyContainer;
@@ -76,29 +77,39 @@ public final class ValueUtils
         }
         else
         {
-            if ( object instanceof Node )
+            if ( object instanceof Entity )
             {
-                return fromNodeProxy( (Node) object );
+                if ( object instanceof Node )
+                {
+                    return fromNodeProxy( (Node) object );
+                }
+                else if ( object instanceof Relationship )
+                {
+                    return fromRelationshipProxy( (Relationship) object );
+                }
+                else
+                {
+                    throw new IllegalArgumentException( "Unknown entity + " + object.getClass().getName() );
+                }
             }
-            else if ( object instanceof Relationship )
+            else if ( object instanceof Iterable<?> )
             {
-                return fromRelationshipProxy( (Relationship) object );
-            }
-            else if ( object instanceof Path )
-            {
-                return asPathValue( (Path) object );
+                if ( object instanceof Path )
+                {
+                    return asPathValue( (Path) object );
+                }
+                else if ( object instanceof List<?> )
+                {
+                    return asListValue( (List<?>) object );
+                }
+                else
+                {
+                    return asListValue( (Iterable<?>) object );
+                }
             }
             else if ( object instanceof Map<?,?> )
             {
                 return asMapValue( (Map<String,Object>) object );
-            }
-            else if ( object instanceof List<?> )
-            {
-                return asListValue( (List<?>) object );
-            }
-            else if ( object instanceof Iterable<?> )
-            {
-                return asListValue( (Iterable<?>) object );
             }
             else if ( object instanceof Iterator<?> )
             {
@@ -110,18 +121,6 @@ public final class ValueUtils
                 }
                 return asListValue( objects );
             }
-            else if ( object instanceof Stream<?> )
-            {
-                return asListValue( ((Stream<Object>) object).collect( Collectors.toList() ) );
-            }
-            else if ( object instanceof Point )
-            {
-                return asPointValue( (Point) object );
-            }
-            else if ( object instanceof Geometry )
-            {
-                return asPointValue( (Geometry) object );
-            }
             else if ( object instanceof Object[] )
             {
                 Object[] array = (Object[]) object;
@@ -131,6 +130,21 @@ public final class ValueUtils
                     anyValues[i] = of( array[i] );
                 }
                 return VirtualValues.list( anyValues );
+            }
+            else if ( object instanceof Stream<?> )
+            {
+                return asListValue( ((Stream<Object>) object).collect( Collectors.toList() ) );
+            }
+            else if ( object instanceof Geometry )
+            {
+                if ( object instanceof Point )
+                {
+                    return asPointValue( (Point) object );
+                }
+                else
+                {
+                    return asPointValue( (Geometry) object );
+                }
             }
             else
             {

--- a/community/values/src/main/java/org/neo4j/values/storable/BooleanValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/BooleanValue.java
@@ -25,13 +25,11 @@ import static java.lang.String.format;
  * This does not extend AbstractProperty since the JVM can take advantage of the 4 byte initial field alignment if
  * we don't extend a class that has fields.
  */
-public final class BooleanValue extends ScalarValue
+public abstract class BooleanValue extends ScalarValue
 {
-    private final boolean value;
 
-    BooleanValue( boolean value )
+    private BooleanValue( )
     {
-        this.value = value;
     }
 
     @Override
@@ -40,16 +38,9 @@ public final class BooleanValue extends ScalarValue
         return other != null && other instanceof Value && equals( (Value) other );
     }
 
-    @Override
-    public boolean equals( Value other )
+    public ValueGroup valueGroup()
     {
-        return other.equals( value );
-    }
-
-    @Override
-    public boolean equals( boolean x )
-    {
-        return value == x;
+        return ValueGroup.BOOLEAN;
     }
 
     @Override
@@ -64,54 +55,127 @@ public final class BooleanValue extends ScalarValue
         return false;
     }
 
-    @Override
-    public int computeHash()
-    {
-        return value ? -1 : 0;
-    }
+    public abstract boolean booleanValue();
 
-    public boolean booleanValue()
-    {
-        return value;
-    }
-
-    public int compareTo( BooleanValue other )
-    {
-        return Boolean.compare( value, other.booleanValue() );
-    }
-
-    @Override
-    public <E extends Exception> void writeTo( ValueWriter<E> writer ) throws E
-    {
-        writer.writeBoolean( value );
-    }
-
-    @Override
-    public Object asObjectCopy()
-    {
-        return value;
-    }
-
-    @Override
-    public String prettyPrint()
-    {
-        return Boolean.toString( value );
-    }
-
-    @Override
-    public String toString()
-    {
-        return format( "Boolean('%s')", Boolean.toString( value ) );
-    }
-
-    public ValueGroup valueGroup()
-    {
-        return ValueGroup.BOOLEAN;
-    }
+    public abstract int compareTo( BooleanValue other );
 
     @Override
     public NumberType numberType()
     {
         return NumberType.NO_NUMBER;
     }
+
+    public static final BooleanValue TRUE = new BooleanValue()
+    {
+        @Override
+        public boolean equals( Value other )
+        {
+            return this == other;
+        }
+
+        @Override
+        public boolean equals( boolean x )
+        {
+            return x;
+        }
+
+        @Override
+        public int computeHash()
+        {
+            //Use same as Boolean.TRUE.hashCode
+            return 1231;
+        }
+
+        public boolean booleanValue()
+        {
+            return true;
+        }
+
+        public int compareTo( BooleanValue other )
+        {
+            return other.booleanValue() ? 0 : 1;
+        }
+
+        @Override
+        public <E extends Exception> void writeTo( ValueWriter<E> writer ) throws E
+        {
+            writer.writeBoolean( true );
+        }
+
+        @Override
+        public Object asObjectCopy()
+        {
+            return Boolean.TRUE;
+        }
+
+        @Override
+        public String prettyPrint()
+        {
+            return Boolean.toString( true );
+        }
+
+        @Override
+        public String toString()
+        {
+            return format( "Boolean('%s')", Boolean.toString( true ) );
+        }
+
+    };
+
+    public static final BooleanValue FALSE = new BooleanValue()
+    {
+        @Override
+        public boolean equals( Value other )
+        {
+            return this == other;
+        }
+
+        @Override
+        public boolean equals( boolean x )
+        {
+            return !x;
+        }
+
+        @Override
+        public int computeHash()
+        {
+            //Use same as Boolean.FALSE.hashCode
+            return 1237;
+        }
+
+        public boolean booleanValue()
+        {
+            return false;
+        }
+
+        public int compareTo( BooleanValue other )
+        {
+            return !other.booleanValue() ? 0 : -1;
+        }
+
+        @Override
+        public <E extends Exception> void writeTo( ValueWriter<E> writer ) throws E
+        {
+            writer.writeBoolean( false );
+        }
+
+        @Override
+        public Object asObjectCopy()
+        {
+            return Boolean.FALSE;
+        }
+
+        @Override
+        public String prettyPrint()
+        {
+            return Boolean.toString( false );
+        }
+
+        @Override
+        public String toString()
+        {
+            return format( "Boolean('%s')", Boolean.toString( false ) );
+        }
+
+    };
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/Values.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Values.java
@@ -190,7 +190,7 @@ public final class Values
 
     public static BooleanValue booleanValue( boolean value )
     {
-        return new BooleanValue( value );
+        return value ? BooleanValue.TRUE : BooleanValue.FALSE;
     }
 
     public static CharValue charValue( char value )

--- a/community/values/src/main/java/org/neo4j/values/storable/Values.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Values.java
@@ -274,6 +274,20 @@ public final class Values
 
     public static Value of( Object value, boolean allowNull )
     {
+        Value of = unsafeOf( value, allowNull );
+        if ( of != null )
+        {
+            return of;
+        }
+        else
+        {
+            throw new IllegalArgumentException(
+                    format( "[%s:%s] is not a supported property value", value, value.getClass().getName() ) );
+        }
+    }
+
+    public static Value unsafeOf( Object value, boolean allowNull )
+    {
         if ( value instanceof String )
         {
             return stringValue( (String) value );
@@ -341,8 +355,7 @@ public final class Values
         }
 
         // otherwise fail
-        throw new IllegalArgumentException(
-                format( "[%s:%s] is not a supported property value", value, value.getClass().getName() ) );
+       return null;
     }
 
     /**

--- a/community/values/src/main/java/org/neo4j/values/storable/Values.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Values.java
@@ -426,9 +426,8 @@ public final class Values
         {
             return shortArray( copy( value, new short[value.length] ) );
         }
-        throw new IllegalArgumentException(
-                format( "%s[] is not a supported property value type",
-                        value.getClass().getComponentType().getName() ) );
+
+        return null;
     }
 
     private static <T> T copy( Object[] value, T target )

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/PrimitiveExecutionContext.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/slotted/PrimitiveExecutionContext.scala
@@ -21,8 +21,8 @@ package org.neo4j.cypher.internal.compatibility.v3_3.runtime.slotted
 
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.{ExecutionContext, PipelineInformation}
 import org.neo4j.cypher.internal.frontend.v3_3.InternalException
-import org.neo4j.kernel.impl.util.ValueUtils
 import org.neo4j.values.AnyValue
+import org.neo4j.values.storable.Values
 
 object PrimitiveExecutionContext {
   def empty = new PrimitiveExecutionContext(new PipelineInformation(Map.empty, 0, 0))
@@ -80,7 +80,7 @@ case class PrimitiveExecutionContext(pipeline: PipelineInformation) extends Exec
   override def iterator =
     // This method implementation is for debug usage only (the debugger will invoke it when stepping).
     // Please do not use in production code.
-    (longs.map(i => ("LongSlot", ValueUtils.of(i))) ++ refs.map(i => ("RefSlot", i))).iterator
+    (longs.map(i => ("LongSlot", Values.longValue(i))) ++ refs.map(i => ("RefSlot", i))).iterator
 
   private def fail(): Nothing = throw new InternalException("Tried using a primitive context as a map")
 


### PR DESCRIPTION
We are trying to avoid using `ValueUtils.of` in the runtime, however there are some situations where it is necessary to use it so having it be really slow doesn't help. The main speed up comes from removing using exceptions as flow control.

Benchmarks for:
```
{
  objects: ["1", "2", ..., "100", { list:  ["1", "2", ..., "100"] }, 
  float: 13.7, 
  int: 13
}
```

Before:
```
Of.of  50.845 ± 3.617  us/op
```
After:
```
Of.of 3.483 ± 0.536  us/op
```