### PR TITLE
Core state downloader will now retry indefinitely

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportSelectionHandler.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportSelectionHandler.java
@@ -26,6 +26,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.websocketx.WebSocketFrameAggregator;
 import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
@@ -42,6 +43,7 @@ public class TransportSelectionHandler extends ByteToMessageDecoder
 {
     private static final String WEBSOCKET_MAGIC = "GET ";
     private static final int MAX_WEBSOCKET_HANDSHAKE_SIZE = 65536;
+    private static final int MAX_WEBSOCKET_FRAME_SIZE = 65536;
 
     private final SslContext sslCtx;
     private final boolean encryptionRequired;
@@ -132,7 +134,8 @@ public class TransportSelectionHandler extends ByteToMessageDecoder
         p.addLast(
                 new HttpServerCodec(),
                 new HttpObjectAggregator( MAX_WEBSOCKET_HANDSHAKE_SIZE ),
-                new WebSocketServerProtocolHandler( "/" ),
+                new WebSocketServerProtocolHandler( "/", null, false, MAX_WEBSOCKET_FRAME_SIZE ),
+                new WebSocketFrameAggregator( MAX_WEBSOCKET_FRAME_SIZE ),
                 new WebSocketFrameTranslator(),
                 new SocketTransportHandler(
                         new ProtocolChooser( protocolVersions, encryptionRequired, isEncrypted ), logging ) );

--- a/community/common/src/main/java/org/neo4j/function/UncaughtCheckedException.java
+++ b/community/common/src/main/java/org/neo4j/function/UncaughtCheckedException.java
@@ -22,7 +22,7 @@ package org.neo4j.function;
 import java.util.Optional;
 
 /**
- * Wrapper around checked exceptions for rethrowing them as runtime exceotions when the signature of the containing method
+ * Wrapper around checked exceptions for rethrowing them as runtime exceptions when the signature of the containing method
  * cannot be changed to declare them.
  *
  * Thrown by {@link ThrowingFunction#catchThrown(Class, ThrowingFunction)}
@@ -42,7 +42,7 @@ public class UncaughtCheckedException extends RuntimeException
     }
 
     /**
-     * Check the that the cause has the given type and if succesful, return it.
+     * Check that the cause has the given type and if successful, return it.
      *
      * @param clazz class object for the desired type of the cause
      * @param <E> the desired type of the cause

--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathRelationshipUniquenessAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathRelationshipUniquenessAcceptanceTest.scala
@@ -81,7 +81,6 @@ class ShortestPathRelationshipUniquenessAcceptanceTest extends ExecutionEngineFu
     WHERE a.id="2228" AND b.id="2638" AND ANY ( n IN nodes(p)[1..-1] WHERE (n.id = "32") )
     RETURN nodes(p) as nodes"""
         .stripMargin
-    println(query)
     val result = executeUsingCostPlannerOnly(query).columnAs("nodes").toList
     result should be(List(List(p0, pLongPath0, pLongPath1, pLongPath2, pLongPath3, pLongPath4, pLongPath5, p3, p2, p4, p5)))
   }

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyLoader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyLoader.java
@@ -346,8 +346,15 @@ public class SslPolicyLoader
             {
                 while ( input.available() > 0 )
                 {
-                    X509Certificate cert = (X509Certificate) certificateFactory.generateCertificate( input );
-                    trustStore.setCertificateEntry( Integer.toString( i++ ), cert );
+                    try
+                    {
+                        X509Certificate cert = (X509Certificate) certificateFactory.generateCertificate( input );
+                        trustStore.setCertificateEntry( Integer.toString( i++ ), cert );
+                    }
+                    catch ( Exception e )
+                    {
+                        throw new CertificateException( "Error loading certificate file: " + trustedCertFile, e );
+                    }
                 }
             }
         }

--- a/community/server/pom.xml
+++ b/community/server/pom.xml
@@ -46,7 +46,7 @@
     <docs-plugin.filter>true</docs-plugin.filter>
 
     <neo4j.version>${project.version}</neo4j.version>
-    <neo4j-browser.version>3.1.2</neo4j-browser.version>
+    <neo4j-browser.version>3.1.4</neo4j-browser.version>
 
     <neo4j-server.mainClass>org.neo4j.server.CommunityEntryPoint</neo4j-server.mainClass>
     <neo-server.home>target/generated-resources/appassembler/jsw</neo-server.home>

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/CausalClusteringSettings.java
@@ -73,6 +73,10 @@ public class CausalClusteringSettings implements LoadableConfig
     public static final Setting<Boolean> refuse_to_be_leader =
             setting( "causal_clustering.refuse_to_be_leader", BOOLEAN, FALSE );
 
+    @Description( "Enable pre-voting extension to the Raft protocol (this is breaking and must match between the core cluster members)" )
+    public static final Setting<Boolean> enable_pre_voting =
+            setting( "causal_clustering.enable_pre_voting", BOOLEAN, FALSE );
+
     @Description( "The maximum batch size when catching up (in unit of entries)" )
     public static final Setting<Integer> catchup_batch_size =
             setting( "causal_clustering.catchup_batch_size", INTEGER, "64" );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/ConsensusModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/ConsensusModule.java
@@ -20,6 +20,7 @@
 package org.neo4j.causalclustering.core.consensus;
 
 import java.io.File;
+import java.time.Duration;
 
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.core.EnterpriseCoreEditionModule;
@@ -35,6 +36,7 @@ import org.neo4j.causalclustering.core.consensus.membership.MemberIdSetBuilder;
 import org.neo4j.causalclustering.core.consensus.membership.RaftMembershipManager;
 import org.neo4j.causalclustering.core.consensus.membership.RaftMembershipState;
 import org.neo4j.causalclustering.core.consensus.schedule.DelayedRenewableTimeoutService;
+import org.neo4j.causalclustering.core.consensus.schedule.RenewableTimeoutService;
 import org.neo4j.causalclustering.core.consensus.shipping.RaftLogShippingManager;
 import org.neo4j.causalclustering.core.consensus.term.MonitoredTermStateStorage;
 import org.neo4j.causalclustering.core.consensus.term.TermState;
@@ -75,6 +77,8 @@ public class ConsensusModule
     private final RaftMembershipManager raftMembershipManager;
     private final InFlightCache inFlightCache;
 
+    private final LeaderAvailabilityTimers leaderAvailabilityTimers;
+
     public ConsensusModule( MemberId myself, final PlatformModule platformModule,
             Outbound<MemberId,RaftMessages.RaftMessage> outbound, File clusterStateDirectory,
             CoreTopologyService coreTopologyService )
@@ -112,8 +116,9 @@ public class ConsensusModule
                         new RaftMembershipState.Marshal(),
                         config.get( CausalClusteringSettings.raft_membership_state_size ), logProvider ) );
 
-        long electionTimeout = config.get( CausalClusteringSettings.leader_election_timeout ).toMillis();
-        long heartbeatInterval = electionTimeout / 3;
+        raftTimeoutService = new DelayedRenewableTimeoutService( systemClock(), logProvider );
+
+        leaderAvailabilityTimers = createElectionTiming( config, raftTimeoutService, logProvider );
 
         Integer expectedClusterSize = config.get( CausalClusteringSettings.expected_core_cluster_size );
 
@@ -122,7 +127,7 @@ public class ConsensusModule
         SendToMyself leaderOnlyReplicator = new SendToMyself( myself, outbound );
 
         raftMembershipManager = new RaftMembershipManager( leaderOnlyReplicator, memberSetBuilder, raftLog, logProvider,
-                expectedClusterSize, electionTimeout, systemClock(), config.get( join_catch_up_timeout ).toMillis(),
+                expectedClusterSize, leaderAvailabilityTimers.getElectionTimeout(), systemClock(), config.get( join_catch_up_timeout ).toMillis(),
                 raftMembershipStorage );
 
         life.add( raftMembershipManager );
@@ -131,21 +136,25 @@ public class ConsensusModule
 
         RaftLogShippingManager logShipping =
                 new RaftLogShippingManager( outbound, logProvider, raftLog, systemClock(), myself,
-                        raftMembershipManager, electionTimeout, config.get( catchup_batch_size ),
+                        raftMembershipManager, leaderAvailabilityTimers.getElectionTimeout(), config.get( catchup_batch_size ),
                         config.get( log_shipping_max_lag ), inFlightCache );
-
-        raftTimeoutService = new DelayedRenewableTimeoutService( systemClock(), logProvider );
 
         boolean supportsPreVoting = config.get( CausalClusteringSettings.enable_pre_voting );
 
-        raftMachine = new RaftMachine( myself, termState, voteState, raftLog, electionTimeout, heartbeatInterval,
-                raftTimeoutService, outbound, logProvider, raftMembershipManager, logShipping, inFlightCache,
+        raftMachine = new RaftMachine( myself, termState, voteState, raftLog, leaderAvailabilityTimers,
+                outbound, logProvider, raftMembershipManager, logShipping, inFlightCache,
                 RefuseToBeLeaderStrategy.shouldRefuseToBeLeader( config, logProvider.getLog( getClass() ) ),
-               supportsPreVoting, platformModule.monitors, systemClock() );
+                supportsPreVoting, platformModule.monitors );
 
         life.add( new RaftCoreTopologyConnector( coreTopologyService, raftMachine ) );
 
         life.add( logShipping );
+    }
+
+    private LeaderAvailabilityTimers createElectionTiming( Config config, RenewableTimeoutService renewableTimeoutService, LogProvider logProvider )
+    {
+        Duration electionTimeout = config.get( CausalClusteringSettings.leader_election_timeout );
+        return new LeaderAvailabilityTimers( electionTimeout, electionTimeout.dividedBy( 3 ), systemClock(), renewableTimeoutService, logProvider );
     }
 
     private RaftLog createRaftLog( Config config, LifeSupport life, FileSystemAbstraction fileSystem,
@@ -202,5 +211,10 @@ public class ConsensusModule
     public InFlightCache inFlightCache()
     {
         return inFlightCache;
+    }
+
+    public LeaderAvailabilityTimers getLeaderAvailabilityTimers()
+    {
+        return leaderAvailabilityTimers;
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/ConsensusModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/ConsensusModule.java
@@ -136,9 +136,12 @@ public class ConsensusModule
 
         raftTimeoutService = new DelayedRenewableTimeoutService( systemClock(), logProvider );
 
+        boolean supportsPreVoting = config.get( CausalClusteringSettings.enable_pre_voting );
+
         raftMachine = new RaftMachine( myself, termState, voteState, raftLog, electionTimeout, heartbeatInterval,
                 raftTimeoutService, outbound, logProvider, raftMembershipManager, logShipping, inFlightCache,
-                RefuseToBeLeaderStrategy.shouldRefuseToBeLeader( config, logProvider.getLog( getClass() ) ), platformModule.monitors, systemClock() );
+                RefuseToBeLeaderStrategy.shouldRefuseToBeLeader( config, logProvider.getLog( getClass() ) ),
+               supportsPreVoting, platformModule.monitors, systemClock() );
 
         life.add( new RaftCoreTopologyConnector( coreTopologyService, raftMachine ) );
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderAvailabilityHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderAvailabilityHandler.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.consensus;
+
+import java.util.Objects;
+import java.util.function.LongSupplier;
+
+import org.neo4j.causalclustering.identity.ClusterId;
+import org.neo4j.causalclustering.messaging.Inbound;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+public class LeaderAvailabilityHandler implements Inbound.MessageHandler<RaftMessages.ClusterIdAwareMessage>
+{
+    private final Inbound.MessageHandler<RaftMessages.ClusterIdAwareMessage> delegateHandler;
+    private final LeaderAvailabilityTimers leaderAvailabilityTimers;
+    private final LongSupplier term;
+    private final Log log;
+    private volatile ClusterId boundClusterId;
+
+    public LeaderAvailabilityHandler( Inbound.MessageHandler<RaftMessages.ClusterIdAwareMessage> delegateHandler, LeaderAvailabilityTimers leaderAvailabilityTimers,
+            LongSupplier term, LogProvider logProvider )
+    {
+        this.delegateHandler = delegateHandler;
+        this.leaderAvailabilityTimers = leaderAvailabilityTimers;
+        this.term = term;
+        this.log = logProvider.getLog( getClass() );
+    }
+
+    public synchronized void start( ClusterId clusterId )
+    {
+        boundClusterId = clusterId;
+    }
+
+    public synchronized void stop()
+    {
+        boundClusterId = null;
+    }
+
+    @Override
+    public void handle( RaftMessages.ClusterIdAwareMessage message )
+    {
+        if ( Objects.isNull( boundClusterId ) )
+        {
+            log.debug( "This pre handler has been stopped, dropping the message: %s", message.message() );
+        }
+        else if ( !Objects.equals( message.clusterId(), boundClusterId ) )
+        {
+            log.info( "Discarding message[%s] owing to mismatched clusterId. Expected: %s, Encountered: %s",
+                    message.message(), boundClusterId, message.clusterId() );
+        }
+        else
+        {
+            handleTimeouts( message );
+
+            delegateHandler.handle( message );
+        }
+    }
+
+    private void handleTimeouts( RaftMessages.ClusterIdAwareMessage message )
+    {
+        if ( shouldRenewElectionTimeout( message.message() ) )
+        {
+            leaderAvailabilityTimers.renewElection();
+        }
+    }
+
+    // TODO replace with visitor pattern
+    private boolean shouldRenewElectionTimeout( RaftMessages.RaftMessage message )
+    {
+        switch ( message.type() )
+        {
+        case HEARTBEAT:
+            RaftMessages.Heartbeat heartbeat = (RaftMessages.Heartbeat) message;
+            return heartbeat.leaderTerm() >= term.getAsLong();
+        case APPEND_ENTRIES_REQUEST:
+            RaftMessages.AppendEntries.Request request = (RaftMessages.AppendEntries.Request) message;
+            return request.leaderTerm() >= term.getAsLong();
+        default:
+            return false;
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderAvailabilityTimers.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/LeaderAvailabilityTimers.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.consensus;
+
+import java.time.Clock;
+import java.time.Duration;
+
+import org.neo4j.causalclustering.core.consensus.schedule.RenewableTimeoutService;
+import org.neo4j.function.ThrowingAction;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+class LeaderAvailabilityTimers
+{
+    private final long electionTimeout;
+    private final long heartbeatInterval;
+    private final Clock clock;
+    private final RenewableTimeoutService renewableTimeoutService;
+    private final Log log;
+
+    private volatile long lastElectionRenewalMillis;
+
+    private RenewableTimeoutService.RenewableTimeout heartbeatTimer;
+    private RenewableTimeoutService.RenewableTimeout electionTimer;
+
+    LeaderAvailabilityTimers( Duration electionTimeout, Duration heartbeatInterval, Clock clock, RenewableTimeoutService renewableTimeoutService,
+            LogProvider logProvider )
+    {
+        this.electionTimeout = electionTimeout.toMillis();
+        this.heartbeatInterval = heartbeatInterval.toMillis();
+        this.clock = clock;
+        this.renewableTimeoutService = renewableTimeoutService;
+        this.log = logProvider.getLog( getClass() );
+
+        if ( this.electionTimeout < this.heartbeatInterval )
+        {
+            throw new IllegalArgumentException( String.format(
+                            "Election timeout %s should not be shorter than heartbeat interval %s", this.electionTimeout, this.heartbeatInterval
+            ) );
+        }
+    }
+
+    synchronized void start( ThrowingAction<Exception> electionAction, ThrowingAction<Exception> heartbeatAction )
+    {
+        this.electionTimer = renewableTimeoutService.create( RaftMachine.Timeouts.ELECTION, getElectionTimeout(), randomTimeoutRange(),
+                renewing( electionAction ) );
+        this.heartbeatTimer = renewableTimeoutService.create( RaftMachine.Timeouts.HEARTBEAT, getHeartbeatInterval(), 0,
+                renewing( heartbeatAction ) );
+        lastElectionRenewalMillis = clock.millis();
+    }
+
+    synchronized void stop()
+    {
+        if ( electionTimer != null )
+        {
+            electionTimer.cancel();
+        }
+        if ( heartbeatTimer != null )
+        {
+            heartbeatTimer.cancel();
+        }
+
+    }
+
+    synchronized void renewElection()
+    {
+        lastElectionRenewalMillis = clock.millis();
+        if ( electionTimer != null )
+        {
+            electionTimer.renew();
+        }
+    }
+
+    synchronized boolean isElectionTimedOut()
+    {
+        return clock.millis() - lastElectionRenewalMillis >= electionTimeout;
+    }
+
+    // Getters for immutable values
+    long getElectionTimeout()
+    {
+        return electionTimeout;
+    }
+
+    long getHeartbeatInterval()
+    {
+        return heartbeatInterval;
+    }
+
+    private long randomTimeoutRange()
+    {
+        return getElectionTimeout();
+    }
+
+    private RenewableTimeoutService.TimeoutHandler renewing( ThrowingAction<Exception> action )
+    {
+        return timeout ->
+        {
+            try
+            {
+                action.apply();
+            }
+            catch ( Exception e )
+            {
+                log.error( "Failed to process timeout.", e );
+            }
+            timeout.renew();
+        };
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/MajorityIncludingSelfQuorum.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/MajorityIncludingSelfQuorum.java
@@ -19,9 +19,16 @@
  */
 package org.neo4j.causalclustering.core.consensus;
 
+import java.util.Collection;
+
 public class MajorityIncludingSelfQuorum
 {
     private static final int MIN_QUORUM = 2;
+
+    public static boolean isQuorum( Collection<?> cluster, Collection<?> countNotIncludingMyself )
+    {
+        return isQuorum( cluster.size(), countNotIncludingMyself.size() );
+    }
 
     public static boolean isQuorum( int clusterSize, int countNotIncludingSelf )
     {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMachine.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMachine.java
@@ -97,7 +97,8 @@ public class RaftMachine implements LeaderLocator, CoreMetaData
             RaftLog entryLog, long electionTimeout, long heartbeatInterval,
             RenewableTimeoutService renewableTimeoutService, Outbound<MemberId,RaftMessages.RaftMessage> outbound,
             LogProvider logProvider, RaftMembershipManager membershipManager, RaftLogShippingManager logShipping,
-            InFlightCache inFlightCache, boolean refuseToBecomeLeader, Monitors monitors, Clock clock )
+            InFlightCache inFlightCache, boolean refuseToBecomeLeader, boolean supportPreVoting, Monitors monitors,
+            Clock clock )
     {
         this.myself = myself;
         this.electionTimeout = electionTimeout;
@@ -115,7 +116,7 @@ public class RaftMachine implements LeaderLocator, CoreMetaData
 
         this.inFlightCache = inFlightCache;
         this.state = new RaftState( myself, termStorage, membershipManager, entryLog, voteStorage, inFlightCache,
-                logProvider );
+                logProvider, supportPreVoting );
 
         leaderNotFoundMonitor = monitors.newMonitor( LeaderNotFoundMonitor.class );
     }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Appending.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Appending.java
