### PR TITLE
add 'WebSocketFrameAggregator' handler to the websockets pipeline

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportSelectionHandler.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportSelectionHandler.java
@@ -26,6 +26,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.websocketx.WebSocketFrameAggregator;
 import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
@@ -42,6 +43,7 @@ public class TransportSelectionHandler extends ByteToMessageDecoder
 {
     private static final String WEBSOCKET_MAGIC = "GET ";
     private static final int MAX_WEBSOCKET_HANDSHAKE_SIZE = 65536;
+    private static final int MAX_WEBSOCKET_FRAME_SIZE = 65536;
 
     private final SslContext sslCtx;
     private final boolean encryptionRequired;
@@ -132,7 +134,8 @@ public class TransportSelectionHandler extends ByteToMessageDecoder
         p.addLast(
                 new HttpServerCodec(),
                 new HttpObjectAggregator( MAX_WEBSOCKET_HANDSHAKE_SIZE ),
-                new WebSocketServerProtocolHandler( "/" ),
+                new WebSocketServerProtocolHandler( "/", null, false, MAX_WEBSOCKET_FRAME_SIZE ),
+                new WebSocketFrameAggregator( MAX_WEBSOCKET_FRAME_SIZE ),
                 new WebSocketFrameTranslator(),
                 new SocketTransportHandler(
                         new ProtocolChooser( protocolVersions, encryptionRequired, isEncrypted ), logging ) );


### PR DESCRIPTION
When browser sends out a message in split frames (a single message split across a sequence of frames), server fails to build up the original message and hangs the request indefinitely. This is caused by the fact that in `org.neo4j.bolt.transport.WebSocketFrameTranslator` we only care of `BinaryWebSocketFrame`, but not `ContinuationWebSocketFrame`.

This PR adds `WebSocketFrameAggregator` into the websocket channel pipeline, so that split frames are aggregated into a single message and processed so.