### PR TITLE
Close Kernel API IndexCursor before reuse.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/IndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/IndexCursor.java
@@ -27,9 +27,9 @@ abstract class IndexCursor
 
     final void initialize( IndexProgressor progressor )
     {
-        if ( progressor != null )
+        if ( this.progressor != null )
         {
-            progressor.close();
+            this.progressor.close();
         }
         this.progressor = progressor;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/IndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/IndexCursor.java
@@ -27,6 +27,10 @@ abstract class IndexCursor
 
     final void initialize( IndexProgressor progressor )
     {
+        if ( progressor != null )
+        {
+            progressor.close();
+        }
         this.progressor = progressor;
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/IndexCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/IndexCursorTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.newapi;
+
+import org.junit.Test;
+
+import org.neo4j.storageengine.api.schema.IndexProgressor;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class IndexCursorTest
+{
+    @Test
+    public void shouldClosePreviousBeforeReinitialize()
+    {
+        // given
+        StubIndexCursor cursor = new StubIndexCursor();
+        StubProgressor progressor = new StubProgressor();
+        cursor.initialize( progressor );
+        assertFalse( "open before re-initialize", progressor.isClosed );
+
+        // when
+        StubProgressor otherProgressor = new StubProgressor();
+        cursor.initialize( otherProgressor );
+
+        // then
+        assertTrue( "closed after re-initialize", progressor.isClosed );
+        assertFalse( "new still open", otherProgressor.isClosed );
+    }
+
+    private static class StubIndexCursor extends IndexCursor
+    {
+    }
+
+    private static class StubProgressor implements IndexProgressor
+    {
+        boolean isClosed;
+
+        StubProgressor()
+        {
+            isClosed = false;
+        }
+
+        @Override
+        public boolean next()
+        {
+            return false;
+        }
+
+        @Override
+        public void close()
+        {
+            isClosed = true;
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueClientFilterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueClientFilterTest.java
@@ -39,7 +39,7 @@ import static org.neo4j.kernel.impl.newapi.MockStore.block;
 import static org.neo4j.kernel.impl.store.record.AbstractBaseRecord.NO_ID;
 import static org.neo4j.values.storable.Values.stringValue;
 
-public class IndexCursorFilterTest implements IndexProgressor, NodeValueClient
+public class NodeValueClientFilterTest implements IndexProgressor, NodeValueClient
 {
     @Rule
     public final MockStore store = new MockStore( new Cursors() );


### PR DESCRIPTION
This fixes an OOM seen in benchmarking.