### PR TITLE
Solves problem around queries with many optional matches

### DIFF
--- a/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/QueryGraph.scala
+++ b/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/QueryGraph.scala
@@ -23,8 +23,10 @@ import org.neo4j.cypher.internal.frontend.v3_2.ast._
 import org.neo4j.cypher.internal.ir.v3_2.helpers.ExpressionConverters._
 
 import scala.collection.{GenTraversableOnce, mutable}
+import scala.runtime.ScalaRunTime
 
-case class QueryGraph(patternRelationships: Set[PatternRelationship] = Set.empty,
+case class QueryGraph(// !!! If you change anything here, make sure to update the equals method at the bottom of this class !!!
+                      patternRelationships: Set[PatternRelationship] = Set.empty,
                       patternNodes: Set[IdName] = Set.empty,
                       argumentIds: Set[IdName] = Set.empty,
                       selections: Selections = Selections(),
@@ -122,7 +124,7 @@ case class QueryGraph(patternRelationships: Set[PatternRelationship] = Set.empty
 
   def addShortestPath(shortestPath: ShortestPathPattern): QueryGraph = {
     val rel = shortestPath.rel
-    copy (
+    copy(
       patternNodes = patternNodes + rel.nodes._1 + rel.nodes._2,
       shortestPathPatterns = shortestPathPatterns + shortestPath
     )
@@ -133,10 +135,10 @@ case class QueryGraph(patternRelationships: Set[PatternRelationship] = Set.empty
    */
   def allPatternNodes: Set[IdName] =
     patternNodes ++
-    optionalMatches.flatMap(_.allPatternNodes) ++
-    createNodePatterns.map(_.nodeName) ++
-    mergeNodePatterns.map(_.createNodePattern.nodeName) ++
-    mergeRelationshipPatterns.flatMap(_.createNodePatterns.map(_.nodeName))
+      optionalMatches.flatMap(_.allPatternNodes) ++
+      createNodePatterns.map(_.nodeName) ++
+      mergeNodePatterns.map(_.createNodePattern.nodeName) ++
+      mergeRelationshipPatterns.flatMap(_.createNodePatterns.map(_.nodeName))
 
   def allPatternRelationshipsRead: Set[PatternRelationship] =
     patternRelationships ++ optionalMatches.flatMap(_.allPatternRelationshipsRead)
@@ -145,8 +147,11 @@ case class QueryGraph(patternRelationships: Set[PatternRelationship] = Set.empty
     patternNodes ++ optionalMatches.flatMap(_.allPatternNodesRead)
 
   def addShortestPaths(shortestPaths: ShortestPathPattern*): QueryGraph = shortestPaths.foldLeft(this)((qg, p) => qg.addShortestPath(p))
+
   def addArgumentId(newId: IdName): QueryGraph = copy(argumentIds = argumentIds + newId)
+
   def addArgumentIds(newIds: Seq[IdName]): QueryGraph = copy(argumentIds = argumentIds ++ newIds)
+
   def addSelections(selections: Selections): QueryGraph =
     copy(selections = Selections(selections.predicates ++ this.selections.predicates))
 
@@ -162,6 +167,7 @@ case class QueryGraph(patternRelationships: Set[PatternRelationship] = Set.empty
   def withoutHints(hintsToIgnore: GenTraversableOnce[Hint]): QueryGraph = copy(hints = hints -- hintsToIgnore)
 
   def withoutArguments(): QueryGraph = withArgumentIds(Set.empty)
+
   def withArgumentIds(newArgumentIds: Set[IdName]): QueryGraph =
     copy(argumentIds = newArgumentIds)
 
@@ -190,7 +196,7 @@ case class QueryGraph(patternRelationships: Set[PatternRelationship] = Set.empty
   def withSelections(selections: Selections): QueryGraph = copy(selections = selections)
 
   def withPatternRelationships(patterns: Set[PatternRelationship]): QueryGraph =
-   copy(patternRelationships = patterns)
+    copy(patternRelationships = patterns)
 
   def withPatternNodes(nodes: Set[IdName]): QueryGraph =
     copy(patternNodes = nodes)
@@ -223,9 +229,9 @@ case class QueryGraph(patternRelationships: Set[PatternRelationship] = Set.empty
 
   def allPatternRelationships: Set[PatternRelationship] =
     patternRelationships ++ optionalMatches.flatMap(_.allPatternRelationships) ++
-    // Recursively add relationships from the merge-read-part
-    mergeNodePatterns.flatMap(_.matchGraph.allPatternRelationships) ++
-    mergeRelationshipPatterns.flatMap(_.matchGraph.allPatternRelationships)
+      // Recursively add relationships from the merge-read-part
+      mergeNodePatterns.flatMap(_.matchGraph.allPatternRelationships) ++
+      mergeRelationshipPatterns.flatMap(_.matchGraph.allPatternRelationships)
 
   def coveredIdsExceptArguments: Set[IdName] = {
     val patternIds = QueryGraph.coveredIdsForPatterns(patternNodes, patternRelationships)
@@ -276,10 +282,10 @@ case class QueryGraph(patternRelationships: Set[PatternRelationship] = Set.empty
     patternNodes.collect { case node: IdName => node -> selections.labelsOnNode(node) }.toMap
 
   /**
-   * Returns the connected patterns of this query graph where each connected pattern is represented by a QG.
-   * Does not include optional matches, shortest paths or predicates that have dependencies across multiple of the
-   * connected query graphs.
-   */
+    * Returns the connected patterns of this query graph where each connected pattern is represented by a QG.
+    * Does not include optional matches, shortest paths or predicates that have dependencies across multiple of the
+    * connected query graphs.
+    */
   def connectedComponents: Seq[QueryGraph] = {
     val visited = mutable.Set.empty[IdName]
 
@@ -318,7 +324,7 @@ case class QueryGraph(patternRelationships: Set[PatternRelationship] = Set.empty
   }
 
   def withoutPatternRelationships(patterns: Set[PatternRelationship]): QueryGraph =
-    copy( patternRelationships = patternRelationships -- patterns )
+    copy(patternRelationships = patternRelationships -- patterns)
 
   def joinHints: Set[UsingJoinHint] =
     hints.collect { case hint: UsingJoinHint => hint }
@@ -361,23 +367,79 @@ case class QueryGraph(patternRelationships: Set[PatternRelationship] = Set.empty
   private def argumentsOverLapsWith(coveredIds: Set[IdName]) = (argumentIds intersect coveredIds).nonEmpty
 
   private def predicatePullsInArguments(node: IdName) = selections.flatPredicates.exists { p =>
-      val deps = p.dependencies.map(IdName.fromVariable)
-      deps(node) && (deps intersect argumentIds).nonEmpty
+    val deps = p.dependencies.map(IdName.fromVariable)
+    deps(node) && (deps intersect argumentIds).nonEmpty
   }
 
   def containsReads: Boolean = {
     (patternNodes -- argumentIds).nonEmpty ||
-    patternRelationships.nonEmpty ||
-    selections.nonEmpty ||
-    shortestPathPatterns.nonEmpty ||
-    optionalMatches.nonEmpty ||
-    containsMergeRecursive
+      patternRelationships.nonEmpty ||
+      selections.nonEmpty ||
+      shortestPathPatterns.nonEmpty ||
+      optionalMatches.nonEmpty ||
+      containsMergeRecursive
   }
 
   def writeOnly: Boolean = !containsReads && containsUpdates
 
   def addMutatingPatterns(patterns: MutatingPattern*): QueryGraph =
     copy(mutatingPatterns = mutatingPatterns ++ patterns)
+
+  /**
+    * We have to do this special treatment of QG to avoid problems when checking that the produced plan actually
+    * solves what we set out to solve. In some rare circumstances, we'll get a few optional matches that are independent of each other.
+    *
+    * Given the way our planner works, it can unpredictably plan these optional matches in different orders, which leads to an exception being thrown when
+    * checking that the correct query has been solved.
+    */
+  override def equals(in: scala.Any): Boolean = in match {
+    case other: QueryGraph =>
+
+      val optionals = if (optionalMatches.isEmpty) {
+        true
+      } else {
+        compareOptionalMatches(other)
+      }
+
+      patternRelationships == other.patternRelationships &&
+        patternNodes == other.patternNodes &&
+        argumentIds == other.argumentIds &&
+        selections == other.selections &&
+        optionals &&
+        hints == other.hints &&
+        shortestPathPatterns == other.shortestPathPatterns &&
+        mutatingPatterns == other.mutatingPatterns
+
+    case _ =>
+      false
+  }
+
+  override def hashCode(): Int = {
+    val optionals = if(optionalMatches.nonEmpty && containsIndependentOptionalMatches)
+      optionalMatches.toSet
+    else
+      optionalMatches
+
+    ScalaRunTime._hashCode((patternRelationships, patternNodes, argumentIds, selections, optionals, hints, shortestPathPatterns, mutatingPatterns))
+  }
+
+  private lazy val containsIndependentOptionalMatches = {
+    val nonOptional = coveredIdsExceptArguments
+
+    val result = this.optionalMatches.foldLeft(false) {
+      case (acc, oqg) =>
+        acc || (oqg.dependencies -- nonOptional).nonEmpty
+    }
+
+    result
+  }
+
+  private def compareOptionalMatches(other: QueryGraph) = {
+    if (containsIndependentOptionalMatches) {
+      optionalMatches.toSet == other.optionalMatches.toSet
+    } else
+      optionalMatches == other.optionalMatches
+  }
 }
 
 object QueryGraph {

--- a/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/QueryGraph.scala
+++ b/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/QueryGraph.scala
@@ -393,7 +393,7 @@ case class QueryGraph(// !!! If you change anything here, make sure to update th
     * checking that the correct query has been solved.
     */
   override def equals(in: scala.Any): Boolean = in match {
-    case other: QueryGraph =>
+    case other: QueryGraph if other canEqual this =>
 
       val optionals = if (optionalMatches.isEmpty) {
         true
@@ -413,6 +413,8 @@ case class QueryGraph(// !!! If you change anything here, make sure to update th
     case _ =>
       false
   }
+
+  override def canEqual(that: Any): Boolean = that.isInstanceOf[QueryGraph]
 
   override def hashCode(): Int = {
     val optionals = if(optionalMatches.nonEmpty && containsIndependentOptionalMatches)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -29,6 +29,39 @@ import scala.collection.mutable.ArrayBuffer
 
 class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with NewPlannerTestSupport {
 
+  test("should not fail") {
+    // Should plan without throwing exception
+    innerExecute(
+      """MATCH (study:Study {UUID:$studyUUID})
+        |MATCH (study)-[hasSubject:HAS_SUBJECT]->(subject:Study_Subject)-[:HAS_DATASET]->(dataset:Study_Dataset)<-[:HAS_DATASET]-(study)
+        |WHERE toLower(COALESCE(subject.Archived,'false')) = 'false' AND toLower(COALESCE(dataset.Archived,'false')) = 'false'
+        |WITH DISTINCT study, { RecordID: COALESCE(hasSubject.RecordID, subject.RecordID), SubjectUUID: subject.UUID } AS derivedData, subject
+        |MATCH (subject)-[:HAS_DATASET]-(dataset:Study_Dataset)<-[:HAS_DATASET]-(study)
+        |  WHERE size(FILTER(x in labels(dataset) WHERE x in ['YPQ','WASI'])) = 1 AND toLower(COALESCE(dataset.Archived,'false')) = 'false'
+        |WITH study, derivedData, subject, collect(dataset) AS datasets
+        |MATCH (stai:Study_Dataset:STAI) WHERE (stai IN datasets)
+        |MATCH (pswq:Study_Dataset:PSWQ) WHERE (pswq IN datasets)
+        |MATCH (pss:Study_Dataset:PSS) WHERE (pss IN datasets)
+        |MATCH (njre_q_r:Study_Dataset:NJRE_Q_R) WHERE (njre_q_r IN datasets)
+        |MATCH (iu:Study_Dataset:IU) WHERE (iu IN datasets)
+        |MATCH (gad_7:Study_Dataset:GAD_7) WHERE (gad_7 IN datasets)
+        |MATCH (fmps:Study_Dataset:FMPS) WHERE (fmps IN datasets)
+        |MATCH (bdi:Study_Dataset:BDI) WHERE (bdi IN datasets)
+        |MATCH (wdq:Study_Dataset:WDQ) WHERE (wdq IN datasets)
+        |MATCH (treasurehunt:Study_Dataset:TREASUREHUNT) WHERE (treasurehunt IN datasets)
+        |MATCH (scid_v2:Study_Dataset:SCID_V2) WHERE (scid_v2 IN datasets)
+        |MATCH (ybocs:Study_Dataset:YBOCS) WHERE (ybocs IN datasets)
+        |MATCH (bis:Study_Dataset:BIS) WHERE (bis IN datasets)
+        |MATCH (sdq:Study_Dataset:SDQ) WHERE (sdq IN datasets)
+        |MATCH (ehi:Study_Dataset:EHI) WHERE (ehi IN datasets)
+        |MATCH (oci_r:Study_Dataset:OCI_R) WHERE (oci_r IN datasets)
+        |MATCH (pi_wsur:Study_Dataset:PI_WSUR) WHERE (pi_wsur IN datasets)
+        |MATCH (rfq:Study_Dataset:RFQ) WHERE (rfq IN datasets)
+        |OPTIONAL MATCH (wasi:Study_Dataset:WASI) WHERE (wasi IN datasets)
+        |OPTIONAL MATCH (ypq:Study_Dataset:YPQ) WHERE (ypq IN datasets)
+        |RETURN DISTINCT derivedData AS DerivedData, subject , stai, pswq, pss, njre_q_r, iu, gad_7, fmps, bdi, wdq, treasurehunt, scid_v2, ybocs, bis, sdq, ehi, oci_r, pi_wsur, rfq, wasi, ypq""".stripMargin)
+  }
+
   test("Should not use both pruning var expand and projections that need path info") {
     val n1 = createLabeledNode("Neo")
     val n2 = createLabeledNode()

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -29,7 +29,7 @@ import scala.collection.mutable.ArrayBuffer
 
 class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with NewPlannerTestSupport {
 
-  test("should not fail") {
+  test("should not fail when planning independent optional matches") {
     // Should plan without throwing exception
     innerExecute(
       """MATCH (study:Study {UUID:$studyUUID})


### PR DESCRIPTION
When multiple optional matches exist, and they do not have dependencies
between each other, the planner is free to solve them in any order. This, unfortunately, 
causes a problem where the planner thinks it has failed to solve the original query.

This PR fixes this by comparing QG in a different way when we encounter this rare case.