### PR TITLE
Disable reduce and map projections in slotted runtime

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
@@ -388,7 +388,7 @@ class PatternComprehensionAcceptanceTest extends ExecutionEngineFunSuite with Cy
   test("pattern comprehension in RETURN following a WITH") {
     val query = """MATCH (e:X) WITH e LIMIT 5 RETURN [(e) --> (t) | t { .amount }]"""
 
-    executeWith(expectedToSucceedIncludingSlottedRestricted, query).toList //does not throw
+    executeWith(expectedToSucceedRestricted, query).toList //does not throw
   }
 
   test("pattern comprehension play nice with map projections") {

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriter.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriter.scala
@@ -21,6 +21,7 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime
 
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.ast._
 import org.neo4j.cypher.internal.compiler.v3_4.planner.CantCompileQueryException
+import org.neo4j.cypher.internal.frontend.v3_4.ast.rewriters.DesugaredMapProjection
 import org.neo4j.cypher.internal.planner.v3_4.spi.TokenContext
 import org.neo4j.cypher.internal.util.v3_4.Foldable._
 import org.neo4j.cypher.internal.util.v3_4.symbols._
@@ -221,6 +222,12 @@ class SlottedRewriter(tokenContext: TokenContext) {
 
       case e@IsNull(Property(Variable(key), PropertyKeyName(propKey))) =>
         Not(checkIfPropertyExists(slotConfiguration, key, propKey))(e.position)
+
+      case _: ReduceExpression =>
+        throw new CantCompileQueryException(s"Expressions with reduce are not yet supported in slot allocation")
+
+      case _: DesugaredMapProjection =>
+        throw new CantCompileQueryException(s"Expressions with map projections are not yet supported in slot allocation")
 
       case _: ShortestPathExpression =>
         throw new CantCompileQueryException(s"Expressions with shortestPath functions not yet supported in slot allocation")


### PR DESCRIPTION
Temporarily disable these expression until we have all the
compatibility implementations in PrimitiveExecutionContext.

Fixes cypher tests in docs build.