### PR TITLE
Added configurable cypher query replan threshold decay algorithms

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/BuildInterpretedExecutionPlan.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/BuildInterpretedExecutionPlan.scala
@@ -109,7 +109,7 @@ object BuildInterpretedExecutionPlan extends Phase[CompilerContext, CompilationS
     override def run(queryContext: QueryContext, planType: ExecutionMode, params: Map[String, Any]): InternalExecutionResult =
       executionPlanFunc(queryContext, planType, params)
 
-    override def isStale(lastTxId: () => Long, statistics: GraphStatistics): Boolean = fingerprint.isStale(lastTxId, statistics)
+    override def isStale(lastTxId: () => Long, statistics: GraphStatistics) = fingerprint.isStale(lastTxId, statistics)
 
     override def runtimeUsed = InterpretedRuntimeName
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/CacheAccessor.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/CacheAccessor.scala
@@ -37,9 +37,9 @@ class QueryCache[K <: AnyRef, T <: AnyRef](cacheAccessor: CacheAccessor[K, T], c
         })
       }.flatMap { value =>
         if (!planned) {
-          val stale = isStale(value)
-          if (stale._1) {
-            cacheAccessor.remove(cache)(key, userKey, stale._2)
+          val (stale, age) = isStale(value)
+          if (stale) {
+            cacheAccessor.remove(cache)(key, userKey, age)
             None
           } else {
             Some((value, planned))

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompiler.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompiler.scala
@@ -146,8 +146,7 @@ case class CypherCompiler[Context <: CompilerContext](createExecutionPlan: Trans
 }
 
 case class CypherCompilerConfiguration(queryCacheSize: Int,
-                                       statsDivergenceThreshold: Double,
-                                       queryPlanTTL: Long,
+                                       statsDivergenceCalculator: StatsDivergenceCalculator,
                                        useErrorsOverWarnings: Boolean,
                                        idpMaxTableSize: Int,
                                        idpIterationDuration: Long,

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompiler.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompiler.scala
@@ -163,7 +163,7 @@ trait CypherCacheFlushingMonitor[T] {
 trait CypherCacheHitMonitor[T] {
   def cacheHit(key: T) {}
   def cacheMiss(key: T) {}
-  def cacheDiscard(key: T, userKey: String) {}
+  def cacheDiscard(key: T, userKey: String, secondsSinceReplan: Int) {}
 }
 
 trait InfoLogger {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompilerFactory.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompilerFactory.scala
@@ -56,7 +56,7 @@ class CypherCompilerFactory[C <: CompilerContext, T <: Transformer[C, Compilatio
     val actualUpdateStrategy: UpdateStrategy = updateStrategy.getOrElse(defaultUpdateStrategy)
 
     val createFingerprintReference: (Option[PlanFingerprint]) => PlanFingerprintReference =
-      new PlanFingerprintReference(clock, config.queryPlanTTL, config.statsDivergenceThreshold, _)
+      new PlanFingerprintReference(clock, config.statsDivergenceCalculator, _)
     val planCacheFactory = () => new LFUCache[Statement, ExecutionPlan](config.queryCacheSize)
     monitors.addMonitorListener(logStalePlanRemovalMonitor(logger), monitorTag)
     val cacheMonitor = monitors.newMonitor[AstCacheMonitor](monitorTag)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompilerFactory.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompilerFactory.scala
@@ -84,8 +84,8 @@ class CypherCompilerFactory[C <: CompilerContext, T <: Transformer[C, Compilatio
   }
 
   private def logStalePlanRemovalMonitor(log: InfoLogger) = new AstCacheMonitor {
-    override def cacheDiscard(key: Statement, userKey: String) {
-      log.info(s"Discarded stale query from the query cache: $userKey")
+    override def cacheDiscard(key: Statement, userKey: String, secondsSinceReplan: Int) {
+      log.info(s"Discarded stale query from the query cache after ${secondsSinceReplan} seconds: $userKey")
     }
   }
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/ExecutionPlan.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/ExecutionPlan.scala
@@ -28,7 +28,7 @@ abstract class ExecutionPlan {
   def run(queryContext: QueryContext, planType: ExecutionMode, params: Map[String, Any]): InternalExecutionResult
   def isPeriodicCommit: Boolean
   def plannerUsed: PlannerName
-  def isStale(lastTxId: () => Long, statistics: GraphStatistics): Boolean
+  def isStale(lastTxId: () => Long, statistics: GraphStatistics): (Boolean, Int)
   def runtimeUsed: RuntimeName
   def notifications(planContext: PlanContext): Seq[InternalNotification]
   def plannedIndexUsage: Seq[IndexUsage] = Seq.empty

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/ExecutionPlan.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/ExecutionPlan.scala
@@ -28,7 +28,7 @@ abstract class ExecutionPlan {
   def run(queryContext: QueryContext, planType: ExecutionMode, params: Map[String, Any]): InternalExecutionResult
   def isPeriodicCommit: Boolean
   def plannerUsed: PlannerName
-  def isStale(lastTxId: () => Long, statistics: GraphStatistics): (Boolean, Int)
+  def isStale(lastTxId: () => Long, statistics: GraphStatistics): CacheCheckResult
   def runtimeUsed: RuntimeName
   def notifications(planContext: PlanContext): Seq[InternalNotification]
   def plannedIndexUsage: Seq[IndexUsage] = Seq.empty

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/PlanFingerprint.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/PlanFingerprint.scala
@@ -98,6 +98,8 @@ object PlanFingerprint {
       name.toLowerCase match {
         case "none" => StatsDivergenceNoDecayCalculator(initialThreshold, initialMillis)
         case "exponential" => StatsDivergenceExponentialDecayCalculator(initialThreshold, targetThreshold, initialMillis, targetMillis)
+        // TODO: Delete the next line to enable decay by default
+        case "default" => StatsDivergenceNoDecayCalculator(initialThreshold, initialMillis)
         case _ => StatsDivergenceInverseDecayCalculator(initialThreshold, targetThreshold, initialMillis, targetMillis)
       }
     }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/PlanFingerprint.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/PlanFingerprint.scala
@@ -47,7 +47,7 @@ class PlanFingerprintReference(clock: Clock, divergence: StatsDivergenceCalculat
           () => {
             fingerprint = Some(f.copy(lastCheckTimeMillis = currentTimeMillis, txId = currentTxId))
           }),
-        ((currentTimeMillis - f.lastCheckTimeMillis)/1000).toInt)
+        ((currentTimeMillis - f.creationTimeMillis)/1000).toInt)
     }
   }
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/PlanFingerprint.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/PlanFingerprint.scala
@@ -73,7 +73,7 @@ case class StatsDivergenceExponentialDecayCalculator(initialThreshold: Double, t
 
   def decay(millisSincePreviousReplan: Long): Double = {
     val exponent = -1.0 * decayFactor * (millisSincePreviousReplan - initialMillis)
-    initialThreshold * Math.pow(Math.E, exponent)
+    initialThreshold * Math.exp(exponent)
   }
 }
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/PlanFingerprint.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/PlanFingerprint.scala
@@ -25,9 +25,9 @@ import org.neo4j.cypher.internal.compiler.v3_2.spi.{GraphStatistics, GraphStatis
 import java.text.SimpleDateFormat
 import java.util.Date
 
-case class PlanFingerprint(creationTimeMillis: Long, txId: Long, snapshot: GraphStatisticsSnapshot)
+case class PlanFingerprint(creationTimeMillis: Long, lastCheckTimeMillis: Long, txId: Long, snapshot: GraphStatisticsSnapshot)
 
-class PlanFingerprintReference(clock: Clock, minimalTimeToLive: Long, statsDivergenceThreshold : Double,
+class PlanFingerprintReference(clock: Clock, divergence: StatsDivergenceCalculator,
                                private var fingerprint: Option[PlanFingerprint]) {
 
   def isStale(lastCommittedTxId: () => Long, statistics: GraphStatistics): Boolean = {
@@ -35,20 +35,20 @@ class PlanFingerprintReference(clock: Clock, minimalTimeToLive: Long, statsDiver
       lazy val currentTimeMillis = clock.millis()
       lazy val currentTxId = lastCommittedTxId()
 
-      PlanFingerprint.log2(s"Creation:${f.creationTimeMillis} TTL:$minimalTimeToLive Current:$currentTimeMillis currentTx:$currentTxId")
+      PlanFingerprint.log2(s"Creation:${f.creationTimeMillis} TTL:${divergence.initialMillis} Current:$currentTimeMillis currentTx:$currentTxId")
 
-      if(!(f.creationTimeMillis + minimalTimeToLive <= currentTimeMillis)) {
+      if (divergence.tooSoon(currentTimeMillis, f.lastCheckTimeMillis)) {
         PlanFingerprint.log2("NO  - Shorter than minimal TTL")
         return false
       }
       if(!(check(currentTxId != f.txId,
-        () => { fingerprint = Some(f.copy(creationTimeMillis = currentTimeMillis)) }))) {
-        PlanFingerprint.log2(s"NO  - Same txID. Setting CreationTime to $currentTimeMillis")
+        () => { fingerprint = Some(f.copy(lastCheckTimeMillis = currentTimeMillis)) }))) {
+        PlanFingerprint.log2(s"NO  - Same txID. Setting LastCheckTime to $currentTimeMillis")
         return false
       }
-      if(!(check(f.snapshot.diverges(f.snapshot.recompute(statistics), statsDivergenceThreshold),
-        () => { fingerprint = Some(f.copy(creationTimeMillis = currentTimeMillis, txId = currentTxId)) }))) {
-        PlanFingerprint.log2(s"NO  - Statistics don't diverge. Setting CreationTime to $currentTimeMillis. Setting txID to $currentTxId")
+      if(!(check(f.snapshot.diverges(f.snapshot.recompute(statistics), divergence.decay(currentTimeMillis - f.creationTimeMillis)),
+        () => { fingerprint = Some(f.copy(lastCheckTimeMillis = currentTimeMillis, txId = currentTxId)) }))) {
+        PlanFingerprint.log2(s"NO  - Statistics don't diverge. Setting LastCheckTime to $currentTimeMillis. Setting txID to $currentTxId")
         return false
       }
       PlanFingerprint.log2("YES")
@@ -59,7 +59,67 @@ class PlanFingerprintReference(clock: Clock, minimalTimeToLive: Long, statsDiver
   private def check(test: => Boolean, ifFalse: () => Unit ) = if (test) { true } else { ifFalse() ; false }
 }
 
+trait StatsDivergenceCalculator {
+  val initialThreshold: Double
+  val initialMillis: Long
+
+  def tooSoon(currentTimeMillis: Long, lastCheckTimeMillis: Long) = currentTimeMillis - initialMillis < lastCheckTimeMillis
+
+  def decay(millisSincePreviousReplan: Long): Double
+}
+
+case class StatsDivergenceInverseDecayCalculator(initialThreshold: Double, targetThreshold: Double, initialMillis: Long, targetMillis: Long) extends StatsDivergenceCalculator {
+  val decayFactor: Double = (initialThreshold / targetThreshold - 1.0) / (targetMillis - initialMillis)
+
+  def decay(millisSincePreviousReplan: Long): Double = {
+    // Note that this equation has a possible singularity for very steep decays, when millisSincePreviousReplan < initialMillis
+    // However, that will never happen because of the 'tooSoon' test above
+    initialThreshold / (1.0 + decayFactor * (millisSincePreviousReplan - initialMillis))
+  }
+}
+
+case class StatsDivergenceExponentialDecayCalculator(initialThreshold: Double, targetThreshold: Double, initialMillis: Long, targetMillis: Long) extends StatsDivergenceCalculator {
+  val decayFactor: Double = (Math.log(initialThreshold) - Math.log(targetThreshold)) / (targetMillis - initialMillis)
+
+  def decay(millisSincePreviousReplan: Long): Double = {
+    val exponent = -1.0 * decayFactor * (millisSincePreviousReplan - initialMillis)
+    initialThreshold * Math.pow(Math.E, exponent)
+  }
+}
+
+case class StatsDivergenceNoDecayCalculator(initialThreshold: Double, initialMillis: Long) extends StatsDivergenceCalculator {
+  def decay(millisSinceThreshold: Long): Double = {
+    initialThreshold
+  }
+}
+
 object PlanFingerprint {
+  val inverse = "inverse"
+  val exponential = "exponential"
+  val none = "none"
+  val similarityTolerance = 0.0001
+
+  def divergenceCalculatorFor(name: String, initialThreshold: Double, targetThreshold: Double, initialMillis: Long, targetMillis: Long): StatsDivergenceCalculator = {
+    if (targetThreshold <= similarityTolerance || initialThreshold - targetThreshold <= similarityTolerance || targetMillis <= initialMillis) {
+      // Input values that disable the threshold decay algorithm
+      StatsDivergenceNoDecayCalculator(initialThreshold, initialMillis)
+    } else {
+      // Input is valid, select decay algorithm, the GraphDatabaseSettings will limit the possible values
+      name.toLowerCase match {
+        case "none" => StatsDivergenceNoDecayCalculator(initialThreshold, initialMillis)
+        case "exponential" => StatsDivergenceExponentialDecayCalculator(initialThreshold, targetThreshold, initialMillis, targetMillis)
+        case _ => StatsDivergenceInverseDecayCalculator(initialThreshold, targetThreshold, initialMillis, targetMillis)
+      }
+    }
+  }
+
+  def divergenceNoDecayCalculator(threshold: Double, ttl: Long) =
+    StatsDivergenceNoDecayCalculator(threshold, ttl)
+
+  def apply(creationTimeMillis: Long, txId: Long, snapshot: GraphStatisticsSnapshot): PlanFingerprint =
+    PlanFingerprint(creationTimeMillis, creationTimeMillis, txId, snapshot)
+
+  //TODO: Remove logging
   val sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss") //Or whatever format fits best your needs.
 
   def log3(msg: String): Unit = {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/procs/ProcedureCallExecutionPlan.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/procs/ProcedureCallExecutionPlan.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v3_2.executionplan.procs
 import org.neo4j.cypher.internal.compiler.v3_2.ast.convert.commands.ExpressionConverters._
 import org.neo4j.cypher.internal.compiler.v3_2.commands.expressions
 import org.neo4j.cypher.internal.compiler.v3_2.commands.expressions.Literal
-import org.neo4j.cypher.internal.compiler.v3_2.executionplan.{ExecutionPlan, InternalExecutionResult, ProcedureCallMode}
+import org.neo4j.cypher.internal.compiler.v3_2.executionplan.{CacheCheckResult, ExecutionPlan, InternalExecutionResult, ProcedureCallMode}
 import org.neo4j.cypher.internal.compiler.v3_2.helpers.{Counter, RuntimeJavaValueConverter}
 import org.neo4j.cypher.internal.compiler.v3_2.pipes.{ExternalCSVResource, QueryState}
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.InternalPlanDescription.Arguments.{DbHits, Rows, Signature}
@@ -116,7 +116,7 @@ case class ProcedureCallExecutionPlan(signature: ProcedureSignature,
   override def notifications(planContext: PlanContext) = Seq.empty
   override def isPeriodicCommit: Boolean = false
   override def runtimeUsed = ProcedureRuntimeName
-  override def isStale(lastTxId: () => Long, statistics: GraphStatistics) = (false,0)
+  override def isStale(lastTxId: () => Long, statistics: GraphStatistics) = CacheCheckResult.empty
   override def plannerUsed = ProcedurePlannerName
 }
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/procs/ProcedureCallExecutionPlan.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/procs/ProcedureCallExecutionPlan.scala
@@ -116,7 +116,7 @@ case class ProcedureCallExecutionPlan(signature: ProcedureSignature,
   override def notifications(planContext: PlanContext) = Seq.empty
   override def isPeriodicCommit: Boolean = false
   override def runtimeUsed = ProcedureRuntimeName
-  override def isStale(lastTxId: () => Long, statistics: GraphStatistics) = false
+  override def isStale(lastTxId: () => Long, statistics: GraphStatistics) = (false,0)
   override def plannerUsed = ProcedurePlannerName
 }
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/procs/PureSideEffectExecutionPlan.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/procs/PureSideEffectExecutionPlan.scala
@@ -19,10 +19,10 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.executionplan.procs
 
-import org.neo4j.cypher.internal.compiler.v3_2.executionplan.{ExecutionPlan, InternalExecutionResult, InternalQueryType, SCHEMA_WRITE}
+import org.neo4j.cypher.internal.compiler.v3_2.executionplan._
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.{Id, NoChildren, PlanDescriptionImpl}
 import org.neo4j.cypher.internal.compiler.v3_2.spi.{GraphStatistics, PlanContext, QueryContext, UpdateCountingQueryContext}
-import org.neo4j.cypher.internal.compiler.v3_2.{ExecutionMode, ExplainExecutionResult, ExplainMode, ProcedurePlannerName, ProcedureRuntimeName, RuntimeName}
+import org.neo4j.cypher.internal.compiler.v3_2._
 import org.neo4j.cypher.internal.frontend.v3_2.PlannerName
 import org.neo4j.cypher.internal.frontend.v3_2.notification.InternalNotification
 
@@ -56,7 +56,7 @@ case class PureSideEffectExecutionPlan(name: String, queryType: InternalQueryTyp
 
   override def runtimeUsed: RuntimeName = ProcedureRuntimeName
 
-  override def isStale(lastTxId: () => Long, statistics: GraphStatistics) = (false, 0)
+  override def isStale(lastTxId: () => Long, statistics: GraphStatistics) = CacheCheckResult.empty
 
   override def plannerUsed: PlannerName = ProcedurePlannerName
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/procs/PureSideEffectExecutionPlan.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/procs/PureSideEffectExecutionPlan.scala
@@ -56,7 +56,7 @@ case class PureSideEffectExecutionPlan(name: String, queryType: InternalQueryTyp
 
   override def runtimeUsed: RuntimeName = ProcedureRuntimeName
 
-  override def isStale(lastTxId: () => Long, statistics: GraphStatistics): Boolean = false
+  override def isStale(lastTxId: () => Long, statistics: GraphStatistics) = (false, 0)
 
   override def plannerUsed: PlannerName = ProcedurePlannerName
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilder.scala
@@ -56,6 +56,7 @@ class PipeExecutionPlanBuilder(clock: Clock,
 
     val fingerprint = planContext.statistics match {
       case igs: InstrumentedGraphStatistics =>
+        PlanFingerprint.log(s"Creating new plan fingerprint for plan: $plan")
         Some(PlanFingerprint(clock.millis(), planContext.txIdProvider(), igs.snapshot.freeze))
       case _ =>
         None

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilder.scala
@@ -56,7 +56,6 @@ class PipeExecutionPlanBuilder(clock: Clock,
 
     val fingerprint = planContext.statistics match {
       case igs: InstrumentedGraphStatistics =>
-        PlanFingerprint.log(s"Creating new plan fingerprint for plan: $plan")
         Some(PlanFingerprint(clock.millis(), planContext.txIdProvider(), igs.snapshot.freeze))
       case _ =>
         None

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/InstrumentedGraphStatistics.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/InstrumentedGraphStatistics.scala
@@ -39,7 +39,7 @@ class MutableGraphStatisticsSnapshot(val map: mutable.Map[StatisticsKey, Double]
   def freeze: GraphStatisticsSnapshot = GraphStatisticsSnapshot(map.toMap)
 }
 
-case class GraphStatisticsSnapshot(statsValues: Map[StatisticsKey, Double] = Map.empty, timestamp: Date = new Date) {
+case class GraphStatisticsSnapshot(statsValues: Map[StatisticsKey, Double] = Map.empty) {
   def recompute(statistics: GraphStatistics): GraphStatisticsSnapshot = {
     val snapshot = new MutableGraphStatisticsSnapshot()
     val instrumented = InstrumentedGraphStatistics(statistics, snapshot)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/InstrumentedGraphStatistics.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/InstrumentedGraphStatistics.scala
@@ -66,7 +66,9 @@ case class GraphStatisticsSnapshot(statsValues: Map[StatisticsKey, Double] = Map
     val divergedStats = (statsValues map {
       case (k, e1) =>
         val e2 = snapshot.statsValues(k)
-        abs(e1 - e2) / max(e1, e2)
+        val r = abs(e1 - e2) / max(e1, e2)
+        println(s"Replanning: $k has diverged by $r. Min threshold: $minThreshold")
+        r
     }).max
     divergedStats > minThreshold
   }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/InstrumentedGraphStatistics.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/spi/InstrumentedGraphStatistics.scala
@@ -20,11 +20,9 @@
 package org.neo4j.cypher.internal.compiler.v3_2.spi
 
 import java.lang.Math.{abs, max}
-import java.text.SimpleDateFormat
 import java.util.Date
 
 import org.neo4j.cypher.internal.compiler.v3_2.IndexDescriptor
-import org.neo4j.cypher.internal.compiler.v3_2.executionplan.PlanFingerprint
 import org.neo4j.cypher.internal.frontend.v3_2.{LabelId, RelTypeId}
 import org.neo4j.cypher.internal.ir.v3_2.{Cardinality, Selectivity}
 
@@ -61,21 +59,15 @@ case class GraphStatisticsSnapshot(statsValues: Map[StatisticsKey, Double] = Map
     snapshot.freeze
   }
 
-  val sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss") //Or whatever format fits best your needs.
-
   //A plan has diverged if there is a relative change in any of the
   //statistics that is bigger than the threshold
   def diverges(snapshot: GraphStatisticsSnapshot, minThreshold: Double): Boolean = {
     assert(statsValues.keySet == snapshot.statsValues.keySet)
     //find the maximum relative difference (|e1 - e2| / max(e1, e2))
-    PlanFingerprint.log3(s"Comparing snapshot from ${sdf.format(timestamp)} against ${sdf.format(snapshot.timestamp)}")
     val divergedStats = (statsValues map {
       case (k, e1) =>
         val e2 = snapshot.statsValues(k)
-        PlanFingerprint.log3(s"Comparing values $e1 against $e2")
-        val r = abs(e1 - e2) / max(e1, e2)
-        PlanFingerprint.log3(s"$k has diverged by $r. Min threshold: $minThreshold")
-        r
+        abs(e1 - e2) / max(e1, e2)
     }).max
     divergedStats > minThreshold
   }

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/PlanFingerprintReferenceTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/PlanFingerprintReferenceTest.scala
@@ -29,104 +29,208 @@ import org.neo4j.time.Clocks
 
 class PlanFingerprintReferenceTest extends CypherFunSuite {
 
-  test("should be stale if all properties are out of date") {
-    val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 4.0))
-    val ttl = 1000l
-    val threshold = 0.0
-    val clock = Clocks.fakeClock()
-    val stats = mock[GraphStatistics]
-    when(stats.nodesWithLabelCardinality(label(21))).thenReturn(5.0)
-    val fingerprint = PlanFingerprint(clock.millis(), 17, snapshot)
+  test("should be stale if statistics increase enough to pass the threshold") {
+    Seq(PlanFingerprint.none, PlanFingerprint.inverse, PlanFingerprint.exponential).foreach { name =>
+      withClue(s"For decay algorithm '$name': ") {
+        val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 5.0))
+        val divergenceCalculator = PlanFingerprint.divergenceCalculatorFor(name, 0.1, 0.05, 1000, 100000)
+        val clock = Clocks.fakeClock()
+        val stats = mock[GraphStatistics]
+        when(stats.nodesWithLabelCardinality(label(21))).thenReturn(6.0)
+        val fingerprint = PlanFingerprint(clock.millis(), 17, snapshot)
 
-    clock.forward(2, SECONDS)
+        clock.forward(2, SECONDS)
 
-    val stale = new PlanFingerprintReference(clock, ttl, threshold, fingerprint).isStale(transactionIdSupplier(42), stats)
+        val stale = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
 
-    stale shouldBe true
+        stale shouldBe true
+      }
+    }
   }
 
-  test("should not be stale if stats are not diverged over the threshold") {
-    val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 5.0))
-    val ttl = 1000l
-    val threshold = 0.5
-    val clock = Clocks.fakeClock()
-    val stats = mock[GraphStatistics]
-    when(stats.nodesWithLabelCardinality(label(21))).thenReturn(5.0)
-    val fingerprint = PlanFingerprint(clock.millis(), 17, snapshot)
+  test("should be stale if statistics decrease enough to pass the threshold") {
+    Seq(PlanFingerprint.none, PlanFingerprint.inverse, PlanFingerprint.exponential).foreach { name =>
+      withClue(s"For decay algorithm '$name': ") {
+        val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 5.0))
+        val divergenceCalculator = PlanFingerprint.divergenceCalculatorFor(name, 0.1, 0.05, 1000, 100000)
+        val clock = Clocks.fakeClock()
+        val stats = mock[GraphStatistics]
+        when(stats.nodesWithLabelCardinality(label(21))).thenReturn(4.0)
+        val fingerprint = PlanFingerprint(clock.millis(), 17, snapshot)
 
-    clock.forward(2, SECONDS)
+        clock.forward(2, SECONDS)
 
-    val stale = new PlanFingerprintReference(clock, ttl, threshold, fingerprint).isStale(transactionIdSupplier(42), stats)
+        val stale = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
 
-    stale shouldBe false
+        stale shouldBe true
+      }
+    }
+  }
+
+  test("should not be stale if stats have increased but not enough to pass the threshold") {
+    Seq(PlanFingerprint.none, PlanFingerprint.inverse, PlanFingerprint.exponential).foreach { name =>
+      withClue(s"For decay algorithm '$name': ") {
+        val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 5.0))
+        val divergenceCalculator = PlanFingerprint.divergenceCalculatorFor(name, 0.5, 0.1, 1000, 100000)
+        val clock = Clocks.fakeClock()
+        val stats = mock[GraphStatistics]
+        when(stats.nodesWithLabelCardinality(label(21))).thenReturn(6.0)
+        val fingerprint = PlanFingerprint(clock.millis(), 17, snapshot)
+
+        clock.forward(2, SECONDS)
+
+        val stale = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
+
+        stale shouldBe false
+      }
+    }
+  }
+
+  test("should not be stale if stats have decreased but not enough to pass the threshold") {
+    Seq(PlanFingerprint.none, PlanFingerprint.inverse, PlanFingerprint.exponential).foreach { name =>
+      withClue(s"For decay algorithm '$name': ") {
+        val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 5.0))
+        val divergenceCalculator = PlanFingerprint.divergenceCalculatorFor(name, 0.5, 0.1, 1000, 100000)
+        val clock = Clocks.fakeClock()
+        val stats = mock[GraphStatistics]
+        when(stats.nodesWithLabelCardinality(label(21))).thenReturn(4.0)
+        val fingerprint = PlanFingerprint(clock.millis(), 17, snapshot)
+
+        clock.forward(2, SECONDS)
+
+        val stale = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
+
+        stale shouldBe false
+      }
+    }
   }
 
   test("should not be stale if txId didn't change") {
-    val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 5.0))
-    val ttl = 1000l
-    val threshold = 0.0
-    val clock = Clocks.fakeClock()
-    val stats = mock[GraphStatistics]
-    when(stats.nodesWithLabelCardinality(label(21))).thenReturn(5.0)
-    val fingerprint = PlanFingerprint(clock.millis(), 17, snapshot)
+    Seq(PlanFingerprint.none, PlanFingerprint.inverse, PlanFingerprint.exponential).foreach { name =>
+      withClue(s"For decay algorithm '$name': ") {
+        val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 5.0))
+        // Create valid calculator, but test that it is never used
+        val divergenceCalculator = PlanFingerprint.divergenceCalculatorFor(name, 0.5, 0.1, 1000, 100000)
+        val clock = Clocks.fakeClock()
+        val stats = mock[GraphStatistics]
+        // even with sufficient stats change we will remain stale
+        when(stats.nodesWithLabelCardinality(label(21))).thenReturn(15.0)
+        val fingerprint = PlanFingerprint(clock.millis(), 17, snapshot)
 
-    clock.forward(2, SECONDS)
+        clock.forward(2, SECONDS)
 
-    val stale = new PlanFingerprintReference(clock, ttl, threshold, fingerprint).isStale(transactionIdSupplier(17), stats)
+        val stale = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(17), stats)
 
-    stale shouldBe false
+        stale shouldBe false
+      }
+    }
   }
 
   test("should not be stale if life time has not expired") {
-    val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 5.0))
-    val ttl = 1000l
-    val threshold = 0.0
-    val clock = Clocks.fakeClock()
-    val stats = mock[GraphStatistics]
-    when(stats.nodesWithLabelCardinality(label(21))).thenReturn(5.0)
-    val fingerprint = PlanFingerprint(clock.millis(), 17, snapshot)
+    Seq(PlanFingerprint.none, PlanFingerprint.inverse, PlanFingerprint.exponential).foreach { name =>
+      withClue(s"For decay algorithm '$name': ") {
+        val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 5.0))
+        // Create valid calculator, but test that it is never used
+        val divergenceCalculator = PlanFingerprint.divergenceCalculatorFor(name, 0.5, 0.1, 1000, 100000)
+        val clock = Clocks.fakeClock()
+        val stats = mock[GraphStatistics]
+        // even with sufficient stats change we will remain stale
+        when(stats.nodesWithLabelCardinality(label(21))).thenReturn(15.0)
+        val fingerprint = PlanFingerprint(clock.millis(), 17, snapshot)
 
-    clock.forward(500, MILLISECONDS)
+        clock.forward(500, MILLISECONDS)
 
-    val stale = new PlanFingerprintReference(clock, ttl, threshold, fingerprint).isStale(transactionIdSupplier(42), stats)
+        val stale = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
 
-    stale shouldBe false
+        stale shouldBe false
+      }
+    }
   }
 
   test("should update the timestamp if the life time is expired but transaction has not changed") {
-    val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 5.0))
-    val ttl = 1000l
-    val threshold = 0.0
-    val clock = Clocks.fakeClock()
-    val stats = mock[GraphStatistics]
-    when(stats.nodesWithLabelCardinality(label(21))).thenReturn(5.0)
-    val fingerprint = PlanFingerprint(clock.millis(), 17, snapshot)
+    Seq(PlanFingerprint.none, PlanFingerprint.inverse, PlanFingerprint.exponential).foreach { name =>
+      withClue(s"For decay algorithm '$name': ") {
+        val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 5.0))
+        // Create valid calculator, but test that it is never used
+        val divergenceCalculator = PlanFingerprint.divergenceCalculatorFor(name, 0.5, 0.1, 1000, 100000)
+        val clock = Clocks.fakeClock()
+        val stats = mock[GraphStatistics]
+        // even with sufficient stats change we will remain stale
+        when(stats.nodesWithLabelCardinality(label(21))).thenReturn(15.0)
+        val fingerprint = PlanFingerprint(clock.millis(), 17, snapshot)
 
-    val reference = new PlanFingerprintReference(clock, ttl, threshold, fingerprint)
+        val reference = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint)
 
-    clock.forward(2, SECONDS)
-    reference.isStale(transactionIdSupplier(17), stats) shouldBe false
+        clock.forward(2, SECONDS)
+        reference.isStale(transactionIdSupplier(17), stats) shouldBe false
 
-    clock.forward(500, MILLISECONDS)
-    reference.isStale(transactionIdSupplier(23), stats) shouldBe false
+        clock.forward(500, MILLISECONDS)
+        reference.isStale(transactionIdSupplier(23), stats) shouldBe false
+      }
+    }
   }
 
   test("should update the timestamp and the txId if the life time is expired the txId is old but stats has not changed over the threshold") {
-    val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 5.0))
-    val ttl = 1000l
-    val threshold = 0.1
-    val clock = Clocks.fakeClock()
-    val stats = mock[GraphStatistics]
-    when(stats.nodesWithLabelCardinality(label(21))).thenReturn(5.0)
-    val fingerprint = PlanFingerprint(clock.millis(), 17, snapshot)
+    Seq(PlanFingerprint.none, PlanFingerprint.inverse, PlanFingerprint.exponential).foreach { name =>
+      withClue(s"For decay algorithm '$name': ") {
+        val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 5.0))
+        val divergenceCalculator = PlanFingerprint.divergenceCalculatorFor(name, 0.1, 0.05, 1000, 100000)
+        val clock = Clocks.fakeClock()
+        val stats = mock[GraphStatistics]
+        when(stats.nodesWithLabelCardinality(label(21))).thenReturn(5.0)
+        val fingerprint = PlanFingerprint(clock.millis(), 17, snapshot)
 
-    val reference = new PlanFingerprintReference(clock, ttl, threshold, fingerprint)
+        val reference = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint)
 
