### PR TITLE
Make Property rewritable by slotted runtime

### DIFF
--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Expand.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Expand.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.v3_4.logical.plans
 
 import org.neo4j.cypher.internal.ir.v3_4.{CardinalityEstimation, IdName, PlannerQuery, VarPatternLength}
-import org.neo4j.cypher.internal.v3_4.expressions.{Expression, RelTypeName, SemanticDirection, Variable}
+import org.neo4j.cypher.internal.v3_4.expressions._
 
 /**
   * For every source row, traverse all the relationships of 'from' which fulfill the
@@ -84,7 +84,7 @@ case class VarExpand(source: LogicalPlan,
                      tempEdge: IdName,
                      nodePredicate: Expression,
                      edgePredicate: Expression,
-                     legacyPredicates: Seq[(Variable, Expression)])
+                     legacyPredicates: Seq[(LogicalVariable, Expression)])
                     (val solved: PlannerQuery with CardinalityEstimation) extends LogicalPlan with LazyLogicalPlan {
   override val lhs = Some(source)
   override def rhs = None
@@ -107,7 +107,7 @@ case class PruningVarExpand(source: LogicalPlan,
                             to: IdName,
                             minLength: Int,
                             maxLength: Int,
-                            predicates: Seq[(Variable, Expression)] = Seq.empty)
+                            predicates: Seq[(LogicalVariable, Expression)] = Seq.empty)
                            (val solved: PlannerQuery with CardinalityEstimation) extends LogicalPlan with LazyLogicalPlan {
 
   override val lhs = Some(source)
@@ -130,7 +130,7 @@ case class FullPruningVarExpand(source: LogicalPlan,
                                 to: IdName,
                                 minLength: Int,
                                 maxLength: Int,
-                                predicates: Seq[(Variable, Expression)] = Seq.empty)
+                                predicates: Seq[(LogicalVariable, Expression)] = Seq.empty)
                                (val solved: PlannerQuery with CardinalityEstimation) extends LogicalPlan with LazyLogicalPlan {
 
   override val lhs = Some(source)

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SeekableArgs.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SeekableArgs.scala
@@ -26,7 +26,7 @@ sealed trait SeekableArgs {
   def expr: Expression
   def sizeHint: Option[Int]
 
-  def dependencies: Set[Variable] = expr.dependencies
+  def dependencies: Set[LogicalVariable] = expr.dependencies
 
   def mapValues(f: Expression => Expression): SeekableArgs
   def asQueryExpression: QueryExpression[Expression]

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/InliningContext.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/InliningContext.scala
@@ -24,14 +24,14 @@ import org.neo4j.cypher.internal.compiler.v3_4.ast.rewriters.InliningContext._
 import org.neo4j.cypher.internal.frontend.v3_4.ast.rewriters.copyVariables
 import org.neo4j.cypher.internal.v3_4.expressions._
 
-case class InliningContext(projections: Map[Variable, Expression] = Map.empty,
-                           seenVariables: Set[Variable] = Set.empty,
-                           usageCount: Map[Variable, Int] = Map.empty) {
+case class InliningContext(projections: Map[LogicalVariable, Expression] = Map.empty,
+                           seenVariables: Set[LogicalVariable] = Set.empty,
+                           usageCount: Map[LogicalVariable, Int] = Map.empty) {
 
   def trackUsageOfVariable(id: Variable) =
     copy(usageCount = usageCount + (id -> (usageCount.withDefaultValue(0)(id) + 1)))
 
-  def enterQueryPart(newProjections: Map[Variable, Expression]): InliningContext = {
+  def enterQueryPart(newProjections: Map[LogicalVariable, Expression]): InliningContext = {
     val inlineExpressions = TypedRewriter[Expression](variableRewriter)
     val containsAggregation = newProjections.values.exists(containsAggregate)
     val shadowing = newProjections.filterKeys(seenVariables.contains).filter {
@@ -57,7 +57,7 @@ case class InliningContext(projections: Map[Variable, Expression] = Map.empty,
       projections.get(variable).map(_.endoRewrite(copyVariables)).getOrElse(variable.copyId)
   })
 
-  def okToRewrite(i: Variable) =
+  def okToRewrite(i: LogicalVariable) =
     projections.contains(i) &&
     usageCount.withDefaultValue(0)(i) < INLINING_THRESHOLD
 

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/inlineProjections.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/inlineProjections.scala
@@ -19,10 +19,10 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.ast.rewriters
 
-import org.neo4j.cypher.internal.util.v3_4._
 import org.neo4j.cypher.internal.frontend.v3_4.ast._
 import org.neo4j.cypher.internal.frontend.v3_4.helpers.fixedPoint
-import org.neo4j.cypher.internal.v3_4.expressions.{Expression, Pattern, Variable}
+import org.neo4j.cypher.internal.util.v3_4._
+import org.neo4j.cypher.internal.v3_4.expressions.{Expression, LogicalVariable, Pattern}
 
 case object inlineProjections extends Rewriter {
 
@@ -67,8 +67,8 @@ case object inlineProjections extends Rewriter {
   }
 
 
-  private def findAllDependencies(variable: Variable, context: InliningContext): Set[Variable] = {
-    val (dependencies, _) = fixedPoint[(Set[Variable], List[Variable])]({
+  private def findAllDependencies(variable: LogicalVariable, context: InliningContext): Set[LogicalVariable] = {
+    val (dependencies, _) = fixedPoint[(Set[LogicalVariable], List[LogicalVariable])]({
       case (deps, Nil) =>
         (deps, Nil)
       case (deps, queue) =>

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/inliningContextCreator.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/inliningContextCreator.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v3_4.ast.rewriters
 
 import org.neo4j.cypher.internal.frontend.v3_4.ast
-import org.neo4j.cypher.internal.v3_4.expressions.{Expression, NodePattern, RelationshipPattern, Variable}
+import org.neo4j.cypher.internal.v3_4.expressions._
 
 object inliningContextCreator extends (ast.Statement => InliningContext) {
 
@@ -61,6 +61,6 @@ object inliningContextCreator extends (ast.Statement => InliningContext) {
     if (context.isAliasedVarible(variable)) context
     else context.spoilVariable(variable)
 
-  private def aliasedReturnItems(items: Seq[ast.ReturnItem]): Map[Variable, Expression] =
+  private def aliasedReturnItems(items: Seq[ast.ReturnItem]): Map[LogicalVariable, Expression] =
     items.collect { case ast.AliasedReturnItem(expr, ident) => ident -> expr }.toMap
 }

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/OptionalMatchRemover.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/OptionalMatchRemover.scala
@@ -41,15 +41,15 @@ case object OptionalMatchRemover extends PlannerQueryRewriter {
   override def instance(ignored: CompilerContext): Rewriter = topDown(Rewriter.lift {
     case RegularPlannerQuery(graph, proj@AggregatingQueryProjection(distinctExpressions, aggregations, _), tail)
       if validAggregations(aggregations) =>
-      val projectionDeps: Iterable[Variable] = (distinctExpressions.values ++ aggregations.values).flatMap(_.dependencies)
+      val projectionDeps: Iterable[LogicalVariable] = (distinctExpressions.values ++ aggregations.values).flatMap(_.dependencies)
       rewrite(projectionDeps, graph, proj, tail)
 
     case RegularPlannerQuery(graph, proj@DistinctQueryProjection(distinctExpressions, _), tail) =>
-      val projectionDeps: Iterable[Variable] = distinctExpressions.values.flatMap(_.dependencies)
+      val projectionDeps: Iterable[LogicalVariable] = distinctExpressions.values.flatMap(_.dependencies)
       rewrite(projectionDeps, graph, proj, tail)
   })
 
-  private def rewrite(projectionDeps: Iterable[Variable], graph: QueryGraph, proj: QueryProjection, tail: Option[PlannerQuery]): RegularPlannerQuery = {
+  private def rewrite(projectionDeps: Iterable[LogicalVariable], graph: QueryGraph, proj: QueryProjection, tail: Option[PlannerQuery]): RegularPlannerQuery = {
     val updateDeps = graph.mutatingPatterns.flatMap(_.dependencies)
     val dependencies: Set[IdName] = projectionDeps.map(IdName.fromVariable).toSet ++ updateDeps
 

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/expandSolverStep.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/expandSolverStep.scala
@@ -117,7 +117,7 @@ object expandSolverStep {
   }
 
   def extractLegacyPredicates(availablePredicates: Seq[Expression], patternRel: PatternRelationship,
-                              nodeId: IdName): Seq[(Variable, Expression)] = {
+                              nodeId: IdName): Seq[(LogicalVariable, Expression)] = {
     availablePredicates.collect {
       //MATCH ()-[r* {prop:1337}]->()
       case all@AllIterablePredicate(FilterScope(variable, Some(innerPredicate)), relId@Variable(patternRel.name.name))

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/extractPredicates.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/extractPredicates.scala
@@ -86,15 +86,15 @@ object extractPredicates {
     }
   }
 
-  private def replaceVariable(from: Variable, to: String): Rewriter =
+  private def replaceVariable(from: LogicalVariable, to: String): Rewriter =
     bottomUp(Rewriter.lift {
       case v: Variable if v == from => Variable(to)(v.position)
     })
 
   object AllRelationships {
-    def unapply(v: Any): Option[(Variable, String, Expression)] =
+    def unapply(v: Any): Option[(LogicalVariable, String, Expression)] =
       v match {
-        case AllIterablePredicate(FilterScope(variable, Some(innerPredicate)), relId @ Variable(name))
+        case AllIterablePredicate(FilterScope(variable, Some(innerPredicate)), relId @ LogicalVariable(name))
             if variable == relId || !innerPredicate.dependencies(relId) =>
           Some((variable, name, innerPredicate))
 
@@ -103,7 +103,7 @@ object extractPredicates {
   }
 
   object AllRelationshipsInPath {
-    def unapply(v: Any): Option[(String, String, Variable, Expression)] =
+    def unapply(v: Any): Option[(String, String, LogicalVariable, Expression)] =
       v match {
         case AllIterablePredicate(
             FilterScope(variable, Some(innerPredicate)),
@@ -114,8 +114,8 @@ object extractPredicates {
               Seq(
                 PathExpression(
                   NodePathStep(
-                    startNode: Variable,
-                    MultiRelationshipPathStep(rel: Variable, _, NilPathStep))))))
+                    startNode: LogicalVariable,
+                    MultiRelationshipPathStep(rel: LogicalVariable, _, NilPathStep))))))
             if fname == "relationships" =>
           Some((startNode.name, rel.name, variable, innerPredicate))
 
@@ -124,7 +124,7 @@ object extractPredicates {
   }
 
   object AllNodesInPath {
-    def unapply(v: Any): Option[(String, String, Variable, Expression)] =
+    def unapply(v: Any): Option[(String, String, LogicalVariable, Expression)] =
       v match {
         case AllIterablePredicate(
             FilterScope(variable, Some(innerPredicate)),
@@ -135,8 +135,8 @@ object extractPredicates {
               Seq(
                 PathExpression(
                   NodePathStep(
-                    startNode: Variable,
-                    MultiRelationshipPathStep(rel: Variable, _, NilPathStep))))))
+                    startNode: LogicalVariable,
+                    MultiRelationshipPathStep(rel: LogicalVariable, _, NilPathStep))))))
             if fname == "nodes" =>
           Some((startNode.name, rel.name, variable, innerPredicate))
 
@@ -145,7 +145,7 @@ object extractPredicates {
   }
 
   object NoRelationshipInPath {
-    def unapply(v: Any): Option[(String, String, Variable, Expression)] =
+    def unapply(v: Any): Option[(String, String, LogicalVariable, Expression)] =
       v match {
         case NoneIterablePredicate(
             FilterScope(variable, Some(innerPredicate)),
@@ -156,8 +156,8 @@ object extractPredicates {
               Seq(
                 PathExpression(
                   NodePathStep(
-                    startNode: Variable,
-                    MultiRelationshipPathStep(rel: Variable, _, NilPathStep))))))
+                    startNode: LogicalVariable,
+                    MultiRelationshipPathStep(rel: LogicalVariable, _, NilPathStep))))))
             if fname == "relationships" =>
           Some((startNode.name, rel.name, variable, innerPredicate))
 
@@ -166,7 +166,7 @@ object extractPredicates {
   }
 
   object NoNodeInPath {
-    def unapply(v: Any): Option[(String, String, Variable, Expression)] =
+    def unapply(v: Any): Option[(String, String, LogicalVariable, Expression)] =
       v match {
         case NoneIterablePredicate(
             FilterScope(variable, Some(innerPredicate)),
@@ -177,8 +177,8 @@ object extractPredicates {
               Seq(
                 PathExpression(
                   NodePathStep(
-                    startNode: Variable,
-                    MultiRelationshipPathStep(rel: Variable, _, NilPathStep))))))
+                    startNode: LogicalVariable,
+                    MultiRelationshipPathStep(rel: LogicalVariable, _, NilPathStep))))))
             if fname == "nodes" =>
           Some((startNode.name, rel.name, variable, innerPredicate))
 

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/Sargable.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/Sargable.scala
@@ -33,7 +33,7 @@ object WithSeekableArgs {
 
 object AsIdSeekable {
   def unapply(v: Any) = v match {
-    case WithSeekableArgs(func@FunctionInvocation(_, _, _, IndexedSeq(ident: Variable)), rhs)
+    case WithSeekableArgs(func@FunctionInvocation(_, _, _, IndexedSeq(ident: LogicalVariable)), rhs)
       if func.function == functions.Id && !rhs.dependencies(ident) =>
       Some(IdSeekable(func, ident, rhs))
     case _ =>
@@ -43,7 +43,7 @@ object AsIdSeekable {
 
 object AsPropertySeekable {
   def unapply(v: Any) = v match {
-    case WithSeekableArgs(prop@Property(ident: Variable, propertyKey), rhs)
+    case WithSeekableArgs(prop@Property(ident: LogicalVariable, propertyKey), rhs)
       if !rhs.dependencies(ident) =>
       Some(PropertySeekable(prop, ident, rhs))
     case _ =>
@@ -54,7 +54,7 @@ object AsPropertySeekable {
 object AsPropertyScannable {
   def unapply(v: Any): Option[Scannable[Expression]] = v match {
 
-    case func@FunctionInvocation(_, _, _, IndexedSeq(property@Property(ident: Variable, _)))
+    case func@FunctionInvocation(_, _, _, IndexedSeq(property@Property(ident: LogicalVariable, _)))
       if func.function == functions.Exists =>
       Some(ExplicitlyPropertyScannable(func, ident, property))
 
@@ -78,7 +78,7 @@ object AsPropertyScannable {
   }
 
   private def partialPropertyPredicate[P <: Expression](predicate: P, lhs: Expression) = lhs match {
-    case property@Property(ident: Variable, _) =>
+    case property@Property(ident: LogicalVariable, _) =>
       PartialPredicate.ifNotEqual(
         FunctionInvocation(FunctionName(functions.Exists.name)(predicate.position), property)(predicate.position),
         predicate
@@ -91,9 +91,9 @@ object AsPropertyScannable {
 
 object AsStringRangeSeekable {
   def unapply(v: Any): Option[PrefixRangeSeekable] = v match {
-    case startsWith@StartsWith(Property(ident: Variable, propertyKey), lit@StringLiteral(prefix)) if prefix.nonEmpty =>
+    case startsWith@StartsWith(Property(ident: LogicalVariable, propertyKey), lit@StringLiteral(prefix)) if prefix.nonEmpty =>
       Some(PrefixRangeSeekable(PrefixRange(lit), startsWith, ident, propertyKey))
-    case startsWith@StartsWith(Property(ident: Variable, propertyKey), rhs) =>
+    case startsWith@StartsWith(Property(ident: LogicalVariable, propertyKey), rhs) =>
       Some(PrefixRangeSeekable(PrefixRange(rhs), startsWith, ident, propertyKey))
     case _ =>
       None
@@ -112,40 +112,40 @@ object AsValueRangeSeekable {
 
 sealed trait Sargable[+T <: Expression] {
   def expr: T
-  def ident: Variable
+  def ident: LogicalVariable
 
   def name = ident.name
 }
 
 sealed trait Seekable[T <: Expression] extends Sargable[T] {
-  def dependencies: Set[Variable]
+  def dependencies: Set[LogicalVariable]
 }
 
 sealed trait EqualitySeekable[T <: Expression] extends Seekable[T] {
   def args: SeekableArgs
 }
 
-case class IdSeekable(expr: FunctionInvocation, ident: Variable, args: SeekableArgs)
+case class IdSeekable(expr: FunctionInvocation, ident: LogicalVariable, args: SeekableArgs)
   extends EqualitySeekable[FunctionInvocation] {
 
-  def dependencies: Set[Variable] = args.dependencies
+  def dependencies: Set[LogicalVariable] = args.dependencies
 }
 
-case class PropertySeekable(expr: Property, ident: Variable, args: SeekableArgs)
-  extends EqualitySeekable[Property] {
+case class PropertySeekable(expr: LogicalProperty, ident: LogicalVariable, args: SeekableArgs)
+  extends EqualitySeekable[LogicalProperty] {
 
   def propertyKey: PropertyKeyName = expr.propertyKey
-  def dependencies: Set[Variable] = args.dependencies
+  def dependencies: Set[LogicalVariable] = args.dependencies
 }
 
 sealed trait RangeSeekable[T <: Expression, V] extends Seekable[T] {
   def range: SeekRange[V]
 }
 
-case class PrefixRangeSeekable(override val range: PrefixRange[Expression], expr: StartsWith, ident: Variable, propertyKey: PropertyKeyName)
+case class PrefixRangeSeekable(override val range: PrefixRange[Expression], expr: StartsWith, ident: LogicalVariable, propertyKey: PropertyKeyName)
   extends RangeSeekable[StartsWith, Expression] {
 
-  def dependencies: Set[Variable] = Set.empty
+  def dependencies: Set[LogicalVariable] = Set.empty
 
   def asQueryExpression: QueryExpression[Expression] =
     RangeQueryExpression(PrefixSeekRangeWrapper(range)(expr.rhs.position))
@@ -154,7 +154,7 @@ case class PrefixRangeSeekable(override val range: PrefixRange[Expression], expr
 case class InequalityRangeSeekable(ident: Variable, propertyKeyName: PropertyKeyName, expr: AndedPropertyInequalities)
   extends RangeSeekable[AndedPropertyInequalities, Expression] {
 
-  def dependencies: Set[Variable] = expr.inequalities.map(_.dependencies).toSet.flatten
+  def dependencies: Set[LogicalVariable] = expr.inequalities.map(_.dependencies).toSet.flatten
 
   def range: InequalitySeekRange[Expression] =
     InequalitySeekRange.fromPartitionedBounds(expr.inequalities.partition {
@@ -171,14 +171,14 @@ case class InequalityRangeSeekable(ident: Variable, propertyKeyName: PropertyKey
 }
 
 sealed trait Scannable[+T <: Expression] extends Sargable[T] {
-  def ident: Variable
-  def property: Property
+  def ident: LogicalVariable
+  def property: LogicalProperty
 
   def propertyKey: PropertyKeyName = property.propertyKey
 }
 
-case class ExplicitlyPropertyScannable(expr: FunctionInvocation, ident: Variable, property: Property)
+case class ExplicitlyPropertyScannable(expr: FunctionInvocation, ident: LogicalVariable, property: LogicalProperty)
   extends Scannable[FunctionInvocation]
 
-case class ImplicitlyPropertyScannable[+T <: Expression](expr: PartialPredicate[T], ident: Variable, property: Property)
+case class ImplicitlyPropertyScannable[+T <: Expression](expr: PartialPredicate[T], ident: LogicalVariable, property: LogicalProperty)
   extends Scannable[PartialPredicate[T]]

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/Sargable.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/Sargable.scala
@@ -151,7 +151,7 @@ case class PrefixRangeSeekable(override val range: PrefixRange[Expression], expr
     RangeQueryExpression(PrefixSeekRangeWrapper(range)(expr.rhs.position))
 }
 
-case class InequalityRangeSeekable(ident: Variable, propertyKeyName: PropertyKeyName, expr: AndedPropertyInequalities)
+case class InequalityRangeSeekable(ident: LogicalVariable, propertyKeyName: PropertyKeyName, expr: AndedPropertyInequalities)
   extends RangeSeekable[AndedPropertyInequalities, Expression] {
 
   def dependencies: Set[LogicalVariable] = expr.inequalities.map(_.dependencies).toSet.flatten

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/AbstractIndexSeekLeafPlanner.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/AbstractIndexSeekLeafPlanner.scala
@@ -53,7 +53,7 @@ abstract class AbstractIndexSeekLeafPlanner extends LeafPlanner with LeafPlanFro
     if (labelPredicateMap.isEmpty)
       Set.empty
     else {
-      val arguments: Set[Variable] = qg.argumentIds.map(n => Variable(n.name)(null))
+      val arguments: Set[LogicalVariable] = qg.argumentIds.map(n => Variable(n.name)(null))
       val plannables: Set[IndexPlannableExpression] = predicates.collect(
         indexPlannableExpression(qg.argumentIds, arguments, qg.hints))
       val result = plannables.map(_.name).flatMap { name =>
@@ -141,7 +141,7 @@ abstract class AbstractIndexSeekLeafPlanner extends LeafPlanner with LeafPlanFro
     }
 
   private def indexPlannableExpression(argumentIds: Set[IdName],
-                                       arguments: Set[Variable],
+                                       arguments: Set[LogicalVariable],
                                        hints: Set[Hint])(implicit labelPredicateMap: Map[IdName, Set[HasLabels]]):
   PartialFunction[Expression, IndexPlannableExpression] = {
     // n.prop IN [ ... ]
@@ -153,7 +153,7 @@ abstract class AbstractIndexSeekLeafPlanner extends LeafPlanner with LeafPlanFro
     // ... = n.prop
     // In some rare cases, we can't rewrite these predicates cleanly,
     // and so planning needs to search for these cases explicitly
-    case predicate@Equals(a, Property(seekable@Variable(_), propKeyName))
+    case predicate@Equals(a, Property(seekable@LogicalVariable(_), propKeyName))
       if a.dependencies.forall(arguments) && !arguments(seekable) =>
       val expr = SingleQueryExpression(a)
       IndexPlannableExpression(seekable.name, propKeyName, predicate, expr, hints, argumentIds)

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/LogicalPlanProducer.scala
@@ -131,7 +131,7 @@ case class LogicalPlanProducer(cardinalityModel: CardinalityModel) extends ListS
                     edgePredicate: Expression,
                     nodePredicate: Expression,
                     solvedPredicates: Seq[Expression],
-                    legacyPredicates: Seq[(Variable, Expression)] = Seq.empty,
+                    legacyPredicates: Seq[(LogicalVariable, Expression)] = Seq.empty,
                     mode: ExpansionMode)(implicit context: LogicalPlanningContext): LogicalPlan = pattern.length match {
     case l: VarPatternLength =>
       val projectedDir = projectedDirection(pattern, from, dir)

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/idSeekLeafPlanner.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/idSeekLeafPlanner.scala
@@ -29,8 +29,8 @@ import org.neo4j.cypher.internal.v3_4.expressions._
 object idSeekLeafPlanner extends LeafPlanner with LeafPlanFromExpression {
 
   override def producePlanFor(e: Expression, qg: QueryGraph)(implicit context: LogicalPlanningContext): Option[LeafPlansForVariable] = {
-    val arguments = qg.argumentIds.map(n => Variable(n.name)(null))
-    val idSeekPredicates: Option[(Expression, Variable, SeekableArgs)] = e match {
+    val arguments: Set[LogicalVariable] = qg.argumentIds.map(n => Variable(n.name)(null))
+    val idSeekPredicates: Option[(Expression, LogicalVariable, SeekableArgs)] = e match {
       // MATCH (a)-[r]-(b) WHERE id(r) IN expr
       // MATCH a WHERE id(a) IN {param}
       case predicate@AsIdSeekable(seekable) if seekable.args.dependencies.forall(arguments) && !arguments(seekable.ident) =>

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/indexScanLeafPlanner.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/indexScanLeafPlanner.scala
@@ -81,7 +81,7 @@ object indexScanLeafPlanner extends LeafPlanner with LeafPlanFromExpression {
 
   type PlanProducer = (IdName, LabelToken, PropertyKeyToken, Seq[Expression], Option[UsingIndexHint], Set[IdName]) => LogicalPlan
 
-  private def produce(variableName: String, propertyKeyName: String, qg: QueryGraph, property: Property,
+  private def produce(variableName: String, propertyKeyName: String, qg: QueryGraph, property: LogicalProperty,
                       predicate: Expression, planProducer: PlanProducer)
                      (implicit context: LogicalPlanningContext, semanticTable: SemanticTable): Set[LogicalPlan] = {
     val labelPredicates: Map[IdName, Set[HasLabels]] = qg.selections.labelPredicates

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/InliningContextTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/InliningContextTest.scala
@@ -30,11 +30,11 @@ class InliningContextTest extends CypherFunSuite with AstConstructionTestSupport
   val identA = varFor("a")
   val astNull: Null = Null()_
 
-  val mapN = Map(identN -> astNull)
-  val mapM = Map(identM -> astNull)
-  val mapA = Map(identA -> astNull)
+  val mapN = Map[LogicalVariable, Expression](identN -> astNull)
+  val mapM = Map[LogicalVariable, Expression](identM -> astNull)
+  val mapA = Map[LogicalVariable, Expression](identA -> astNull)
 
-  val mapAtoN = Map(identA -> identN)
+  val mapAtoN = Map[LogicalVariable, Expression](identA -> identN)
 
   test("update projections on enterQueryPart") {
     val ctx = InliningContext(mapM).enterQueryPart(mapN)

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/SargableTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/SargableTest.scala
@@ -67,7 +67,7 @@ class SargableTest extends CypherFunSuite with AstConstructionTestSupport {
 
   test("IdSeekable works") {
     val leftExpr: FunctionInvocation = FunctionInvocation(FunctionName("id") _, nodeA)_
-    Mockito.when(expr2.dependencies).thenReturn(Set.empty[Variable])
+    Mockito.when(expr2.dependencies).thenReturn(Set.empty[LogicalVariable])
     val expr: Equals = Equals(leftExpr, expr2) _
 
     assertMatches(expr) {
@@ -82,7 +82,7 @@ class SargableTest extends CypherFunSuite with AstConstructionTestSupport {
 
   test("IdSeekable does not match if rhs depends on lhs variable") {
     val leftExpr: FunctionInvocation = FunctionInvocation(FunctionName("id") _, nodeA)_
-    Mockito.when(expr2.dependencies).thenReturn(Set(nodeA))
+    Mockito.when(expr2.dependencies).thenReturn(Set[LogicalVariable](nodeA))
     val expr: Equals = Equals(leftExpr, expr2) _
 
     assertDoesNotMatch(expr) {
@@ -92,7 +92,7 @@ class SargableTest extends CypherFunSuite with AstConstructionTestSupport {
 
   test("IdSeekable does not match if function is not the id function") {
     val leftExpr: FunctionInvocation = FunctionInvocation(FunctionName("rand") _, nodeA)_
-    Mockito.when(expr2.dependencies).thenReturn(Set.empty[Variable])
+    Mockito.when(expr2.dependencies).thenReturn(Set.empty[LogicalVariable])
     val expr: Equals = Equals(leftExpr, expr2) _
 
     assertDoesNotMatch(expr) {
@@ -103,7 +103,7 @@ class SargableTest extends CypherFunSuite with AstConstructionTestSupport {
   test("PropertySeekable works with plain expressions") {
     val leftExpr: Property = Property(nodeA, PropertyKeyName("id")_)_
     val expr: Expression = In(leftExpr, expr2)_
-    Mockito.when(expr2.dependencies).thenReturn(Set.empty[Variable])
+    Mockito.when(expr2.dependencies).thenReturn(Set.empty[LogicalVariable])
 
     assertMatches(expr) {
       case AsPropertySeekable(seekable) =>
@@ -119,8 +119,8 @@ class SargableTest extends CypherFunSuite with AstConstructionTestSupport {
     val leftExpr: Property = Property(nodeA, PropertyKeyName("id")_)_
     val rightExpr: ListLiteral = ListLiteral(Seq(expr1, expr2))_
     val expr: Expression = In(leftExpr, rightExpr)_
-    Mockito.when(expr1.dependencies).thenReturn(Set.empty[Variable])
-    Mockito.when(expr2.dependencies).thenReturn(Set.empty[Variable])
+    Mockito.when(expr1.dependencies).thenReturn(Set.empty[LogicalVariable])
+    Mockito.when(expr2.dependencies).thenReturn(Set.empty[LogicalVariable])
 
     assertMatches(expr) {
       case AsPropertySeekable(seekable) =>
@@ -134,7 +134,7 @@ class SargableTest extends CypherFunSuite with AstConstructionTestSupport {
 
   test("PropertySeekable does not match if rhs depends on lhs variable") {
     val leftExpr: Property = Property(nodeA, PropertyKeyName("id")_)_
-    Mockito.when(expr2.dependencies).thenReturn(Set(nodeA))
+    Mockito.when(expr2.dependencies).thenReturn(Set[LogicalVariable](nodeA))
     val expr: Expression = In(leftExpr, expr2)_
 
     assertDoesNotMatch(expr) {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/CommunityPipeBuilder.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/CommunityPipeBuilder.scala
@@ -314,9 +314,9 @@ case class CommunityPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe
     }
   }
 
-  private def varLengthPredicate(predicates: Seq[(Variable, ASTExpression)]): VarLengthPredicate  = {
+  private def varLengthPredicate(predicates: Seq[(LogicalVariable, ASTExpression)]): VarLengthPredicate  = {
     //Creates commands out of the predicates
-    def asCommand(predicates: Seq[(Variable, ASTExpression)]) = {
+    def asCommand(predicates: Seq[(LogicalVariable, ASTExpression)]) = {
       val (keys: Seq[Variable], exprs) = predicates.unzip
 
       val commands = exprs.map(buildPredicate)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/CommunityPipeBuilder.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/CommunityPipeBuilder.scala
@@ -256,20 +256,24 @@ case class CommunityPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe
         SetPipe(source, SetLabelsOperation(name, labels.map(LazyLabel.apply)))(id = id)
 
       case SetNodeProperty(_, IdName(name), propertyKey, expression) =>
+        val needsExclusiveLock = ASTExpression.hasPropertyReadDependency(name, expression, propertyKey)
         SetPipe(source, SetNodePropertyOperation(name, LazyPropertyKey(propertyKey),
-          buildExpression(expression)))(id = id)
+          buildExpression(expression), needsExclusiveLock))(id = id)
 
       case SetNodePropertiesFromMap(_, IdName(name), expression, removeOtherProps) =>
+        val needsExclusiveLock = ASTExpression.mapExpressionHasPropertyReadDependency(name, expression)
         SetPipe(source,
-          SetNodePropertyFromMapOperation(name, buildExpression(expression), removeOtherProps))(id = id)
+          SetNodePropertyFromMapOperation(name, buildExpression(expression), removeOtherProps, needsExclusiveLock))(id = id)
 
       case SetRelationshipPropery(_, IdName(name), propertyKey, expression) =>
+        val needsExclusiveLock = ASTExpression.hasPropertyReadDependency(name, expression, propertyKey)
         SetPipe(source,
-          SetRelationshipPropertyOperation(name, LazyPropertyKey(propertyKey), buildExpression(expression)))(id = id)
+          SetRelationshipPropertyOperation(name, LazyPropertyKey(propertyKey), buildExpression(expression), needsExclusiveLock))(id = id)
 
       case SetRelationshipPropertiesFromMap(_, IdName(name), expression, removeOtherProps) =>
+        val needsExclusiveLock = ASTExpression.mapExpressionHasPropertyReadDependency(name, expression)
         SetPipe(source,
-          SetRelationshipPropertyFromMapOperation(name, buildExpression(expression), removeOtherProps))(id = id)
+          SetRelationshipPropertyFromMapOperation(name, buildExpression(expression), removeOtherProps, needsExclusiveLock))(id = id)
 
       case SetProperty(_, entityExpr, propertyKey, expression) =>
         SetPipe(source, SetPropertyOperation(

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/AndedPropertyInequalities.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/AndedPropertyInequalities.scala
@@ -20,7 +20,7 @@ import org.neo4j.cypher.internal.util.v3_4.NonEmptyList
 
 case class AndedPropertyInequalities(
                                       variable: Variable,
-                                      property: Property,
+                                      property: LogicalProperty,
                                       inequalities: NonEmptyList[InequalityExpression]
                                     ) extends Expression {
   def position = variable.position

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Expression.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Expression.scala
@@ -45,7 +45,7 @@ object Expression {
     mapExpression match {
       case MapExpression(items) => items.exists {
         case (k, v) => v.subExpressions.exists {
-          case Property(Variable(entityName), propertyKey) =>
+          case LogicalProperty(LogicalVariable(entityName), propertyKey) =>
             entityName == mapEntityName && propertyKey == k
           case _ => false
         }
@@ -55,7 +55,7 @@ object Expression {
 
   def hasPropertyReadDependency(entityName: String, expression: Expression, propertyKey: PropertyKeyName): Boolean =
     expression.subExpressions.exists {
-      case Property(Variable(name), key) =>
+      case LogicalProperty(LogicalVariable(name), key) =>
         name == entityName && key == propertyKey
       case _ =>
         false

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/IterableExpressions.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/IterableExpressions.scala
@@ -20,7 +20,7 @@ import org.neo4j.cypher.internal.util.v3_4.InputPosition
 
 trait FilteringExpression extends Expression {
   def name: String
-  def variable: Variable
+  def variable: LogicalVariable
   def expression: Expression
   def innerPredicate: Option[Expression]
 
@@ -74,18 +74,18 @@ object ListComprehension {
     ListComprehension(ExtractScope(variable, innerPredicate, extractExpression)(position), expression)(position)
 }
 
-case class PatternComprehension(namedPath: Option[Variable], pattern: RelationshipsPattern,
+case class PatternComprehension(namedPath: Option[LogicalVariable], pattern: RelationshipsPattern,
                                 predicate: Option[Expression], projection: Expression,
-                                outerScope: Set[Variable] = Set.empty)
+                                outerScope: Set[LogicalVariable] = Set.empty)
                                (val position: InputPosition)
   extends ScopeExpression {
 
   self =>
 
-  def withOuterScope(outerScope: Set[Variable]) =
+  def withOuterScope(outerScope: Set[LogicalVariable]) =
     copy(outerScope = outerScope)(position)
 
-  override val introducedVariables: Set[Variable] = {
+  override val introducedVariables: Set[LogicalVariable] = {
     val introducedInternally = namedPath.toSet ++ pattern.element.allVariables
     val introducedExternally = introducedInternally -- outerScope
     introducedExternally
@@ -95,7 +95,7 @@ case class PatternComprehension(namedPath: Option[Variable], pattern: Relationsh
 sealed trait IterablePredicateExpression extends FilteringExpression {
 
   def scope: FilterScope
-  def variable: Variable = scope.variable
+  def variable: LogicalVariable = scope.variable
   def innerPredicate: Option[Expression] = scope.innerPredicate
 
   override def asCanonicalStringVal: String = {

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/LogicalProperty.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/LogicalProperty.scala
@@ -16,8 +16,11 @@
  */
 package org.neo4j.cypher.internal.v3_4.expressions
 
