### PR TITLE
Online backup transaction logs location

### DIFF
--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommandConfigLoader.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommandConfigLoader.java
@@ -19,11 +19,13 @@
  */
 package org.neo4j.backup;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
 
 import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.configuration.Config;
 
@@ -38,9 +40,10 @@ class OnlineBackupCommandConfigLoader
         this.configDir = configDir;
     }
 
-    Config loadConfig( Optional<Path> additionalConfig ) throws CommandFailed
+    Config loadConfig( Optional<Path> additionalConfig, File folder ) throws CommandFailed
     {
         Config config = Config.fromFile( configDir.resolve( Config.DEFAULT_CONFIG_FILE_NAME ) ).withHome( homeDir )
+                .withSetting( GraphDatabaseSettings.logical_logs_location, folder.getAbsolutePath() )
                 .withConnectorsDisabled().build();
         return withAdditionalConfig( additionalConfig, config );
     }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupContext.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupContext.java
@@ -54,6 +54,6 @@ public class OnlineBackupContext
 
     public File getResolvedLocationFromName()
     {
-        return requiredArguments.getFolder().resolve( requiredArguments.getName() ).toFile();
+        return requiredArguments.getResolvedLocationFromName();
     }
 }

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupContextLoader.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupContextLoader.java
@@ -32,7 +32,7 @@ public class OnlineBackupContextLoader
     private final BackupCommandArgumentHandler backupCommandArgumentHandler;
     private final OnlineBackupCommandConfigLoader onlineBackupCommandConfigLoader;
 
-    public OnlineBackupContextLoader( BackupCommandArgumentHandler backupCommandArgumentHandler,
+    OnlineBackupContextLoader( BackupCommandArgumentHandler backupCommandArgumentHandler,
             OnlineBackupCommandConfigLoader onlineBackupCommandConfigLoader )
     {
         this.backupCommandArgumentHandler = backupCommandArgumentHandler;
@@ -49,7 +49,8 @@ public class OnlineBackupContextLoader
         try
         {
             OnlineBackupRequiredArguments requiredArguments = backupCommandArgumentHandler.establishRequiredArguments( commandlineArgs );
-            Config config = onlineBackupCommandConfigLoader.loadConfig( requiredArguments.getAdditionalConfig() );
+            Config config = onlineBackupCommandConfigLoader.loadConfig( requiredArguments.getAdditionalConfig(),
+                    requiredArguments.getResolvedLocationFromName() );
             ConsistencyFlags consistencyFlags = backupCommandArgumentHandler.readFlagsFromArgumentsOrDefaultToConfig( config );
 
             return new OnlineBackupContext( requiredArguments, config, consistencyFlags );

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupRequiredArguments.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupRequiredArguments.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.backup;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -86,5 +87,10 @@ public class OnlineBackupRequiredArguments
     public Path getReportDir()
     {
         return reportDir;
+    }
+
+    public File getResolvedLocationFromName()
+    {
+        return folder.resolve( name ).toFile();
     }
 }

--- a/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandConfigLoaderTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandConfigLoaderTest.java
@@ -85,7 +85,7 @@ public class OnlineBackupCommandConfigLoaderTest
 
         // expect
         assertFalse( additionalConf.exists() );
-        subject.loadConfig( Optional.of( additionalConf.toPath() ) );
+        subject.loadConfig( Optional.of( additionalConf.toPath() ), new File( "destination" ) );
     }
 
     @Test
@@ -101,7 +101,7 @@ public class OnlineBackupCommandConfigLoaderTest
         appendToFile( homeDirConfigFile, "causal_clustering.raft_in_queue_max_batch=21" );
 
         // when
-        Config config  = subject.loadConfig( Optional.empty() );
+        Config config  = subject.loadConfig( Optional.empty(), new File( "destination" ) );
 
         // then
         assertEquals( Integer.valueOf( 4 ), config.get( CausalClusteringSettings.expected_core_cluster_size ) );
@@ -121,7 +121,8 @@ public class OnlineBackupCommandConfigLoaderTest
         appendToFile( additionalConfigFile, "causal_clustering.expected_core_cluster_size=5" );
 
         // when
-        Config config = subject.loadConfig( Optional.of( additionalConfigFile.toPath() ) );
+        Config config = subject.loadConfig( Optional.of( additionalConfigFile.toPath() ),
+                new File( "destination" ) );
 
         // then
         assertEquals( Integer.valueOf( 5 ), config.get( CausalClusteringSettings.expected_core_cluster_size ) );


### PR DESCRIPTION
Put transaction logs into the same folder as backup directory always.
Previously online backup tried to put them into a folder that was related to
neo4j_home that can be either empty either incorrect for backup case.