@@ -49,7 +49,6 @@ class Appending
             return;
         }
 
-        outcome.renewElectionTimeout();
         outcome.setPreElection( false );
         outcome.setNextTerm( request.leaderTerm() );
         outcome.setLeader( request.from() );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Appending.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Appending.java
@@ -50,11 +50,12 @@ class Appending
         }
 
         outcome.renewElectionTimeout();
+        outcome.setPreElection( false );
         outcome.setNextTerm( request.leaderTerm() );
         outcome.setLeader( request.from() );
         outcome.setLeaderCommit( request.leaderCommit() );
 
-        if ( !Follower.logHistoryMatches( state, request.prevLogIndex(), request.prevLogTerm(), log ) )
+        if ( !Follower.logHistoryMatches( state, request.prevLogIndex(), request.prevLogTerm() ) )
         {
             assert request.prevLogIndex() > -1 && request.prevLogTerm() > -1;
             RaftMessages.AppendEntries.Response appendResponse = new RaftMessages.AppendEntries.Response(

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Election.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Election.java
@@ -30,7 +30,7 @@ import org.neo4j.logging.Log;
 
 public class Election
 {
-    public static boolean start( ReadableRaftState ctx, Outcome outcome, Log log ) throws IOException
+    public static boolean startRealElection( ReadableRaftState ctx, Outcome outcome, Log log ) throws IOException
     {
         Set<MemberId> currentMembers = ctx.votingMembers();
         if ( currentMembers == null || !currentMembers.contains( ctx.myself() ) )
@@ -52,6 +52,28 @@ public class Election
 
         outcome.setVotedFor( ctx.myself() );
         log.info( "Election started with vote request: %s and members: %s", voteForMe, currentMembers );
+        return true;
+    }
+
+    public static boolean startPreElection( ReadableRaftState ctx, Outcome outcome, Log log ) throws IOException
+    {
+        Set<MemberId> currentMembers = ctx.votingMembers();
+        if ( currentMembers == null || !currentMembers.contains( ctx.myself() ) )
+        {
+            log.info( "Pre-election attempted but not started, current members are %s, I am %s",
+                    currentMembers, ctx.myself()  );
+            return false;
+        }
+
+        RaftMessages.PreVote.Request preVoteForMe =
+                new RaftMessages.PreVote.Request( ctx.myself(), outcome.getTerm(), ctx.myself(), ctx.entryLog()
+                        .appendIndex(), ctx.entryLog().readEntryTerm( ctx.entryLog().appendIndex() ) );
+
+        currentMembers.stream().filter( member -> !member.equals( ctx.myself() ) ).forEach( member ->
+                outcome.addOutgoingMessage( new RaftMessages.Directed( member, preVoteForMe ) )
+        );
+
+        log.info( "Pre-election started with: %s and members: %s", preVoteForMe, currentMembers );
         return true;
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Follower.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Follower.java
@@ -30,12 +30,13 @@ import org.neo4j.causalclustering.core.consensus.state.ReadableRaftState;
 import org.neo4j.logging.Log;
 
 import static java.lang.Long.min;
+import static org.neo4j.causalclustering.core.consensus.MajorityIncludingSelfQuorum.isQuorum;
 import static org.neo4j.causalclustering.core.consensus.roles.Role.CANDIDATE;
 import static org.neo4j.causalclustering.core.consensus.roles.Role.FOLLOWER;
 
 class Follower implements RaftMessageHandler
 {
-    static boolean logHistoryMatches( ReadableRaftState ctx, long leaderSegmentPrevIndex, long leaderSegmentPrevTerm, Log log )
+    static boolean logHistoryMatches( ReadableRaftState ctx, long leaderSegmentPrevIndex, long leaderSegmentPrevTerm )
             throws IOException
     {
         // NOTE: A prevLogIndex before or at our log's prevIndex means that we
@@ -47,11 +48,8 @@ class Follower implements RaftMessageHandler
         long localLogPrevIndex = ctx.entryLog().prevIndex();
         long localSegmentPrevTerm = ctx.entryLog().readEntryTerm( leaderSegmentPrevIndex );
 
-        boolean logHistoryMatches =
-                leaderSegmentPrevIndex > -1 &&
-                (leaderSegmentPrevIndex <= localLogPrevIndex || localSegmentPrevTerm == leaderSegmentPrevTerm);
-
-        return logHistoryMatches;
+        return leaderSegmentPrevIndex > -1 &&
+        (leaderSegmentPrevIndex <= localLogPrevIndex || localSegmentPrevTerm == leaderSegmentPrevTerm);
     }
 
     static void commitToLogOnUpdate( ReadableRaftState ctx, long indexOfLastNewEntry, long leaderCommit, Outcome outcome )
@@ -80,62 +78,238 @@ class Follower implements RaftMessageHandler
     @Override
     public Outcome handle( RaftMessages.RaftMessage message, ReadableRaftState ctx, Log log ) throws IOException
     {
-        Outcome outcome = new Outcome( FOLLOWER, ctx );
+        return message.dispatch( visitor( ctx, log ) );
+    }
 
-        switch ( message.type() )
+    private abstract static class Handler implements RaftMessages.Handler<Outcome, IOException>
+    {
+        protected final ReadableRaftState ctx;
+        protected final Log log;
+        protected final Outcome outcome;
+
+        Handler( ReadableRaftState ctx, Log log )
         {
-            case HEARTBEAT:
-            {
-                Heart.beat( ctx, outcome, (Heartbeat) message, log );
-                break;
-            }
-
-            case APPEND_ENTRIES_REQUEST:
-            {
-                Appending.handleAppendEntriesRequest( ctx, outcome, (AppendEntries.Request) message, log );
-                break;
-            }
-
-            case VOTE_REQUEST:
-            {
-                Voting.handleVoteRequest( ctx, outcome, (RaftMessages.Vote.Request) message, log );
-                break;
-            }
-
-            case LOG_COMPACTION_INFO:
-            {
-                handleLeaderLogCompaction( ctx, outcome, (RaftMessages.LogCompactionInfo) message );
-                break;
-            }
-
-            case ELECTION_TIMEOUT:
-            {
-                log.info( "Election timeout triggered" );
-                if ( Election.start( ctx, outcome, log ) )
-                {
-                    outcome.setNextRole( CANDIDATE );
-                    log.info( "Moving to CANDIDATE state after successfully starting election" );
-                }
-                break;
-            }
-
-            case VOTE_RESPONSE:
-            {
-                RaftMessages.Vote.Response voteResponse = (RaftMessages.Vote.Response) message;
-                log.info( "Late vote response: %s", voteResponse );
-                break;
-            }
-
-            case PRUNE_REQUEST:
-            {
-                Pruning.handlePruneRequest( outcome, (RaftMessages.PruneRequest) message );
-                break;
-            }
-
-            default:
-                break;
+            this.ctx = ctx;
+            this.log = log;
+            this.outcome = new Outcome( FOLLOWER, ctx );
         }
 
-        return outcome;
+        @Override
+        public Outcome handle( Heartbeat heartbeat ) throws IOException
+        {
+            Heart.beat( ctx, outcome, heartbeat, log );
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( AppendEntries.Request request ) throws IOException
+        {
+            Appending.handleAppendEntriesRequest( ctx, outcome, request, log );
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.Vote.Request request ) throws IOException
+        {
+            Voting.handleVoteRequest( ctx, outcome, request, log );
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.LogCompactionInfo logCompactionInfo ) throws IOException
+        {
+            handleLeaderLogCompaction( ctx, outcome, logCompactionInfo );
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.Vote.Response response ) throws IOException
+        {
+            log.info( "Late vote response: %s", response );
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.PruneRequest pruneRequest ) throws IOException
+        {
+            Pruning.handlePruneRequest( outcome, pruneRequest );
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( AppendEntries.Response response ) throws IOException
+        {
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.HeartbeatResponse heartbeatResponse ) throws IOException
+        {
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.Timeout.Heartbeat heartbeat ) throws IOException
+        {
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.NewEntry.Request request ) throws IOException
+        {
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.NewEntry.BatchRequest batchRequest ) throws IOException
+        {
+            return outcome;
+        }
+    }
+
+    abstract class PreVoteSupportedHandler extends Handler
+    {
+
+        PreVoteSupportedHandler( ReadableRaftState ctx, Log log )
+        {
+            super( ctx, log );
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.Timeout.Election election ) throws IOException
+        {
+            log.info( "Election timeout triggered" );
+            if ( Election.startPreElection( ctx, outcome, log ) )
+            {
+                outcome.setPreElection( true );
+            }
+            return outcome;
+        }
+    }
+
+    class PreVoteActiveHandler extends PreVoteSupportedHandler
+    {
+
+        PreVoteActiveHandler( ReadableRaftState ctx, Log log )
+        {
+            super( ctx, log );
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.PreVote.Request request ) throws IOException
+        {
+            Voting.handlePreVoteRequest( ctx, outcome, request, log );
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.PreVote.Response res ) throws IOException
+        {
+            if ( res.term() > ctx.term() )
+            {
+                outcome.setNextTerm( res.term() );
+                log.info( "Aborting pre-election after receiving pre-vote response from %s at term %d (I am at %d)",
+                        res.from(), res.term(), ctx.term() );
+                return outcome;
+            }
+            else if ( res.term() < ctx.term() || !res.voteGranted() )
+            {
+                return outcome;
+            }
+
+            if ( !res.from().equals( ctx.myself() ) )
+            {
+                outcome.addPreVoteForMe( res.from() );
+            }
+
+            if ( isQuorum( ctx.votingMembers(), outcome.getPreVotesForMe() ) )
+            {
+                outcome.renewElectionTimeout();
+                outcome.setPreElection( false );
+                if ( Election.startRealElection( ctx, outcome, log ) )
+                {
+                    outcome.setNextRole( CANDIDATE );
+                    log.info( "Moving to CANDIDATE state after successful pre-election stage" );
+                }
+            }
+            return outcome;
+        }
+    }
+
+    class PreVoteInactiveHandler extends PreVoteSupportedHandler
+    {
+
+        PreVoteInactiveHandler( ReadableRaftState ctx, Log log )
+        {
+            super( ctx, log );
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.PreVote.Response response ) throws IOException
+        {
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.PreVote.Request request ) throws IOException
+        {
+            outcome.addOutgoingMessage( new RaftMessages.Directed(
+                    request.from(),
+                    new RaftMessages.PreVote.Response( ctx.myself(), outcome.getTerm(), false )
+            ) );
+            return outcome;
+        }
+    }
+
+    class PreVoteUnsupportedHandler extends Handler
+    {
+
+        PreVoteUnsupportedHandler( ReadableRaftState ctx, Log log )
+        {
+            super( ctx, log );
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.Timeout.Election election ) throws IOException
+        {
+            log.info( "Election timeout triggered" );
+            if ( Election.startRealElection( ctx, outcome, log ) )
+            {
+                outcome.setNextRole( CANDIDATE );
+                log.info( "Moving to CANDIDATE state after successfully starting election" );
+            }
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.PreVote.Response response ) throws IOException
+        {
+            return outcome;
+        }
+
+        @Override
+        public Outcome handle( RaftMessages.PreVote.Request request ) throws IOException
+        {
+            return outcome;
+        }
+    }
+
+    private Handler visitor( ReadableRaftState ctx, Log log )
+    {
+        if ( ctx.supportPreVoting() )
+        {
+            if ( ctx.isPreElection() )
+            {
+                return new PreVoteActiveHandler( ctx, log );
+            }
+            else
+            {
+                return new PreVoteInactiveHandler( ctx, log );
+            }
+        }
+        else
+        {
+            return new PreVoteUnsupportedHandler( ctx, log );
+        }
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Heart.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Heart.java
@@ -36,7 +36,6 @@ class Heart
             return;
         }
 
-        outcome.renewElectionTimeout();
         outcome.setPreElection( false );
         outcome.setNextTerm( request.leaderTerm() );
         outcome.setLeader( request.from() );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Heart.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Heart.java
@@ -37,13 +37,14 @@ class Heart
         }
 
         outcome.renewElectionTimeout();
+        outcome.setPreElection( false );
         outcome.setNextTerm( request.leaderTerm() );
         outcome.setLeader( request.from() );
         outcome.setLeaderCommit( request.commitIndex() );
         outcome.addOutgoingMessage( new RaftMessages.Directed( request.from(),
                 new RaftMessages.HeartbeatResponse( state.myself() ) ) );
 
-        if ( !Follower.logHistoryMatches( state, request.commitIndex(), request.commitIndexTerm(), log ) )
+        if ( !Follower.logHistoryMatches( state, request.commitIndex(), request.commitIndexTerm() ) )
         {
             return;
         }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Voting.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Voting.java
@@ -30,7 +30,7 @@ import org.neo4j.logging.Log;
 
 public class Voting
 {
-    static  void handleVoteRequest( ReadableRaftState state, Outcome outcome,
+    static void handleVoteRequest( ReadableRaftState state, Outcome outcome,
             RaftMessages.Vote.Request voteRequest, Log log ) throws IOException
     {
         if ( voteRequest.term() > state.term() )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/state/ReadableRaftState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/state/ReadableRaftState.java
@@ -52,4 +52,10 @@ public interface ReadableRaftState
     ReadableRaftLog entryLog();
 
     long commitIndex();
+
+    boolean supportPreVoting();
+
+    boolean isPreElection();
+
+    Set<MemberId> preVotesForMe();
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/term/TermState.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/term/TermState.java
@@ -27,7 +27,7 @@ import org.neo4j.storageengine.api.WritableChannel;
 
 public class TermState
 {
-    private long term = 0;
+    private volatile long term = 0;
 
     public TermState()
     {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
@@ -54,6 +54,7 @@ import org.neo4j.causalclustering.core.state.RaftLogPruner;
 import org.neo4j.causalclustering.core.state.RaftMessageHandler;
 import org.neo4j.causalclustering.core.state.machines.CoreStateMachinesModule;
 import org.neo4j.causalclustering.core.state.snapshot.CoreStateDownloader;
+import org.neo4j.causalclustering.core.state.snapshot.CoreStateDownloaderService;
 import org.neo4j.causalclustering.core.state.storage.DurableStateStorage;
 import org.neo4j.causalclustering.core.state.storage.StateStorage;
 import org.neo4j.causalclustering.discovery.TopologyService;
@@ -176,10 +177,13 @@ public class CoreServerModule
 
         CoreStateDownloader downloader = new CoreStateDownloader( localDatabase, servicesToStopOnStoreCopy,
                 remoteStore, catchUpClient, logProvider, storeCopyProcess, coreStateMachinesModule.coreStateMachines,
-                snapshotService, commandApplicationProcess, topologyService );
+                snapshotService, topologyService );
+
+        CoreStateDownloaderService downloadService = new CoreStateDownloaderService( platformModule
+                .jobScheduler, downloader, commandApplicationProcess, logProvider );
 
         RaftMessageHandler messageHandler = new RaftMessageHandler( localDatabase, logProvider,
-                consensusModule.raftMachine(), downloader, commandApplicationProcess );
+                consensusModule.raftMachine(), downloadService, commandApplicationProcess );
 
         CoreLife coreLife = new CoreLife( consensusModule.raftMachine(), localDatabase,
                 clusteringModule.clusterBinder(), commandApplicationProcess,

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
@@ -40,6 +40,7 @@ import org.neo4j.causalclustering.core.IdentityModule;
 import org.neo4j.causalclustering.core.consensus.ConsensusModule;
 import org.neo4j.causalclustering.core.consensus.ContinuousJob;
 import org.neo4j.causalclustering.core.consensus.RaftMessages;
+import org.neo4j.causalclustering.core.consensus.LeaderAvailabilityHandler;
 import org.neo4j.causalclustering.core.consensus.RaftServer;
 import org.neo4j.causalclustering.core.consensus.log.pruning.PruningScheduler;
 import org.neo4j.causalclustering.core.consensus.membership.MembershipWaiter;
@@ -181,21 +182,20 @@ public class CoreServerModule
         RaftMessageHandler messageHandler = new RaftMessageHandler( localDatabase, logProvider,
                 consensusModule.raftMachine(), downloader, commandApplicationProcess );
 
-        CoreLife coreLife = new CoreLife( consensusModule.raftMachine(), localDatabase,
-                clusteringModule.clusterBinder(), commandApplicationProcess,
-                coreStateMachinesModule.coreStateMachines, messageHandler, snapshotService );
-
-        RaftLogPruner raftLogPruner = new RaftLogPruner( consensusModule.raftMachine(), commandApplicationProcess );
-        dependencies.satisfyDependency( raftLogPruner );
-
-        life.add( new PruningScheduler( raftLogPruner, jobScheduler,
-                config.get( CausalClusteringSettings.raft_log_pruning_frequency ).toMillis(), logProvider ) );
-
         int queueSize = config.get( CausalClusteringSettings.raft_in_queue_size );
         int maxBatch = config.get( CausalClusteringSettings.raft_in_queue_max_batch );
 
         BatchingMessageHandler batchingMessageHandler = new BatchingMessageHandler( messageHandler, queueSize, maxBatch,
                 logProvider );
+
+        LeaderAvailabilityHandler leaderAvailabilityHandler = new LeaderAvailabilityHandler( batchingMessageHandler, consensusModule.getLeaderAvailabilityTimers(),
+                consensusModule.raftMachine()::term, logProvider );
+
+        CoreLife coreLife = new CoreLife( consensusModule.raftMachine(), localDatabase,
+                clusteringModule.clusterBinder(), commandApplicationProcess,
+                coreStateMachinesModule.coreStateMachines, messageHandler, leaderAvailabilityHandler, snapshotService );
+
+        loggingRaftInbound.registerHandler( leaderAvailabilityHandler );
 
         long electionTimeout = config.get( CausalClusteringSettings.leader_election_timeout ).toMillis();
 
@@ -205,14 +205,18 @@ public class CoreServerModule
         membershipWaiterLifecycle = new MembershipWaiterLifecycle( membershipWaiter, joinCatchupTimeout,
                 consensusModule.raftMachine(), logProvider );
 
-        loggingRaftInbound.registerHandler( batchingMessageHandler );
-
         CatchupServer catchupServer = new CatchupServer( logProvider, userLogProvider, localDatabase::storeId,
                 platformModule.dependencies.provideDependency( TransactionIdStore.class ),
                 platformModule.dependencies.provideDependency( LogicalTransactionStore.class ),
                 localDatabase::dataSource, localDatabase::isAvailable, snapshotService, config, platformModule.monitors,
                 new CheckpointerSupplier( platformModule.dependencies ), fileSystem, platformModule.pageCache,
                 platformModule.storeCopyCheckPointMutex, sslPolicy );
+
+        RaftLogPruner raftLogPruner = new RaftLogPruner( consensusModule.raftMachine(), commandApplicationProcess );
+        dependencies.satisfyDependency( raftLogPruner );
+
+        life.add( new PruningScheduler( raftLogPruner, jobScheduler,
+                config.get( CausalClusteringSettings.raft_log_pruning_frequency ).toMillis(), logProvider ) );
 
         // Exposes this so that tests can start/stop the catchup server
         dependencies.satisfyDependency( catchupServer );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/server/CoreServerModule.java
@@ -55,6 +55,7 @@ import org.neo4j.causalclustering.core.state.RaftLogPruner;
 import org.neo4j.causalclustering.core.state.RaftMessageHandler;
 import org.neo4j.causalclustering.core.state.machines.CoreStateMachinesModule;
 import org.neo4j.causalclustering.core.state.snapshot.CoreStateDownloader;
+import org.neo4j.causalclustering.core.state.snapshot.CoreStateDownloaderService;
 import org.neo4j.causalclustering.core.state.storage.DurableStateStorage;
 import org.neo4j.causalclustering.core.state.storage.StateStorage;
 import org.neo4j.causalclustering.discovery.TopologyService;
@@ -177,10 +178,13 @@ public class CoreServerModule
 
         CoreStateDownloader downloader = new CoreStateDownloader( localDatabase, servicesToStopOnStoreCopy,
                 remoteStore, catchUpClient, logProvider, storeCopyProcess, coreStateMachinesModule.coreStateMachines,
-                snapshotService, commandApplicationProcess, topologyService );
+                snapshotService, topologyService );
+
+        CoreStateDownloaderService downloadService = new CoreStateDownloaderService( platformModule
+                .jobScheduler, downloader, commandApplicationProcess, logProvider );
 
         RaftMessageHandler messageHandler = new RaftMessageHandler( localDatabase, logProvider,
-                consensusModule.raftMachine(), downloader, commandApplicationProcess );
+                consensusModule.raftMachine(), downloadService, commandApplicationProcess );
 
         int queueSize = config.get( CausalClusteringSettings.raft_in_queue_size );
         int maxBatch = config.get( CausalClusteringSettings.raft_in_queue_max_batch );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloader.java
@@ -28,7 +28,6 @@ import org.neo4j.causalclustering.catchup.storecopy.LocalDatabase;
 import org.neo4j.causalclustering.catchup.storecopy.RemoteStore;
 import org.neo4j.causalclustering.catchup.storecopy.StoreCopyFailedException;
 import org.neo4j.causalclustering.catchup.storecopy.StoreCopyProcess;
-import org.neo4j.causalclustering.core.state.CommandApplicationProcess;
 import org.neo4j.causalclustering.core.state.CoreSnapshotService;
 import org.neo4j.causalclustering.core.state.machines.CoreStateMachines;
 import org.neo4j.causalclustering.discovery.TopologyService;
@@ -45,8 +44,6 @@ import static org.neo4j.causalclustering.catchup.CatchupResult.SUCCESS_END_OF_ST
 
 public class CoreStateDownloader
 {
-    private static final String OPERATION_NAME = "download of snapshot";
-
     private final LocalDatabase localDatabase;
     private final Lifecycle startStopOnStoreCopy;
     private final RemoteStore remoteStore;
@@ -55,14 +52,12 @@ public class CoreStateDownloader
     private final StoreCopyProcess storeCopyProcess;
     private final CoreStateMachines coreStateMachines;
     private final CoreSnapshotService snapshotService;
-    private final CommandApplicationProcess applicationProcess;
     private final TopologyService topologyService;
 
     public CoreStateDownloader( LocalDatabase localDatabase, Lifecycle startStopOnStoreCopy,
             RemoteStore remoteStore, CatchUpClient catchUpClient, LogProvider logProvider,
             StoreCopyProcess storeCopyProcess, CoreStateMachines coreStateMachines,
-            CoreSnapshotService snapshotService, CommandApplicationProcess applicationProcess,
-            TopologyService topologyService )
+            CoreSnapshotService snapshotService, TopologyService topologyService )
     {
         this.localDatabase = localDatabase;
         this.startStopOnStoreCopy = startStopOnStoreCopy;
@@ -72,13 +67,11 @@ public class CoreStateDownloader
         this.storeCopyProcess = storeCopyProcess;
         this.coreStateMachines = coreStateMachines;
         this.snapshotService = snapshotService;
-        this.applicationProcess = applicationProcess;
         this.topologyService = topologyService;
     }
 
-    public void downloadSnapshot( MemberId source ) throws StoreCopyFailedException
+    void downloadSnapshot( MemberId source ) throws StoreCopyFailedException
     {
-        applicationProcess.pauseApplier( OPERATION_NAME );
         try
         {
             /* Extract some key properties before shutting it down. */
@@ -161,10 +154,6 @@ public class CoreStateDownloader
         catch ( Throwable e )
         {
             throw new StoreCopyFailedException( e );
-        }
-        finally
-        {
-            applicationProcess.resumeApplier( OPERATION_NAME );
         }
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderService.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.state.snapshot;
+
+import org.neo4j.causalclustering.core.consensus.LeaderLocator;
+import org.neo4j.causalclustering.core.state.CommandApplicationProcess;
+import org.neo4j.kernel.impl.util.JobScheduler;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+import static org.neo4j.kernel.impl.util.JobScheduler.SchedulingStrategy.POOLED;
+
+public class CoreStateDownloaderService
+{
+    static final String OPERATION_NAME = "download of snapshot";
+
+    private final JobScheduler jobScheduler;
+    private final CoreStateDownloader downloader;
+    private final CommandApplicationProcess applicationProcess;
+    private final Log log;
+
+    public CoreStateDownloaderService( JobScheduler jobScheduler, CoreStateDownloader downloader,
+            CommandApplicationProcess applicationProcess,
+            LogProvider logProvider )
+    {
+        this.jobScheduler = jobScheduler;
+        this.downloader = downloader;
+        this.applicationProcess = applicationProcess;
+        this.log = logProvider.getLog( getClass() );
+    }
+
+    public void scheduleDownload( LeaderLocator leaderLocator )
+    {
+        jobScheduler.schedule( new JobScheduler.Group( "download snapshot", POOLED ),
+                new PersistentSnapshotDownloader( leaderLocator, applicationProcess, downloader, log ) );
+    }
+
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/PersistentSnapshotDownloader.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/state/snapshot/PersistentSnapshotDownloader.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.state.snapshot;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
+
+import org.neo4j.causalclustering.catchup.storecopy.StoreCopyFailedException;
+import org.neo4j.causalclustering.core.consensus.LeaderLocator;
+import org.neo4j.causalclustering.core.consensus.NoLeaderFoundException;
+import org.neo4j.causalclustering.core.state.CommandApplicationProcess;
+import org.neo4j.causalclustering.helper.ExponentialBackoffStrategy;
+import org.neo4j.causalclustering.helper.TimeoutStrategy;
+import org.neo4j.logging.Log;
+
+class PersistentSnapshotDownloader implements Runnable
+{
+    private final CommandApplicationProcess applicationProcess;
+    private final LeaderLocator leaderLocator;
+    private final CoreStateDownloader downloader;
+    private final Log log;
+    private final TimeoutStrategy.Timeout timeout;
+
+    PersistentSnapshotDownloader( LeaderLocator leaderLocator,
+            CommandApplicationProcess applicationProcess, CoreStateDownloader downloader, Log log,
+            TimeoutStrategy.Timeout timeout )
+    {
+        this.applicationProcess = applicationProcess;
+        this.leaderLocator = leaderLocator;
+        this.downloader = downloader;
+        this.log = log;
+        this.timeout = timeout;
+    }
+
+    PersistentSnapshotDownloader( LeaderLocator leaderLocator,
+            CommandApplicationProcess applicationProcess, CoreStateDownloader downloader, Log log )
+    {
+        this( leaderLocator, applicationProcess, downloader, log,
+                new ExponentialBackoffStrategy( 1, 30, TimeUnit.SECONDS ).newTimeout() );
+    }
+
+    @Override
+    public void run()
+    {
+        applicationProcess.pauseApplier( CoreStateDownloaderService.OPERATION_NAME );
+        while ( true )
+        {
+            if ( Thread.interrupted() )
+            {
+                break;
+            }
+            try
+            {
+                downloader.downloadSnapshot( leaderLocator.getLeader() );
+                applicationProcess.resumeApplier( CoreStateDownloaderService.OPERATION_NAME );
+                break;
+            }
+            catch ( StoreCopyFailedException e )
+            {
+                log.error( "Failed to download snapshot. Retrying in {} ms.", timeout.getMillis(), e );
+            }
+            catch ( NoLeaderFoundException e )
+            {
+                log.warn( "No leader found. Retrying in {} ms.", timeout.getMillis() );
+            }
+            LockSupport.parkNanos( TimeUnit.MILLISECONDS.toNanos( timeout.getMillis() ) );
+            timeout.increment();
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastClient.java
@@ -106,8 +106,8 @@ class HazelcastClient extends LifecycleAdapter implements TopologyService
     @Override
     public void stop() throws Throwable
     {
-        scheduler.cancelAndWaitTermination( keepAliveJob );
-        scheduler.cancelAndWaitTermination( refreshTopologyJob );
+        keepAliveJob.cancel( true );
+        refreshTopologyJob.cancel( true );
         disconnectFromCore();
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/discovery/HazelcastCoreTopologyService.java
@@ -122,7 +122,7 @@ class HazelcastCoreTopologyService extends LifecycleAdapter implements CoreTopol
         log.info( String.format( "HazelcastCoreTopologyService stopping and unbinding from %s",
                 config.get( discovery_listen_address ) ) );
 
-        scheduler.cancelAndWaitTermination( refreshJob );
+        refreshJob.cancel( true );
 
         try
         {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/RobustJobSchedulerWrapper.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/helper/RobustJobSchedulerWrapper.java
@@ -77,32 +77,4 @@ public class RobustJobSchedulerWrapper
             throw t;
         }
     }
-
-    /**
-     * Note that because of the cancellation, the effects of the job
-     * are not necessarily visible after this call, which is different
-     * from a pure waitForTermination call.
-     *
-     * @param job The job to terminate.
-     */
-    public void cancelAndWaitTermination( JobScheduler.JobHandle job )
-    {
-        try
-        {
-            job.cancel( true );
-
-            try
-            {
-                job.waitTermination();
-            }
-            catch ( CancellationException e )
-            {
-                // expected sometimes because of cancellation above
-            }
-        }
-        catch ( Throwable e )
-        {
-            log.warn( "Termination experienced exception", e );
-        }
-    }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/RaftMessageDecoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/marshalling/RaftMessageDecoder.java
@@ -41,6 +41,8 @@ import static org.neo4j.causalclustering.core.consensus.RaftMessages.Type.HEARTB
 import static org.neo4j.causalclustering.core.consensus.RaftMessages.Type.HEARTBEAT_RESPONSE;
 import static org.neo4j.causalclustering.core.consensus.RaftMessages.Type.LOG_COMPACTION_INFO;
 import static org.neo4j.causalclustering.core.consensus.RaftMessages.Type.NEW_ENTRY_REQUEST;
+import static org.neo4j.causalclustering.core.consensus.RaftMessages.Type.PRE_VOTE_REQUEST;
+import static org.neo4j.causalclustering.core.consensus.RaftMessages.Type.PRE_VOTE_RESPONSE;
 import static org.neo4j.causalclustering.core.consensus.RaftMessages.Type.VOTE_REQUEST;
 import static org.neo4j.causalclustering.core.consensus.RaftMessages.Type.VOTE_RESPONSE;
 
@@ -82,6 +84,23 @@ public class RaftMessageDecoder extends ByteToMessageDecoder
             boolean voteGranted = channel.get() == 1;
 
             result = new RaftMessages.Vote.Response( from, term, voteGranted );
+        }
+        else if ( messageType.equals( PRE_VOTE_REQUEST ) )
+        {
+            MemberId candidate = retrieveMember( channel );
+
+            long term = channel.getLong();
+            long lastLogIndex = channel.getLong();
+            long lastLogTerm = channel.getLong();
+
+            result = new RaftMessages.PreVote.Request( from, term, candidate, lastLogIndex, lastLogTerm );
+        }
+        else if ( messageType.equals( PRE_VOTE_RESPONSE ) )
+        {
+            long term = channel.getLong();
+            boolean voteGranted = channel.get() == 1;
+
+            result = new RaftMessages.PreVote.Response( from, term, voteGranted );
         }
         else if ( messageType.equals( APPEND_ENTRIES_REQUEST ) )
         {

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/RejectCustomIOTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/RejectCustomIOTest.java
@@ -67,7 +67,7 @@ public class RejectCustomIOTest
                     stringMap( GraphDatabaseSettings.pagecache_swapper.name(), TEST_PAGESWAPPER_NAME );
             CoreClusterMember clusterMember = new CoreClusterMember( 0, 3, emptyList(), discovery,
                     defaultFormat().toString(), storeDir.directory(), extraParams, emptyMap(),
-                    "127.0.0.1", "localhost" );
+                    "127.0.0.1", "localhost", new Monitors() );
             clusterMember.start();
             fail( "Should not have created database with custom IO configuration in Core Mode." );
         }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/ClusterSeedingIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/ClusterSeedingIT.java
@@ -29,24 +29,30 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.nio.file.attribute.FileTime;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.IntFunction;
 
 import org.neo4j.backup.OnlineBackupSettings;
+import org.neo4j.causalclustering.catchup.tx.FileCopyMonitor;
+import org.neo4j.causalclustering.catchup.tx.PullRequestMonitor;
 import org.neo4j.causalclustering.core.CoreGraphDatabase;
 import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.CoreClusterMember;
 import org.neo4j.causalclustering.discovery.SharedDiscoveryService;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
+import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.rule.TestDirectory;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.neo4j.backup.OnlineBackupCommandIT.runBackupToolFromOtherJvmToGetExitCode;
 import static org.neo4j.causalclustering.backup.BackupCoreIT.backupAddress;
 import static org.neo4j.causalclustering.discovery.Cluster.dataMatchesEventually;
@@ -57,6 +63,8 @@ public class ClusterSeedingIT
     private Cluster backupCluster;
     private Cluster cluster;
     private DefaultFileSystemAbstraction fsa = new DefaultFileSystemAbstraction();
+    private DetectFileCopyMonitor detectFileCopyMonitor;
+    private PullRequestMonitor pullRequestMonitor;
 
     @Rule
     public TestDirectory testDir = TestDirectory.testDirectory();
@@ -65,13 +73,25 @@ public class ClusterSeedingIT
     @Before
     public void setup() throws Exception
     {
+        Monitors monitors = new Monitors();
+        addMonitorListeners( monitors );
         backupCluster = new Cluster( testDir.directory( "cluster-for-backup" ), 3, 0,
-                new SharedDiscoveryService(), emptyMap(), backupParams(), emptyMap(), emptyMap(), StandardV3_0.NAME );
+                new SharedDiscoveryService(), emptyMap(), backupParams(), emptyMap(), emptyMap(), StandardV3_0.NAME,
+                new Monitors() );
 
         cluster = new Cluster( testDir.directory( "cluster-b" ), 3, 0,
-                new SharedDiscoveryService(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), StandardV3_0.NAME );
+                new SharedDiscoveryService(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), StandardV3_0.NAME,
+                monitors );
 
         baseBackupDir = testDir.directory( "backups" );
+    }
+
+    private void addMonitorListeners( Monitors monitors )
+    {
+        this.detectFileCopyMonitor = new DetectFileCopyMonitor();
+        this.pullRequestMonitor = new DetectPullRequestMonitor();
+        monitors.addMonitorListener( detectFileCopyMonitor );
+        monitors.addMonitorListener( pullRequestMonitor );
     }
 
     private Map<String,IntFunction<String>> backupParams()
@@ -124,63 +144,78 @@ public class ClusterSeedingIT
         fsa.copyRecursively( backupDir, cluster.getCoreMemberById( 1 ).storeDir() );
         fsa.copyRecursively( backupDir, cluster.getCoreMemberById( 2 ).storeDir() );
 
-        Map<File,FileTime> creation1 = creationTimes( cluster.getCoreMemberById( 0 ).storeDir() );
-        Map<File,FileTime> creation2 = creationTimes( cluster.getCoreMemberById( 1 ).storeDir() );
-        Map<File,FileTime> creation3 = creationTimes( cluster.getCoreMemberById( 2 ).storeDir() );
+        Map<File,Object> creation1 = fileKeys( cluster.getCoreMemberById( 0 ).storeDir() );
+        Map<File,Object> creation2 = fileKeys( cluster.getCoreMemberById( 1 ).storeDir() );
+        Map<File,Object> creation3 = fileKeys( cluster.getCoreMemberById( 2 ).storeDir() );
 
         cluster.start();
 
         // then
         dataMatchesEventually( before, cluster.coreMembers() );
+        assertFalse( detectFileCopyMonitor.fileCopyDetected.get() );
+        assertEquals( 4, pullRequestMonitor.numberOfRequests() );
 
-        assertCreationTimesUnchanged( creation1 );
-        assertCreationTimesUnchanged( creation2 );
-        assertCreationTimesUnchanged( creation3 );
+        assertFileKeysAreTheSame( creation1 );
+        assertFileKeysAreTheSame( creation2 );
+        assertFileKeysAreTheSame( creation3 );
     }
 
     @Test
     public void shouldSeedNewMemberFromEmptyIdleCluster() throws Throwable
     {
         // given
+        Monitors monitors = new Monitors();
         cluster = new Cluster( testDir.directory( "cluster-b" ), 3, 0,
-                new SharedDiscoveryService(), emptyMap(), backupParams(), emptyMap(), emptyMap(), StandardV3_0.NAME );
+                new SharedDiscoveryService(), emptyMap(), backupParams(), emptyMap(), emptyMap(), StandardV3_0.NAME,
+                monitors );
         cluster.start();
 
         // when: creating a backup
         File backupDir = createBackup( cluster.getCoreMemberById( 0 ).database(), "the-backup" );
+        // we are only interested in monitoring the new instance
+        addMonitorListeners( monitors );
 
         // and: seeding new member with said backup
         CoreClusterMember newMember = cluster.addCoreMemberWithId( 3 );
         fsa.copyRecursively( backupDir, newMember.storeDir() );
-        Map<File,FileTime> creationTimes = creationTimes( cluster.getCoreMemberById( 3 ).storeDir() );
+        Map<File,Object> creationTimes = fileKeys( cluster.getCoreMemberById( 3 ).storeDir() );
         newMember.start();
 
         // then
         dataMatchesEventually( DbRepresentation.of( newMember.database() ), cluster.coreMembers() );
-        assertCreationTimesUnchanged( creationTimes );
+        assertFalse( detectFileCopyMonitor.fileCopyDetected.get() );
+        assertEquals( 1, pullRequestMonitor.numberOfRequests() );
+        assertEquals( 1, pullRequestMonitor.lastRequestedTxId() );
+        assertFileKeysAreTheSame( creationTimes );
     }
 
     @Test
     public void shouldSeedNewMemberFromNonEmptyIdleCluster() throws Throwable
     {
         // given
+        Monitors monitors = new Monitors();
         cluster = new Cluster( testDir.directory( "cluster-b" ), 3, 0,
-                new SharedDiscoveryService(), emptyMap(), backupParams(), emptyMap(), emptyMap(), StandardV3_0.NAME );
+                new SharedDiscoveryService(), emptyMap(), backupParams(), emptyMap(), emptyMap(), StandardV3_0.NAME,
+                monitors );
         cluster.start();
         createNodes( cluster, 100 );
 
         // when: creating a backup
         File backupDir = createBackup( cluster.getCoreMemberById( 0 ).database(), "the-backup" );
+        // we are only interested in monitoring the new instance
+        addMonitorListeners( monitors );
 
         // and: seeding new member with said backup
         CoreClusterMember newMember = cluster.addCoreMemberWithId( 3 );
         fsa.copyRecursively( backupDir, newMember.storeDir() );
-        Map<File,FileTime> creationTimes = creationTimes( cluster.getCoreMemberById( 3 ).storeDir() );
+        Map<File,Object> creationTimes = fileKeys( cluster.getCoreMemberById( 3 ).storeDir() );
         newMember.start();
 
         // then
         dataMatchesEventually( DbRepresentation.of( newMember.database() ), cluster.coreMembers() );
-        assertCreationTimesUnchanged( creationTimes );
+        assertFalse( detectFileCopyMonitor.fileCopyDetected.get() );
+        assertEquals( 1, pullRequestMonitor.numberOfRequests() );
+        assertFileKeysAreTheSame( creationTimes );
     }
 
     @Test
@@ -202,30 +237,79 @@ public class ClusterSeedingIT
         dataMatchesEventually( before, cluster.coreMembers() );
     }
 
-    private void assertCreationTimesUnchanged( Map<File,FileTime> creationTimes ) throws IOException
+    private void assertFileKeysAreTheSame( Map<File,Object> fileKeys ) throws IOException
     {
-        for ( Map.Entry<File,FileTime> e : creationTimes.entrySet() )
+        for ( Map.Entry<File,Object> e : fileKeys.entrySet() )
         {
             File file = e.getKey();
-            FileTime oldTime = e.getValue();
+            Object oldKey = e.getValue();
 
             BasicFileAttributes attr = Files.readAttributes( file.toPath(), BasicFileAttributes.class );
-            assertEquals( "Creation time for file: " + file, oldTime, attr.creationTime() );
+            assertEquals( "Creation time for file: " + file, oldKey, attr.fileKey() );
         }
     }
 
-    private Map<File,FileTime> creationTimes( File dir ) throws IOException
+    private Map<File,Object> fileKeys( File dir ) throws IOException
     {
-        Map<File,FileTime> map = new HashMap<>();
+        Map<File,Object> map = new HashMap<>();
         File[] files = dir.listFiles();
         assert files != null;
 
         for ( File file : files )
         {
             BasicFileAttributes attr = Files.readAttributes( file.toPath(), BasicFileAttributes.class );
-            map.put( file, attr.creationTime() );
+            map.put( file, attr.fileKey() );
         }
 
         return map;
+    }
+
+    private class DetectPullRequestMonitor implements PullRequestMonitor
+    {
+
+        private final AtomicLong lastPullRequest = new AtomicLong();
+        private final AtomicInteger numberOfRequest = new AtomicInteger();
+
+        @Override
+        public void txPullRequest( long txId )
+        {
+            lastPullRequest.set( txId );
+            numberOfRequest.incrementAndGet();
+        }
+
+        @Override
+        public void txPullResponse( long txId )
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
+        public long lastRequestedTxId()
+        {
+            return lastPullRequest.get();
+        }
+
+        @Override
+        public long lastReceivedTxId()
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
+        public long numberOfRequests()
+        {
+            return numberOfRequest.get();
+        }
+    }
+
+    private class DetectFileCopyMonitor implements FileCopyMonitor
+    {
+        private final AtomicBoolean fileCopyDetected = new AtomicBoolean( false );
+
+        @Override
+        public void copyFile( File file )
+        {
+            fileCopyDetected.compareAndSet( false, true );
+        }
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/ClusterSeedingIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/ClusterSeedingIT.java
@@ -245,7 +245,7 @@ public class ClusterSeedingIT
             Object oldKey = e.getValue();
 
             BasicFileAttributes attr = Files.readAttributes( file.toPath(), BasicFileAttributes.class );
-            assertEquals( "Creation time for file: " + file, oldKey, attr.fileKey() );
+            assertEquals( "File key for file: " + file, oldKey, attr.fileKey() );
         }
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/LeaderAvailabilityHandlerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/LeaderAvailabilityHandlerTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.consensus;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.UUID;
+import java.util.function.LongSupplier;
+
+import org.neo4j.causalclustering.core.consensus.log.RaftLogEntry;
+import org.neo4j.causalclustering.identity.ClusterId;
+import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.causalclustering.messaging.Inbound;
+import org.neo4j.logging.NullLogProvider;
+
+public class LeaderAvailabilityHandlerTest
+{
+    @SuppressWarnings( "unchecked" )
+    private Inbound.MessageHandler<RaftMessages.ClusterIdAwareMessage> delegate = Mockito.mock( Inbound.MessageHandler.class );
+    private LeaderAvailabilityTimers leaderAvailabilityTimers = Mockito.mock( LeaderAvailabilityTimers.class );
+    private ClusterId clusterId = new ClusterId( UUID.randomUUID() );
+    private LongSupplier term = () -> 3;
+
+    private LeaderAvailabilityHandler handler = new LeaderAvailabilityHandler( delegate, leaderAvailabilityTimers, term, NullLogProvider.getInstance() );
+
+    private MemberId leader = new MemberId( UUID.randomUUID() );
+    private RaftMessages.ClusterIdAwareMessage heartbeat =
+            new RaftMessages.ClusterIdAwareMessage( clusterId, new RaftMessages.Heartbeat( leader, term.getAsLong(), 0, 0 ) );
+    private RaftMessages.ClusterIdAwareMessage appendEntries =
+            new RaftMessages.ClusterIdAwareMessage( clusterId,
+                    new RaftMessages.AppendEntries.Request( leader, term.getAsLong(), 0, 0, RaftLogEntry.empty, 0 )
+            );
+    private RaftMessages.ClusterIdAwareMessage voteResponse =
+            new RaftMessages.ClusterIdAwareMessage( clusterId, new RaftMessages.Vote.Response( leader, term.getAsLong(), false ) );
+
+    @Test
+    public void shouldDropMessagesIfHasNotBeenStarted() throws Exception
+    {
+        // when
+        handler.handle( heartbeat );
+
+        // then
+        Mockito.verify( delegate, Mockito.never() ).handle( heartbeat );
+    }
+
+    @Test
+    public void shouldDropMessagesIfHasBeenStopped() throws Exception
+    {
+        // given
+        handler.start( clusterId );
+        handler.stop();
+
+        // when
+        handler.handle( heartbeat );
+
+        // then
+        Mockito.verify( delegate, Mockito.never() ).handle( heartbeat );
+    }
+
+    @Test
+    public void shouldDropMessagesIfForDifferentClusterId() throws Exception
+    {
+        // given
+        handler.start( clusterId );
+
+        // when
+        handler.handle( new RaftMessages.ClusterIdAwareMessage(
+                new ClusterId( UUID.randomUUID() ), new RaftMessages.Heartbeat( leader, term.getAsLong(), 0, 0 )
+        ) );
+
+        // then
+        Mockito.verify( delegate, Mockito.never() ).handle( heartbeat );
+    }
+
+    @Test
+    public void shouldDelegateMessages() throws Exception
+    {
+        // given
+        handler.start( clusterId );
+
+        // when
+        handler.handle( heartbeat );
+
+        // then
+        Mockito.verify( delegate ).handle( heartbeat );
+    }
+
+    @Test
+    public void shouldRenewElectionForHeartbeats() throws Exception
+    {
+        // given
+        handler.start( clusterId );
+
+        // when
+        handler.handle( heartbeat );
+
+        // then
+        Mockito.verify( leaderAvailabilityTimers ).renewElection();
+    }
+
+    @Test
+    public void shouldRenewElectionForAppendEntriesRequests() throws Exception
+    {
+        // given
+        handler.start( clusterId );
+
+        // when
+        handler.handle( appendEntries );
+
+        // then
+        Mockito.verify( leaderAvailabilityTimers ).renewElection();
+    }
+
+    @Test
+    public void shouldNotRenewElectionForOtherMessages() throws Exception
+    {
+        // given
+        handler.start( clusterId );
+
+        // when
+        handler.handle( voteResponse );
+
+        // then
+        Mockito.verify( leaderAvailabilityTimers, Mockito.never() ).renewElection();
+    }
+
+    @Test
+    public void shouldNotRenewElectionTimeoutsForHeartbeatsFromEarlierTerm() throws Exception
+    {
+        // given
+        RaftMessages.ClusterIdAwareMessage heartbeat =
+                new RaftMessages.ClusterIdAwareMessage( clusterId, new RaftMessages.Heartbeat( leader, term.getAsLong() - 1, 0, 0 ) );
+
+        handler.start( clusterId );
+
+        // when
+        handler.handle( heartbeat );
+
+        // then
+        Mockito.verify( leaderAvailabilityTimers, Mockito.never() ).renewElection();
+    }
+
+    @Test
+    public void shouldNotRenewElectionTimeoutsForAppendEntriesRequestsFromEarlierTerms() throws Exception
+    {
+        RaftMessages.ClusterIdAwareMessage appendEntries =
+                new RaftMessages.ClusterIdAwareMessage( clusterId,
+                        new RaftMessages.AppendEntries.Request( leader, term.getAsLong() - 1, 0, 0, RaftLogEntry.empty, 0 )
+                );
+
+        handler.start( clusterId );
+
+        // when
+        handler.handle( appendEntries );
+
+        // then
+        Mockito.verify( leaderAvailabilityTimers, Mockito.never() ).renewElection();
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftMachineBuilder.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftMachineBuilder.java
@@ -21,6 +21,7 @@ package org.neo4j.causalclustering.core.consensus;
 
 import java.io.IOException;
 import java.time.Clock;
+import java.time.Duration;
 
 import org.neo4j.causalclustering.core.consensus.log.cache.ConsecutiveInFlightCache;
 import org.neo4j.causalclustering.core.consensus.log.cache.InFlightCache;
@@ -55,8 +56,9 @@ public class RaftMachineBuilder
     private int expectedClusterSize;
     private RaftGroup.Builder memberSetBuilder;
 
-    private StateStorage<TermState> termState = new InMemoryStateStorage<>( new TermState() );
-    private StateStorage<VoteState> voteState = new InMemoryStateStorage<>( new VoteState() );
+    private TermState termState = new TermState();
+    private StateStorage<TermState> termStateStorage = new InMemoryStateStorage<>( termState );
+    private StateStorage<VoteState> voteStateStorage = new InMemoryStateStorage<>( new VoteState() );
     private RaftLog raftLog = new InMemoryRaftLog();
     private RenewableTimeoutService renewableTimeoutService = new DelayedRenewableTimeoutService( Clocks.systemClock(),
             getInstance() );
@@ -68,8 +70,11 @@ public class RaftMachineBuilder
     private Clock clock = Clocks.systemClock();
     private Clock shippingClock = Clocks.systemClock();
 
+    private long term = termState.currentTerm();
+
     private long electionTimeout = 500;
     private long heartbeatInterval = 150;
+
     private long catchupTimeout = 30000;
     private long retryTimeMillis = electionTimeout / 2;
     private int catchupBatchSize = 64;
@@ -89,17 +94,20 @@ public class RaftMachineBuilder
 
     public RaftMachine build()
     {
+        termState.update( term );
+        LeaderAvailabilityTimers
+                leaderAvailabilityTimers = new LeaderAvailabilityTimers( Duration.ofMillis( electionTimeout ), Duration.ofMillis( heartbeatInterval ), clock,
+                renewableTimeoutService, logProvider );
         SendToMyself leaderOnlyReplicator = new SendToMyself( member, outbound );
         RaftMembershipManager membershipManager = new RaftMembershipManager( leaderOnlyReplicator,
-                memberSetBuilder, raftLog, logProvider, expectedClusterSize, electionTimeout, clock, catchupTimeout,
+                memberSetBuilder, raftLog, logProvider, expectedClusterSize, leaderAvailabilityTimers.getElectionTimeout(), clock, catchupTimeout,
                 raftMembership );
         membershipManager.setRecoverFromIndexSupplier( () -> 0 );
         RaftLogShippingManager logShipping =
                 new RaftLogShippingManager( outbound, logProvider, raftLog, shippingClock, member, membershipManager,
                         retryTimeMillis, catchupBatchSize, maxAllowedShippingLag, inFlightCache );
-        RaftMachine raft = new RaftMachine( member, termState, voteState, raftLog, electionTimeout,
-                heartbeatInterval, renewableTimeoutService, outbound, logProvider,
-                membershipManager, logShipping, inFlightCache, false, false, monitors, clock );
+        RaftMachine raft = new RaftMachine( member, termStateStorage, voteStateStorage, raftLog, leaderAvailabilityTimers, outbound, logProvider,
+                membershipManager, logShipping, inFlightCache, false, false, monitors );
         inbound.registerHandler( ( incomingMessage ) ->
         {
             try
@@ -182,6 +190,12 @@ public class RaftMachineBuilder
     RaftMachineBuilder monitors( Monitors monitors )
     {
         this.monitors = monitors;
+        return this;
+    }
+
+    public RaftMachineBuilder term( long term )
+    {
+        this.term = term;
         return this;
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftMachineBuilder.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/RaftMachineBuilder.java
@@ -99,7 +99,7 @@ public class RaftMachineBuilder
                         retryTimeMillis, catchupBatchSize, maxAllowedShippingLag, inFlightCache );
         RaftMachine raft = new RaftMachine( member, termState, voteState, raftLog, electionTimeout,
                 heartbeatInterval, renewableTimeoutService, outbound, logProvider,
-                membershipManager, logShipping, inFlightCache, false, monitors, clock );
+                membershipManager, logShipping, inFlightCache, false, false, monitors, clock );
         inbound.registerHandler( ( incomingMessage ) ->
         {
             try

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/ComparableRaftState.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/explorer/ComparableRaftState.java
@@ -50,12 +50,14 @@ public class ComparableRaftState implements ReadableRaftState
     private long leaderCommit = -1;
     private MemberId votedFor = null;
     private Set<MemberId> votesForMe = new HashSet<>();
+    private Set<MemberId> preVotesForMe = new HashSet<>();
     private Set<MemberId> heartbeatResponses = new HashSet<>();
     private long lastLogIndexBeforeWeBecameLeader = -1;
     private FollowerStates<MemberId> followerStates = new FollowerStates<>();
     protected final RaftLog entryLog;
     private final InFlightCache inFlightCache;
     private long commitIndex = -1;
+    private boolean isPreElection = false;
 
     ComparableRaftState( MemberId myself, Set<MemberId> votingMembers, Set<MemberId> replicationMembers,
                          RaftLog entryLog, InFlightCache inFlightCache, LogProvider logProvider )
@@ -152,6 +154,24 @@ public class ComparableRaftState implements ReadableRaftState
         return commitIndex;
     }
 
+    @Override
+    public boolean supportPreVoting()
+    {
+        return false;
+    }
+
+    @Override
+    public boolean isPreElection()
+    {
+        return isPreElection;
+    }
+
+    @Override
+    public Set<MemberId> preVotesForMe()
+    {
+        return preVotesForMe;
+    }
+
     public void update( Outcome outcome ) throws IOException
     {
         term = outcome.getTerm();
@@ -160,6 +180,7 @@ public class ComparableRaftState implements ReadableRaftState
         votesForMe = outcome.getVotesForMe();
         lastLogIndexBeforeWeBecameLeader = outcome.getLastLogIndexBeforeWeBecameLeader();
         followerStates = outcome.getFollowerStates();
+        isPreElection = outcome.isPreElection();
 
         for ( RaftLogCommand logCommand : outcome.getLogCommands() )
         {

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/FollowerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/FollowerTest.java
@@ -20,9 +20,6 @@
 package org.neo4j.causalclustering.core.consensus.roles;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -38,7 +35,6 @@ import org.neo4j.causalclustering.core.consensus.membership.RaftTestGroup;
 import org.neo4j.causalclustering.core.consensus.outcome.Outcome;
 import org.neo4j.causalclustering.core.consensus.state.RaftState;
 import org.neo4j.causalclustering.identity.MemberId;
-import org.neo4j.causalclustering.messaging.Inbound;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.NullLogProvider;
 
@@ -55,7 +51,6 @@ import static org.neo4j.causalclustering.core.consensus.state.RaftStateBuilder.r
 import static org.neo4j.causalclustering.identity.RaftTestMember.member;
 import static org.neo4j.helpers.collection.Iterators.asSet;
 
-@RunWith(MockitoJUnitRunner.class)
 public class FollowerTest
 {
     private MemberId myself = member( 0 );
@@ -63,9 +58,6 @@ public class FollowerTest
     /* A few members that we use at will in tests. */
     private MemberId member1 = member( 1 );
     private MemberId member2 = member( 2 );
-
-    @Mock
-    private Inbound inbound;
 
     @Test
     public void followerShouldTransitToCandidateAndInstigateAnElectionAfterTimeout() throws Exception

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/FollowerTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/FollowerTest.java
@@ -234,24 +234,6 @@ public class FollowerTest
     }
 
     @Test
-    public void shouldRenewElectionTimeoutOnReceiptOfHeartbeatInCurrentOrHigherTerm() throws Exception
-    {
-        // given
-        RaftState state = raftState()
-                .myself( myself )
-                .term(0)
-                .build();
-
-        Follower follower = new Follower();
-
-        Outcome outcome = follower.handle( new RaftMessages.Heartbeat( myself, 1, 1, 1 ),
-                state, log() );
-
-        // then
-        assertTrue( outcome.electionTimeoutRenewed() );
-    }
-
-    @Test
     public void shouldNotRenewElectionTimeoutOnReceiptOfHeartbeatInLowerTerm() throws Exception
     {
         // given

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/LeaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/LeaderTest.java
@@ -45,9 +45,13 @@ import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
 
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
@@ -325,6 +329,68 @@ public class LeaderTest
     }
 
     @Test
+    public void shouldSendCompactionInfoIfFailureWithNoEarlierEntries() throws Exception
+    {
+        // given
+        Leader leader = new Leader();
+        long term = 1;
+        long leaderPrevIndex = 3;
+        long followerIndex = leaderPrevIndex - 1;
+
+        InMemoryRaftLog raftLog = new InMemoryRaftLog();
+        raftLog.skip( leaderPrevIndex, term );
+
+        RaftState state = raftState()
+                .term( term )
+                .entryLog( raftLog )
+                .build();
+
+        RaftMessages.AppendEntries.Response incomingResponse = appendEntriesResponse()
+                .failure()
+                .term( term )
+                .appendIndex( followerIndex )
+                .from( member1 ).build();
+
+        // when
+        Outcome outcome = leader.handle( incomingResponse, state, log() );
+
+        // then
+        RaftMessages.RaftMessage outgoingMessage = messageFor( outcome, member1 );
+        assertThat( outgoingMessage, instanceOf( RaftMessages.LogCompactionInfo.class ) );
+
+        RaftMessages.LogCompactionInfo typedOutgoingMessage = (RaftMessages.LogCompactionInfo) outgoingMessage;
+        assertThat( typedOutgoingMessage.prevIndex(), equalTo( leaderPrevIndex ) );
+    }
+
+    @Test
+    public void shouldIgnoreAppendResponsesFromOldTerms() throws Exception
+    {
+        // given
+        Leader leader = new Leader();
+        long leaderTerm = 5;
+        long followerTerm = 3;
+
+        RaftState state = raftState()
+                .term( leaderTerm )
+                .build();
+
+                RaftMessages.AppendEntries.Response incomingResponse = appendEntriesResponse()
+                .failure()
+                .term( followerTerm )
+                .from( member1 ).build();
+
+        // when
+        Outcome outcome = leader.handle( incomingResponse, state, log() );
+
+        // then
+        assertThat( outcome.getTerm(), equalTo( leaderTerm ) );
+        assertThat( outcome.getRole(), equalTo( LEADER ) );
+
+        assertThat( outcome.getOutgoingMessages(), empty() );
+        assertThat( outcome.getShipCommands(), empty() );
+    }
+
+    @Test
     public void leaderShouldRejectAppendEntriesResponseWithNewerTermAndBecomeAFollower() throws Exception
     {
         // given
@@ -556,6 +622,167 @@ public class LeaderTest
 
         // then
         assertEquals( 2, state.commitIndex() );
+    }
+
+    @Test
+    public void shouldSendNegativeResponseForVoteRequestFromTermNotGreaterThanLeader() throws Exception
+    {
+        // given
+        long leaderTerm = 5;
+        long leaderCommitIndex = 10;
+        long rivalTerm = leaderTerm - 1;
+
+        Leader leader = new Leader();
+        RaftState state = raftState()
+                .term( leaderTerm )
+                .commitIndex( leaderCommitIndex )
+                .build();
+
+        // when
+        Outcome outcome = leader.handle( new RaftMessages.Vote.Request( member1, rivalTerm, member1, leaderCommitIndex, leaderTerm ), state, log() );
+
+        // then
+        assertThat( outcome.getRole(), equalTo( LEADER) );
+        assertThat( outcome.getTerm(), equalTo( leaderTerm ) );
+
+        RaftMessages.RaftMessage response = messageFor( outcome, member1 );
+        assertThat( response, instanceOf( RaftMessages.Vote.Response.class ) );
+        RaftMessages.Vote.Response typedResponse = (RaftMessages.Vote.Response) response;
+        assertThat( typedResponse.voteGranted(), equalTo( false ) );
+    }
+
+    @Test
+    public void shouldStepDownIfReceiveVoteRequestFromGreaterTermThanLeader() throws Exception
+    {
+        // given
+        long leaderTerm = 1;
+        long leaderCommitIndex = 10;
+        long rivalTerm = leaderTerm + 1;
+
+        Leader leader = new Leader();
+        RaftState state = raftState()
+                .term( leaderTerm )
+                .commitIndex( leaderCommitIndex )
+                .build();
+
+        // when
+        Outcome outcome = leader.handle( new RaftMessages.Vote.Request( member1, rivalTerm, member1, leaderCommitIndex, leaderTerm ), state, log() );
+
+        // then
+        assertThat( outcome.getRole(), equalTo( FOLLOWER ) );
+        assertThat( outcome.getLeader(), nullValue() );
+        assertThat( outcome.getTerm(), equalTo( rivalTerm ) );
+
+        RaftMessages.RaftMessage response = messageFor( outcome, member1 );
+        assertThat( response, instanceOf( RaftMessages.Vote.Response.class ) );
+        RaftMessages.Vote.Response typedResponse = (RaftMessages.Vote.Response) response;
+        assertThat( typedResponse.voteGranted(), equalTo( true ) );
+    }
+
+    @Test
+    public void shouldIgnoreHeartbeatFromOlderTerm() throws Exception
+    {
+        // given
+        long leaderTerm = 5;
+        long leaderCommitIndex = 10;
+        long rivalTerm = leaderTerm - 1;
+
+        Leader leader = new Leader();
+        RaftState state = raftState()
+                .term( leaderTerm )
+                .commitIndex( leaderCommitIndex )
+                .build();
+
+        // when
+        Outcome outcome = leader.handle( new RaftMessages.Heartbeat( member1, rivalTerm, leaderCommitIndex, leaderTerm ), state, log() );
+
+        // then
+        assertThat( outcome.getRole(), equalTo( LEADER) );
+        assertThat( outcome.getTerm(), equalTo( leaderTerm ) );
+    }
+
+    @Test
+    public void shouldStepDownIfHeartbeatReceivedWithGreaterOrEqualTerm() throws Exception
+    {
+        // given
+        long leaderTerm = 1;
+        long leaderCommitIndex = 10;
+        long rivalTerm = leaderTerm + 1;
+
+        Leader leader = new Leader();
+        RaftState state = raftState()
+                .term( leaderTerm )
+                .commitIndex( leaderCommitIndex )
+                .build();
+
+        // when
+        Outcome outcome = leader.handle( new RaftMessages.Heartbeat( member1, rivalTerm, leaderCommitIndex, leaderTerm ), state, log() );
+
+        // then
+        assertThat( outcome.getRole(), equalTo( FOLLOWER ) );
+        assertThat( outcome.getLeader(), equalTo( member1 ) );
+        assertThat( outcome.getTerm(), equalTo( rivalTerm ) );
+    }
+
+    @Test
+    public void shouldRespondNegativelyToAppendEntriesRequestFromEarlierTerm() throws Exception
+    {
+        // given
+        long leaderTerm = 5;
+        long leaderCommitIndex = 10;
+        long rivalTerm = leaderTerm - 1;
+        long logIndex = 20;
+        RaftLogEntry[] entries = { new RaftLogEntry( rivalTerm, ReplicatedInteger.valueOf( 99 ) ) };
+
+        Leader leader = new Leader();
+        RaftState state = raftState()
+                .term( leaderTerm )
+                .commitIndex( leaderCommitIndex )
+                .build();
+
+        // when
+        Outcome outcome = leader.handle( new RaftMessages.AppendEntries.Request( member1, rivalTerm, logIndex, leaderTerm, entries, leaderCommitIndex ), state, log() );
+
+        // then
+        assertThat( outcome.getRole(), equalTo( LEADER) );
+        assertThat( outcome.getTerm(), equalTo( leaderTerm ) );
+
+        RaftMessages.RaftMessage response = messageFor( outcome, member1 );
+        assertThat( response, instanceOf( RaftMessages.AppendEntries.Response.class ) );
+        RaftMessages.AppendEntries.Response typedResponse = (RaftMessages.AppendEntries.Response) response;
+        assertThat( typedResponse.term(), equalTo( leaderTerm ) );
+        assertThat( typedResponse.success(), equalTo( false ) );
+    }
+
+    @Test
+    public void shouldStepDownIfAppendEntriesRequestFromLaterTerm() throws Exception
+    {
+        // given
+        long leaderTerm = 1;
+        long leaderCommitIndex = 10;
+        long rivalTerm = leaderTerm + 1;
+        long logIndex = 20;
+        RaftLogEntry[] entries = { new RaftLogEntry( rivalTerm, ReplicatedInteger.valueOf( 99 ) ) };
+
+        Leader leader = new Leader();
+        RaftState state = raftState()
+                .term( leaderTerm )
+                .commitIndex( leaderCommitIndex )
+                .build();
+
+        // when
+        Outcome outcome = leader.handle( new RaftMessages.AppendEntries.Request( member1, rivalTerm, logIndex, leaderTerm, entries, leaderCommitIndex ), state, log() );
+
+        // then
+        assertThat( outcome.getRole(), equalTo( FOLLOWER ) );
+        assertThat( outcome.getLeader(), equalTo( member1 ) );
+        assertThat( outcome.getTerm(), equalTo( rivalTerm ) );
+
+        RaftMessages.RaftMessage response = messageFor( outcome, member1 );
+        assertThat( response, instanceOf( RaftMessages.AppendEntries.Response.class ) );
+        RaftMessages.AppendEntries.Response typedResponse = (RaftMessages.AppendEntries.Response) response;
+        assertThat( typedResponse.term(), equalTo( rivalTerm ) );
+        // Not checking success or failure of append
     }
 
     private Log log()

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/PreVotingInitiatorTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/PreVotingInitiatorTest.java
@@ -1,0 +1,355 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.consensus.roles;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import org.neo4j.causalclustering.core.consensus.RaftMessages;
+import org.neo4j.causalclustering.core.consensus.outcome.Outcome;
+import org.neo4j.causalclustering.core.consensus.state.RaftState;
+import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.NullLogProvider;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.causalclustering.core.consensus.MessageUtils.messageFor;
+import static org.neo4j.causalclustering.core.consensus.roles.Role.CANDIDATE;
+import static org.neo4j.causalclustering.core.consensus.roles.Role.FOLLOWER;
+import static org.neo4j.causalclustering.core.consensus.state.RaftStateBuilder.raftState;
+import static org.neo4j.causalclustering.identity.RaftTestMember.member;
+import static org.neo4j.helpers.collection.Iterators.asSet;
+
+public class PreVotingInitiatorTest
+{
+    private MemberId myself = member( 0 );
+
+    /* A few members that we use at will in tests. */
+    private MemberId member1 = member( 1 );
+    private MemberId member2 = member( 2 );
+    private MemberId member3 = member( 3 );
+    private MemberId member4 = member( 4 );
+
+    @Test
+    public void shouldSetPreElectionOnElectionTimeout() throws Exception
+    {
+        // given
+        RaftState state = initialState();
+
+        // when
+        Outcome outcome = new Follower().handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome );
+
+        // then
+        assertThat( outcome.getRole(), equalTo( FOLLOWER ) );
+        assertThat( outcome.isPreElection(), equalTo( true ) );
+    }
+
+    @Test
+    public void shouldSendPreVoteRequestsOnElectionTimeout() throws Exception
+    {
+        // given
+        RaftState state = initialState();
+
+        // when
+        Outcome outcome = new Follower().handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome );
+
+        // then
+        assertThat( messageFor( outcome, member1 ).type(), equalTo( RaftMessages.Type.PRE_VOTE_REQUEST ) );
+        assertThat( messageFor( outcome, member2 ).type(), equalTo( RaftMessages.Type.PRE_VOTE_REQUEST ) );
+    }
+
+    @Test
+    public void shouldProceedToRealElectionIfReceiveQuorumOfPositiveResponses() throws Exception
+    {
+        // given
+        RaftState state = initialState();
+
+        Follower underTest = new Follower();
+
+        Outcome outcome1 = underTest.handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome1 );
+
+        // when
+        Outcome outcome2 = underTest.handle( new RaftMessages.PreVote.Response( member1, 0L, true ), state, log() );
+
+        // then
+        assertThat( outcome2.getRole(), equalTo( CANDIDATE ) );
+        assertThat( outcome2.isPreElection(), equalTo( false ) );
+        assertThat( outcome2.getPreVotesForMe(), contains( member1 ) );
+    }
+
+    @Test
+    public void shouldIgnorePositiveResponsesFromOlderTerm() throws Exception
+    {
+        // given
+        RaftState state = raftState()
+                .myself( myself )
+                .term( 1 )
+                .supportsPreVoting( true )
+                .votingMembers( asSet( myself, member1, member2 ) )
+                .build();
+
+        Follower underTest = new Follower();
+
+        Outcome outcome1 = underTest.handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome1 );
+
+        // when
+        Outcome outcome2 = underTest.handle( new RaftMessages.PreVote.Response( member1, 0L, true ), state, log() );
+
+        // then
+        assertThat( outcome2.getRole(), equalTo( FOLLOWER ) );
+        assertThat( outcome2.isPreElection(), equalTo( true ) );
+        assertThat( outcome2.getPreVotesForMe(), empty() );
+    }
+
+    @Test
+    public void shouldIgnorePositiveResponsesIfNotInPreVotingStage() throws Exception
+    {
+        // given
+        RaftState state = raftState()
+                .myself( myself )
+                .supportsPreVoting( true )
+                .votingMembers( asSet( myself, member1, member2 ) )
+                .build();
+
+        Follower underTest = new Follower();
+
+        // when
+        Outcome outcome = underTest.handle( new RaftMessages.PreVote.Response( member1, 0L, true ), state, log() );
+
+        // then
+        assertThat( outcome.getRole(), equalTo( FOLLOWER ) );
+        assertThat( outcome.isPreElection(), equalTo( false ) );
+        assertThat( outcome.getPreVotesForMe(), empty() );
+    }
+
+    @Test
+    public void shouldNotMoveToRealElectionWithoutQuorum() throws Exception
+    {
+        // given
+        RaftState state = raftState()
+                .myself( myself )
+                .supportsPreVoting( true )
+                .votingMembers( asSet( myself, member1, member2, member3, member4 ) )
+                .build();
+
+        Follower underTest = new Follower();
+        Outcome outcome1 = underTest.handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome1 );
+
+        // when
+        Outcome outcome2 = underTest.handle( new RaftMessages.PreVote.Response( member1, 0L, true ), state, log() );
+
+        // then
+        assertThat( outcome2.getRole(), equalTo( FOLLOWER ) );
+        assertThat( outcome2.isPreElection(), equalTo( true ) );
+        assertThat( outcome2.getPreVotesForMe(), contains( member1 ) );
+    }
+
+    @Test
+    public void shouldMoveToRealElectionWithQuorumOf5() throws Exception
+    {
+        // given
+        RaftState state = raftState()
+                .myself( myself )
+                .supportsPreVoting( true )
+                .votingMembers( asSet( myself, member1, member2, member3, member4 ) )
+                .build();
+
+        Follower underTest = new Follower();
+        Outcome outcome1 = underTest.handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome1 );
+
+        // when
+        Outcome outcome2 = underTest.handle( new RaftMessages.PreVote.Response( member1, 0L, true ), state, log() );
+        state.update( outcome2 );
+        Outcome outcome3 = underTest.handle( new RaftMessages.PreVote.Response( member2, 0L, true ), state, log() );
+
+        // then
+        assertThat( outcome3.getRole(), equalTo( CANDIDATE ) );
+        assertThat( outcome3.isPreElection(), equalTo( false ) );
+    }
+
+    @Test
+    public void shouldNotCountVotesFromSameMemberTwice() throws Exception
+    {
+        // given
+        RaftState state = raftState()
+                .myself( myself )
+                .supportsPreVoting( true )
+                .votingMembers( asSet( myself, member1, member2, member3, member4 ) )
+                .build();
+
+        Follower underTest = new Follower();
+        Outcome outcome1 = underTest.handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome1 );
+
+        // when
+        Outcome outcome2 = underTest.handle( new RaftMessages.PreVote.Response( member1, 0L, true ), state, log() );
+        state.update( outcome2 );
+        Outcome outcome3 = underTest.handle( new RaftMessages.PreVote.Response( member1, 0L, true ), state, log() );
+
+        // then
+        assertThat( outcome3.getRole(), equalTo( FOLLOWER ) );
+        assertThat( outcome3.isPreElection(), equalTo( true ) );
+    }
+
+    @Test
+    public void shouldResetPreVotesWhenMovingBackToFollower() throws Exception
+    {
+        // given
+        RaftState state = initialState();
+
+        Outcome outcome1 = new Follower().handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome1 );
+        Outcome outcome2 = new Follower().handle( new RaftMessages.PreVote.Response( member1, 0L, true ), state, log() );
+        assertThat( CANDIDATE, equalTo( outcome2.getRole() ) );
+        assertThat( outcome2.getPreVotesForMe(), contains( member1 ) );
+
+        // when
+        Outcome outcome3 = new Candidate().handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+
+        // then
+        assertThat( outcome3.getPreVotesForMe(), empty() );
+    }
+
+    @Test
+    public void shouldSendRealVoteRequestsIfReceivePositiveResponses() throws Exception
+    {
+        // given
+        RaftState state = initialState();
+
+        Follower underTest = new Follower();
+
+        Outcome outcome1 = underTest.handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome1 );
+
+        // when
+        Outcome outcome2 = underTest.handle( new RaftMessages.PreVote.Response( member1, 0L, true ), state, log() );
+
+        // then
+        assertThat( messageFor( outcome2, member1 ).type(), equalTo( RaftMessages.Type.VOTE_REQUEST ) );
+        assertThat( messageFor( outcome2, member2 ).type(), equalTo( RaftMessages.Type.VOTE_REQUEST ) );
+    }
+
+    @Test
+    public void shouldNotProceedToRealElectionIfReceiveNegativeResponses() throws Exception
+    {
+                // given
+        RaftState state = initialState();
+
+        Follower underTest = new Follower();
+
+        Outcome outcome1 = underTest.handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome1 );
+
+        // when
+        Outcome outcome2 = underTest.handle( new RaftMessages.PreVote.Response( member1, 0L, false ), state, log() );
+        state.update( outcome2 );
+        Outcome outcome3 = underTest.handle( new RaftMessages.PreVote.Response( member2, 0L, false ), state, log() );
+
+        // then
+        assertThat( outcome3.getRole(), equalTo( FOLLOWER ) );
+        assertThat( outcome3.isPreElection(), equalTo( true ) );
+        assertThat( outcome3.getPreVotesForMe(), empty() );
+    }
+
+    @Test
+    public void shouldNotSendRealVoteRequestsIfReceiveNegativeResponses() throws Exception
+    {
+        // given
+        RaftState state = initialState();
+
+        Follower underTest = new Follower();
+
+        Outcome outcome1 = underTest.handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome1 );
+
+        // when
+        Outcome outcome2 = underTest.handle( new RaftMessages.PreVote.Response( member1, 0L, false ), state, log() );
+        state.update( outcome2 );
+        Outcome outcome3 = underTest.handle( new RaftMessages.PreVote.Response( member2, 0L, false ), state, log() );
+
+        // then
+        assertThat( outcome2.getOutgoingMessages(), empty() );
+        assertThat( outcome3.getOutgoingMessages(), empty() );
+    }
+
+    @Test
+    public void shouldResetPreVoteIfReceiveHeartbeatFromLeader() throws Exception
+    {
+        // given
+        RaftState state = initialState();
+
+        Follower underTest = new Follower();
+
+        Outcome outcome1 = underTest.handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome1 );
+
+        // when
+        Outcome outcome2 = underTest.handle( new RaftMessages.Heartbeat( member1, 0L, 0L, 0L ), state, log() );
+
+        // then
+        assertThat( outcome2.getRole(), equalTo( FOLLOWER ) );
+        assertThat( outcome2.isPreElection(), equalTo( false ) );
+        assertThat( outcome2.getPreVotesForMe(), empty() );
+    }
+
+    @Test
+    public void shouldNotSendPreVoteRequestsIfReceiveHeartbeatFromLeader() throws Exception
+    {
+        // given
+        RaftState state = initialState();
+
+        Follower underTest = new Follower();
+
+        Outcome outcome1 = underTest.handle( new RaftMessages.Timeout.Election( myself ), state, log() );
+        state.update( outcome1 );
+
+        // when
+        Outcome outcome2 = underTest.handle( new RaftMessages.Heartbeat( member1, 0L, 0L, 0L ), state, log() );
+        state.update( outcome2 );
+        Outcome outcome3 = underTest.handle( new RaftMessages.PreVote.Response( member2, 0L, true ), state, log() );
+
+        // then
+        assertThat( outcome3.isPreElection(), equalTo( false ) );
+    }
+
+    private Log log()
+    {
+        return NullLogProvider.getInstance().getLog( getClass() );
+    }
+
+    private RaftState initialState() throws IOException
+    {
+        return raftState()
+                .myself( myself )
+                .supportsPreVoting( true )
+                .votingMembers( asSet( myself, member1, member2 ) )
+                .build();
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/PreVotingVoterTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/roles/PreVotingVoterTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.consensus.roles;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+import org.neo4j.causalclustering.core.consensus.RaftMessages;
+import org.neo4j.causalclustering.core.consensus.outcome.Outcome;
+import org.neo4j.causalclustering.core.consensus.state.RaftState;
+import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.NullLogProvider;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.causalclustering.core.consensus.MessageUtils.messageFor;
+import static org.neo4j.causalclustering.core.consensus.state.RaftStateBuilder.raftState;
+import static org.neo4j.causalclustering.identity.RaftTestMember.member;
+import static org.neo4j.helpers.collection.Iterators.asSet;
+
+public class PreVotingVoterTest
+{
+    private MemberId myself = member( 0 );
+
+    /* A few members that we use at will in tests. */
+    private MemberId member1 = member( 1 );
+    private MemberId member2 = member( 2 );
+
+    @Test
+    public void shouldRespondPositivelyIfWouldVoteForCandidate() throws Exception
+    {
+        // given
+        RaftState raftState = initialState();
+
+        // when
+        Outcome outcome = new Follower().handle( new RaftMessages.PreVote.Request( member1, 0, member1, 0, 0 ), raftState, log() );
+
+        // then
+        RaftMessages.RaftMessage raftMessage = messageFor( outcome, member1 );
+        assertThat( raftMessage.type(), equalTo( RaftMessages.Type.PRE_VOTE_RESPONSE ) );
+        assertThat( ( (RaftMessages.PreVote.Response)raftMessage ).voteGranted() , equalTo( true )  );
+    }
+
+    @Test
+    public void shouldRespondPositivelyEvenIfAlreadyVotedInRealElection() throws Exception
+    {
+        // given
+        RaftState raftState = initialState();
+        raftState.update( new Follower().handle( new RaftMessages.Vote.Request( member1, 0, member1, 0, 0 ), raftState, log() ) );
+
+        // when
+        Outcome outcome = new Follower().handle( new RaftMessages.PreVote.Request( member2, 0, member2, 0, 0 ), raftState, log() );
+
+        // then
+        RaftMessages.RaftMessage raftMessage = messageFor( outcome, member2 );
+        assertThat( raftMessage.type(), equalTo( RaftMessages.Type.PRE_VOTE_RESPONSE ) );
+        assertThat( ( (RaftMessages.PreVote.Response)raftMessage ).voteGranted() , equalTo( true )  );
+    }
+
+    @Test
+    public void shouldRespondNegativelyIfLeaderAndRequestNotFromGreaterTerm() throws Exception
+    {
+        // given
+        RaftState raftState = initialState();
+
+        // when
+        Outcome outcome = new Leader().handle( new RaftMessages.PreVote.Request( member1, Long.MIN_VALUE, member1, 0, 0 ), raftState, log() );
+
+        // then
+        RaftMessages.RaftMessage raftMessage = messageFor( outcome, member1 );
+        assertThat( raftMessage.type(), equalTo( RaftMessages.Type.PRE_VOTE_RESPONSE ) );
+        assertThat( ( (RaftMessages.PreVote.Response)raftMessage ).voteGranted() , equalTo( false )  );
+    }
+
+    @Test
+    public void shouldRespondPositivelyIfLeaderAndRequestFromGreaterTerm() throws Exception
+    {
+        // given
+        RaftState raftState = initialState();
+
+        // when
+        Outcome outcome = new Leader().handle( new RaftMessages.PreVote.Request( member1, Long.MAX_VALUE, member1, 0, 0 ), raftState, log() );
+
+        // then
+        RaftMessages.RaftMessage raftMessage = messageFor( outcome, member1 );
+        assertThat( raftMessage.type(), equalTo( RaftMessages.Type.PRE_VOTE_RESPONSE ) );
+        assertThat( ( (RaftMessages.PreVote.Response)raftMessage ).voteGranted() , equalTo( true )  );
+    }
+
+    @Test
+    public void shouldRespondNegativelyIfNotInPreVoteMyself() throws Exception
+    {
+        // given
+        RaftState raftState = raftState()
+                .myself( myself )
+                .supportsPreVoting( true )
+                .votingMembers( asSet( myself, member1, member2 ) )
+                .setPreElection( false )
+                .build();
+
+        // when
+        Outcome outcome = new Follower().handle( new RaftMessages.PreVote.Request( member1, 0, member1, 0, 0 ), raftState, log() );
+
+        // then
+        RaftMessages.RaftMessage raftMessage = messageFor( outcome, member1 );
+        assertThat( raftMessage.type(), equalTo( RaftMessages.Type.PRE_VOTE_RESPONSE ) );
+        assertThat( ( (RaftMessages.PreVote.Response)raftMessage ).voteGranted() , equalTo( false )  );
+    }
+
+    @Test
+    public void shouldRespondNegativelyIfWouldNotVoteForCandidate() throws Exception
+    {
+        // given
+        RaftState raftState = raftState()
+                .myself( myself )
+                .term( 1 )
+                .setPreElection( true )
+                .supportsPreVoting( true )
+                .votingMembers( asSet( myself, member1, member2 ) )
+                .build();
+
+        // when
+        Outcome outcome = new Follower().handle( new RaftMessages.PreVote.Request( member1, 0, member1, 0, 0 ), raftState, log() );
+
+        // then
+        RaftMessages.RaftMessage raftMessage = messageFor( outcome, member1 );
+        assertThat( raftMessage.type(), equalTo( RaftMessages.Type.PRE_VOTE_RESPONSE ) );
+        assertThat( ( (RaftMessages.PreVote.Response)raftMessage ).voteGranted() , equalTo( false )  );
+    }
+
+    @Test
+    public void shouldRespondPositivelyToMultipleMembersIfWouldVoteForAny() throws Exception
+    {
+        // given
+        RaftState raftState = initialState();
+
+        // when
+        Outcome outcome1 = new Follower().handle( new RaftMessages.PreVote.Request( member1, 0, member1, 0, 0 ), raftState, log() );
+        raftState.update( outcome1 );
+        Outcome outcome2 = new Follower().handle( new RaftMessages.PreVote.Request( member2, 0, member2, 0, 0 ), raftState, log() );
+        raftState.update( outcome2 );
+
+        // then
+        RaftMessages.RaftMessage raftMessage = messageFor( outcome2, member2 );
+
+        assertThat( raftMessage.type(), equalTo( RaftMessages.Type.PRE_VOTE_RESPONSE ) );
+        assertThat( ( (RaftMessages.PreVote.Response)raftMessage ).voteGranted() , equalTo( true )  );
+    }
+
+    @Test
+    public void shouldUseTermFromRequestIfHigherThanOwn() throws Exception
+    {
+        // given
+        RaftState raftState = initialState();
+        long newTerm = 1;
+
+        // when
+        Outcome outcome = new Follower().handle( new RaftMessages.PreVote.Request( member1, newTerm, member1, 0, 0 ), raftState, log() );
+
+        // then
+        RaftMessages.RaftMessage raftMessage = messageFor( outcome, member1 );
+
+        assertThat( raftMessage.type(), equalTo( RaftMessages.Type.PRE_VOTE_RESPONSE ) );
+        assertThat( ( (RaftMessages.PreVote.Response)raftMessage ).term() , equalTo( newTerm )  );
+    }
+
+    private RaftState initialState() throws IOException
+    {
+        return raftState()
+                .myself( myself )
+                .supportsPreVoting( true )
+                .setPreElection( true )
+                .votingMembers( asSet( myself, member1, member2 ) )
+                .build();
+    }
+
+    private Log log()
+    {
+        return NullLogProvider.getInstance().getLog( getClass() );
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/state/RaftStateBuilder.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/state/RaftStateBuilder.java
@@ -58,10 +58,13 @@ public class RaftStateBuilder
     public long leaderCommit = -1;
     private MemberId votedFor;
     private RaftLog entryLog = new InMemoryRaftLog();
+    private boolean supportPreVoting;
     private Set<MemberId> votesForMe = emptySet();
+    private Set<MemberId> preVotesForMe = emptySet();
     private long lastLogIndexBeforeWeBecameLeader = -1;
     public long commitIndex = -1;
     private FollowerStates<MemberId> followerStates = new FollowerStates<>();
+    private boolean isPreElection = false;
 
     public RaftStateBuilder myself( MemberId myself )
     {
@@ -117,6 +120,12 @@ public class RaftStateBuilder
         return this;
     }
 
+    public RaftStateBuilder supportsPreVoting( boolean supportPreVoting )
+    {
+        this.supportPreVoting = supportPreVoting;
+        return this;
+    }
+
     public RaftStateBuilder lastLogIndexBeforeWeBecameLeader( long lastLogIndexBeforeWeBecameLeader )
     {
         this.lastLogIndexBeforeWeBecameLeader = lastLogIndexBeforeWeBecameLeader;
@@ -129,6 +138,12 @@ public class RaftStateBuilder
         return this;
     }
 
+    public RaftStateBuilder setPreElection( boolean isPreElection )
+    {
+        this.isPreElection = isPreElection;
+        return this;
+    }
+
     public RaftState build() throws IOException
     {
         StateStorage<TermState> termStore = new InMemoryStateStorage<>( new TermState() );
@@ -136,14 +151,14 @@ public class RaftStateBuilder
         StubMembership membership = new StubMembership( votingMembers, replicationMembers );
 
         RaftState state = new RaftState( myself, termStore, membership, entryLog,
-                voteStore, new ConsecutiveInFlightCache(), NullLogProvider.getInstance() );
+                voteStore, new ConsecutiveInFlightCache(), NullLogProvider.getInstance(), supportPreVoting );
 
         Collection<RaftMessages.Directed> noMessages = Collections.emptyList();
         List<RaftLogCommand> noLogCommands = Collections.emptyList();
 
-        state.update( new Outcome( null, term, leader, leaderCommit, votedFor, votesForMe,
+        state.update( new Outcome( null, term, leader, leaderCommit, votedFor, votesForMe, preVotesForMe,
                 lastLogIndexBeforeWeBecameLeader, followerStates, false, noLogCommands,
-                noMessages, emptySet(), commitIndex, emptySet() ) );
+                noMessages, emptySet(), commitIndex, emptySet(), isPreElection ) );
 
         return state;
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/state/RaftStateTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/state/RaftStateTest.java
@@ -66,7 +66,7 @@ public class RaftStateTest
         InFlightCache cache = new ConsecutiveInFlightCache();
         RaftState raftState = new RaftState( member( 0 ),
                 new InMemoryStateStorage<>( new TermState() ), new FakeMembership(), new InMemoryRaftLog(),
-                new InMemoryStateStorage<>( new VoteState() ), cache, NullLogProvider.getInstance() );
+                new InMemoryStateStorage<>( new VoteState() ), cache, NullLogProvider.getInstance(), false );
 
         List<RaftLogCommand> logCommands = new LinkedList<RaftLogCommand>()
         {{
@@ -79,8 +79,8 @@ public class RaftStateTest
         }};
 
         Outcome raftTestMemberOutcome =
-                new Outcome( CANDIDATE, 0, null, -1, null, emptySet(), -1, initialFollowerStates(), true,
-                        logCommands, emptyOutgoingMessages(), emptySet(), -1, emptySet() );
+                new Outcome( CANDIDATE, 0, null, -1, null, emptySet(), emptySet(), -1, initialFollowerStates(), true,
+                        logCommands, emptyOutgoingMessages(), emptySet(), -1, emptySet(), false );
 
         //when
         raftState.update(raftTestMemberOutcome);
@@ -101,14 +101,15 @@ public class RaftStateTest
                 new InMemoryStateStorage<>( new TermState() ),
                 new FakeMembership(), new InMemoryRaftLog(),
                 new InMemoryStateStorage<>( new VoteState( ) ),
-                new ConsecutiveInFlightCache(), NullLogProvider.getInstance() );
+                new ConsecutiveInFlightCache(), NullLogProvider.getInstance(),
+                false );
 
-        raftState.update( new Outcome( CANDIDATE, 1, null, -1, null, emptySet(), -1, initialFollowerStates(), true, emptyLogCommands(),
-                emptyOutgoingMessages(), emptySet(), -1, emptySet() ) );
+        raftState.update( new Outcome( CANDIDATE, 1, null, -1, null, emptySet(), emptySet(), -1, initialFollowerStates(), true, emptyLogCommands(),
+                emptyOutgoingMessages(), emptySet(), -1, emptySet(), false ) );
 
         // when
-        raftState.update( new Outcome( CANDIDATE, 1, null, -1, null, emptySet(), -1, new FollowerStates<>(), true, emptyLogCommands(),
-                emptyOutgoingMessages(), emptySet(), -1, emptySet() ) );
+        raftState.update( new Outcome( CANDIDATE, 1, null, -1, null, emptySet(), emptySet(), -1, new FollowerStates<>(), true, emptyLogCommands(),
+                emptyOutgoingMessages(), emptySet(), -1, emptySet(), false ) );
 
         // then
         assertEquals( 0, raftState.followerStates().size() );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/vote/VotingTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/vote/VotingTest.java
@@ -20,9 +20,8 @@
 package org.neo4j.causalclustering.core.consensus.vote;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.Optional;
 import java.util.UUID;
 
 import org.neo4j.causalclustering.core.consensus.roles.Voting;
@@ -33,7 +32,6 @@ import org.neo4j.logging.NullLog;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-@RunWith(MockitoJUnitRunner.class)
 public class VotingTest
 {
     MemberId candidate = new MemberId( UUID.randomUUID() );
@@ -56,7 +54,7 @@ public class VotingTest
                 logTerm,
                 appendIndex,
                 appendIndex,
-                null,
+                Optional.empty(),
                 log
         ) );
     }