-import org.neo4j.cypher.internal.util.v3_4.InputPosition
+abstract class LogicalProperty extends Expression {
+  def map: Expression
+  def propertyKey: PropertyKeyName
+}
 
-case class Property(map: Expression, propertyKey: PropertyKeyName)(val position: InputPosition) extends Expression {
-  override def asCanonicalStringVal = s"${map.asCanonicalStringVal}.${propertyKey.asCanonicalStringVal}"
+object LogicalProperty {
+  def unapply(p: LogicalProperty): Option[(Expression, PropertyKeyName)] = Some((p.map, p.propertyKey))
 }

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/LogicalVariable.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/LogicalVariable.scala
@@ -18,20 +18,19 @@ package org.neo4j.cypher.internal.v3_4.expressions
 
 import org.neo4j.cypher.internal.util.v3_4.InputPosition
 
-case class Variable(name: String)(val position: InputPosition) extends LogicalVariable {
+abstract class LogicalVariable extends Expression {
+  def name: String
 
-  override def copyId = copy()(position)
+  def copyId: LogicalVariable
 
-  override def renameId(newName: String) = copy(name = newName)(position)
+  def renameId(newName: String): LogicalVariable
 
-  override def bumpId = copy()(position.bumped())
+  def bumpId: LogicalVariable
 
-  override def asCanonicalStringVal: String = name
+  def position: InputPosition
 }
 
-object Variable {
-  implicit val byName: Ordering[Variable] =
-    Ordering.by { (variable: Variable) =>
-      (variable.name, variable.position)
-    }(Ordering.Tuple2(implicitly[Ordering[String]], InputPosition.byOffset))
+object LogicalVariable {
+  def unapply(arg: Variable): Option[String] = Some(arg.name)
 }
+

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/MapProjection.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/MapProjection.scala
@@ -19,7 +19,8 @@ package org.neo4j.cypher.internal.v3_4.expressions
 import org.neo4j.cypher.internal.util.v3_4.InputPosition
 
 case class MapProjection(
-                          name: Variable,
+                          name: Variable, // Since this is always rewritten to DesugaredMapProjection this
+                                          // (and in the elements below) may not need to be LogicalVariable
                           items: Seq[MapProjectionElement],
                           definitionPos: Option[InputPosition] = None)
                         (val position: InputPosition)

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Property.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Property.scala
@@ -18,6 +18,6 @@ package org.neo4j.cypher.internal.v3_4.expressions
 
 import org.neo4j.cypher.internal.util.v3_4.InputPosition
 
-case class Property(map: Expression, propertyKey: PropertyKeyName)(val position: InputPosition) extends Expression {
+case class Property(map: Expression, propertyKey: PropertyKeyName)(val position: InputPosition) extends LogicalProperty {
   override def asCanonicalStringVal = s"${map.asCanonicalStringVal}.${propertyKey.asCanonicalStringVal}"
 }

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Property.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Property.scala
@@ -18,6 +18,35 @@ package org.neo4j.cypher.internal.v3_4.expressions
 
 import org.neo4j.cypher.internal.util.v3_4.InputPosition
 
-case class Property(map: Expression, propertyKey: PropertyKeyName)(val position: InputPosition) extends Expression {
+class Property(val map: Expression, val propertyKey: PropertyKeyName)(val position: InputPosition) extends Expression {
   override def asCanonicalStringVal = s"${map.asCanonicalStringVal}.${propertyKey.asCanonicalStringVal}"
+
+  //--------------------------------------------------------------------------------------------------
+  // The methods below are what we would get automatically if this was a case class
+  //--------------------------------------------------------------------------------------------------
+  def copy(map: Expression = this.map, propertyKey: PropertyKeyName = this.propertyKey)(position: InputPosition): Property =
+    new Property(map, propertyKey)(position)
+
+  override def productElement(n: Int) =
+    n match {
+      case 0 => map
+      case 1 => propertyKey
+      case _ => throw new java.lang.IndexOutOfBoundsException(n.toString)
+    }
+
+  override def productArity = 2
+
+  override def canEqual(that: Any) = that.isInstanceOf[Property]
+
+  override def toString: String = s"Property($map, $propertyKey)"
+
+  override def hashCode(): Int = runtime.ScalaRunTime._hashCode(Property.this)
+
+  override def equals(obj: scala.Any): Boolean = runtime.ScalaRunTime._equals(Property.this, obj)
+}
+
+object Property {
+  def apply(map: Expression, propertyKey: PropertyKeyName)(position: InputPosition) = new Property(map, propertyKey)(position)
+
+  def unapply(p: Property): Option[(Expression, PropertyKeyName)] = Some((p.map, p.propertyKey))
 }

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/ScopeExpression.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/ScopeExpression.scala
@@ -28,17 +28,17 @@ import org.neo4j.cypher.internal.util.v3_4.InputPosition
 // - or child expressions in a scope where those variables are bound
 //
 trait ScopeExpression extends Expression {
-  def introducedVariables: Set[Variable]
+  def introducedVariables: Set[LogicalVariable]
 }
 
-case class FilterScope(variable: Variable, innerPredicate: Option[Expression])(val position: InputPosition) extends ScopeExpression {
+case class FilterScope(variable: LogicalVariable, innerPredicate: Option[Expression])(val position: InputPosition) extends ScopeExpression {
   val introducedVariables = Set(variable)
 }
 
-case class ExtractScope(variable: Variable, innerPredicate: Option[Expression], extractExpression: Option[Expression])(val position: InputPosition) extends ScopeExpression {
+case class ExtractScope(variable: LogicalVariable, innerPredicate: Option[Expression], extractExpression: Option[Expression])(val position: InputPosition) extends ScopeExpression {
   val introducedVariables = Set(variable)
 }
 
-case class ReduceScope(accumulator: Variable, variable: Variable, expression: Expression)(val position: InputPosition) extends ScopeExpression {
+case class ReduceScope(accumulator: LogicalVariable, variable: LogicalVariable, expression: Expression)(val position: InputPosition) extends ScopeExpression {
   val introducedVariables = Set(accumulator, variable)
 }

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ASTSlicingPhrase.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ASTSlicingPhrase.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.v3_4.expressions._
 trait ASTSlicingPhrase extends SemanticCheckable with SemanticAnalysisTooling {
   self: ASTNode =>
   def name: String
-  def dependencies: Set[Variable] = expression.dependencies
+  def dependencies: Set[LogicalVariable] = expression.dependencies
   def expression: Expression
 
   def semanticCheck: SemanticCheck =

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Clause.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Clause.scala
@@ -643,7 +643,7 @@ case class Return(distinct: Boolean,
     }
 }
 
-case class PragmaWithout(excluded: Seq[Variable])(val position: InputPosition) extends HorizonClause {
+case class PragmaWithout(excluded: Seq[LogicalVariable])(val position: InputPosition) extends HorizonClause {
   override def name = "_PRAGMA WITHOUT"
   val excludedNames: Set[String] = excluded.map(_.name).toSet
 

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Order.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Order.scala
@@ -16,15 +16,15 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_4.ast
 
-import org.neo4j.cypher.internal.util.v3_4.{ASTNode, InputPosition}
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.{SemanticCheckable, SemanticExpressionCheck}
-import org.neo4j.cypher.internal.v3_4.expressions.{Expression, Variable}
+import org.neo4j.cypher.internal.util.v3_4.{ASTNode, InputPosition}
+import org.neo4j.cypher.internal.v3_4.expressions.{Expression, LogicalVariable}
 
 case class OrderBy(sortItems: Seq[SortItem])(val position: InputPosition) extends ASTNode with SemanticCheckable {
   def semanticCheck = sortItems.semanticCheck
 
-  def dependencies: Set[Variable] =
-    sortItems.foldLeft(Set.empty[Variable]) { case (acc, item) => acc ++ item.expression.dependencies }
+  def dependencies: Set[LogicalVariable] =
+    sortItems.foldLeft(Set.empty[LogicalVariable]) { case (acc, item) => acc ++ item.expression.dependencies }
 }
 
 sealed trait SortItem extends ASTNode with SemanticCheckable {

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/RemoveItem.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/RemoveItem.scala
@@ -16,20 +16,20 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_4.ast
 
-import org.neo4j.cypher.internal.util.v3_4.{ASTNode, InputPosition}
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.{SemanticCheckable, SemanticExpressionCheck}
 import org.neo4j.cypher.internal.util.v3_4.symbols._
-import org.neo4j.cypher.internal.v3_4.expressions.{LabelName, Property, Variable}
+import org.neo4j.cypher.internal.util.v3_4.{ASTNode, InputPosition}
+import org.neo4j.cypher.internal.v3_4.expressions.{LabelName, LogicalProperty, LogicalVariable}
 
 sealed trait RemoveItem extends ASTNode with SemanticCheckable
 
-case class RemoveLabelItem(variable: Variable, labels: Seq[LabelName])(val position: InputPosition) extends RemoveItem {
+case class RemoveLabelItem(variable: LogicalVariable, labels: Seq[LabelName])(val position: InputPosition) extends RemoveItem {
   def semanticCheck =
     SemanticExpressionCheck.simple(variable) chain
     SemanticExpressionCheck.expectType(CTNode.covariant, variable)
 }
 
-case class RemovePropertyItem(property: Property) extends RemoveItem {
+case class RemovePropertyItem(property: LogicalProperty) extends RemoveItem {
   def position = property.position
 
   def semanticCheck = SemanticExpressionCheck.simple(property)

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ReturnItem.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ReturnItem.scala
@@ -16,11 +16,11 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_4.ast
 
-import org.neo4j.cypher.internal.util.v3_4.{ASTNode, InputPosition, InternalException}
-import org.neo4j.cypher.internal.frontend.v3_4.semantics.SemanticCheckResult.success
 import org.neo4j.cypher.internal.frontend.v3_4._
+import org.neo4j.cypher.internal.frontend.v3_4.semantics.SemanticCheckResult.success
 import org.neo4j.cypher.internal.frontend.v3_4.semantics._
-import org.neo4j.cypher.internal.v3_4.expressions.{Expression, MapProjection, Variable}
+import org.neo4j.cypher.internal.util.v3_4.{ASTNode, InputPosition, InternalException}
+import org.neo4j.cypher.internal.v3_4.expressions.{Expression, LogicalVariable, MapProjection}
 
 sealed trait ReturnItemsDef extends ASTNode with SemanticCheckable with SemanticAnalysisTooling {
   /**
@@ -57,9 +57,9 @@ final case class ReturnItems(
 
   override def semanticCheck: SemanticCheck = items.semanticCheck chain ensureProjectedToUniqueIds
 
-  def aliases: Set[Variable] = items.flatMap(_.alias).toSet
+  def aliases: Set[LogicalVariable] = items.flatMap(_.alias).toSet
 
-  def passedThrough: Set[Variable] = items.collect {
+  def passedThrough: Set[LogicalVariable] = items.collect {
     case item => item.alias.collect { case ident if ident == item.expression => ident }
   }.flatten.toSet
 
@@ -91,7 +91,7 @@ final case class ReturnItems(
 
 sealed trait ReturnItem extends ASTNode with SemanticCheckable {
   def expression: Expression
-  def alias: Option[Variable]
+  def alias: Option[LogicalVariable]
   def name: String
   def makeSureIsNotUnaliased(state: SemanticState): SemanticCheckResult
 
@@ -100,7 +100,7 @@ sealed trait ReturnItem extends ASTNode with SemanticCheckable {
 
 case class UnaliasedReturnItem(expression: Expression, inputText: String)(val position: InputPosition) extends ReturnItem {
   val alias = expression match {
-    case i: Variable => Some(i.bumpId)
+    case i: LogicalVariable => Some(i.bumpId)
     case x: MapProjection => Some(x.name.bumpId)
     case _ => None
   }
@@ -111,11 +111,11 @@ case class UnaliasedReturnItem(expression: Expression, inputText: String)(val po
 }
 
 object AliasedReturnItem {
-  def apply(v:Variable):AliasedReturnItem = AliasedReturnItem(v.copyId, v.copyId)(v.position)
+  def apply(v:LogicalVariable):AliasedReturnItem = AliasedReturnItem(v.copyId, v.copyId)(v.position)
 }
 
 //TODO variable should not be a Variable. A Variable is an expression, and the return item alias isn't
-case class AliasedReturnItem(expression: Expression, variable: Variable)(val position: InputPosition) extends ReturnItem {
+case class AliasedReturnItem(expression: Expression, variable: LogicalVariable)(val position: InputPosition) extends ReturnItem {
   val alias = Some(variable)
   val name = variable.name
 

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/SetItem.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/SetItem.scala
@@ -19,7 +19,7 @@ package org.neo4j.cypher.internal.frontend.v3_4.ast
 import org.neo4j.cypher.internal.util.v3_4.{ASTNode, InputPosition}
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.{SemanticAnalysisTooling, SemanticCheckable, SemanticExpressionCheck}
 import org.neo4j.cypher.internal.util.v3_4.symbols._
-import org.neo4j.cypher.internal.v3_4.expressions.{Expression, LabelName, Property, Variable}
+import org.neo4j.cypher.internal.v3_4.expressions._
 
 sealed trait SetItem extends ASTNode with SemanticCheckable
 
@@ -31,7 +31,7 @@ case class SetLabelItem(variable: Variable, labels: Seq[LabelName])(val position
 
 sealed trait SetProperty extends SetItem with SemanticAnalysisTooling
 
-case class SetPropertyItem(property: Property, expression: Expression)(val position: InputPosition) extends SetProperty {
+case class SetPropertyItem(property: LogicalProperty, expression: Expression)(val position: InputPosition) extends SetProperty {
   def semanticCheck =
     SemanticExpressionCheck.simple(property) chain
       SemanticExpressionCheck.simple(expression) chain

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/Namespacer.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/Namespacer.scala
@@ -21,7 +21,7 @@ import org.neo4j.cypher.internal.frontend.v3_4.ast._
 import org.neo4j.cypher.internal.frontend.v3_4.phases.CompilationPhaseTracer.CompilationPhase
 import org.neo4j.cypher.internal.frontend.v3_4.phases.{BaseContext, BaseState, Condition, Phase}
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.{Scope, SemanticTable, SymbolUse}
-import org.neo4j.cypher.internal.v3_4.expressions.{ProcedureOutput, Variable}
+import org.neo4j.cypher.internal.v3_4.expressions.{LogicalVariable, ProcedureOutput, Variable}
 
 object Namespacer extends Phase[BaseContext, BaseState, BaseState] {
   type VariableRenamings = Map[Ref[Variable], Variable]
@@ -56,8 +56,8 @@ object Namespacer extends Phase[BaseContext, BaseState, BaseState] {
     }.toSet
   }
 
-  private def returnAliases(statement: Statement): Set[Ref[Variable]] =
-    statement.treeFold(Set.empty[Ref[Variable]]) {
+  private def returnAliases(statement: Statement): Set[Ref[LogicalVariable]] =
+    statement.treeFold(Set.empty[Ref[LogicalVariable]]) {
 
       case With(_, _, GraphReturnItems(_, items), _, _, _, _) =>
         val gVars = extractGraphVars(items)
@@ -65,12 +65,12 @@ object Namespacer extends Phase[BaseContext, BaseState, BaseState] {
 
       // ignore variable in StartItem that represents index names and key names
       case Return(_, ReturnItems(_, items), graphItems, _, _, _, _) =>
-        val variables = items.map(_.alias.map(Ref[Variable]).get)
+        val variables = items.map(_.alias.map(Ref[LogicalVariable]).get)
         val gVars = graphItems.map(_.items).map(extractGraphVars).getOrElse(Seq.empty)
         acc => (acc ++ variables ++ gVars, Some(identity))
     }
 
-  private def extractGraphVars(items: Seq[GraphReturnItem]): Seq[Ref[Variable]] = {
+  private def extractGraphVars(items: Seq[GraphReturnItem]): Seq[Ref[LogicalVariable]] = {
     items.flatMap { item =>
       item.graphs.flatMap {
         case g: GraphAs =>
@@ -82,7 +82,7 @@ object Namespacer extends Phase[BaseContext, BaseState, BaseState] {
   }
 
   private def variableRenamings(statement: Statement, variableDefinitions: Map[SymbolUse, SymbolUse],
-                                ambiguousNames: Set[String], protectedVariables: Set[Ref[Variable]]): VariableRenamings =
+                                ambiguousNames: Set[String], protectedVariables: Set[Ref[LogicalVariable]]): VariableRenamings =
     statement.treeFold(Map.empty[Ref[Variable], Variable]) {
       case i: Variable if ambiguousNames(i.name) && !protectedVariables(Ref(i)) =>
         val symbolDefinition = variableDefinitions(SymbolUse(i))

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/desugarMapProjection.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/desugarMapProjection.scala
@@ -60,7 +60,7 @@ case class desugarMapProjection(state: SemanticState) extends Rewriter {
 }
 
 case class DesugaredMapProjection(
-                                   name: Variable,
+                                   name: LogicalVariable,
                                    items: Seq[LiteralEntry],
                                    includeAllProps: Boolean
                                  )(val position: InputPosition) extends Expression

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/inlineNamedPathsInPatternComprehensions.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/inlineNamedPathsInPatternComprehensions.scala
@@ -32,7 +32,7 @@ case object inlineNamedPathsInPatternComprehensions extends Rewriter {
   })
 
   private implicit final class InliningExpression(val expr: Expression) extends AnyVal {
-    def inline(path: Variable, patternElement: PatternElement) =
+    def inline(path: LogicalVariable, patternElement: PatternElement) =
       expr.copyAndReplace(path) by {
         PathExpression(projectNamedPaths.patternPartPathExpression(patternElement))(expr.position)
       }

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/projectNamedPaths.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/projectNamedPaths.scala
@@ -26,15 +26,15 @@ import scala.annotation.tailrec
 case object projectNamedPaths extends Rewriter {
 
   case class Projectibles(paths: Map[Variable, PathExpression] = Map.empty,
-                          protectedVariables: Set[Ref[Variable]] = Set.empty,
-                          variableRewrites: Map[Ref[Variable], PathExpression] = Map.empty) {
+                          protectedVariables: Set[Ref[LogicalVariable]] = Set.empty,
+                          variableRewrites: Map[Ref[LogicalVariable], PathExpression] = Map.empty) {
 
     self =>
 
     def withoutNamedPaths = copy(paths = Map.empty)
-    def withProtectedVariable(ident: Ref[Variable]) = copy(protectedVariables = protectedVariables + ident)
+    def withProtectedVariable(ident: Ref[LogicalVariable]) = copy(protectedVariables = protectedVariables + ident)
     def withNamedPath(entry: (Variable, PathExpression)) = copy(paths = paths + entry)
-    def withRewrittenVariable(entry: (Ref[Variable], PathExpression)) = {
+    def withRewrittenVariable(entry: (Ref[LogicalVariable], PathExpression)) = {
       val (ref, pathExpr) = entry
       copy(variableRewrites = variableRewrites + (ref -> pathExpr.endoRewrite(copyVariables)))
     }

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/Transformer.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/Transformer.scala
@@ -16,8 +16,8 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_4.phases
 
-import org.neo4j.cypher.internal.util.v3_4.{AssertionRunner, InternalException}
-import org.neo4j.cypher.internal.util.v3_4.AssertionRunner.Thunk
+import org.neo4j.cypher.internal.util.v3_4.AssertionUtils.ifAssertionsEnabled
+import org.neo4j.cypher.internal.util.v3_4.InternalException
 
 trait Transformer[-C <: BaseContext, -FROM, TO] {
   def transform(from: FROM, context: C): TO
@@ -64,12 +64,6 @@ class PipeLine[-C <: BaseContext, FROM, MID, TO](first: Transformer[C, FROM, MID
   }
 
   override def name: String = first.name + ", " + after.name
-
-  private def ifAssertionsEnabled(f: => Unit): Unit = {
-    AssertionRunner.runUnderAssertion(new Thunk {
-      override def apply() = f
-    })
-  }
 }
 
 

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticAnalysisTooling.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticAnalysisTooling.scala
@@ -167,14 +167,14 @@ trait SemanticAnalysisTooling {
       case e:java.lang.NumberFormatException => false
     }
 
-  def ensureDefined(v:Variable): (SemanticState) => Either[SemanticError, SemanticState] =
+  def ensureDefined(v:LogicalVariable): (SemanticState) => Either[SemanticError, SemanticState] =
     (_: SemanticState).ensureVariableDefined(v)
 
-  def declareVariable(v:Variable, possibleTypes: TypeSpec): (SemanticState) => Either[SemanticError, SemanticState] =
+  def declareVariable(v:LogicalVariable, possibleTypes: TypeSpec): (SemanticState) => Either[SemanticError, SemanticState] =
     (_: SemanticState).declareVariable(v, possibleTypes)
 
   def declareVariable(
-                       v:Variable,
+                       v:LogicalVariable,
                        typeGen: TypeGenerator,
                        positions: Set[InputPosition] = Set.empty
                      ): (SemanticState) => Either[SemanticError, SemanticState] =

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticTable.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticTable.scala
@@ -72,9 +72,9 @@ class SemanticTable(
 
   def isNodeCollection(expr: String) = getTypeFor(expr) == CTList(CTNode).invariant
 
-  def isNode(expr: Variable) = types(expr).specified == CTNode.invariant
+  def isNode(expr: LogicalVariable) = types(expr).specified == CTNode.invariant
 
-  def isRelationship(expr: Variable) = types(expr).specified == CTRelationship.invariant
+  def isRelationship(expr: LogicalVariable) = types(expr).specified == CTRelationship.invariant
 
   def addNode(expr: Variable) =
     copy(types = types.updated(expr, ExpressionTypeInfo(CTNode.invariant, None)))

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/convert/CommunityExpressionConverter.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/convert/CommunityExpressionConverter.scala
@@ -309,7 +309,7 @@ object CommunityExpressionConverter extends ExpressionConverter {
 
   private def toCommandParameter(e: ast.Parameter) = commandexpressions.ParameterExpression(e.name)
 
-  private def toCommandProperty(e: ast.Property, self: ExpressionConverters): commandexpressions.Property =
+  private def toCommandProperty(e: ast.LogicalProperty, self: ExpressionConverters): commandexpressions.Property =
     commandexpressions.Property(self.toCommandExpression(e.map), PropertyKey(e.propertyKey.name))
 
   private def toCommandExpression(expression: Option[ast.Expression], self: ExpressionConverters): Option[CommandExpression] =

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/convert/CommunityExpressionConverter.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/convert/CommunityExpressionConverter.scala
@@ -318,7 +318,7 @@ object CommunityExpressionConverter extends ExpressionConverter {
   private def toCommandExpression(expressions: Seq[ast.Expression], self: ExpressionConverters): Seq[CommandExpression] =
     expressions.map(self.toCommandExpression)
 
-  private def variable(e: ast.Variable) = commands.expressions.Variable(e.name)
+  private def variable(e: ast.LogicalVariable) = commands.expressions.Variable(e.name)
 
   private def inequalityExpression(original: ast.InequalityExpression, self: ExpressionConverters): predicates.ComparablePredicate = original match {
     case e: ast.LessThan => predicates.LessThan(self.toCommandExpression(e.lhs), self.toCommandExpression(e.rhs))

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Expression.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Expression.scala
@@ -116,25 +116,3 @@ trait ExpressionWInnerExpression extends Expression {
   def myType:CypherType
   def expectedInnerType:CypherType
 }
-
-object Expression {
-  def mapExpressionHasPropertyReadDependency(mapEntityName: String, mapExpression: Expression): Boolean =
-    mapExpression match {
-      case LiteralMap(map) => map.exists {
-        case (k, v) => v.subExpressions.exists {
-          case Property(Variable(entityName), propertyKey) =>
-            entityName == mapEntityName && propertyKey.name == k
-          case _ => false
-        }
-      }
-      case _ => false
-    }
-
-  def hasPropertyReadDependency(entityName: String, expression: Expression, propertyKey: String): Boolean =
-    expression.subExpressions.exists {
-      case Property(Variable(name), key) =>
-        name == entityName && key.name == propertyKey
-      case _ =>
-        false
-    }
-}

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SetOperation.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SetOperation.scala
@@ -28,7 +28,7 @@ import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Expres
 import org.neo4j.graphdb.{Node, PropertyContainer, Relationship}
 import org.neo4j.values.AnyValue
 import org.neo4j.values.storable.Values
-import org.neo4j.values.virtual.{EdgeValue, MapValue, NodeValue}
+import org.neo4j.values.virtual._
 
 import scala.collection.Map
 
@@ -37,6 +37,8 @@ sealed trait SetOperation {
   def set(executionContext: ExecutionContext, state: QueryState): Unit
 
   def name: String
+
+  def needsExclusiveLock: Boolean
 }
 
 object SetOperation {
@@ -93,8 +95,6 @@ abstract class SetEntityPropertyOperation[T <: PropertyContainer](itemName: Stri
                                                                   expression: Expression)
   extends AbstractSetPropertyOperation {
 
-  private val needsExclusiveLock = Expression.hasPropertyReadDependency(itemName, expression, propertyKey.name)
-
   override def set(executionContext: ExecutionContext, state: QueryState) = {
     val item = executionContext.get(itemName).get
     if (item != Values.NO_VALUE) {
@@ -114,23 +114,23 @@ abstract class SetEntityPropertyOperation[T <: PropertyContainer](itemName: Stri
 }
 
 case class SetNodePropertyOperation(nodeName: String, propertyKey: LazyPropertyKey,
-                                    expression: Expression)
+                                    expression: Expression, needsExclusiveLock: Boolean = true)
   extends SetEntityPropertyOperation[Node](nodeName, propertyKey, expression) {
 
   override def name = "SetNodeProperty"
 
-  override protected def id(item: Any) = CastSupport.castOrFail[NodeValue](item).id()
+  override protected def id(item: Any) = CastSupport.castOrFail[VirtualNodeValue](item).id()
 
   override protected def operations(qtx: QueryContext) = qtx.nodeOps
 }
 
 case class SetRelationshipPropertyOperation(relName: String, propertyKey: LazyPropertyKey,
-                                            expression: Expression)
+                                            expression: Expression, needsExclusiveLock: Boolean = true)
   extends SetEntityPropertyOperation[Relationship](relName, propertyKey, expression) {
 
   override def name = "SetRelationshipProperty"
 
-  override protected def id(item: Any) = CastSupport.castOrFail[EdgeValue](item).id()
+  override protected def id(item: Any) = CastSupport.castOrFail[VirtualEdgeValue](item).id()
 
   override protected def operations(qtx: QueryContext) = qtx.relationshipOps
 }
@@ -144,8 +144,8 @@ case class SetPropertyOperation(entityExpr: Expression, propertyKey: LazyPropert
     val resolvedEntity = entityExpr(executionContext, state)
     if (resolvedEntity != Values.NO_VALUE) {
       val (entityId, ops) = resolvedEntity match {
-        case node: NodeValue => (node.id(), state.query.nodeOps)
-        case rel: EdgeValue => (rel.id(), state.query.relationshipOps)
+        case node: VirtualNodeValue => (node.id(), state.query.nodeOps)
+        case rel: VirtualEdgeValue => (rel.id(), state.query.relationshipOps)
         case _ => throw new InvalidArgumentException(
           s"The expression $entityExpr should have been a node or a relationship, but got $resolvedEntity")
       }
@@ -157,13 +157,12 @@ case class SetPropertyOperation(entityExpr: Expression, propertyKey: LazyPropert
       } finally ops.releaseExclusiveLock(entityId)
     }
   }
+
+  override def needsExclusiveLock = true
 }
 
 abstract class SetPropertyFromMapOperation[T <: PropertyContainer](itemName: String, expression: Expression,
                                                                    removeOtherProps: Boolean) extends SetOperation {
-
-  private val needsExclusiveLock = Expression.mapExpressionHasPropertyReadDependency(itemName, expression)
-
   override def set(executionContext: ExecutionContext, state: QueryState) = {
     val item = executionContext.get(itemName).get
     if (item != Values.NO_VALUE) {
@@ -206,23 +205,23 @@ abstract class SetPropertyFromMapOperation[T <: PropertyContainer](itemName: Str
 }
 
 case class SetNodePropertyFromMapOperation(nodeName: String, expression: Expression,
-                                           removeOtherProps: Boolean)
+                                           removeOtherProps: Boolean, needsExclusiveLock: Boolean = true)
   extends SetPropertyFromMapOperation[Node](nodeName, expression, removeOtherProps) {
 
   override def name = "SetNodePropertyFromMap"
 
-  override protected def id(item: Any) = CastSupport.castOrFail[NodeValue](item).id()
+  override protected def id(item: Any) = CastSupport.castOrFail[VirtualNodeValue](item).id()
 
   override protected def operations(qtx: QueryContext) = qtx.nodeOps
 }
 
 case class SetRelationshipPropertyFromMapOperation(relName: String, expression: Expression,
-                                                   removeOtherProps: Boolean)
+                                                   removeOtherProps: Boolean, needsExclusiveLock: Boolean = true)
   extends SetPropertyFromMapOperation[Relationship](relName, expression, removeOtherProps) {
 
   override def name = "SetRelationshipPropertyFromMap"
 
-  override protected def id(item: Any) = CastSupport.castOrFail[EdgeValue](item).id()
+  override protected def id(item: Any) = CastSupport.castOrFail[VirtualEdgeValue](item).id()
 
   override protected def operations(qtx: QueryContext) = qtx.relationshipOps
 }
@@ -232,11 +231,13 @@ case class SetLabelsOperation(nodeName: String, labels: Seq[LazyLabel]) extends 
   override def set(executionContext: ExecutionContext, state: QueryState) = {
     val value: AnyValue = executionContext.get(nodeName).get
     if (value != Values.NO_VALUE) {
-      val nodeId = CastSupport.castOrFail[NodeValue](value).id()
+      val nodeId = CastSupport.castOrFail[VirtualNodeValue](value).id()
       val labelIds = labels.map(_.getOrCreateId(state.query).id)
       state.query.setLabelsOnNode(nodeId, labelIds.iterator)
     }
   }
 
   override def name = "SetLabels"
+
+  override def needsExclusiveLock = false
 }

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SetPropertyPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SetPropertyPipeTest.scala
@@ -21,39 +21,66 @@ package org.neo4j.cypher.internal.runtime.interpreted.pipes
 
 import org.mockito.ArgumentMatchers.{anyInt, anyLong}
 import org.mockito.Mockito._
-import org.neo4j.cypher.internal.util.v3_4.{InputPosition, PropertyKeyId}
-import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions._
-import org.neo4j.cypher.internal.runtime.interpreted.commands.values.{KeyToken, TokenType}
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.SemanticTable
+import org.neo4j.cypher.internal.planner.v3_4.spi.TokenContext
+import org.neo4j.cypher.internal.runtime.interpreted.commands.convert.{CommunityExpressionConverter, ExpressionConverters}
+import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions._
+import org.neo4j.cypher.internal.runtime.interpreted.commands.values.KeyToken
 import org.neo4j.cypher.internal.runtime.{Operations, QueryContext}
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.util.v3_4.{DummyPosition, PropertyKeyId}
 import org.neo4j.cypher.internal.v3_4.expressions.PropertyKeyName
+import org.neo4j.cypher.internal.v3_4.{expressions => ast}
 import org.neo4j.graphdb.{Node, Relationship}
 import org.neo4j.values.storable.Values
 import org.neo4j.values.storable.Values.longValue
 
 class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
+  private val pos = DummyPosition(0)
+  private val entity1 = "x"
+  private val entity2 = "y"
+  private val property1 = "prop"
+  private val property2 = "prop2"
+  private val propertyKey1 = PropertyKeyName(property1)(pos)
+  private val propertyKey2 = PropertyKeyName(property2)(pos)
+  private val literalInt1 = ast.SignedDecimalIntegerLiteral("1")(pos)
 
-  implicit val table = new SemanticTable()
-  table.resolvedPropertyKeyNames.put("prop", PropertyKeyId(1))
-  table.resolvedPropertyKeyNames.put("prop2", PropertyKeyId(2))
+  private implicit val table = new SemanticTable()
+  table.resolvedPropertyKeyNames.put(property1, PropertyKeyId(1))
+  table.resolvedPropertyKeyNames.put(property2, PropertyKeyId(2))
 
-  val state = mock[QueryState]
-  val qtx = mock[QueryContext]
+  private val state = mock[QueryState]
+  private val qtx = mock[QueryContext]
+  when(qtx.getOptPropertyKeyId(property1)).thenReturn(Some(1))
+  when(qtx.getOptPropertyKeyId(property2)).thenReturn(Some(2))
   when(state.query).thenReturn(qtx)
   when(state.decorator).thenReturn(NullPipeDecorator)
-  val emptyExpression = mock[Expression]
+  private val emptyExpression = mock[Expression]
   when(emptyExpression.children).thenReturn(Seq.empty)
+
+  private val expressionConverter = new ExpressionConverters(CommunityExpressionConverter)
+  private def convertExpression(astExpression: ast.Expression): Expression = {
+    def resolveTokens(expr: Expression, ctx: TokenContext): Expression = expr match {
+      case (keyToken: KeyToken) => keyToken.resolve(ctx)
+      case _ => expr
+    }
+
+    expressionConverter.toCommandExpression(astExpression).rewrite(resolveTokens(_, qtx))
+  }
 
   // match (n) set n.prop = n.prop + 1
   test("should grab an exclusive lock if the rhs reads from the same node property") {
-    val rhs = Add(Property(Variable("n"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))
-    val mockedSource = newMockedPipe("n", row("n" -> newMockedNode(10)))
-    val pipe = SetPipe(mockedSource, SetNodePropertyOperation("n", LazyPropertyKey(PropertyKeyName("prop")(InputPosition.NONE)), rhs))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedNode(10)))
+    val astRhs: ast.Expression = ast.Add(ast.Property(ast.Variable(entity1)(pos), propertyKey1)(pos), literalInt1)(pos)
+    val needsExclusiveLock = ast.Expression.hasPropertyReadDependency(entity1, astRhs, propertyKey1)
+    val rhs = convertExpression(astRhs)
+    val pipe = SetPipe(mockedSource, SetNodePropertyOperation(entity1, LazyPropertyKey(propertyKey1), rhs, needsExclusiveLock))()
 
     val nodeOps = mock[Operations[Node]]
     when(nodeOps.getProperty(10L, 1)).thenReturn(longValue(13L))
     when(qtx.nodeOps).thenReturn(nodeOps)
+
+    needsExclusiveLock shouldBe true
 
     pipe.createResults(state).toVector
     verify(nodeOps).acquireExclusiveLock(10)
@@ -62,13 +89,18 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
 
   // match ()-[r]-() set r.prop = r.prop + 1
   test("should grab an exclusive lock if the rhs reads from the same relationship property") {
-    val rhs = Add(Property(Variable("r"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))
-    val mockedSource = newMockedPipe("r", row("r" -> newMockedRelationship(10, mock[Node], mock[Node])))
-    val pipe = SetPipe(mockedSource, SetRelationshipPropertyOperation("r", LazyPropertyKey(PropertyKeyName("prop")(InputPosition.NONE)), rhs))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedRelationship(10, mock[Node], mock[Node])))
+    val astRhs: ast.Expression = ast.Add(ast.Property(ast.Variable(entity1)(pos), propertyKey1)(pos), literalInt1)(pos)
+    val needsExclusiveLock = ast.Expression.hasPropertyReadDependency(entity1, astRhs, propertyKey1)
+    val rhs = convertExpression(astRhs)
+    val pipe = SetPipe(mockedSource,
+      SetRelationshipPropertyOperation(entity1, LazyPropertyKey(propertyKey1), rhs, needsExclusiveLock))()
 
     val relOps = mock[Operations[Relationship]]
     when(qtx.relationshipOps).thenReturn(relOps)
     when(relOps.getProperty(anyLong(), anyInt())).thenReturn(Values.NO_VALUE)
+
+    needsExclusiveLock shouldBe true
 
     pipe.createResults(state).toVector
     verify(relOps).acquireExclusiveLock(10)
@@ -77,13 +109,18 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
 
   // match (n) set n.prop2 = n.prop + 1
   test("should not grab an exclusive lock if the rhs reads from another node property") {
-    val rhs = Add(Property(Variable("n"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))
-    val mockedSource = newMockedPipe("n", row("n" -> newMockedNode(10)))
-    val pipe = SetPipe(mockedSource, SetNodePropertyOperation("n", LazyPropertyKey(PropertyKeyName("prop2")(InputPosition.NONE)), rhs))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedNode(10)))
+    val astRhs: ast.Expression = ast.Add(ast.Property(ast.Variable(entity1)(pos), propertyKey1)(pos), literalInt1)(pos)
+    val needsExclusiveLock = ast.Expression.hasPropertyReadDependency(entity1, astRhs, propertyKey2)
+    val rhs = convertExpression(astRhs)
+    val pipe = SetPipe(mockedSource,
+      SetNodePropertyOperation(entity1, LazyPropertyKey(propertyKey2), rhs, needsExclusiveLock))()
 
     val nodeOps = mock[Operations[Node]]
     when(nodeOps.getProperty(10L, 1)).thenReturn(longValue(13L))
     when(qtx.nodeOps).thenReturn(nodeOps)
+
+    needsExclusiveLock shouldBe false
 
     pipe.createResults(state).toVector
     verify(nodeOps, never()).acquireExclusiveLock(10)
@@ -92,13 +129,19 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
 
   // match ()-[r]-() set r.prop2 = r.prop + 1
   test("should not grab an exclusive lock if the rhs reads from another relationship property") {
-    val rhs = Add(Property(Variable("r"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))
-    val mockedSource = newMockedPipe("r", row("r" -> newMockedRelationship(10, mock[Node], mock[Node])))
-    val pipe = SetPipe(mockedSource, SetRelationshipPropertyOperation("r", LazyPropertyKey(PropertyKeyName("prop2")(InputPosition.NONE)), rhs))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedRelationship(10, mock[Node], mock[Node])))
+
+    val astRhs: ast.Expression = ast.Add(ast.Property(ast.Variable(entity1)(pos), propertyKey1)(pos), ast.SignedDecimalIntegerLiteral("1")(pos))(pos)
+    val needsExclusiveLock = ast.Expression.hasPropertyReadDependency(entity1, astRhs, propertyKey2)
+    val rhs = convertExpression(astRhs)
+    val pipe = SetPipe(mockedSource,
+      SetRelationshipPropertyOperation(entity1, LazyPropertyKey(propertyKey2), rhs, needsExclusiveLock))()
 
     val relOps = mock[Operations[Relationship]]
     when(qtx.relationshipOps).thenReturn(relOps)
     when(relOps.getProperty(anyLong(), anyInt())).thenReturn(Values.NO_VALUE)
+
+    needsExclusiveLock shouldBe false
 
     pipe.createResults(state).toVector
     verify(relOps, never()).acquireExclusiveLock(10)
@@ -107,13 +150,18 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
 
   // match (n), (n2) set n2.prop = n.prop + 1
   test("should not grab an exclusive lock if the rhs reads from the same node property on another node") {
-    val rhs = Add(Property(Variable("n"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))
-    val mockedSource = newMockedPipe("n", row("n" -> newMockedNode(10), "n2" -> newMockedNode(20)))
-    val pipe = SetPipe(mockedSource, SetNodePropertyOperation("n2", LazyPropertyKey(PropertyKeyName("prop")(InputPosition.NONE)), rhs))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedNode(10), entity2 -> newMockedNode(20)))
+    val astRhs: ast.Expression = ast.Add(ast.Property(ast.Variable(entity1)(pos), propertyKey1)(pos), ast.SignedDecimalIntegerLiteral("1")(pos))(pos)
+    val needsExclusiveLock = ast.Expression.hasPropertyReadDependency(entity2, astRhs, propertyKey1)
+    val rhs = convertExpression(astRhs)
+    val pipe = SetPipe(mockedSource,
+      SetNodePropertyOperation(entity2, LazyPropertyKey(propertyKey1), rhs, needsExclusiveLock))()
 
     val nodeOps = mock[Operations[Node]]
     when(nodeOps.getProperty(10L, 1)).thenReturn(longValue(13L))
     when(qtx.nodeOps).thenReturn(nodeOps)
+
+    needsExclusiveLock shouldBe false
 
     pipe.createResults(state).toVector
     verify(nodeOps, never()).acquireExclusiveLock(10)
@@ -124,14 +172,19 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
 
   // match ()-[r]-(), ()-[r2]-() set r2.prop = r.prop + 1
   test("should not grab an exclusive lock if the rhs reads from the same relationship property on another relationship") {
-    val rhs = Add(Property(Variable("r"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))
-    val mockedSource = newMockedPipe("r", row("r" -> newMockedRelationship(10, mock[Node], mock[Node]),
-                                              "r2" -> newMockedRelationship(20, mock[Node], mock[Node])))
-    val pipe = SetPipe(mockedSource, SetRelationshipPropertyOperation("r2", LazyPropertyKey(PropertyKeyName("prop")(InputPosition.NONE)), rhs))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedRelationship(10, mock[Node], mock[Node]),
+                                                  entity2 -> newMockedRelationship(20, mock[Node], mock[Node])))
+    val astRhs: ast.Expression = ast.Add(ast.Property(ast.Variable(entity1)(pos), propertyKey1)(pos), ast.SignedDecimalIntegerLiteral("1")(pos))(pos)
+    val needsExclusiveLock = ast.Expression.hasPropertyReadDependency(entity2, astRhs, propertyKey1)
+    val rhs = convertExpression(astRhs)
+    val pipe = SetPipe(mockedSource,
+      SetRelationshipPropertyOperation(entity2, LazyPropertyKey(propertyKey1), rhs, needsExclusiveLock))()
 
     val relOps = mock[Operations[Relationship]]
     when(qtx.relationshipOps).thenReturn(relOps)
     when(relOps.getProperty(anyLong(), anyInt())).thenReturn(Values.NO_VALUE)
+
+    needsExclusiveLock shouldBe false
 
     pipe.createResults(state).toVector
     verify(relOps, never()).acquireExclusiveLock(10)
@@ -142,15 +195,21 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
 
   // match n set n += { prop: n.prop + 1 }
   test("should grab an exclusive lock when setting node props from a map with dependencies") {
-    val rhs = LiteralMap(Map("prop" -> Add(Property(Variable("n"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))))
-    val mockedSource = newMockedPipe("n", row("n" -> newMockedNode(10)))
-    val pipe = SetPipe(mockedSource, SetNodePropertyFromMapOperation("n", rhs, removeOtherProps = false))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedNode(10)))
+
+    val innerAst = ast.Add(ast.Property(ast.Variable(entity1)(pos), propertyKey1)(pos), ast.SignedDecimalIntegerLiteral("1")(pos))(pos)
+    val astRhs = ast.MapExpression(Seq(propertyKey1 -> innerAst))(pos)
+    val needsExclusiveLock = ast.Expression.mapExpressionHasPropertyReadDependency(entity1, astRhs)
+    val rhs = convertExpression(astRhs)
+    val pipe = SetPipe(mockedSource, SetNodePropertyFromMapOperation(entity1, rhs, removeOtherProps = false, needsExclusiveLock))()
 
     val nodeOps = mock[Operations[Node]]
     when(nodeOps.getProperty(10L, 1)).thenReturn(longValue(13L))
     when(qtx.nodeOps).thenReturn(nodeOps)
-    when(qtx.getOptPropertyKeyId("prop")).thenReturn(None)
+    when(qtx.getOptPropertyKeyId(property1)).thenReturn(None)
     when(nodeOps.propertyKeyIds(10)).thenReturn(Iterator.empty)
+
+    needsExclusiveLock shouldBe true
 
     pipe.createResults(state).toVector
     verify(nodeOps).acquireExclusiveLock(10)
@@ -159,15 +218,22 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
 
   // match ()-[r]-() set r = { prop: r.prop + 1 }
   test("should grab an exclusive lock when setting rel props from a map with dependencies") {
-    val rhs = LiteralMap(Map("prop" -> Add(Property(Variable("r"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))))
-    val mockedSource = newMockedPipe("r", row("r" -> newMockedRelationship(10, mock[Node], mock[Node])))
-    val pipe = SetPipe(mockedSource, SetRelationshipPropertyFromMapOperation("r", rhs, removeOtherProps = true))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedRelationship(10, mock[Node], mock[Node])))
+    val innerAst = ast.Add(ast.Property(ast.Variable(entity1)(pos), propertyKey1)(pos), ast.SignedDecimalIntegerLiteral("1")(pos))(pos)
+    val astRhs = ast.MapExpression(Seq(propertyKey1 -> innerAst))(pos)
+    val needsExclusiveLock = ast.Expression.mapExpressionHasPropertyReadDependency(entity1, astRhs)
+    val rhs = convertExpression(astRhs)
+
+    val pipe = SetPipe(mockedSource,
+      SetRelationshipPropertyFromMapOperation(entity1, rhs, removeOtherProps = true, needsExclusiveLock))()
 
     val relOps = mock[Operations[Relationship]]
     when(qtx.relationshipOps).thenReturn(relOps)
-    when(qtx.getOptPropertyKeyId("prop")).thenReturn(None)
+    when(qtx.getOptPropertyKeyId(property1)).thenReturn(None)
     when(relOps.propertyKeyIds(10)).thenReturn(Iterator.empty)
     when(relOps.getProperty(anyLong(), anyInt())).thenReturn(Values.NO_VALUE)
+
+    needsExclusiveLock shouldBe true
 
     pipe.createResults(state).toVector
     verify(relOps).acquireExclusiveLock(10)
@@ -176,16 +242,23 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
 
   // match (n), (n2) set n += { prop: n2.prop + 1 }
   test("should not grab an exclusive lock when setting node props from a map with same prop but other node") {
-    val rhs = LiteralMap(Map("prop" -> Add(Property(Variable("n2"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))))
-    val mockedSource = newMockedPipe("n", row("n" -> newMockedNode(10), "n2" -> newMockedNode(20)))
-    val pipe = SetPipe(mockedSource, SetNodePropertyFromMapOperation("n", rhs, removeOtherProps = false))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedNode(10), entity2 -> newMockedNode(20)))
+
+    val innerAst = ast.Add(ast.Property(ast.Variable(entity2)(pos), propertyKey1)(pos), ast.SignedDecimalIntegerLiteral("1")(pos))(pos)
+    val astRhs = ast.MapExpression(Seq(propertyKey1 -> innerAst))(pos)
+    val needsExclusiveLock = ast.Expression.mapExpressionHasPropertyReadDependency(entity1, astRhs)
+    val rhs = convertExpression(astRhs)
+    val pipe = SetPipe(mockedSource,
+      SetNodePropertyFromMapOperation(entity1, rhs, removeOtherProps = false, needsExclusiveLock))()
 
     val nodeOps = mock[Operations[Node]]
     when(nodeOps.getProperty(10L, 1)).thenReturn(longValue(13L))
     when(nodeOps.getProperty(20L, 1)).thenReturn(longValue(13L))
     when(qtx.nodeOps).thenReturn(nodeOps)
-    when(qtx.getOptPropertyKeyId("prop")).thenReturn(None)
+    when(qtx.getOptPropertyKeyId(property1)).thenReturn(None)
     when(nodeOps.propertyKeyIds(10)).thenReturn(Iterator.empty)
+
+    needsExclusiveLock shouldBe false
 
     pipe.createResults(state).toVector
     verify(nodeOps, never()).acquireExclusiveLock(10)
@@ -197,16 +270,22 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
 
   // match ()-[r]-(), ()-[r2]-() set r = { prop: r2.prop + 1 }
   test("should not grab an exclusive lock when setting rel props from a map with same prop but other rel") {
-    val rhs = LiteralMap(Map("prop" -> Add(Property(Variable("r2"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))))
-    val mockedSource = newMockedPipe("r", row("r" -> newMockedRelationship(10, mock[Node], mock[Node]),
-                                              "r2" -> newMockedRelationship(20, mock[Node], mock[Node])))
-    val pipe = SetPipe(mockedSource, SetRelationshipPropertyFromMapOperation("r", rhs, removeOtherProps = true))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedRelationship(10, mock[Node], mock[Node]),
+                                                  entity2 -> newMockedRelationship(20, mock[Node], mock[Node])))
+    val innerAst = ast.Add(ast.Property(ast.Variable(entity2)(pos), propertyKey1)(pos), ast.SignedDecimalIntegerLiteral("1")(pos))(pos)
+    val astRhs = ast.MapExpression(Seq(propertyKey1 -> innerAst))(pos)
+    val needsExclusiveLock = ast.Expression.mapExpressionHasPropertyReadDependency(entity1, astRhs)
+    val rhs = convertExpression(astRhs)
+    val pipe = SetPipe(mockedSource,
+      SetRelationshipPropertyFromMapOperation(entity1, rhs, removeOtherProps = true, needsExclusiveLock))()
 
     val relOps = mock[Operations[Relationship]]
     when(qtx.relationshipOps).thenReturn(relOps)
-    when(qtx.getOptPropertyKeyId("prop")).thenReturn(None)
+    when(qtx.getOptPropertyKeyId(property1)).thenReturn(None)
     when(relOps.propertyKeyIds(10)).thenReturn(Iterator.empty)
     when(relOps.getProperty(anyLong(), anyInt())).thenReturn(Values.NO_VALUE)
+
+    needsExclusiveLock shouldBe false
 
     pipe.createResults(state).toVector
     verify(relOps, never()).acquireExclusiveLock(10)
@@ -217,15 +296,23 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
 
   // match (n) set n += { prop: n.prop2 + 1 }
   test("should not grab an exclusive lock when setting node props from a map with same node but other prop") {
-    val rhs = LiteralMap(Map("prop" -> Add(Property(Variable("n"), KeyToken.Resolved("prop2", 2, TokenType.PropertyKey)), Literal(1))))
-    val mockedSource = newMockedPipe("n", row("n" -> newMockedNode(10)))
-    val pipe = SetPipe(mockedSource, SetNodePropertyFromMapOperation("n", rhs, removeOtherProps = false))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedNode(10)))
+
+    val innerAst = ast.Add(ast.Property(ast.Variable(entity1)(pos), propertyKey2)(pos), ast.SignedDecimalIntegerLiteral("1")(pos))(pos)
+    val astRhs = ast.MapExpression(Seq(propertyKey1 -> innerAst))(pos)
+    val needsExclusiveLock = ast.Expression.mapExpressionHasPropertyReadDependency(entity1, astRhs)
+    val rhs = convertExpression(astRhs)
+
+    val pipe = SetPipe(mockedSource,
+      SetNodePropertyFromMapOperation(entity1, rhs, removeOtherProps = false, needsExclusiveLock))()
 
     val nodeOps = mock[Operations[Node]]
     when(nodeOps.getProperty(10L, 2)).thenReturn(longValue(13L))
     when(qtx.nodeOps).thenReturn(nodeOps)
-    when(qtx.getOptPropertyKeyId("prop")).thenReturn(None)
+    when(qtx.getOptPropertyKeyId(property1)).thenReturn(None)
     when(nodeOps.propertyKeyIds(10)).thenReturn(Iterator.empty)
+
+    needsExclusiveLock shouldBe false
 
     pipe.createResults(state).toVector
     verify(nodeOps, never()).acquireExclusiveLock(10)
@@ -235,15 +322,22 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
 
   // match ()-[r]-() set r = { prop: r.prop2 + 1 }
   test("should not grab an exclusive lock when setting rel props from a map with same rel but other prop") {
-    val rhs = LiteralMap(Map("prop" -> Add(Property(Variable("r"), KeyToken.Resolved("prop2", 2, TokenType.PropertyKey)), Literal(1))))
-    val mockedSource = newMockedPipe("r", row("r" -> newMockedRelationship(10, mock[Node], mock[Node])))
-    val pipe = SetPipe(mockedSource, SetRelationshipPropertyFromMapOperation("r", rhs, removeOtherProps = true))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedRelationship(10, mock[Node], mock[Node])))
+
+    val innerAst = ast.Add(ast.Property(ast.Variable(entity1)(pos), propertyKey2)(pos), ast.SignedDecimalIntegerLiteral("1")(pos))(pos)
+    val astRhs = ast.MapExpression(Seq(propertyKey1 -> innerAst))(pos)
+    val needsExclusiveLock = ast.Expression.mapExpressionHasPropertyReadDependency(entity1, astRhs)
+    val rhs = convertExpression(astRhs)
+    val pipe = SetPipe(mockedSource,
+      SetRelationshipPropertyFromMapOperation(entity1, rhs, removeOtherProps = true, needsExclusiveLock))()
 
     val relOps = mock[Operations[Relationship]]
     when(qtx.relationshipOps).thenReturn(relOps)
-    when(qtx.getOptPropertyKeyId("prop")).thenReturn(None)
+    when(qtx.getOptPropertyKeyId(property1)).thenReturn(None)
     when(relOps.propertyKeyIds(10)).thenReturn(Iterator.empty)
     when(relOps.getProperty(anyLong(), anyInt())).thenReturn(Values.NO_VALUE)
+
+    needsExclusiveLock shouldBe false
 
     pipe.createResults(state).toVector
     verify(relOps, never()).acquireExclusiveLock(10)

--- a/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/IdName.scala
+++ b/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/IdName.scala
@@ -19,12 +19,12 @@
  */
 package org.neo4j.cypher.internal.ir.v3_4
 
-import org.neo4j.cypher.internal.v3_4.expressions.Variable
+import org.neo4j.cypher.internal.v3_4.expressions.LogicalVariable
 
 final case class IdName(name: String)
 
 object IdName {
   implicit val byName = Ordering[String].on[IdName](_.name)
 
-  def fromVariable(variable: Variable) = IdName(variable.name)
+  def fromVariable(variable: LogicalVariable) = IdName(variable.name)
 }

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/AssertionUtils.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/AssertionUtils.scala
@@ -14,14 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.cypher.internal.v3_4.expressions
+package org.neo4j.cypher.internal.util.v3_4
 
-import org.neo4j.cypher.internal.util.v3_4.NonEmptyList
+import org.neo4j.cypher.internal.util.v3_4.AssertionRunner.Thunk
 
-case class AndedPropertyInequalities(
-                                      variable: LogicalVariable,
-                                      property: LogicalProperty,
-                                      inequalities: NonEmptyList[InequalityExpression]
-                                    ) extends Expression {
-  def position = variable.position
+object AssertionUtils {
+  def ifAssertionsEnabled(f: => Unit): Unit = {
+    AssertionRunner.runUnderAssertion(new Thunk {
+      override def apply() = f
+    })
+  }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcQueries.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcQueries.scala
@@ -522,7 +522,7 @@ object LdbcQueries {
       Map("tagName" -> "tag3-ᚠさ丵פش", "postCount" -> 2),
       Map("tagName" -> "tag5-ᚠさ丵פش", "postCount" -> 1))
 
-    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+    override def expectedToSucceedIn: TestConfiguration = Configs.Interpreted
 
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -119,7 +119,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     createNode(Map("x" -> "Zzing"))
     createNode(Map("x" -> 'Ä'))
 
-    val result = executeWith(Configs.CommunityInterpreted, s"match (n) where n.x < 'Z' AND n.x < 'z' return n")
+    val result = executeWith(Configs.Interpreted, s"match (n) where n.x < 'Z' AND n.x < 'z' return n")
 
     result.columnAs("n").toList should equal(List(n1, n2))
   }

--- a/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -7,15 +7,6 @@ Support column renaming for aggregates as well
 Support multiple divisions in aggregate function
 Aggregates in aggregates
 Aggregates with arithmetics
-Handling numerical ranges 1
-Handling numerical ranges 2
-Handling numerical ranges 3
-Handling numerical ranges 4
-Handling string ranges 1
-Handling string ranges 2
-Handling string ranges 3
-Handling string ranges 4
-Handling empty range
 Fail at runtime when attempting to index with an Int into a Map
 Fail at runtime when trying to index into a map with a non-string
 Fail at runtime when attempting to index with a String into a Collection

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/DebugPrettyPrinter.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/DebugPrettyPrinter.scala
@@ -44,11 +44,15 @@ trait DebugPrettyPrinter {
     println("\u001b[30m")
   }
 
-  protected def printPipeInfo(logicalPlan: LogicalPlan, slotConfigurations: Map[LogicalPlanId, SlotConfiguration], pipeInfo: PipeInfo) = {
+  protected def printRewrittenPlanInfo(logicalPlan: LogicalPlan) = {
     if (PRINT_REWRITTEN_LOGICAL_PLAN) {
       println(s"\n\u001b[35m[REWRITTEN LOGICAL PLAN]\n") // Magenta
       prettyPrintLogicalPlan(logicalPlan)
     }
+    println("\u001b[30m")
+  }
+
+  protected def printPipeInfo(slotConfigurations: Map[LogicalPlanId, SlotConfiguration], pipeInfo: PipeInfo) = {
     if (PRINT_PIPELINE_INFO) {
       println(s"\n\u001b[36m[SLOT CONFIGURATIONS]\n") // Cyan
       prettyPrintPipelines(slotConfigurations)

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/NodeProperty.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/NodeProperty.scala
@@ -19,20 +19,22 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.ast
 
-case class NodeProperty(offset: Int, propToken: Int, name: String) extends RuntimeExpression {
+import org.neo4j.cypher.internal.v3_4.expressions.Property
+
+case class NodeProperty(offset: Int, propToken: Int, name: String)(prop: Property) extends RuntimeProperty(prop) {
   override def asCanonicalStringVal: String = name
 }
 
 // Token did not exist at plan time, so we'll need to look it up at runtime
-case class NodePropertyLate(offset: Int, propKey: String, name: String) extends RuntimeExpression {
+case class NodePropertyLate(offset: Int, propKey: String, name: String)(prop: Property) extends RuntimeProperty(prop) {
   override def asCanonicalStringVal: String = name
 }
 
-case class NodePropertyExists(offset: Int, propToken: Int, name: String) extends RuntimeExpression {
+case class NodePropertyExists(offset: Int, propToken: Int, name: String)(prop: Property) extends RuntimeProperty(prop) {
   override def asCanonicalStringVal: String = name
 }
 
 // Token did not exist at plan time, so we'll need to look it up at runtime
-case class NodePropertyExistsLate(offset: Int, propKey: String, name: String) extends RuntimeExpression {
+case class NodePropertyExistsLate(offset: Int, propKey: String, name: String)(prop: Property) extends RuntimeProperty(prop) {
   override def asCanonicalStringVal: String = name
 }

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/NullCheck.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/NullCheck.scala
@@ -19,6 +19,24 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.ast
 
-import org.neo4j.cypher.internal.v3_4.expressions.Expression
+import org.neo4j.cypher.internal.v3_4.expressions.{Expression, LogicalProperty, LogicalVariable}
 
 case class NullCheck(offset: Int, inner: Expression) extends RuntimeExpression
+
+// This needs to be used to be able to rewrite an expression declared as a LogicalVariable
+case class NullCheckVariable(offset: Int, inner: LogicalVariable) extends RuntimeVariable(inner.name)
+
+// This needs to be used to be able to rewrite an expression declared as a LogicalProperty
+case class NullCheckProperty(offset: Int, inner: LogicalProperty) extends RuntimeProperty(inner) {
+
+  // We have to override the implementation in RuntimeProperty for correctness. This smells a bit...
+  override def dup(children: Seq[AnyRef]): this.type = {
+    val newOffset = children.head.asInstanceOf[Int]
+    val newInner = children(1).asInstanceOf[LogicalProperty]
+    // We only ever rewrite this with inner already rewritten, so we should not need to copy
+    if (offset == newOffset && inner == newInner)
+      this
+    else
+      copy(offset = newOffset, inner = newInner).asInstanceOf[this.type]
+  }
+}

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RelationshipProperty.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RelationshipProperty.scala
@@ -19,20 +19,20 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.ast
 
-import org.neo4j.cypher.internal.v3_4.expressions.Property
+import org.neo4j.cypher.internal.v3_4.expressions.LogicalProperty
 
-case class RelationshipProperty(offset: Int, propToken: Int, name: String)(prop: Property) extends RuntimeProperty(prop) {
+case class RelationshipProperty(offset: Int, propToken: Int, name: String)(prop: LogicalProperty) extends RuntimeProperty(prop) {
   override def asCanonicalStringVal: String = name
 }
 
-case class RelationshipPropertyLate(offset: Int, propKey: String, name: String)(prop: Property) extends RuntimeProperty(prop) {
+case class RelationshipPropertyLate(offset: Int, propKey: String, name: String)(prop: LogicalProperty) extends RuntimeProperty(prop) {
   override def asCanonicalStringVal: String = name
 }
 
-case class RelationshipPropertyExists(offset: Int, propToken: Int, name: String)(prop: Property) extends RuntimeProperty(prop) {
+case class RelationshipPropertyExists(offset: Int, propToken: Int, name: String)(prop: LogicalProperty) extends RuntimeProperty(prop) {
   override def asCanonicalStringVal: String = name
 }
 
-case class RelationshipPropertyExistsLate(offset: Int, propKey: String, name: String)(prop: Property) extends RuntimeProperty(prop) {
+case class RelationshipPropertyExistsLate(offset: Int, propKey: String, name: String)(prop: LogicalProperty) extends RuntimeProperty(prop) {
   override def asCanonicalStringVal: String = name
 }

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeProperty.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeProperty.scala
@@ -21,15 +21,32 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime.ast
 
 import org.neo4j.cypher.internal.frontend.v3_4.SemanticCheck
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.{SemanticCheckResult, SemanticCheckableExpression}
-import org.neo4j.cypher.internal.util.v3_4.InputPosition
-import org.neo4j.cypher.internal.v3_4.expressions.{Expression, LogicalProperty, Property, PropertyKeyName}
+import org.neo4j.cypher.internal.util.v3_4.AssertionUtils.ifAssertionsEnabled
+import org.neo4j.cypher.internal.util.v3_4.{InputPosition, InternalException}
+import org.neo4j.cypher.internal.v3_4.expressions.{Expression, LogicalProperty, PropertyKeyName}
 
-abstract class RuntimeProperty(val prop: Property) extends LogicalProperty with SemanticCheckableExpression{
+abstract class RuntimeProperty(val prop: LogicalProperty) extends LogicalProperty with SemanticCheckableExpression{
   override def semanticCheck(ctx: Expression.SemanticContext): SemanticCheck = SemanticCheckResult.success
+
+  override def position: InputPosition = InputPosition.NONE
 
   override def map: Expression = prop.map
 
   override def propertyKey: PropertyKeyName = prop.propertyKey
 
-  override def position: InputPosition = InputPosition.NONE
+  override def dup(children: Seq[AnyRef]): this.type = {
+    val constructor = this.copyConstructor
+    val args = children.toVector
+
+    ifAssertionsEnabled {
+      val params = constructor.getParameterTypes
+      val ok = params.length == args.length + 1 && classOf[LogicalProperty].isAssignableFrom(params.last)
+      if (!ok)
+        throw new InternalException(s"Unexpected rewrite children $children")
+    }
+
+    val ctorArgs = args :+ prop // Add the original Property expression
+    val duped = constructor.invoke(this, ctorArgs: _*)
+    duped.asInstanceOf[this.type]
+  }
 }

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeProperty.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeProperty.scala
@@ -22,9 +22,14 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime.ast
 import org.neo4j.cypher.internal.frontend.v3_4.SemanticCheck
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.{SemanticCheckResult, SemanticCheckableExpression}
 import org.neo4j.cypher.internal.util.v3_4.InputPosition
-import org.neo4j.cypher.internal.v3_4.expressions.{Expression, Property}
+import org.neo4j.cypher.internal.v3_4.expressions.{Expression, LogicalProperty, Property, PropertyKeyName}
 
-class RuntimeProperty(val prop: Property) extends Property(map = prop.map, propertyKey = prop.propertyKey)(InputPosition.NONE)
-  with SemanticCheckableExpression {
+abstract class RuntimeProperty(val prop: Property) extends LogicalProperty with SemanticCheckableExpression{
   override def semanticCheck(ctx: Expression.SemanticContext): SemanticCheck = SemanticCheckResult.success
+
+  override def map: Expression = prop.map
+
+  override def propertyKey: PropertyKeyName = prop.propertyKey
+
+  override def position: InputPosition = InputPosition.NONE
 }

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeProperty.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeProperty.scala
@@ -19,20 +19,12 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.ast
 
-import org.neo4j.cypher.internal.v3_4.expressions.Property
+import org.neo4j.cypher.internal.frontend.v3_4.SemanticCheck
+import org.neo4j.cypher.internal.frontend.v3_4.semantics.{SemanticCheckResult, SemanticCheckableExpression}
+import org.neo4j.cypher.internal.util.v3_4.InputPosition
+import org.neo4j.cypher.internal.v3_4.expressions.{Expression, Property}
 
-case class RelationshipProperty(offset: Int, propToken: Int, name: String)(prop: Property) extends RuntimeProperty(prop) {
-  override def asCanonicalStringVal: String = name
-}
-
-case class RelationshipPropertyLate(offset: Int, propKey: String, name: String)(prop: Property) extends RuntimeProperty(prop) {
-  override def asCanonicalStringVal: String = name
-}
-
-case class RelationshipPropertyExists(offset: Int, propToken: Int, name: String)(prop: Property) extends RuntimeProperty(prop) {
-  override def asCanonicalStringVal: String = name
-}
-
-case class RelationshipPropertyExistsLate(offset: Int, propKey: String, name: String)(prop: Property) extends RuntimeProperty(prop) {
-  override def asCanonicalStringVal: String = name
+class RuntimeProperty(val prop: Property) extends Property(map = prop.map, propertyKey = prop.propertyKey)(InputPosition.NONE)
+  with SemanticCheckableExpression {
+  override def semanticCheck(ctx: Expression.SemanticContext): SemanticCheck = SemanticCheckResult.success
 }

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeVariable.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeVariable.scala
@@ -21,9 +21,19 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime.ast
 
 import org.neo4j.cypher.internal.frontend.v3_4.SemanticCheck
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.{SemanticCheckResult, SemanticCheckableExpression}
-import org.neo4j.cypher.internal.util.v3_4.InputPosition
-import org.neo4j.cypher.internal.v3_4.expressions.{Variable, Expression => ASTExpression}
+import org.neo4j.cypher.internal.util.v3_4.{InputPosition, InternalException}
+import org.neo4j.cypher.internal.v3_4.expressions.{LogicalVariable, Expression => ASTExpression}
 
-class RuntimeVariable(name: String) extends Variable(name = name)(InputPosition.NONE) with SemanticCheckableExpression {
+abstract class RuntimeVariable(override val name: String) extends LogicalVariable with SemanticCheckableExpression {
   override def semanticCheck(ctx: ASTExpression.SemanticContext): SemanticCheck = SemanticCheckResult.success
+
+  override def position: InputPosition = InputPosition.NONE
+
+  override def copyId = fail()
+
+  override def renameId(newName: String) = fail()
+
+  override def bumpId = fail()
+
+  private def fail(): Nothing = throw new InternalException("Tried using a RuntimeVariable as Variable")
 }

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriterTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriterTest.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.compatibility.v3_4.runtime.ast._
 import org.neo4j.cypher.internal.frontend.v3_4.ast._
 import org.neo4j.cypher.internal.ir.v3_4.{CardinalityEstimation, IdName, PlannerQuery}
 import org.neo4j.cypher.internal.planner.v3_4.spi.TokenContext
-import org.neo4j.cypher.internal.util.v3_4.Cardinality
+import org.neo4j.cypher.internal.util.v3_4.{Cardinality, NonEmptyList}
 import org.neo4j.cypher.internal.util.v3_4.symbols._
 import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.v3_4.expressions._
@@ -198,7 +198,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val result = rewriter(selection, lookup)
 
     // then
-    val expectedPredicate = Equals(NullCheck(0, NodeProperty(0, 666, "a.prop")(aProp)), literalInt(42))(pos)
+    val expectedPredicate = Equals(NullCheckProperty(0, NodeProperty(0, 666, "a.prop")(aProp)), literalInt(42))(pos)
     result should equal(Selection(Seq(expectedPredicate), argument)(solved))
     lookup(result.assignedId) should equal(slots)
   }
@@ -331,8 +331,8 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val nodeOffset = slots.getLongOffsetFor("x")
     resultPlan should equal(
       Projection(leaf, Map(
-        "x" -> NullCheck(0, NodeFromSlot(0, "x")),
-        "x.propertyKey" -> NullCheck(nodeOffset, NodeProperty(nodeOffset, tokenId, "x.propertyKey")(propFor("x", "propertyKey")))
+        "x" -> NullCheckVariable(0, NodeFromSlot(0, "x")),
+        "x.propertyKey" -> NullCheckProperty(nodeOffset, NodeProperty(nodeOffset, tokenId, "x.propertyKey")(propFor("x", "propertyKey")))
       ))(solved)
     )
   }
@@ -373,7 +373,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     lookup(sr2.assignedId) should equal(rhsPipeline)
   }
 
-  test("ValueHashJoin needs to execute expressions with two different slotss") {
+  test("ValueHashJoin needs to execute expressions with two different slots") {
     // MATCH (a:labelA), (b:labelB) WHERE a.prop = b.prop
     val leafA = NodeByLabelScan(IdName("a"), LabelName("labelA")(pos), Set.empty)(solved)
     val leafB = NodeByLabelScan(IdName("b"), LabelName("labelB")(pos), Set.empty)(solved)
@@ -475,4 +475,33 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     lookup(result.assignedId) should equal(slots)
   }
 
+  test("should be able to rewrite expressions declared as Variable or Property") {
+    // given
+    val arg = Argument()(solved)()
+    val predicate = AndedPropertyInequalities(varFor("n"), nProp, NonEmptyList(LessThan(literalInt(42), varFor("z"))(pos)))
+    val selection = Selection(Seq(predicate), arg)(solved)
+    selection.assignIds()
+
+    val offsetN = 0
+    val offsetZ = 0
+    val slots = SlotConfiguration.empty.
+      newLong("n", nullable = true, CTNode).
+      newReference("z", nullable = false, CTAny)
+    val lookup: Map[LogicalPlanId, SlotConfiguration] = Map(
+      arg.assignedId -> SlotConfiguration.empty,
+      selection.assignedId -> slots)
+    val tokenContext = mock[TokenContext]
+    val tokenId = 666
+    when(tokenContext.getOptPropertyKeyId("prop")).thenReturn(Some(tokenId))
+    val rewriter = new SlottedRewriter(tokenContext)
+
+    // when
+    val result = rewriter(selection, lookup)
+
+    // then
+    val newPred = AndedPropertyInequalities(NullCheckVariable(0, NodeFromSlot(offsetN, "n")),
+      NullCheckProperty(offsetN, NodeProperty(offsetN, 666, "n.prop")(xProp)),
+      NonEmptyList(LessThan(literalInt(42), ReferenceFromSlot(offsetZ, "z"))(pos)))
+    result should equal(Selection(Seq(newPred), arg)(solved))
+  }
 }

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriterTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriterTest.scala
@@ -32,6 +32,12 @@ import org.neo4j.cypher.internal.v3_4.logical.plans.{AllNodesScan, ProduceResult
 
 class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport {
   private val solved = CardinalityEstimation.lift(PlannerQuery.empty, Cardinality(1))
+  private def propFor(v: String, key: String) = Property(Variable(v)(pos), PropertyKeyName(key)(pos))(pos)
+  private val xProp = propFor("x", "prop")
+  private val aProp = propFor("a", "prop")
+  private val bProp = propFor("b", "prop")
+  private val nProp = propFor("n", "prop")
+  private val rProp = propFor("r", "prop")
 
   test("selection with property comparison MATCH (n) WHERE n.prop > 42 RETURN n") {
     val allNodes = AllNodesScan(IdName("x"), Set.empty)(solved)
@@ -52,7 +58,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val rewriter = new SlottedRewriter(tokenContext)
     val result = rewriter(produceResult, lookup)
 
-    val newPredicate = GreaterThan(NodeProperty(offset, tokenId, "x.prop"), literalInt(42))(pos)
+    val newPredicate = GreaterThan(NodeProperty(offset, tokenId, "x.prop")(xProp), literalInt(42))(pos)
 
     result should equal(ProduceResult(Selection(Seq(newPredicate), allNodes)(solved), Seq("x")))
     lookup(result.assignedId) should equal(slots)
@@ -192,7 +198,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val result = rewriter(selection, lookup)
 
     // then
-    val expectedPredicate = Equals(NullCheck(0, NodeProperty(0, 666, "a.prop")), literalInt(42))(pos)
+    val expectedPredicate = Equals(NullCheck(0, NodeProperty(0, 666, "a.prop")(aProp)), literalInt(42))(pos)
     result should equal(Selection(Seq(expectedPredicate), argument)(solved))
     lookup(result.assignedId) should equal(slots)
   }
@@ -215,7 +221,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val rewriter = new SlottedRewriter(tokenContext)
     val result = rewriter(produceResult, lookup)
 
-    val newPredicate = GreaterThan(NodePropertyLate(offset, "prop", "x.prop"), literalInt(42))(pos)
+    val newPredicate = GreaterThan(NodePropertyLate(offset, "prop", "x.prop")(xProp), literalInt(42))(pos)
 
     result should equal(ProduceResult(Selection(Seq(newPredicate), allNodes)(solved), Seq("x")))
     lookup(result.assignedId) should equal(slots)
@@ -247,7 +253,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     // when
     val result = rewriter(selection, lookup)
 
-    result should equal(Selection(Seq(Equals(RelationshipPropertyLate(2, "prop", "r.prop"), literalInt(42))(pos)), argument)(solved))
+    result should equal(Selection(Seq(Equals(RelationshipPropertyLate(2, "prop", "r.prop")(rProp), literalInt(42))(pos)), argument)(solved))
     lookup(result.assignedId) should equal(slots)
   }
 
@@ -274,7 +280,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val result = rewriter(produceResult, lookup)
 
     //then
-    val newProjection = Projection(allNodes, Map("n.prop" -> NodePropertyLate(nodeOffset, "prop", "n.prop")))(solved)
+    val newProjection = Projection(allNodes, Map("n.prop" -> NodePropertyLate(nodeOffset, "prop", "n.prop")(nProp)))(solved)
     result should equal(
       ProduceResult(newProjection, Seq("n.prop")))
     lookup(result.assignedId) should equal(slots)
@@ -300,7 +306,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     resultPlan should equal(
       Projection(leaf, Map(
         "x" -> NodeFromSlot(0, "x"),
-        "x.propertyKey" -> NodeProperty(slots.getLongOffsetFor("x"), tokenId, "x.propertyKey")
+        "x.propertyKey" -> NodeProperty(slots.getLongOffsetFor("x"), tokenId, "x.propertyKey")(propFor("x", "propertyKey"))
       ))(solved)
     )
   }
@@ -326,7 +332,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     resultPlan should equal(
       Projection(leaf, Map(
         "x" -> NullCheck(0, NodeFromSlot(0, "x")),
-        "x.propertyKey" -> NullCheck(nodeOffset, NodeProperty(nodeOffset, tokenId, "x.propertyKey"))
+        "x.propertyKey" -> NullCheck(nodeOffset, NodeProperty(nodeOffset, tokenId, "x.propertyKey")(propFor("x", "propertyKey")))
       ))(solved)
     )
   }
@@ -398,8 +404,8 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val resultPlan = rewriter(join, lookup)
 
     // then
-    val lhsExpAfterRewrite = NodeProperty(0, tokenId, "a.prop")
-    val rhsExpAfterRewrite = NodeProperty(0, tokenId, "b.prop")  // Same offsets, but on different contexts
+    val lhsExpAfterRewrite = NodeProperty(0, tokenId, "a.prop")(aProp)
+    val rhsExpAfterRewrite = NodeProperty(0, tokenId, "b.prop")(bProp)  // Same offsets, but on different contexts
     val joinAfterRewrite = ValueHashJoin(leafA, leafB, Equals(lhsExpAfterRewrite, rhsExpAfterRewrite)(pos))(solved)
 
     resultPlan should equal(

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilder.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilder.scala
@@ -36,9 +36,9 @@ import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.{Aggre
 import org.neo4j.cypher.internal.runtime.interpreted.commands.predicates.{Predicate, True}
 import org.neo4j.cypher.internal.runtime.interpreted.commands.{expressions => commandExpressions}
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.{ColumnOrder => _, _}
-import org.neo4j.cypher.internal.util.v3_4.AssertionRunner.Thunk
+import org.neo4j.cypher.internal.util.v3_4.AssertionUtils._
+import org.neo4j.cypher.internal.util.v3_4.InternalException
 import org.neo4j.cypher.internal.util.v3_4.symbols._
-import org.neo4j.cypher.internal.util.v3_4.{AssertionRunner, InternalException}
 import org.neo4j.cypher.internal.v3_4.expressions.{Equals, SignedDecimalIntegerLiteral}
 import org.neo4j.cypher.internal.v3_4.logical.plans
 import org.neo4j.cypher.internal.v3_4.logical.plans._
@@ -398,12 +398,6 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
 
       case _ => throw new CantCompileQueryException(s"Unsupported logical plan operator: $plan")
     }
-  }
-
-  private def ifAssertionsEnabled(f: => Unit): Unit = {
-    AssertionRunner.runUnderAssertion(new Thunk {
-      override def apply() = f
-    })
   }
 
   // Verifies the assumption that all shared slots are arguments with slot offsets within the first argument size number of slots

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/expressions/SlottedExpressionConverters.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/expressions/SlottedExpressionConverters.scala
@@ -63,6 +63,12 @@ object SlottedExpressionConverters extends ExpressionConverter {
       case runtimeAst.NullCheck(offset, inner) =>
         val a = self.toCommandExpression(inner)
         Some(runtimeExpression.NullCheck(offset, a))
+      case runtimeAst.NullCheckVariable(offset, inner) =>
+        val a = self.toCommandExpression(inner)
+        Some(runtimeExpression.NullCheck(offset, a))
+      case runtimeAst.NullCheckProperty(offset, inner) =>
+        val a = self.toCommandExpression(inner)
+        Some(runtimeExpression.NullCheck(offset, a))
       case e: ast.PathExpression =>
         Some(toCommandProjectedPath(e, self))
       case runtimeAst.IsPrimitiveNull(offset) =>


### PR DESCRIPTION
For the SlottedRewriter to be able to rewrite property expressions
where they are declared as Property, the corresponding runtime
expressions (e.g. NodeProperty) needs to extend Property.
To do this we change Property from a case class to a class, and
implement the methods that case class gave us to allow us to still
treat it as a case class (when matching, rewriting etc.).

- Introduces an abstract class LogicalProperty that is inherited by both Property and RuntimeProperty
- Introduces an abstract class LogicalVariable that is inherited by both Variable and RuntimeVariable
The previous solution with a class that is extended instead of a case class had problems with the copy method potentially breaking tree rewriting.

- Move calculation of needsExclusiveLock from the constructor of
the runtime SetOperation to the pipe builder, and compute it on the
AST expressions instead of the command expressions.