-    clock.forward(2, SECONDS)
-    reference.isStale(transactionIdSupplier(23), stats) shouldBe false
+        clock.forward(2, SECONDS)
+        reference.isStale(transactionIdSupplier(23), stats) shouldBe false
 
-    clock.forward(2, SECONDS)
-    reference.isStale(transactionIdSupplier(23), stats) shouldBe false
+        clock.forward(2, SECONDS)
+        reference.isStale(transactionIdSupplier(23), stats) shouldBe false
+      }
+    }
+  }
+
+  test("should be stale if statistics increase enough to pass the decayed threshold") {
+    Seq(PlanFingerprint.none, PlanFingerprint.inverse, PlanFingerprint.exponential).foreach { name =>
+      withClue(s"For decay algorithm '$name': ") {
+        val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 5.0))
+        val divergenceCalculator = PlanFingerprint.divergenceCalculatorFor(name, 0.5, 0.1, 1000, 100000)
+        val clock = Clocks.fakeClock()
+        val stats = mock[GraphStatistics]
+        when(stats.nodesWithLabelCardinality(label(21))).thenReturn(6.0)
+        val fingerprint = PlanFingerprint(clock.millis(), 17, snapshot)
+
+        val reference = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint)
+
+        clock.forward(2, SECONDS)
+        reference.isStale(transactionIdSupplier(23), stats) shouldBe false
+
+        clock.forward(100, SECONDS)
+        reference.isStale(transactionIdSupplier(73), stats) shouldBe (name != PlanFingerprint.none)
+      }
+    }
+  }
+
+  test("should be stale if statistics decrease enough to pass the decayed threshold") {
+    Seq(PlanFingerprint.none, PlanFingerprint.inverse, PlanFingerprint.exponential).foreach { name =>
+      withClue(s"For decay algorithm '$name': ") {
+        val snapshot = GraphStatisticsSnapshot(Map(NodesWithLabelCardinality(label(21)) -> 5.0))
+        val divergenceCalculator = PlanFingerprint.divergenceCalculatorFor(name, 0.5, 0.1, 1000, 100000)
+        val clock = Clocks.fakeClock()
+        val stats = mock[GraphStatistics]
+        when(stats.nodesWithLabelCardinality(label(21))).thenReturn(4.0)
+        val fingerprint = PlanFingerprint(clock.millis(), 17, snapshot)
+
+        val reference = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint)
+
+        clock.forward(2, SECONDS)
+        reference.isStale(transactionIdSupplier(23), stats) shouldBe false
+
+        clock.forward(100, SECONDS)
+        reference.isStale(transactionIdSupplier(73), stats) shouldBe (name != PlanFingerprint.none)
+      }
+    }
   }
 
   implicit def liftToOption[T](item: T): Option[T] = Option(item)

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/PlanFingerprintReferenceTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/PlanFingerprintReferenceTest.scala
@@ -41,9 +41,9 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
 
         clock.forward(2, SECONDS)
 