@@ -72,7 +70,7 @@ public class VotingTest
                 logTerm,
                 appendIndex,
                 appendIndex,
-                null,
+                Optional.empty(),
                 log
         ) );
     }
@@ -88,7 +86,7 @@ public class VotingTest
                 logTerm - 1,
                 appendIndex,
                 appendIndex,
-                null,
+                Optional.empty(),
                 log
         ) );
     }
@@ -104,7 +102,7 @@ public class VotingTest
                 logTerm,
                 appendIndex,
                 appendIndex - 1,
-                null,
+                Optional.empty(),
                 log
         ) );
     }
@@ -120,7 +118,7 @@ public class VotingTest
                 logTerm,
                 appendIndex,
                 appendIndex,
-                null,
+                Optional.empty(),
                 log
         ) );
     }
@@ -136,7 +134,7 @@ public class VotingTest
                 logTerm,
                 appendIndex,
                 appendIndex + 1,
-                null,
+                Optional.empty(),
                 log
         ) );
     }
@@ -152,7 +150,7 @@ public class VotingTest
                 logTerm + 1,
                 appendIndex,
                 appendIndex - 1,
-                null,
+                Optional.empty(),
                 log
         ) );
     }
@@ -168,7 +166,7 @@ public class VotingTest
                 logTerm + 1,
                 appendIndex,
                 appendIndex,
