### PR TITLE
Support ScopeExpression in slotted runtime

### DIFF
--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Variable.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Variable.scala
@@ -18,7 +18,7 @@ package org.neo4j.cypher.internal.v3_4.expressions
 
 import org.neo4j.cypher.internal.util.v3_4.InputPosition
 
-case class Variable(name: String)(val position: InputPosition) extends Expression {
+class Variable(val name: String)(val position: InputPosition) extends Expression {
 
   def copyId: Variable = copy()(position)
 
@@ -27,6 +27,25 @@ case class Variable(name: String)(val position: InputPosition) extends Expressio
   def bumpId: Variable = copy()(position.bumped())
 
   override def asCanonicalStringVal: String = name
+
+  //--------------------------------------------------------------------------------------------------
+  // The methods below are what we would get automatically if this was a case class
+  //--------------------------------------------------------------------------------------------------
+  def copy(name: String = this.name)(position: InputPosition): Variable = new Variable(name)(position)
+
+  override def productElement(n: Int) =
+    if (n == 0) name
+    else throw new java.lang.IndexOutOfBoundsException(n.toString)
+
+  override def productArity = 1
+
+  override def canEqual(that: Any) = that.isInstanceOf[Variable]
+
+  override def toString: String = s"Variable($name)"
+
+  override def hashCode(): Int = runtime.ScalaRunTime._hashCode(Variable.this)
+
+  override def equals(obj: scala.Any): Boolean = runtime.ScalaRunTime._equals(Variable.this, obj)
 }
 
 object Variable {
@@ -34,4 +53,8 @@ object Variable {
     Ordering.by { (variable: Variable) =>
       (variable.name, variable.position)
     }(Ordering.Tuple2(implicitly[Ordering[String]], InputPosition.byOffset))
+
+  def apply(name: String)(position: InputPosition) = new Variable(name)(position)
+
+  def unapply(arg: Variable): Option[String] = Some(arg.name)
 }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ExecutionContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ExecutionContext.scala
@@ -50,6 +50,11 @@ trait ExecutionContext extends MutableMap[String, AnyValue] {
   def newWith3(key1: String, value1: AnyValue, key2: String, value2: AnyValue, key3: String, value3: AnyValue): ExecutionContext
   def mergeWith(other: ExecutionContext): ExecutionContext
   def createClone(): ExecutionContext
+
+  /**
+    * Like newWith1 but guarantees that we will never overwrite the value of an existing key
+    */
+  def newScopeWith1(key1: String, value1: AnyValue): ExecutionContext
 }
 
 case class MapExecutionContext(m: MutableMap[String, AnyValue])
@@ -101,6 +106,9 @@ case class MapExecutionContext(m: MutableMap[String, AnyValue])
     newMap.put(key1, value1)
     createWithNewMap(newMap)
   }
+
+  override def newScopeWith1(key1: String, value1: AnyValue): MapExecutionContext.this.type =
+    newWith1(key1, value1)
 
   override def newWith2(key1: String, value1: AnyValue, key2: String, value2: AnyValue): MapExecutionContext.this.type = {
     val newMap = m.clone()

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/InList.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/InList.scala
@@ -46,7 +46,9 @@ abstract class InList(collectionExpression: Expression, id: String, predicate: P
     else {
       val seq = makeTraversable(list)
 
-      seqMethod(seq)(item => predicate.isMatch(m.newWith1(id, item), state))
+      seqMethod(seq)(item =>
+        // Since we can override an existing id here we use a method that guarantees that we do not overwrite an existing variable
+        predicate.isMatch(m.newScopeWith1(id, item), state))
     }
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -75,10 +75,6 @@ Find a combination of a shortest path and a pattern expression
 //SkipLimitAcceptance.feature
 Using a optional match after aggregation and before an aggregation
 
-//VarLengthAcceptance.feature
-Handles checking properties on nodes in multistep path - using ALL() function on path node properties
-Handles checking properties on relationships in multistep path - using ALL() function on path relationship properties
-
 //MatchAcceptance.feature
 difficult to plan query number 3
 Variable length path with both sides already bound

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -30,9 +30,6 @@ Using a longer pattern
 Using bound nodes in mid-pattern
 Using bound nodes in mid-pattern when pattern partly matches
 Introduce named paths
-Returning an `extract()` expression
-Using an `extract()` expression in a WITH
-Using an `extract()` expression in a WHERE
 Returning a pattern expression with bound nodes
 Using a variable-length pattern expression in a WITH
 Pattern expression inside list comprehension
@@ -58,7 +55,6 @@ In-query call to procedure with argument of type NUMBER accepts value of type IN
 In-query call to procedure with argument of type NUMBER accepts value of type FLOAT
 In-query call to procedure with argument of type FLOAT accepts value of type INTEGER
 In-query call to procedure with null argument
-Filter should work
 Find a shortest path among paths that fulfill a predicate on all nodes
 Find a shortest path among paths that fulfill a predicate on all relationships
 Find a shortest path among paths that fulfill a predicate on all relationships 2

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionEngineTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionEngineTest.scala
@@ -382,7 +382,7 @@ order by a.COL1""".format(a, b))
   test("shouldAllowAllPredicateOnArrayProperty") {
     val a = createNode("array" -> Array(1, 2, 3, 4))
 
-    val result = executeWith(Configs.CommunityInterpreted, "match (a) where id(a) = 0 and any(x in a.array where x = 2) return a")
+    val result = executeWith(Configs.Interpreted, "match (a) where id(a) = 0 and any(x in a.array where x = 2) return a")
 
     result.toList should equal(List(Map("a" -> a)))
   }
@@ -390,7 +390,7 @@ order by a.COL1""".format(a, b))
   test("shouldAllowStringComparisonsInArray") {
     val a = createNode("array" -> Array("Cypher duck", "Gremlin orange", "I like the snow"))
 
-    val result = executeWith(Configs.CommunityInterpreted, "match (a) where id(a) = 0 and single(x in a.array where x =~ '.*the.*') return a")
+    val result = executeWith(Configs.Interpreted, "match (a) where id(a) = 0 and single(x in a.array where x =~ '.*the.*') return a")
 
     result.toList should equal(List(Map("a" -> a)))
   }
@@ -611,7 +611,7 @@ order by a.COL1""".format(a, b))
   test("extract string from node collection") {
     createNode("name"->"a")
 
-    val result = executeWith(Configs.CommunityInterpreted, """match (n) where id(n) = 0 with collect(n) as nodes return head(extract(x in nodes | x.name)) + "test" as test """)
+    val result = executeWith(Configs.Interpreted, """match (n) where id(n) = 0 with collect(n) as nodes return head(extract(x in nodes | x.name)) + "test" as test """)
 
     result.toList should equal(List(Map("test" -> "atest")))
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -263,7 +263,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
   test("length on filter") {
     val q = "match (n) optional match (n)-[r]->(m) return length(filter(x in collect(r) WHERE x <> null)) as cn"
 
-    executeWith(Configs.CommunityInterpreted, q)
+    executeWith(Configs.Interpreted, q)
       .toList should equal(List(Map("cn" -> 0)))
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ParameterValuesAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ParameterValuesAcceptanceTest.scala
@@ -41,7 +41,7 @@ class ParameterValuesAcceptanceTest extends ExecutionEngineFunSuite with CypherC
       """ WITH 1 AS node, [] AS nodes1
         | RETURN ANY(n IN collect(distinct node) WHERE n IN nodes1) as exists """.stripMargin
 
-    val r = executeWith(Configs.CommunityInterpreted - Configs.Version2_3, query)
+    val r = executeWith(Configs.Interpreted - Configs.Version2_3, query)
     r.next().apply("exists") should equal(false)
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
@@ -90,7 +90,7 @@ class PatternComprehensionAcceptanceTest extends ExecutionEngineFunSuite with Cy
         | ) > 0)
         | RETURN childD.id""".stripMargin
 
-    val result = executeWith(expectedToSucceedRestricted, query)
+    val result = executeWith(expectedToSucceedIncludingSlottedRestricted, query)
 
     result.toList should equal(
       List(
@@ -176,7 +176,7 @@ class PatternComprehensionAcceptanceTest extends ExecutionEngineFunSuite with Cy
 
     val query = "MATCH (n:Start) RETURN [p = (n)-->(b) WHERE head([p IN ['foo'] | true ]) | p] AS list"
 
-    val result = executeWith(expectedToSucceedRestricted, query)
+    val result = executeWith(expectedToSucceedIncludingSlottedRestricted, query)
 
     result.toList should equal(List(Map("list" -> List(PathImpl(n1, r, n2)))))
   }
@@ -188,7 +188,7 @@ class PatternComprehensionAcceptanceTest extends ExecutionEngineFunSuite with Cy
 
     val query = "MATCH (n:Start) RETURN [p = (n)-->() | {path: p, other: [p IN ['foo'] | true ]} ] AS list"
 
-    val result = executeWith(expectedToSucceed, query)
+    val result = executeWith(expectedToSucceedIncludingSlotted, query)
 
     result.toList should equal(List(Map("list" -> List(Map("path" -> PathImpl(n1, r, n2), "other" -> List(true))))))
   }
@@ -388,7 +388,7 @@ class PatternComprehensionAcceptanceTest extends ExecutionEngineFunSuite with Cy
   test("pattern comprehension in RETURN following a WITH") {
     val query = """MATCH (e:X) WITH e LIMIT 5 RETURN [(e) --> (t) | t { .amount }]"""
 
-    executeWith(expectedToSucceedRestricted, query).toList //does not throw
+    executeWith(expectedToSucceedIncludingSlottedRestricted, query).toList //does not throw
   }
 
   test("pattern comprehension play nice with map projections") {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternExpressionImplementationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternExpressionImplementationAcceptanceTest.scala
@@ -250,7 +250,7 @@ class PatternExpressionImplementationAcceptanceTest extends ExecutionEngineFunSu
     relate(start, createNode())
     relate(start, createNode())
 
-    val result = executeWith(Configs.CommunityInterpreted, "match (n) return extract(x IN (n)-->() | head(nodes(x)) )  as p")
+    val result = executeWith(Configs.Interpreted, "match (n) return extract(x IN (n)-->() | head(nodes(x)) )  as p")
 
     result.toList.head("p").asInstanceOf[Seq[_]] should equal(List(start, start))
   }
@@ -260,7 +260,7 @@ class PatternExpressionImplementationAcceptanceTest extends ExecutionEngineFunSu
     relate(start, createNode())
     relate(start, createNode())
 
-    val result = executeWith(Configs.CommunityInterpreted, "match (n:A) with extract(x IN (n)-->() | head(nodes(x)) ) as p, count(n) as c return p, c")
+    val result = executeWith(Configs.Interpreted, "match (n:A) with extract(x IN (n)-->() | head(nodes(x)) ) as p, count(n) as c return p, c")
       .toList.head("p").asInstanceOf[Seq[_]]
 
     result should equal(List(start, start))
@@ -271,7 +271,7 @@ class PatternExpressionImplementationAcceptanceTest extends ExecutionEngineFunSu
     relate(start, createNode())
     relate(start, createNode())
 
-    val result = executeWith(Configs.CommunityInterpreted, "match (n) where n IN extract(x IN (n)-->() | head(nodes(x)) ) return n")
+    val result = executeWith(Configs.Interpreted, "match (n) where n IN extract(x IN (n)-->() | head(nodes(x)) ) return n")
       .toList
 
     result should equal(List(

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/VarLengthPlanningTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/VarLengthPlanningTest.scala
@@ -37,7 +37,7 @@ class VarLengthPlanningTest extends ExecutionEngineFunSuite with QueryStatistics
     //Given
     makeTreeModel(maxNodeDepth = 4)
     //When
-    val result = executeWith(Configs.CommunityInterpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES*0]->()-[r:LIKES]->(c) RETURN c")
+    val result = executeWith(Configs.Interpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES*0]->()-[r:LIKES]->(c) RETURN c")
     //Then
     result should haveNoneRelFilter
   }
@@ -46,7 +46,7 @@ class VarLengthPlanningTest extends ExecutionEngineFunSuite with QueryStatistics
     //Given
     makeTreeModel(maxNodeDepth = 4)
     //When
-    val result = executeWith(Configs.CommunityInterpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()-[r:LIKES*0]->(c) RETURN c")
+    val result = executeWith(Configs.Interpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()-[r:LIKES*0]->(c) RETURN c")
     //Then
     result should haveNoneRelFilter
   }
@@ -55,7 +55,7 @@ class VarLengthPlanningTest extends ExecutionEngineFunSuite with QueryStatistics
     //Given
     makeTreeModel(maxNodeDepth = 4)
     //When
-    val result = executeWith(Configs.CommunityInterpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES*1]->()-[r:LIKES]->(c) RETURN c")
+    val result = executeWith(Configs.Interpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES*1]->()-[r:LIKES]->(c) RETURN c")
     //Then
     result should haveNoneRelFilter
   }
@@ -64,7 +64,7 @@ class VarLengthPlanningTest extends ExecutionEngineFunSuite with QueryStatistics
     //Given
     makeTreeModel(maxNodeDepth = 4)
     //When
-    val result = executeWith(Configs.CommunityInterpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()-[r:LIKES*1]->(c) RETURN c")
+    val result = executeWith(Configs.Interpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()-[r:LIKES*1]->(c) RETURN c")
     //Then
     result should haveNoneRelFilter
   }
@@ -73,7 +73,7 @@ class VarLengthPlanningTest extends ExecutionEngineFunSuite with QueryStatistics
     //Given
     makeTreeModel(maxNodeDepth = 4)
     //When
-    val result = executeWith(Configs.CommunityInterpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES*2]->()-[r:LIKES]->(c) RETURN c")
+    val result = executeWith(Configs.Interpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES*2]->()-[r:LIKES]->(c) RETURN c")
     //Then
     result should haveNoneRelFilter
   }
@@ -82,7 +82,7 @@ class VarLengthPlanningTest extends ExecutionEngineFunSuite with QueryStatistics
     //Given
     makeTreeModel(maxNodeDepth = 4)
     //When
-    val result = executeWith(Configs.CommunityInterpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()-[r:LIKES*2]->(c) RETURN c")
+    val result = executeWith(Configs.Interpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()-[r:LIKES*2]->(c) RETURN c")
     //Then
     result should haveNoneRelFilter
   }
@@ -91,7 +91,7 @@ class VarLengthPlanningTest extends ExecutionEngineFunSuite with QueryStatistics
     //Given
     makeTreeModel(maxNodeDepth = 5)
     //When
-    val result = executeWith(Configs.CommunityInterpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()-[r:LIKES*3]->(c) RETURN c")
+    val result = executeWith(Configs.Interpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()-[r:LIKES*3]->(c) RETURN c")
     //Then
     result should haveNoneRelFilter
   }
@@ -100,7 +100,7 @@ class VarLengthPlanningTest extends ExecutionEngineFunSuite with QueryStatistics
     //Given
     makeTreeModel(maxNodeDepth = 5, directions = Seq(INCOMING))
     //When
-    val result = executeWith(Configs.CommunityInterpreted, "MATCH (p { id:'n0' }) MATCH (p)<-[:LIKES]-()-[r:LIKES*3]->(c) RETURN c")
+    val result = executeWith(Configs.Interpreted, "MATCH (p { id:'n0' }) MATCH (p)<-[:LIKES]-()-[r:LIKES*3]->(c) RETURN c")
     //Then
     result should haveNoneRelFilter
   }
@@ -109,7 +109,7 @@ class VarLengthPlanningTest extends ExecutionEngineFunSuite with QueryStatistics
     //Given
     makeTreeModel(maxNodeDepth = 5, directions = Seq(OUTGOING, INCOMING, INCOMING, INCOMING))
     //When
-    val result = executeWith(Configs.CommunityInterpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()<-[r:LIKES*3]->(c) RETURN c")
+    val result = executeWith(Configs.Interpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()<-[r:LIKES*3]->(c) RETURN c")
     //Then
     result should haveNoneRelFilter
   }
@@ -118,7 +118,7 @@ class VarLengthPlanningTest extends ExecutionEngineFunSuite with QueryStatistics
     //Given
     makeTreeModel(maxNodeDepth = 5)
     //When
-    val result = executeWith(Configs.CommunityInterpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES*1]->()-[:LIKES]->()-[r:LIKES*2]->(c) RETURN c")
+    val result = executeWith(Configs.Interpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES*1]->()-[:LIKES]->()-[r:LIKES*2]->(c) RETURN c")
     //Then
     result should haveNoneRelFilter
   }
@@ -127,7 +127,7 @@ class VarLengthPlanningTest extends ExecutionEngineFunSuite with QueryStatistics
     //Given
     makeTreeModel(maxNodeDepth = 5)
     //When
-    val result = executeWith(Configs.CommunityInterpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()-[:LIKES*2]->()-[r:LIKES]->(c) RETURN c")
+    val result = executeWith(Configs.Interpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()-[:LIKES*2]->()-[r:LIKES]->(c) RETURN c")
     //Then
     result should haveNoneRelFilter
   }

--- a/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -35,9 +35,6 @@ Ignoring intermediate whitespace 1
 Ignoring intermediate whitespace 2
 Removing a label
 Removing a non-existent label
-Returning a list comprehension
-Using a list comprehension in a WITH
-Using a list comprehension in a WHERE
 Optionally matching named paths with single and variable length patterns
 Optionally matching named paths with variable length patterns
 Variable length relationship in OPTIONAL MATCH
@@ -103,16 +100,8 @@ Failing when performing property access on a non-map 2
 Bad arguments for `range()`
 Using `rand()` in aggregations
 `toBoolean()` on invalid types
-`toInteger()` handling mixed number types
-`toInteger()` handling Any type
-`toInteger()` on a list of strings
 `toInteger()` failing on invalid arguments
-`toFloat()` on mixed number types
-`toFloat()` handling Any type
-`toFloat()` on a list of strings
 `toFloat()` failing on invalid arguments
-`toString()` should work on Any type
-`toString()` on a list of integers
 `toString()` failing on invalid arguments
 Creating nodes from an unwound parameter list
 Unwind does not remove variables from scope

--- a/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -107,17 +107,6 @@ Creating nodes from an unwound parameter list
 Unwind does not remove variables from scope
 Fail when asterisk operator is missing
 Fail on negative bound
-Handling a variable length relationship and a standard relationship in chain, zero length 1
-Handling a variable length relationship and a standard relationship in chain, zero length 2
-Handling a variable length relationship and a standard relationship in chain, single length 1
-Handling a variable length relationship and a standard relationship in chain, single length 2
-Handling a variable length relationship and a standard relationship in chain, longer 1
-Handling a variable length relationship and a standard relationship in chain, longer 2
-Handling a variable length relationship and a standard relationship in chain, longer 3
-Handling mixed relationship patterns and directions 1
-Handling mixed relationship patterns and directions 2
-Handling mixed relationship patterns 1
-Handling mixed relationship patterns 2
 Handling relationships that are already bound in variable length paths
 A simple pattern with one bound endpoint
 Fail at compile time when attempting to index with a non-integer into a list

--- a/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -55,7 +55,6 @@ Matching and optionally matching with unbound nodes and equality predicate in re
 Fail when using property access on primitive type
 Counting an empty graph
 Variable length pattern checking labels on endnodes
-Named path with undirected fixed variable length pattern
 Variable length patterns and nulls
 Failing on merging relationship with null property
 Failing on merging node with null property

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/MorselExecutionContext.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/MorselExecutionContext.scala
@@ -64,4 +64,6 @@ class MorselExecutionContext(morsel: Morsel, longsPerRow: Int, refsPerRow: Int, 
   override def get(key: String): Option[AnyValue] = ???
 
   override def iterator: Iterator[(String, AnyValue)] = ???
+
+  override def newScopeWith1(key1: String, value1: AnyValue) = ???
 }

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/NodeFromSlot.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/NodeFromSlot.scala
@@ -19,6 +19,6 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.ast
 
-case class NodeFromSlot(offset: Int, name: String) extends RuntimeExpression {
+case class NodeFromSlot(offset: Int, override val name: String) extends RuntimeVariable(name) {
   override def asCanonicalStringVal: String = name
 }

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RelationshipFromSlot.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RelationshipFromSlot.scala
@@ -19,6 +19,6 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.ast
 
-case class RelationshipFromSlot(offset: Int, name: String) extends RuntimeExpression {
+case class RelationshipFromSlot(offset: Int, override val name: String) extends RuntimeVariable(name = name) {
   override def asCanonicalStringVal: String = name
 }

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeVariable.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeVariable.scala
@@ -19,4 +19,11 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.ast
 
-case class ReferenceFromSlot(offset: Int, override val name: String) extends RuntimeVariable(name = name)
+import org.neo4j.cypher.internal.frontend.v3_4.SemanticCheck
+import org.neo4j.cypher.internal.frontend.v3_4.semantics.{SemanticCheckResult, SemanticCheckableExpression}
+import org.neo4j.cypher.internal.util.v3_4.InputPosition
+import org.neo4j.cypher.internal.v3_4.expressions.{Variable, Expression => ASTExpression}
+
+class RuntimeVariable(name: String) extends Variable(name = name)(InputPosition.NONE) with SemanticCheckableExpression {
+  override def semanticCheck(ctx: ASTExpression.SemanticContext): SemanticCheck = SemanticCheckResult.success
+}

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriterTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriterTest.scala
@@ -355,7 +355,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
 
     // then
 
-    val pr1BafterRewrite = Projection(pr1A, Map("xx" -> ReferenceFromSlot(0)))(solved)
+    val pr1BafterRewrite = Projection(pr1A, Map("xx" -> ReferenceFromSlot(0, "xx")))(solved)
     val applyAfterRewrite = Apply(pr1BafterRewrite, pr2)(solved)
 
     resultPlan should equal(
@@ -463,8 +463,8 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val result = rewriter(produceResult, lookup)
 
     // then
-    val newPred1 = Equals(ReferenceFromSlot(offsetX), ReferenceFromSlot(offsetZ))(pos)
-    val newPred2 = Not(Equals(ReferenceFromSlot(offsetX), ReferenceFromSlot(offsetZ))(pos))(pos)
+    val newPred1 = Equals(ReferenceFromSlot(offsetX, "x"), ReferenceFromSlot(offsetZ, "z"))(pos)
+    val newPred2 = Not(Equals(ReferenceFromSlot(offsetX, "x"), ReferenceFromSlot(offsetZ, "z"))(pos))(pos)
     result should equal(ProduceResult(Selection(Seq(newPred1, newPred2), arg)(solved), Seq("x", "z")))
     lookup(result.assignedId) should equal(slots)
   }

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriterTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriterTest.scala
@@ -355,7 +355,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
 
     // then
 
-    val pr1BafterRewrite = Projection(pr1A, Map("xx" -> ReferenceFromSlot(0, "xx")))(solved)
+    val pr1BafterRewrite = Projection(pr1A, Map("xx" -> ReferenceFromSlot(0, "x")))(solved)
     val applyAfterRewrite = Apply(pr1BafterRewrite, pr2)(solved)
 
     resultPlan should equal(

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/PrimitiveExecutionContext.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/PrimitiveExecutionContext.scala
@@ -118,6 +118,15 @@ case class PrimitiveExecutionContext(slots: SlotConfiguration) extends Execution
     this
   }
 
+  // This method is used instead of newWith1 from a ScopeExpression where the key in the new scope is overriding an existing key
+  // and it has to have the same name due to syntactic constraints. In this case we actually make a copy in order to not corrupt the existing slot.
+  override def newScopeWith1(key1: String, value1: AnyValue): ExecutionContext = {
+    val scopeContext = PrimitiveExecutionContext(slots)
+    copyTo(scopeContext)
+    scopeContext.asInstanceOf[PrimitiveExecutionContext].setValue(key1, value1)
+    scopeContext
+  }
+
   override def newWith2(key1: String, value1: AnyValue, key2: String, value2: AnyValue): ExecutionContext = fail()
 
   override def newWith3(key1: String, value1: AnyValue, key2: String, value2: AnyValue, key3: String, value3: AnyValue): ExecutionContext = fail()

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/expressions/SlottedExpressionConverters.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/expressions/SlottedExpressionConverters.scala
@@ -34,7 +34,7 @@ object SlottedExpressionConverters extends ExpressionConverter {
         Some(runtimeExpression.NodeFromSlot(offset))
       case runtimeAst.RelationshipFromSlot(offset, _) =>
         Some(runtimeExpression.RelationshipFromSlot(offset))
-      case runtimeAst.ReferenceFromSlot(offset) =>
+      case runtimeAst.ReferenceFromSlot(offset, _) =>
         Some(runtimeExpression.ReferenceFromSlot(offset))
       case runtimeAst.NodeProperty(offset, token, _) =>
         Some(runtimeExpression.NodeProperty(offset, token))


### PR DESCRIPTION
Fixes `PrimitiveExecutionContext` to work with `ScopeExpression`.

Since we already allocated a slot for the variable in a `ScopeExpression`
we implement `newWith1` on `PrimitiveExcecutionContext` to just set the
value in the existing slot instead of creating a new context like in
the `MapExecutionContext`.

For the SlottedRewriter to be able to rewrite variables in expressions
where they are declared as Variable, the corresponding runtime
variable expressions (e.g. NodeFromSlot) needs to extend Variable.
To do this we change Variable from a case class to a class, and
implement the methods that case class gave us to allow us to still
treat it as a case class (when matching, rewriting etc.).
