### PR TITLE
Bump procedure compiler test utils

### DIFF
--- a/community/procedure-compiler/processor/pom.xml
+++ b/community/procedure-compiler/processor/pom.xml
@@ -97,8 +97,6 @@
         <dependency>
             <groupId>com.google.testing.compile</groupId>
             <artifactId>compile-testing</artifactId>
-            <version>0.10</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>

--- a/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/DuplicationAwareBaseProcessor.java
+++ b/community/procedure-compiler/processor/src/main/java/org/neo4j/tooling/procedure/DuplicationAwareBaseProcessor.java
@@ -111,7 +111,7 @@ public class DuplicationAwareBaseProcessor<T extends Annotation> extends Abstrac
     @Override
     public SourceVersion getSupportedSourceVersion()
     {
-        return SourceVersion.RELEASE_8;
+        return SourceVersion.latestSupported();
     }
 
     @Override

--- a/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_record_type/BadRecord.java
+++ b/community/procedure-compiler/processor/src/test/java/org/neo4j/tooling/procedure/procedures/invalid/bad_record_type/BadRecord.java
@@ -22,11 +22,11 @@ package org.neo4j.tooling.procedure.procedures.invalid.bad_record_type;
 public class BadRecord
 {
 
-    private static final int DEFAULT_AGE = 42;
+    private static final long DEFAULT_AGE = 42L;
     private final String label; /* nonstatic fields should be public */
-    private final int age;
+    private final long age;
 
-    public BadRecord( String label, int age )
+    public BadRecord( String label, long age )
     {
         this.label = label;
         this.age = age < 0 ? DEFAULT_AGE : age;

--- a/enterprise/procedure-compiler-enterprise-tests/pom.xml
+++ b/enterprise/procedure-compiler-enterprise-tests/pom.xml
@@ -57,8 +57,6 @@
         <dependency>
             <groupId>com.google.testing.compile</groupId>
             <artifactId>compile-testing</artifactId>
-            <version>0.9</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1157,6 +1157,12 @@
         <version>${findbugs.version}</version>
         <scope>provided</scope>
       </dependency>
+      <dependency>
+        <groupId>com.google.testing.compile</groupId>
+        <artifactId>compile-testing</artifactId>
+        <version>0.13</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>


### PR DESCRIPTION
- Bump version of compile-testing to be able to compile with java 9.
- In DuplicationAwareBaseProcessor change source version to be
     SourceVersion.latestSupported() instead of SourceVersion.RELEASE_8
- Update BadRecord age type to be long instead of int.
  Because of https://bugs.openjdk.java.net/browse/JDK-8066843 incorrect
  type of age field in BadRecord was not notices before.