### PR TITLE
Fully read and write buffers from/into channels

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexConfigStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/IndexConfigStore.java
@@ -295,7 +295,7 @@ public class IndexConfigStore extends LifecycleAdapter
         try
         {
             channel = fileSystem.open( file, "rw" );
-            channel.write( ByteBuffer.wrap( MAGICK ) );
+            channel.writeAll( ByteBuffer.wrap( MAGICK ) );
             IoPrimitiveUtils.writeInt( channel, buffer( 4 ), VERSION );
             writeMap( channel, nodeConfig );
             writeMap( channel, relConfig );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/CountsMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/CountsMigrator.java
@@ -163,6 +163,7 @@ public class CountsMigrator extends AbstractStoreMigrationParticipant
                 .openNeoStores( StoreType.NODE, StoreType.RELATIONSHIP, StoreType.LABEL_TOKEN,
                         StoreType.RELATIONSHIP_TYPE_TOKEN ) )
         {
+            neoStores.verifyStoreOk();
             NodeStore nodeStore = neoStores.getNodeStore();
             RelationshipStore relationshipStore = neoStores.getRelationshipStore();
             try ( Lifespan life = new Lifespan() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigrator.java
@@ -73,6 +73,7 @@ public class NativeLabelScanStoreMigrator extends AbstractStoreMigrationParticip
             try ( NeoStores neoStores = storeFactory.openAllNeoStores();
                     Lifespan lifespan = new Lifespan() )
             {
+                neoStores.verifyStoreOk();
                 // Remove any existing file to ensure we always do migration
                 deleteNativeIndexFile( migrationDir );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogHeaderWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/entry/LogHeaderWriter.java
@@ -66,7 +66,7 @@ public class LogHeaderWriter
     {
         ByteBuffer buffer = ByteBuffer.allocate( LOG_HEADER_SIZE );
         writeLogHeader( buffer, logVersion, previousLastCommittedTxId );
-        channel.write( buffer );
+        channel.writeAll( buffer );
     }
 
     public static long encodeLogVersion( long logVersion )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/IdContainerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/id/IdContainerTest.java
@@ -19,13 +19,17 @@
  */
 package org.neo4j.kernel.impl.store.id;
 
-import java.io.File;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.fs.StoreFileChannel;
 import org.neo4j.kernel.impl.store.InvalidIdGeneratorException;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
@@ -171,8 +175,61 @@ public class IdContainerTest
         assertTrue( idContainer.init() );
     }
 
+    @Test
+    public void idContainerReadWriteBySingleByte() throws IOException
+    {
+        SingleByteFileSystemAbstraction fileSystem = new SingleByteFileSystemAbstraction();
+        IdContainer idContainer = new IdContainer( fileSystem, file, 100, false );
+        idContainer.init();
+        idContainer.close( 100 );
+
+        idContainer = new IdContainer( fileSystem, file, 100, false );
+        idContainer.init();
+        assertEquals( 100, idContainer.getInitialHighId() );
+        fileSystem.close();
+    }
+
     private void createEmptyFile()
     {
         IdContainer.createEmptyIdFile( fs, file, 42, false );
+    }
+
+    private static class SingleByteFileSystemAbstraction extends DefaultFileSystemAbstraction
+    {
+        @Override
+        public StoreFileChannel open( File fileName, String mode ) throws IOException
+        {
+            return new SingleByteBufferChannel( super.open( fileName, mode ) );
+        }
+    }
+
+    private static class SingleByteBufferChannel extends StoreFileChannel
+    {
+
+        SingleByteBufferChannel( StoreFileChannel channel )
+        {
+            super( channel );
+        }
+
+        @Override
+        public int write( ByteBuffer src ) throws IOException
+        {
+            byte b = src.get();
+            ByteBuffer byteBuffer = ByteBuffer.wrap( new byte[]{b} );
+            return super.write( byteBuffer );
+        }
+
+        @Override
+        public int read( ByteBuffer dst ) throws IOException
+        {
+            ByteBuffer byteBuffer = ByteBuffer.allocate( 1 );
+            int read = super.read( byteBuffer );
+            if ( read > 0 )
+            {
+                byteBuffer.flip();
+                dst.put( byteBuffer.get() );
+            }
+            return read;
+        }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigratorTest.java
@@ -43,7 +43,9 @@ import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.scan.FullStoreChangeStream;
 import org.neo4j.kernel.impl.index.labelscan.NativeLabelScanStore;
+import org.neo4j.kernel.impl.store.InvalidIdGeneratorException;
 import org.neo4j.kernel.impl.store.MetaDataStore;
+import org.neo4j.kernel.impl.store.StoreFile;
 import org.neo4j.kernel.impl.store.format.standard.StandardV2_3;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_2;
 import org.neo4j.kernel.impl.storemigration.monitoring.MigrationProgressMonitor;
@@ -100,7 +102,7 @@ public class NativeLabelScanStoreMigratorTest
     @Test
     public void skipMigrationIfNativeIndexExist() throws Exception
     {
-        ByteBuffer sourceBuffer = writeNativeIndexFile( nativeLabelIndex, new byte[]{1, 2, 3} );
+        ByteBuffer sourceBuffer = writeFile( nativeLabelIndex, new byte[]{1, 2, 3} );
 
         indexMigrator.migrate( storeDir, migrationDir, progressMonitor, StandardV3_2.STORE_VERSION, StandardV3_2.STORE_VERSION );
         indexMigrator.moveMigratedFiles( migrationDir, storeDir, StandardV3_2.STORE_VERSION, StandardV3_2.STORE_VERSION );
@@ -108,6 +110,16 @@ public class NativeLabelScanStoreMigratorTest
         ByteBuffer resultBuffer = readFileContent( nativeLabelIndex, 3 );
         assertEquals( sourceBuffer, resultBuffer );
         assertTrue( fileSystem.fileExists( luceneLabelScanStore ) );
+    }
+
+    @Test( expected = InvalidIdGeneratorException.class )
+    public void failMigrationWhenNodeIdFileIsBroken() throws Exception
+    {
+        prepareEmpty23Database();
+        File nodeIdFile = new File( storeDir, StoreFile.NODE_STORE.storeFileName() + ".id" );
+        writeFile( nodeIdFile, new byte[]{1, 2, 3} );
+
+        indexMigrator.migrate( storeDir, migrationDir, progressMonitor, StandardV3_2.STORE_VERSION, StandardV3_2.STORE_VERSION );
     }
 
     @Test
@@ -143,7 +155,7 @@ public class NativeLabelScanStoreMigratorTest
         prepareEmpty23Database();
         indexMigrator.migrate( storeDir, migrationDir, progressMonitor, StandardV2_3.STORE_VERSION, StandardV3_2.STORE_VERSION );
         File migrationNativeIndex = new File( migrationDir, NativeLabelScanStore.FILE_NAME );
-        ByteBuffer migratedFileContent = writeNativeIndexFile( migrationNativeIndex, new byte[]{5, 4, 3, 2, 1} );
+        ByteBuffer migratedFileContent = writeFile( migrationNativeIndex, new byte[]{5, 4, 3, 2, 1} );
 
         indexMigrator.moveMigratedFiles( migrationDir, storeDir, StandardV2_3.STORE_VERSION, StandardV3_2.STORE_VERSION );
 
@@ -219,7 +231,7 @@ public class NativeLabelScanStoreMigratorTest
         }
     }
 
-    private ByteBuffer writeNativeIndexFile( File file, byte[] content ) throws IOException
+    private ByteBuffer writeFile( File file, byte[] content ) throws IOException
     {
         ByteBuffer sourceBuffer = ByteBuffer.wrap( content );
         storeFileContent( file, sourceBuffer );
@@ -271,9 +283,9 @@ public class NativeLabelScanStoreMigratorTest
         }
     }
 