-                null,
+                Optional.empty(),
                 log
         ) );
     }
@@ -184,7 +182,7 @@ public class VotingTest
                 logTerm + 1,
                 appendIndex,
                 appendIndex + 1,
-                null,
+                Optional.empty(),
                 log
         ) );
     }
@@ -200,7 +198,7 @@ public class VotingTest
                 logTerm,
                 appendIndex,
                 appendIndex,
-                otherMember,
+                Optional.of( otherMember ),
                 log
         ) );
     }
@@ -216,7 +214,7 @@ public class VotingTest
                 logTerm,
                 appendIndex,
                 appendIndex,
-                candidate,
+                Optional.of( candidate ),
                 log
         ) );
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderServiceTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderServiceTest.java
@@ -53,13 +53,11 @@ public class CoreStateDownloaderServiceTest
         neo4jJobScheduler.init();
     }
 
-
     @After
     public void shutdown()
     {
         neo4jJobScheduler.shutdown();
     }
-
 
     @Test
     public void shouldRunPersistentDownloader() throws Exception
@@ -74,7 +72,8 @@ public class CoreStateDownloaderServiceTest
         LeaderLocator leaderLocator = mock( LeaderLocator.class );
         when( leaderLocator.getLeader() ).thenReturn( someMember );
         coreStateDownloaderService.scheduleDownload( leaderLocator );
