### PR TITLE
Removed private modifiers from TypeSpec

### DIFF
--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/symbols/TypeSpec.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/symbols/TypeSpec.scala
@@ -66,7 +66,7 @@ object TypeSpec {
  *
  * @param ranges A set of TypeRanges, the intersection of which constitutes the entire set of types matched by this specification
  */
-class TypeSpec private (private val ranges: Seq[TypeRange]) extends Equals {
+class TypeSpec(val ranges: Seq[TypeRange]) extends Equals {
   def contains(that: CypherType): Boolean = contains(that, ranges)
   private def contains(that: CypherType, rs: Seq[TypeRange]): Boolean = rs.exists(_ contains that)
 


### PR DESCRIPTION
When supporting 3.3 in 3.4 we need to be able to access the TypeRanges
of a TypeSpec. Also, we should be able to create TypeSpecs from the
conversion code.

This PR should be normally forward merged to 3.4