### PR TITLE
Store correct last stored transaction id in transaction log file header on rotation

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MetaDataStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/MetaDataStore.java
@@ -718,6 +718,14 @@ public class MetaDataStore extends CommonAbstractStore<MetaDataRecord,NoStoreHea
     }
 
     @Override
+    public long committingTransactionId()
+    {
+        assertNotClosed();
+        checkInitialized( lastCommittingTxField.get() );
+        return lastCommittingTxField.get();
+    }
+
+    @Override
     public void transactionCommitted( long transactionId, long checksum, long commitTimestamp )
     {
         assertNotClosed();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadOnlyTransactionIdStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/ReadOnlyTransactionIdStore.java
@@ -66,6 +66,12 @@ public class ReadOnlyTransactionIdStore implements TransactionIdStore
     }
 
     @Override
+    public long committingTransactionId()
+    {
+        throw new UnsupportedOperationException( "Read-only transaction ID store" );
+    }
+
+    @Override
     public void transactionCommitted( long transactionId, long checksum, long commitTimestamp )
     {
         throw new UnsupportedOperationException( "Read-only transaction ID store" );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionIdStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/TransactionIdStore.java
@@ -79,6 +79,11 @@ public interface TransactionIdStore
     long nextCommittingTransactionId();
 
     /**
+     * @return the transaction id of last committing transaction.
+     */
+    long committingTransactionId();
+
+    /**
      * Signals that a transaction with the given transaction id has been committed (i.e. appended to a log).
      * Calls to this method may come in out-of-transaction-id order. The highest transaction id
      * seen given to this method will be visible in {@link #getLastCommittedTransactionId()}.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/LogFilesBuilder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/LogFilesBuilder.java
@@ -283,7 +283,7 @@ public class LogFilesBuilder
         }
         if ( transactionIdStore != null )
         {
-            return () -> transactionIdStore.getLastCommittedTransactionId();
+            return transactionIdStore::getLastCommittedTransactionId;
         }
         if ( fileBasedOperationsOnly )
         {
@@ -314,7 +314,7 @@ public class LogFilesBuilder
     {
         if ( transactionIdStore != null )
         {
-            return () -> transactionIdStore.committingTransactionId();
+            return transactionIdStore::committingTransactionId;
         }
         if ( fileBasedOperationsOnly )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFilesContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFilesContext.java
@@ -31,18 +31,20 @@ class TransactionLogFilesContext
     private final long rotationThreshold;
     private final LogEntryReader logEntryReader;
     private final LongSupplier lastCommittedTransactionIdSupplier;
+    private final LongSupplier committingTransactionIdSupplier;
     private final Supplier<LogVersionRepository> logVersionRepositorySupplier;
     private final LogFileCreationMonitor logFileCreationMonitor;
     private final FileSystemAbstraction fileSystem;
 
     TransactionLogFilesContext( long rotationThreshold, LogEntryReader logEntryReader,
-            LongSupplier lastCommittedTransactionIdSupplier, LogFileCreationMonitor logFileCreationMonitor,
-            Supplier<LogVersionRepository> logVersionRepositorySupplier,
+            LongSupplier lastCommittedTransactionIdSupplier, LongSupplier committingTransactionIdSupplier,
+            LogFileCreationMonitor logFileCreationMonitor, Supplier<LogVersionRepository> logVersionRepositorySupplier,
             FileSystemAbstraction fileSystem )
     {
         this.rotationThreshold = rotationThreshold;
         this.logEntryReader = logEntryReader;
         this.lastCommittedTransactionIdSupplier = lastCommittedTransactionIdSupplier;
+        this.committingTransactionIdSupplier = committingTransactionIdSupplier;
         this.logVersionRepositorySupplier = logVersionRepositorySupplier;
         this.logFileCreationMonitor = logFileCreationMonitor;
         this.fileSystem = fileSystem;
@@ -66,6 +68,11 @@ class TransactionLogFilesContext
     long getLastCommittedTransactionId()
     {
         return lastCommittedTransactionIdSupplier.getAsLong();
+    }
+
+    long committingTransactionId()
+    {
+        return committingTransactionIdSupplier.getAsLong();
     }
 
     LogFileCreationMonitor getLogFileCreationMonitor()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/MetaDataStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/MetaDataStoreTest.java
@@ -111,14 +111,6 @@ public class MetaDataStoreTest
         };
     }
 
-    private MetaDataStore newMetaDataStore() throws IOException
-    {
-        LogProvider logProvider = NullLogProvider.getInstance();
-        StoreFactory storeFactory = new StoreFactory( STORE_DIR, Config.defaults(), new DefaultIdGeneratorFactory( fs ),
-                pageCacheWithFakeOverflow, fs, logProvider );
-        return storeFactory.openNeoStores( true, StoreType.META_DATA ).getMetaDataStore();
-    }
-
     @Test
     public void getCreationTimeShouldFailWhenStoreIsClosed() throws IOException
     {
@@ -325,6 +317,22 @@ public class MetaDataStoreTest
         {
             assertThat( e, instanceOf( IllegalStateException.class ) );
         }
+    }
+
+    @Test
+    public void currentCommittingTransactionId() throws IOException
+    {
+        MetaDataStore metaDataStore = newMetaDataStore();
+        metaDataStore.nextCommittingTransactionId();
+        long lastCommittingTxId = metaDataStore.nextCommittingTransactionId();
+        assertEquals( lastCommittingTxId, metaDataStore.committingTransactionId() );
+
+        metaDataStore.nextCommittingTransactionId();
+        metaDataStore.nextCommittingTransactionId();
+
+        lastCommittingTxId = metaDataStore.nextCommittingTransactionId();
+        assertEquals( lastCommittingTxId, metaDataStore.committingTransactionId() );
+        metaDataStore.close();
     }
 
     @Test
@@ -768,4 +776,13 @@ public class MetaDataStoreTest
             store.logRecords( NullLogger.getInstance() );
         }
     }
+
+    private MetaDataStore newMetaDataStore() throws IOException
+    {
+        LogProvider logProvider = NullLogProvider.getInstance();
+        StoreFactory storeFactory = new StoreFactory( STORE_DIR, Config.defaults(), new DefaultIdGeneratorFactory( fs ),
+                pageCacheWithFakeOverflow, fs, logProvider );
+        return storeFactory.openNeoStores( true, StoreType.META_DATA ).getMetaDataStore();
+    }
+
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/SimpleTransactionIdStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/SimpleTransactionIdStore.java
@@ -67,6 +67,12 @@ public class SimpleTransactionIdStore implements TransactionIdStore
     }
 
     @Override
+    public long committingTransactionId()
+    {
+        return committingTransactionId.get();
+    }
+
+    @Override
     public synchronized void transactionCommitted( long transactionId, long checksum, long commitTimestamp )
     {
         TransactionId current = committedTransactionId.get();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/BatchingTransactionAppenderRotationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/BatchingTransactionAppenderRotationIT.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.log;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import org.neo4j.kernel.impl.api.TransactionToApply;
+import org.neo4j.kernel.impl.core.DatabasePanicEventGenerator;
+import org.neo4j.kernel.impl.store.record.NodeRecord;
+import org.neo4j.kernel.impl.transaction.SimpleLogVersionRepository;
+import org.neo4j.kernel.impl.transaction.SimpleTransactionIdStore;
+import org.neo4j.kernel.impl.transaction.command.Command;
+import org.neo4j.kernel.impl.transaction.log.entry.LogHeader;
+import org.neo4j.kernel.impl.transaction.log.entry.LogHeaderReader;
+import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
+import org.neo4j.kernel.impl.transaction.log.files.LogFilesBuilder;
+import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
+import org.neo4j.kernel.impl.transaction.log.rotation.LogRotationImpl;
+import org.neo4j.kernel.impl.transaction.tracing.LogAppendEvent;
+import org.neo4j.kernel.impl.transaction.tracing.LogForceEvent;
+import org.neo4j.kernel.impl.transaction.tracing.LogForceWaitEvent;
+import org.neo4j.kernel.impl.transaction.tracing.LogRotateEvent;
+import org.neo4j.kernel.impl.transaction.tracing.SerializeTransactionEvent;
+import org.neo4j.kernel.impl.util.SynchronizedArrayIdOrderingQueue;
+import org.neo4j.kernel.internal.DatabaseHealth;
+import org.neo4j.kernel.internal.KernelEventHandlers;
+import org.neo4j.kernel.lifecycle.LifeRule;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.NullLog;
+import org.neo4j.storageengine.api.StorageCommand;
+import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+
+public class BatchingTransactionAppenderRotationIT
+{
+
+    @Rule
+    public final TestDirectory testDirectory = TestDirectory.testDirectory();
+    @Rule
+    public final DefaultFileSystemRule fileSystem = new DefaultFileSystemRule();
+    @Rule
+    public final LifeRule life = new LifeRule( true );
+    private final SimpleLogVersionRepository logVersionRepository = new SimpleLogVersionRepository();
+    private final SimpleTransactionIdStore transactionIdStore = new SimpleTransactionIdStore();
+    private final Monitors monitors = new Monitors();
+
+    @Test
+    public void correctLastAppliedToPreviousLogTransactionInHeaderOnLogFileRotation() throws IOException
+    {
+        LogFiles logFiles = getLogFiles( logVersionRepository, transactionIdStore );
+        life.add( logFiles );
+        DatabaseHealth databaseHealth = getDatabaseHealth();
+
+        LogRotationImpl logRotation =
+                new LogRotationImpl( monitors.newMonitor( LogRotation.Monitor.class ), logFiles, databaseHealth );
+        TransactionMetadataCache transactionMetadataCache = new TransactionMetadataCache( 1024 );
+        SynchronizedArrayIdOrderingQueue idOrderingQueue = new SynchronizedArrayIdOrderingQueue( 20 );
+
+        BatchingTransactionAppender transactionAppender =
+                new BatchingTransactionAppender( logFiles, logRotation, transactionMetadataCache, transactionIdStore,
+                        idOrderingQueue, databaseHealth );
+
+        life.add( transactionAppender );
+
+        LogAppendEvent logAppendEvent = new RotationLogAppendEvent( logRotation );
+        TransactionToApply transactionToApply = prepareTransaction();
+        transactionAppender.append( transactionToApply, logAppendEvent );
+
+        assertEquals( 1, logFiles.getHighestLogVersion() );
+        File highestLogFile = logFiles.getHighestLogFile();
+        LogHeader logHeader = LogHeaderReader.readLogHeader( fileSystem, highestLogFile );
+        assertEquals( 2, logHeader.lastCommittedTxId );
+    }
+
+    private TransactionToApply prepareTransaction()
+    {
+        List<StorageCommand> commands = createCommands();
+        PhysicalTransactionRepresentation transactionRepresentation = new PhysicalTransactionRepresentation( commands );
+        transactionRepresentation.setHeader( new byte[0], 0, 0, 0, 0, 0, 0 );
+        return new TransactionToApply( transactionRepresentation );
+    }
+
+    private List<StorageCommand> createCommands()
+    {
+        return singletonList( new Command.NodeCommand( new NodeRecord( 1L ), new NodeRecord( 2L ) ) );
+    }
+
+    private LogFiles getLogFiles( SimpleLogVersionRepository logVersionRepository,
+            SimpleTransactionIdStore transactionIdStore ) throws IOException
+    {
+        return LogFilesBuilder.builder( testDirectory.directory(), fileSystem.get() )
+                .withLogVersionRepository( logVersionRepository ).withTransactionIdStore( transactionIdStore ).build();
+    }
+
+    private DatabaseHealth getDatabaseHealth()
+    {
+        DatabasePanicEventGenerator databasePanicEventGenerator =
+                new DatabasePanicEventGenerator( new KernelEventHandlers( NullLog.getInstance() ) );
+        return new DatabaseHealth( databasePanicEventGenerator, NullLog.getInstance() );
+    }
+
+    private static class RotationLogAppendEvent implements LogAppendEvent
+    {
+
+        private final LogRotationImpl logRotation;
+
+        RotationLogAppendEvent( LogRotationImpl logRotation )
+        {
+            this.logRotation = logRotation;
+        }
+
+        @Override
+        public LogForceWaitEvent beginLogForceWait()
+        {
+            return null;
+        }
+
+        @Override
+        public LogForceEvent beginLogForce()
+        {
+            return null;
+        }
+
+        @Override
+        public void close()
+        {
+        }
+
+        @Override
+        public void setLogRotated( boolean logRotated )
+        {
+
+        }
+
+        @Override
+        public LogRotateEvent beginLogRotate()
+        {
+            return null;
+        }
+
+        @Override
+        public SerializeTransactionEvent beginSerializeTransaction()
+        {
+            return () ->
+            {
+                try
+                {
+                    logRotation.rotateLogFile();
+                }
+                catch ( IOException e )
+                {
+                    throw new RuntimeException( "Should be able to rotate file", e );
+                }
+            };
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogicalTransactionStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/PhysicalLogicalTransactionStoreTest.java
@@ -155,7 +155,6 @@ public class PhysicalLogicalTransactionStoreTest
         // GIVEN
         TransactionIdStore transactionIdStore = new SimpleTransactionIdStore();
         TransactionMetadataCache positionCache = new TransactionMetadataCache( 100 );
-        LogHeaderCache logHeaderCache = new LogHeaderCache( 10 );
         final byte[] additionalHeader = new byte[]{1, 2, 5};
         final int masterId = 2;
         int authorId = 1;
@@ -296,7 +295,6 @@ public class PhysicalLogicalTransactionStoreTest
     public void shouldThrowNoSuchTransactionExceptionIfMetadataNotFound() throws Exception
     {
         // GIVEN
-        LogFile logFile = mock( LogFile.class );
         LogFiles logFiles = mock( LogFiles.class );
         TransactionMetadataCache cache = new TransactionMetadataCache( 10 );
 
@@ -455,7 +453,7 @@ public class PhysicalLogicalTransactionStoreTest
             return false;
         }
 
-        public int getVisitedTransactions()
+        int getVisitedTransactions()
         {
             return visitedTransactions;
         }


### PR DESCRIPTION
Previously on transactional log file rotation we were using last committed
transaction id as the id of the last transaction that can be found in the previous log file.
And that is not always correct since there is a window where transaction is already
stored in transaction log file, but not yet published as committed.
In case if the wrong header will be stored we will not gonna be able to find transactions
that were stored in older files since we will look for them in the incorrect place.

This PR change that behavior by using current committing transaction id
instead of last committed transaction id.
It's safe to do so since during rotation:
- we flush previous tx log file so we guarantee the durability of tx that still registered as committing;
- the operation is done under tx file lock so its impossible to race with
any ongoing commit