-        Predicates.await( () -> {
+        Predicates.await( () ->
+        {
             try
             {
                 verify( applicationProcess, times( 1 ) ).resumeApplier( OPERATION_NAME );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderServiceTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderServiceTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.state.snapshot;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.causalclustering.core.consensus.LeaderLocator;
+import org.neo4j.causalclustering.core.state.CommandApplicationProcess;
+import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.function.Predicates;
+import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.LogProvider;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+import static org.neo4j.causalclustering.core.state.snapshot.CoreStateDownloaderService.OPERATION_NAME;
+
+public class CoreStateDownloaderServiceTest
+{
+    private final MemberId someMember = new MemberId( UUID.randomUUID() );
+    private Neo4jJobScheduler neo4jJobScheduler;
+
+    @Before
+    public void create()
+    {
+        neo4jJobScheduler = new Neo4jJobScheduler();
+        neo4jJobScheduler.init();
+    }
+
+
+    @After
+    public void shutdown()
+    {
+        neo4jJobScheduler.shutdown();
+    }
+
+
+    @Test
+    public void shouldRunPersistentDownloader() throws Exception
+    {
+        CoreStateDownloader coreStateDownloader = mock( CoreStateDownloader.class );
+        final CommandApplicationProcess applicationProcess = mock( CommandApplicationProcess.class );
+
+        final Log log = mock( Log.class );
+        CoreStateDownloaderService coreStateDownloaderService =
+                new CoreStateDownloaderService( neo4jJobScheduler, coreStateDownloader, applicationProcess,
+                        logProvider( log ) );
+        LeaderLocator leaderLocator = mock( LeaderLocator.class );
+        when( leaderLocator.getLeader() ).thenReturn( someMember );
+        coreStateDownloaderService.scheduleDownload( leaderLocator );
+        Predicates.await( () -> {
+            try
+            {
+                verify( applicationProcess, times( 1 ) ).resumeApplier( OPERATION_NAME );
+                return true;
+            }
+            catch ( Throwable t )
+            {
+                return false;
+            }
+        }, 1, TimeUnit.SECONDS );
+
+        verify( applicationProcess, times( 1 ) ).pauseApplier( OPERATION_NAME );
+        verify( applicationProcess, times( 1 ) ).resumeApplier( OPERATION_NAME );
+        verify( coreStateDownloader, times( 1 ) ).downloadSnapshot( any() );
+    }
+
+    private LogProvider logProvider( Log log )
+    {
+        return new LogProvider()
+        {
+            @Override
+            public Log getLog( Class loggingClass )
+            {
+                return log;
+            }
+
+            @Override
+            public Log getLog( String name )
+            {
+                return log;
+            }
+        };
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/CoreStateDownloaderTest.java
@@ -59,7 +59,6 @@ public class CoreStateDownloaderTest
     private final CatchUpClient catchUpClient = mock( CatchUpClient.class );
     private final StoreCopyProcess storeCopyProcess = mock( StoreCopyProcess.class );
     private CoreSnapshotService snaptshotService = mock( CoreSnapshotService.class );
-    private CommandApplicationProcess applicationProcess = mock( CommandApplicationProcess.class );
     private TopologyService topologyService = mock( TopologyService.class );
 
     private final CoreStateMachines coreStateMachines = mock( CoreStateMachines.class );
@@ -73,7 +72,7 @@ public class CoreStateDownloaderTest
 
     private final CoreStateDownloader downloader =
             new CoreStateDownloader( localDatabase, startStopLife, remoteStore, catchUpClient, logProvider,
-                    storeCopyProcess, coreStateMachines, snaptshotService, applicationProcess, topologyService );
+                    storeCopyProcess, coreStateMachines, snaptshotService, topologyService );
 
     @Before
     public void commonMocking() throws IOException

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/PersistentSnapshotDownloaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/PersistentSnapshotDownloaderTest.java
@@ -35,6 +35,8 @@ import org.neo4j.logging.Log;
 import org.neo4j.logging.NullLogProvider;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.startsWith;
@@ -70,6 +72,7 @@ public class PersistentSnapshotDownloaderTest
         verify( applicationProcess, times( 1 ) ).pauseApplier( OPERATION_NAME );
         verify( applicationProcess, times( 1 ) ).resumeApplier( OPERATION_NAME );
         verify( coreStateDownloader, times( 1 ) ).downloadSnapshot( any() );
+        assertFalse( persistentSnapshotDownloader.isRunning() );
     }
 
     @Test
@@ -103,6 +106,11 @@ public class PersistentSnapshotDownloaderTest
                 return false;
             }
         }, 1, TimeUnit.SECONDS );
+
+        // then
+        assertTrue( persistentSnapshotDownloader.isRunning() );
+
+        // when
         thread.stop();
 
         // then
@@ -141,6 +149,11 @@ public class PersistentSnapshotDownloaderTest
                 return false;
             }
         }, 1, TimeUnit.SECONDS );
