### PR TITLE
Only open an InputStream in LoadCSV when needed

### DIFF
--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/CSVResources.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/spi/CSVResources.scala
@@ -59,11 +59,11 @@ object CSVResources {
 class CSVResources(cleaner: TaskCloser) extends ExternalCSVResource {
 
   def getCsvIterator(url: URL, fieldTerminator: Option[String], legacyCsvQuoteEscaping: Boolean): Iterator[Array[String]] = {
-    val inputStream = openStream(url)
 
     val reader = if (url.getProtocol == "file") {
       Readables.files(StandardCharsets.UTF_8, Paths.get(url.toURI).toFile)
     } else {
+      val inputStream = openStream(url)
       Readables.wrap(inputStream, url.toString, StandardCharsets.UTF_8)
     }
     val delimiter: Char = fieldTerminator.map(_.charAt(0)).getOrElse(CSVResources.DEFAULT_FIELD_TERMINATOR)


### PR DESCRIPTION
When using "file://" URIs, the input file was left open by mistake.