### PR TITLE
[tls] make version 1.2 the only default

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyConfig.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyConfig.java
@@ -44,7 +44,7 @@ import static org.neo4j.kernel.configuration.Settings.setting;
 @Group( "dbms.ssl.policy" )
 public class SslPolicyConfig
 {
-    private static final String TLS_VERSION_DEFAULTS = join( ",", new String[]{"TLSv1.2", "TLSv1.1", "TLSv1"} );
+    private static final String TLS_VERSION_DEFAULTS = join( ",", new String[]{"TLSv1.2"} );
 
     @Description( "The mandatory base directory for cryptographic objects of this policy." +
                   " It is also possible to override each individual configuration with absolute paths." )

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/ssl/SslPolicyConfigTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/ssl/SslPolicyConfigTest.java
@@ -32,6 +32,7 @@ import org.neo4j.ssl.ClientAuth;
 import org.neo4j.test.rule.TestDirectory;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -85,7 +86,7 @@ public class SslPolicyConfigTest
         assertEquals( null, privateKeyPassword );
         assertFalse( allowKeyGeneration );
         assertFalse( trustAll );
-        assertEquals( asList( "TLSv1.2", "TLSv1.1", "TLSv1" ), tlsVersions );
+        assertEquals( singletonList( "TLSv1.2" ), tlsVersions );
         assertNull( ciphers );
         assertEquals( ClientAuth.REQUIRE, clientAuth );
     }

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/conf/neo4j.conf
@@ -172,7 +172,7 @@ dbms.connector.https.enabled=true
 #dbms.ssl.policy.default.client_auth=require
 
 # A comma-separated list of allowed TLS versions.
-# By default TLSv1, TLSv1.1 and TLSv1.2 are allowed.
+# By default only TLSv1.2 is allowed.
 
 #dbms.ssl.policy.default.tls_versions=
 


### PR DESCRIPTION
This is the securest default, but might break deployments already
relying on 1.0 or 1.1.