### PR TITLE
Fix typo: 'cypher.forbid_shortestpath_common_node'

### DIFF
--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/CypherException.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/CypherException.scala
@@ -198,7 +198,7 @@ object ShortestPathCommonEndNodesForbiddenException {
        |perform a shortestPath search after a cartesian product that might have the same start and end nodes for some
        |of the rows passed to shortestPath. If you would rather not experience this exception, and can accept the
        |possibility of missing results for those rows, disable this in the Neo4j configuration by setting
-       |`cypher.forbid_shortestpath_common_node` to false. If you cannot accept missing results, and really want the
+       |`cypher.forbid_shortestpath_common_nodes` to false. If you cannot accept missing results, and really want the
        |shortestPath between two common nodes, then re-write the query using a standard Cypher variable length pattern
        |expression followed by ordering by path length and limiting to one result.""".stripMargin
 }


### PR DESCRIPTION
The configration option is called `cypher.forbid_shortestpath_common_nodes` (with an **s** at the end) not `cypher.forbid_shortestpath_common_node`. 

See #9992.