### PR TITLE
Close new kernel storage statement on shutdown.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -701,6 +701,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
                 config, storageEngine );
 
         kernel.registerTransactionHook( transactionEventHandlers );
+        life.add( kernel );
 
         final NeoStoreFileListing fileListing = new NeoStoreFileListing( storeDir, labelScanStore, indexingService,
                 explicitIndexProviderLookup, storageEngine );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.impl.api;
 
 
 import org.neo4j.internal.kernel.api.CursorFactory;
-import org.neo4j.internal.kernel.api.Permissions;
 import org.neo4j.internal.kernel.api.Session;
 import org.neo4j.internal.kernel.api.Transaction;
 import org.neo4j.kernel.api.InwardKernel;
@@ -87,7 +86,7 @@ public class Kernel extends LifecycleAdapter implements InwardKernel
         this.transactionMonitor = transactionMonitor;
         this.procedures = procedures;
         this.config = config;
-        this.newKernel = new NewKernel( engine, transactions, this );
+        this.newKernel = new NewKernel( engine, transactions.explicitIndexTxStateSupplier(), this );
     }
 
     @Override
@@ -132,9 +131,15 @@ public class Kernel extends LifecycleAdapter implements InwardKernel
     }
 
     @Override
+    public void start() throws Throwable
+    {
+        newKernel.start();
+    }
+
+    @Override
     public void stop() throws Throwable
     {
-        transactions.disposeAll();
+        newKernel.stop();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NewKernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NewKernel.java
@@ -43,7 +43,7 @@ public class NewKernel implements Kernel
     private Read read;
     private Cursors cursors;
 
-    private boolean isRunning;
+    private volatile boolean isRunning;
 
     public NewKernel( StorageEngine engine, Supplier<ExplicitIndexTransactionState> explicitIndexes, InwardKernel kernel )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NewKernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NewKernel.java
@@ -19,12 +19,15 @@
  */
 package org.neo4j.kernel.impl.newapi;
 
+import java.util.function.Supplier;
+
 import org.neo4j.internal.kernel.api.CursorFactory;
 import org.neo4j.internal.kernel.api.Kernel;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.InwardKernel;
-import org.neo4j.kernel.impl.api.KernelTransactions;
+import org.neo4j.kernel.api.txstate.ExplicitIndexTransactionState;
 import org.neo4j.storageengine.api.StorageEngine;
+import org.neo4j.storageengine.api.StorageStatement;
 
 /**
  * This is a temporary implementation of the Kernel API, used to enable early testing. The plan is to merge this
@@ -32,31 +35,57 @@ import org.neo4j.storageengine.api.StorageEngine;
  */
 public class NewKernel implements Kernel
 {
-    private final Cursors cursors;
     private final StorageEngine engine;
     private final InwardKernel kernel;
-    private final Read read;
+    private final Supplier<ExplicitIndexTransactionState> explicitIndexes;
 
-    public NewKernel( StorageEngine engine, KernelTransactions ktxs, InwardKernel kernel )
+    private StorageStatement statement;
+    private Read read;
+    private Cursors cursors;
+
+    private boolean isRunning;
+
+    public NewKernel( StorageEngine engine, Supplier<ExplicitIndexTransactionState> explicitIndexes, InwardKernel kernel )
     {
         this.engine = engine;
+        this.explicitIndexes = explicitIndexes;
         this.kernel = kernel;
-        // This extra statement will be remove once we start adding tx-state. That is because
-        // by then we cannot use a global Read in the CursorFactory, but need to use transaction
-        // specific Read instances which are given to the Cursors on initialization.
-        this.read = new AllStoreHolder( engine, engine.storeReadLayer().newStatement(), ktxs.explicitIndexTxStateSupplier() );
-        this.cursors = new Cursors( read );
+        this.isRunning = false;
     }
 
     @Override
     public CursorFactory cursors()
     {
+        assert isRunning : "kernel is not running, so it is not possible to use it";
         return cursors;
     }
 
     @Override
     public KernelSession beginSession( SecurityContext securityContext )
     {
+        assert isRunning : "kernel is not running, so it is not possible to use it";
         return new KernelSession( engine, kernel, securityContext );
+    }
+
+    public void start()
+    {
+        // This extra statement will be remove once we start adding tx-state. That is because
+        // by then we cannot use a global Read in the CursorFactory, but need to use transaction
+        // specific Read instances which are given to the Cursors on initialization.
+        statement = engine.storeReadLayer().newStatement();
+        this.read = new AllStoreHolder( engine, statement, explicitIndexes );
+        this.cursors = new Cursors( read );
+        isRunning = true;
+
+    }
+
+    public void stop()
+    {
+        if ( !isRunning )
+        {
+            throw new IllegalStateException( "kernel is not running, so it is not possible to stop it" );
+        }
+        statement.close();
+        isRunning = false;
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
@@ -547,11 +547,12 @@ public class KernelIT extends KernelIntegrationTest
     {
         // Given
         assumeThat(kernel, instanceOf( Kernel.class ));
+        Kernel lifeKernel = (Kernel) kernel;
 
         // Then
-        try ( KernelTransaction tx = kernel.newTransaction( KernelTransaction.Type.implicit, AnonymousContext.read() ) )
+        try ( KernelTransaction tx = this.kernel.newTransaction( KernelTransaction.Type.implicit, AnonymousContext.read() ) )
         {
-            ((Kernel)kernel).stop();
+            lifeKernel.stop();
             tx.acquireStatement().readOperations().nodeExists( 0L );
             fail("Should have been terminated.");
         }
@@ -559,6 +560,8 @@ public class KernelIT extends KernelIntegrationTest
         {
             // Success
         }
+
+        lifeKernel.start(); // to allow graceful test completion
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
@@ -543,28 +543,6 @@ public class KernelIT extends KernelIntegrationTest
     }
 
     @Test
-    public void shouldKillTransactionsOnShutdown() throws Throwable
-    {
-        // Given
-        assumeThat(kernel, instanceOf( Kernel.class ));
-        Kernel lifeKernel = (Kernel) kernel;
-
-        // Then
-        try ( KernelTransaction tx = this.kernel.newTransaction( KernelTransaction.Type.implicit, AnonymousContext.read() ) )
-        {
-            lifeKernel.stop();
-            tx.acquireStatement().readOperations().nodeExists( 0L );
-            fail("Should have been terminated.");
-        }
-        catch ( TransactionTerminatedException e )
-        {
-            // Success
-        }
-
-        lifeKernel.start(); // to allow graceful test completion
-    }
-
-    @Test
     public void txReturnsCorrectIdWhenCommitted() throws Exception
     {
         executeDummyTxs( db, 42 );


### PR DESCRIPTION
Note that we are about to refactor that statement away, but this fix should avoid
flakyness in shutdown until those changes are merged.

This solves the problem locally when testing on IBM-JDK8.