-        val (stale, wait) = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
+        val cacheCheck = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
 
-        stale shouldBe true
+        cacheCheck.isStale shouldBe true
       }
     }
   }
@@ -60,9 +60,9 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
 
         clock.forward(2, SECONDS)
 
-        val (stale, wait) = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
+        val cacheCheck = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
 
-        stale shouldBe true
+        cacheCheck.isStale shouldBe true
       }
     }
   }
@@ -79,9 +79,9 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
 
         clock.forward(2, SECONDS)
 
-        val (stale, wait) = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
+        val cacheCheck = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
 
-        stale shouldBe false
+        cacheCheck.isStale shouldBe false
       }
     }
   }
@@ -98,9 +98,9 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
 
         clock.forward(2, SECONDS)
 
-        val (stale, wait) = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
+        val cacheCheck = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
 
-        stale shouldBe false
+        cacheCheck.isStale shouldBe false
       }
     }
   }
@@ -119,9 +119,9 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
 
         clock.forward(2, SECONDS)
 
-        val (stale, wait) = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(17), stats)
+        val cacheCheck = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(17), stats)
 
-        stale shouldBe false
+        cacheCheck.isStale shouldBe false
       }
     }
   }
@@ -140,9 +140,9 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
 
         clock.forward(500, MILLISECONDS)
 
