### PR TITLE
Acceptance tests for calling public APIs from procedures

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/java/org/neo4j/internal/cypher/acceptance/TestProcedure.java
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/java/org/neo4j/internal/cypher/acceptance/TestProcedure.java
@@ -19,7 +19,9 @@
  */
 package org.neo4j.internal.cypher.acceptance;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
@@ -28,7 +30,10 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.traversal.Evaluation;
 import org.neo4j.graphdb.traversal.Evaluator;
 import org.neo4j.graphdb.traversal.Evaluators;
@@ -42,11 +47,78 @@ import org.neo4j.procedure.Procedure;
 import static org.neo4j.graphdb.traversal.Evaluation.EXCLUDE_AND_CONTINUE;
 import static org.neo4j.graphdb.traversal.Evaluation.EXCLUDE_AND_PRUNE;
 import static org.neo4j.graphdb.traversal.Evaluation.INCLUDE_AND_CONTINUE;
+import static org.neo4j.procedure.Mode.WRITE;
 
 public class TestProcedure
 {
     @Context
     public GraphDatabaseService db;
+
+    @Procedure( "org.neo4j.aNodeWithLabel" )
+    @Description( "org.neo4j.aNodeWithLabel" )
+    public Stream<NodeResult> aNodeWithLabel( @Name( "label" ) String label ) throws Exception
+    {
+        Result result = db.execute( "MATCH (n:" + label + ") RETURN n LIMIT 1" );
+        return result.stream().map( row -> new NodeResult( (Node)row.get( "n" ) ) );
+    }
+
+    @Procedure( "org.neo4j.recurseN" )
+    @Description( "org.neo4j.recurseN" )
+    public Stream<NodeResult> recurseN( @Name( "n" ) Long n ) throws Exception
+    {
+        Result result;
+        if ( n == 0 )
+        {
+            result = db.execute( "MATCH (n) RETURN n LIMIT 1" );
+        }
+        else
+        {
+            result = db.execute( "UNWIND [1] AS i CALL org.neo4j.recurseN(" + ( n - 1 ) + ") YIELD node RETURN node" );
+        }
+        return result.stream().map( row -> new NodeResult( (Node)row.get( "node" ) ) );
+    }
+
+    @Procedure( "org.neo4j.findNodesWithLabel" )
+    @Description( "org.neo4j.findNodesWithLabel" )
+    public Stream<NodeResult> findNodesWithLabel( @Name( "label" ) String label ) throws Exception
+    {
+        ResourceIterator<Node> nodes = db.findNodes( Label.label( label ) );
+        return nodes.stream().map( NodeResult::new );
+    }
+
+    @Procedure( "org.neo4j.expandNode" )
+    @Description( "org.neo4j.expandNode" )
+    public Stream<NodeResult> expandNode( @Name( "nodeId" ) Long nodeId ) throws Exception
+    {
+        Node node = db.getNodeById( nodeId );
+        List<Node> result = new ArrayList<>();
+        for ( Relationship r : node.getRelationships() )
+        {
+            result.add( r.getOtherNode( node ) );
+        }
+
+        return result.stream().map( NodeResult::new );
+    }
+
+    @Procedure( name = "org.neo4j.createNodeWithLoop", mode = WRITE )
+    @Description( "org.neo4j.createNodeWithLoop" )
+    public Stream<NodeResult> createNodeWithLoop(
+            @Name( "nodeLabel" ) String label, @Name( "relType" ) String relType ) throws Exception
+    {
+        Node node = db.createNode( Label.label( label ) );
+        node.createRelationshipTo( node, RelationshipType.withName( relType ) );
+        return Stream.of( new NodeResult( node ) );
+    }
+
+    public static class NodeResult
+    {
+        public Node node;
+
+        NodeResult( Node node )
+        {
+            this.node = node;
+        }
+    }
 
     @Procedure( "org.neo4j.movieTraversal" )
     @Description( "org.neo4j.movieTraversal" )

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProceduresAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProceduresAcceptanceTest.scala
@@ -95,6 +95,37 @@ class ProceduresAcceptanceTest extends ExecutionEngineFunSuite {
       })
   }
 
+  test("should find shortest path using Graph Algos Djikstra") {
+    registerTestProcedures()
+
+    graph.execute(
+      """
+        |CREATE (s:Start)
+        |CREATE (e:End)
+        |CREATE (n1)
+        |CREATE (n2)
+        |CREATE (n3)
+        |CREATE (n4)
+        |CREATE (n5)
+        |CREATE (s)-[:Rel {weight:5}]->(n1)
+        |CREATE (s)-[:Rel {weight:7}]->(n2)
+        |CREATE (s)-[:Rel {weight:1}]->(n3)
+        |CREATE (n1)-[:Rel {weight:2}]->(n2)
+        |CREATE (n1)-[:Rel {weight:6}]->(n4)
+        |CREATE (n3)-[:Rel {weight:1}]->(n4)
+        |CREATE (n4)-[:Rel {weight:1}]->(n5)
+        |CREATE (n5)-[:Rel {weight:1}]->(e)
+        |CREATE (n2)-[:Rel {weight:2}]->(e)
+        |""".stripMargin)
+
+    testResult(graph.getGraphDatabaseService,
+      "MATCH (s:Start),(e:End) CALL org.neo4j.graphAlgosDjikstra( s, e, 'Rel', 'weight' ) YIELD node RETURN node",
+      result => {
+        val maps = Iterators.asList(result)
+        assertEquals(5, maps.size) // s -> n3 -> n4 -> n5 -> e
+      })
+  }
+
   test("should use traversal API") {
     registerTestProcedures()
 


### PR DESCRIPTION
In the 3.3 cycle we almost broke usage of the Traversal API from inside of procedures. As the cypher team owns procedures, we should add some tests which emulate some likely procedure uses that we support. With this PR we have testing for procedures doing

 * Executing `Cypher`
 * Recursively calling same procedure through `Cypher`
 * Label scan over `Core API`
 * Expand over `Core API`
 * Create Node and Relationship over `Core API`
 * Find shortest path using `GraphAlgos` djikstra implementation
 * (since before) Traverse using `Traversal API`