-    private void storeFileContent( File nativeLabelIndex, ByteBuffer sourceBuffer ) throws IOException
+    private void storeFileContent( File file, ByteBuffer sourceBuffer ) throws IOException
     {
-        try ( StoreChannel storeChannel = fileSystem.create( nativeLabelIndex ) )
+        try ( StoreChannel storeChannel = fileSystem.create( file ) )
         {
             storeChannel.write( sourceBuffer );
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigratorTest.java
@@ -287,7 +287,7 @@ public class NativeLabelScanStoreMigratorTest
     {
         try ( StoreChannel storeChannel = fileSystem.create( file ) )
         {
-            storeChannel.write( sourceBuffer );
+            storeChannel.writeAll( sourceBuffer );
         }
     }
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/FailureStorage.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/storage/FailureStorage.java
@@ -70,7 +70,7 @@ public class FailureStorage
         File failureFile = failureFile();
         try ( StoreChannel channel = fs.create( failureFile ) )
         {
-            channel.write( ByteBuffer.wrap( new byte[MAX_FAILURE_SIZE] ) );
+            channel.writeAll( ByteBuffer.wrap( new byte[MAX_FAILURE_SIZE] ) );
             channel.force( true );
         }
     }
@@ -120,7 +120,7 @@ public class FailureStorage
             channel.position( lengthOf( existingData ) );
 
             byte[] data = UTF8.encode( failure );
-            channel.write( ByteBuffer.wrap( data, 0, Math.min( data.length, MAX_FAILURE_SIZE ) ) );
+            channel.writeAll( ByteBuffer.wrap( data, 0, Math.min( data.length, MAX_FAILURE_SIZE ) ) );
 
             channel.force( true );
             channel.close();


### PR DESCRIPTION
Update places where ByteBuffers were not fully written or read.
Most affected from change set was IdContainer that had both problems
and any of those can potentially cause id file corruption (real or "heisen")

Add additional checks into NativeLabelScanStoreMigrator and CountsMigrator
that will check that stores are in "store ok" state before performing
migration.