-        val (stale, wait) = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
+        val cacheCheck = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
 
-        stale shouldBe false
+        cacheCheck.isStale shouldBe false
       }
     }
   }
@@ -162,10 +162,10 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
         val reference = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint)
 
         clock.forward(2, SECONDS)
-        reference.isStale(transactionIdSupplier(17), stats)._1 shouldBe false
+        reference.isStale(transactionIdSupplier(17), stats).isStale shouldBe false
 
         clock.forward(500, MILLISECONDS)
-        reference.isStale(transactionIdSupplier(23), stats)._1 shouldBe false
+        reference.isStale(transactionIdSupplier(23), stats).isStale shouldBe false
       }
     }
   }
@@ -183,10 +183,10 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
         val reference = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint)
 
         clock.forward(2, SECONDS)
-        reference.isStale(transactionIdSupplier(23), stats)._1 shouldBe false
+        reference.isStale(transactionIdSupplier(23), stats).isStale shouldBe false
 
         clock.forward(2, SECONDS)
-        reference.isStale(transactionIdSupplier(23), stats)._1 shouldBe false
+        reference.isStale(transactionIdSupplier(23), stats).isStale shouldBe false
       }
     }
   }
@@ -204,10 +204,10 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
         val reference = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint)
 
         clock.forward(2, SECONDS)
-        reference.isStale(transactionIdSupplier(23), stats)._1 shouldBe false
+        reference.isStale(transactionIdSupplier(23), stats).isStale shouldBe false
 
         clock.forward(100, SECONDS)
-        reference.isStale(transactionIdSupplier(73), stats)._1 shouldBe (name != PlanFingerprint.none)
+        reference.isStale(transactionIdSupplier(73), stats).isStale shouldBe (name != PlanFingerprint.none)
       }
     }
   }
@@ -225,10 +225,10 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
         val reference = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint)
 
         clock.forward(2, SECONDS)
-        reference.isStale(transactionIdSupplier(23), stats)._1 shouldBe false
+        reference.isStale(transactionIdSupplier(23), stats).isStale shouldBe false
 
         clock.forward(100, SECONDS)
-        reference.isStale(transactionIdSupplier(73), stats)._1 shouldBe (name != PlanFingerprint.none)
+        reference.isStale(transactionIdSupplier(73), stats).isStale shouldBe (name != PlanFingerprint.none)
       }
     }
   }

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/PlanFingerprintReferenceTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/PlanFingerprintReferenceTest.scala
@@ -41,7 +41,7 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
 
         clock.forward(2, SECONDS)
 
-        val stale = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
+        val (stale, wait) = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
 
         stale shouldBe true
       }
@@ -60,7 +60,7 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
 
         clock.forward(2, SECONDS)
 
-        val stale = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
+        val (stale, wait) = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
 
         stale shouldBe true
       }
@@ -79,7 +79,7 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
 
         clock.forward(2, SECONDS)
 
-        val stale = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
+        val (stale, wait) = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
 
         stale shouldBe false
       }
@@ -98,7 +98,7 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
 
         clock.forward(2, SECONDS)
 
-        val stale = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
+        val (stale, wait) = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
 
         stale shouldBe false
       }
@@ -119,7 +119,7 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
 
         clock.forward(2, SECONDS)
 
-        val stale = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(17), stats)
+        val (stale, wait) = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(17), stats)
 
         stale shouldBe false
       }
@@ -140,7 +140,7 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
 
         clock.forward(500, MILLISECONDS)
 
-        val stale = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
+        val (stale, wait) = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint).isStale(transactionIdSupplier(42), stats)
 
         stale shouldBe false
       }
@@ -162,10 +162,10 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
         val reference = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint)
 
         clock.forward(2, SECONDS)
-        reference.isStale(transactionIdSupplier(17), stats) shouldBe false
+        reference.isStale(transactionIdSupplier(17), stats)._1 shouldBe false
 
         clock.forward(500, MILLISECONDS)
-        reference.isStale(transactionIdSupplier(23), stats) shouldBe false
+        reference.isStale(transactionIdSupplier(23), stats)._1 shouldBe false
       }
     }
   }
@@ -183,10 +183,10 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
         val reference = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint)
 
         clock.forward(2, SECONDS)
-        reference.isStale(transactionIdSupplier(23), stats) shouldBe false
+        reference.isStale(transactionIdSupplier(23), stats)._1 shouldBe false
 
         clock.forward(2, SECONDS)
-        reference.isStale(transactionIdSupplier(23), stats) shouldBe false
+        reference.isStale(transactionIdSupplier(23), stats)._1 shouldBe false
       }
     }
   }
@@ -204,10 +204,10 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
         val reference = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint)
 
         clock.forward(2, SECONDS)
-        reference.isStale(transactionIdSupplier(23), stats) shouldBe false
+        reference.isStale(transactionIdSupplier(23), stats)._1 shouldBe false
 
         clock.forward(100, SECONDS)
-        reference.isStale(transactionIdSupplier(73), stats) shouldBe (name != PlanFingerprint.none)
+        reference.isStale(transactionIdSupplier(73), stats)._1 shouldBe (name != PlanFingerprint.none)
       }
     }
   }
@@ -225,10 +225,10 @@ class PlanFingerprintReferenceTest extends CypherFunSuite {
         val reference = new PlanFingerprintReference(clock, divergenceCalculator, fingerprint)
 
         clock.forward(2, SECONDS)
-        reference.isStale(transactionIdSupplier(23), stats) shouldBe false
+        reference.isStale(transactionIdSupplier(23), stats)._1 shouldBe false
 
         clock.forward(100, SECONDS)
-        reference.isStale(transactionIdSupplier(73), stats) shouldBe (name != PlanFingerprint.none)
+        reference.isStale(transactionIdSupplier(73), stats)._1 shouldBe (name != PlanFingerprint.none)
       }
     }
   }

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/StatsDivergenceCalculatorTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/StatsDivergenceCalculatorTest.scala
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_2.executionplan
+
+import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
+import org.neo4j.graphdb.factory.GraphDatabaseSettings
+import org.neo4j.kernel.configuration.Settings
+
+class StatsDivergenceCalculatorTest extends CypherFunSuite {
+  val defaultInitialThreshold = GraphDatabaseSettings.query_statistics_divergence_threshold.getDefaultValue().toDouble
+  val defaultTargetThreshold = GraphDatabaseSettings.query_statistics_divergence_target.getDefaultValue.toDouble
+  val defaultInitialInterval = Settings.DURATION.apply(GraphDatabaseSettings.cypher_min_replan_interval.getDefaultValue).toMillis
+  val defaultTargetInterval = Settings.DURATION.apply(GraphDatabaseSettings.cypher_replan_interval_target.getDefaultValue).toMillis
+  val marginOfError = 0.0001
+
+  test("Disabling decay should show no decay") {
+    val divergence = PlanFingerprint.divergenceNoDecayCalculator(defaultInitialThreshold, defaultInitialInterval)
+    assertNoDecay(PlanFingerprint.none, divergence, defaultInitialThreshold, defaultInitialInterval)
+  }
+
+  test("Using algorithm 'none' decay should show no decay") {
+    assertNoDecay(PlanFingerprint.none, defaultInitialThreshold, defaultTargetThreshold, defaultInitialInterval, defaultTargetInterval)
+  }
+
+  test("Default values should make sense") {
+    assertDecaysMakeSense(Settings.DEFAULT, defaultInitialThreshold, defaultTargetThreshold, defaultInitialInterval, defaultTargetInterval)
+  }
+
+  test("Default values should make sense with inverse decay") {
+    assertDecaysMakeSense(PlanFingerprint.inverse, defaultInitialThreshold, defaultTargetThreshold, defaultInitialInterval, defaultTargetInterval)
+  }
+
+  test("Default values should make sense with exponential decay") {
+    assertDecaysMakeSense(PlanFingerprint.exponential, defaultInitialThreshold, defaultTargetThreshold, defaultInitialInterval, defaultTargetInterval)
+  }
+
+  test("Equal threshold should disable decay") {
+    Seq(PlanFingerprint.inverse, PlanFingerprint.exponential).foreach { name =>
+      assertNoDecay(name, 0.5, 0.5, defaultInitialInterval, defaultTargetInterval)
+    }
+  }
+
+  test("Increasing threshold should disable decay") {
+    Seq(PlanFingerprint.inverse, PlanFingerprint.exponential).foreach { name =>
+      assertNoDecay(name, 0.5, 0.75, defaultInitialInterval, defaultTargetInterval)
+    }
+  }
+
+  test("Target threshold of zero should disable decay") {
+    Seq(PlanFingerprint.inverse, PlanFingerprint.exponential).foreach { name =>
+      assertNoDecay(name, 0.5, 0.0, defaultInitialInterval, defaultTargetInterval)
+    }
+  }
+
+  test("Small target threshold should work") {
+    Seq(PlanFingerprint.inverse, PlanFingerprint.exponential).foreach { name =>
+      assertDecaysMakeSense(name, 0.5, 0.001, defaultInitialInterval, defaultTargetInterval)
+    }
+  }
+
+  test("Not changing time should disable decay") {
+    Seq(PlanFingerprint.inverse, PlanFingerprint.exponential).foreach { name =>
+      assertNoDecay(name, defaultInitialThreshold, defaultTargetThreshold, 1000, 1000)
+    }
+  }
+
+  test("Going back in time should disable decay") {
+    Seq(PlanFingerprint.inverse, PlanFingerprint.exponential).foreach { name =>
+      assertNoDecay(name, defaultInitialThreshold, defaultTargetThreshold, 1000, 500)
+    }
+  }
+
+  test("Small time interval should work") {
+    Seq(PlanFingerprint.inverse, PlanFingerprint.exponential).foreach { name =>
+      assertDecaysMakeSense(name, defaultInitialThreshold, defaultTargetThreshold, 1000, 1002)
+    }
+  }
+
+  private def assertNoDecay(name: String, initialThreshold: Double, targetThreshold: Double, initialInterval: Long, targetInterval: Long): Unit = {
+    val divergence = PlanFingerprint.divergenceCalculatorFor(name, initialThreshold, targetThreshold, initialInterval, targetInterval)
+    assertNoDecay(name, divergence, initialThreshold, initialInterval)
+  }
+
+  private def assertNoDecay(name: String, divergence: StatsDivergenceCalculator, threshold: Double, interval: Long): Unit = {
+    withClue(s"For decay algorithm '$name': ") {
+      divergence.decay(0) should be(threshold)
+      divergence.decay(interval / 2) should be(threshold)
+      divergence.decay(interval) should be(threshold)
+      divergence.decay(interval * 2) should be(threshold)
+    }
+  }
+
+  private def assertDecaysMakeSense(name: String, initialThreshold: Double, targetThreshold: Double, initialInterval: Long, targetInterval: Long): Unit = {
+    withClue("Testing intervals that differ by only 1 is not supported in this test:") {
+      targetInterval should be >= initialInterval + 2
+    }
+    withClue(s"For decay algorithm '$name': ") {
+      val divergence = PlanFingerprint.divergenceCalculatorFor(name, initialThreshold, targetThreshold, initialInterval, targetInterval)
+      divergence.decay(initialInterval) should be(initialThreshold +- marginOfError)
+      val decayed = divergence.decay((initialInterval + targetInterval) / 2)
+      decayed should be > targetThreshold
+      decayed should be < initialThreshold
+      divergence.decay(targetInterval) should be(targetThreshold +- marginOfError)
+      val furtherDecayed = divergence.decay(targetInterval * 2)
+      furtherDecayed should be < targetThreshold
+      furtherDecayed should be >= 0.0
+    }
+  }
+}

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/StatsDivergenceCalculatorTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/StatsDivergenceCalculatorTest.scala
@@ -39,7 +39,8 @@ class StatsDivergenceCalculatorTest extends CypherFunSuite {
     assertNoDecay(PlanFingerprint.none, defaultInitialThreshold, defaultTargetThreshold, defaultInitialInterval, defaultTargetInterval)
   }
 
