### PR TITLE
Fix bugs in the DelegateFileSystemAbstraction

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/fs/DelegateFileSystemAbstraction.java
+++ b/community/io/src/main/java/org/neo4j/io/fs/DelegateFileSystemAbstraction.java
@@ -230,7 +230,7 @@ public class DelegateFileSystemAbstraction implements FileSystemAbstraction
     @Override
     public void copyToDirectory( File file, File toDirectory ) throws IOException
     {
-        Files.copy( path( file ), toDirectory.toPath().resolve( file.getName() ) );
+        Files.copy( path( file ), path( toDirectory ).resolve( file.getName() ), REPLACE_EXISTING );
     }
 
     @Override


### PR DESCRIPTION
* The `copyToDirectory` method was not getting the correct `Path` implementation for the target directory, if it was anything other than the default file system.
* And the `copyToDirectory` method was also not passing the `REPLACE_EXISTING` option to `Files.copy`, which is implied by the method on the `FileSystemAbstraction` API.