### PR TITLE
Enable use of community pipes in slotted runtime

### DIFF
--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Expand.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/Expand.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.v3_4.logical.plans
 
 import org.neo4j.cypher.internal.ir.v3_4.{CardinalityEstimation, IdName, PlannerQuery, VarPatternLength}
-import org.neo4j.cypher.internal.v3_4.expressions.{Expression, RelTypeName, SemanticDirection, Variable}
+import org.neo4j.cypher.internal.v3_4.expressions._
 
 /**
   * For every source row, traverse all the relationships of 'from' which fulfill the
@@ -84,7 +84,7 @@ case class VarExpand(source: LogicalPlan,
                      tempEdge: IdName,
                      nodePredicate: Expression,
                      edgePredicate: Expression,
-                     legacyPredicates: Seq[(Variable, Expression)])
+                     legacyPredicates: Seq[(LogicalVariable, Expression)])
                     (val solved: PlannerQuery with CardinalityEstimation) extends LogicalPlan with LazyLogicalPlan {
   override val lhs = Some(source)
   override def rhs = None
@@ -107,7 +107,7 @@ case class PruningVarExpand(source: LogicalPlan,
                             to: IdName,
                             minLength: Int,
                             maxLength: Int,
-                            predicates: Seq[(Variable, Expression)] = Seq.empty)
+                            predicates: Seq[(LogicalVariable, Expression)] = Seq.empty)
                            (val solved: PlannerQuery with CardinalityEstimation) extends LogicalPlan with LazyLogicalPlan {
 
   override val lhs = Some(source)
@@ -130,7 +130,7 @@ case class FullPruningVarExpand(source: LogicalPlan,
                                 to: IdName,
                                 minLength: Int,
                                 maxLength: Int,
-                                predicates: Seq[(Variable, Expression)] = Seq.empty)
+                                predicates: Seq[(LogicalVariable, Expression)] = Seq.empty)
                                (val solved: PlannerQuery with CardinalityEstimation) extends LogicalPlan with LazyLogicalPlan {
 
   override val lhs = Some(source)

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeByIdSeek.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeByIdSeek.scala
@@ -27,7 +27,7 @@ import org.neo4j.cypher.internal.ir.v3_4.{CardinalityEstimation, IdName, Planner
   */
 case class NodeByIdSeek(idName: IdName, nodeIds: SeekableArgs, argumentIds: Set[IdName])
                        (val solved: PlannerQuery with CardinalityEstimation)