+
+        // then
+        assertTrue( persistentSnapshotDownloader.isRunning() );
+
+        // when
         thread.stop();
 
         // then
@@ -170,6 +183,7 @@ public class PersistentSnapshotDownloaderTest
         verify( applicationProcess, times( 1 ) ).pauseApplier( OPERATION_NAME );
         verify( applicationProcess, times( 1 ) ).resumeApplier( OPERATION_NAME );
         assertEquals( 3, timeout.increments );
+        assertFalse(persistentSnapshotDownloader.isRunning());
     }
 
     private class EventuallySuccessfulDownloader extends CoreStateDownloader

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/PersistentSnapshotDownloaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/PersistentSnapshotDownloaderTest.java
@@ -90,7 +90,8 @@ public class PersistentSnapshotDownloaderTest
         Thread thread = new Thread( persistentSnapshotDownloader );
         thread.start();
 
-        Predicates.await( () -> {
+        Predicates.await( () ->
+        {
             try
             {
                 verify( log, atLeast( 1 ) ).error( startsWith( "Failed to download snapshot. Retrying in" )
@@ -126,7 +127,8 @@ public class PersistentSnapshotDownloaderTest
         Thread thread = new Thread( persistentSnapshotDownloader );
         thread.start();
 
-        Predicates.await( () -> {
+        Predicates.await( () ->
+        {
             try
             {
                 verify( log, atLeast( 1 ) ).warn(

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/PersistentSnapshotDownloaderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/state/snapshot/PersistentSnapshotDownloaderTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.core.state.snapshot;
+
+import org.junit.Test;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.causalclustering.catchup.storecopy.StoreCopyFailedException;
+import org.neo4j.causalclustering.core.consensus.LeaderLocator;
+import org.neo4j.causalclustering.core.consensus.NoLeaderFoundException;
+import org.neo4j.causalclustering.core.state.CommandApplicationProcess;
+import org.neo4j.causalclustering.helper.TimeoutStrategy;
+import org.neo4j.causalclustering.identity.MemberId;
+import org.neo4j.function.Predicates;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.NullLogProvider;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.startsWith;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+import static org.neo4j.causalclustering.core.state.snapshot.CoreStateDownloaderService.OPERATION_NAME;
+
+public class PersistentSnapshotDownloaderTest
+{
+    private final MemberId someMember = new MemberId( UUID.randomUUID() );
+
+    @Test
+    public void shouldPauseAndResumeApplicationProcessIfDownloadIsSuccessful() throws Exception
+    {
+        // given
+        CoreStateDownloader coreStateDownloader = mock( CoreStateDownloader.class );
+        final CommandApplicationProcess applicationProcess = mock( CommandApplicationProcess.class );
+        final Log log = mock( Log.class );
+        LeaderLocator leaderLocator = mock( LeaderLocator.class );
+        when( leaderLocator.getLeader() ).thenReturn( someMember );
+        PersistentSnapshotDownloader persistentSnapshotDownloader =
+                new PersistentSnapshotDownloader( leaderLocator, applicationProcess, coreStateDownloader, log );
+
+        // when
+        persistentSnapshotDownloader.run();
+
+        // then
+        verify( applicationProcess, times( 1 ) ).pauseApplier( OPERATION_NAME );
+        verify( applicationProcess, times( 1 ) ).resumeApplier( OPERATION_NAME );
+        verify( coreStateDownloader, times( 1 ) ).downloadSnapshot( any() );
+    }
+
+    @Test
+    public void shouldNotResumeCommandApplicationProcessWhileDownloadIsFailing() throws Exception
+    {
+        // given
+        CoreStateDownloader coreStateDownloader = mock( CoreStateDownloader.class );
+        doThrow( StoreCopyFailedException.class ).when( coreStateDownloader ).downloadSnapshot( someMember );
+        final CommandApplicationProcess applicationProcess = mock( CommandApplicationProcess.class );
+        LeaderLocator leaderLocator = mock( LeaderLocator.class );
+        when( leaderLocator.getLeader() ).thenReturn( someMember );
+
+        final Log log = mock( Log.class );
+        PersistentSnapshotDownloader persistentSnapshotDownloader =
+                new PersistentSnapshotDownloader( leaderLocator, applicationProcess, coreStateDownloader, log );
+
+        // when
+        Thread thread = new Thread( persistentSnapshotDownloader );
+        thread.start();
+
+        Predicates.await( () -> {
+            try
+            {
+                verify( log, atLeast( 1 ) ).error( startsWith( "Failed to download snapshot. Retrying in" )
+                        , anyInt(), any( StoreCopyFailedException.class ) );
+                return true;
+            }
+            catch ( Throwable throwable )
+            {
+                return false;
+            }
+        }, 1, TimeUnit.SECONDS );
+        thread.stop();
+
+        // then
+        verify( applicationProcess, times( 1 ) ).pauseApplier( OPERATION_NAME );
+        verify( applicationProcess, never() ).resumeApplier( OPERATION_NAME );
+    }
+
+    @Test
+    public void shouldNotResumeCommandApplicationProcessIfNoLeaderIsFound() throws Exception
+    {
+        // given
+        CoreStateDownloader coreStateDownloader = mock( CoreStateDownloader.class );
+        final CommandApplicationProcess applicationProcess = mock( CommandApplicationProcess.class );
+        LeaderLocator leaderLocator = mock( LeaderLocator.class );
+        doThrow( NoLeaderFoundException.class ).when( leaderLocator ).getLeader();
+
+        final Log log = mock( Log.class );
+        PersistentSnapshotDownloader persistentSnapshotDownloader =
+                new PersistentSnapshotDownloader( leaderLocator, applicationProcess, coreStateDownloader, log );
+
+        // when
+        Thread thread = new Thread( persistentSnapshotDownloader );
+        thread.start();
+
+        Predicates.await( () -> {
+            try
+            {
+                verify( log, atLeast( 1 ) ).warn(
+                        startsWith( "No leader found. Retrying in" ),
+                        anyInt() );
+                return true;
+            }
+            catch ( Throwable throwable )
+            {
+                return false;
+            }
+        }, 1, TimeUnit.SECONDS );
+        thread.stop();
+
+        // then
+        verify( applicationProcess, times( 1 ) ).pauseApplier( OPERATION_NAME );
+        verify( applicationProcess, never() ).resumeApplier( OPERATION_NAME );
+    }
+
+    @Test
+    public void shouldEventuallySucceed() throws Exception
+    {
+        // given
+        CoreStateDownloader coreStateDownloader = new EventuallySuccessfulDownloader( 3 );
+
+        final CommandApplicationProcess applicationProcess = mock( CommandApplicationProcess.class );
+        LeaderLocator leaderLocator = mock( LeaderLocator.class );
+        when( leaderLocator.getLeader() ).thenReturn( someMember );
+        final Log log = mock( Log.class );
+        NoTimeout timeout = new NoTimeout();
+        PersistentSnapshotDownloader persistentSnapshotDownloader =
+                new PersistentSnapshotDownloader( leaderLocator, applicationProcess, coreStateDownloader, log,
+                        timeout );
+
+        // when
+        persistentSnapshotDownloader.run();
+
+        // then
+        verify( applicationProcess, times( 1 ) ).pauseApplier( OPERATION_NAME );
+        verify( applicationProcess, times( 1 ) ).resumeApplier( OPERATION_NAME );
+        assertEquals( 3, timeout.increments );
+    }
+
+    private class EventuallySuccessfulDownloader extends CoreStateDownloader
+    {
+        private int after;
+
+        private EventuallySuccessfulDownloader( int after )
+        {
+            super( null, null, null,
+                    null, NullLogProvider.getInstance(), null, null,
+                    null, null );
+            this.after = after;
+        }
+
+        @Override
+        void downloadSnapshot( MemberId source ) throws StoreCopyFailedException
+        {
+            if ( after-- > 0 )
+            {
+                throw new StoreCopyFailedException( "sorry" );
+            }
+        }
+    }
+
+    private class NoTimeout implements TimeoutStrategy.Timeout
+    {
+        private int increments = 0;
+
+        @Override
+        public long getMillis()
+        {
+            return 0;
+        }
+
+        @Override
+        public void increment()
+        {
+            increments++;
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
@@ -187,8 +187,8 @@ public class Cluster
     {
         try ( ErrorHandler errorHandler = new ErrorHandler( "Error when trying to shutdown cluster" ) )
         {
-            shutdownReadReplicas( errorHandler );
             shutdownCoreMembers( errorHandler );
+            shutdownReadReplicas( errorHandler );
         }
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
@@ -77,6 +77,7 @@ public class Cluster
     private static final int DEFAULT_CLUSTER_SIZE = 3;
 
     private final File parentDir;
+    private final Monitors monitors;
     private final DiscoveryServiceFactory discoveryServiceFactory;
     private final String listenAddress;
     private final String advertisedAddress;
@@ -88,20 +89,22 @@ public class Cluster
             DiscoveryServiceFactory discoveryServiceFactory,
             Map<String,String> coreParams, Map<String,IntFunction<String>> instanceCoreParams,
             Map<String,String> readReplicaParams, Map<String,IntFunction<String>> instanceReadReplicaParams,
-            String recordFormat )
+            String recordFormat, Monitors monitors )
     {
         this( parentDir, noOfCoreMembers, noOfReadReplicas, discoveryServiceFactory, coreParams,
-                instanceCoreParams, readReplicaParams, instanceReadReplicaParams, recordFormat, IpFamily.IPV4, false );
+                instanceCoreParams, readReplicaParams, instanceReadReplicaParams, recordFormat, IpFamily.IPV4,
+                false, monitors );
     }
 
     public Cluster( File parentDir, int noOfCoreMembers, int noOfReadReplicas,
             DiscoveryServiceFactory discoveryServiceFactory,
             Map<String,String> coreParams, Map<String,IntFunction<String>> instanceCoreParams,
             Map<String,String> readReplicaParams, Map<String,IntFunction<String>> instanceReadReplicaParams,
-            String recordFormat, IpFamily ipFamily, boolean useWildcard )
+            String recordFormat, IpFamily ipFamily, boolean useWildcard, Monitors monitors )
     {
         this.discoveryServiceFactory = discoveryServiceFactory;
         this.parentDir = parentDir;
+        this.monitors = monitors;
         HashSet<Integer> coreServerIds = new HashSet<>();
         for ( int i = 0; i < noOfCoreMembers; i++ )
         {
@@ -315,7 +318,7 @@ public class Cluster
         List<AdvertisedSocketAddress> initialHosts = buildInitialHosts( coreMembers.keySet() );
         CoreClusterMember coreClusterMember = new CoreClusterMember( memberId, DEFAULT_CLUSTER_SIZE, initialHosts,
                 discoveryServiceFactory, recordFormat, parentDir, extraParams, instanceExtraParams,
-                listenAddress, advertisedAddress );
+                listenAddress, advertisedAddress, monitors );
         coreMembers.put( memberId, coreClusterMember );
         return coreClusterMember;
     }
@@ -406,7 +409,7 @@ public class Cluster
         {
             CoreClusterMember coreClusterMember = new CoreClusterMember( i, noOfCoreMembers, addresses,
                     discoveryServiceFactory, recordFormat, parentDir, extraParams, instanceExtraParams,
-                    listenAddress, advertisedAddress );
+                    listenAddress, advertisedAddress, monitors );
             coreMembers.put( i, coreClusterMember );
         }
     }
@@ -458,7 +461,7 @@ public class Cluster
         for ( int i = 0; i < noOfReadReplicas; i++ )
         {
             readReplicas.put( i, new ReadReplica( parentDir, i, discoveryServiceFactory, coreMemberAddresses, extraParams,
-                    instanceExtraParams, recordFormat, new Monitors(), advertisedAddress, listenAddress ) );
+                    instanceExtraParams, recordFormat, monitors, advertisedAddress, listenAddress ) );
         }
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
@@ -178,8 +178,8 @@ public class Cluster
     {
         try ( ErrorHandler errorHandler = new ErrorHandler( "Error when trying to shutdown cluster" ) )
         {
-            shutdownCoreMembers( errorHandler );
             shutdownReadReplicas( errorHandler );
+            shutdownCoreMembers( errorHandler );
         }
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/Cluster.java
@@ -174,21 +174,37 @@ public class Cluster
         return member;
     }
 
-    public void shutdown() throws ExecutionException, InterruptedException
+    public void shutdown()
     {
-        shutdownReadReplicas();
-        shutdownCoreMembers();
+        try ( ErrorHandler errorHandler = new ErrorHandler( "Error when trying to shutdown cluster" ) )
+        {
+            shutdownCoreMembers( errorHandler );
+            shutdownReadReplicas( errorHandler );
+        }
     }
 
-    public void shutdownCoreMembers() throws InterruptedException, ExecutionException
+    private void shutdownCoreMembers( ErrorHandler errorHandler )
+    {
+        shutdownMembers( coreMembers(), errorHandler );
+    }
+
+    public void shutdownCoreMembers()
+    {
+        try ( ErrorHandler errorHandler = new ErrorHandler( "Error when trying to shutdown core members" ) )
+        {
+            shutdownCoreMembers( errorHandler );
+        }
+    }
+
+    private void shutdownMembers( Collection<? extends ClusterMember> clusterMembers, ErrorHandler errorHandler )
     {
         ExecutorService executor = Executors.newCachedThreadPool();
         List<Callable<Object>> memberShutdownSuppliers = new ArrayList<>();
-        for ( final CoreClusterMember coreClusterMember : coreMembers.values() )
+        for ( final ClusterMember clusterMember : clusterMembers )
         {
             memberShutdownSuppliers.add( () ->
             {
-                coreClusterMember.shutdown();
+                clusterMember.shutdown();
                 return null;
             } );
         }
@@ -196,6 +212,10 @@ public class Cluster
         try
         {
             combine( executor.invokeAll( memberShutdownSuppliers ) ).get();
+        }
+        catch ( Exception e )
+        {
+            errorHandler.add( e );
         }
         finally
         {
@@ -462,9 +482,9 @@ public class Cluster
         }
     }
 
-    private void shutdownReadReplicas()
+    private void shutdownReadReplicas( ErrorHandler errorHandler )
     {
-        readReplicas.values().forEach( ReadReplica::shutdown );
+        shutdownMembers( readReplicas(), errorHandler );
     }
 
     /**

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ClusterTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ClusterTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.discovery;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ClusterTest
+{
+    @Test
+    public void shouldShutdownAllMembersThenThrowException() throws Exception
+    {
+        // given
+        Cluster clusterMock = mock( Cluster.class );
+        CoreClusterMember unhealthyCore = mock( CoreClusterMember.class );
+        doThrow( IllegalStateException.class ).when( unhealthyCore ).shutdown();
+        CoreClusterMember healthyCore = mock( CoreClusterMember.class );
+        ReadReplica unhealthyReadReplica = mock( ReadReplica.class );
+        doThrow( IllegalStateException.class ).when( unhealthyReadReplica ).shutdown();
+        ReadReplica healthyReadReplica = mock( ReadReplica.class );
+
+        doCallRealMethod().when( clusterMock ).shutdown();
+        when( clusterMock.coreMembers() ).thenReturn( Arrays.asList( unhealthyCore, healthyCore ) );
+        when( clusterMock.readReplicas() ).thenReturn( Arrays.asList( unhealthyReadReplica, healthyReadReplica ) );
+
+        // when
+        RuntimeException exception = null;
+        try
+        {
+            clusterMock.shutdown();
+        }
+        catch ( RuntimeException e )
+        {
+            exception = e;
+        }
+
+        // then
+        assertNotNull( exception );
+        verify( healthyCore, only() ).shutdown();
+        verify( unhealthyCore, only() ).shutdown();
+        verify( healthyReadReplica, only() ).shutdown();
+        verify( unhealthyReadReplica, only() ).shutdown();
+
+        assertEquals( IllegalStateException.class, exception.getCause().getCause().getClass() );
+        assertEquals( 1, exception.getSuppressed().length );
+        assertEquals( IllegalStateException.class, exception.getSuppressed()[0].getCause().getClass() );
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ErrorHandler.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/ErrorHandler.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.discovery;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ErrorHandler implements AutoCloseable
+{
+    private final List<Throwable> throwables = new ArrayList<>();
+    private final String message;
+
+    public ErrorHandler( String message )
+    {
+        this.message = message;
+    }
+
+    public void add( Throwable throwable )
+    {
+        throwables.add( throwable );
+    }
+
+    public List<Throwable> throwables()
+    {
+        return Collections.unmodifiableList( throwables );
+    }
+
+    @Override
+    public void close() throws RuntimeException
+    {
+        throwIfException();
+    }
+
+    private void throwIfException()
+    {
+        if ( !throwables.isEmpty() )
+        {
+            RuntimeException runtimeException = null;
+            for ( Throwable throwable : throwables )
+            {
+                if ( runtimeException == null )
+                {
+                    runtimeException = new RuntimeException( message, throwable );
+                }
+                else
+                {
+                    runtimeException.addSuppressed( throwable );
+                }
+            }
+            throw runtimeException;
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterCommunityToEnterpriseIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterCommunityToEnterpriseIT.java
@@ -34,6 +34,7 @@ import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.impl.store.format.highlimit.HighLimit;
+import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
@@ -58,7 +59,8 @@ public class ClusterCommunityToEnterpriseIT
         fsa = fileSystemRule.get();
 
         cluster = new Cluster( testDir.directory( "cluster" ), 3, 0,
-                new SharedDiscoveryService(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), HighLimit.NAME );
+                new SharedDiscoveryService(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), HighLimit.NAME,
+                new Monitors() );
     }
 
     @After

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/PreElectionIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/PreElectionIT.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.scenarios;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
+import org.neo4j.causalclustering.core.consensus.roles.Role;
+import org.neo4j.causalclustering.discovery.Cluster;
+import org.neo4j.causalclustering.discovery.CoreClusterMember;
+import org.neo4j.test.Race;
+import org.neo4j.test.assertion.Assert;
+import org.neo4j.test.causalclustering.ClusterRule;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class PreElectionIT
+{
+    @Rule
+    public ClusterRule clusterRule = new ClusterRule( getClass() )
+            .withNumberOfCoreMembers( 3 )
+            .withNumberOfReadReplicas( 0 )
+            .withSharedCoreParam( CausalClusteringSettings.leader_election_timeout, "10s" )
+            .withSharedCoreParam( CausalClusteringSettings.enable_pre_voting, "true" );
+
+    private Cluster cluster;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        cluster = clusterRule.startCluster();
+    }
+
+    @Test
+    public void shouldActuallyStartAClusterWithPreVoting() throws Exception
+    {
+        // pass
+    }
+
+    @Test
+    public void shouldStartAnElectionIfAllServersHaveTimedOutOnHeartbeats() throws Exception
+    {
+        Collection<CompletableFuture<Void>> futures = new ArrayList<>( cluster.coreMembers().size() );
+
+        // given
+        long initialTerm = cluster.awaitLeader().raft().term();
+
+        // when
+        for ( CoreClusterMember member : cluster.coreMembers() )
+        {
+            if ( Role.FOLLOWER == member.raft().currentRole() )
+            {
+                futures.add( CompletableFuture.runAsync( Race.throwing( () -> member.raft().triggerElection() ) ) );
+            }
+        }
+
+        // then
+        Assert.assertEventually(
+                "Should be on a new term following an election",
+                () -> cluster.awaitLeader().raft().term(), not( equalTo( initialTerm ) ),
+                1,
+                TimeUnit.MINUTES );
+
+        // cleanup
+        for ( CompletableFuture<Void> future : futures )
+        {
+            future.cancel( false );
+        }
+    }
+
+    @Test
+    public void shouldNotStartAnElectionIfAMinorityOfServersHaveTimedOutOnHeartbeats() throws Exception
+    {
+        // given
+        CoreClusterMember follower = cluster.awaitCoreMemberWithRole( Role.FOLLOWER, 1, TimeUnit.MINUTES );
+
+        // when
+        follower.raft().triggerElection();
+
+        // then
+        try
+        {
+            cluster.awaitCoreMemberWithRole( Role.CANDIDATE, 1, TimeUnit.MINUTES );
+            fail( "Should not have started an election if less than a quorum have timed out" );
+        }
+        catch ( TimeoutException e )
+        {
+            // pass
+        }
+    }
+
+    @Test
+    public void shouldStartElectionIfLeaderRemoved() throws Exception
+    {
+        // given
+        CoreClusterMember oldLeader = cluster.awaitLeader();
+
+        // when
+        cluster.removeCoreMember( oldLeader );
+
+        // then
+        CoreClusterMember newLeader = cluster.awaitLeader();
+
+        assertThat( newLeader.serverId(), not( equalTo( oldLeader.serverId() ) ) );
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/test/causalclustering/ClusterRule.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/test/causalclustering/ClusterRule.java
@@ -29,8 +29,8 @@ import java.util.Map;
 import java.util.function.IntFunction;
 
 import org.neo4j.causalclustering.discovery.Cluster;
-import org.neo4j.causalclustering.discovery.IpFamily;
 import org.neo4j.causalclustering.discovery.DiscoveryServiceFactory;
+import org.neo4j.causalclustering.discovery.IpFamily;
 import org.neo4j.causalclustering.discovery.SharedDiscoveryService;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
@@ -88,14 +88,7 @@ public class ClusterRule extends ExternalResource
     {
         if ( cluster != null )
         {
-            try
-            {
-                cluster.shutdown();
-            }
-            catch ( Throwable e )
-            {
-                throw new RuntimeException( e );
-            }
+            cluster.shutdown();
         }
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/test/causalclustering/ClusterRule.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/test/causalclustering/ClusterRule.java
@@ -34,6 +34,7 @@ import org.neo4j.causalclustering.discovery.DiscoveryServiceFactory;
 import org.neo4j.causalclustering.discovery.SharedDiscoveryService;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
+import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.rule.TestDirectory;
 
 import static org.neo4j.causalclustering.discovery.IpFamily.IPV4;
@@ -116,7 +117,8 @@ public class ClusterRule extends ExternalResource
         if ( cluster == null )
         {
             cluster = new Cluster( clusterDirectory, noCoreMembers, noReadReplicas, discoveryServiceFactory, coreParams,
-                    instanceCoreParams, readReplicaParams, instanceReadReplicaParams, recordFormat, ipFamily, useWildcard );
+                    instanceCoreParams, readReplicaParams, instanceReadReplicaParams, recordFormat, ipFamily, useWildcard,
+                    new Monitors() );
         }
 
         return cluster;

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
@@ -301,6 +301,9 @@ dbms.jvm.additional=-XX:+DisableExplicitGC
 # This is to protect the server from any potential passive eavesdropping.
 dbms.jvm.additional=-Djdk.tls.ephemeralDHKeySize=2048
 
+# This mitigates a DDoS vector.
+dbms.jvm.additional=-Djdk.tls.rejectClientInitiatedRenegotiation=true
+
 #********************************************************************
 # Wrapper Windows NT/2000/XP Service Properties
 #********************************************************************

--- a/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
+++ b/packaging/standalone/standalone-enterprise/src/main/distribution/text/enterprise/conf/neo4j.conf
@@ -747,6 +747,9 @@ dbms.jvm.additional=-XX:+DisableExplicitGC
 # This is to protect the server from any potential passive eavesdropping.
 dbms.jvm.additional=-Djdk.tls.ephemeralDHKeySize=2048
 
+# This mitigates a DDoS vector.
+dbms.jvm.additional=-Djdk.tls.rejectClientInitiatedRenegotiation=true
+
 #********************************************************************
 # Wrapper Windows NT/2000/XP Service Properties
 #********************************************************************

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/BackupStoreCopyInteractionStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/BackupStoreCopyInteractionStressTesting.java
@@ -40,6 +40,7 @@ import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
+import org.neo4j.kernel.monitoring.Monitors;
 
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.Integer.parseInt;
@@ -106,7 +107,8 @@ public class BackupStoreCopyInteractionStressTesting
         HazelcastDiscoveryServiceFactory discoveryServiceFactory = new HazelcastDiscoveryServiceFactory();
         Cluster cluster =
                 new Cluster( clusterDirectory, numberOfCores, numberOfEdges, discoveryServiceFactory, coreParams,
-                        instanceCoreParams, readReplicaParams, instanceReadReplicaParams, StandardV3_0.NAME );
+                        instanceCoreParams, readReplicaParams, instanceReadReplicaParams, StandardV3_0.NAME,
+                        new Monitors() );
 
         AtomicBoolean stopTheWorld = new AtomicBoolean();
         BooleanSupplier notExpired = untilTimeExpired( durationInMinutes, MINUTES );

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/CatchupStoreCopyInteractionStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/CatchupStoreCopyInteractionStressTesting.java
@@ -36,6 +36,7 @@ import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
+import org.neo4j.kernel.monitoring.Monitors;
 
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.Integer.parseInt;
@@ -87,7 +88,7 @@ public class CatchupStoreCopyInteractionStressTesting
         HazelcastDiscoveryServiceFactory discoveryServiceFactory = new HazelcastDiscoveryServiceFactory();
         Cluster cluster =
                 new Cluster( clusterDirectory, numberOfCores, numberOfEdges, discoveryServiceFactory, coreParams,
-                        emptyMap(), edgeParams, emptyMap(), StandardV3_0.NAME );
+                        emptyMap(), edgeParams, emptyMap(), StandardV3_0.NAME, new Monitors() );
 
         AtomicBoolean stopTheWorld = new AtomicBoolean();
         BooleanSupplier notExpired = untilTimeExpired( durationInMinutes, MINUTES );


### PR DESCRIPTION
When the raft message handler need a new snapshot it will schedule
this on the downloader service. This will pause the application process
until download is successful.