-  test("Default values should make sense") {
+  //TODO: Unignore this test once decay is on by default
+  ignore("Default values should make sense") {
     assertDecaysMakeSense(Settings.DEFAULT, defaultInitialThreshold, defaultTargetThreshold, defaultInitialInterval, defaultTargetInterval)
   }
 

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/LogicalPlanningTestSupport.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/LogicalPlanningTestSupport.scala
@@ -24,6 +24,7 @@ import org.mockito.Mockito._
 import org.neo4j.cypher.internal.compiler.v3_2._
 import org.neo4j.cypher.internal.compiler.v3_2.ast.rewriters.{namePatternPredicatePatternElements, _}
 import org.neo4j.cypher.internal.compiler.v3_2.ast.rewriters._
+import org.neo4j.cypher.internal.compiler.v3_2.executionplan.PlanFingerprint
 import org.neo4j.cypher.internal.compiler.v3_2.phases._
 import org.neo4j.cypher.internal.compiler.v3_2.planner.execution.PipeExecutionBuilderContext
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.Metrics._
@@ -164,8 +165,7 @@ trait LogicalPlanningTestSupport extends CypherTestSupport with AstConstructionT
 
   val config = CypherCompilerConfiguration(
     queryCacheSize = 100,
-    statsDivergenceThreshold = 0.5,
-    queryPlanTTL = 1000,
+    statsDivergenceCalculator = PlanFingerprint.divergenceNoDecayCalculator(0.5, 1000),
     useErrorsOverWarnings = false,
     idpMaxTableSize = DefaultIDPSolverConfig.maxTableSize,
     idpIterationDuration = DefaultIDPSolverConfig.iterationDurationLimit,

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/LogicalPlanningTestSupport2.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/LogicalPlanningTestSupport2.scala
@@ -21,6 +21,7 @@ package org.neo4j.cypher.internal.compiler.v3_2.planner
 
 import org.neo4j.cypher.internal.compiler.v3_2._
 import org.neo4j.cypher.internal.compiler.v3_2.ast.rewriters._
+import org.neo4j.cypher.internal.compiler.v3_2.executionplan.PlanFingerprint
 import org.neo4j.cypher.internal.compiler.v3_2.phases._
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.Metrics._
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.cardinality.QueryGraphCardinalityModel
@@ -63,8 +64,7 @@ trait LogicalPlanningTestSupport2 extends CypherTestSupport with AstConstruction
   val realConfig = new RealLogicalPlanningConfiguration
   val cypherCompilerConfig = CypherCompilerConfiguration(
     queryCacheSize = 100,
-    statsDivergenceThreshold = 0.5,
-    queryPlanTTL = 1000,
+    statsDivergenceCalculator = PlanFingerprint.divergenceNoDecayCalculator(0.5, 1000),
     useErrorsOverWarnings = false,
     idpMaxTableSize = DefaultIDPSolverConfig.maxTableSize,
     idpIterationDuration = DefaultIDPSolverConfig.iterationDurationLimit,

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/PlanCacheMetricsMonitor.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/PlanCacheMetricsMonitor.scala
@@ -25,9 +25,14 @@ import org.neo4j.cypher.internal.StringCacheMonitor
 
 class PlanCacheMetricsMonitor extends StringCacheMonitor {
   private val counter = new AtomicLong()
-  override def cacheDiscard(ignored1: String, ignored2: String): Unit = {
+  private val waitTime = new AtomicLong()
+
+  override def cacheDiscard(ignored1: String, ignored2: String, secondsSinceReplan: Int): Unit = {
     counter.incrementAndGet()
+    waitTime.addAndGet(secondsSinceReplan)
   }
 
   def numberOfReplans: Long = counter.get()
+
+  def replanWaitTime: Long = waitTime.get()
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CompilerEngineDelegator.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/CompilerEngineDelegator.scala
@@ -23,6 +23,7 @@ import java.time.Clock
 
 import org.neo4j.cypher.internal.compatibility.v3_2.exceptionHandler
 import org.neo4j.cypher.internal.compiler.v3_2._
+import org.neo4j.cypher.internal.compiler.v3_2.executionplan.{PlanFingerprint, StatsDivergenceCalculator}
 import org.neo4j.cypher.internal.frontend.v3_2
 import org.neo4j.cypher.internal.frontend.v3_2.InputPosition
 import org.neo4j.cypher.internal.frontend.v3_2.helpers.fixedPoint
@@ -39,8 +40,11 @@ import org.neo4j.logging.{Log, LogProvider}
 object CompilerEngineDelegator {
   val DEFAULT_QUERY_CACHE_SIZE: Int = 128
   val DEFAULT_QUERY_PLAN_TTL: Long = 1000 // 1 second
+  val DEFAULT_QUERY_PLAN_TARGET: Long = 1000 * 60 * 60 * 7 // 7 hours
   val CLOCK: Clock = Clock.systemUTC()
   val DEFAULT_STATISTICS_DIVERGENCE_THRESHOLD = 0.5
+  val DEFAULT_STATISTICS_DIVERGENCE_TARGET = 0.1
+  val DEFAULT_DIVERGENCE_ALGORITHM = PlanFingerprint.inverse
   val DEFAULT_NON_INDEXED_LABEL_WARNING_THRESHOLD = 10000
 }
 
@@ -92,8 +96,7 @@ class CompilerEngineDelegator(graph: GraphDatabaseQueryService,
 
   private val config = CypherCompilerConfiguration(
     queryCacheSize = getQueryCacheSize,
-    statsDivergenceThreshold = getStatisticsDivergenceThreshold,
-    queryPlanTTL = getMinimumTimeBeforeReplanning,
+    statsDivergenceCalculator = getStatisticsDivergenceCalculator,
     useErrorsOverWarnings = useErrorsOverWarnings,
     idpMaxTableSize = idpMaxTableSize,
     idpIterationDuration = idpIterationDuration,
@@ -210,19 +213,28 @@ class CompilerEngineDelegator(graph: GraphDatabaseQueryService,
     getSetting(graph, setting, DEFAULT_QUERY_CACHE_SIZE)
   }
 
-  private def getStatisticsDivergenceThreshold : Double = {
-    val setting: (Config) => Double = config => config.get(GraphDatabaseSettings.query_statistics_divergence_threshold).doubleValue()
-    getSetting(graph, setting, DEFAULT_STATISTICS_DIVERGENCE_THRESHOLD)
+  private def getStatisticsDivergenceCalculator: StatsDivergenceCalculator = {
+    val divergenceThreshold = getSetting(graph,
+      config => config.get(GraphDatabaseSettings.query_statistics_divergence_threshold).doubleValue(),
+      DEFAULT_STATISTICS_DIVERGENCE_THRESHOLD)
+    val targetThreshold = getSetting(graph,
+      config => config.get(GraphDatabaseSettings.query_statistics_divergence_target).doubleValue(),
+      DEFAULT_STATISTICS_DIVERGENCE_TARGET)
+    val minReplanTime = getSetting(graph,
+      config => config.get(GraphDatabaseSettings.cypher_min_replan_interval).toMillis().longValue(),
+      DEFAULT_QUERY_PLAN_TTL)
+    val targetReplanTime = getSetting(graph,
+      config => config.get(GraphDatabaseSettings.cypher_replan_interval_target).toMillis().longValue(),
+      DEFAULT_QUERY_PLAN_TARGET)
+    val divergenceAlgorithm = getSetting(graph,
+      config => config.get(GraphDatabaseSettings.cypher_replan_algorithm),
+      DEFAULT_DIVERGENCE_ALGORITHM)
+    PlanFingerprint.divergenceCalculatorFor(divergenceAlgorithm, divergenceThreshold, targetThreshold, minReplanTime, targetReplanTime)
   }
 
   private def getNonIndexedLabelWarningThreshold: Long = {
     val setting: (Config) => Long = config => config.get(GraphDatabaseSettings.query_non_indexed_label_warning_threshold).longValue()
     getSetting(graph, setting, DEFAULT_NON_INDEXED_LABEL_WARNING_THRESHOLD)
-  }
-
-  private def getMinimumTimeBeforeReplanning: Long = {
-    val setting: (Config) => Long = config => config.get(GraphDatabaseSettings.cypher_min_replan_interval).toMillis().longValue()
-    getSetting(graph, setting, DEFAULT_QUERY_PLAN_TTL)
   }
 
   private def getSetting[A](gds: GraphDatabaseQueryService, configLookup: Config => A, default: A): A = gds match {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
@@ -62,8 +62,8 @@ class ExecutionEngine(val queryService: GraphDatabaseQueryService,
   private val log = logProvider.getLog( getClass )
   private val cacheMonitor = kernelMonitors.newMonitor(classOf[StringCacheMonitor])
   kernelMonitors.addMonitorListener( new StringCacheMonitor {
-    override def cacheDiscard(ignored: String, query: String) {
-      log.info(s"Discarded stale query from the query cache: $query")
+    override def cacheDiscard(ignored: String, query: String, secondsSinceReplan: Int) {
+      log.info(s"Discarded stale query from the query cache after ${secondsSinceReplan} seconds: $query")
     }
   })
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
@@ -23,7 +23,6 @@ import java.util.{Map => JavaMap}
 
 import org.neo4j.cypher._
 import org.neo4j.cypher.internal.compiler.v3_2._
-import org.neo4j.cypher.internal.compiler.v3_2.executionplan.PlanFingerprint
 import org.neo4j.cypher.internal.compiler.v3_2.helpers.{RuntimeJavaValueConverter, RuntimeScalaValueConverter}
 import org.neo4j.cypher.internal.compiler.v3_2.prettifier.Prettifier
 import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer
@@ -162,10 +161,7 @@ class ExecutionEngine(val queryService: GraphDatabaseQueryService,
             new QueryCache(cacheAccessor, lruCache)
           })
 
-          def isStale(plan: ExecutionPlan, ignored: Map[String, Any]) = {
-            PlanFingerprint.log(s"Is query stale?: $cacheKey")
-            plan.isStale(lastCommittedTxId, tc)
-          }
+          def isStale(plan: ExecutionPlan, ignored: Map[String, Any]) = plan.isStale(lastCommittedTxId, tc)
           def producePlan() = {
             val parsedQuery = parsePreParsedQuery(preParsedQuery, phaseTracer)
             parsedQuery.plan(tc, phaseTracer)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
@@ -161,7 +161,10 @@ class ExecutionEngine(val queryService: GraphDatabaseQueryService,
             new QueryCache(cacheAccessor, lruCache)
           })
 
-          def isStale(plan: ExecutionPlan, ignored: Map[String, Any]) = plan.isStale(lastCommittedTxId, tc)
+          def isStale(plan: ExecutionPlan, ignored: Map[String, Any]) = {
+            println(s"Replanning: Is query stale?: $cacheKey")
+            plan.isStale(lastCommittedTxId, tc)
+          }
           def producePlan() = {
             val parsedQuery = parsePreParsedQuery(preParsedQuery, phaseTracer)
             parsedQuery.plan(tc, phaseTracer)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
@@ -23,6 +23,7 @@ import java.util.{Map => JavaMap}
 
 import org.neo4j.cypher._
 import org.neo4j.cypher.internal.compiler.v3_2._
+import org.neo4j.cypher.internal.compiler.v3_2.executionplan.PlanFingerprint
 import org.neo4j.cypher.internal.compiler.v3_2.helpers.{RuntimeJavaValueConverter, RuntimeScalaValueConverter}
 import org.neo4j.cypher.internal.compiler.v3_2.prettifier.Prettifier
 import org.neo4j.cypher.internal.frontend.v3_2.phases.CompilationPhaseTracer
@@ -162,7 +163,7 @@ class ExecutionEngine(val queryService: GraphDatabaseQueryService,
           })
 
           def isStale(plan: ExecutionPlan, ignored: Map[String, Any]) = {
-            println(s"Replanning: Is query stale?: $cacheKey")
+            PlanFingerprint.log(s"Is query stale?: $cacheKey")
             plan.isStale(lastCommittedTxId, tc)
           }
           def producePlan() = {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionPlan.scala
@@ -19,6 +19,7 @@
  */
 package org.neo4j.cypher.internal
 
+import org.neo4j.cypher.internal.compiler.v3_2.executionplan.CacheCheckResult
 import org.neo4j.cypher.internal.spi.v3_2.TransactionalContextWrapper
 import org.neo4j.graphdb.Transaction
 import org.neo4j.kernel.api.Statement
@@ -32,7 +33,7 @@ trait ExecutionPlan {
 
   def isPeriodicCommit: Boolean
 
-  def isStale(lastCommittedTxId: LastCommittedTxIdProvider, ctx: TransactionalContextWrapper): (Boolean, Int)
+  def isStale(lastCommittedTxId: LastCommittedTxIdProvider, ctx: TransactionalContextWrapper): CacheCheckResult
 
   def plannerInfo: PlannerInfo
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionPlan.scala
@@ -32,7 +32,7 @@ trait ExecutionPlan {
 
   def isPeriodicCommit: Boolean
 
-  def isStale(lastCommittedTxId: LastCommittedTxIdProvider, ctx: TransactionalContextWrapper): Boolean
+  def isStale(lastCommittedTxId: LastCommittedTxIdProvider, ctx: TransactionalContextWrapper): (Boolean, Int)
 
   def plannerInfo: PlannerInfo
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/Compatibility.scala
@@ -28,6 +28,7 @@ import org.neo4j.cypher.internal.compiler.v2_3.executionplan.{EntityAccessor, Ex
 import org.neo4j.cypher.internal.compiler.v2_3.spi.{PlanContext, QueryContext}
 import org.neo4j.cypher.internal.compiler.v2_3.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.compiler.v2_3.{InfoLogger, ExplainMode => ExplainModev2_3, NormalMode => NormalModev2_3, ProfileMode => ProfileModev2_3, _}
+import org.neo4j.cypher.internal.compiler.v3_2.executionplan.CacheCheckResult
 import org.neo4j.cypher.internal.frontend.v3_2
 import org.neo4j.cypher.internal.spi.v2_3.{TransactionBoundGraphStatistics, TransactionBoundPlanContext, TransactionBoundQueryContext}
 import org.neo4j.cypher.internal.spi.v3_2.TransactionalContextWrapper
@@ -113,7 +114,7 @@ trait Compatibility {
     def isPeriodicCommit = inner.isPeriodicCommit
 
     def isStale(lastCommittedTxId: LastCommittedTxIdProvider, ctx: TransactionalContextWrapper) =
-      (inner.isStale(lastCommittedTxId, TransactionBoundGraphStatistics(ctx.readOperations)), 0)
+      CacheCheckResult(inner.isStale(lastCommittedTxId, TransactionBoundGraphStatistics(ctx.readOperations)), 0)
 
     override def plannerInfo = new PlannerInfo(inner.plannerUsed.name, inner.runtimeUsed.name, emptyList[IndexUsage])
   }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/Compatibility.scala
@@ -112,8 +112,8 @@ trait Compatibility {
 
     def isPeriodicCommit = inner.isPeriodicCommit
 
-    def isStale(lastCommittedTxId: LastCommittedTxIdProvider, ctx: TransactionalContextWrapper): Boolean =
-      inner.isStale(lastCommittedTxId, TransactionBoundGraphStatistics(ctx.readOperations))
+    def isStale(lastCommittedTxId: LastCommittedTxIdProvider, ctx: TransactionalContextWrapper) =
+      (inner.isStale(lastCommittedTxId, TransactionBoundGraphStatistics(ctx.readOperations)), 0)
 
     override def plannerInfo = new PlannerInfo(inner.plannerUsed.name, inner.runtimeUsed.name, emptyList[IndexUsage])
   }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/helpers.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/helpers.scala
@@ -36,8 +36,9 @@ object helpers {
   }
 
   def as2_3(config: CypherCompilerConfiguration) = CypherCompilerConfiguration2_3(config.queryCacheSize,
-    config.statsDivergenceThreshold, config.queryPlanTTL, config.useErrorsOverWarnings,
-    config.idpMaxTableSize, config.idpIterationDuration, config.nonIndexedLabelWarningThreshold)
+    config.statsDivergenceCalculator.initialThreshold, config.statsDivergenceCalculator.initialMillis,
+    config.useErrorsOverWarnings, config.idpMaxTableSize, config.idpIterationDuration,
+    config.nonIndexedLabelWarningThreshold)
 
   /** This is awful but needed until 2.3 is updated no to send in the tracer here */
   def as2_3(tracer: CompilationPhaseTracer): v2_3.CompilationPhaseTracer = {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/Compatibility.scala
@@ -113,8 +113,8 @@ trait Compatibility {
 
     def isPeriodicCommit = inner.isPeriodicCommit
 
-    def isStale(lastCommittedTxId: LastCommittedTxIdProvider, ctx: TransactionalContextWrapperV3_2): Boolean =
-      inner.isStale(lastCommittedTxId, TransactionBoundGraphStatistics(ctx.readOperations))
+    def isStale(lastCommittedTxId: LastCommittedTxIdProvider, ctx: TransactionalContextWrapperV3_2) =
+      (inner.isStale(lastCommittedTxId, TransactionBoundGraphStatistics(ctx.readOperations)), 0)
 
     override def plannerInfo = new PlannerInfo(inner.plannerUsed.name, inner.runtimeUsed.name, emptyList[IndexUsage])
   }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/Compatibility.scala
@@ -27,6 +27,7 @@ import org.neo4j.cypher.internal.compiler.v3_1
 import org.neo4j.cypher.internal.compiler.v3_1.executionplan.{ExecutionPlan => ExecutionPlan_v3_1}
 import org.neo4j.cypher.internal.compiler.v3_1.tracing.rewriters.RewriterStepSequencer
 import org.neo4j.cypher.internal.compiler.v3_1.{CompilationPhaseTracer, InfoLogger, ExplainMode => ExplainModev3_1, NormalMode => NormalModev3_1, ProfileMode => ProfileModev3_1, _}
+import org.neo4j.cypher.internal.compiler.v3_2.executionplan.CacheCheckResult
 import org.neo4j.cypher.internal.spi.v3_1.TransactionBoundQueryContext.IndexSearchMonitor
 import org.neo4j.cypher.internal.spi.v3_1.{TransactionalContextWrapper => TransactionalContextWrapperV3_1, _}
 import org.neo4j.cypher.internal.spi.v3_2.{TransactionalContextWrapper => TransactionalContextWrapperV3_2}
@@ -114,7 +115,7 @@ trait Compatibility {
     def isPeriodicCommit = inner.isPeriodicCommit
 
     def isStale(lastCommittedTxId: LastCommittedTxIdProvider, ctx: TransactionalContextWrapperV3_2) =
-      (inner.isStale(lastCommittedTxId, TransactionBoundGraphStatistics(ctx.readOperations)), 0)
+      CacheCheckResult(inner.isStale(lastCommittedTxId, TransactionBoundGraphStatistics(ctx.readOperations)), 0)
 
     override def plannerInfo = new PlannerInfo(inner.plannerUsed.name, inner.runtimeUsed.name, emptyList[IndexUsage])
   }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/helpers.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/helpers.scala
@@ -37,8 +37,8 @@ object helpers {
   def as3_1(config: CypherCompilerConfiguration) =
     CypherCompilerConfiguration3_1(
       config.queryCacheSize,
-      config.statsDivergenceThreshold,
-      config.queryPlanTTL,
+      config.statsDivergenceCalculator.initialThreshold,
+      config.statsDivergenceCalculator.initialMillis,
       config.useErrorsOverWarnings,
       config.idpMaxTableSize,
       config.idpIterationDuration,

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/Compatibility.scala
@@ -111,7 +111,7 @@ trait Compatibility[C <: CompilerContext] {
 
     def isPeriodicCommit = inner.isPeriodicCommit
 
-    def isStale(lastCommittedTxId: LastCommittedTxIdProvider, ctx: TransactionalContextWrapper): Boolean =
+    def isStale(lastCommittedTxId: LastCommittedTxIdProvider, ctx: TransactionalContextWrapper) =
       inner.isStale(lastCommittedTxId, TransactionBoundGraphStatistics(ctx.readOperations))
 
     override def plannerInfo = {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CartesianProductNotificationAcceptanceTest.scala
@@ -25,6 +25,7 @@ import org.mockito.Matchers._
 import org.mockito.Mockito.{verify, _}
 import org.neo4j.cypher.internal.compatibility.v3_2.{StringInfoLogger, WrappedMonitors}
 import org.neo4j.cypher.internal.compiler.v3_2._
+import org.neo4j.cypher.internal.compiler.v3_2.executionplan.PlanFingerprint
 import org.neo4j.cypher.internal.compiler.v3_2.helpers.IdentityTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_2.phases.CompilerContext
 import org.neo4j.cypher.internal.frontend.v3_2.InputPosition
@@ -100,8 +101,7 @@ class CartesianProductNotificationAcceptanceTest extends CypherFunSuite with Gra
     new CypherCompilerFactory().costBasedCompiler(
       CypherCompilerConfiguration(
         queryCacheSize = 128,
-        statsDivergenceThreshold = 0.5,
-        queryPlanTTL = 1000L,
+        statsDivergenceCalculator = PlanFingerprint.divergenceNoDecayCalculator(0.5, 1000L),
         useErrorsOverWarnings = false,
         idpMaxTableSize = 128,
         idpIterationDuration = 1000,

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherCompilerStringCacheMonitoringAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/CypherCompilerStringCacheMonitoringAcceptanceTest.scala
@@ -47,7 +47,7 @@ class CypherCompilerStringCacheMonitoringAcceptanceTest extends ExecutionEngineF
       counts = counts.copy(flushes = counts.flushes + 1)
     }
 
-    override def cacheDiscard(key: String, key2: String) {
+    override def cacheDiscard(key: String, key2: String, secondsSinceReplan: Int) {
       counts = counts.copy(evicted = counts.evicted + 1)
     }
   }
@@ -129,7 +129,7 @@ class CypherCompilerStringCacheMonitoringAcceptanceTest extends ExecutionEngineF
 
     // then
     logProvider.assertAtLeastOnce(
-      AssertableLogProvider.inLog( classOf[ExecutionEngine] ).info( s"Discarded stale query from the query cache: $query" )
+      AssertableLogProvider.inLog( classOf[ExecutionEngine] ).info( s"Discarded stale query from the query cache after 0 seconds: $query" )
     )
   }
 }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/GraphDatabaseTestSupport.scala
@@ -23,6 +23,7 @@ import org.mockito.Mockito.when
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.idp.DefaultIDPSolverConfig
 import org.neo4j.cypher.internal.compiler.v3_2.spi.PlanContext
 import org.neo4j.cypher.internal.compiler.v3_2.CypherCompilerConfiguration
+import org.neo4j.cypher.internal.compiler.v3_2.executionplan.PlanFingerprint
 import org.neo4j.cypher.internal.frontend.v3_2.phases.devNullLogger
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.{CypherFunSuite, CypherTestSupport}
 import org.neo4j.cypher.internal.helpers.GraphIcing
@@ -276,8 +277,7 @@ trait GraphDatabaseTestSupport extends CypherTestSupport with GraphIcing {
 
   val config = CypherCompilerConfiguration(
     queryCacheSize = 100,
-    statsDivergenceThreshold = 0.5,
-    queryPlanTTL = 1000,
+    statsDivergenceCalculator = PlanFingerprint.divergenceNoDecayCalculator(0.5, 1000L),
     useErrorsOverWarnings = false,
     nonIndexedLabelWarningThreshold = 10000,
     idpMaxTableSize = DefaultIDPSolverConfig.maxTableSize,

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryCachingTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/QueryCachingTest.scala
@@ -96,7 +96,7 @@ class QueryCachingTest extends CypherFunSuite with GraphDatabaseTestSupport with
       log += s"cacheMiss: $key"
     }
 
-    override def cacheDiscard(key: String, ignored: String): Unit = {
+    override def cacheDiscard(key: String, ignored: String, secondsSinceReplan: Int): Unit = {
       log += s"cacheDiscard: $key"
     }
   }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompilerAstCacheAcceptanceTest.scala
@@ -216,7 +216,7 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
 
     // then
     logProvider.assertExactly(
-      inLog(logName).info( s"Discarded stale query from the query cache: $query" )
+      inLog(logName).info( s"Discarded stale query from the query cache after 0 seconds: $query" )
     )
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompilerAstCacheAcceptanceTest.scala
@@ -23,7 +23,7 @@ import java.time.{Clock, Instant, ZoneOffset}
 
 import org.neo4j.cypher.GraphDatabaseTestSupport
 import org.neo4j.cypher.internal.compatibility.v3_2.{StringInfoLogger, WrappedMonitors}
-import org.neo4j.cypher.internal.compiler.v3_2.executionplan.ExecutionPlan
+import org.neo4j.cypher.internal.compiler.v3_2.executionplan.{ExecutionPlan, PlanFingerprint}
 import org.neo4j.cypher.internal.compiler.v3_2.helpers.IdentityTypeConverter
 import org.neo4j.cypher.internal.compiler.v3_2.phases.CompilerContext
 import org.neo4j.cypher.internal.frontend.v3_2.ast.Statement
@@ -44,8 +44,7 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
     new CypherCompilerFactory().costBasedCompiler(
       CypherCompilerConfiguration(
         queryCacheSize,
-        statsDivergenceThreshold,
-        queryPlanTTL,
+        PlanFingerprint.divergenceNoDecayCalculator(statsDivergenceThreshold, queryPlanTTL),
         useErrorsOverWarnings = false,
         idpMaxTableSize = 128,
         idpIterationDuration = 1000,

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompilerAstCacheAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/CypherCompilerAstCacheAcceptanceTest.scala
@@ -83,7 +83,7 @@ class CypherCompilerAstCacheAcceptanceTest extends CypherFunSuite with GraphData
       counts = counts.copy(flushes = counts.flushes + 1)
     }
 
-    override def cacheDiscard(key: Statement, ignored: String): Unit = {
+    override def cacheDiscard(key: Statement, ignored: String, secondsSinceReplan: Int): Unit = {
       counts = counts.copy(evicted = counts.evicted + 1)
     }
   }

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -255,7 +255,7 @@ public class GraphDatabaseSettings implements LoadableConfig
                   "shrink over time using the algorithm set here. This will cause the threshold to reach " +
                   "the value set by unsupported.cypher.statistics_divergence_target once the time since the " +
                   "previous replanning has reached the value set in unsupported.cypher.target_replan_interval. " +
-                  "Setting the algorthm to 'none' will cause the threshold to not decay over time." )
+                  "Setting the algorithm to 'none' will cause the threshold to not decay over time." )
     public static Setting<String> cypher_replan_algorithm = setting( "unsupported.cypher.replan_algorithm",
             options( "inverse", "exponential", "none", DEFAULT ), DEFAULT );
 

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -208,6 +208,7 @@ public class GraphDatabaseSettings implements LoadableConfig
                   "replanning has reached unsupported.cypher.target_replan_interval. " +
                   "Setting this value to higher than the cypher.statistics_divergence_threshold will cause the " +
                   "threshold to not decay over time." )
+    @Internal
     public static Setting<Double> query_statistics_divergence_target = setting(
             "unsupported.cypher.statistics_divergence_target", DOUBLE, "0.10", min( 0.0 ), max(
                     1.0 ) );
@@ -247,6 +248,7 @@ public class GraphDatabaseSettings implements LoadableConfig
                   "the value set by unsupported.cypher.statistics_divergence_target once the time since the " +
                   "previous replanning has reached the value set here. Setting this value to less than the " +
                   "value of cypher.min_replan_interval will cause the threshold to not decay over time." )
+    @Internal
     public static Setting<Duration> cypher_replan_interval_target =
             setting( "unsupported.cypher.target_replan_interval", DURATION, "7h" );
 
@@ -256,6 +258,7 @@ public class GraphDatabaseSettings implements LoadableConfig
                   "the value set by unsupported.cypher.statistics_divergence_target once the time since the " +
                   "previous replanning has reached the value set in unsupported.cypher.target_replan_interval. " +
                   "Setting the algorithm to 'none' will cause the threshold to not decay over time." )
+    @Internal
     public static Setting<String> cypher_replan_algorithm = setting( "unsupported.cypher.replan_algorithm",
             options( "inverse", "exponential", "none", DEFAULT ), DEFAULT );
 

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -191,12 +191,25 @@ public class GraphDatabaseSettings implements LoadableConfig
     @Description( "The number of Cypher query execution plans that are cached." )
     public static Setting<Integer> query_cache_size = setting( "dbms.query_cache_size", INTEGER, "1000", min( 0 ) );
 
-    @Description( "The threshold when a plan is considered stale. If any of the underlying" +
-                  " statistics used to create the plan has changed more than this value, " +
-                  "the plan is considered stale and will be replanned. " +
-                  "A value of 0 means always replan, and 1 means never replan." )
+    @Description( "The threshold when a plan is considered stale. If any of the underlying " +
+                  "statistics used to create the plan have changed more than this value, " +
+                  "the plan will be considered stale and will be replanned. Change is calculated as " +
+                  "abs(a-b)/max(a,b). This means that a value of 0.75 requires the database to approximately " +
+                  "quadruple in size. A value of 0 means always replan, and 1 means never replan." )
     public static Setting<Double> query_statistics_divergence_threshold = setting(
             "cypher.statistics_divergence_threshold", DOUBLE, "0.75", min( 0.0 ), max(
+                    1.0 ) );
+
+    @Description( "Large databases might change slowly, and so to prevent queries from never being replanned " +
+                  "the divergence threshold set by cypher.statistics_divergence_threshold is configured to " +
+                  "shrink over time. " +
+                  "The algorithm used to manage this change is set by cypher.statistics_divergence_algorithm " +
+                  "and will cause the threshold to reach the value set here once the time since the previous " +
+                  "replanning has reached unsupported.cypher.target_replan_interval. " +
+                  "Setting this value to higher than the cypher.statistics_divergence_threshold will cause the " +
+                  "threshold to not decay over time." )
+    public static Setting<Double> query_statistics_divergence_target = setting(
+            "unsupported.cypher.statistics_divergence_target", DOUBLE, "0.10", min( 0.0 ), max(
                     1.0 ) );
 
     @Description( "The threshold when a warning is generated if a label scan is done after a load csv " +
@@ -219,8 +232,32 @@ public class GraphDatabaseSettings implements LoadableConfig
     public static Setting<Long> cypher_idp_solver_duration_threshold = setting(
             "unsupported.cypher.idp_solver_duration_threshold", LONG, "1000", min( 10L ) );
 
-    @Description("The minimum lifetime of a query plan before a query is considered for replanning")
-    public static Setting<Duration> cypher_min_replan_interval = setting( "cypher.min_replan_interval", DURATION, "10s" );
+    @Description( "The minimum time between possible cypher query replanning events. After this time, the graph " +
+                  "statistics will be evaluated, and if they have changed by more than the value set by " +
+                  "cypher.statistics_divergence_threshold, the query will be replanned. If the statistics have " +
+                  "not changed sufficiently, the same interval will need to pass before the statistics will be " +
+                  "evaluated again." )
+    public static Setting<Duration> cypher_min_replan_interval =
+            setting( "cypher.min_replan_interval", DURATION, "10s" );
+
+    @Description( "Large databases might change slowly, and to prevent queries from never being replanned " +
+                  "the divergence threshold set by cypher.statistics_divergence_threshold is configured to " +
+                  "shrink over time. The algorithm used to manage this change is set by " +
+                  "unsupported.cypher.statistics_divergence_algorithm and will cause the threshold to reach " +
+                  "the value set by unsupported.cypher.statistics_divergence_target once the time since the " +
+                  "previous replanning has reached the value set here. Setting this value to less than the " +
+                  "value of cypher.min_replan_interval will cause the threshold to not decay over time." )
+    public static Setting<Duration> cypher_replan_interval_target =
+            setting( "unsupported.cypher.target_replan_interval", DURATION, "7h" );
+
+    @Description( "Large databases might change slowly, and to prevent queries from never being replanned " +
+                  "the divergence threshold set by cypher.statistics_divergence_threshold is configured to " +
+                  "shrink over time using the algorithm set here. This will cause the threshold to reach " +
+                  "the value set by unsupported.cypher.statistics_divergence_target once the time since the " +
+                  "previous replanning has reached the value set in unsupported.cypher.target_replan_interval. " +
+                  "Setting the algorthm to 'none' will cause the threshold to not decay over time." )
+    public static Setting<String> cypher_replan_algorithm = setting( "unsupported.cypher.replan_algorithm",
+            options( "inverse", "exponential", "none", DEFAULT ), DEFAULT );
 
     @Description( "Determines if Cypher will allow using file URLs when loading data using `LOAD CSV`. Setting this "
                   + "value to `false` will cause Neo4j to fail `LOAD CSV` clauses that load data from the file system." )

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -29,6 +29,17 @@ import scala.collection.mutable.ArrayBuffer
 
 class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with NewPlannerTestSupport {
 
+  test("replanning") {
+    graph.execute("CREATE (:Label)")
+    Range(0, 100).foreach { i =>
+      Thread.sleep(1000)
+      graph.inTx ({
+        graph.execute(s"MATCH (n:${if(i % 2 == 0) "Label" else "Babel"}) RETURN n LIMIT ${i % 2}")
+        graph.execute("CREATE (:Babel)")
+      }, org.neo4j.kernel.api.KernelTransaction.Type.explicit)
+    }
+  }
+
   test("Should not use both pruning var expand and projections that need path info") {
     val n1 = createLabeledNode("Neo")
     val n2 = createLabeledNode()

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -21,7 +21,6 @@ package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher._
 import org.neo4j.cypher.internal.compiler.v3_2.commands.expressions.PathImpl
-import org.neo4j.cypher.internal.compiler.v3_2.executionplan.PlanFingerprint
 import org.neo4j.graphdb._
 import org.neo4j.helpers.collection.Iterators.single
 
@@ -29,63 +28,6 @@ import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
 class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with NewPlannerTestSupport {
-
-  test("replanning") {
-    graph.execute("CREATE (:Label)")
-    Range(0, 100).foreach { i =>
-      Thread.sleep(1000)
-      graph.inTx ({
-        graph.execute(s"MATCH (n:${if(i % 2 == 0) "Label" else "Babel"}) RETURN n LIMIT ${i % 2}")
-        graph.execute("CREATE (:Babel)")
-      }, org.neo4j.kernel.api.KernelTransaction.Type.explicit)
-    }
-  }
-
-  test("plot decay - 200 hours") {
-    val threshold = 0.75
-    val minTime = 10 * 1000
-    val inverse = PlanFingerprint.divergenceCalculatorFor("inverse", threshold, 0.1, minTime, 1000 * 60 * 60 * 7)
-    val exponential = PlanFingerprint.divergenceCalculatorFor("exponential", threshold, 0.1, minTime, 1000 * 60 * 60 * 7)
-    println("Seconds\tHours\tDays\tInverse\tExponential")
-    Range(0,200).foreach { hours =>
-      val seconds = hours * 60 * 60
-      val millis = seconds * 1000
-      val days = 1.0 * hours / 24.0
-      println(s"$seconds\t$hours\t$days\t${inverse.decay(millis)}\t${exponential.decay(millis)}")
-    }
-  }
-
-  test("plot decay2 - seconds times 1.2") {
-    val threshold = 0.75
-    val minTime = 10 * 1000
-    val inverse = PlanFingerprint.divergenceCalculatorFor("inverse", threshold, 0.1, minTime, 1000 * 60 * 60 * 7)
-    val exponential = PlanFingerprint.divergenceCalculatorFor("exponential", threshold, 0.1, minTime, 1000 * 60 * 60 * 7)
-    println("Seconds\tHours\tDays\tInverse\tExponential")
-    var seconds = 1.0
-    Range(0,200).foreach { index =>
-      val millis = (seconds * 1000).toLong
-      val hours = 1.0 * seconds / (60 * 60)
-      val days = hours / 24
-      println(s"$seconds\t$hours\t$days\t${inverse.decay(millis)}\t${exponential.decay(millis)}")
-      seconds = 1.2 * seconds
-    }
-  }
-
-  test("plot decay3 - closeup") {
-    val threshold = 0.75
-    val minTime = 10 * 1000
-//    val targetTime = 1000 * 60 * 60 * 7
-    val targetTime = minTime + 1000
-    val inverse = PlanFingerprint.divergenceCalculatorFor("inverse", threshold, 0.1, minTime, targetTime)
-    val exponential = PlanFingerprint.divergenceCalculatorFor("exponential", threshold, 0.1, minTime, targetTime)
-    println("Seconds\tHours\tDays\tInverse\tExponential")
-    Range(0,100).foreach { seconds =>
-      val millis = seconds * 1000
-      val hours = 1.0 * seconds / (60 * 60)
-      val days = hours / 24
-      println(s"$seconds\t$hours\t$days\t${inverse.decay(millis)}\t${exponential.decay(millis)}")
-    }
-  }
 
   test("Should not use both pruning var expand and projections that need path info") {
     val n1 = createLabeledNode("Neo")

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/BuildCompiledExecutionPlan.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/BuildCompiledExecutionPlan.scala
@@ -111,7 +111,7 @@ object BuildCompiledExecutionPlan extends Phase[CompiledRuntimeContext, Compilat
       }
     }
 
-    override def isStale(lastTxId: () => Long, statistics: GraphStatistics): Boolean = fingerprint.isStale(lastTxId, statistics)
+    override def isStale(lastTxId: () => Long, statistics: GraphStatistics) = fingerprint.isStale(lastTxId, statistics)
 
     override def runtimeUsed = CompiledRuntimeName
 

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/CodeGenerator.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/CodeGenerator.scala
@@ -58,7 +58,6 @@ class CodeGenerator(val structure: CodeStructure[GeneratedQuery], clock: Clock, 
 
         val fp = planContext.statistics match {
           case igs: InstrumentedGraphStatistics =>
-            PlanFingerprint.log(s"Creating new plan fingerprint for plan: $plan")
             Some(PlanFingerprint(clock.millis(), planContext.txIdProvider(), igs.snapshot.freeze))
           case _ =>
             None

--- a/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/CodeGenerator.scala
+++ b/enterprise/cypher/cypher-compiled-runtime-3.2/src/main/scala/org/neo4j/cypher/internal/compiled_runtime/v3_2/codegen/CodeGenerator.scala
@@ -58,6 +58,7 @@ class CodeGenerator(val structure: CodeStructure[GeneratedQuery], clock: Clock, 
 
         val fp = planContext.statistics match {
           case igs: InstrumentedGraphStatistics =>
+            PlanFingerprint.log(s"Creating new plan fingerprint for plan: $plan")
             Some(PlanFingerprint(clock.millis(), planContext.txIdProvider(), igs.snapshot.freeze))
           case _ =>
             None

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/db/CypherMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/db/CypherMetrics.java
@@ -37,6 +37,9 @@ public class CypherMetrics extends LifecycleAdapter
     @Documented( "The total number of times Cypher has decided to re-plan a query" )
     public static final String REPLAN_EVENTS = name( NAME_PREFIX, "replan_events" );
 
+    @Documented( "The total number of seconds waited between query replans" )
+    public static final String REPLAN_WAIT_TIME = name( NAME_PREFIX, "replan_wait_time" );
+
     private final MetricRegistry registry;
     private final Monitors monitors;
     private final PlanCacheMetricsMonitor cacheMonitor = new PlanCacheMetricsMonitor();
@@ -52,12 +55,14 @@ public class CypherMetrics extends LifecycleAdapter
     {
         monitors.addMonitorListener( cacheMonitor );
         registry.register( REPLAN_EVENTS, (Gauge<Long>) cacheMonitor::numberOfReplans );
+        registry.register( REPLAN_WAIT_TIME, (Gauge<Long>) cacheMonitor::replanWaitTime );
     }
 
     @Override
     public void stop()
     {
         registry.remove( REPLAN_EVENTS );
+        registry.remove( REPLAN_WAIT_TIME );
         monitors.removeMonitorListener( cacheMonitor );
     }
 }

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/MetricsKernelExtensionFactoryIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/MetricsKernelExtensionFactoryIT.java
@@ -172,7 +172,8 @@ public class MetricsKernelExtensionFactoryIT
             addNodes( 1 );
         }
 
-        File metricFile = metricsCsv( outputPath, CypherMetrics.REPLAN_EVENTS );
+        File replanCountMetricFile = metricsCsv( outputPath, CypherMetrics.REPLAN_EVENTS );
+        File replanWaitMetricFile = metricsCsv( outputPath, CypherMetrics.REPLAN_WAIT_TIME );
 
         // THEN see that the replan metric have pickup up at least one replan event
         // since reporting happens in an async fashion then give it some time and check now and then
@@ -180,7 +181,8 @@ public class MetricsKernelExtensionFactoryIT
         long events = 0;
         while ( currentTimeMillis() < endTime && events == 0 )
         {
-            events = readLongValueAndAssert( metricFile, ( newValue, currentValue ) -> newValue >= currentValue );
+            readLongValueAndAssert( replanWaitMetricFile, ( newValue, currentValue ) -> newValue >= currentValue );
+            events = readLongValueAndAssert( replanCountMetricFile, ( newValue, currentValue ) -> newValue >= currentValue );
             if ( events == 0 )
             {
                 Thread.sleep( 300 );


### PR DESCRIPTION
Current neo4j.conf defaults are optimized for new databases and initial import scenarios, designed to prevent too frequent query replanning. However, for larger databases, these setting will result in query planning never happening unless you edit indexes (create or drop), or manually run the new query plan cache clearing procedure (only available in 3.4). This is because the statistics threshold of 0.75 actually implies that the database needs to quadruple in size in order to replan.

We have seen this issue in particular on clusters where instances that join the cluster after initial import will plan once, and then never again, even if the database doubles or triples in size, dramatically changing the statistics, and quite possibly needing a replan.

This PR adds a decay function to the threshold, such that the older the plan is in the case, the smaller the statistics change required to trigger a replan. The new defaults are:

* `cypher.min_replan_interval=10s` (same as before, never check the stats more frequently than once every 10s)
* `cypher.statistics_divergence_threshold=0.75` (same as before, do not replan unless relevant graph statistics change by more than 75%, which for increasing database sizes means quadruple in size)
* `unsupported.cypher.statistics_divergence_target=0.1` (slowly reduce the threshold down to 10% so that queries ultimately get replanned even with small database changes)
* `unsupported.cypher.target_replan_interval=7h` (take 7h to reduce the threshold down to 10%)
* `unsupported.cypher.replan_algorithm=inverse` (use an inverse function to model threshold decay)

changelog: Fixes issue with medium and large databases that might change relatively slowly from never having their Cypher queries replanned. This has been achieved by having the database statistics divergence threshold set by `cypher.statistics_divergence_threshold` shrink over time, by default from 75% to 10% over 7 hours. The decay is modelled using an inverse function that tends toward zero over many days, and so ultimately all queries will get replanned if even small changes occur.