-  extends LogicalLeafPlan {
+  extends NodeLogicalLeafPlan {
 
   def availableSymbols: Set[IdName] = argumentIds + idName
 }

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SeekableArgs.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/SeekableArgs.scala
@@ -26,7 +26,7 @@ sealed trait SeekableArgs {
   def expr: Expression
   def sizeHint: Option[Int]
 
-  def dependencies: Set[Variable] = expr.dependencies
+  def dependencies: Set[LogicalVariable] = expr.dependencies
 
   def mapValues(f: Expression => Expression): SeekableArgs
   def asQueryExpression: QueryExpression[Expression]

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/InliningContext.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/InliningContext.scala
@@ -24,14 +24,14 @@ import org.neo4j.cypher.internal.compiler.v3_4.ast.rewriters.InliningContext._
 import org.neo4j.cypher.internal.frontend.v3_4.ast.rewriters.copyVariables
 import org.neo4j.cypher.internal.v3_4.expressions._
 
-case class InliningContext(projections: Map[Variable, Expression] = Map.empty,
-                           seenVariables: Set[Variable] = Set.empty,
-                           usageCount: Map[Variable, Int] = Map.empty) {
+case class InliningContext(projections: Map[LogicalVariable, Expression] = Map.empty,
+                           seenVariables: Set[LogicalVariable] = Set.empty,
+                           usageCount: Map[LogicalVariable, Int] = Map.empty) {
 
   def trackUsageOfVariable(id: Variable) =
     copy(usageCount = usageCount + (id -> (usageCount.withDefaultValue(0)(id) + 1)))
 
-  def enterQueryPart(newProjections: Map[Variable, Expression]): InliningContext = {
+  def enterQueryPart(newProjections: Map[LogicalVariable, Expression]): InliningContext = {
     val inlineExpressions = TypedRewriter[Expression](variableRewriter)
     val containsAggregation = newProjections.values.exists(containsAggregate)
     val shadowing = newProjections.filterKeys(seenVariables.contains).filter {
@@ -57,7 +57,7 @@ case class InliningContext(projections: Map[Variable, Expression] = Map.empty,
       projections.get(variable).map(_.endoRewrite(copyVariables)).getOrElse(variable.copyId)
   })
 
-  def okToRewrite(i: Variable) =
+  def okToRewrite(i: LogicalVariable) =
     projections.contains(i) &&
     usageCount.withDefaultValue(0)(i) < INLINING_THRESHOLD
 

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/inlineProjections.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/inlineProjections.scala
@@ -19,10 +19,10 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_4.ast.rewriters
 
-import org.neo4j.cypher.internal.util.v3_4._
 import org.neo4j.cypher.internal.frontend.v3_4.ast._
 import org.neo4j.cypher.internal.frontend.v3_4.helpers.fixedPoint
-import org.neo4j.cypher.internal.v3_4.expressions.{Expression, Pattern, Variable}
+import org.neo4j.cypher.internal.util.v3_4._
+import org.neo4j.cypher.internal.v3_4.expressions.{Expression, LogicalVariable, Pattern}
 
 case object inlineProjections extends Rewriter {
 
@@ -67,8 +67,8 @@ case object inlineProjections extends Rewriter {
   }
 
 
-  private def findAllDependencies(variable: Variable, context: InliningContext): Set[Variable] = {
-    val (dependencies, _) = fixedPoint[(Set[Variable], List[Variable])]({
+  private def findAllDependencies(variable: LogicalVariable, context: InliningContext): Set[LogicalVariable] = {
+    val (dependencies, _) = fixedPoint[(Set[LogicalVariable], List[LogicalVariable])]({
       case (deps, Nil) =>
         (deps, Nil)
       case (deps, queue) =>

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/inliningContextCreator.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/inliningContextCreator.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.compiler.v3_4.ast.rewriters
 
 import org.neo4j.cypher.internal.frontend.v3_4.ast
-import org.neo4j.cypher.internal.v3_4.expressions.{Expression, NodePattern, RelationshipPattern, Variable}
+import org.neo4j.cypher.internal.v3_4.expressions._
 
 object inliningContextCreator extends (ast.Statement => InliningContext) {
 
@@ -61,6 +61,6 @@ object inliningContextCreator extends (ast.Statement => InliningContext) {
     if (context.isAliasedVarible(variable)) context
     else context.spoilVariable(variable)
 
-  private def aliasedReturnItems(items: Seq[ast.ReturnItem]): Map[Variable, Expression] =
+  private def aliasedReturnItems(items: Seq[ast.ReturnItem]): Map[LogicalVariable, Expression] =
     items.collect { case ast.AliasedReturnItem(expr, ident) => ident -> expr }.toMap
 }

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/OptionalMatchRemover.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/OptionalMatchRemover.scala
@@ -41,15 +41,15 @@ case object OptionalMatchRemover extends PlannerQueryRewriter {
   override def instance(ignored: CompilerContext): Rewriter = topDown(Rewriter.lift {
     case RegularPlannerQuery(graph, proj@AggregatingQueryProjection(distinctExpressions, aggregations, _), tail)
       if validAggregations(aggregations) =>
-      val projectionDeps: Iterable[Variable] = (distinctExpressions.values ++ aggregations.values).flatMap(_.dependencies)
+      val projectionDeps: Iterable[LogicalVariable] = (distinctExpressions.values ++ aggregations.values).flatMap(_.dependencies)
       rewrite(projectionDeps, graph, proj, tail)
 
     case RegularPlannerQuery(graph, proj@DistinctQueryProjection(distinctExpressions, _), tail) =>
-      val projectionDeps: Iterable[Variable] = distinctExpressions.values.flatMap(_.dependencies)
+      val projectionDeps: Iterable[LogicalVariable] = distinctExpressions.values.flatMap(_.dependencies)
       rewrite(projectionDeps, graph, proj, tail)
   })
 
-  private def rewrite(projectionDeps: Iterable[Variable], graph: QueryGraph, proj: QueryProjection, tail: Option[PlannerQuery]): RegularPlannerQuery = {
+  private def rewrite(projectionDeps: Iterable[LogicalVariable], graph: QueryGraph, proj: QueryProjection, tail: Option[PlannerQuery]): RegularPlannerQuery = {
     val updateDeps = graph.mutatingPatterns.flatMap(_.dependencies)
     val dependencies: Set[IdName] = projectionDeps.map(IdName.fromVariable).toSet ++ updateDeps
 

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/expandSolverStep.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/expandSolverStep.scala
@@ -117,7 +117,7 @@ object expandSolverStep {
   }
 
   def extractLegacyPredicates(availablePredicates: Seq[Expression], patternRel: PatternRelationship,
-                              nodeId: IdName): Seq[(Variable, Expression)] = {
+                              nodeId: IdName): Seq[(LogicalVariable, Expression)] = {
     availablePredicates.collect {
       //MATCH ()-[r* {prop:1337}]->()
       case all@AllIterablePredicate(FilterScope(variable, Some(innerPredicate)), relId@Variable(patternRel.name.name))

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/extractPredicates.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/idp/extractPredicates.scala
@@ -86,15 +86,15 @@ object extractPredicates {
     }
   }
 
-  private def replaceVariable(from: Variable, to: String): Rewriter =
+  private def replaceVariable(from: LogicalVariable, to: String): Rewriter =
     bottomUp(Rewriter.lift {
       case v: Variable if v == from => Variable(to)(v.position)
     })
 
   object AllRelationships {
-    def unapply(v: Any): Option[(Variable, String, Expression)] =
+    def unapply(v: Any): Option[(LogicalVariable, String, Expression)] =
       v match {
-        case AllIterablePredicate(FilterScope(variable, Some(innerPredicate)), relId @ Variable(name))
+        case AllIterablePredicate(FilterScope(variable, Some(innerPredicate)), relId @ LogicalVariable(name))
             if variable == relId || !innerPredicate.dependencies(relId) =>
           Some((variable, name, innerPredicate))
 
@@ -103,7 +103,7 @@ object extractPredicates {
   }
 
   object AllRelationshipsInPath {
-    def unapply(v: Any): Option[(String, String, Variable, Expression)] =
+    def unapply(v: Any): Option[(String, String, LogicalVariable, Expression)] =
       v match {
         case AllIterablePredicate(
             FilterScope(variable, Some(innerPredicate)),
@@ -114,8 +114,8 @@ object extractPredicates {
               Seq(
                 PathExpression(
                   NodePathStep(
-                    startNode: Variable,
-                    MultiRelationshipPathStep(rel: Variable, _, NilPathStep))))))
+                    startNode: LogicalVariable,
+                    MultiRelationshipPathStep(rel: LogicalVariable, _, NilPathStep))))))
             if fname == "relationships" =>
           Some((startNode.name, rel.name, variable, innerPredicate))
 
@@ -124,7 +124,7 @@ object extractPredicates {
   }
 
   object AllNodesInPath {
-    def unapply(v: Any): Option[(String, String, Variable, Expression)] =
+    def unapply(v: Any): Option[(String, String, LogicalVariable, Expression)] =
       v match {
         case AllIterablePredicate(
             FilterScope(variable, Some(innerPredicate)),
@@ -135,8 +135,8 @@ object extractPredicates {
               Seq(
                 PathExpression(
                   NodePathStep(
-                    startNode: Variable,
-                    MultiRelationshipPathStep(rel: Variable, _, NilPathStep))))))
+                    startNode: LogicalVariable,
+                    MultiRelationshipPathStep(rel: LogicalVariable, _, NilPathStep))))))
             if fname == "nodes" =>
           Some((startNode.name, rel.name, variable, innerPredicate))
 
@@ -145,7 +145,7 @@ object extractPredicates {
   }
 
   object NoRelationshipInPath {
-    def unapply(v: Any): Option[(String, String, Variable, Expression)] =
+    def unapply(v: Any): Option[(String, String, LogicalVariable, Expression)] =
       v match {
         case NoneIterablePredicate(
             FilterScope(variable, Some(innerPredicate)),
@@ -156,8 +156,8 @@ object extractPredicates {
               Seq(
                 PathExpression(
                   NodePathStep(
-                    startNode: Variable,
-                    MultiRelationshipPathStep(rel: Variable, _, NilPathStep))))))
+                    startNode: LogicalVariable,
+                    MultiRelationshipPathStep(rel: LogicalVariable, _, NilPathStep))))))
             if fname == "relationships" =>
           Some((startNode.name, rel.name, variable, innerPredicate))
 
@@ -166,7 +166,7 @@ object extractPredicates {
   }
 
   object NoNodeInPath {
-    def unapply(v: Any): Option[(String, String, Variable, Expression)] =
+    def unapply(v: Any): Option[(String, String, LogicalVariable, Expression)] =
       v match {
         case NoneIterablePredicate(
             FilterScope(variable, Some(innerPredicate)),
@@ -177,8 +177,8 @@ object extractPredicates {
               Seq(
                 PathExpression(
                   NodePathStep(
-                    startNode: Variable,
-                    MultiRelationshipPathStep(rel: Variable, _, NilPathStep))))))
+                    startNode: LogicalVariable,
+                    MultiRelationshipPathStep(rel: LogicalVariable, _, NilPathStep))))))
             if fname == "nodes" =>
           Some((startNode.name, rel.name, variable, innerPredicate))
 

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/Sargable.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/Sargable.scala
@@ -33,7 +33,7 @@ object WithSeekableArgs {
 
 object AsIdSeekable {
   def unapply(v: Any) = v match {
-    case WithSeekableArgs(func@FunctionInvocation(_, _, _, IndexedSeq(ident: Variable)), rhs)
+    case WithSeekableArgs(func@FunctionInvocation(_, _, _, IndexedSeq(ident: LogicalVariable)), rhs)
       if func.function == functions.Id && !rhs.dependencies(ident) =>
       Some(IdSeekable(func, ident, rhs))
     case _ =>
@@ -43,7 +43,7 @@ object AsIdSeekable {
 
 object AsPropertySeekable {
   def unapply(v: Any) = v match {
-    case WithSeekableArgs(prop@Property(ident: Variable, propertyKey), rhs)
+    case WithSeekableArgs(prop@Property(ident: LogicalVariable, propertyKey), rhs)
       if !rhs.dependencies(ident) =>
       Some(PropertySeekable(prop, ident, rhs))
     case _ =>
@@ -54,7 +54,7 @@ object AsPropertySeekable {
 object AsPropertyScannable {
   def unapply(v: Any): Option[Scannable[Expression]] = v match {
 
-    case func@FunctionInvocation(_, _, _, IndexedSeq(property@Property(ident: Variable, _)))
+    case func@FunctionInvocation(_, _, _, IndexedSeq(property@Property(ident: LogicalVariable, _)))
       if func.function == functions.Exists =>
       Some(ExplicitlyPropertyScannable(func, ident, property))
 
@@ -78,7 +78,7 @@ object AsPropertyScannable {
   }
 
   private def partialPropertyPredicate[P <: Expression](predicate: P, lhs: Expression) = lhs match {
-    case property@Property(ident: Variable, _) =>
+    case property@Property(ident: LogicalVariable, _) =>
       PartialPredicate.ifNotEqual(
         FunctionInvocation(FunctionName(functions.Exists.name)(predicate.position), property)(predicate.position),
         predicate
@@ -91,9 +91,9 @@ object AsPropertyScannable {
 
 object AsStringRangeSeekable {
   def unapply(v: Any): Option[PrefixRangeSeekable] = v match {
-    case startsWith@StartsWith(Property(ident: Variable, propertyKey), lit@StringLiteral(prefix)) if prefix.nonEmpty =>
+    case startsWith@StartsWith(Property(ident: LogicalVariable, propertyKey), lit@StringLiteral(prefix)) if prefix.nonEmpty =>
       Some(PrefixRangeSeekable(PrefixRange(lit), startsWith, ident, propertyKey))
-    case startsWith@StartsWith(Property(ident: Variable, propertyKey), rhs) =>
+    case startsWith@StartsWith(Property(ident: LogicalVariable, propertyKey), rhs) =>
       Some(PrefixRangeSeekable(PrefixRange(rhs), startsWith, ident, propertyKey))
     case _ =>
       None
@@ -112,40 +112,40 @@ object AsValueRangeSeekable {
 
 sealed trait Sargable[+T <: Expression] {
   def expr: T
-  def ident: Variable
+  def ident: LogicalVariable
 
   def name = ident.name
 }
 
 sealed trait Seekable[T <: Expression] extends Sargable[T] {
-  def dependencies: Set[Variable]
+  def dependencies: Set[LogicalVariable]
 }
 
 sealed trait EqualitySeekable[T <: Expression] extends Seekable[T] {
   def args: SeekableArgs
 }
 
-case class IdSeekable(expr: FunctionInvocation, ident: Variable, args: SeekableArgs)
+case class IdSeekable(expr: FunctionInvocation, ident: LogicalVariable, args: SeekableArgs)
   extends EqualitySeekable[FunctionInvocation] {
 
-  def dependencies: Set[Variable] = args.dependencies
+  def dependencies: Set[LogicalVariable] = args.dependencies
 }
 
-case class PropertySeekable(expr: Property, ident: Variable, args: SeekableArgs)
-  extends EqualitySeekable[Property] {
+case class PropertySeekable(expr: LogicalProperty, ident: LogicalVariable, args: SeekableArgs)
+  extends EqualitySeekable[LogicalProperty] {
 
   def propertyKey: PropertyKeyName = expr.propertyKey
-  def dependencies: Set[Variable] = args.dependencies
+  def dependencies: Set[LogicalVariable] = args.dependencies
 }
 
 sealed trait RangeSeekable[T <: Expression, V] extends Seekable[T] {
   def range: SeekRange[V]
 }
 
-case class PrefixRangeSeekable(override val range: PrefixRange[Expression], expr: StartsWith, ident: Variable, propertyKey: PropertyKeyName)
+case class PrefixRangeSeekable(override val range: PrefixRange[Expression], expr: StartsWith, ident: LogicalVariable, propertyKey: PropertyKeyName)
   extends RangeSeekable[StartsWith, Expression] {
 
-  def dependencies: Set[Variable] = Set.empty
+  def dependencies: Set[LogicalVariable] = Set.empty
 
   def asQueryExpression: QueryExpression[Expression] =
     RangeQueryExpression(PrefixSeekRangeWrapper(range)(expr.rhs.position))
@@ -154,7 +154,7 @@ case class PrefixRangeSeekable(override val range: PrefixRange[Expression], expr
 case class InequalityRangeSeekable(ident: Variable, propertyKeyName: PropertyKeyName, expr: AndedPropertyInequalities)
   extends RangeSeekable[AndedPropertyInequalities, Expression] {
 
-  def dependencies: Set[Variable] = expr.inequalities.map(_.dependencies).toSet.flatten
+  def dependencies: Set[LogicalVariable] = expr.inequalities.map(_.dependencies).toSet.flatten
 
   def range: InequalitySeekRange[Expression] =
     InequalitySeekRange.fromPartitionedBounds(expr.inequalities.partition {
@@ -171,14 +171,14 @@ case class InequalityRangeSeekable(ident: Variable, propertyKeyName: PropertyKey
 }
 
 sealed trait Scannable[+T <: Expression] extends Sargable[T] {
-  def ident: Variable
-  def property: Property
+  def ident: LogicalVariable
+  def property: LogicalProperty
 
   def propertyKey: PropertyKeyName = property.propertyKey
 }
 
-case class ExplicitlyPropertyScannable(expr: FunctionInvocation, ident: Variable, property: Property)
+case class ExplicitlyPropertyScannable(expr: FunctionInvocation, ident: LogicalVariable, property: LogicalProperty)
   extends Scannable[FunctionInvocation]
 
-case class ImplicitlyPropertyScannable[+T <: Expression](expr: PartialPredicate[T], ident: Variable, property: Property)
+case class ImplicitlyPropertyScannable[+T <: Expression](expr: PartialPredicate[T], ident: LogicalVariable, property: LogicalProperty)
   extends Scannable[PartialPredicate[T]]

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/Sargable.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/Sargable.scala
@@ -151,7 +151,7 @@ case class PrefixRangeSeekable(override val range: PrefixRange[Expression], expr
     RangeQueryExpression(PrefixSeekRangeWrapper(range)(expr.rhs.position))
 }
 
-case class InequalityRangeSeekable(ident: Variable, propertyKeyName: PropertyKeyName, expr: AndedPropertyInequalities)
+case class InequalityRangeSeekable(ident: LogicalVariable, propertyKeyName: PropertyKeyName, expr: AndedPropertyInequalities)
   extends RangeSeekable[AndedPropertyInequalities, Expression] {
 
   def dependencies: Set[LogicalVariable] = expr.inequalities.map(_.dependencies).toSet.flatten

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/AbstractIndexSeekLeafPlanner.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/AbstractIndexSeekLeafPlanner.scala
@@ -53,7 +53,7 @@ abstract class AbstractIndexSeekLeafPlanner extends LeafPlanner with LeafPlanFro
     if (labelPredicateMap.isEmpty)
       Set.empty
     else {
-      val arguments: Set[Variable] = qg.argumentIds.map(n => Variable(n.name)(null))
+      val arguments: Set[LogicalVariable] = qg.argumentIds.map(n => Variable(n.name)(null))
       val plannables: Set[IndexPlannableExpression] = predicates.collect(
         indexPlannableExpression(qg.argumentIds, arguments, qg.hints))
       val result = plannables.map(_.name).flatMap { name =>
@@ -141,7 +141,7 @@ abstract class AbstractIndexSeekLeafPlanner extends LeafPlanner with LeafPlanFro
     }
 
   private def indexPlannableExpression(argumentIds: Set[IdName],
-                                       arguments: Set[Variable],
+                                       arguments: Set[LogicalVariable],
                                        hints: Set[Hint])(implicit labelPredicateMap: Map[IdName, Set[HasLabels]]):
   PartialFunction[Expression, IndexPlannableExpression] = {
     // n.prop IN [ ... ]
@@ -153,7 +153,7 @@ abstract class AbstractIndexSeekLeafPlanner extends LeafPlanner with LeafPlanFro
     // ... = n.prop
     // In some rare cases, we can't rewrite these predicates cleanly,
     // and so planning needs to search for these cases explicitly
-    case predicate@Equals(a, Property(seekable@Variable(_), propKeyName))
+    case predicate@Equals(a, Property(seekable@LogicalVariable(_), propKeyName))
       if a.dependencies.forall(arguments) && !arguments(seekable) =>
       val expr = SingleQueryExpression(a)
       IndexPlannableExpression(seekable.name, propKeyName, predicate, expr, hints, argumentIds)

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/LogicalPlanProducer.scala
@@ -131,7 +131,7 @@ case class LogicalPlanProducer(cardinalityModel: CardinalityModel) extends ListS
                     edgePredicate: Expression,
                     nodePredicate: Expression,
                     solvedPredicates: Seq[Expression],
-                    legacyPredicates: Seq[(Variable, Expression)] = Seq.empty,
+                    legacyPredicates: Seq[(LogicalVariable, Expression)] = Seq.empty,
                     mode: ExpansionMode)(implicit context: LogicalPlanningContext): LogicalPlan = pattern.length match {
     case l: VarPatternLength =>
       val projectedDir = projectedDirection(pattern, from, dir)

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/idSeekLeafPlanner.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/idSeekLeafPlanner.scala
@@ -29,8 +29,8 @@ import org.neo4j.cypher.internal.v3_4.expressions._
 object idSeekLeafPlanner extends LeafPlanner with LeafPlanFromExpression {
 
   override def producePlanFor(e: Expression, qg: QueryGraph)(implicit context: LogicalPlanningContext): Option[LeafPlansForVariable] = {
-    val arguments = qg.argumentIds.map(n => Variable(n.name)(null))
-    val idSeekPredicates: Option[(Expression, Variable, SeekableArgs)] = e match {
+    val arguments: Set[LogicalVariable] = qg.argumentIds.map(n => Variable(n.name)(null))
+    val idSeekPredicates: Option[(Expression, LogicalVariable, SeekableArgs)] = e match {
       // MATCH (a)-[r]-(b) WHERE id(r) IN expr
       // MATCH a WHERE id(a) IN {param}
       case predicate@AsIdSeekable(seekable) if seekable.args.dependencies.forall(arguments) && !arguments(seekable.ident) =>

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/indexScanLeafPlanner.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/indexScanLeafPlanner.scala
@@ -81,7 +81,7 @@ object indexScanLeafPlanner extends LeafPlanner with LeafPlanFromExpression {
 
   type PlanProducer = (IdName, LabelToken, PropertyKeyToken, Seq[Expression], Option[UsingIndexHint], Set[IdName]) => LogicalPlan
 
-  private def produce(variableName: String, propertyKeyName: String, qg: QueryGraph, property: Property,
+  private def produce(variableName: String, propertyKeyName: String, qg: QueryGraph, property: LogicalProperty,
                       predicate: Expression, planProducer: PlanProducer)
                      (implicit context: LogicalPlanningContext, semanticTable: SemanticTable): Set[LogicalPlan] = {
     val labelPredicates: Map[IdName, Set[HasLabels]] = qg.selections.labelPredicates

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/InliningContextTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/InliningContextTest.scala
@@ -30,11 +30,11 @@ class InliningContextTest extends CypherFunSuite with AstConstructionTestSupport
   val identA = varFor("a")
   val astNull: Null = Null()_
 
-  val mapN = Map(identN -> astNull)
-  val mapM = Map(identM -> astNull)
-  val mapA = Map(identA -> astNull)
+  val mapN = Map[LogicalVariable, Expression](identN -> astNull)
+  val mapM = Map[LogicalVariable, Expression](identM -> astNull)
+  val mapA = Map[LogicalVariable, Expression](identA -> astNull)
 
-  val mapAtoN = Map(identA -> identN)
+  val mapAtoN = Map[LogicalVariable, Expression](identA -> identN)
 
   test("update projections on enterQueryPart") {
     val ctx = InliningContext(mapM).enterQueryPart(mapN)

--- a/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/SargableTest.scala
+++ b/community/cypher/cypher-planner-3.4/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/plans/SargableTest.scala
@@ -67,7 +67,7 @@ class SargableTest extends CypherFunSuite with AstConstructionTestSupport {
 
   test("IdSeekable works") {
     val leftExpr: FunctionInvocation = FunctionInvocation(FunctionName("id") _, nodeA)_
-    Mockito.when(expr2.dependencies).thenReturn(Set.empty[Variable])
+    Mockito.when(expr2.dependencies).thenReturn(Set.empty[LogicalVariable])
     val expr: Equals = Equals(leftExpr, expr2) _
 
     assertMatches(expr) {
@@ -82,7 +82,7 @@ class SargableTest extends CypherFunSuite with AstConstructionTestSupport {
 
   test("IdSeekable does not match if rhs depends on lhs variable") {
     val leftExpr: FunctionInvocation = FunctionInvocation(FunctionName("id") _, nodeA)_
-    Mockito.when(expr2.dependencies).thenReturn(Set(nodeA))
+    Mockito.when(expr2.dependencies).thenReturn(Set[LogicalVariable](nodeA))
     val expr: Equals = Equals(leftExpr, expr2) _
 
     assertDoesNotMatch(expr) {
@@ -92,7 +92,7 @@ class SargableTest extends CypherFunSuite with AstConstructionTestSupport {
 
   test("IdSeekable does not match if function is not the id function") {
     val leftExpr: FunctionInvocation = FunctionInvocation(FunctionName("rand") _, nodeA)_
-    Mockito.when(expr2.dependencies).thenReturn(Set.empty[Variable])
+    Mockito.when(expr2.dependencies).thenReturn(Set.empty[LogicalVariable])
     val expr: Equals = Equals(leftExpr, expr2) _
 
     assertDoesNotMatch(expr) {
@@ -103,7 +103,7 @@ class SargableTest extends CypherFunSuite with AstConstructionTestSupport {
   test("PropertySeekable works with plain expressions") {
     val leftExpr: Property = Property(nodeA, PropertyKeyName("id")_)_
     val expr: Expression = In(leftExpr, expr2)_
-    Mockito.when(expr2.dependencies).thenReturn(Set.empty[Variable])
+    Mockito.when(expr2.dependencies).thenReturn(Set.empty[LogicalVariable])
 
     assertMatches(expr) {
       case AsPropertySeekable(seekable) =>
@@ -119,8 +119,8 @@ class SargableTest extends CypherFunSuite with AstConstructionTestSupport {
     val leftExpr: Property = Property(nodeA, PropertyKeyName("id")_)_
     val rightExpr: ListLiteral = ListLiteral(Seq(expr1, expr2))_
     val expr: Expression = In(leftExpr, rightExpr)_
-    Mockito.when(expr1.dependencies).thenReturn(Set.empty[Variable])
-    Mockito.when(expr2.dependencies).thenReturn(Set.empty[Variable])
+    Mockito.when(expr1.dependencies).thenReturn(Set.empty[LogicalVariable])
+    Mockito.when(expr2.dependencies).thenReturn(Set.empty[LogicalVariable])
 
     assertMatches(expr) {
       case AsPropertySeekable(seekable) =>
@@ -134,7 +134,7 @@ class SargableTest extends CypherFunSuite with AstConstructionTestSupport {
 
   test("PropertySeekable does not match if rhs depends on lhs variable") {
     val leftExpr: Property = Property(nodeA, PropertyKeyName("id")_)_
-    Mockito.when(expr2.dependencies).thenReturn(Set(nodeA))
+    Mockito.when(expr2.dependencies).thenReturn(Set[LogicalVariable](nodeA))
     val expr: Expression = In(leftExpr, expr2)_
 
     assertDoesNotMatch(expr) {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/BuildInterpretedExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/BuildInterpretedExecutionPlan.scala
@@ -53,7 +53,7 @@ object BuildInterpretedExecutionPlan extends Phase[CommunityRuntimeContext, Logi
     val pipeInfo = executionPlanBuilder.build(from.periodicCommit, logicalPlan)(pipeBuildContext, context.planContext)
     val PipeInfo(pipe, updating, periodicCommitInfo, fp, planner) = pipeInfo
     val columns = from.statement().returnColumns
-    val resultBuilderFactory = DefaultExecutionResultBuilderFactory(pipeInfo, columns, logicalPlan)
+    val resultBuilderFactory = new DefaultExecutionResultBuilderFactory(pipeInfo, columns, logicalPlan)
     val func = getExecutionPlanFunction(periodicCommitInfo, from.queryText, updating, resultBuilderFactory,
                                         context.notificationLogger, InterpretedRuntimeName)
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/CommunityPipeBuilder.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/CommunityPipeBuilder.scala
@@ -314,9 +314,9 @@ case class CommunityPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe
     }
   }
 
-  private def varLengthPredicate(predicates: Seq[(Variable, ASTExpression)]): VarLengthPredicate  = {
+  private def varLengthPredicate(predicates: Seq[(LogicalVariable, ASTExpression)]): VarLengthPredicate  = {
     //Creates commands out of the predicates
-    def asCommand(predicates: Seq[(Variable, ASTExpression)]) = {
+    def asCommand(predicates: Seq[(LogicalVariable, ASTExpression)]) = {
       val (keys: Seq[Variable], exprs) = predicates.unzip
 
       val commands = exprs.map(buildPredicate)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/CommunityPipeBuilder.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/CommunityPipeBuilder.scala
@@ -256,20 +256,24 @@ case class CommunityPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe
         SetPipe(source, SetLabelsOperation(name, labels.map(LazyLabel.apply)))(id = id)
 
       case SetNodeProperty(_, IdName(name), propertyKey, expression) =>
+        val needsExclusiveLock = ASTExpression.hasPropertyReadDependency(name, expression, propertyKey)
         SetPipe(source, SetNodePropertyOperation(name, LazyPropertyKey(propertyKey),
-          buildExpression(expression)))(id = id)
+          buildExpression(expression), needsExclusiveLock))(id = id)
 
       case SetNodePropertiesFromMap(_, IdName(name), expression, removeOtherProps) =>
+        val needsExclusiveLock = ASTExpression.mapExpressionHasPropertyReadDependency(name, expression)
         SetPipe(source,
-          SetNodePropertyFromMapOperation(name, buildExpression(expression), removeOtherProps))(id = id)
+          SetNodePropertyFromMapOperation(name, buildExpression(expression), removeOtherProps, needsExclusiveLock))(id = id)
 
       case SetRelationshipPropery(_, IdName(name), propertyKey, expression) =>
+        val needsExclusiveLock = ASTExpression.hasPropertyReadDependency(name, expression, propertyKey)
         SetPipe(source,
-          SetRelationshipPropertyOperation(name, LazyPropertyKey(propertyKey), buildExpression(expression)))(id = id)
+          SetRelationshipPropertyOperation(name, LazyPropertyKey(propertyKey), buildExpression(expression), needsExclusiveLock))(id = id)
 
       case SetRelationshipPropertiesFromMap(_, IdName(name), expression, removeOtherProps) =>
+        val needsExclusiveLock = ASTExpression.mapExpressionHasPropertyReadDependency(name, expression)
         SetPipe(source,
-          SetRelationshipPropertyFromMapOperation(name, buildExpression(expression), removeOtherProps))(id = id)
+          SetRelationshipPropertyFromMapOperation(name, buildExpression(expression), removeOtherProps, needsExclusiveLock))(id = id)
 
       case SetProperty(_, entityExpr, propertyKey, expression) =>
         SetPipe(source, SetPropertyOperation(

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/ExecutionWorkflowBuilderTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/ExecutionWorkflowBuilderTest.scala
@@ -49,7 +49,7 @@ class ExecutionWorkflowBuilderTest extends CypherFunSuite {
     when(context.transactionalContext).thenReturn(mock[QueryTransactionalContext])
 
     val pipeInfo = PipeInfo(pipe, updating = true, None, None, PlannerName)
-    val builderFactory = DefaultExecutionResultBuilderFactory(pipeInfo, List.empty, logicalPlan)
+    val builderFactory = new DefaultExecutionResultBuilderFactory(pipeInfo, List.empty, logicalPlan)
 
     // WHEN
     val builder = builderFactory.create()
@@ -67,7 +67,7 @@ class ExecutionWorkflowBuilderTest extends CypherFunSuite {
     when(pipe.createResults(any())).thenReturn(Iterator.empty)
     val context = mock[QueryContext]
     val pipeInfo = PipeInfo(pipe, updating = false, None, None, PlannerName)
-    val builderFactory = DefaultExecutionResultBuilderFactory(pipeInfo, List.empty, logicalPlan)
+    val builderFactory = new DefaultExecutionResultBuilderFactory(pipeInfo, List.empty, logicalPlan)
 
     // WHEN
     val builder = builderFactory.create()
@@ -86,7 +86,7 @@ class ExecutionWorkflowBuilderTest extends CypherFunSuite {
     val context = mock[QueryContext]
     when(context.transactionalContext).thenReturn(mock[QueryTransactionalContext])
     val pipeInfo = PipeInfo(pipe, updating = false, None, None, PlannerName)
-    val builderFactory = DefaultExecutionResultBuilderFactory(pipeInfo, List.empty, logicalPlan)
+    val builderFactory = new DefaultExecutionResultBuilderFactory(pipeInfo, List.empty, logicalPlan)
 
     // WHEN
     val builder = builderFactory.create()

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/AndedPropertyInequalities.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/AndedPropertyInequalities.scala
@@ -20,7 +20,7 @@ import org.neo4j.cypher.internal.util.v3_4.NonEmptyList
 
 case class AndedPropertyInequalities(
                                       variable: Variable,
-                                      property: Property,
+                                      property: LogicalProperty,
                                       inequalities: NonEmptyList[InequalityExpression]
                                     ) extends Expression {
   def position = variable.position

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Expression.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Expression.scala
@@ -45,7 +45,7 @@ object Expression {
     mapExpression match {
       case MapExpression(items) => items.exists {
         case (k, v) => v.subExpressions.exists {
-          case Property(Variable(entityName), propertyKey) =>
+          case LogicalProperty(LogicalVariable(entityName), propertyKey) =>
             entityName == mapEntityName && propertyKey == k
           case _ => false
         }
@@ -55,7 +55,7 @@ object Expression {
 
   def hasPropertyReadDependency(entityName: String, expression: Expression, propertyKey: PropertyKeyName): Boolean =
     expression.subExpressions.exists {
-      case Property(Variable(name), key) =>
+      case LogicalProperty(LogicalVariable(name), key) =>
         name == entityName && key == propertyKey
       case _ =>
         false

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/IterableExpressions.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/IterableExpressions.scala
@@ -20,7 +20,7 @@ import org.neo4j.cypher.internal.util.v3_4.InputPosition
 
 trait FilteringExpression extends Expression {
   def name: String
-  def variable: Variable
+  def variable: LogicalVariable
   def expression: Expression
   def innerPredicate: Option[Expression]
 
@@ -74,18 +74,18 @@ object ListComprehension {
     ListComprehension(ExtractScope(variable, innerPredicate, extractExpression)(position), expression)(position)
 }
 
-case class PatternComprehension(namedPath: Option[Variable], pattern: RelationshipsPattern,
+case class PatternComprehension(namedPath: Option[LogicalVariable], pattern: RelationshipsPattern,
                                 predicate: Option[Expression], projection: Expression,
-                                outerScope: Set[Variable] = Set.empty)
+                                outerScope: Set[LogicalVariable] = Set.empty)
                                (val position: InputPosition)
   extends ScopeExpression {
 
   self =>
 
-  def withOuterScope(outerScope: Set[Variable]) =
+  def withOuterScope(outerScope: Set[LogicalVariable]) =
     copy(outerScope = outerScope)(position)
 
-  override val introducedVariables: Set[Variable] = {
+  override val introducedVariables: Set[LogicalVariable] = {
     val introducedInternally = namedPath.toSet ++ pattern.element.allVariables
     val introducedExternally = introducedInternally -- outerScope
     introducedExternally
@@ -95,7 +95,7 @@ case class PatternComprehension(namedPath: Option[Variable], pattern: Relationsh
 sealed trait IterablePredicateExpression extends FilteringExpression {
 
   def scope: FilterScope
-  def variable: Variable = scope.variable
+  def variable: LogicalVariable = scope.variable
   def innerPredicate: Option[Expression] = scope.innerPredicate
 
   override def asCanonicalStringVal: String = {

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/LogicalProperty.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/LogicalProperty.scala
@@ -16,8 +16,11 @@
  */
 package org.neo4j.cypher.internal.v3_4.expressions
 
-import org.neo4j.cypher.internal.util.v3_4.InputPosition
+abstract class LogicalProperty extends Expression {
+  def map: Expression
+  def propertyKey: PropertyKeyName
+}
 
-case class Property(map: Expression, propertyKey: PropertyKeyName)(val position: InputPosition) extends Expression {
-  override def asCanonicalStringVal = s"${map.asCanonicalStringVal}.${propertyKey.asCanonicalStringVal}"
+object LogicalProperty {
+  def unapply(p: LogicalProperty): Option[(Expression, PropertyKeyName)] = Some((p.map, p.propertyKey))
 }

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/LogicalVariable.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/LogicalVariable.scala
@@ -18,20 +18,19 @@ package org.neo4j.cypher.internal.v3_4.expressions
 
 import org.neo4j.cypher.internal.util.v3_4.InputPosition
 
-case class Variable(name: String)(val position: InputPosition) extends LogicalVariable {
+abstract class LogicalVariable extends Expression {
+  def name: String
 
-  override def copyId = copy()(position)
+  def copyId: LogicalVariable
 
-  override def renameId(newName: String) = copy(name = newName)(position)
+  def renameId(newName: String): LogicalVariable
 
-  override def bumpId = copy()(position.bumped())
+  def bumpId: LogicalVariable
 
-  override def asCanonicalStringVal: String = name
+  def position: InputPosition
 }
 
-object Variable {
-  implicit val byName: Ordering[Variable] =
-    Ordering.by { (variable: Variable) =>
-      (variable.name, variable.position)
-    }(Ordering.Tuple2(implicitly[Ordering[String]], InputPosition.byOffset))
+object LogicalVariable {
+  def unapply(arg: Variable): Option[String] = Some(arg.name)
 }
+

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/MapProjection.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/MapProjection.scala
@@ -19,7 +19,8 @@ package org.neo4j.cypher.internal.v3_4.expressions
 import org.neo4j.cypher.internal.util.v3_4.InputPosition
 
 case class MapProjection(
-                          name: Variable,
+                          name: Variable, // Since this is always rewritten to DesugaredMapProjection this
+                                          // (and in the elements below) may not need to be LogicalVariable
                           items: Seq[MapProjectionElement],
                           definitionPos: Option[InputPosition] = None)
                         (val position: InputPosition)

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Property.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Property.scala
@@ -18,6 +18,6 @@ package org.neo4j.cypher.internal.v3_4.expressions
 
 import org.neo4j.cypher.internal.util.v3_4.InputPosition
 
-case class Property(map: Expression, propertyKey: PropertyKeyName)(val position: InputPosition) extends Expression {
+case class Property(map: Expression, propertyKey: PropertyKeyName)(val position: InputPosition) extends LogicalProperty {
   override def asCanonicalStringVal = s"${map.asCanonicalStringVal}.${propertyKey.asCanonicalStringVal}"
 }

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Property.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Property.scala
@@ -18,6 +18,35 @@ package org.neo4j.cypher.internal.v3_4.expressions
 
 import org.neo4j.cypher.internal.util.v3_4.InputPosition
 
-case class Property(map: Expression, propertyKey: PropertyKeyName)(val position: InputPosition) extends Expression {
+class Property(val map: Expression, val propertyKey: PropertyKeyName)(val position: InputPosition) extends Expression {
   override def asCanonicalStringVal = s"${map.asCanonicalStringVal}.${propertyKey.asCanonicalStringVal}"
+
+  //--------------------------------------------------------------------------------------------------
+  // The methods below are what we would get automatically if this was a case class
+  //--------------------------------------------------------------------------------------------------
+  def copy(map: Expression = this.map, propertyKey: PropertyKeyName = this.propertyKey)(position: InputPosition): Property =
+    new Property(map, propertyKey)(position)
+
+  override def productElement(n: Int) =
+    n match {
+      case 0 => map
+      case 1 => propertyKey
+      case _ => throw new java.lang.IndexOutOfBoundsException(n.toString)
+    }
+
+  override def productArity = 2
+
+  override def canEqual(that: Any) = that.isInstanceOf[Property]
+
+  override def toString: String = s"Property($map, $propertyKey)"
+
+  override def hashCode(): Int = runtime.ScalaRunTime._hashCode(Property.this)
+
+  override def equals(obj: scala.Any): Boolean = runtime.ScalaRunTime._equals(Property.this, obj)
+}
+
+object Property {
+  def apply(map: Expression, propertyKey: PropertyKeyName)(position: InputPosition) = new Property(map, propertyKey)(position)
+
+  def unapply(p: Property): Option[(Expression, PropertyKeyName)] = Some((p.map, p.propertyKey))
 }

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/ScopeExpression.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/ScopeExpression.scala
@@ -28,17 +28,17 @@ import org.neo4j.cypher.internal.util.v3_4.InputPosition
 // - or child expressions in a scope where those variables are bound
 //
 trait ScopeExpression extends Expression {
-  def introducedVariables: Set[Variable]
+  def introducedVariables: Set[LogicalVariable]
 }
 
-case class FilterScope(variable: Variable, innerPredicate: Option[Expression])(val position: InputPosition) extends ScopeExpression {
+case class FilterScope(variable: LogicalVariable, innerPredicate: Option[Expression])(val position: InputPosition) extends ScopeExpression {
   val introducedVariables = Set(variable)
 }
 
-case class ExtractScope(variable: Variable, innerPredicate: Option[Expression], extractExpression: Option[Expression])(val position: InputPosition) extends ScopeExpression {
+case class ExtractScope(variable: LogicalVariable, innerPredicate: Option[Expression], extractExpression: Option[Expression])(val position: InputPosition) extends ScopeExpression {
   val introducedVariables = Set(variable)
 }
 
-case class ReduceScope(accumulator: Variable, variable: Variable, expression: Expression)(val position: InputPosition) extends ScopeExpression {
+case class ReduceScope(accumulator: LogicalVariable, variable: LogicalVariable, expression: Expression)(val position: InputPosition) extends ScopeExpression {
   val introducedVariables = Set(accumulator, variable)
 }

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ASTSlicingPhrase.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ASTSlicingPhrase.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.v3_4.expressions._
 trait ASTSlicingPhrase extends SemanticCheckable with SemanticAnalysisTooling {
   self: ASTNode =>
   def name: String
-  def dependencies: Set[Variable] = expression.dependencies
+  def dependencies: Set[LogicalVariable] = expression.dependencies
   def expression: Expression
 
   def semanticCheck: SemanticCheck =

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Clause.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Clause.scala
@@ -643,7 +643,7 @@ case class Return(distinct: Boolean,
     }
 }
 
-case class PragmaWithout(excluded: Seq[Variable])(val position: InputPosition) extends HorizonClause {
+case class PragmaWithout(excluded: Seq[LogicalVariable])(val position: InputPosition) extends HorizonClause {
   override def name = "_PRAGMA WITHOUT"
   val excludedNames: Set[String] = excluded.map(_.name).toSet
 

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Order.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/Order.scala
@@ -16,15 +16,15 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_4.ast
 
-import org.neo4j.cypher.internal.util.v3_4.{ASTNode, InputPosition}
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.{SemanticCheckable, SemanticExpressionCheck}
-import org.neo4j.cypher.internal.v3_4.expressions.{Expression, Variable}
+import org.neo4j.cypher.internal.util.v3_4.{ASTNode, InputPosition}
+import org.neo4j.cypher.internal.v3_4.expressions.{Expression, LogicalVariable}
 
 case class OrderBy(sortItems: Seq[SortItem])(val position: InputPosition) extends ASTNode with SemanticCheckable {
   def semanticCheck = sortItems.semanticCheck
 
-  def dependencies: Set[Variable] =
-    sortItems.foldLeft(Set.empty[Variable]) { case (acc, item) => acc ++ item.expression.dependencies }
+  def dependencies: Set[LogicalVariable] =
+    sortItems.foldLeft(Set.empty[LogicalVariable]) { case (acc, item) => acc ++ item.expression.dependencies }
 }
 
 sealed trait SortItem extends ASTNode with SemanticCheckable {

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/RemoveItem.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/RemoveItem.scala
@@ -16,20 +16,20 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_4.ast
 
-import org.neo4j.cypher.internal.util.v3_4.{ASTNode, InputPosition}
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.{SemanticCheckable, SemanticExpressionCheck}
 import org.neo4j.cypher.internal.util.v3_4.symbols._
-import org.neo4j.cypher.internal.v3_4.expressions.{LabelName, Property, Variable}
+import org.neo4j.cypher.internal.util.v3_4.{ASTNode, InputPosition}
+import org.neo4j.cypher.internal.v3_4.expressions.{LabelName, LogicalProperty, LogicalVariable}
 
 sealed trait RemoveItem extends ASTNode with SemanticCheckable
 
-case class RemoveLabelItem(variable: Variable, labels: Seq[LabelName])(val position: InputPosition) extends RemoveItem {
+case class RemoveLabelItem(variable: LogicalVariable, labels: Seq[LabelName])(val position: InputPosition) extends RemoveItem {
   def semanticCheck =
     SemanticExpressionCheck.simple(variable) chain
     SemanticExpressionCheck.expectType(CTNode.covariant, variable)
 }
 
-case class RemovePropertyItem(property: Property) extends RemoveItem {
+case class RemovePropertyItem(property: LogicalProperty) extends RemoveItem {
   def position = property.position
 
   def semanticCheck = SemanticExpressionCheck.simple(property)

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ReturnItem.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ReturnItem.scala
@@ -16,11 +16,11 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_4.ast
 
-import org.neo4j.cypher.internal.util.v3_4.{ASTNode, InputPosition, InternalException}
-import org.neo4j.cypher.internal.frontend.v3_4.semantics.SemanticCheckResult.success
 import org.neo4j.cypher.internal.frontend.v3_4._
+import org.neo4j.cypher.internal.frontend.v3_4.semantics.SemanticCheckResult.success
 import org.neo4j.cypher.internal.frontend.v3_4.semantics._
-import org.neo4j.cypher.internal.v3_4.expressions.{Expression, MapProjection, Variable}
+import org.neo4j.cypher.internal.util.v3_4.{ASTNode, InputPosition, InternalException}
+import org.neo4j.cypher.internal.v3_4.expressions.{Expression, LogicalVariable, MapProjection}
 
 sealed trait ReturnItemsDef extends ASTNode with SemanticCheckable with SemanticAnalysisTooling {
   /**
@@ -57,9 +57,9 @@ final case class ReturnItems(
 
   override def semanticCheck: SemanticCheck = items.semanticCheck chain ensureProjectedToUniqueIds
 
-  def aliases: Set[Variable] = items.flatMap(_.alias).toSet
+  def aliases: Set[LogicalVariable] = items.flatMap(_.alias).toSet
 
-  def passedThrough: Set[Variable] = items.collect {
+  def passedThrough: Set[LogicalVariable] = items.collect {
     case item => item.alias.collect { case ident if ident == item.expression => ident }
   }.flatten.toSet
 
@@ -91,7 +91,7 @@ final case class ReturnItems(
 
 sealed trait ReturnItem extends ASTNode with SemanticCheckable {
   def expression: Expression
-  def alias: Option[Variable]
+  def alias: Option[LogicalVariable]
   def name: String
   def makeSureIsNotUnaliased(state: SemanticState): SemanticCheckResult
 
@@ -100,7 +100,7 @@ sealed trait ReturnItem extends ASTNode with SemanticCheckable {
 
 case class UnaliasedReturnItem(expression: Expression, inputText: String)(val position: InputPosition) extends ReturnItem {
   val alias = expression match {
-    case i: Variable => Some(i.bumpId)
+    case i: LogicalVariable => Some(i.bumpId)
     case x: MapProjection => Some(x.name.bumpId)
     case _ => None
   }
@@ -111,11 +111,11 @@ case class UnaliasedReturnItem(expression: Expression, inputText: String)(val po
 }
 
 object AliasedReturnItem {
-  def apply(v:Variable):AliasedReturnItem = AliasedReturnItem(v.copyId, v.copyId)(v.position)
+  def apply(v:LogicalVariable):AliasedReturnItem = AliasedReturnItem(v.copyId, v.copyId)(v.position)
 }
 
 //TODO variable should not be a Variable. A Variable is an expression, and the return item alias isn't
-case class AliasedReturnItem(expression: Expression, variable: Variable)(val position: InputPosition) extends ReturnItem {
+case class AliasedReturnItem(expression: Expression, variable: LogicalVariable)(val position: InputPosition) extends ReturnItem {
   val alias = Some(variable)
   val name = variable.name
 

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/SetItem.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/SetItem.scala
@@ -19,7 +19,7 @@ package org.neo4j.cypher.internal.frontend.v3_4.ast
 import org.neo4j.cypher.internal.util.v3_4.{ASTNode, InputPosition}
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.{SemanticAnalysisTooling, SemanticCheckable, SemanticExpressionCheck}
 import org.neo4j.cypher.internal.util.v3_4.symbols._
-import org.neo4j.cypher.internal.v3_4.expressions.{Expression, LabelName, Property, Variable}
+import org.neo4j.cypher.internal.v3_4.expressions._
 
 sealed trait SetItem extends ASTNode with SemanticCheckable
 
@@ -31,7 +31,7 @@ case class SetLabelItem(variable: Variable, labels: Seq[LabelName])(val position
 
 sealed trait SetProperty extends SetItem with SemanticAnalysisTooling
 
-case class SetPropertyItem(property: Property, expression: Expression)(val position: InputPosition) extends SetProperty {
+case class SetPropertyItem(property: LogicalProperty, expression: Expression)(val position: InputPosition) extends SetProperty {
   def semanticCheck =
     SemanticExpressionCheck.simple(property) chain
       SemanticExpressionCheck.simple(expression) chain

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/Namespacer.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/Namespacer.scala
@@ -21,7 +21,7 @@ import org.neo4j.cypher.internal.frontend.v3_4.ast._
 import org.neo4j.cypher.internal.frontend.v3_4.phases.CompilationPhaseTracer.CompilationPhase
 import org.neo4j.cypher.internal.frontend.v3_4.phases.{BaseContext, BaseState, Condition, Phase}
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.{Scope, SemanticTable, SymbolUse}
-import org.neo4j.cypher.internal.v3_4.expressions.{ProcedureOutput, Variable}
+import org.neo4j.cypher.internal.v3_4.expressions.{LogicalVariable, ProcedureOutput, Variable}
 
 object Namespacer extends Phase[BaseContext, BaseState, BaseState] {
   type VariableRenamings = Map[Ref[Variable], Variable]
@@ -56,8 +56,8 @@ object Namespacer extends Phase[BaseContext, BaseState, BaseState] {
     }.toSet
   }
 
-  private def returnAliases(statement: Statement): Set[Ref[Variable]] =
-    statement.treeFold(Set.empty[Ref[Variable]]) {
+  private def returnAliases(statement: Statement): Set[Ref[LogicalVariable]] =
+    statement.treeFold(Set.empty[Ref[LogicalVariable]]) {
 
       case With(_, _, GraphReturnItems(_, items), _, _, _, _) =>
         val gVars = extractGraphVars(items)
@@ -65,12 +65,12 @@ object Namespacer extends Phase[BaseContext, BaseState, BaseState] {
 
       // ignore variable in StartItem that represents index names and key names
       case Return(_, ReturnItems(_, items), graphItems, _, _, _, _) =>
-        val variables = items.map(_.alias.map(Ref[Variable]).get)
+        val variables = items.map(_.alias.map(Ref[LogicalVariable]).get)
         val gVars = graphItems.map(_.items).map(extractGraphVars).getOrElse(Seq.empty)
         acc => (acc ++ variables ++ gVars, Some(identity))
     }
 
-  private def extractGraphVars(items: Seq[GraphReturnItem]): Seq[Ref[Variable]] = {
+  private def extractGraphVars(items: Seq[GraphReturnItem]): Seq[Ref[LogicalVariable]] = {
     items.flatMap { item =>
       item.graphs.flatMap {
         case g: GraphAs =>
@@ -82,7 +82,7 @@ object Namespacer extends Phase[BaseContext, BaseState, BaseState] {
   }
 
   private def variableRenamings(statement: Statement, variableDefinitions: Map[SymbolUse, SymbolUse],
-                                ambiguousNames: Set[String], protectedVariables: Set[Ref[Variable]]): VariableRenamings =
+                                ambiguousNames: Set[String], protectedVariables: Set[Ref[LogicalVariable]]): VariableRenamings =
     statement.treeFold(Map.empty[Ref[Variable], Variable]) {
       case i: Variable if ambiguousNames(i.name) && !protectedVariables(Ref(i)) =>
         val symbolDefinition = variableDefinitions(SymbolUse(i))

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/desugarMapProjection.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/desugarMapProjection.scala
@@ -60,7 +60,7 @@ case class desugarMapProjection(state: SemanticState) extends Rewriter {
 }
 
 case class DesugaredMapProjection(
-                                   name: Variable,
+                                   name: LogicalVariable,
                                    items: Seq[LiteralEntry],
                                    includeAllProps: Boolean
                                  )(val position: InputPosition) extends Expression

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/inlineNamedPathsInPatternComprehensions.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/inlineNamedPathsInPatternComprehensions.scala
@@ -32,7 +32,7 @@ case object inlineNamedPathsInPatternComprehensions extends Rewriter {
   })
 
   private implicit final class InliningExpression(val expr: Expression) extends AnyVal {
-    def inline(path: Variable, patternElement: PatternElement) =
+    def inline(path: LogicalVariable, patternElement: PatternElement) =
       expr.copyAndReplace(path) by {
         PathExpression(projectNamedPaths.patternPartPathExpression(patternElement))(expr.position)
       }

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/projectNamedPaths.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/projectNamedPaths.scala
@@ -26,15 +26,15 @@ import scala.annotation.tailrec
 case object projectNamedPaths extends Rewriter {
 
   case class Projectibles(paths: Map[Variable, PathExpression] = Map.empty,
-                          protectedVariables: Set[Ref[Variable]] = Set.empty,
-                          variableRewrites: Map[Ref[Variable], PathExpression] = Map.empty) {
+                          protectedVariables: Set[Ref[LogicalVariable]] = Set.empty,
+                          variableRewrites: Map[Ref[LogicalVariable], PathExpression] = Map.empty) {
 
     self =>
 
     def withoutNamedPaths = copy(paths = Map.empty)
-    def withProtectedVariable(ident: Ref[Variable]) = copy(protectedVariables = protectedVariables + ident)
+    def withProtectedVariable(ident: Ref[LogicalVariable]) = copy(protectedVariables = protectedVariables + ident)
     def withNamedPath(entry: (Variable, PathExpression)) = copy(paths = paths + entry)
-    def withRewrittenVariable(entry: (Ref[Variable], PathExpression)) = {
+    def withRewrittenVariable(entry: (Ref[LogicalVariable], PathExpression)) = {
       val (ref, pathExpr) = entry
       copy(variableRewrites = variableRewrites + (ref -> pathExpr.endoRewrite(copyVariables)))
     }

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/Transformer.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/Transformer.scala
@@ -16,8 +16,8 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_4.phases
 
-import org.neo4j.cypher.internal.util.v3_4.{AssertionRunner, InternalException}
-import org.neo4j.cypher.internal.util.v3_4.AssertionRunner.Thunk
+import org.neo4j.cypher.internal.util.v3_4.AssertionUtils.ifAssertionsEnabled
+import org.neo4j.cypher.internal.util.v3_4.InternalException
 
 trait Transformer[-C <: BaseContext, -FROM, TO] {
   def transform(from: FROM, context: C): TO
@@ -64,12 +64,6 @@ class PipeLine[-C <: BaseContext, FROM, MID, TO](first: Transformer[C, FROM, MID
   }
 
   override def name: String = first.name + ", " + after.name
-
-  private def ifAssertionsEnabled(f: => Unit): Unit = {
-    AssertionRunner.runUnderAssertion(new Thunk {
-      override def apply() = f
-    })
-  }
 }
 
 

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticAnalysisTooling.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticAnalysisTooling.scala
@@ -167,14 +167,14 @@ trait SemanticAnalysisTooling {
       case e:java.lang.NumberFormatException => false
     }
 
-  def ensureDefined(v:Variable): (SemanticState) => Either[SemanticError, SemanticState] =
+  def ensureDefined(v:LogicalVariable): (SemanticState) => Either[SemanticError, SemanticState] =
     (_: SemanticState).ensureVariableDefined(v)
 
-  def declareVariable(v:Variable, possibleTypes: TypeSpec): (SemanticState) => Either[SemanticError, SemanticState] =
+  def declareVariable(v:LogicalVariable, possibleTypes: TypeSpec): (SemanticState) => Either[SemanticError, SemanticState] =
     (_: SemanticState).declareVariable(v, possibleTypes)
 
   def declareVariable(
-                       v:Variable,
+                       v:LogicalVariable,
                        typeGen: TypeGenerator,
                        positions: Set[InputPosition] = Set.empty
                      ): (SemanticState) => Either[SemanticError, SemanticState] =

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticTable.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticTable.scala
@@ -72,9 +72,9 @@ class SemanticTable(
 
   def isNodeCollection(expr: String) = getTypeFor(expr) == CTList(CTNode).invariant
 
-  def isNode(expr: Variable) = types(expr).specified == CTNode.invariant
+  def isNode(expr: LogicalVariable) = types(expr).specified == CTNode.invariant
 
-  def isRelationship(expr: Variable) = types(expr).specified == CTRelationship.invariant
+  def isRelationship(expr: LogicalVariable) = types(expr).specified == CTRelationship.invariant
 
   def addNode(expr: Variable) =
     copy(types = types.updated(expr, ExpressionTypeInfo(CTNode.invariant, None)))

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/convert/CommunityExpressionConverter.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/convert/CommunityExpressionConverter.scala
@@ -309,7 +309,7 @@ object CommunityExpressionConverter extends ExpressionConverter {
 
   private def toCommandParameter(e: ast.Parameter) = commandexpressions.ParameterExpression(e.name)
 
-  private def toCommandProperty(e: ast.Property, self: ExpressionConverters): commandexpressions.Property =
+  private def toCommandProperty(e: ast.LogicalProperty, self: ExpressionConverters): commandexpressions.Property =
     commandexpressions.Property(self.toCommandExpression(e.map), PropertyKey(e.propertyKey.name))
 
   private def toCommandExpression(expression: Option[ast.Expression], self: ExpressionConverters): Option[CommandExpression] =

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/convert/CommunityExpressionConverter.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/convert/CommunityExpressionConverter.scala
@@ -318,7 +318,7 @@ object CommunityExpressionConverter extends ExpressionConverter {
   private def toCommandExpression(expressions: Seq[ast.Expression], self: ExpressionConverters): Seq[CommandExpression] =
     expressions.map(self.toCommandExpression)
 
-  private def variable(e: ast.Variable) = commands.expressions.Variable(e.name)
+  private def variable(e: ast.LogicalVariable) = commands.expressions.Variable(e.name)
 
   private def inequalityExpression(original: ast.InequalityExpression, self: ExpressionConverters): predicates.ComparablePredicate = original match {
     case e: ast.LessThan => predicates.LessThan(self.toCommandExpression(e.lhs), self.toCommandExpression(e.rhs))

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Expression.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Expression.scala
@@ -116,25 +116,3 @@ trait ExpressionWInnerExpression extends Expression {
   def myType:CypherType
   def expectedInnerType:CypherType
 }
-
-object Expression {
-  def mapExpressionHasPropertyReadDependency(mapEntityName: String, mapExpression: Expression): Boolean =
-    mapExpression match {
-      case LiteralMap(map) => map.exists {
-        case (k, v) => v.subExpressions.exists {
-          case Property(Variable(entityName), propertyKey) =>
-            entityName == mapEntityName && propertyKey.name == k
-          case _ => false
-        }
-      }
-      case _ => false
-    }
-
-  def hasPropertyReadDependency(entityName: String, expression: Expression, propertyKey: String): Boolean =
-    expression.subExpressions.exists {
-      case Property(Variable(name), key) =>
-        name == entityName && key.name == propertyKey
-      case _ =>
-        false
-    }
-}

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Property.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/Property.scala
@@ -26,19 +26,19 @@ import org.neo4j.cypher.internal.runtime.interpreted.IsMap
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.QueryState
 import org.neo4j.values.AnyValue
 import org.neo4j.values.storable.Values
-import org.neo4j.values.virtual.{EdgeValue, NodeValue}
+import org.neo4j.values.virtual.{VirtualEdgeValue, VirtualNodeValue}
 
 case class Property(mapExpr: Expression, propertyKey: KeyToken)
   extends Expression with Product with Serializable
 {
   def apply(ctx: ExecutionContext, state: QueryState): AnyValue = mapExpr(ctx, state) match {
     case n if n == Values.NO_VALUE => Values.NO_VALUE
-    case n: NodeValue =>
+    case n: VirtualNodeValue =>
       propertyKey.getOptId(state.query) match {
         case None => Values.NO_VALUE
         case Some(propId) => state.query.nodeOps.getProperty(n.id(), propId)
       }
-    case r: EdgeValue =>
+    case r: VirtualEdgeValue =>
       propertyKey.getOptId(state.query) match {
         case None => Values.NO_VALUE
         case Some(propId) => state.query.relationshipOps.getProperty(r.id(), propId)

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/predicates/Predicate.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/predicates/Predicate.scala
@@ -20,14 +20,13 @@
 package org.neo4j.cypher.internal.runtime.interpreted.commands.predicates
 
 import org.neo4j.cypher.InvalidSemanticsException
-import org.neo4j.cypher.internal.util.v3_4.{CypherTypeException, NonEmptyList}
-import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.{Expression, Literal}
 import org.neo4j.cypher.internal.runtime.interpreted.commands.values.KeyToken
-import org.neo4j.cypher.internal.runtime.interpreted.{CastSupport, IsList, IsMap}
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.QueryState
+import org.neo4j.cypher.internal.runtime.interpreted.{CastSupport, ExecutionContext, IsList, IsMap}
+import org.neo4j.cypher.internal.util.v3_4.{CypherTypeException, NonEmptyList}
 import org.neo4j.values.storable.{BooleanValue, TextValue, Value, Values}
-import org.neo4j.values.virtual.{EdgeValue, NodeValue}
+import org.neo4j.values.virtual.{VirtualEdgeValue, VirtualNodeValue}
 
 import scala.util.{Failure, Success, Try}
 
@@ -152,8 +151,8 @@ case class True() extends Predicate {
 
 case class PropertyExists(variable: Expression, propertyKey: KeyToken) extends Predicate {
   def isMatch(m: ExecutionContext, state: QueryState): Option[Boolean] = variable(m, state) match {
-    case pc: NodeValue => Some(propertyKey.getOptId(state.query).exists(state.query.nodeOps.hasProperty(pc.id, _)))
-    case pc: EdgeValue => Some(
+    case pc: VirtualNodeValue => Some(propertyKey.getOptId(state.query).exists(state.query.nodeOps.hasProperty(pc.id, _)))
+    case pc: VirtualEdgeValue => Some(
       propertyKey.getOptId(state.query).exists(state.query.relationshipOps.hasProperty(pc.id, _)))
     case IsMap(map) => Some(map(state.query).get(propertyKey.name) != Values.NO_VALUE)
     case Values.NO_VALUE => None
@@ -290,7 +289,7 @@ case class HasLabel(entity: Expression, label: KeyToken) extends Predicate {
       None
 
     case value =>
-      val node = CastSupport.castOrFail[NodeValue](value)
+      val node = CastSupport.castOrFail[VirtualNodeValue](value)
       val nodeId = node.id
       val queryCtx = state.query
 

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/AllNodesScanPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/AllNodesScanPipe.scala
@@ -26,7 +26,7 @@ import org.neo4j.kernel.impl.util.ValueUtils
 case class AllNodesScanPipe(ident: String)(val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends Pipe {
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
-    val baseContext = state.createOrGetInitialContext()
+    val baseContext = state.createOrGetInitialContext(executionContextFactory)
     state.query.nodeOps.all.map(n => baseContext.newWith1(ident, ValueUtils.fromNodeProxy(n)))
   }
 

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/AssertSameNodePipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/AssertSameNodePipe.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.util.v3_4.MergeConstraintConflictException
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.CastSupport
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
-import org.neo4j.values.virtual.NodeValue
+import org.neo4j.values.virtual.VirtualNodeValue
 
 case class AssertSameNodePipe(source: Pipe, inner: Pipe, node: String)
                              (val id: LogicalPlanId = LogicalPlanId.DEFAULT)
@@ -37,9 +37,9 @@ case class AssertSameNodePipe(source: Pipe, inner: Pipe, node: String)
     }
 
     lhsResult.map { leftRow =>
-      val lhsNode = CastSupport.castOrFail[NodeValue](leftRow.get(node).get)
+      val lhsNode = CastSupport.castOrFail[VirtualNodeValue](leftRow.get(node).get)
       rhsResults.foreach { rightRow =>
-        val rhsNode = CastSupport.castOrFail[NodeValue](rightRow.get(node).get)
+        val rhsNode = CastSupport.castOrFail[VirtualNodeValue](rightRow.get(node).get)
         if (lhsNode.id != rhsNode.id) {
           throw new MergeConstraintConflictException(
             s"Merge did not find a matching node $node and can not create a new node due to conflicts with existing unique nodes")

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/DirectedRelationshipByIdSeekPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/DirectedRelationshipByIdSeekPipe.scala
@@ -36,7 +36,7 @@ case class DirectedRelationshipByIdSeekPipe(ident: String, relIdExpr: SeekArgs, 
   relIdExpr.registerOwningPipe(this)
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
-    val ctx = state.createOrGetInitialContext()
+    val ctx = state.createOrGetInitialContext(executionContextFactory)
     val relIds = VirtualValues.filter(relIdExpr.expressions(ctx, state), new function.Function[AnyValue, java.lang.Boolean] {
       override def apply(t: AnyValue): lang.Boolean = t != Values.NO_VALUE
     })

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/DistinctPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/DistinctPipe.scala
@@ -19,8 +19,8 @@
  */
 package org.neo4j.cypher.internal.runtime.interpreted.pipes
 
+import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Expression
-import org.neo4j.cypher.internal.runtime.interpreted.{ExecutionContext, MapExecutionContext}
 import org.neo4j.cypher.internal.util.v3_4.Eagerly
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 import org.neo4j.values.AnyValue
@@ -40,7 +40,7 @@ case class DistinctPipe(source: Pipe, expressions: Map[String, Expression])
     // Run the return item expressions, and replace the execution context's with their values
     val result = input.map(ctx => {
       val newMap = Eagerly.mutableMapValues(expressions, (expression: Expression) => expression(ctx, state))
-      MapExecutionContext(newMap)
+      executionContextFactory.newExecutionContext(newMap)
     })
 
     /*

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LimitPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LimitPipe.scala
@@ -34,7 +34,7 @@ case class LimitPipe(source: Pipe, exp: Expression)
     if(input.isEmpty)
       return Iterator.empty
 
-    val limit = asInt(exp(state.createOrGetInitialContext(), state))
+    val limit = asInt(exp(state.createOrGetInitialContext(executionContextFactory), state))
 
     input.take(limit.value())
   }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LockNodesPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LockNodesPipe.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.runtime.interpreted.pipes
 
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
-import org.neo4j.values.virtual.NodeValue
+import org.neo4j.values.virtual.VirtualNodeValue
 
 case class LockNodesPipe(src: Pipe, variablesToLock: Set[String])(val id: LogicalPlanId = LogicalPlanId.DEFAULT)
   extends PipeWithSource(src)  {
@@ -29,7 +29,7 @@ case class LockNodesPipe(src: Pipe, variablesToLock: Set[String])(val id: Logica
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] =
     input.map { ctx =>
       val nodesToLock: Set[Long] = variablesToLock.flatMap { varName =>
-        Option(ctx(varName).asInstanceOf[NodeValue]).map(_.id)
+        Option(ctx(varName).asInstanceOf[VirtualNodeValue]).map(_.id)
       }
       state.query.lockNodes(nodesToLock.toSeq: _*)
       ctx

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeByIdSeekPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeByIdSeekPipe.scala
@@ -65,7 +65,7 @@ case class NodeByIdSeekPipe(ident: String, nodeIdsExpr: SeekArgs)
   nodeIdsExpr.registerOwningPipe(this)
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
-    val ctx = state.createOrGetInitialContext()
+    val ctx = state.createOrGetInitialContext(executionContextFactory)
     val nodeIds = nodeIdsExpr.expressions(ctx, state)
     new NodeIdSeekIterator(ident, ctx, state.query.nodeOps, nodeIds.iterator().asScala)
   }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeByLabelScanPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeByLabelScanPipe.scala
@@ -31,7 +31,7 @@ case class NodeByLabelScanPipe(ident: String, label: LazyLabel)
     label.getOptId(state.query) match {
       case Some(labelId) =>
         val nodes = state.query.getNodesByLabel(labelId.id)
-        val baseContext = state.createOrGetInitialContext()
+        val baseContext = state.createOrGetInitialContext(executionContextFactory)
         nodes.map(n => baseContext.newWith1(ident, ValueUtils.fromNodeProxy(n)))
       case None =>
         Iterator.empty

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeCountFromCountStorePipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeCountFromCountStorePipe.scala
@@ -28,7 +28,7 @@ case class NodeCountFromCountStorePipe(ident: String, labels: List[Option[LazyLa
                                       (val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends Pipe {
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
-    val baseContext = state.createOrGetInitialContext()
+    val baseContext = state.createOrGetInitialContext(executionContextFactory)
     var count = 1L
     val it = labels.iterator
     while (it.hasNext) {

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeHashJoinPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeHashJoinPipe.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.util.v3_4.CypherTypeException
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 import org.neo4j.values.storable.Values
-import org.neo4j.values.virtual.NodeValue
+import org.neo4j.values.virtual.VirtualNodeValue
 
 import scala.collection.mutable
 
@@ -74,7 +74,7 @@ case class NodeHashJoinPipe(nodeVariables: Set[String], left: Pipe, right: Pipe)
 
     for (idx <- cachedVariables.indices) {
       key(idx) = context(cachedVariables(idx)) match {
-        case n: NodeValue => n.id()
+        case n: VirtualNodeValue => n.id()
         case Values.NO_VALUE => return None
         case _ => throw new CypherTypeException("Created a plan that uses non-nodes when expecting a node")
       }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexContainsScanPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexContainsScanPipe.scala
@@ -39,7 +39,7 @@ abstract class AbstractNodeIndexStringScanPipe(ident: String,
   valueExpr.registerOwningPipe(this)
 
   override protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
-    val baseContext = state.createOrGetInitialContext()
+    val baseContext = state.createOrGetInitialContext(executionContextFactory)
     val value = valueExpr(baseContext, state)
 
     val resultNodes = value match {

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexScanPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexScanPipe.scala
@@ -33,7 +33,7 @@ case class NodeIndexScanPipe(ident: String,
   private val descriptor = IndexDescriptor(label.nameId.id, propertyKey.nameId.id)
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
-    val baseContext = state.createOrGetInitialContext()
+    val baseContext = state.createOrGetInitialContext(executionContextFactory)
     val resultNodes = state.query.indexScan(descriptor)
     resultNodes.map(node => baseContext.newWith1(ident, ValueUtils.fromNodeProxy(node)))
   }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexSeekPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexSeekPipe.scala
@@ -44,7 +44,7 @@ case class NodeIndexSeekPipe(ident: String,
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
     val index = indexFactory(state)
-    val baseContext = state.createOrGetInitialContext()
+    val baseContext = state.createOrGetInitialContext(executionContextFactory)
     val resultNodes = indexQuery(valueExpr, baseContext, state, index, label.name, propertyKeys.map(_.name))
     resultNodes.map(node => baseContext.newWith1(ident, fromNodeProxy(node)))
   }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeOuterHashJoinPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeOuterHashJoinPipe.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 import org.neo4j.values.AnyValue
 import org.neo4j.values.storable.Values
-import org.neo4j.values.virtual.NodeValue
+import org.neo4j.values.virtual.VirtualNodeValue
 
 import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
@@ -83,7 +83,7 @@ case class NodeOuterHashJoinPipe(nodeVariables: Set[String], source: Pipe, inner
 
     for (idx <- myVariables.indices) {
       key(idx) = context(myVariables(idx)) match {
-        case n: NodeValue => n.id
+        case n: VirtualNodeValue => n.id
         case _ => return None
       }
     }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/Pipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/Pipe.scala
@@ -46,12 +46,21 @@ trait Pipe {
 
   // Used by profiling to identify where to report dbhits and rows
   def id: LogicalPlanId
+
+  // TODO: Alternatively we could pass the logicalPlanId when we create contexts, and in the SlottedQueryState use the
+  // SlotConfigurations map to get the slot configuration needed for the context creation,
+  // but then we would get an extra map lookup at runtime every time we create a new context.
+  protected var executionContextFactory: ExecutionContextFactory = CommunityExecutionContextFactory()
+
+  def setExecutionContextFactory(factory: ExecutionContextFactory) = {
+    executionContextFactory = factory
+  }
 }
 
 case class ArgumentPipe()(val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends Pipe {
 
   def internalCreateResults(state: QueryState) =
-    Iterator(state.createOrGetInitialContext())
+    Iterator(state.createOrGetInitialContext(executionContextFactory))
 }
 
 abstract class PipeWithSource(source: Pipe) extends Pipe {

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/RelationshipCountFromCountStorePipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/RelationshipCountFromCountStorePipe.scala
@@ -41,7 +41,7 @@ case class RelationshipCountFromCountStorePipe(ident: String, startLabel: Option
         0
     }
 
-    val baseContext = state.createOrGetInitialContext()
+    val baseContext = state.createOrGetInitialContext(executionContextFactory)
     Seq(baseContext.newWith1(ident, Values.longValue(count))).iterator
   }
 

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/RemoveLabelsPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/RemoveLabelsPipe.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.runtime.interpreted.CastSupport
 import org.neo4j.cypher.internal.runtime.interpreted.GraphElementPropertyFunctions
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 import org.neo4j.values.storable.Values
-import org.neo4j.values.virtual.NodeValue
+import org.neo4j.values.virtual.VirtualNodeValue
 
 case class RemoveLabelsPipe(src: Pipe, variable: String, labels: Seq[LazyLabel])
                            (val id: LogicalPlanId = LogicalPlanId.DEFAULT)
@@ -34,7 +34,7 @@ case class RemoveLabelsPipe(src: Pipe, variable: String, labels: Seq[LazyLabel])
                                                state: QueryState): Iterator[ExecutionContext] = {
     input.map { row =>
       val item = row.get(variable).get
-      if (item != Values.NO_VALUE) removeLabels(row, state, CastSupport.castOrFail[NodeValue](item).id)
+      if (item != Values.NO_VALUE) removeLabels(row, state, CastSupport.castOrFail[VirtualNodeValue](item).id)
       row
     }
   }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SetOperation.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SetOperation.scala
@@ -28,7 +28,7 @@ import org.neo4j.cypher.internal.util.v3_4.{CypherTypeException, InvalidArgument
 import org.neo4j.graphdb.{Node, PropertyContainer, Relationship}
 import org.neo4j.values.AnyValue
 import org.neo4j.values.storable.Values
-import org.neo4j.values.virtual.{EdgeValue, MapValue, NodeValue}
+import org.neo4j.values.virtual.{VirtualEdgeValue, MapValue, VirtualNodeValue}
 
 import scala.collection.Map
 
@@ -119,7 +119,7 @@ case class SetNodePropertyOperation(nodeName: String, propertyKey: LazyPropertyK
 
   override def name = "SetNodeProperty"
 
-  override protected def id(item: Any) = CastSupport.castOrFail[NodeValue](item).id()
+  override protected def id(item: Any) = CastSupport.castOrFail[VirtualNodeValue](item).id()
 
   override protected def operations(qtx: QueryContext) = qtx.nodeOps
 }
@@ -130,7 +130,7 @@ case class SetRelationshipPropertyOperation(relName: String, propertyKey: LazyPr
 
   override def name = "SetRelationshipProperty"
 
-  override protected def id(item: Any) = CastSupport.castOrFail[EdgeValue](item).id()
+  override protected def id(item: Any) = CastSupport.castOrFail[VirtualEdgeValue](item).id()
 
   override protected def operations(qtx: QueryContext) = qtx.relationshipOps
 }
@@ -144,8 +144,8 @@ case class SetPropertyOperation(entityExpr: Expression, propertyKey: LazyPropert
     val resolvedEntity = entityExpr(executionContext, state)
     if (resolvedEntity != Values.NO_VALUE) {
       val (entityId, ops) = resolvedEntity match {
-        case node: NodeValue => (node.id(), state.query.nodeOps)
-        case rel: EdgeValue => (rel.id(), state.query.relationshipOps)
+        case node: VirtualNodeValue => (node.id(), state.query.nodeOps)
+        case rel: VirtualEdgeValue => (rel.id(), state.query.relationshipOps)
         case _ => throw new InvalidArgumentException(
           s"The expression $entityExpr should have been a node or a relationship, but got $resolvedEntity")
       }
@@ -210,7 +210,7 @@ case class SetNodePropertyFromMapOperation(nodeName: String, expression: Express
 
   override def name = "SetNodePropertyFromMap"
 
-  override protected def id(item: Any) = CastSupport.castOrFail[NodeValue](item).id()
+  override protected def id(item: Any) = CastSupport.castOrFail[VirtualNodeValue](item).id()
 
   override protected def operations(qtx: QueryContext) = qtx.nodeOps
 }
@@ -221,7 +221,7 @@ case class SetRelationshipPropertyFromMapOperation(relName: String, expression: 
 
   override def name = "SetRelationshipPropertyFromMap"
 
-  override protected def id(item: Any) = CastSupport.castOrFail[EdgeValue](item).id()
+  override protected def id(item: Any) = CastSupport.castOrFail[VirtualEdgeValue](item).id()
 
   override protected def operations(qtx: QueryContext) = qtx.relationshipOps
 }
@@ -231,7 +231,7 @@ case class SetLabelsOperation(nodeName: String, labels: Seq[LazyLabel]) extends 
   override def set(executionContext: ExecutionContext, state: QueryState) = {
     val value: AnyValue = executionContext.get(nodeName).get
     if (value != Values.NO_VALUE) {
-      val nodeId = CastSupport.castOrFail[NodeValue](value).id()
+      val nodeId = CastSupport.castOrFail[VirtualNodeValue](value).id()
       val labelIds = labels.map(_.getOrCreateId(state.query).id)
       state.query.setLabelsOnNode(nodeId, labelIds.iterator)
     }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SetOperation.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SetOperation.scala
@@ -28,7 +28,7 @@ import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Expres
 import org.neo4j.graphdb.{Node, PropertyContainer, Relationship}
 import org.neo4j.values.AnyValue
 import org.neo4j.values.storable.Values
-import org.neo4j.values.virtual.{EdgeValue, MapValue, NodeValue}
+import org.neo4j.values.virtual._
 
 import scala.collection.Map
 
@@ -37,6 +37,8 @@ sealed trait SetOperation {
   def set(executionContext: ExecutionContext, state: QueryState): Unit
 
   def name: String
+
+  def needsExclusiveLock: Boolean
 }
 
 object SetOperation {
@@ -93,8 +95,6 @@ abstract class SetEntityPropertyOperation[T <: PropertyContainer](itemName: Stri
                                                                   expression: Expression)
   extends AbstractSetPropertyOperation {
 
-  private val needsExclusiveLock = Expression.hasPropertyReadDependency(itemName, expression, propertyKey.name)
-
   override def set(executionContext: ExecutionContext, state: QueryState) = {
     val item = executionContext.get(itemName).get
     if (item != Values.NO_VALUE) {
@@ -114,23 +114,23 @@ abstract class SetEntityPropertyOperation[T <: PropertyContainer](itemName: Stri
 }
 
 case class SetNodePropertyOperation(nodeName: String, propertyKey: LazyPropertyKey,
-                                    expression: Expression)
+                                    expression: Expression, needsExclusiveLock: Boolean = true)
   extends SetEntityPropertyOperation[Node](nodeName, propertyKey, expression) {
 
   override def name = "SetNodeProperty"
 
-  override protected def id(item: Any) = CastSupport.castOrFail[NodeValue](item).id()
+  override protected def id(item: Any) = CastSupport.castOrFail[VirtualNodeValue](item).id()
 
   override protected def operations(qtx: QueryContext) = qtx.nodeOps
 }
 
 case class SetRelationshipPropertyOperation(relName: String, propertyKey: LazyPropertyKey,
-                                            expression: Expression)
+                                            expression: Expression, needsExclusiveLock: Boolean = true)
   extends SetEntityPropertyOperation[Relationship](relName, propertyKey, expression) {
 
   override def name = "SetRelationshipProperty"
 
-  override protected def id(item: Any) = CastSupport.castOrFail[EdgeValue](item).id()
+  override protected def id(item: Any) = CastSupport.castOrFail[VirtualEdgeValue](item).id()
 
   override protected def operations(qtx: QueryContext) = qtx.relationshipOps
 }
@@ -144,8 +144,8 @@ case class SetPropertyOperation(entityExpr: Expression, propertyKey: LazyPropert
     val resolvedEntity = entityExpr(executionContext, state)
     if (resolvedEntity != Values.NO_VALUE) {
       val (entityId, ops) = resolvedEntity match {
-        case node: NodeValue => (node.id(), state.query.nodeOps)
-        case rel: EdgeValue => (rel.id(), state.query.relationshipOps)
+        case node: VirtualNodeValue => (node.id(), state.query.nodeOps)
+        case rel: VirtualEdgeValue => (rel.id(), state.query.relationshipOps)
         case _ => throw new InvalidArgumentException(
           s"The expression $entityExpr should have been a node or a relationship, but got $resolvedEntity")
       }
@@ -157,13 +157,12 @@ case class SetPropertyOperation(entityExpr: Expression, propertyKey: LazyPropert
       } finally ops.releaseExclusiveLock(entityId)
     }
   }
+
+  override def needsExclusiveLock = true
 }
 
 abstract class SetPropertyFromMapOperation[T <: PropertyContainer](itemName: String, expression: Expression,
                                                                    removeOtherProps: Boolean) extends SetOperation {
-
-  private val needsExclusiveLock = Expression.mapExpressionHasPropertyReadDependency(itemName, expression)
-
   override def set(executionContext: ExecutionContext, state: QueryState) = {
     val item = executionContext.get(itemName).get
     if (item != Values.NO_VALUE) {
@@ -206,23 +205,23 @@ abstract class SetPropertyFromMapOperation[T <: PropertyContainer](itemName: Str
 }
 
 case class SetNodePropertyFromMapOperation(nodeName: String, expression: Expression,
-                                           removeOtherProps: Boolean)
+                                           removeOtherProps: Boolean, needsExclusiveLock: Boolean = true)
   extends SetPropertyFromMapOperation[Node](nodeName, expression, removeOtherProps) {
 
   override def name = "SetNodePropertyFromMap"
 
-  override protected def id(item: Any) = CastSupport.castOrFail[NodeValue](item).id()
+  override protected def id(item: Any) = CastSupport.castOrFail[VirtualNodeValue](item).id()
 
   override protected def operations(qtx: QueryContext) = qtx.nodeOps
 }
 
 case class SetRelationshipPropertyFromMapOperation(relName: String, expression: Expression,
-                                                   removeOtherProps: Boolean)
+                                                   removeOtherProps: Boolean, needsExclusiveLock: Boolean = true)
   extends SetPropertyFromMapOperation[Relationship](relName, expression, removeOtherProps) {
 
   override def name = "SetRelationshipPropertyFromMap"
 
-  override protected def id(item: Any) = CastSupport.castOrFail[EdgeValue](item).id()
+  override protected def id(item: Any) = CastSupport.castOrFail[VirtualEdgeValue](item).id()
 
   override protected def operations(qtx: QueryContext) = qtx.relationshipOps
 }
@@ -232,11 +231,13 @@ case class SetLabelsOperation(nodeName: String, labels: Seq[LazyLabel]) extends 
   override def set(executionContext: ExecutionContext, state: QueryState) = {
     val value: AnyValue = executionContext.get(nodeName).get
     if (value != Values.NO_VALUE) {
-      val nodeId = CastSupport.castOrFail[NodeValue](value).id()
+      val nodeId = CastSupport.castOrFail[VirtualNodeValue](value).id()
       val labelIds = labels.map(_.getOrCreateId(state.query).id)
       state.query.setLabelsOnNode(nodeId, labelIds.iterator)
     }
   }
 
   override def name = "SetLabels"
+
+  override def needsExclusiveLock = false
 }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SkipPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SkipPipe.scala
@@ -33,7 +33,7 @@ case class SkipPipe(source: Pipe, exp: Expression)
     if(input.isEmpty)
       return Iterator.empty
 
-    val skip = asInt(exp(state.createOrGetInitialContext(), state))
+    val skip = asInt(exp(state.createOrGetInitialContext(executionContextFactory), state))
 
     input.drop(skip.value())
   }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/VarLengthExpandPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/VarLengthExpandPipe.scala
@@ -25,7 +25,7 @@ import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection
 import org.neo4j.kernel.impl.util.ValueUtils
 import org.neo4j.values.storable.Values
-import org.neo4j.values.virtual.{EdgeValue, NodeReference, NodeValue, VirtualValues}
+import org.neo4j.values.virtual._
 
 import scala.collection.mutable
 
@@ -88,15 +88,23 @@ case class VarLengthExpandPipe(source: Pipe,
   }
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
+    def expand(row: ExecutionContext, n: NodeValue) = {
+      val paths = varLengthExpand(n, state, max, row)
+      paths.collect {
+        case (node, rels) if rels.length >= min && isToNodeValid(row, state, node) =>
+          row.newWith2(relName, VirtualValues.list(rels: _*), toName, node)
+      }
+    }
+
     input.flatMap {
       row => {
         fetchFromContext(row, state, fromName) match {
-          case n: NodeValue =>
-            val paths = varLengthExpand(n, state, max, row)
-            paths.collect {
-              case (node, rels) if rels.length >= min && isToNodeValid(row, state, node) =>
-                row.newWith2(relName, VirtualValues.list(rels:_*), toName, node)
-            }
+          case node: NodeValue =>
+            expand(row, node)
+
+          case nodeRef: NodeReference =>
+            val node = ValueUtils.fromNodeProxy(state.query.nodeOps.getById(nodeRef.id))
+            expand(row, node)
 
           case Values.NO_VALUE => Iterator(row.newWith2(relName, Values.NO_VALUE, toName, Values.NO_VALUE))
 
@@ -106,16 +114,16 @@ case class VarLengthExpandPipe(source: Pipe,
     }
   }
 
-  private def isToNodeValid(row: ExecutionContext, state: QueryState, node: Any): Boolean =
-    !nodeInScope || fetchFromContext(row, state, toName) == node
+  private def isToNodeValid(row: ExecutionContext, state: QueryState, node: VirtualNodeValue): Boolean =
+    !nodeInScope || {
+      fetchFromContext(row, state, toName) match {
+        case toNode: VirtualNodeValue =>
+          toNode.id == node.id
+        case _ =>
+          false
+      }
+    }
 
   def fetchFromContext(row: ExecutionContext, state: QueryState, name: String): Any =
-    row.getOrElse(name, throw new InternalException(s"Expected to find a node at $name but found nothing")) match {
-      case node: NodeValue =>
-        node
-      case nodeRef: NodeReference =>
-        ValueUtils.fromNodeProxy(state.query.nodeOps.getById(nodeRef.id()))
-      case Values.NO_VALUE =>
-        Values.NO_VALUE
-    }
+    row.getOrElse(name, throw new InternalException(s"Expected to find a node at $name but found nothing"))
 }

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SetPropertyPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SetPropertyPipeTest.scala
@@ -21,39 +21,66 @@ package org.neo4j.cypher.internal.runtime.interpreted.pipes
 
 import org.mockito.ArgumentMatchers.{anyInt, anyLong}
 import org.mockito.Mockito._
-import org.neo4j.cypher.internal.util.v3_4.{InputPosition, PropertyKeyId}
-import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions._
-import org.neo4j.cypher.internal.runtime.interpreted.commands.values.{KeyToken, TokenType}
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.SemanticTable
+import org.neo4j.cypher.internal.planner.v3_4.spi.TokenContext
+import org.neo4j.cypher.internal.runtime.interpreted.commands.convert.{CommunityExpressionConverter, ExpressionConverters}
+import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions._
+import org.neo4j.cypher.internal.runtime.interpreted.commands.values.KeyToken
 import org.neo4j.cypher.internal.runtime.{Operations, QueryContext}
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.util.v3_4.{DummyPosition, PropertyKeyId}
 import org.neo4j.cypher.internal.v3_4.expressions.PropertyKeyName
+import org.neo4j.cypher.internal.v3_4.{expressions => ast}
 import org.neo4j.graphdb.{Node, Relationship}
 import org.neo4j.values.storable.Values
 import org.neo4j.values.storable.Values.longValue
 
 class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
+  private val pos = DummyPosition(0)
+  private val entity1 = "x"
+  private val entity2 = "y"
+  private val property1 = "prop"
+  private val property2 = "prop2"
+  private val propertyKey1 = PropertyKeyName(property1)(pos)
+  private val propertyKey2 = PropertyKeyName(property2)(pos)
+  private val literalInt1 = ast.SignedDecimalIntegerLiteral("1")(pos)
 
-  implicit val table = new SemanticTable()
-  table.resolvedPropertyKeyNames.put("prop", PropertyKeyId(1))
-  table.resolvedPropertyKeyNames.put("prop2", PropertyKeyId(2))
+  private implicit val table = new SemanticTable()
+  table.resolvedPropertyKeyNames.put(property1, PropertyKeyId(1))
+  table.resolvedPropertyKeyNames.put(property2, PropertyKeyId(2))
 
-  val state = mock[QueryState]
-  val qtx = mock[QueryContext]
+  private val state = mock[QueryState]
+  private val qtx = mock[QueryContext]
+  when(qtx.getOptPropertyKeyId(property1)).thenReturn(Some(1))
+  when(qtx.getOptPropertyKeyId(property2)).thenReturn(Some(2))
   when(state.query).thenReturn(qtx)
   when(state.decorator).thenReturn(NullPipeDecorator)
-  val emptyExpression = mock[Expression]
+  private val emptyExpression = mock[Expression]
   when(emptyExpression.children).thenReturn(Seq.empty)
+
+  private val expressionConverter = new ExpressionConverters(CommunityExpressionConverter)
+  private def convertExpression(astExpression: ast.Expression): Expression = {
+    def resolveTokens(expr: Expression, ctx: TokenContext): Expression = expr match {
+      case (keyToken: KeyToken) => keyToken.resolve(ctx)
+      case _ => expr
+    }
+
+    expressionConverter.toCommandExpression(astExpression).rewrite(resolveTokens(_, qtx))
+  }
 
   // match (n) set n.prop = n.prop + 1
   test("should grab an exclusive lock if the rhs reads from the same node property") {
-    val rhs = Add(Property(Variable("n"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))
-    val mockedSource = newMockedPipe("n", row("n" -> newMockedNode(10)))
-    val pipe = SetPipe(mockedSource, SetNodePropertyOperation("n", LazyPropertyKey(PropertyKeyName("prop")(InputPosition.NONE)), rhs))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedNode(10)))
+    val astRhs: ast.Expression = ast.Add(ast.Property(ast.Variable(entity1)(pos), propertyKey1)(pos), literalInt1)(pos)
+    val needsExclusiveLock = ast.Expression.hasPropertyReadDependency(entity1, astRhs, propertyKey1)
+    val rhs = convertExpression(astRhs)
+    val pipe = SetPipe(mockedSource, SetNodePropertyOperation(entity1, LazyPropertyKey(propertyKey1), rhs, needsExclusiveLock))()
 
     val nodeOps = mock[Operations[Node]]
     when(nodeOps.getProperty(10L, 1)).thenReturn(longValue(13L))
     when(qtx.nodeOps).thenReturn(nodeOps)
+
+    needsExclusiveLock shouldBe true
 
     pipe.createResults(state).toVector
     verify(nodeOps).acquireExclusiveLock(10)
@@ -62,13 +89,18 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
 
   // match ()-[r]-() set r.prop = r.prop + 1
   test("should grab an exclusive lock if the rhs reads from the same relationship property") {
-    val rhs = Add(Property(Variable("r"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))
-    val mockedSource = newMockedPipe("r", row("r" -> newMockedRelationship(10, mock[Node], mock[Node])))
-    val pipe = SetPipe(mockedSource, SetRelationshipPropertyOperation("r", LazyPropertyKey(PropertyKeyName("prop")(InputPosition.NONE)), rhs))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedRelationship(10, mock[Node], mock[Node])))
+    val astRhs: ast.Expression = ast.Add(ast.Property(ast.Variable(entity1)(pos), propertyKey1)(pos), literalInt1)(pos)
+    val needsExclusiveLock = ast.Expression.hasPropertyReadDependency(entity1, astRhs, propertyKey1)
+    val rhs = convertExpression(astRhs)
+    val pipe = SetPipe(mockedSource,
+      SetRelationshipPropertyOperation(entity1, LazyPropertyKey(propertyKey1), rhs, needsExclusiveLock))()
 
     val relOps = mock[Operations[Relationship]]
     when(qtx.relationshipOps).thenReturn(relOps)
     when(relOps.getProperty(anyLong(), anyInt())).thenReturn(Values.NO_VALUE)
+
+    needsExclusiveLock shouldBe true
 
     pipe.createResults(state).toVector
     verify(relOps).acquireExclusiveLock(10)
@@ -77,13 +109,18 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
 
   // match (n) set n.prop2 = n.prop + 1
   test("should not grab an exclusive lock if the rhs reads from another node property") {
-    val rhs = Add(Property(Variable("n"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))
-    val mockedSource = newMockedPipe("n", row("n" -> newMockedNode(10)))
-    val pipe = SetPipe(mockedSource, SetNodePropertyOperation("n", LazyPropertyKey(PropertyKeyName("prop2")(InputPosition.NONE)), rhs))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedNode(10)))
+    val astRhs: ast.Expression = ast.Add(ast.Property(ast.Variable(entity1)(pos), propertyKey1)(pos), literalInt1)(pos)
+    val needsExclusiveLock = ast.Expression.hasPropertyReadDependency(entity1, astRhs, propertyKey2)
+    val rhs = convertExpression(astRhs)
+    val pipe = SetPipe(mockedSource,
+      SetNodePropertyOperation(entity1, LazyPropertyKey(propertyKey2), rhs, needsExclusiveLock))()
 
     val nodeOps = mock[Operations[Node]]
     when(nodeOps.getProperty(10L, 1)).thenReturn(longValue(13L))
     when(qtx.nodeOps).thenReturn(nodeOps)
+
+    needsExclusiveLock shouldBe false
 
     pipe.createResults(state).toVector
     verify(nodeOps, never()).acquireExclusiveLock(10)
@@ -92,13 +129,19 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
 
   // match ()-[r]-() set r.prop2 = r.prop + 1
   test("should not grab an exclusive lock if the rhs reads from another relationship property") {
-    val rhs = Add(Property(Variable("r"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))
-    val mockedSource = newMockedPipe("r", row("r" -> newMockedRelationship(10, mock[Node], mock[Node])))
-    val pipe = SetPipe(mockedSource, SetRelationshipPropertyOperation("r", LazyPropertyKey(PropertyKeyName("prop2")(InputPosition.NONE)), rhs))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedRelationship(10, mock[Node], mock[Node])))
+
+    val astRhs: ast.Expression = ast.Add(ast.Property(ast.Variable(entity1)(pos), propertyKey1)(pos), ast.SignedDecimalIntegerLiteral("1")(pos))(pos)
+    val needsExclusiveLock = ast.Expression.hasPropertyReadDependency(entity1, astRhs, propertyKey2)
+    val rhs = convertExpression(astRhs)
+    val pipe = SetPipe(mockedSource,
+      SetRelationshipPropertyOperation(entity1, LazyPropertyKey(propertyKey2), rhs, needsExclusiveLock))()
 
     val relOps = mock[Operations[Relationship]]
     when(qtx.relationshipOps).thenReturn(relOps)
     when(relOps.getProperty(anyLong(), anyInt())).thenReturn(Values.NO_VALUE)
+
+    needsExclusiveLock shouldBe false
 
     pipe.createResults(state).toVector
     verify(relOps, never()).acquireExclusiveLock(10)
@@ -107,13 +150,18 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
 
   // match (n), (n2) set n2.prop = n.prop + 1
   test("should not grab an exclusive lock if the rhs reads from the same node property on another node") {
-    val rhs = Add(Property(Variable("n"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))
-    val mockedSource = newMockedPipe("n", row("n" -> newMockedNode(10), "n2" -> newMockedNode(20)))
-    val pipe = SetPipe(mockedSource, SetNodePropertyOperation("n2", LazyPropertyKey(PropertyKeyName("prop")(InputPosition.NONE)), rhs))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedNode(10), entity2 -> newMockedNode(20)))
+    val astRhs: ast.Expression = ast.Add(ast.Property(ast.Variable(entity1)(pos), propertyKey1)(pos), ast.SignedDecimalIntegerLiteral("1")(pos))(pos)
+    val needsExclusiveLock = ast.Expression.hasPropertyReadDependency(entity2, astRhs, propertyKey1)
+    val rhs = convertExpression(astRhs)
+    val pipe = SetPipe(mockedSource,
+      SetNodePropertyOperation(entity2, LazyPropertyKey(propertyKey1), rhs, needsExclusiveLock))()
 
     val nodeOps = mock[Operations[Node]]
     when(nodeOps.getProperty(10L, 1)).thenReturn(longValue(13L))
     when(qtx.nodeOps).thenReturn(nodeOps)
+
+    needsExclusiveLock shouldBe false
 
     pipe.createResults(state).toVector
     verify(nodeOps, never()).acquireExclusiveLock(10)
@@ -124,14 +172,19 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
 
   // match ()-[r]-(), ()-[r2]-() set r2.prop = r.prop + 1
   test("should not grab an exclusive lock if the rhs reads from the same relationship property on another relationship") {
-    val rhs = Add(Property(Variable("r"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))
-    val mockedSource = newMockedPipe("r", row("r" -> newMockedRelationship(10, mock[Node], mock[Node]),
-                                              "r2" -> newMockedRelationship(20, mock[Node], mock[Node])))
-    val pipe = SetPipe(mockedSource, SetRelationshipPropertyOperation("r2", LazyPropertyKey(PropertyKeyName("prop")(InputPosition.NONE)), rhs))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedRelationship(10, mock[Node], mock[Node]),
+                                                  entity2 -> newMockedRelationship(20, mock[Node], mock[Node])))
+    val astRhs: ast.Expression = ast.Add(ast.Property(ast.Variable(entity1)(pos), propertyKey1)(pos), ast.SignedDecimalIntegerLiteral("1")(pos))(pos)
+    val needsExclusiveLock = ast.Expression.hasPropertyReadDependency(entity2, astRhs, propertyKey1)
+    val rhs = convertExpression(astRhs)
+    val pipe = SetPipe(mockedSource,
+      SetRelationshipPropertyOperation(entity2, LazyPropertyKey(propertyKey1), rhs, needsExclusiveLock))()
 
     val relOps = mock[Operations[Relationship]]
     when(qtx.relationshipOps).thenReturn(relOps)
     when(relOps.getProperty(anyLong(), anyInt())).thenReturn(Values.NO_VALUE)
+
+    needsExclusiveLock shouldBe false
 
     pipe.createResults(state).toVector
     verify(relOps, never()).acquireExclusiveLock(10)
@@ -142,15 +195,21 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
 
   // match n set n += { prop: n.prop + 1 }
   test("should grab an exclusive lock when setting node props from a map with dependencies") {
-    val rhs = LiteralMap(Map("prop" -> Add(Property(Variable("n"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))))
-    val mockedSource = newMockedPipe("n", row("n" -> newMockedNode(10)))
-    val pipe = SetPipe(mockedSource, SetNodePropertyFromMapOperation("n", rhs, removeOtherProps = false))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedNode(10)))
+
+    val innerAst = ast.Add(ast.Property(ast.Variable(entity1)(pos), propertyKey1)(pos), ast.SignedDecimalIntegerLiteral("1")(pos))(pos)
+    val astRhs = ast.MapExpression(Seq(propertyKey1 -> innerAst))(pos)
+    val needsExclusiveLock = ast.Expression.mapExpressionHasPropertyReadDependency(entity1, astRhs)
+    val rhs = convertExpression(astRhs)
+    val pipe = SetPipe(mockedSource, SetNodePropertyFromMapOperation(entity1, rhs, removeOtherProps = false, needsExclusiveLock))()
 
     val nodeOps = mock[Operations[Node]]
     when(nodeOps.getProperty(10L, 1)).thenReturn(longValue(13L))
     when(qtx.nodeOps).thenReturn(nodeOps)
-    when(qtx.getOptPropertyKeyId("prop")).thenReturn(None)
+    when(qtx.getOptPropertyKeyId(property1)).thenReturn(None)
     when(nodeOps.propertyKeyIds(10)).thenReturn(Iterator.empty)
+
+    needsExclusiveLock shouldBe true
 
     pipe.createResults(state).toVector
     verify(nodeOps).acquireExclusiveLock(10)
@@ -159,15 +218,22 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
 
   // match ()-[r]-() set r = { prop: r.prop + 1 }
   test("should grab an exclusive lock when setting rel props from a map with dependencies") {
-    val rhs = LiteralMap(Map("prop" -> Add(Property(Variable("r"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))))
-    val mockedSource = newMockedPipe("r", row("r" -> newMockedRelationship(10, mock[Node], mock[Node])))
-    val pipe = SetPipe(mockedSource, SetRelationshipPropertyFromMapOperation("r", rhs, removeOtherProps = true))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedRelationship(10, mock[Node], mock[Node])))
+    val innerAst = ast.Add(ast.Property(ast.Variable(entity1)(pos), propertyKey1)(pos), ast.SignedDecimalIntegerLiteral("1")(pos))(pos)
+    val astRhs = ast.MapExpression(Seq(propertyKey1 -> innerAst))(pos)
+    val needsExclusiveLock = ast.Expression.mapExpressionHasPropertyReadDependency(entity1, astRhs)
+    val rhs = convertExpression(astRhs)
+
+    val pipe = SetPipe(mockedSource,
+      SetRelationshipPropertyFromMapOperation(entity1, rhs, removeOtherProps = true, needsExclusiveLock))()
 
     val relOps = mock[Operations[Relationship]]
     when(qtx.relationshipOps).thenReturn(relOps)
-    when(qtx.getOptPropertyKeyId("prop")).thenReturn(None)
+    when(qtx.getOptPropertyKeyId(property1)).thenReturn(None)
     when(relOps.propertyKeyIds(10)).thenReturn(Iterator.empty)
     when(relOps.getProperty(anyLong(), anyInt())).thenReturn(Values.NO_VALUE)
+
+    needsExclusiveLock shouldBe true
 
     pipe.createResults(state).toVector
     verify(relOps).acquireExclusiveLock(10)
@@ -176,16 +242,23 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
 
   // match (n), (n2) set n += { prop: n2.prop + 1 }
   test("should not grab an exclusive lock when setting node props from a map with same prop but other node") {
-    val rhs = LiteralMap(Map("prop" -> Add(Property(Variable("n2"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))))
-    val mockedSource = newMockedPipe("n", row("n" -> newMockedNode(10), "n2" -> newMockedNode(20)))
-    val pipe = SetPipe(mockedSource, SetNodePropertyFromMapOperation("n", rhs, removeOtherProps = false))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedNode(10), entity2 -> newMockedNode(20)))
+
+    val innerAst = ast.Add(ast.Property(ast.Variable(entity2)(pos), propertyKey1)(pos), ast.SignedDecimalIntegerLiteral("1")(pos))(pos)
+    val astRhs = ast.MapExpression(Seq(propertyKey1 -> innerAst))(pos)
+    val needsExclusiveLock = ast.Expression.mapExpressionHasPropertyReadDependency(entity1, astRhs)
+    val rhs = convertExpression(astRhs)
+    val pipe = SetPipe(mockedSource,
+      SetNodePropertyFromMapOperation(entity1, rhs, removeOtherProps = false, needsExclusiveLock))()
 
     val nodeOps = mock[Operations[Node]]
     when(nodeOps.getProperty(10L, 1)).thenReturn(longValue(13L))
     when(nodeOps.getProperty(20L, 1)).thenReturn(longValue(13L))
     when(qtx.nodeOps).thenReturn(nodeOps)
-    when(qtx.getOptPropertyKeyId("prop")).thenReturn(None)
+    when(qtx.getOptPropertyKeyId(property1)).thenReturn(None)
     when(nodeOps.propertyKeyIds(10)).thenReturn(Iterator.empty)
+
+    needsExclusiveLock shouldBe false
 
     pipe.createResults(state).toVector
     verify(nodeOps, never()).acquireExclusiveLock(10)
@@ -197,16 +270,22 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
 
   // match ()-[r]-(), ()-[r2]-() set r = { prop: r2.prop + 1 }
   test("should not grab an exclusive lock when setting rel props from a map with same prop but other rel") {
-    val rhs = LiteralMap(Map("prop" -> Add(Property(Variable("r2"), KeyToken.Resolved("prop", 1, TokenType.PropertyKey)), Literal(1))))
-    val mockedSource = newMockedPipe("r", row("r" -> newMockedRelationship(10, mock[Node], mock[Node]),
-                                              "r2" -> newMockedRelationship(20, mock[Node], mock[Node])))
-    val pipe = SetPipe(mockedSource, SetRelationshipPropertyFromMapOperation("r", rhs, removeOtherProps = true))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedRelationship(10, mock[Node], mock[Node]),
+                                                  entity2 -> newMockedRelationship(20, mock[Node], mock[Node])))
+    val innerAst = ast.Add(ast.Property(ast.Variable(entity2)(pos), propertyKey1)(pos), ast.SignedDecimalIntegerLiteral("1")(pos))(pos)
+    val astRhs = ast.MapExpression(Seq(propertyKey1 -> innerAst))(pos)
+    val needsExclusiveLock = ast.Expression.mapExpressionHasPropertyReadDependency(entity1, astRhs)
+    val rhs = convertExpression(astRhs)
+    val pipe = SetPipe(mockedSource,
+      SetRelationshipPropertyFromMapOperation(entity1, rhs, removeOtherProps = true, needsExclusiveLock))()
 
     val relOps = mock[Operations[Relationship]]
     when(qtx.relationshipOps).thenReturn(relOps)
-    when(qtx.getOptPropertyKeyId("prop")).thenReturn(None)
+    when(qtx.getOptPropertyKeyId(property1)).thenReturn(None)
     when(relOps.propertyKeyIds(10)).thenReturn(Iterator.empty)
     when(relOps.getProperty(anyLong(), anyInt())).thenReturn(Values.NO_VALUE)
+
+    needsExclusiveLock shouldBe false
 
     pipe.createResults(state).toVector
     verify(relOps, never()).acquireExclusiveLock(10)
@@ -217,15 +296,23 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
 
   // match (n) set n += { prop: n.prop2 + 1 }
   test("should not grab an exclusive lock when setting node props from a map with same node but other prop") {
-    val rhs = LiteralMap(Map("prop" -> Add(Property(Variable("n"), KeyToken.Resolved("prop2", 2, TokenType.PropertyKey)), Literal(1))))
-    val mockedSource = newMockedPipe("n", row("n" -> newMockedNode(10)))
-    val pipe = SetPipe(mockedSource, SetNodePropertyFromMapOperation("n", rhs, removeOtherProps = false))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedNode(10)))
+
+    val innerAst = ast.Add(ast.Property(ast.Variable(entity1)(pos), propertyKey2)(pos), ast.SignedDecimalIntegerLiteral("1")(pos))(pos)
+    val astRhs = ast.MapExpression(Seq(propertyKey1 -> innerAst))(pos)
+    val needsExclusiveLock = ast.Expression.mapExpressionHasPropertyReadDependency(entity1, astRhs)
+    val rhs = convertExpression(astRhs)
+
+    val pipe = SetPipe(mockedSource,
+      SetNodePropertyFromMapOperation(entity1, rhs, removeOtherProps = false, needsExclusiveLock))()
 
     val nodeOps = mock[Operations[Node]]
     when(nodeOps.getProperty(10L, 2)).thenReturn(longValue(13L))
     when(qtx.nodeOps).thenReturn(nodeOps)
-    when(qtx.getOptPropertyKeyId("prop")).thenReturn(None)
+    when(qtx.getOptPropertyKeyId(property1)).thenReturn(None)
     when(nodeOps.propertyKeyIds(10)).thenReturn(Iterator.empty)
+
+    needsExclusiveLock shouldBe false
 
     pipe.createResults(state).toVector
     verify(nodeOps, never()).acquireExclusiveLock(10)
@@ -235,15 +322,22 @@ class SetPropertyPipeTest extends CypherFunSuite with PipeTestSupport {
 
   // match ()-[r]-() set r = { prop: r.prop2 + 1 }
   test("should not grab an exclusive lock when setting rel props from a map with same rel but other prop") {
-    val rhs = LiteralMap(Map("prop" -> Add(Property(Variable("r"), KeyToken.Resolved("prop2", 2, TokenType.PropertyKey)), Literal(1))))
-    val mockedSource = newMockedPipe("r", row("r" -> newMockedRelationship(10, mock[Node], mock[Node])))
-    val pipe = SetPipe(mockedSource, SetRelationshipPropertyFromMapOperation("r", rhs, removeOtherProps = true))()
+    val mockedSource = newMockedPipe(entity1, row(entity1 -> newMockedRelationship(10, mock[Node], mock[Node])))
+
+    val innerAst = ast.Add(ast.Property(ast.Variable(entity1)(pos), propertyKey2)(pos), ast.SignedDecimalIntegerLiteral("1")(pos))(pos)
+    val astRhs = ast.MapExpression(Seq(propertyKey1 -> innerAst))(pos)
+    val needsExclusiveLock = ast.Expression.mapExpressionHasPropertyReadDependency(entity1, astRhs)
+    val rhs = convertExpression(astRhs)
+    val pipe = SetPipe(mockedSource,
+      SetRelationshipPropertyFromMapOperation(entity1, rhs, removeOtherProps = true, needsExclusiveLock))()
 
     val relOps = mock[Operations[Relationship]]
     when(qtx.relationshipOps).thenReturn(relOps)
-    when(qtx.getOptPropertyKeyId("prop")).thenReturn(None)
+    when(qtx.getOptPropertyKeyId(property1)).thenReturn(None)
     when(relOps.propertyKeyIds(10)).thenReturn(Iterator.empty)
     when(relOps.getProperty(anyLong(), anyInt())).thenReturn(Values.NO_VALUE)
+
+    needsExclusiveLock shouldBe false
 
     pipe.createResults(state).toVector
     verify(relOps, never()).acquireExclusiveLock(10)

--- a/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/IdName.scala
+++ b/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/IdName.scala
@@ -19,12 +19,12 @@
  */
 package org.neo4j.cypher.internal.ir.v3_4
 
-import org.neo4j.cypher.internal.v3_4.expressions.Variable
+import org.neo4j.cypher.internal.v3_4.expressions.LogicalVariable
 
 final case class IdName(name: String)
 
 object IdName {
   implicit val byName = Ordering[String].on[IdName](_.name)
 
-  def fromVariable(variable: Variable) = IdName(variable.name)
+  def fromVariable(variable: LogicalVariable) = IdName(variable.name)
 }

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/AssertionUtils.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/AssertionUtils.scala
@@ -14,14 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.neo4j.cypher.internal.v3_4.expressions
+package org.neo4j.cypher.internal.util.v3_4
 
-import org.neo4j.cypher.internal.util.v3_4.NonEmptyList
+import org.neo4j.cypher.internal.util.v3_4.AssertionRunner.Thunk
 
-case class AndedPropertyInequalities(
-                                      variable: LogicalVariable,
-                                      property: LogicalProperty,
-                                      inequalities: NonEmptyList[InequalityExpression]
-                                    ) extends Expression {
-  def position = variable.position
+object AssertionUtils {
+  def ifAssertionsEnabled(f: => Unit): Unit = {
+    AssertionRunner.runUnderAssertion(new Thunk {
+      override def apply() = f
+    })
+  }
 }

--- a/community/values/src/main/java/org/neo4j/values/virtual/VirtualEdgeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/VirtualEdgeValue.java
@@ -25,7 +25,7 @@ import java.util.Comparator;
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.VirtualValue;
 
-abstract class VirtualEdgeValue extends VirtualValue
+public abstract class VirtualEdgeValue extends VirtualValue
 {
     public abstract long id();
 

--- a/community/values/src/main/java/org/neo4j/values/virtual/VirtualNodeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/VirtualNodeValue.java
@@ -25,7 +25,7 @@ import java.util.Comparator;
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.VirtualValue;
 
-abstract class VirtualNodeValue extends VirtualValue
+public abstract class VirtualNodeValue extends VirtualValue
 {
     public abstract long id();
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -1,20 +1,11 @@
 Shorthand case with filter should work as expected
 Add labels inside FOREACH
-Merge using unique constraint should update existing node
-Merge using unique constraint should create missing node
-Should match on merge using multiple unique indexes if only found single node for both indexes
-Should match on merge using multiple unique indexes and labels if only found single node for both indexes
-Should match on merge using multiple unique indexes using same key if only found single node for both indexes
-Should create on merge using multiple unique indexes if found no nodes
-Should create on merge using multiple unique indexes and labels if found no nodes
 Should fail on merge using multiple unique indexes using same key if found different nodes
 Should fail on merge using multiple unique indexes if found different nodes
 Should fail on merge using multiple unique indexes if it found a node matching single property only
 Should fail on merge using multiple unique indexes if it found a node matching single property only flipped order
 Should fail on merge using multiple unique indexes and labels if found different nodes
 Merge with uniqueness constraints must properly handle multiple labels
-Works with property repeated in literal map in set
-Works with property in map that gets set
 Failing when creation would violate constraint
 Explanation of in-query procedure call
 Merging inside a FOREACH using a previously matched node
@@ -25,21 +16,10 @@ Inside nested FOREACH
 Inside nested FOREACH, nodes inlined
 Should handle running merge inside a foreach loop
 Merge inside foreach should see variables introduced by update actions outside foreach
-Using a single bound node
-Using a longer pattern
-Using bound nodes in mid-pattern
-Using bound nodes in mid-pattern when pattern partly matches
-Introduce named paths
 Returning a pattern expression with bound nodes
 Using a variable-length pattern expression in a WITH
 Pattern expression inside list comprehension
-Filter using a pattern predicate that is a logical OR between an expression and a subquery
-Filter using a pattern predicate that is a logical OR between two expressions and a subquery
-Filter using a pattern predicate that is a logical OR between one expression and a negated subquery
-Filter using a pattern predicate that is a logical OR between one subquery and a negated subquery
-Filter using a pattern predicate that is a logical OR between one negated subquery and a subquery
 Filter using a pattern predicate that is a logical OR between two subqueries
-Filter using a pattern predicate that is a logical OR between one negated subquery, a subquery, and an equality expression
 Filter using a pattern predicate that is a logical OR between one negated subquery, two subqueries, and an equality expression
 Filter using a pattern predicate that is a logical OR between one negated subquery, two subqueries, and an equality expression 2
 Using a pattern predicate after aggregation 1

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeNodeKeyConstraintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeNodeKeyConstraintAcceptanceTest.scala
@@ -157,7 +157,7 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
     createLabeledNode(Map("name" -> "A"), "Person")
     graph.execute("CREATE CONSTRAINT ON (person:Person) ASSERT (person.name) IS NODE KEY".fixNewLines)
 
-    val config = TestConfiguration(Versions.Default, Planners.Default, Runtimes(Interpreted, ProcedureOrSchema)) +
+    val config = TestConfiguration(Versions.Default, Planners.Default, Runtimes(Interpreted, Slotted, ProcedureOrSchema)) +
         TestConfiguration(V3_1 -> V3_1, Cost, Runtimes.Default) +
         TestConfiguration(Versions(V2_3, V3_1, Versions.Default), Rule, Runtimes.Default)
     failWithError(
@@ -171,7 +171,7 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
     createLabeledNode(Map("name" -> "A", "surname" -> "B"), "Person")
     graph.execute("CREATE CONSTRAINT ON (person:Person) ASSERT (person.name, person.surname) IS NODE KEY".fixNewLines)
 
-    val config = TestConfiguration(Versions.Default, Planners.Default, Runtimes(Interpreted, ProcedureOrSchema)) +
+    val config = TestConfiguration(Versions.Default, Planners.Default, Runtimes(Interpreted, Slotted, ProcedureOrSchema)) +
         TestConfiguration(V3_1, Cost, Runtimes.Default) +
         TestConfiguration(Versions(V2_3, V3_1, Versions.Default), Rule, Runtimes.Default)
     failWithError(
@@ -223,7 +223,7 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
     createLabeledNode(Map("name" -> "A", "surname" -> "B"), "Person")
     graph.execute("CREATE CONSTRAINT ON (person:Person) ASSERT (person.name, person.surname) IS NODE KEY".fixNewLines)
 
-    val config = TestConfiguration(Versions.Default, Planners.Default, Runtimes(Interpreted, ProcedureOrSchema)) +
+    val config = TestConfiguration(Versions.Default, Planners.Default, Runtimes(Interpreted, Slotted, ProcedureOrSchema)) +
         TestConfiguration(V3_1, Cost, Runtimes.Default) +
         TestConfiguration(Versions(V2_3, V3_1, Versions.Default), Rule, Runtimes.Default)
     failWithError(
@@ -237,7 +237,7 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
     createLabeledNode(Map("name" -> "A", "surname" -> "B"), "Person")
     graph.execute("CREATE CONSTRAINT ON (person:Person) ASSERT (person.name, person.surname) IS NODE KEY".fixNewLines)
 
-    val config = TestConfiguration(Versions.Default, Planners.Default, Runtimes(Interpreted, ProcedureOrSchema)) +
+    val config = TestConfiguration(Versions.Default, Planners.Default, Runtimes(Interpreted, Slotted, ProcedureOrSchema)) +
         TestConfiguration(V3_1, Cost, Runtimes.Default) +
         TestConfiguration(Versions(V2_3, V3_1, Versions.Default), Rule, Runtimes.Default)
     failWithError(
@@ -280,7 +280,7 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
     val id = createLabeledNode(Map("firstname" -> "John", "surname" -> "Wood"), "Person").getId
 
     // Expect
-    val config = TestConfiguration(Versions.Default, Planners.Default, Runtimes(Interpreted, ProcedureOrSchema)) +
+    val config = TestConfiguration(Versions.Default, Planners.Default, Runtimes(Interpreted, Slotted, ProcedureOrSchema)) +
         TestConfiguration(V3_1, Planners.all, Runtimes.Default) +
         TestConfiguration(Versions(V2_3, Versions.Default), Rule, Runtimes.Default)
     failWithError(config,
@@ -295,7 +295,7 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
     val node = createLabeledNode(Map("firstname" -> "John", "surname" -> "Wood", "foo" -> "bar"), "Person")
 
     // When
-    val config = TestScenario(Versions.Default, Planners.Default, Interpreted) +
+    val config = TestConfiguration(Versions.Default, Planners.Default, Runtimes(Interpreted, Slotted)) +
       TestConfiguration(V3_1, Planners.all, Runtimes.Default) +
       TestConfiguration(Versions(Versions.Default, V2_3), Rule, Runtimes.Default)
     executeWith(config, "MATCH (p:Person {firstname: 'John', surname: 'Wood'}) REMOVE p.foo".fixNewLines)
@@ -312,7 +312,7 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
     createLabeledNode(Map("firstname" -> "John", "surname" -> "Wood", "foo" -> "bar"), "Person")
 
     // When
-    val configWhen = TestScenario(Versions.Default, Planners.Default, Interpreted) +
+    val configWhen = TestConfiguration(Versions.Default, Planners.Default, Runtimes(Interpreted, Slotted)) +
       TestConfiguration(V3_1, Planners.all, Runtimes.Default) +
       TestConfiguration(Versions(Versions.Default, V2_3), Rule, Runtimes.Default)
     executeWith(configWhen, "MATCH (p:Person {firstname: 'John', surname: 'Wood'}) DELETE p".fixNewLines)
@@ -330,7 +330,7 @@ class CompositeNodeKeyConstraintAcceptanceTest extends ExecutionEngineFunSuite w
     createLabeledNode(Map("firstname" -> "John", "surname" -> "Wood", "foo" -> "bar"), "Person")
 
     // When
-    val configWhen = TestScenario(Versions.Default, Planners.Default, Interpreted) +
+    val configWhen = TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Slotted)) +
       TestConfiguration(V3_1, Planners.all, Runtimes.Default) +
       TestConfiguration(Versions(Versions.Default, V2_3), Rule, Runtimes.Default)
     executeWith(configWhen, "MATCH (p:Person {firstname: 'John', surname: 'Wood'}) REMOVE p:Person".fixNewLines)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateAcceptanceTest.scala
@@ -42,7 +42,7 @@ class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
     createNode(("foo", 42), ("bar", "fu"))
     val query = "MATCH (a) SET a = {props} RETURN a.foo, a.bar"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, params = Map("props" -> Map("foo" -> null, "bar" -> "baz")))
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query, params = Map("props" -> Map("foo" -> null, "bar" -> "baz")))
 
     result.toSet should equal(Set(Map("a.foo" -> null, "a.bar" -> "baz")))
     assertStats(result, propertiesWritten = 2)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
@@ -61,7 +61,7 @@ class EagerizationAcceptanceTest
         |RETURN n.val AS nv, m.val AS mv
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Cost2_3 + Configs.Rule2_3))
 
     result.toList should equal(List(Map("nv" -> 2, "mv" -> 2),
@@ -81,7 +81,7 @@ class EagerizationAcceptanceTest
         |RETURN n.val AS nv, m.val AS mv
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
 
     result.toList should equal(List(Map("nv" -> 2, "mv" -> 2),
@@ -104,7 +104,7 @@ class EagerizationAcceptanceTest
       """.stripMargin
 
     val result = executeWith(
-      Configs.CommunityInterpreted - Configs.Cost2_3, query,
+      Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
 
     result.toList should equal(List(Map("nv" -> 2, "mv" -> 2),
@@ -124,7 +124,7 @@ class EagerizationAcceptanceTest
       """.stripMargin
 
     val result = executeWith(
-      Configs.CommunityInterpreted - Configs.Cost2_3,
+      Configs.Interpreted - Configs.Cost2_3,
       expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3),
       query = query)
@@ -146,7 +146,7 @@ class EagerizationAcceptanceTest
       """.stripMargin
 
     val result = executeWith(
-      Configs.CommunityInterpreted - Configs.Cost2_3,
+      Configs.Interpreted - Configs.Cost2_3,
       expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1),
       query = query)
@@ -167,7 +167,7 @@ class EagerizationAcceptanceTest
         |RETURN count(*)
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query = query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query = query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
 
     result.columnAs[Long]("count(*)").next should equal(2)
@@ -180,7 +180,7 @@ class EagerizationAcceptanceTest
     relate(a, b, "T")
     val query = "MATCH (a)-[t:T]-(b) DELETE t RETURN count(*) as count"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query = query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query = query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsDeleted = 1)
@@ -409,7 +409,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH p=(:L)-[*]-() DELETE p RETURN count(*) as count"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsDeleted = 1, nodesDeleted = 2)
@@ -422,7 +422,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH p=(:L)-[*]-() DETACH DELETE p RETURN count(*) as count"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsDeleted = 1, nodesDeleted = 2)
@@ -432,7 +432,7 @@ class EagerizationAcceptanceTest
     graph.execute("CREATE (a:Person {id: 42})-[:FRIEND_OF]->(b:Person {id:42}), (b)-[:FRIEND_OF]->(a), (:Person)-[:FRIEND_OF]->(b)")
 
     val query = "MATCH (p1:Person {id: 42})-[r:FRIEND_OF]->(p2:Person {id:42}) DETACH DELETE r, p1, p2 RETURN count(*) AS count"
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsDeleted = 3, nodesDeleted = 2)
@@ -442,7 +442,7 @@ class EagerizationAcceptanceTest
     graph.execute("CREATE (a:Person {id: 42})-[:FRIEND_OF]->(b:Person {id:42}), (b)-[:FRIEND_OF]->(a), (:Person)-[:FRIEND_OF]->(b)")
 
     val query = "MATCH p = (p1:Person {id: 42})-[r:FRIEND_OF]->(p2:Person {id:42}) DETACH DELETE p RETURN count(*) AS count"
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsDeleted = 3, nodesDeleted = 2)
@@ -480,7 +480,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (n) DELETE n MERGE (m {p: 0}) ON CREATE SET m.p = 1 RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
 
     assertStats(result, nodesCreated = 2, propertiesWritten = 4, nodesDeleted = 2)
@@ -501,7 +501,7 @@ class EagerizationAcceptanceTest
         |RETURN count(*)
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
     assertStats(result, nodesCreated = 1, nodesDeleted = 2, propertiesWritten = 1, labelsAdded = 1)
     result.columnAs[Long]("count(*)").next shouldBe 2
@@ -520,7 +520,7 @@ class EagerizationAcceptanceTest
         |RETURN b2.deleted
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
     assertStats(result, nodesCreated = 1, nodesDeleted = 3, propertiesWritten = 1, labelsAdded = 1)
     result.columnAs[Node]("b2.deleted").toList should equal(List(null, null, null))
@@ -540,7 +540,7 @@ class EagerizationAcceptanceTest
         |RETURN b2.deleted
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, optimalEagerCount = 1, expectPlansToFailPredicate = Configs.AllRulePlanners - Configs.Rule2_3))
     assertStats(result, nodesCreated = 2, nodesDeleted = 2, propertiesWritten = 2, labelsAdded = 2)
     result.columnAs[Node]("b2.deleted").toList should equal(List(null, null))
@@ -558,7 +558,7 @@ class EagerizationAcceptanceTest
         |RETURN count(*)
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query)
     result.toList should equal(List(Map("count(*)" -> 2)))
     assertStats(result, nodesCreated = 1, nodesDeleted = 2)
   }
@@ -598,7 +598,7 @@ class EagerizationAcceptanceTest
         |RETURN exists(t2.id)
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, optimalEagerCount = 1))
     assertStats(result, relationshipsDeleted = 2, relationshipsCreated = 1)
 
@@ -618,7 +618,7 @@ class EagerizationAcceptanceTest
         |RETURN count(*)
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2))
     assertStats(result, relationshipsDeleted = 1, relationshipsCreated = 1)
     result.columnAs[Long]("count(*)").next shouldBe 1
@@ -637,7 +637,7 @@ class EagerizationAcceptanceTest
         |RETURN exists(t2.id)
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, optimalEagerCount = 1))
     assertStats(result, relationshipsDeleted = 2, relationshipsCreated = 1)
     result.toList should equal(List(Map("exists(t2.id)" -> false), Map("exists(t2.id)" -> false)))
@@ -656,7 +656,7 @@ class EagerizationAcceptanceTest
         |RETURN exists(t2.id)
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, optimalEagerCount = 1))
     assertStats(result, relationshipsDeleted = 2, relationshipsCreated = 1)
     result.toList should equal(List(Map("exists(t2.id)" -> false), Map("exists(t2.id)" -> false)))
@@ -675,7 +675,7 @@ class EagerizationAcceptanceTest
         |RETURN count(*)
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2))
     assertStats(result, relationshipsDeleted = 2, relationshipsCreated = 1)
     result.columnAs[Long]("count(*)").next shouldBe 2
@@ -814,7 +814,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (a), (b) CREATE (a)-[r:KNOWS]->(b) SET r = { key: 42 } RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 4, propertiesWritten = 4)
@@ -953,7 +953,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode(), "TYPE")
     val query = "MATCH (a)-[:TYPE]-(b) MERGE (a)-[:TYPE]->(b) RETURN count(*) as count"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, relationshipsCreated = 2)
     result.columnAs[Int]("count").next should equal(4)
@@ -1026,7 +1026,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Person), (m:Movie) DELETE a, m RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, nodesDeleted = 4)
@@ -1039,7 +1039,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Person) DELETE a RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, nodesDeleted = 2)
@@ -1050,7 +1050,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r]-(b) DELETE r,a,b RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, nodesDeleted = 2, relationshipsDeleted = 1)
@@ -1063,7 +1063,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r]-(b) DELETE r, a, b RETURN count(*) as count"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.toList should equal(List(Map("count" -> 2)))
     assertStats(result, nodesDeleted = 2, relationshipsDeleted = 1)
@@ -1076,7 +1076,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r {prop : 3}]-(b) DELETE r, a, b RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, nodesDeleted = 2, relationshipsDeleted = 1)
@@ -1090,7 +1090,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r]->(b) DETACH DELETE a, b RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
 
     result.toList should equal(List(Map("count(*)" -> 2)))
@@ -1105,7 +1105,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r]->(b) DELETE r RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, optimalEagerCount = 0))
 
     result.toList should equal(List(Map("count(*)" -> 2)))
@@ -1118,7 +1118,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:A)-[r]->(b:B) DELETE r, a, b RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, optimalEagerCount = 0))
     result.toList should equal(List(Map("count(*)" -> 2)))
     assertStats(result, nodesDeleted = 4, relationshipsDeleted = 2)
@@ -1130,7 +1130,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (b:B)<-[r]-(a:A) DELETE r, a, b RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, optimalEagerCount = 0))
     result.toList should equal(List(Map("count(*)" -> 2)))
     assertStats(result, nodesDeleted = 4, relationshipsDeleted = 2)
@@ -1144,7 +1144,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r {prop : 3}]->(b) DELETE r, a, b RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, optimalEagerCount = 0))
     result.toList should equal(List(Map("count(*)" -> 4)))
     assertStats(result, nodesDeleted = 8, relationshipsDeleted = 4)
@@ -1160,7 +1160,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r]-(b) DELETE r, a, b RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.toList should equal(List(Map("count(*)" -> 12)))
     assertStats(result, nodesDeleted = 12, relationshipsDeleted = 6)
@@ -1173,7 +1173,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:A)-[r]-(b) DELETE r, a, b RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.toList should equal(List(Map("count(*)" -> 4)))
     assertStats(result, nodesDeleted = 6, relationshipsDeleted = 3)
@@ -1187,7 +1187,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r {prop : 3}]-(b) DELETE r, a, b RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.toList should equal(List(Map("count(*)" -> 8)))
     assertStats(result, nodesDeleted = 8, relationshipsDeleted = 4)
@@ -1202,7 +1202,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r1]->(b)-[r2]->(c) DELETE r1, r2, a, b, c RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.toList should equal(List(Map("count(*)" -> 4)))
     assertStats(result, nodesDeleted = 5, relationshipsDeleted = 4)
@@ -1217,7 +1217,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r*]->(b) DETACH DELETE a, b RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.toList should equal(List(Map("count(*)" -> 8)))
     assertStats(result, nodesDeleted = 5, relationshipsDeleted = 4)
@@ -1227,7 +1227,7 @@ class EagerizationAcceptanceTest
   test("create directional relationship with property, match and delete relationship and nodes within same query should be eager and work") {
     val query = "CREATE ()-[:T {prop: 3}]->() WITH * MATCH (a)-[r {prop : 3}]->(b) DELETE r, a, b RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 2, relationshipsCreated = 1, propertiesWritten = 1, nodesDeleted = 2, relationshipsDeleted = 1)
@@ -1274,7 +1274,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Person) OPTIONAL MATCH (a)-[r1]-() DELETE a, r1 RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 7
     assertStats(result, nodesDeleted = 2, relationshipsDeleted = 7)
@@ -1288,7 +1288,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Person) MERGE (b) WITH * OPTIONAL MATCH (a)-[r1]-(b) DELETE r1 RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, optimalEagerCount = 1, expectPlansToFailPredicate = Configs.AllRulePlanners - Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 3
     assertStats(result, relationshipsDeleted = 2)
@@ -1307,7 +1307,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Person) OPTIONAL MATCH (a)-[r1]-(), (m:Movie)-[r2]-() DELETE a, r1, m, r2 RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 6
     assertStats(result, nodesDeleted = 3, relationshipsDeleted = 4)
@@ -1332,7 +1332,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (m1:Two), (m2:Two), (n) MERGE (q) ON MATCH SET q:Two RETURN count(*) AS c"
 
-    val result: InternalExecutionResult = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result: InternalExecutionResult = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, labelsAdded = 1)
     result.toList should equal(List(Map("c" -> 36)))
@@ -1344,7 +1344,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (m1:Two), (m2:Two), (n) MERGE (q:Three) ON MATCH SET q:Two RETURN count(*) AS c"
 
-    val result: InternalExecutionResult = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result: InternalExecutionResult = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, labelsAdded = 2, nodesCreated = 1)
     result.toList should equal(List(Map("c" -> 12)))
@@ -1368,7 +1368,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (m1:Two), (m2:Two) MERGE (q) ON MATCH SET q:One RETURN count(*) AS c"
 
-    val result: InternalExecutionResult = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result: InternalExecutionResult = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     assertStats(result, labelsAdded = 3)
     result.toList should equal(List(Map("c" -> 12)))
@@ -1380,7 +1380,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (m1:Two), (m2:Two), (n) MERGE (q) ON CREATE SET q:Two RETURN count(*) AS c"
 
-    val result: InternalExecutionResult = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result: InternalExecutionResult = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, labelsAdded = 0)
     result.toList should equal(List(Map("c" -> 36)))
@@ -1392,7 +1392,7 @@ class EagerizationAcceptanceTest
     createNode(Map("id" -> 0))
     val query = "MATCH (b {id: 0}), (c {id: 0}), (a) MERGE () ON MATCH SET a.id = 0 RETURN count(*) AS c"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.toList should equal(List(Map("c" -> 36)))
     assertStats(result, propertiesWritten = 36)
@@ -1404,7 +1404,7 @@ class EagerizationAcceptanceTest
     createNode(Map("id" -> 0))
     val query = "MATCH (b {id: 0}), (c {id: 0}) MERGE (a) ON MATCH SET a.id2 = 0 RETURN count(*) AS c"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.AllRulePlanners))
     result.toList should equal(List(Map("c" -> 12)))
     assertStats(result, propertiesWritten = 12)
@@ -1416,7 +1416,7 @@ class EagerizationAcceptanceTest
     createNode(Map("id" -> 0))
     val query = "MATCH (b {id: 0}), (c {id: 0}), (a) MERGE () ON CREATE SET a = {id: 0} RETURN count(*) AS c"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.toList should equal(List(Map("c" -> 36)))
     assertStats(result, propertiesWritten = 0)
@@ -1428,7 +1428,7 @@ class EagerizationAcceptanceTest
     createNode(Map("id" -> 0))
     val query = "MATCH (b {id: 0}), (c {id: 0}), (a) MERGE () ON CREATE SET a += {id: 0} RETURN count(*) AS c"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.toList should equal(List(Map("c" -> 36)))
     assertStats(result, propertiesWritten = 0)
@@ -1440,7 +1440,7 @@ class EagerizationAcceptanceTest
     createNode(Map("id" -> 0))
     val query = "MATCH (b {id: 0}), (c {id: 0}), (a) MERGE () ON MATCH SET a = {map} RETURN count(*) AS c"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1),
       params = Map("map" -> Map("id" -> 0)))
     result.toList should equal(List(Map("c" -> 36)))
@@ -1459,7 +1459,7 @@ class EagerizationAcceptanceTest
         |RETURN count(*)
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, nodesDeleted = 2, relationshipsDeleted = 2)
     result.columnAs[Long]("count(*)").next shouldBe 2
@@ -1479,7 +1479,7 @@ class EagerizationAcceptanceTest
         |RETURN count(*)
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, nodesDeleted = 2, relationshipsDeleted = 2)
     result.columnAs[Long]("count(*)").next shouldBe 2
@@ -1490,7 +1490,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (a), (b) MERGE (a)-[r:KNOWS]->(b) RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 4)
@@ -1503,7 +1503,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON MATCH SET a.prop = 42 RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
@@ -1518,7 +1518,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON MATCH SET b:Foo RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, optimalEagerCount = 0, expectPlansToFailPredicate = Configs.AllRulePlanners - Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 3, labelsAdded = 1)
@@ -1535,7 +1535,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON MATCH SET a:Bar RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 3, labelsAdded = 1)
@@ -1550,7 +1550,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON CREATE SET b:Foo RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, optimalEagerCount = 0, expectPlansToFailPredicate = Configs.AllRulePlanners - Configs.Rule2_3))
 
     result.columnAs[Long]("count(*)").next shouldBe 4
@@ -1567,7 +1567,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON CREATE SET a:Bar RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
 
     result.columnAs[Long]("count(*)").next shouldBe 4
@@ -1578,7 +1578,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("A")
     val query = "MATCH (a:A) MERGE (a)-[:BAR]->(b:B) WITH a MATCH (a) WHERE (a)-[:FOO]->() RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 0
     assertStats(result, relationshipsCreated = 1, nodesCreated = 1, labelsAdded = 1)
@@ -1592,7 +1592,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:A) MERGE (a)-[:BAR]->(b:A) WITH a MATCH (a2) RETURN count (a2) AS nodes"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
 
     assertStats(result, nodesCreated = 2, relationshipsCreated = 2, labelsAdded = 2)
@@ -1604,7 +1604,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("B")
     val query = "MATCH (a:A), (b:B) MERGE (a)-[:BAR]->(b) WITH a MATCH (a) WHERE (a)-[:FOO]->() RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 0
     assertStats(result, relationshipsCreated = 1)
@@ -1624,7 +1624,7 @@ class EagerizationAcceptanceTest
 
     val query = "UNWIND range(0, 9) AS i MATCH (x) MERGE (m {v: i % 2}) ON CREATE SET m:Merged CREATE ({v: (i + 1) % 2}) RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2))
 
     result.columnAs[Long]("count(*)").next shouldBe 20
@@ -1650,7 +1650,7 @@ class EagerizationAcceptanceTest
 
     val query = "UNWIND range(0, 9) AS i MATCH (x) WITH * CREATE ({v: i % 2}) MERGE (m {v: (i + 1) % 2}) ON CREATE SET m:Merged RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2))
 
     result.columnAs[Long]("count(*)").next shouldBe 200
@@ -1662,7 +1662,7 @@ class EagerizationAcceptanceTest
   test("should not be eager when merging on two different labels") {
     val query = "MERGE(:L1) MERGE(p:L2) ON CREATE SET p.name = 'Blaine' RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 2, propertiesWritten = 1, labelsAdded = 2)
@@ -1673,7 +1673,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("L1")
     val query = "MERGE(:L1) MERGE(p:L1) ON CREATE SET p.name = 'Blaine' RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result)
@@ -1742,7 +1742,7 @@ class EagerizationAcceptanceTest
   test("Multiple single node merges should be eager") {
     val query = "UNWIND [0, 1] AS i MERGE (a {p: i % 2}) MERGE (b {p: (i + 1) % 2}) ON CREATE SET b:ShouldNotBeSet RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
 
     result.columnAs[Long]("count(*)").next shouldBe 2
@@ -1752,7 +1752,7 @@ class EagerizationAcceptanceTest
   test("should not be eager when merging on already bound variables") {
     val query = "MERGE (city:City) MERGE (country:Country) MERGE (city)-[:IN]->(country) RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
 
     result.columnAs[Long]("count(*)").next shouldBe 1
@@ -1766,7 +1766,7 @@ class EagerizationAcceptanceTest
       """MATCH (src:LeftLabel), (dst:RightLabel)
         |MERGE (src)-[r:IS_RELATED_TO ]->(dst)
         |ON CREATE SET r.p3 = 42""".stripMargin
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
 
     assertStats(result, relationshipsCreated = 1, propertiesWritten = 1)
@@ -1778,7 +1778,7 @@ class EagerizationAcceptanceTest
     createLabeledNode(Map("prop" -> 5), "Node")
     val query = "MATCH (n:Node {prop:5}) SET n.value = 10 RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
@@ -1788,7 +1788,7 @@ class EagerizationAcceptanceTest
     createLabeledNode(Map("prop" -> 5), "Node")
     val query = "MATCH (n:Node) SET n:Lol RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, labelsAdded = 1)
@@ -1798,7 +1798,7 @@ class EagerizationAcceptanceTest
     createLabeledNode(Map("prop" -> 5), "Lol")
     val query = "MATCH (n:Lol) SET n:Lol RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, labelsAdded = 0)
@@ -1810,7 +1810,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (m1:Two), (m2:Two), (n) SET n:Two RETURN count(*) AS c"
 
-    val result: InternalExecutionResult = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result: InternalExecutionResult = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, labelsAdded = 1)
     result.toList should equal(List(Map("c" -> 12)))
@@ -1821,7 +1821,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (n), (m1:Lol), (m2:Lol) SET n:Rofl RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, labelsAdded = 2)
@@ -1834,7 +1834,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Foo")
     val query = "MATCH (n) CREATE (m) WITH * MATCH (o:Foo) SET n:Foo RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 8
     assertStats(result, labelsAdded = 2, nodesCreated = 4)
@@ -1847,7 +1847,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("B")
     val query = "MATCH (n:A) CREATE (m:C) WITH * MATCH (o:B), (p:C) SET p:B RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, Configs.AllRulePlanners))
     result.columnAs[Long]("count(*)").next shouldBe 8
     assertStats(result, labelsAdded = 4, nodesCreated = 2)
@@ -1860,7 +1860,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Bar")
     val query = "MATCH (n) CREATE (m) WITH * MATCH (o:Bar) SET n:Foo RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 8
     assertStats(result, labelsAdded = 2, nodesCreated = 4)
@@ -1870,7 +1870,7 @@ class EagerizationAcceptanceTest
     createNode(Map("name" -> "thing"))
     val query = "MATCH (n {name : 'thing'}) SET n:Lol RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, labelsAdded = 1)
@@ -1880,7 +1880,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (n) SET n.prop = 5 RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
@@ -1890,7 +1890,7 @@ class EagerizationAcceptanceTest
     createNode(Map("prop" -> 20))
     val query = "MATCH (n { prop: 20 }) SET n.prop = 10 RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
@@ -1900,7 +1900,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Node")
     val query = "MATCH (n:Node) SET n.prop = 10 RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
@@ -1909,7 +1909,7 @@ class EagerizationAcceptanceTest
   test("single label+property match followed by set property should not be eager") {
     val query = "MATCH (n:Node {prop:5}) SET n.prop = 10 RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 0
   }
@@ -1920,7 +1920,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (b :Book {isbn : '123'}) SET b.isbn = '456' RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
 
     result.columnAs[Long]("count(*)").next shouldBe 1
@@ -1932,7 +1932,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a), (b :Book {isbn : '123'}) SET a.isbn = '456' RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
 
     result.columnAs[Long]("count(*)").next shouldBe 1
@@ -1944,7 +1944,7 @@ class EagerizationAcceptanceTest
     createNode(Map("id" -> 0))
     val query = "MATCH (a),(b {id: 0}),(c {id: 0}) SET a.id = 0 RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, propertiesWritten = 2)
@@ -1955,7 +1955,7 @@ class EagerizationAcceptanceTest
     createNode(Map("id" -> 0))
     val query = "MATCH (a),(b {id: 0}),(c {id: 0}) SET c.id = 1 RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, propertiesWritten = 2)
@@ -1967,7 +1967,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (b {id: 0}) SET b.id = 1 RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
@@ -1978,7 +1978,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (n {prop : 5})-[r]-() SET r.prop = 6 RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
 
     result.columnAs[Long]("count(*)").next shouldBe 1
@@ -1990,7 +1990,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (n {prop : 5})-[r]-(m) SET m.prop = 5 RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, propertiesWritten = 1)
     result.toList should equal(List(Map("count(*)" -> 1)))
@@ -2000,7 +2000,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode(), "prop" -> 3)
     val query = "MATCH ()-[r {prop : 3}]-() SET r.prop = 6 RETURN count(*) AS c"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
 
     assertStats(result, propertiesWritten = 2)
@@ -2013,7 +2013,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH ()-[r {prop1 : 3}]-() SET r.prop2 = 6 RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
 
     result.columnAs[Long]("count(*)").next shouldBe 2
@@ -2024,7 +2024,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode(), "prop" -> 3)
     val query = "MATCH (n)-[r {prop : 3}]-() SET n.prop = 6 RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, propertiesWritten = 2)
@@ -2036,7 +2036,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH ()-[r]-() WHERE exists(r.prop) SET r.prop = 'foo' RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
 
     result.columnAs[Long]("count(*)").next shouldBe 2
@@ -2049,7 +2049,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH ()-[r]-() WHERE exists(r.prop1) SET r.prop2 = 'foo'"
 
-    assertStats(executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    assertStats(executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0)), propertiesWritten = 2)
   }
 
@@ -2061,7 +2061,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH ()-[r {prop: 42}]-(), (:L)-[r2]-() SET r2.prop = 42"
 
-    assertStats(executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, planComparisonStrategy = testEagerPlanComparisonStrategy(1)), propertiesWritten = 2)
+    assertStats(executeWith(Configs.Interpreted - Configs.Cost2_3, query, planComparisonStrategy = testEagerPlanComparisonStrategy(1)), propertiesWritten = 2)
 
   }
 
@@ -2072,7 +2072,7 @@ class EagerizationAcceptanceTest
     createNode("prop" -> 42)
     val query = "MATCH (n) CREATE (m) WITH * MATCH (o {prop:42}) SET n.prop = 42 RETURN count(*) as count"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.AllRulePlanners))
     result.columnAs[Int]("count").next should equal(8)
     assertStats(result, propertiesWritten = 8, nodesCreated = 4)
@@ -2085,7 +2085,7 @@ class EagerizationAcceptanceTest
     createNode("prop" -> 42)
     val query = "MATCH (n {prop: 42}) CREATE (m) WITH * MATCH (o) SET n.prop = 42 RETURN count(*) as count"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Int]("count").next should equal(12)
     assertStats(result, propertiesWritten = 12, nodesCreated = 2)
@@ -2106,7 +2106,7 @@ class EagerizationAcceptanceTest
         |SET m.prop = 42
         |RETURN count(*) as count""".stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.AllRulePlanners - Configs.Rule2_3))
     result.columnAs[Int]("count").next should equal(14)
     assertStats(result, propertiesWritten = 14, nodesCreated = 3)
@@ -2119,7 +2119,7 @@ class EagerizationAcceptanceTest
     createNode("prop" -> 42)
     val query = "MATCH (n) CREATE (m) WITH * MATCH (o {prop:42}) SET n.prop2 = 42 RETURN count(*) as count"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.AllRulePlanners))
     result.columnAs[Int]("count").next should equal(8)
     assertStats(result, propertiesWritten = 8, nodesCreated = 4)
@@ -2128,7 +2128,7 @@ class EagerizationAcceptanceTest
   test("matching node property, writing with += should be eager") {
     relate(createNode(Map("prop" -> 5)), createNode())
     val query = "MATCH (n {prop : 5})-[r]-(m) SET m += {prop: 5} RETURN count(*)"
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, propertiesWritten = 1)
     result.toList should equal(List(Map("count(*)" -> 1)))
@@ -2137,7 +2137,7 @@ class EagerizationAcceptanceTest
   test("matching node property, writing with += should not be eager when we can avoid it") {
     relate(createNode(Map("prop" -> 5)), createNode())
     val query = "MATCH (n {prop : 5})-[r]-(m) SET m += {prop2: 5} RETURN count(*)"
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.AllRulePlanners))
     assertStats(result, propertiesWritten = 1)
     result.toList should equal(List(Map("count(*)" -> 1)))
@@ -2151,7 +2151,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (n {prop : 5})-[r]->(m) SET m += {props} RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1), params = Map("props" -> Map("prop" -> 5)))
     assertStats(result, propertiesWritten = 1)
     result.toList should equal(List(Map("count(*)" -> 1)))
@@ -2160,7 +2160,7 @@ class EagerizationAcceptanceTest
   test("matching rel property, writing with += should not be eager when we can avoid it") {
     relate(createNode(Map("prop" -> 5)), createNode())
     val query = "MATCH (n {prop : 5})-[r]-(m) SET m += {prop2: 5} RETURN count(*)"
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.AllRulePlanners))
     assertStats(result, propertiesWritten = 1)
     result.toList should equal(List(Map("count(*)" -> 1)))
@@ -2171,7 +2171,7 @@ class EagerizationAcceptanceTest
     createLabeledNode(Map("prop" -> 5), "Node", "Lol")
     val query = "MATCH (n:Node) REMOVE n:Lol"
 
-    assertStats(executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    assertStats(executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0)), labelsRemoved = 1)
   }
 
@@ -2179,7 +2179,7 @@ class EagerizationAcceptanceTest
     createLabeledNode(Map("prop" -> 5), "Node")
     val query = "MATCH (n:Node) REMOVE n:Node"
 
-    assertStats(executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    assertStats(executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3)), labelsRemoved = 1)
   }
 
@@ -2188,7 +2188,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (m:Lol), (n) REMOVE n:Lol RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
 
     assertStats(result, labelsRemoved = 1)
@@ -2200,7 +2200,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Lol")
     val query = "MATCH (m:Lol), (n:Lol) REMOVE m:Lol RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
 
     assertStats(result, labelsRemoved = 2)
@@ -2213,7 +2213,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("C")
     val query = "MATCH  (m1:A), (m2:B), (n:C) REMOVE n:C RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.AllRulePlanners))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, labelsRemoved = 1)
@@ -2225,7 +2225,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (m1:Two), (m2:Two), (n) REMOVE n:Two RETURN count(*) AS c"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, labelsRemoved = 2)
     result.toList should equal(List(Map("c" -> 12)))
@@ -2237,7 +2237,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("B")
     val query = "MATCH (n), (m1:A), (m2:A) REMOVE n:B RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 12
     assertStats(result, labelsRemoved = 3)
@@ -2248,7 +2248,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Foo")
     val query = "MATCH (n) CREATE (m) WITH * MATCH (o:Foo) REMOVE n:Foo RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, labelsRemoved = 2, nodesCreated = 2)
@@ -2259,7 +2259,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Foo")
     val query = "MATCH (n) CREATE (m:Foo) WITH * MATCH (o:Foo) REMOVE n:Foo RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 8
     assertStats(result, labelsAdded = 2, labelsRemoved = 2, nodesCreated = 2)
@@ -2272,7 +2272,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Bar")
     val query = "MATCH (n) CREATE (m) WITH * MATCH (o:Bar) REMOVE n:Foo RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 8
     assertStats(result, labelsRemoved = 2, nodesCreated = 4)
@@ -2284,7 +2284,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (n:Foo)--(m) REMOVE m:Foo RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, labelsRemoved = 4)
@@ -2300,7 +2300,7 @@ class EagerizationAcceptanceTest
     // Relationship match is non-directional, so should give 2 rows
     val query = "MATCH (a)-[t:T]-(b) UNWIND [1] as i DELETE t RETURN count(*) as count"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsDeleted = 1)
@@ -2315,7 +2315,7 @@ class EagerizationAcceptanceTest
     // Relationship match is non-directional, so should give 2 rows
     val query = "CREATE () WITH * MATCH (a)-[t:T]-(b) UNWIND [1] as i DELETE t RETURN count(*) as count"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, nodesCreated = 1, relationshipsDeleted = 1)
@@ -2330,7 +2330,7 @@ class EagerizationAcceptanceTest
     // Relationship match is non-directional, so should give 2 rows
     val query = "CREATE () WITH * CREATE () WITH * MATCH (a)-[t:T]-(b) UNWIND [1] as i DELETE t RETURN count(*) as count"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, optimalEagerCount = 1, expectPlansToFailPredicate = Configs.Rule2_3))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, nodesCreated = 2, relationshipsDeleted = 1)
@@ -2634,7 +2634,7 @@ class EagerizationAcceptanceTest
         |RETURN d, c2""".stripMargin
 
     cookies.foreach { case (name, node) =>
-      val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+      val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
         planComparisonStrategy = testEagerPlanComparisonStrategy(2),
         params = Map("cookie" -> name))
       assertStats(result, nodesDeleted = 1, relationshipsDeleted = 2)
@@ -2650,7 +2650,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (c:Cookie) DELETE c WITH 1 as t MATCH (x:Cookie) RETURN count(*) as count"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
 
     result.columnAs[Int]("count").next should equal(0)
@@ -2666,7 +2666,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH p=(:Cookie) DELETE p WITH 1 as t MATCH (x:Cookie) RETURN count(*) as count"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
 
     result.columnAs[Int]("count").next should equal(0)
@@ -2685,7 +2685,7 @@ class EagerizationAcceptanceTest
         |RETURN labels
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
     result.toList should equal(List(Map("labels" -> List()), Map("labels" -> List())))
     assertStats(result, labelsAdded = 2)
@@ -2703,7 +2703,7 @@ class EagerizationAcceptanceTest
         |RETURN labels
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
     result.toList should equal(List(Map("labels" -> List("Foo")), Map("labels" -> List("Foo"))))
     assertStats(result, labelsRemoved = 2)
@@ -2720,7 +2720,7 @@ class EagerizationAcceptanceTest
         |RETURN labels(n), labels(m)
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
     result.toList should equal(List(Map("labels(n)" -> List("Foo"), "labels(m)" -> List("Foo")),
       Map("labels(n)" -> List("Foo"), "labels(m)" -> List("Foo"))))
@@ -2739,7 +2739,7 @@ class EagerizationAcceptanceTest
         |RETURN labels(n), labels(m)
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
     result.toList should equal(List(Map("labels(n)" -> List("Foo"), "labels(m)" -> List("Foo")),
       Map("labels(n)" -> List("Foo"), "labels(m)" -> List("Foo"))))
@@ -2757,7 +2757,7 @@ class EagerizationAcceptanceTest
         |RETURN labels(n), labels(m)
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, expectedDifferentResults = Configs.Rule2_3, query = query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, expectedDifferentResults = Configs.Rule2_3, query = query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
     result.toList should equal(List(Map("labels(n)" -> List(), "labels(m)" -> List()),
       Map("labels(n)" -> List(), "labels(m)" -> List())))

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionEngineTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionEngineTest.scala
@@ -550,7 +550,7 @@ order by a.COL1""".format(a, b))
 
   test("with should not forget parameters2") {
     val id = createNode().getId
-    val result = executeWith(createConf - Configs.SlottedInterpreted, "match (n) where id(n) = {id} with n set n.foo={id} return n", params = Map("id" -> id)).toList
+    val result = executeWith(createConf, "match (n) where id(n) = {id} with n set n.foo={id} return n", params = Map("id" -> id)).toList
 
     result should have size 1
     graph.inTx {
@@ -654,28 +654,28 @@ order by a.COL1""".format(a, b))
 
   test("should add label to node") {
     val a = createNode()
-    val result = executeWith(createConf - Configs.SlottedInterpreted, "match (a) where id(a) = 0 SET a :foo RETURN a")
+    val result = executeWith(createConf, "match (a) where id(a) = 0 SET a :foo RETURN a")
 
     result.toList should equal(List(Map("a" -> a)))
   }
 
   test("should add multiple labels to node") {
     val a = createNode()
-    val result = executeWith(createConf - Configs.SlottedInterpreted, "match (a) where id(a) = 0 SET a :foo:bar RETURN a")
+    val result = executeWith(createConf, "match (a) where id(a) = 0 SET a :foo:bar RETURN a")
 
     result.toList should equal(List(Map("a" -> a)))
   }
 
   test("should set label on node") {
     val a = createNode()
-    val result = executeWith(createConf - Configs.SlottedInterpreted, "match (a) SET a:foo RETURN a")
+    val result = executeWith(createConf, "match (a) SET a:foo RETURN a")
 
     result.toList should equal(List(Map("a" -> a)))
   }
 
   test("should set multiple labels on node") {
     val a = createNode()
-    val result = executeWith(createConf - Configs.SlottedInterpreted, "match (a) where id(a) = 0 SET a:foo:bar RETURN a")
+    val result = executeWith(createConf, "match (a) where id(a) = 0 SET a:foo:bar RETURN a")
 
     result.toList should equal(List(Map("a" -> a)))
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcQueries.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcQueries.scala
@@ -522,7 +522,7 @@ object LdbcQueries {
       Map("tagName" -> "tag3-ᚠさ丵פش", "postCount" -> 2),
       Map("tagName" -> "tag5-ᚠさ丵פش", "postCount" -> 1))
 
-    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+    override def expectedToSucceedIn: TestConfiguration = Configs.Interpreted
 
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -119,7 +119,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     createNode(Map("x" -> "Zzing"))
     createNode(Map("x" -> 'Ä'))
 
-    val result = executeWith(Configs.CommunityInterpreted, s"match (n) where n.x < 'Z' AND n.x < 'z' return n")
+    val result = executeWith(Configs.Interpreted, s"match (n) where n.x < 'Z' AND n.x < 'z' return n")
 
     result.columnAs("n").toList should equal(List(n1, n2))
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -73,7 +73,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
   test("OPTIONAL MATCH, DISTINCT and DELETE in an unfortunate combination") {
     val start = createLabeledNode("Start")
     createLabeledNode("End")
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3,
       """
         |MATCH (start:Start),(end:End)
         |OPTIONAL MATCH (start)-[rel]->(end)
@@ -355,8 +355,8 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
   test("should be able to set properties with a literal map twice in the same transaction") {
     val node = createLabeledNode("FOO")
 
-    executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, "MATCH (n:FOO) SET n = { first: 'value' }")
-    executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, "MATCH (n:FOO) SET n = { second: 'value' }")
+    executeWith(Configs.Interpreted - Configs.Cost2_3, "MATCH (n:FOO) SET n = { first: 'value' }")
+    executeWith(Configs.Interpreted - Configs.Cost2_3, "MATCH (n:FOO) SET n = { second: 'value' }")
 
     graph.inTx {
       node.getProperty("first", null) should equal(null)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeCompatibilityAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeCompatibilityAcceptanceTest.scala
@@ -38,6 +38,7 @@ class MergeNodeCompatibilityAcceptanceTest extends ExecutionEngineFunSuite with 
   }
 
   val expectedSucceed: TestConfiguration = Configs.CommunityInterpreted - Configs.Cost2_3
+  val expectedSucceedIncludingSlotted: TestConfiguration = Configs.Interpreted - Configs.Cost2_3
 
   Seq(UniquenessConstraintCreator, NodeKeyConstraintCreator).foreach { constraintCreator =>
 
@@ -50,7 +51,7 @@ class MergeNodeCompatibilityAcceptanceTest extends ExecutionEngineFunSuite with 
 
       // when
       val results =
-        executeWith(expectedSucceed, "merge (a:Person {id: 23, mail: 'emil@neo.com'}) on match set a.country='Sweden' return a")
+        executeWith(expectedSucceedIncludingSlotted, "merge (a:Person {id: 23, mail: 'emil@neo.com'}) on match set a.country='Sweden' return a")
       val result = results.columnAs("a").next().asInstanceOf[Node]
 
       // then
@@ -71,7 +72,7 @@ class MergeNodeCompatibilityAcceptanceTest extends ExecutionEngineFunSuite with 
 
       // when
       val results =
-        executeWith(expectedSucceed, "merge (a:Person:User {id: 23, mail: 'emil@neo.com'}) on match set a.country='Sweden' return a")
+        executeWith(expectedSucceedIncludingSlotted, "merge (a:Person:User {id: 23, mail: 'emil@neo.com'}) on match set a.country='Sweden' return a")
       val result = results.columnAs("a").next().asInstanceOf[Node]
 
       // then
@@ -92,7 +93,7 @@ class MergeNodeCompatibilityAcceptanceTest extends ExecutionEngineFunSuite with 
 
       // when
       val results =
-        executeWith(expectedSucceed, "merge (a:Person:User {id: 23}) on match set a.country='Sweden' return a")
+        executeWith(expectedSucceedIncludingSlotted, "merge (a:Person:User {id: 23}) on match set a.country='Sweden' return a")
       val result = results.columnAs("a").next().asInstanceOf[Node]
 
       // then
@@ -112,7 +113,7 @@ class MergeNodeCompatibilityAcceptanceTest extends ExecutionEngineFunSuite with 
       createLabeledNode(Map("id" -> 23), "User")
 
       // when + then
-      failWithError(expectedSucceed + Configs.Procs, "merge (a:Person:User {id: 23}) return a",
+      failWithError(expectedSucceedIncludingSlotted + Configs.Procs, "merge (a:Person:User {id: 23}) return a",
         List("can not create a new node due to conflicts with existing unique nodes"))
       countNodes() should equal(2)
     }
@@ -124,7 +125,7 @@ class MergeNodeCompatibilityAcceptanceTest extends ExecutionEngineFunSuite with 
 
       // when
       val results =
-        executeWith(expectedSucceed, "merge (a:Person {id: 23, mail: 'emil@neo.com'}) on create set a.country='Sweden' return a.id, a.mail, a.country, labels(a)")
+        executeWith(expectedSucceedIncludingSlotted, "merge (a:Person {id: 23, mail: 'emil@neo.com'}) on create set a.country='Sweden' return a.id, a.mail, a.country, labels(a)")
 
       // then
       results.toSet should equal(Set(Map("a.id" -> 23, "a.mail" -> "emil@neo.com", "a.country" -> "Sweden", "labels(a)" -> List("Person"))))
@@ -137,7 +138,7 @@ class MergeNodeCompatibilityAcceptanceTest extends ExecutionEngineFunSuite with 
 
       // when
       val results =
-        executeWith(expectedSucceed, "merge (a:Person:User {id: 23, mail: 'emil@neo.com'}) on create set a.country='Sweden' return a.id, a.mail, a.country, labels(a)")
+        executeWith(expectedSucceedIncludingSlotted, "merge (a:Person:User {id: 23, mail: 'emil@neo.com'}) on create set a.country='Sweden' return a.id, a.mail, a.country, labels(a)")
 
       // then
       results.toSet should equal(Set(Map("a.id" -> 23, "a.mail" -> "emil@neo.com", "a.country" -> "Sweden", "labels(a)" -> List("Person", "User"))))

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MutatingIntegrationTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MutatingIntegrationTest.scala
@@ -31,7 +31,7 @@ import scala.collection.JavaConverters._
 class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with CypherComparisonSupport {
 
   val createConf = Configs.Interpreted - Configs.Cost2_3
-  val deleteConf = Configs.CommunityInterpreted - Configs.Cost2_3
+  val deleteConf = Configs.Interpreted - Configs.Cost2_3
 
   test("create a single node") {
     val before = graph.inTx(graph.getAllNodes.asScala.size)
@@ -201,7 +201,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
       Map("name" -> "Michael", "prefers" -> "Java"),
       Map("name" -> "Peter", "prefers" -> "Java"))
 
-    val result = executeWith(createConf - Configs.SlottedInterpreted, "unwind {params} as m create (x) set x = m ", params = Map("params" -> maps))
+    val result = executeWith(createConf, "unwind {params} as m create (x) set x = m ", params = Map("params" -> maps))
 
     assertStats(result,
       nodesCreated = 3,
@@ -322,7 +322,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
 
   test("delete and delete again") {
     createNode()
-    val result = executeWith(deleteConf, "match (a) where id(a) = 0 delete a foreach( x in [1] | delete a)")
+    val result = executeWith(deleteConf - Configs.SlottedInterpreted, "match (a) where id(a) = 0 delete a foreach( x in [1] | delete a)")
 
     assertStats(result, nodesDeleted = 1)
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NotificationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NotificationAcceptanceTest.scala
@@ -133,6 +133,8 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
       """explain cypher runtime=slotted
          MATCH (b:B)
          MERGE (a)-[r1:TYPE]->(b)<-[r2:TYPE]-(c)
+         WITH r1, r2, collect(b) as b_nodes
+         FOREACH (n in b_nodes | SET n.prop = 1)
          RETURN type(r1), type(r2)""", Map.empty)
 
     result.notifications.toList should equal(List(

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ParameterValuesAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ParameterValuesAcceptanceTest.scala
@@ -53,7 +53,7 @@ class ParameterValuesAcceptanceTest extends ExecutionEngineFunSuite with CypherC
       emptyBooleanArray, Array[String]()).foreach { array =>
 
       val q = "CREATE (n) SET n.prop = $param RETURN n.prop AS p"
-      val r = executeWith(Configs.CommunityInterpreted - Configs.Version2_3, q, params = Map("param" -> array))
+      val r = executeWith(Configs.Interpreted - Configs.Version2_3, q, params = Map("param" -> array))
 
       assertStats(r, nodesCreated = 1, propertiesWritten = 1)
       val returned = r.columnAs[Array[_]]("p").next()
@@ -68,7 +68,7 @@ class ParameterValuesAcceptanceTest extends ExecutionEngineFunSuite with CypherC
       Array[Boolean](false, true), Array[String]("", " ")).foreach { array =>
 
       val q = "CREATE (n) SET n.prop = $param RETURN n.prop AS p"
-      val r = executeWith(Configs.CommunityInterpreted - Configs.Version2_3, q, params = Map("param" -> array))
+      val r = executeWith(Configs.Interpreted - Configs.Version2_3, q, params = Map("param" -> array))
 
       assertStats(r, nodesCreated = 1, propertiesWritten = 1)
       val returned = r.columnAs[Array[_]]("p").next()
@@ -101,7 +101,7 @@ class ParameterValuesAcceptanceTest extends ExecutionEngineFunSuite with CypherC
   test("removing property when not sure if it is a node or relationship should still work - NODE") {
     val n = createNode("name" -> "Anders")
 
-    executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, "WITH {p} as p SET p.lastname = p.name REMOVE p.name", params = Map("p" -> n))
+    executeWith(Configs.Interpreted - Configs.Cost2_3, "WITH {p} as p SET p.lastname = p.name REMOVE p.name", params = Map("p" -> n))
 
     graph.inTx {
       n.getProperty("lastname") should equal("Anders")
@@ -112,7 +112,7 @@ class ParameterValuesAcceptanceTest extends ExecutionEngineFunSuite with CypherC
   test("removing property when not sure if it is a node or relationship should still work - REL") {
     val r = relate(createNode(), createNode(), "name" -> "Anders")
 
-    executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, "WITH {p} as p SET p.lastname = p.name REMOVE p.name", params = Map("p" -> r))
+    executeWith(Configs.Interpreted - Configs.Cost2_3, "WITH {p} as p SET p.lastname = p.name REMOVE p.name", params = Map("p" -> r))
 
     graph.inTx {
       r.getProperty("lastname") should equal("Anders")

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SetAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SetAcceptanceTest.scala
@@ -25,8 +25,9 @@ import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
 class SetAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with CypherComparisonSupport {
 
   val expectedToSucceed = Configs.CommunityInterpreted - Configs.Cost2_3
-  val expectedToFail = Configs.CommunityInterpreted - Configs.Cost2_3 + TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.ProcedureOrSchema))
-  val expectedToFail2 = Configs.CommunityInterpreted - Configs.Version2_3 + TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.ProcedureOrSchema))
+  val expectedToSucceedIncludingSlotted = Configs.Interpreted - Configs.Cost2_3
+  val expectedToFail = Configs.Interpreted - Configs.Cost2_3 + TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.ProcedureOrSchema))
+  val expectedToFail2 = Configs.Interpreted - Configs.Version2_3 + TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.ProcedureOrSchema))
 
   test("optional match and set") {
     val n1 = createLabeledNode("L1")
@@ -34,7 +35,7 @@ class SetAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTest
     relate(n1, n2, "R1")
 
     // only fails when returning distinct...
-    val result = executeWith(expectedToSucceed,
+    val result = executeWith(expectedToSucceedIncludingSlotted,
       """
         |MATCH (n1:L1)-[:R1]->(n2:L2)
         |OPTIONAL MATCH (n3)<-[r:R2]-(n2)
@@ -50,7 +51,7 @@ class SetAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTest
     val node = createNode()
 
     // when
-    val result = executeWith(expectedToSucceed, "MATCH (n) SET n.property = ['foo','bar'] RETURN n.property")
+    val result = executeWith(expectedToSucceedIncludingSlotted, "MATCH (n) SET n.property = ['foo','bar'] RETURN n.property")
 
     // then
     assertStats(result, propertiesWritten = 1)
@@ -86,7 +87,7 @@ class SetAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTest
     val a = createNode()
 
     // when
-    val result = executeWith(expectedToSucceed, "MATCH (n) SET (CASE WHEN true THEN n END).name = 'neo4j' RETURN count(*)")
+    val result = executeWith(expectedToSucceedIncludingSlotted, "MATCH (n) SET (CASE WHEN true THEN n END).name = 'neo4j' RETURN count(*)")
 
     // then
     assertStats(result, propertiesWritten = 1)
@@ -99,7 +100,7 @@ class SetAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTest
     val r = relate(createNode(), createNode())
 
     // when
-    val result = executeWith(expectedToSucceed, "MATCH ()-[r]->() SET (CASE WHEN true THEN r END).name = 'neo4j' RETURN count(*)")
+    val result = executeWith(expectedToSucceedIncludingSlotted, "MATCH ()-[r]->() SET (CASE WHEN true THEN r END).name = 'neo4j' RETURN count(*)")
 
     // then
     assertStats(result, propertiesWritten = 1)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StoreIntegrationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StoreIntegrationAcceptanceTest.scala
@@ -29,7 +29,7 @@ class StoreIntegrationAcceptanceTest extends ExecutionEngineFunSuite with QueryS
   test("should not create labels id when trying to delete non-existing labels") {
     createNode()
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, "MATCH (n) REMOVE n:BAR RETURN id(n) AS id")
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, "MATCH (n) REMOVE n:BAR RETURN id(n) AS id")
 
     assertStats(result, labelsRemoved = 0)
     result.toList should equal(List(Map("id" -> 0)))

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueIndexAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueIndexAcceptanceTest.scala
@@ -152,7 +152,7 @@ class UniqueIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
       graph should haveConstraints(s"${constraintCreator.typeName}:Person(name)")
 
       //WHEN
-      executeWith(Configs.CommunityInterpreted - Configs.Cost2_3,
+      executeWith(Configs.Interpreted - Configs.Cost2_3,
         "PROFILE MATCH (n:Person {name: 'Andres'}) MERGE (n)-[:KNOWS]->(m:Person {name: 'Maria'}) RETURN n.name",
         planComparisonStrategy = ComparePlansWithAssertion((plan) => {
           // THEN
@@ -171,7 +171,7 @@ class UniqueIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
 
       val query = "MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name IN {coll} SET n:Foo RETURN n.name"
       //WHEN
-      executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query, params = Map("coll" -> List("Jacob")),
+      executeWith(Configs.Interpreted - Configs.Cost2_3, query, params = Map("coll" -> List("Jacob")),
         planComparisonStrategy = ComparePlansWithAssertion((plan) => {
           //THEN
           plan shouldNot useOperators("NodeIndexSeek")

--- a/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -7,15 +7,6 @@ Support column renaming for aggregates as well
 Support multiple divisions in aggregate function
 Aggregates in aggregates
 Aggregates with arithmetics
-Handling numerical ranges 1
-Handling numerical ranges 2
-Handling numerical ranges 3
-Handling numerical ranges 4
-Handling string ranges 1
-Handling string ranges 2
-Handling string ranges 3
-Handling string ranges 4
-Handling empty range
 Fail at runtime when attempting to index with an Int into a Map
 Fail at runtime when trying to index into a map with a non-string
 Fail at runtime when attempting to index with a String into a Collection

--- a/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -19,13 +19,6 @@ IS NOT NULL with literal maps
 `percentileDisc()` failing on bad arguments
 `percentileDisc()` failing in more involved query
 `type()` failing on invalid arguments
-Adding a single label
-Ignore space before colon
-Adding multiple labels
-Ignoring intermediate whitespace 1
-Ignoring intermediate whitespace 2
-Removing a label
-Removing a non-existent label
 Optionally matching named paths with single and variable length patterns
 Optionally matching named paths with variable length patterns
 Variable length relationship in OPTIONAL MATCH
@@ -47,17 +40,8 @@ Fail when using property access on primitive type
 Counting an empty graph
 Variable length pattern checking labels on endnodes
 Variable length patterns and nulls
-Failing on merging relationship with null property
 Failing on merging node with null property
 Failing when setting a list of maps as a property
-Ignore null when setting property
-Ignore null when removing property
-Ignore null when setting properties using an appending map
-Ignore null when setting properties using an overriding map
-Ignore null when setting label
-Ignore null when removing label
-Ignore null when deleting node
-Ignore null when deleting relationship
 MATCH after OPTIONAL MATCH
 Variable length optional relationships
 Variable length optional relationships with length predicates
@@ -66,22 +50,10 @@ Variable length optional relationships with bound nodes, no matches
 Returning a pattern comprehension with bound nodes
 Using a variable-length pattern comprehension in a WITH
 Pattern comprehension inside list comprehension
-Should ignore nulls
-Remove a single label
-Remove multiple labels
-Remove a single node property
-Remove multiple node properties
-Remove a single relationship property
-Remove a single relationship property
-Remove multiple relationship properties
-Remove a missing property should be a valid operation
 Fail when returning properties of deleted nodes
 Fail when returning labels of deleted nodes
 Fail when returning properties of deleted relationships
-Do not fail when returning type of deleted relationships
 Fail when sorting on variable removed by DISTINCT
-Setting and returning the size of a list property
-Setting and returning the size of a list property
 Arithmetic expressions inside aggregation
 Concatenating and returning the size of literal lists
 Concatenating and returning the size of literal lists
@@ -119,27 +91,11 @@ Failing when using a variable that is already bound in CREATE
 // Updating queries
 Fail when imposing new predicates on a variable that is already bound
 Create a relationship with the correct direction
-A bound node should be recognized after projection with WITH + MERGE pattern
-Delete nodes
-Detach delete node
-Delete relationships
 Deleting connected nodes
 Detach deleting connected nodes and relationships
 Detach deleting paths
-Undirected expand followed by delete and count
-Undirected variable length expand followed by delete and count
 Create and delete in same query
-Delete optionally matched relationship
-Delete on null node
-Detach delete on null node
-Delete on null path
-Delete node from a list
-Delete node from a list
-Delete relationship from a list
 Delete nodes from a map
-Delete relationships from a map
-Detach delete nodes from nested map/list
-Delete relationships from nested map/list
 Delete paths from nested map/list
 Delete relationship with bidirectional matching
 Updating one property with ON CREATE
@@ -148,65 +104,19 @@ Copying properties from literal map with ON CREATE
 Copying properties from literal map with ON MATCH
 Copying properties from node with ON CREATE
 Copying properties from node with ON MATCH
-Merge node with label add label on create
-Merge node with label add property on create
-Merge node with label add label on match when it exists
-Merge node with label add property on update when it exists
-Merge node and set property on match
-Should be able to use properties from match in ON CREATE
-Should be able to use properties from match in ON MATCH
 Should be able to use properties from match in ON MATCH and ON CREATE
-Should be able to set labels on match
-Should be able to set labels on match and on create
 Merges should not be able to match on deleted nodes
-ON CREATE on created nodes
-Creating a relationship
-Matching a relationship
-Matching two relationships
-Filtering relationships
-Creating relationship when all matches filtered out
-Matching incoming relationship
-Creating relationship with property
-Using ON CREATE on a node
-Using ON CREATE on a relationship
-Using ON MATCH on created node
-Using ON MATCH on created relationship
-Using ON MATCH on a relationship
-Using ON CREATE and ON MATCH
-Creating relationship using merged nodes
-Mixing MERGE with CREATE
-Introduce named paths 1
-Use outgoing direction when unspecified
-Match outgoing relationship when direction unspecified
-Match both incoming and outgoing relationships when direction unspecified
-Using list properties via variable
-Matching using list property
-Using bound variables from other updating clause
 UNWIND with multiple merges
 Do not match on deleted entities
 Do not match on deleted relationships
-Aliasing of existing nodes 1
-Aliasing of existing nodes 2
-Double aliasing of existing nodes 1
-Double aliasing of existing nodes 2
-Setting a node property to null removes the existing property
-Setting a relationship property to null removes the existing property
 Set a property
 Set a property to an expression
-Set a property by selecting the node using a simple expression
-Set a property by selecting the relationship using a simple expression
-Setting a property to null removes the property
-Add a label to a node
-Adding a list property
 Concatenate elements onto a list property
 Concatenate elements in reverse onto a list property
 Overwrite values when using +=
-Retain old values when using +=
-Explicit null values in a map remove old values
 Non-existent values in a property map are removed with SET =
 Unwind with merge
 Fail when trying to create using an undirected relationship pattern
-Returning nested expressions based on list property
 
 Many CREATE clauses
 

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildSlottedExecutionPlan.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildSlottedExecutionPlan.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.compatibility.v3_4.runtime._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.EnterpriseRuntimeContext
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.phases.CompilationState
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.SlottedPipeBuilder
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.{SlottedExecutionResultBuilderFactory, SlottedPipeBuilder}
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.expressions.SlottedExpressionConverters
 import org.neo4j.cypher.internal.compiler.v3_4.CypherCompilerConfiguration
 import org.neo4j.cypher.internal.compiler.v3_4.phases.{CompilationContains, LogicalPlanState}
@@ -89,7 +89,8 @@ object BuildSlottedExecutionPlan extends Phase[EnterpriseRuntimeContext, Logical
         .build(from.periodicCommit, logicalPlan)(pipeBuildContext, context.planContext)
       val PipeInfo(pipe: Pipe, updating, periodicCommitInfo, fp, planner) = pipeInfo
       val columns = from.statement().returnColumns
-      val resultBuilderFactory = DefaultExecutionResultBuilderFactory(pipeInfo, columns, logicalPlan)
+      val resultBuilderFactory =
+        new SlottedExecutionResultBuilderFactory(pipeInfo, columns, logicalPlan, physicalPlan.slotConfigurations)
       val func = BuildInterpretedExecutionPlan.getExecutionPlanFunction(periodicCommitInfo, from.queryText, updating,
                                                                         resultBuilderFactory,
                                                                         context.notificationLogger,

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/DebugPrettyPrinter.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/DebugPrettyPrinter.scala
@@ -44,11 +44,15 @@ trait DebugPrettyPrinter {
     println("\u001b[30m")
   }
 
-  protected def printPipeInfo(logicalPlan: LogicalPlan, slotConfigurations: Map[LogicalPlanId, SlotConfiguration], pipeInfo: PipeInfo) = {
+  protected def printRewrittenPlanInfo(logicalPlan: LogicalPlan) = {
     if (PRINT_REWRITTEN_LOGICAL_PLAN) {
       println(s"\n\u001b[35m[REWRITTEN LOGICAL PLAN]\n") // Magenta
       prettyPrintLogicalPlan(logicalPlan)
     }
+    println("\u001b[30m")
+  }
+
+  protected def printPipeInfo(slotConfigurations: Map[LogicalPlanId, SlotConfiguration], pipeInfo: PipeInfo) = {
     if (PRINT_PIPELINE_INFO) {
       println(s"\n\u001b[36m[SLOT CONFIGURATIONS]\n") // Cyan
       prettyPrintPipelines(slotConfigurations)

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/ExpandAllOperator.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/operators/ExpandAllOperator.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.runtime.vectorized.operators
 
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker.nodeIsNull
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker.entityIsNull
 import org.neo4j.cypher.internal.runtime.QueryContext
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.LazyTypes
 import org.neo4j.cypher.internal.runtime.vectorized._
@@ -78,7 +78,7 @@ class ExpandAllOperator(toSlots: SlotConfiguration,
     while (readPos < input.validRows && writePos < output.validRows) {
 
       val fromNode = input.longs(readPos * inputLongCount + fromOffset)
-      if (nodeIsNull(fromNode))
+      if (entityIsNull(fromNode))
       readPos += 1
       else {
         if (relationships == null) {

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
@@ -379,7 +379,29 @@ object SlotAllocation {
       case Eager(_) =>
         source.copy()
 
-      case p => throw new SlotAllocationFailed(s"Don't know how to handle $p")
+      case _: DeleteNode |
+           _: DeleteRelationship |
+           _: DeletePath |
+           _: DeleteExpression |
+           _: DetachDeleteNode |
+           _: DetachDeletePath |
+           _: DetachDeleteExpression =>
+        source
+
+      case _: SetLabels |
+           _: SetNodeProperty |
+           _: SetNodePropertiesFromMap |
+           _: SetRelationshipPropery |
+           _: SetRelationshipPropertiesFromMap |
+           _: SetProperty |
+           _: RemoveLabels =>
+        source
+
+      case _: LockNodes =>
+        source
+
+      case p =>
+        throw new SlotAllocationFailed(s"Don't know how to handle $p")
     }
 
   /**
@@ -400,8 +422,8 @@ object SlotAllocation {
       case _: Apply =>
         rhs
 
-      case _: SemiApply |
-           _: AntiSemiApply =>
+      case _: AbstractSemiApply |
+           _: AbstractSelectOrSemiApply =>
         lhs
 
       case _: AntiConditionalApply |
@@ -471,7 +493,12 @@ object SlotAllocation {
             }
         }
         result
-      case p => throw new SlotAllocationFailed(s"Don't know how to handle $p")
+
+      case _: AssertSameNode =>
+        lhs
+
+      case p =>
+        throw new SlotAllocationFailed(s"Don't know how to handle $p")
     }
 
   private def addGroupingMap(groupingExpressions: Map[String, Expression],

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/NodeProperty.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/NodeProperty.scala
@@ -19,20 +19,22 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.ast
 
-case class NodeProperty(offset: Int, propToken: Int, name: String) extends RuntimeExpression {
+import org.neo4j.cypher.internal.v3_4.expressions.Property
+
+case class NodeProperty(offset: Int, propToken: Int, name: String)(prop: Property) extends RuntimeProperty(prop) {
   override def asCanonicalStringVal: String = name
 }
 
 // Token did not exist at plan time, so we'll need to look it up at runtime
-case class NodePropertyLate(offset: Int, propKey: String, name: String) extends RuntimeExpression {
+case class NodePropertyLate(offset: Int, propKey: String, name: String)(prop: Property) extends RuntimeProperty(prop) {
   override def asCanonicalStringVal: String = name
 }
 
-case class NodePropertyExists(offset: Int, propToken: Int, name: String) extends RuntimeExpression {
+case class NodePropertyExists(offset: Int, propToken: Int, name: String)(prop: Property) extends RuntimeProperty(prop) {
   override def asCanonicalStringVal: String = name
 }
 
 // Token did not exist at plan time, so we'll need to look it up at runtime
-case class NodePropertyExistsLate(offset: Int, propKey: String, name: String) extends RuntimeExpression {
+case class NodePropertyExistsLate(offset: Int, propKey: String, name: String)(prop: Property) extends RuntimeProperty(prop) {
   override def asCanonicalStringVal: String = name
 }

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/NullCheck.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/NullCheck.scala
@@ -19,6 +19,24 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.ast
 
-import org.neo4j.cypher.internal.v3_4.expressions.Expression
+import org.neo4j.cypher.internal.v3_4.expressions.{Expression, LogicalProperty, LogicalVariable}
 
 case class NullCheck(offset: Int, inner: Expression) extends RuntimeExpression
+
+// This needs to be used to be able to rewrite an expression declared as a LogicalVariable
+case class NullCheckVariable(offset: Int, inner: LogicalVariable) extends RuntimeVariable(inner.name)
+
+// This needs to be used to be able to rewrite an expression declared as a LogicalProperty
+case class NullCheckProperty(offset: Int, inner: LogicalProperty) extends RuntimeProperty(inner) {
+
+  // We have to override the implementation in RuntimeProperty for correctness. This smells a bit...
+  override def dup(children: Seq[AnyRef]): this.type = {
+    val newOffset = children.head.asInstanceOf[Int]
+    val newInner = children(1).asInstanceOf[LogicalProperty]
+    // We only ever rewrite this with inner already rewritten, so we should not need to copy
+    if (offset == newOffset && inner == newInner)
+      this
+    else
+      copy(offset = newOffset, inner = newInner).asInstanceOf[this.type]
+  }
+}

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RelationshipProperty.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RelationshipProperty.scala
@@ -19,20 +19,20 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.ast
 
-import org.neo4j.cypher.internal.v3_4.expressions.Property
+import org.neo4j.cypher.internal.v3_4.expressions.LogicalProperty
 
-case class RelationshipProperty(offset: Int, propToken: Int, name: String)(prop: Property) extends RuntimeProperty(prop) {
+case class RelationshipProperty(offset: Int, propToken: Int, name: String)(prop: LogicalProperty) extends RuntimeProperty(prop) {
   override def asCanonicalStringVal: String = name
 }
 
-case class RelationshipPropertyLate(offset: Int, propKey: String, name: String)(prop: Property) extends RuntimeProperty(prop) {
+case class RelationshipPropertyLate(offset: Int, propKey: String, name: String)(prop: LogicalProperty) extends RuntimeProperty(prop) {
   override def asCanonicalStringVal: String = name
 }
 
-case class RelationshipPropertyExists(offset: Int, propToken: Int, name: String)(prop: Property) extends RuntimeProperty(prop) {
+case class RelationshipPropertyExists(offset: Int, propToken: Int, name: String)(prop: LogicalProperty) extends RuntimeProperty(prop) {
   override def asCanonicalStringVal: String = name
 }
 
-case class RelationshipPropertyExistsLate(offset: Int, propKey: String, name: String)(prop: Property) extends RuntimeProperty(prop) {
+case class RelationshipPropertyExistsLate(offset: Int, propKey: String, name: String)(prop: LogicalProperty) extends RuntimeProperty(prop) {
   override def asCanonicalStringVal: String = name
 }

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeProperty.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeProperty.scala
@@ -21,15 +21,32 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime.ast
 
 import org.neo4j.cypher.internal.frontend.v3_4.SemanticCheck
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.{SemanticCheckResult, SemanticCheckableExpression}
-import org.neo4j.cypher.internal.util.v3_4.InputPosition
-import org.neo4j.cypher.internal.v3_4.expressions.{Expression, LogicalProperty, Property, PropertyKeyName}
+import org.neo4j.cypher.internal.util.v3_4.AssertionUtils.ifAssertionsEnabled
+import org.neo4j.cypher.internal.util.v3_4.{InputPosition, InternalException}
+import org.neo4j.cypher.internal.v3_4.expressions.{Expression, LogicalProperty, PropertyKeyName}
 
-abstract class RuntimeProperty(val prop: Property) extends LogicalProperty with SemanticCheckableExpression{
+abstract class RuntimeProperty(val prop: LogicalProperty) extends LogicalProperty with SemanticCheckableExpression{
   override def semanticCheck(ctx: Expression.SemanticContext): SemanticCheck = SemanticCheckResult.success
+
+  override def position: InputPosition = InputPosition.NONE
 
   override def map: Expression = prop.map
 
   override def propertyKey: PropertyKeyName = prop.propertyKey
 
-  override def position: InputPosition = InputPosition.NONE
+  override def dup(children: Seq[AnyRef]): this.type = {
+    val constructor = this.copyConstructor
+    val args = children.toVector
+
+    ifAssertionsEnabled {
+      val params = constructor.getParameterTypes
+      val ok = params.length == args.length + 1 && classOf[LogicalProperty].isAssignableFrom(params.last)
+      if (!ok)
+        throw new InternalException(s"Unexpected rewrite children $children")
+    }
+
+    val ctorArgs = args :+ prop // Add the original Property expression
+    val duped = constructor.invoke(this, ctorArgs: _*)
+    duped.asInstanceOf[this.type]
+  }
 }

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeProperty.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeProperty.scala
@@ -22,9 +22,14 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime.ast
 import org.neo4j.cypher.internal.frontend.v3_4.SemanticCheck
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.{SemanticCheckResult, SemanticCheckableExpression}
 import org.neo4j.cypher.internal.util.v3_4.InputPosition
-import org.neo4j.cypher.internal.v3_4.expressions.{Expression, Property}
+import org.neo4j.cypher.internal.v3_4.expressions.{Expression, LogicalProperty, Property, PropertyKeyName}
 
-class RuntimeProperty(val prop: Property) extends Property(map = prop.map, propertyKey = prop.propertyKey)(InputPosition.NONE)
-  with SemanticCheckableExpression {
+abstract class RuntimeProperty(val prop: Property) extends LogicalProperty with SemanticCheckableExpression{
   override def semanticCheck(ctx: Expression.SemanticContext): SemanticCheck = SemanticCheckResult.success
+
+  override def map: Expression = prop.map
+
+  override def propertyKey: PropertyKeyName = prop.propertyKey
+
+  override def position: InputPosition = InputPosition.NONE
 }

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeProperty.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeProperty.scala
@@ -19,20 +19,12 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.ast
 
-import org.neo4j.cypher.internal.v3_4.expressions.Property
+import org.neo4j.cypher.internal.frontend.v3_4.SemanticCheck
+import org.neo4j.cypher.internal.frontend.v3_4.semantics.{SemanticCheckResult, SemanticCheckableExpression}
+import org.neo4j.cypher.internal.util.v3_4.InputPosition
+import org.neo4j.cypher.internal.v3_4.expressions.{Expression, Property}
 
-case class RelationshipProperty(offset: Int, propToken: Int, name: String)(prop: Property) extends RuntimeProperty(prop) {
-  override def asCanonicalStringVal: String = name
-}
-
-case class RelationshipPropertyLate(offset: Int, propKey: String, name: String)(prop: Property) extends RuntimeProperty(prop) {
-  override def asCanonicalStringVal: String = name
-}
-
-case class RelationshipPropertyExists(offset: Int, propToken: Int, name: String)(prop: Property) extends RuntimeProperty(prop) {
-  override def asCanonicalStringVal: String = name
-}
-
-case class RelationshipPropertyExistsLate(offset: Int, propKey: String, name: String)(prop: Property) extends RuntimeProperty(prop) {
-  override def asCanonicalStringVal: String = name
+class RuntimeProperty(val prop: Property) extends Property(map = prop.map, propertyKey = prop.propertyKey)(InputPosition.NONE)
+  with SemanticCheckableExpression {
+  override def semanticCheck(ctx: Expression.SemanticContext): SemanticCheck = SemanticCheckResult.success
 }

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeVariable.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeVariable.scala
@@ -21,9 +21,19 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime.ast
 
 import org.neo4j.cypher.internal.frontend.v3_4.SemanticCheck
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.{SemanticCheckResult, SemanticCheckableExpression}
-import org.neo4j.cypher.internal.util.v3_4.InputPosition
-import org.neo4j.cypher.internal.v3_4.expressions.{Variable, Expression => ASTExpression}
+import org.neo4j.cypher.internal.util.v3_4.{InputPosition, InternalException}
+import org.neo4j.cypher.internal.v3_4.expressions.{LogicalVariable, Expression => ASTExpression}
 
-class RuntimeVariable(name: String) extends Variable(name = name)(InputPosition.NONE) with SemanticCheckableExpression {
+abstract class RuntimeVariable(override val name: String) extends LogicalVariable with SemanticCheckableExpression {
   override def semanticCheck(ctx: ASTExpression.SemanticContext): SemanticCheck = SemanticCheckResult.success
+
+  override def position: InputPosition = InputPosition.NONE
+
+  override def copyId = fail()
+
+  override def renameId(newName: String) = fail()
+
+  override def bumpId = fail()
+
+  private def fail(): Nothing = throw new InternalException("Tried using a RuntimeVariable as Variable")
 }

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriterTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriterTest.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.compatibility.v3_4.runtime.ast._
 import org.neo4j.cypher.internal.frontend.v3_4.ast._
 import org.neo4j.cypher.internal.ir.v3_4.{CardinalityEstimation, IdName, PlannerQuery}
 import org.neo4j.cypher.internal.planner.v3_4.spi.TokenContext
-import org.neo4j.cypher.internal.util.v3_4.Cardinality
+import org.neo4j.cypher.internal.util.v3_4.{Cardinality, NonEmptyList}
 import org.neo4j.cypher.internal.util.v3_4.symbols._
 import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.v3_4.expressions._
@@ -198,7 +198,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val result = rewriter(selection, lookup)
 
     // then
-    val expectedPredicate = Equals(NullCheck(0, NodeProperty(0, 666, "a.prop")(aProp)), literalInt(42))(pos)
+    val expectedPredicate = Equals(NullCheckProperty(0, NodeProperty(0, 666, "a.prop")(aProp)), literalInt(42))(pos)
     result should equal(Selection(Seq(expectedPredicate), argument)(solved))
     lookup(result.assignedId) should equal(slots)
   }
@@ -331,8 +331,8 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val nodeOffset = slots.getLongOffsetFor("x")
     resultPlan should equal(
       Projection(leaf, Map(
-        "x" -> NullCheck(0, NodeFromSlot(0, "x")),
-        "x.propertyKey" -> NullCheck(nodeOffset, NodeProperty(nodeOffset, tokenId, "x.propertyKey")(propFor("x", "propertyKey")))
+        "x" -> NullCheckVariable(0, NodeFromSlot(0, "x")),
+        "x.propertyKey" -> NullCheckProperty(nodeOffset, NodeProperty(nodeOffset, tokenId, "x.propertyKey")(propFor("x", "propertyKey")))
       ))(solved)
     )
   }
@@ -373,7 +373,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     lookup(sr2.assignedId) should equal(rhsPipeline)
   }
 
-  test("ValueHashJoin needs to execute expressions with two different slotss") {
+  test("ValueHashJoin needs to execute expressions with two different slots") {
     // MATCH (a:labelA), (b:labelB) WHERE a.prop = b.prop
     val leafA = NodeByLabelScan(IdName("a"), LabelName("labelA")(pos), Set.empty)(solved)
     val leafB = NodeByLabelScan(IdName("b"), LabelName("labelB")(pos), Set.empty)(solved)
@@ -475,4 +475,33 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     lookup(result.assignedId) should equal(slots)
   }
 
+  test("should be able to rewrite expressions declared as Variable or Property") {
+    // given
+    val arg = Argument()(solved)()
+    val predicate = AndedPropertyInequalities(varFor("n"), nProp, NonEmptyList(LessThan(literalInt(42), varFor("z"))(pos)))
+    val selection = Selection(Seq(predicate), arg)(solved)
+    selection.assignIds()
+
+    val offsetN = 0
+    val offsetZ = 0
+    val slots = SlotConfiguration.empty.
+      newLong("n", nullable = true, CTNode).
+      newReference("z", nullable = false, CTAny)
+    val lookup: Map[LogicalPlanId, SlotConfiguration] = Map(
+      arg.assignedId -> SlotConfiguration.empty,
+      selection.assignedId -> slots)
+    val tokenContext = mock[TokenContext]
+    val tokenId = 666
+    when(tokenContext.getOptPropertyKeyId("prop")).thenReturn(Some(tokenId))
+    val rewriter = new SlottedRewriter(tokenContext)
+
+    // when
+    val result = rewriter(selection, lookup)
+
+    // then
+    val newPred = AndedPropertyInequalities(NullCheckVariable(0, NodeFromSlot(offsetN, "n")),
+      NullCheckProperty(offsetN, NodeProperty(offsetN, 666, "n.prop")(xProp)),
+      NonEmptyList(LessThan(literalInt(42), ReferenceFromSlot(offsetZ, "z"))(pos)))
+    result should equal(Selection(Seq(newPred), arg)(solved))
+  }
 }

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriterTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriterTest.scala
@@ -32,6 +32,12 @@ import org.neo4j.cypher.internal.v3_4.logical.plans.{AllNodesScan, ProduceResult
 
 class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport {
   private val solved = CardinalityEstimation.lift(PlannerQuery.empty, Cardinality(1))
+  private def propFor(v: String, key: String) = Property(Variable(v)(pos), PropertyKeyName(key)(pos))(pos)
+  private val xProp = propFor("x", "prop")
+  private val aProp = propFor("a", "prop")
+  private val bProp = propFor("b", "prop")
+  private val nProp = propFor("n", "prop")
+  private val rProp = propFor("r", "prop")
 
   test("selection with property comparison MATCH (n) WHERE n.prop > 42 RETURN n") {
     val allNodes = AllNodesScan(IdName("x"), Set.empty)(solved)
@@ -52,7 +58,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val rewriter = new SlottedRewriter(tokenContext)
     val result = rewriter(produceResult, lookup)
 
-    val newPredicate = GreaterThan(NodeProperty(offset, tokenId, "x.prop"), literalInt(42))(pos)
+    val newPredicate = GreaterThan(NodeProperty(offset, tokenId, "x.prop")(xProp), literalInt(42))(pos)
 
     result should equal(ProduceResult(Selection(Seq(newPredicate), allNodes)(solved), Seq("x")))
     lookup(result.assignedId) should equal(slots)
@@ -192,7 +198,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val result = rewriter(selection, lookup)
 
     // then
-    val expectedPredicate = Equals(NullCheck(0, NodeProperty(0, 666, "a.prop")), literalInt(42))(pos)
+    val expectedPredicate = Equals(NullCheck(0, NodeProperty(0, 666, "a.prop")(aProp)), literalInt(42))(pos)
     result should equal(Selection(Seq(expectedPredicate), argument)(solved))
     lookup(result.assignedId) should equal(slots)
   }
@@ -215,7 +221,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val rewriter = new SlottedRewriter(tokenContext)
     val result = rewriter(produceResult, lookup)
 
-    val newPredicate = GreaterThan(NodePropertyLate(offset, "prop", "x.prop"), literalInt(42))(pos)
+    val newPredicate = GreaterThan(NodePropertyLate(offset, "prop", "x.prop")(xProp), literalInt(42))(pos)
 
     result should equal(ProduceResult(Selection(Seq(newPredicate), allNodes)(solved), Seq("x")))
     lookup(result.assignedId) should equal(slots)
@@ -247,7 +253,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     // when
     val result = rewriter(selection, lookup)
 
-    result should equal(Selection(Seq(Equals(RelationshipPropertyLate(2, "prop", "r.prop"), literalInt(42))(pos)), argument)(solved))
+    result should equal(Selection(Seq(Equals(RelationshipPropertyLate(2, "prop", "r.prop")(rProp), literalInt(42))(pos)), argument)(solved))
     lookup(result.assignedId) should equal(slots)
   }
 
@@ -274,7 +280,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val result = rewriter(produceResult, lookup)
 
     //then
-    val newProjection = Projection(allNodes, Map("n.prop" -> NodePropertyLate(nodeOffset, "prop", "n.prop")))(solved)
+    val newProjection = Projection(allNodes, Map("n.prop" -> NodePropertyLate(nodeOffset, "prop", "n.prop")(nProp)))(solved)
     result should equal(
       ProduceResult(newProjection, Seq("n.prop")))
     lookup(result.assignedId) should equal(slots)
@@ -300,7 +306,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     resultPlan should equal(
       Projection(leaf, Map(
         "x" -> NodeFromSlot(0, "x"),
-        "x.propertyKey" -> NodeProperty(slots.getLongOffsetFor("x"), tokenId, "x.propertyKey")
+        "x.propertyKey" -> NodeProperty(slots.getLongOffsetFor("x"), tokenId, "x.propertyKey")(propFor("x", "propertyKey"))
       ))(solved)
     )
   }
@@ -326,7 +332,7 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     resultPlan should equal(
       Projection(leaf, Map(
         "x" -> NullCheck(0, NodeFromSlot(0, "x")),
-        "x.propertyKey" -> NullCheck(nodeOffset, NodeProperty(nodeOffset, tokenId, "x.propertyKey"))
+        "x.propertyKey" -> NullCheck(nodeOffset, NodeProperty(nodeOffset, tokenId, "x.propertyKey")(propFor("x", "propertyKey")))
       ))(solved)
     )
   }
@@ -398,8 +404,8 @@ class SlottedRewriterTest extends CypherFunSuite with AstConstructionTestSupport
     val resultPlan = rewriter(join, lookup)
 
     // then
-    val lhsExpAfterRewrite = NodeProperty(0, tokenId, "a.prop")
-    val rhsExpAfterRewrite = NodeProperty(0, tokenId, "b.prop")  // Same offsets, but on different contexts
+    val lhsExpAfterRewrite = NodeProperty(0, tokenId, "a.prop")(aProp)
+    val rhsExpAfterRewrite = NodeProperty(0, tokenId, "b.prop")(bProp)  // Same offsets, but on different contexts
     val joinAfterRewrite = ValueHashJoin(leafA, leafB, Equals(lhsExpAfterRewrite, rhsExpAfterRewrite)(pos))(solved)
 
     resultPlan should equal(

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/PrimitiveExecutionContext.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/PrimitiveExecutionContext.scala
@@ -19,6 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted
 
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker.nodeIsNull
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.{LongSlot, RefSlot, SlotConfiguration}
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.util.v3_4.InternalException
@@ -26,6 +27,7 @@ import org.neo4j.cypher.internal.util.v3_4.symbols.{CTNode, CTRelationship}
 import org.neo4j.kernel.impl.util.{NodeProxyWrappingNodeValue, RelationshipProxyWrappingEdgeValue}
 import org.neo4j.values.AnyValue
 import org.neo4j.values.storable.Values
+import org.neo4j.values.virtual.VirtualValues
 
 object PrimitiveExecutionContext {
   def empty = new PrimitiveExecutionContext(SlotConfiguration.empty)
@@ -39,6 +41,7 @@ object PrimitiveExecutionContext {
 case class PrimitiveExecutionContext(slots: SlotConfiguration) extends ExecutionContext {
 
   override val longs = new Array[Long](slots.numberOfLongs)
+  //java.util.Arrays.fill(longs, -2L) // Uncomment this to check for uninitialized long slots
   override val refs = new Array[AnyValue](slots.numberOfReferences)
 
   override def toString(): String = {
@@ -77,24 +80,29 @@ case class PrimitiveExecutionContext(slots: SlotConfiguration) extends Execution
     case _ => fail()
   }
 
-  override def setLongAt(offset: Int, value: Long): Unit = longs(offset) = value
+  override def setLongAt(offset: Int, value: Long): Unit =
+    longs(offset) = value
 
-  override def getLongAt(offset: Int): Long = longs(offset)
+  override def getLongAt(offset: Int): Long =
+    longs(offset)
+    // Uncomment and replace with this to check for uninitialized long slots
+    //  {
+    //    val value = longs(offset)
+    //    if (value == -2L)
+    //      throw new InternalException(s"Long value not initialised at offset $offset in $this")
+    //    value
+    //  }
 
   override def setRefAt(offset: Int, value: AnyValue): Unit = refs(offset) = value
 
   override def getRefAt(offset: Int): AnyValue = {
     val value = refs(offset)
     if (value == null)
-      throw new InternalException("Value not initialised")
+      throw new InternalException(s"Reference value not initialised at offset $offset in $this")
     value
   }
 
-  override def +=(kv: (String, AnyValue)): Nothing = fail()
-
   override def -=(key: String): Nothing = fail()
-
-  override def get(key: String): Nothing = fail()
 
   override def iterator: Iterator[(String, AnyValue)] = {
     // This method implementation is for debug usage only (the debugger will invoke it when stepping).
@@ -110,11 +118,75 @@ case class PrimitiveExecutionContext(slots: SlotConfiguration) extends Execution
 
   private def fail(): Nothing = throw new InternalException("Tried using a primitive context as a map")
 
-  // This method is called from ScopeExpressions. We should already have allocated a slot for the given
-  // key, so we just set the value in the existing slot instead of creating a new context like in
-  // the MapExecutionContext.
+  //-----------------------------------------------------------------------------------------------------------
+  // Compatibility implementations of the old ExecutionContext API used by Community interpreted runtime pipes
+  //-----------------------------------------------------------------------------------------------------------
+  override def get(key: String): Option[AnyValue] = {
+    slots.get(key) match {
+      case Some(LongSlot(offset, false, CTNode)) =>
+        Some(VirtualValues.node(getLongAt(offset)))
+
+      case Some(LongSlot(offset, false, CTRelationship)) =>
+        Some(VirtualValues.edge(getLongAt(offset)))
+
+      case Some(LongSlot(offset, true, CTNode)) =>
+        val nodeId = getLongAt(offset)
+        if (nodeIsNull(nodeId))
+          Some(Values.NO_VALUE)
+        else
+          Some(VirtualValues.node(nodeId))
+
+      case Some(LongSlot(offset, true, CTRelationship)) =>
+        val relId = getLongAt(offset)
+        if (nodeIsNull(relId))
+          Some(Values.NO_VALUE)
+        else
+          Some(VirtualValues.edge(relId))
+
+      case Some(RefSlot(offset, _, _)) =>
+        Some(getRefAt(offset))
+
+      case _ =>
+        None
+    }
+  }
+
+  override def +=(kv: (String, AnyValue)): this.type = {
+    val offset = slots.getReferenceOffsetFor(kv._1)
+    setRefAt(offset, kv._2)
+    this
+  }
+
+  override def getOrElse[B1 >: AnyValue](key: String, default: => B1): B1 = get(key) match {
+    case Some(v) => v
+    case None => default
+  }
+
+  // The newWith methods are called from Community pipes. We should already have allocated slots for the given keys,
+  // so we just set the values in the existing slots instead of creating a new context like in the MapExecutionContext.
+  override def newWith(newEntries: Seq[(String, AnyValue)]): ExecutionContext = {
+    newEntries.foreach {
+      case (k, v) =>
+        setValue(k, v)
+    }
+    this
+  }
+
   override def newWith1(key1: String, value1: AnyValue): ExecutionContext = {
     setValue(key1, value1)
+    this
+  }
+
+  override def newWith2(key1: String, value1: AnyValue, key2: String, value2: AnyValue): ExecutionContext = {
+    setValue(key1, value1)
+    setValue(key2, value2)
+    this
+  }
+
+  override def newWith3(key1: String, value1: AnyValue, key2: String, value2: AnyValue, key3: String, value3: AnyValue): ExecutionContext = {
+    setValue(key1, value1)
+    setValue(key2, value2)
+    setValue(key3, value3)
     this
   }
 
@@ -126,16 +198,6 @@ case class PrimitiveExecutionContext(slots: SlotConfiguration) extends Execution
     scopeContext.asInstanceOf[PrimitiveExecutionContext].setValue(key1, value1)
     scopeContext
   }
-
-  override def newWith2(key1: String, value1: AnyValue, key2: String, value2: AnyValue): ExecutionContext = fail()
-
-  override def newWith3(key1: String, value1: AnyValue, key2: String, value2: AnyValue, key3: String, value3: AnyValue): ExecutionContext = fail()
-
-  override def mergeWith(other: ExecutionContext): ExecutionContext = fail()
-
-  override def createClone(): ExecutionContext = fail()
-
-  override def newWith(newEntries: Seq[(String, AnyValue)]): ExecutionContext = fail()
 
   private def setValue(key1: String, value1: AnyValue): Unit = {
     (slots.get(key1), value1) match {
@@ -167,5 +229,41 @@ case class PrimitiveExecutionContext(slots: SlotConfiguration) extends Execution
       case _ =>
         throw new InternalException(s"Ouch, no suitable slot for key $key1 = $value1\nSlots: ${slots}")
     }
+  }
+
+  def isRefInitialized(offset: Int): Boolean = {
+    refs(offset) != null
+  }
+
+  def getRefAtWithoutCheckingInitialized(offset: Int): AnyValue =
+    refs(offset)
+
+  override def mergeWith(other: ExecutionContext): ExecutionContext = other match {
+    case primitiveOther: PrimitiveExecutionContext =>
+      primitiveOther.slots.foreachSlot {
+        case (key, otherSlot) =>
+          val thisSlot = slots.get(key).getOrElse(
+            throw new InternalException(s"Tried to merge slot $otherSlot from $other but it is missing from $this." +
+              "Looks like something needs to be fixed in slot allocation.")
+          )
+          assert(thisSlot.isTypeCompatibleWith(otherSlot))
+          otherSlot match {
+            case LongSlot(offset, _, _) =>
+              setLongAt(thisSlot.offset, other.getLongAt(offset))
+            case RefSlot(offset, _, _) if primitiveOther.isRefInitialized(offset) =>
+              setRefAt(thisSlot.offset, primitiveOther.getRefAtWithoutCheckingInitialized(offset))
+            case _ =>
+          }
+      }
+      this
+
+    case _ =>
+      throw new InternalException("Well well, isn't this a delicate situation?")
+  }
+
+  override def createClone(): ExecutionContext = {
+    val clone = PrimitiveExecutionContext(slots)
+    copyTo(clone)
+    clone
   }
 }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/PrimitiveExecutionContext.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/PrimitiveExecutionContext.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker.nodeIsNull
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker.entityIsNull
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.{LongSlot, RefSlot, SlotConfiguration}
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.util.v3_4.InternalException
@@ -131,14 +131,14 @@ case class PrimitiveExecutionContext(slots: SlotConfiguration) extends Execution
 
       case Some(LongSlot(offset, true, CTNode)) =>
         val nodeId = getLongAt(offset)
-        if (nodeIsNull(nodeId))
+        if (entityIsNull(nodeId))
           Some(Values.NO_VALUE)
         else
           Some(VirtualValues.node(nodeId))
 
       case Some(LongSlot(offset, true, CTRelationship)) =>
         val relId = getLongAt(offset)
-        if (nodeIsNull(relId))
+        if (entityIsNull(relId))
           Some(Values.NO_VALUE)
         else
           Some(VirtualValues.edge(relId))

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/PrimitiveExecutionContext.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/PrimitiveExecutionContext.scala
@@ -102,7 +102,7 @@ case class PrimitiveExecutionContext(slots: SlotConfiguration) extends Execution
     value
   }
 
-  override def -=(key: String): Nothing = fail()
+  override def -=(key: String): Nothing = fail() // We do not expect this to be used
 
   override def iterator: Iterator[(String, AnyValue)] = {
     // This method implementation is for debug usage only (the debugger will invoke it when stepping).
@@ -152,6 +152,8 @@ case class PrimitiveExecutionContext(slots: SlotConfiguration) extends Execution
   }
 
   override def +=(kv: (String, AnyValue)): this.type = {
+    // NOTE: Here we assume the slot has been allocated as a RefSlot
+    // If we aim for always using LongSlots internally we sho
     val offset = slots.getReferenceOffsetFor(kv._1)
     setRefAt(offset, kv._2)
     this

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedExecutionResultBuilderFactory.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedExecutionResultBuilderFactory.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted
+
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan.{DefaultExecutionResultBuilderFactory, ExecutionResultBuilder, PipeInfo}
+import org.neo4j.cypher.internal.v3_4.logical.plans.{LogicalPlan, LogicalPlanId}
+import org.neo4j.values.virtual.MapValue
+
+import scala.collection.mutable
+
+class SlottedExecutionResultBuilderFactory(pipeInfo: PipeInfo,
+                                           columns: List[String],
+                                           logicalPlan: LogicalPlan,
+                                           pipelines: Map[LogicalPlanId, SlotConfiguration])
+  extends DefaultExecutionResultBuilderFactory(pipeInfo, columns, logicalPlan) {
+
+  override def create(): ExecutionResultBuilder =
+    new SlottedExecutionWorkflowBuilder()
+
+  class SlottedExecutionWorkflowBuilder() extends ExecutionWorkflowBuilder {
+    override protected def createQueryState(params: MapValue, queryId: AnyRef) = {
+      new SlottedQueryState(queryContext, externalResource, params, pipeDecorator,
+        queryId = queryId,
+        triadicState = mutable.Map.empty, repeatableReads = mutable.Map.empty)
+    }
+  }
+}

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilder.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilder.scala
@@ -36,9 +36,9 @@ import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.{Aggre
 import org.neo4j.cypher.internal.runtime.interpreted.commands.predicates.{Predicate, True}
 import org.neo4j.cypher.internal.runtime.interpreted.commands.{expressions => commandExpressions}
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.{ColumnOrder => _, _}
-import org.neo4j.cypher.internal.util.v3_4.AssertionRunner.Thunk
+import org.neo4j.cypher.internal.util.v3_4.AssertionUtils._
+import org.neo4j.cypher.internal.util.v3_4.InternalException
 import org.neo4j.cypher.internal.util.v3_4.symbols._
-import org.neo4j.cypher.internal.util.v3_4.{AssertionRunner, InternalException}
 import org.neo4j.cypher.internal.v3_4.expressions.{Equals, SignedDecimalIntegerLiteral}
 import org.neo4j.cypher.internal.v3_4.logical.plans
 import org.neo4j.cypher.internal.v3_4.logical.plans._
@@ -398,12 +398,6 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
 
       case _ => throw new CantCompileQueryException(s"Unsupported logical plan operator: $plan")
     }
-  }
-
-  private def ifAssertionsEnabled(f: => Unit): Unit = {
-    AssertionRunner.runUnderAssertion(new Thunk {
-      override def apply() = f
-    })
   }
 
   // Verifies the assumption that all shared slots are arguments with slot offsets within the first argument size number of slots

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedQueryState.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedQueryState.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted
+
+import java.util.UUID
+
+import org.neo4j.collection.primitive.PrimitiveLongSet
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
+import org.neo4j.cypher.internal.runtime.QueryContext
+import org.neo4j.cypher.internal.runtime.interpreted.commands.predicates.{InCheckContainer, SingleThreadedLRUCache}
+import org.neo4j.cypher.internal.runtime.interpreted.pipes._
+import org.neo4j.cypher.internal.runtime.interpreted.{ExecutionContext, MutableMaps}
+import org.neo4j.values.AnyValue
+import org.neo4j.values.virtual.MapValue
+
+import scala.collection.mutable
+
+class SlottedQueryState(query: QueryContext,
+                        resources: ExternalCSVResource,
+                        params: MapValue,
+                        decorator: PipeDecorator = NullPipeDecorator,
+                        timeReader: TimeReader = new TimeReader,
+                        initialContext: Option[ExecutionContext] = None,
+                        queryId: AnyRef = UUID.randomUUID().toString,
+                        triadicState: mutable.Map[String, PrimitiveLongSet] = mutable.Map.empty,
+                        repeatableReads: mutable.Map[Pipe, Seq[ExecutionContext]] = mutable.Map.empty,
+                        cachedIn: SingleThreadedLRUCache[Any, InCheckContainer] =
+                        new SingleThreadedLRUCache(maxSize = 16))
+  extends QueryState(query, resources, params, decorator, timeReader, initialContext, queryId, triadicState,
+    repeatableReads, cachedIn) {
+
+  override def createOrGetInitialContext(factory: ExecutionContextFactory): ExecutionContext =
+    initialContext.getOrElse(factory.newExecutionContext())
+
+  override def withDecorator(decorator: PipeDecorator) =
+    new SlottedQueryState(query, resources, params, decorator, timeReader, initialContext, queryId, triadicState, repeatableReads, cachedIn)
+
+  override def withInitialContext(initialContext: ExecutionContext) =
+    new SlottedQueryState(query, resources, params, decorator, timeReader, Some(initialContext), queryId, triadicState, repeatableReads, cachedIn)
+
+  override def withQueryContext(query: QueryContext) =
+    new SlottedQueryState(query, resources, params, decorator, timeReader, initialContext, queryId, triadicState, repeatableReads, cachedIn)
+}
+
+case class SlottedExecutionContextFactory(slots: SlotConfiguration) extends ExecutionContextFactory {
+  override def newExecutionContext(m: mutable.Map[String, AnyValue] = MutableMaps.empty): ExecutionContext =
+    throw new UnsupportedOperationException("Please implement")
+
+  override def newExecutionContext(): ExecutionContext =
+    PrimitiveExecutionContext(slots)
+}

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/expressions/IsPrimitiveNull.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/expressions/IsPrimitiveNull.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.expressions
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker.nodeIsNull
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker.entityIsNull
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Expression
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.QueryState
@@ -28,5 +28,5 @@ import org.neo4j.values.storable.Values.booleanValue
 
 case class IsPrimitiveNull(offset: Int) extends Expression with SlottedExpression {
   override def apply(ctx: ExecutionContext, state: QueryState): BooleanValue =
-    booleanValue(nodeIsNull(ctx.getLongAt(offset)))
+    booleanValue(entityIsNull(ctx.getLongAt(offset)))
 }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/expressions/NullCheck.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/expressions/NullCheck.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.expressions
 
 import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Expression
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.QueryState
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker.nodeIsNull
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker.entityIsNull
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.values.AnyValue
 import org.neo4j.values.storable.Values
@@ -29,6 +29,6 @@ import org.neo4j.values.storable.Values
 case class NullCheck(offset: Int, inner: Expression) extends Expression with SlottedExpression {
 
   override def apply(ctx: ExecutionContext, state: QueryState): AnyValue =
-    if (nodeIsNull(ctx.getLongAt(offset))) Values.NO_VALUE else inner(ctx, state)
+    if (entityIsNull(ctx.getLongAt(offset))) Values.NO_VALUE else inner(ctx, state)
 
 }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/expressions/SlottedExpressionConverters.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/expressions/SlottedExpressionConverters.scala
@@ -63,6 +63,12 @@ object SlottedExpressionConverters extends ExpressionConverter {
       case runtimeAst.NullCheck(offset, inner) =>
         val a = self.toCommandExpression(inner)
         Some(runtimeExpression.NullCheck(offset, a))
+      case runtimeAst.NullCheckVariable(offset, inner) =>
+        val a = self.toCommandExpression(inner)
+        Some(runtimeExpression.NullCheck(offset, a))
+      case runtimeAst.NullCheckProperty(offset, inner) =>
+        val a = self.toCommandExpression(inner)
+        Some(runtimeExpression.NullCheck(offset, a))
       case e: ast.PathExpression =>
         Some(toCommandProjectedPath(e, self))
       case runtimeAst.IsPrimitiveNull(offset) =>

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/expressions/SlottedProjectedPath.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/expressions/SlottedProjectedPath.scala
@@ -19,10 +19,9 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.expressions
 
+import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.{Expression, PathValueBuilder}
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.QueryState
-import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
-import org.neo4j.values.virtual.{EdgeValue, ListValue, NodeValue}
 
 object SlottedProjectedPath {
 
@@ -34,14 +33,14 @@ object SlottedProjectedPath {
 
   case class singleNodeProjector(node: Expression, tailProjector: Projector) extends Projector {
     def apply(ctx: ExecutionContext, state: QueryState, builder: PathValueBuilder) = {
-      val nodeValue = node.apply(ctx, state).asInstanceOf[NodeValue]
+      val nodeValue = node.apply(ctx, state)
       tailProjector(ctx, state, builder.addNode(nodeValue))
     }
   }
 
   case class singleIncomingRelationshipProjector(rel: Expression, tailProjector: Projector) extends Projector {
     def apply(ctx: ExecutionContext, state: QueryState, builder: PathValueBuilder) = {
-      val relValue = rel.apply(ctx, state).asInstanceOf[EdgeValue]
+      val relValue = rel.apply(ctx, state)
       tailProjector(ctx, state, builder.addIncomingRelationship(relValue))
     }
   }
@@ -55,28 +54,28 @@ object SlottedProjectedPath {
 
   case class singleUndirectedRelationshipProjector(rel: Expression, tailProjector: Projector) extends Projector {
     def apply(ctx: ExecutionContext, state: QueryState, builder: PathValueBuilder) = {
-      val relValue = rel.apply(ctx, state).asInstanceOf[EdgeValue]
+      val relValue = rel.apply(ctx, state)
       tailProjector(ctx, state, builder.addUndirectedRelationship(relValue))
     }
   }
 
   case class multiIncomingRelationshipProjector(rel: Expression, tailProjector: Projector) extends Projector {
     def apply(ctx: ExecutionContext, state: QueryState, builder: PathValueBuilder) = {
-      val relListValue = rel.apply(ctx, state).asInstanceOf[ListValue]
+      val relListValue = rel.apply(ctx, state)
       tailProjector(ctx, state, builder.addIncomingRelationships(relListValue))
     }
   }
 
   case class multiOutgoingRelationshipProjector(rel: Expression, tailProjector: Projector) extends Projector {
     def apply(ctx: ExecutionContext, state: QueryState, builder: PathValueBuilder) = {
-      val relListValue = rel.apply(ctx, state).asInstanceOf[ListValue]
+      val relListValue = rel.apply(ctx, state)
       tailProjector(ctx, state, builder.addOutgoingRelationships(relListValue))
     }
   }
 
   case class multiUndirectedRelationshipProjector(rel: Expression, tailProjector: Projector) extends Projector {
     def apply(ctx: ExecutionContext, state: QueryState, builder: PathValueBuilder) = {
-      val relListValue = rel.apply(ctx, state).asInstanceOf[ListValue]
+      val relListValue = rel.apply(ctx, state)
       tailProjector(ctx, state, builder.addUndirectedRelationships(relListValue))
     }
   }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/helpers/NullChecker.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/helpers/NullChecker.scala
@@ -20,5 +20,5 @@
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers
 
 object NullChecker {
-  def nodeIsNull(nodeId: Long): Boolean = nodeId == -1
+  def entityIsNull(nodeId: Long): Boolean = nodeId == -1
 }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/BaseRelationshipSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/BaseRelationshipSlottedPipe.scala
@@ -30,6 +30,7 @@ import org.neo4j.cypher.internal.runtime.interpreted.{ExecutionContext, IsMap, m
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 import org.neo4j.graphdb.{Node, Relationship}
 import org.neo4j.values.AnyValue
+import org.neo4j.values.storable.Values
 import org.neo4j.values.virtual.MapValue
 
 abstract class BaseRelationshipSlottedPipe(src: Pipe,
@@ -84,7 +85,7 @@ abstract class BaseRelationshipSlottedPipe(src: Pipe,
 
   private def setProperty(relId: Long, key: String, value: AnyValue, qtx: QueryContext) {
     //do not set properties for null values
-    if (value == null) {
+    if (value == Values.NO_VALUE) {
       handleNull(key: String)
     } else {
       val propertyKeyId = qtx.getOrCreatePropertyKeyId(key)

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ConditionalApplySlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ConditionalApplySlottedPipe.scala
@@ -52,7 +52,7 @@ case class ConditionalApplySlottedPipe(lhs: Pipe,
     }
 
   private def condition(context: ExecutionContext) = {
-    val cond = longOffsets.exists(offset => !NullChecker.nodeIsNull(context.getLongAt(offset))) ||
+    val cond = longOffsets.exists(offset => !NullChecker.entityIsNull(context.getLongAt(offset))) ||
       refOffsets.exists(context.getRefAt(_) != Values.NO_VALUE)
     if (negated) !cond else cond
   }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ExpandAllSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ExpandAllSlottedPipe.scala
@@ -45,7 +45,7 @@ case class ExpandAllSlottedPipe(source: Pipe,
       (inputRow: ExecutionContext) =>
         val fromNode = inputRow.getLongAt(fromOffset)
 
-        if (NullChecker.nodeIsNull(fromNode))
+        if (NullChecker.entityIsNull(fromNode))
           Iterator.empty
         else {
           val relationships: RelationshipIterator = state.query.getRelationshipsForIdsPrimitive(fromNode, dir, types.types(state.query))

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ExpandIntoSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ExpandIntoSlottedPipe.scala
@@ -23,7 +23,7 @@ import org.neo4j.collection.primitive.PrimitiveLongIterator
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.helpers.PrimitiveLongHelper
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker.nodeIsNull
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker.entityIsNull
 import org.neo4j.cypher.internal.runtime.interpreted.pipes._
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
@@ -59,7 +59,7 @@ case class ExpandIntoSlottedPipe(source: Pipe,
         val fromNode = inputRow.getLongAt(fromOffset)
         val toNode = inputRow.getLongAt(toOffset)
 
-        if (nodeIsNull(fromNode) || nodeIsNull(toNode))
+        if (entityIsNull(fromNode) || entityIsNull(toNode))
           Iterator.empty
         else {
           val relationships: PrimitiveLongIterator = relCache.get(fromNode, toNode, dir)

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/NodeHashJoinSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/NodeHashJoinSlottedPipe.scala
@@ -23,7 +23,7 @@ import java.util
 
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker.nodeIsNull
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker.entityIsNull
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.{Pipe, QueryState}
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
@@ -49,7 +49,7 @@ case class NodeHashJoinSlottedPipe(leftSide: Array[Int],
     for (i <- keyColumns.indices) {
       val idx = keyColumns(i)
       val nodeId = context.getLongAt(idx)
-      if (nodeIsNull(nodeId))
+      if (entityIsNull(nodeId))
         return None
       key(i) = nodeId
     }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalExpandAllSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalExpandAllSlottedPipe.scala
@@ -47,7 +47,7 @@ case class OptionalExpandAllSlottedPipe(source: Pipe,
       (inputRow: ExecutionContext) =>
         val fromNode = inputRow.getLongAt(fromOffset)
 
-        if (NullChecker.nodeIsNull(fromNode)) {
+        if (NullChecker.entityIsNull(fromNode)) {
           Iterator(withNulls(inputRow))
         } else {
           val relationships: RelationshipIterator = state.query.getRelationshipsForIdsPrimitive(fromNode, dir, types.types(state.query))

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalExpandIntoSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalExpandIntoSlottedPipe.scala
@@ -25,7 +25,7 @@ import org.neo4j.cypher.internal.compatibility.v3_4.runtime.helpers.PrimitiveLon
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.commands.predicates.Predicate
 import org.neo4j.cypher.internal.runtime.interpreted.pipes._
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker.nodeIsNull
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker.entityIsNull
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection
@@ -52,7 +52,7 @@ case class OptionalExpandIntoSlottedPipe(source: Pipe,
         val fromNode = inputRow.getLongAt(fromOffset)
         val toNode = inputRow.getLongAt(toOffset)
 
-        if (nodeIsNull(fromNode) || nodeIsNull(toNode)) {
+        if (entityIsNull(fromNode) || entityIsNull(toNode)) {
           Iterator(withNulls(inputRow))
         } else {
           val relationships: PrimitiveLongIterator = relCache.get(fromNode, toNode, dir)


### PR DESCRIPTION
Make PrimitiveExecutionContext compatible with MapExecutionContext
Add compatibility implementations of parts of the old 
ExecutionContext API used by the Community interpreted runtime pipes,
based on the assumption that slot allocation will allocate slots for
all symbols that the pipes will access.

This will enable us to fallback on using community pipes where we
lack specialized implementations in the slotted runtime.

For now we enable the remaining operators that do not do any
actual allocation during slot allocation:

- Deletes
- Set property
- Set/remove label
- LockNodes
- AssertSameNode
- SemiApplys
- SelectOrSemiApplys

Builds on https://github.com/neo4j/neo4j/pull/10520, first commit is 
"Make PrimitiveExecutionContext compatible with MapExecutionContext"