### PR TITLE
Support Foreach in slotted runtime

### DIFF
--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticTable.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticTable.scala
@@ -51,6 +51,9 @@ class SemanticTable(
       throw new InternalException(s"Did not find any type information for variable $s", e)
   }
 
+  def getActualTypeFor(expr: Expression): TypeSpec =
+    types.getOrElse(expr, throw new InternalException(s"Did not find any type information for expression $expr")).actual
+
   def containsNode(expr: String): Boolean = types.exists {
     case (v@Variable(name), _) => name == expr && isNode(v) // NOTE: Profiling showed that checking node type last is better
     case _ => false

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -1,5 +1,4 @@
 Shorthand case with filter should work as expected
-Add labels inside FOREACH
 Should fail on merge using multiple unique indexes using same key if found different nodes
 Should fail on merge using multiple unique indexes if found different nodes
 Should fail on merge using multiple unique indexes if it found a node matching single property only
@@ -8,14 +7,6 @@ Should fail on merge using multiple unique indexes and labels if found different
 Merge with uniqueness constraints must properly handle multiple labels
 Failing when creation would violate constraint
 Explanation of in-query procedure call
-Merging inside a FOREACH using a previously matched node
-Merging inside a FOREACH using a previously matched node and a previously merged node
-Merging inside a FOREACH using two previously merged nodes
-Merging inside a FOREACH using two previously merged nodes that also depend on WITH
-Inside nested FOREACH
-Inside nested FOREACH, nodes inlined
-Should handle running merge inside a foreach loop
-Merge inside foreach should see variables introduced by update actions outside foreach
 Returning a pattern expression with bound nodes
 Using a variable-length pattern expression in a WITH
 Pattern expression inside list comprehension

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateAcceptanceTest.scala
@@ -90,7 +90,7 @@ class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
   test("should have bound node recognized after projection with WITH + FOREACH") {
     val query = "CREATE (a) WITH a FOREACH (i in [] | SET a.prop = 1) CREATE (b) CREATE (a)<-[:T]-(b)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query)
 
     assertStats(result, nodesCreated = 2, relationshipsCreated = 1)
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
@@ -258,7 +258,7 @@ trait CypherComparisonSupport extends CypherTestSupport {
   // Should this really be deprecated? We have real use cases where we want to get the InternalExecutionResult
   // But do NOT want comparison support, for example see the query statistics support used in CompositeNodeKeyAcceptanceTests
   @deprecated("Rewrite to use executeWith instead")
-  protected def innerExecuteDeprecated(queryText: String, params: Map[String, Any]): InternalExecutionResult =
+  protected def innerExecuteDeprecated(queryText: String, params: Map[String, Any] = Map.empty): InternalExecutionResult =
     innerExecute(queryText, params)
 
   private def innerExecute(queryText: String, params: Map[String, Any]): InternalExecutionResult = {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
@@ -2417,7 +2417,7 @@ class EagerizationAcceptanceTest
     //val query = "UNWIND [0] as u MATCH (a), (b) FOREACH(i in range(0, 1) | DELETE a) RETURN count(*)"
     val query = "MATCH (a), (b) FOREACH(i in range(0, 1) | DELETE a) RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next() should equal(4)
     assertStats(result, nodesDeleted = 2)
@@ -2436,7 +2436,7 @@ class EagerizationAcceptanceTest
         |)
         |RETURN count(*)""".stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next() should equal(2)
     assertStats(result, nodesCreated = 2, labelsAdded = 2, propertiesWritten = 8)
@@ -2460,7 +2460,7 @@ class EagerizationAcceptanceTest
         |RETURN count(*)
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
     assertStats(result, nodesCreated = 2, nodesDeleted = 2, propertiesWritten = 6, labelsAdded = 2)
     result.columnAs[Long]("count(*)").next shouldBe 2
@@ -2481,7 +2481,7 @@ class EagerizationAcceptanceTest
         |)
         |RETURN count(*)""".stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next() should equal(2)
     assertStats(result, nodesCreated = 2, labelsAdded = 2, propertiesWritten = 6)
@@ -2503,7 +2503,7 @@ class EagerizationAcceptanceTest
         |)
         |RETURN count(*)""".stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, Configs.AllRulePlanners))
     result.columnAs[Long]("count(*)").next() should equal(2)
     assertStats(result, nodesCreated = 4, labelsAdded = 4, propertiesWritten = 24)
@@ -2523,7 +2523,7 @@ class EagerizationAcceptanceTest
         |)
         |RETURN count(*)""".stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next() should equal(1)
     assertStats(result, nodesCreated = 4, labelsAdded = 4)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionEngineTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionEngineTest.scala
@@ -596,7 +596,7 @@ order by a.COL1""".format(a, b))
 
   test("can use variables created inside the foreach") {
     createNode()
-    val result = executeWith(createConf - Configs.SlottedInterpreted, "match (n) where id(n) = 0 foreach (x in [1,2,3] | create (a { name: 'foo'})  set a.id = x)")
+    val result = executeWith(createConf, "match (n) where id(n) = 0 foreach (x in [1,2,3] | create (a { name: 'foo'})  set a.id = x)")
 
     result.toList shouldBe empty
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ForeachAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ForeachAcceptanceTest.scala
@@ -53,7 +53,7 @@ class ForeachAcceptanceTest extends ExecutionEngineFunSuite with CypherCompariso
         | )
         |)""".stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query)
 
     // then
     assertStats(result, nodesCreated = 110, relationshipsCreated = 110, propertiesWritten = 110, labelsAdded = 110)
@@ -68,7 +68,7 @@ class ForeachAcceptanceTest extends ExecutionEngineFunSuite with CypherCompariso
     val query = "FOREACH( n in range( 0, 1 ) | CREATE (p:Person) )"
 
     // when
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperators("Foreach", "CreateNode")
@@ -104,7 +104,7 @@ class ForeachAcceptanceTest extends ExecutionEngineFunSuite with CypherCompariso
         |RETURN e.foo, i.foo, p.foo""".stripMargin
 
     // when
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query)
 
     // then
     assertStats(result, nodesCreated = 2, relationshipsCreated = 1, labelsAdded = 2, propertiesWritten = 3)
@@ -140,7 +140,7 @@ class ForeachAcceptanceTest extends ExecutionEngineFunSuite with CypherCompariso
          |  MERGE (a)-[:FOO]->(b))""".stripMargin
 
     // when
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query)
 
     // then
     assertStats(result, nodesCreated = 2, relationshipsCreated = 1)
@@ -171,7 +171,7 @@ class ForeachAcceptanceTest extends ExecutionEngineFunSuite with CypherCompariso
         |   MERGE (x)-[:FOOBAR]->(m) );""".stripMargin
 
     // when
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query)
 
     // then
     assertStats(result, relationshipsCreated = 1)
@@ -188,14 +188,14 @@ class ForeachAcceptanceTest extends ExecutionEngineFunSuite with CypherCompariso
         |FOREACH (x IN mixedTypeCollection | CREATE (n)-[:FOOBAR]->(x) );""".stripMargin
 
     // when
-    val explain = executeWith(Configs.CommunityInterpreted - Configs.Version2_3, s"EXPLAIN $query")
+    val explain = executeWith(Configs.Interpreted - Configs.Version2_3, s"EXPLAIN $query")
 
     // then
     explain.executionPlanDescription().toString shouldNot include("CreateNode")
 
     // when
-    val config = TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.ProcedureOrSchema)) +
+    val config = TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Slotted, Runtimes.ProcedureOrSchema)) +
       TestConfiguration(Versions.V3_1, Planners.Cost, Runtimes.Default)
-    failWithError(config, query, List("Expected to find a node at x but"))
+    failWithError(config, query, List("Expected to find a node at"))
   }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MutatingIntegrationTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MutatingIntegrationTest.scala
@@ -250,7 +250,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
   }
 
   test("create node and rel in foreach") {
-    executeWith(createConf - Configs.SlottedInterpreted, """
+    executeWith(createConf, """
       |create (center {name: "center"})
       |foreach(x in range(1,10) |
       |  create (leaf1 {number : x}) , (center)-[:X]->(leaf1)
@@ -322,7 +322,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
 
   test("delete and delete again") {
     createNode()
-    val result = executeWith(deleteConf - Configs.SlottedInterpreted, "match (a) where id(a) = 0 delete a foreach( x in [1] | delete a)")
+    val result = executeWith(deleteConf, "match (a) where id(a) = 0 delete a foreach( x in [1] | delete a)")
 
     assertStats(result, nodesDeleted = 1)
   }
@@ -365,14 +365,14 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
 
   test("can create anonymous nodes inside foreach") {
     createNode()
-    val result = executeWith(createConf - Configs.SlottedInterpreted, "match (me) where id(me) = 0 foreach (i in range(1,10) | create (me)-[:FRIEND]->())")
+    val result = executeWith(createConf, "match (me) where id(me) = 0 foreach (i in range(1,10) | create (me)-[:FRIEND]->())")
 
     result.toList shouldBe empty
   }
 
   test("should be able to use external variables inside foreach") {
     createNode()
-    val result = executeWith(createConf - Configs.SlottedInterpreted, "match (a), (b) where id(a) = 0 AND id(b) = 0 foreach(x in [b] | create (x)-[:FOO]->(a)) ")
+    val result = executeWith(createConf, "match (a), (b) where id(a) = 0 AND id(b) = 0 foreach(x in [b] | create (x)-[:FOO]->(a)) ")
 
     result.toList shouldBe empty
   }
@@ -386,7 +386,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
 
   test("complete graph") {
     val result =
-      executeWith(createConf - Configs.SlottedInterpreted, """CREATE (center { count:0 })
+      executeWith(createConf, """CREATE (center { count:0 })
                  FOREACH (x IN range(1,6) | CREATE (leaf { count : x }),(center)-[:X]->(leaf))
                  WITH center
                  MATCH (leaf1)<--(center)-->(leaf2)
@@ -400,13 +400,13 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
   }
 
   test("for each applied to null should never execute") {
-    val result = executeWith(createConf - Configs.SlottedInterpreted, "foreach(x in null| create ())")
+    val result = executeWith(createConf, "foreach(x in null| create ())")
 
     assertStats(result, nodesCreated = 0)
   }
 
   test("should execute when null is contained in a collection") {
-    val result = executeWith(createConf - Configs.SlottedInterpreted, "foreach(x in [null]| create ())")
+    val result = executeWith(createConf, "foreach(x in [null]| create ())")
 
     assertStats(result, nodesCreated = 1)
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NotificationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NotificationAcceptanceTest.scala
@@ -131,11 +131,7 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
   test("Warn unsupported runtime with explain and runtime=slotted") {
     val result = innerExecuteDeprecated(
       """explain cypher runtime=slotted
-         MATCH (b:B)
-         MERGE (a)-[r1:TYPE]->(b)<-[r2:TYPE]-(c)
-         WITH r1, r2, collect(b) as b_nodes
-         FOREACH (n in b_nodes | SET n.prop = 1)
-         RETURN type(r1), type(r2)""", Map.empty)
+         RETURN reduce(y=0, x IN [0] | x) AS z""", Map.empty)
 
     result.notifications.toList should equal(List(
       RUNTIME_UNSUPPORTED.notification(graphdb.InputPosition.empty)))

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SetAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SetAcceptanceTest.scala
@@ -114,7 +114,7 @@ class SetAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTest
     val n3 = createNode()
 
     val query = "MATCH (n) WITH collect(n) AS nodes, {param} AS data FOREACH (idx IN range(0,size(nodes)-1) | SET (nodes[idx]).num = data[idx])"
-    val result = executeWith(expectedToSucceed, query, params = Map("param" ->  Array("1", "2", "3")))
+    val result = executeWith(expectedToSucceedIncludingSlotted, query, params = Map("param" ->  Array("1", "2", "3")))
 
     assertStats(result, propertiesWritten = 3)
     n1 should haveProperty("num").withValue("1")
@@ -129,7 +129,7 @@ class SetAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTest
     val r3 = relate(createNode(), createNode())
 
     val query = "MATCH ()-[r]->() WITH collect(r) AS rels, {param} as data FOREACH (idx IN range(0,size(rels)-1) | SET (rels[idx]).num = data[idx])"
-    val result = executeWith(expectedToSucceed, query, params = Map("param" ->  Array("1", "2", "3")))
+    val result = executeWith(expectedToSucceedIncludingSlotted, query, params = Map("param" ->  Array("1", "2", "3")))
 
     assertStats(result, propertiesWritten = 3)
     r1 should haveProperty("num").withValue("1")
@@ -155,7 +155,7 @@ class SetAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTest
     // when
     val q = "MATCH p=(a)-->(b)-->(c) WHERE id(a) = 0 AND id(c) = 2 WITH p FOREACH(n IN nodes(p) | SET n.marked = true)"
 
-    executeWith(expectedToSucceed, q)
+    executeWith(expectedToSucceedIncludingSlotted, q)
 
     // then
     a should haveProperty("marked").withValue(true)
@@ -171,7 +171,7 @@ class SetAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTest
     val c = createNode("c"->"C")
 
     // when
-    val result = executeWith(expectedToSucceed, "MATCH (n) WITH collect(n) AS nodes FOREACH(x IN nodes | SET x += {x:'X'})")
+    val result = executeWith(expectedToSucceedIncludingSlotted, "MATCH (n) WITH collect(n) AS nodes FOREACH(x IN nodes | SET x += {x:'X'})")
 
     // then
     a should haveProperty("a").withValue("A")
@@ -190,7 +190,7 @@ class SetAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTest
     val c = createNode("c"->"C")
 
     // when
-   executeWith(expectedToSucceed, "MATCH (n) WITH collect(n) as nodes FOREACH(x IN nodes | SET x = {a:'D', x:'X'})")
+   executeWith(expectedToSucceedIncludingSlotted, "MATCH (n) WITH collect(n) as nodes FOREACH(x IN nodes | SET x = {a:'D', x:'X'})")
 
     // then
     a should haveProperty("a").withValue("D")

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilderTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilderTest.scala
@@ -57,7 +57,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
     when(planContext.statistics).thenReturn(HardcodedGraphStatistics)
     when(planContext.getOptPropertyKeyId("propertyKey")).thenReturn(Some(0))
     val context: EnterpriseRuntimeContext = CompiledRuntimeContextHelper.create(planContext = planContext)
-    val physicalPlan: PhysicalPlan = SlotAllocation.allocateSlots(beforeRewrite)
+    val physicalPlan: PhysicalPlan = SlotAllocation.allocateSlots(beforeRewrite, table)
     val slottedRewriter = new SlottedRewriter(context.planContext)
     val logicalPlan = slottedRewriter(beforeRewrite, physicalPlan.slotConfigurations)
     val converters = new ExpressionConverters(CommunityExpressionConverter, SlottedExpressionConverters)

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
@@ -20,6 +20,7 @@
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime
 
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration.Size
+import org.neo4j.cypher.internal.frontend.v3_4.semantics.SemanticTable
 import org.neo4j.cypher.internal.ir.v3_4.IdName
 import org.neo4j.cypher.internal.util.v3_4.InternalException
 import org.neo4j.cypher.internal.util.v3_4.symbols._
@@ -56,6 +57,7 @@ object SlotAllocation {
     * @return the slot configurations of every operator.
     */
   def allocateSlots(lp: LogicalPlan,
+                    semanticTable: SemanticTable,
                     initialSlotsAndArgument: Option[SlotsAndArgument] = None): PhysicalPlan = {
 
     val allocations = new mutable.OpenHashMap[LogicalPlanId, SlotConfiguration]()
@@ -99,7 +101,7 @@ object SlotAllocation {
           val argument = if (argumentStack.isEmpty) NO_ARGUMENT()
                          else argumentStack.top
           recordArgument(current, argument)
-          val slotsIncludingExpressions = allocateExpressions(current, nullable, argument.slotConfiguration.copy(), allocations, arguments)
+          val slotsIncludingExpressions = allocateExpressions(current, nullable, argument.slotConfiguration.copy(), allocations, arguments)(semanticTable)
           val result = allocate(current, nullable, slotsIncludingExpressions)
           allocations += (current.assignedId -> result)
           resultStack.push(result)
@@ -108,7 +110,7 @@ object SlotAllocation {
           val sourceSlots = resultStack.pop()
           val argument = if (argumentStack.isEmpty) NO_ARGUMENT()
                          else argumentStack.top
-          val slotsIncludingExpressions = allocateExpressions(current, nullable, sourceSlots, allocations, arguments)
+          val slotsIncludingExpressions = allocateExpressions(current, nullable, sourceSlots, allocations, arguments)(semanticTable)
           val result = allocate(current, nullable, slotsIncludingExpressions, recordArgument(_, argument))
           allocations += (current.assignedId -> result)
           resultStack.push(result)
@@ -116,6 +118,7 @@ object SlotAllocation {
         case (Some(left), Some(right)) if (comingFrom eq left) && isAnApplyPlan(current) =>
           planStack.push((nullable, current))
           val argumentSlots = resultStack.top
+          allocateLhsOfApply(current, nullable, argumentSlots)(semanticTable) // This never copies the slot configuration
           argumentStack.push(SlotsAndArgument(argumentSlots.copy(), argumentSlots.size()))
           populate(right, nullable)
 
@@ -130,8 +133,8 @@ object SlotAllocation {
                          else argumentStack.top
           // NOTE: If we introduce a two sourced logical plan with an expression that needs to be evaluated in a
           //       particular scope (lhs or rhs) we need to add handling of it to allocateExpressions.
-          val lhsSlotsIncludingExpressions = allocateExpressions(current, nullable, lhsSlots, allocations, arguments, shouldAllocateLhs = true)
-          val rhsSlotsIncludingExpressions = allocateExpressions(current, nullable, rhsSlots, allocations, arguments, shouldAllocateLhs = false)
+          val lhsSlotsIncludingExpressions = allocateExpressions(current, nullable, lhsSlots, allocations, arguments, shouldAllocateLhs = true)(semanticTable)
+          val rhsSlotsIncludingExpressions = allocateExpressions(current, nullable, rhsSlots, allocations, arguments, shouldAllocateLhs = false)(semanticTable)
           val result = allocate(current, nullable, lhsSlotsIncludingExpressions, rhsSlotsIncludingExpressions, recordArgument(_, argument))
           allocations += (current.assignedId -> result)
           if (isAnApplyPlan(current))
@@ -149,7 +152,8 @@ object SlotAllocation {
   private def allocateExpressions(lp: LogicalPlan, nullable: Boolean, slots: SlotConfiguration,
                                   slotConfigurations: mutable.Map[LogicalPlanId, SlotConfiguration],
                                   argumentSizes: mutable.Map[LogicalPlanId, Size],
-                                  shouldAllocateLhs: Boolean = true): SlotConfiguration = {
+                                  shouldAllocateLhs: Boolean = true)
+                                 (semanticTable: SemanticTable): SlotConfiguration = {
     case class Accumulator(slots: SlotConfiguration, doNotTraverseExpression: Option[Expression])
 
     val TRAVERSE_INTO_CHILDREN = Some((s: Accumulator) => s)
@@ -200,7 +204,7 @@ object SlotAllocation {
             val slotsAndArgument = SlotsAndArgument(argumentSlotConfiguration, Size(slots.numberOfLongs, slots.numberOfReferences))
 
             // Allocate slots for nested plan
-            val nestedPhysicalPlan = allocateSlots(e.plan, initialSlotsAndArgument = Some(slotsAndArgument))
+            val nestedPhysicalPlan = allocateSlots(e.plan, semanticTable, initialSlotsAndArgument = Some(slotsAndArgument))
 
             // Update the physical plan
             slotConfigurations ++= nestedPhysicalPlan.slotConfigurations
@@ -469,6 +473,9 @@ object SlotAllocation {
         lhs.newReference(collectionName.name, nullable, CTList(CTAny))
         lhs
 
+      case _: ForeachApply =>
+        lhs
+
       case _: Union  =>
         // The result slot configuration should only contain the variables we join on.
         // If both lhs and rhs has a long slot with the same type the result should
@@ -501,6 +508,30 @@ object SlotAllocation {
         throw new SlotAllocationFailed(s"Don't know how to handle $p")
     }
 
+  private def allocateLhsOfApply(plan: LogicalPlan,
+                                 nullable: Boolean,
+                                 lhs: SlotConfiguration)
+                                (semanticTable: SemanticTable): SlotConfiguration =
+    plan match {
+      case ForeachApply(_, _, variableName, listExpression) =>
+        // TODO: Because the ForeachApplyPipe calls newWith1() on the lhs context unfortunately we have to add it also on lhs
+        //       This should not be needed when we have ForeachApplySlottedPipe
+        val typeSpec = semanticTable.getActualTypeFor(listExpression)
+        if (typeSpec.contains(ListType(CTNode))) {
+          lhs.newLong(variableName, true, CTNode)
+        }
+        else if (typeSpec.contains(ListType(CTRelationship))) {
+          lhs.newLong(variableName, true, CTRelationship)
+        }
+        else {
+          lhs.newReference(variableName, true, CTAny)
+        }
+        lhs
+
+      case _ =>
+        lhs
+    }
+
   private def addGroupingMap(groupingExpressions: Map[String, Expression],
                              source: SlotConfiguration,
                              target: SlotConfiguration): Unit =
@@ -518,9 +549,11 @@ object SlotAllocation {
          _: AbstractSemiApply |
          _: AbstractSelectOrSemiApply |
          _: AbstractLetSelectOrSemiApply |
+         _: AbstractLetSemiApply |
          _: ConditionalApply |
          _: ForeachApply |
-         _: RollUpApply => true
+         _: RollUpApply =>
+      true
 
     case _ => false
   }

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
@@ -514,8 +514,8 @@ object SlotAllocation {
                                 (semanticTable: SemanticTable): SlotConfiguration =
     plan match {
       case ForeachApply(_, _, variableName, listExpression) =>
-        // TODO: Because the ForeachApplyPipe calls newWith1() on the lhs context unfortunately we have to add it also on lhs
-        //       This should not be needed when we have ForeachApplySlottedPipe
+        // The slot for the iteration variable of foreach needs to be available as an argument on the rhs of the apply
+        // so we allocate it on the lhs (even though its value will not be needed after the foreach is done)
         val typeSpec = semanticTable.getActualTypeFor(listExpression)
         if (typeSpec.contains(ListType(CTNode))) {
           lhs.newLong(variableName, true, CTNode)

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocationArgumentsTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocationArgumentsTest.scala
@@ -21,6 +21,7 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime
 
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration.Size
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport2
+import org.neo4j.cypher.internal.frontend.v3_4.semantics.SemanticTable
 import org.neo4j.cypher.internal.ir.v3_4.IdName
 import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.v3_4.expressions._
@@ -33,6 +34,7 @@ class SlotAllocationArgumentsTest extends CypherFunSuite with LogicalPlanningTes
   private val z = IdName("z")
   private val LABEL = LabelName("label")(pos)
   private val r = IdName("r")
+  private val semanticTable = SemanticTable()
 
   test("zero size argument for single all nodes scan") {
     // given
@@ -40,7 +42,7 @@ class SlotAllocationArgumentsTest extends CypherFunSuite with LogicalPlanningTes
     plan.assignIds()
 
     // when
-    val arguments = SlotAllocation.allocateSlots(plan).argumentSizes
+    val arguments = SlotAllocation.allocateSlots(plan, semanticTable).argumentSizes
 
     // then
     arguments should have size 1
@@ -54,7 +56,7 @@ class SlotAllocationArgumentsTest extends CypherFunSuite with LogicalPlanningTes
     expand.assignIds()
 
     // when
-    val arguments = SlotAllocation.allocateSlots(expand).argumentSizes
+    val arguments = SlotAllocation.allocateSlots(expand, semanticTable).argumentSizes
 
     // then
     arguments should have size 1
@@ -66,7 +68,7 @@ class SlotAllocationArgumentsTest extends CypherFunSuite with LogicalPlanningTes
     argument.assignIds()
 
     // when
-    val arguments = SlotAllocation.allocateSlots(argument).argumentSizes
+    val arguments = SlotAllocation.allocateSlots(argument, semanticTable).argumentSizes
 
     // then
     arguments should have size 1
@@ -81,7 +83,7 @@ class SlotAllocationArgumentsTest extends CypherFunSuite with LogicalPlanningTes
     plan.assignIds()
 
     // when
-    val arguments = SlotAllocation.allocateSlots(plan).argumentSizes
+    val arguments = SlotAllocation.allocateSlots(plan, semanticTable).argumentSizes
 
     // then
     arguments should have size 2
@@ -97,7 +99,7 @@ class SlotAllocationArgumentsTest extends CypherFunSuite with LogicalPlanningTes
     plan.assignIds()
 
     // when
-    val arguments = SlotAllocation.allocateSlots(plan).argumentSizes
+    val arguments = SlotAllocation.allocateSlots(plan, semanticTable).argumentSizes
 
     // then
     arguments should have size 2
@@ -113,7 +115,7 @@ class SlotAllocationArgumentsTest extends CypherFunSuite with LogicalPlanningTes
     plan.assignIds()
 
     // when
-    val arguments = SlotAllocation.allocateSlots(plan).argumentSizes
+    val arguments = SlotAllocation.allocateSlots(plan, semanticTable).argumentSizes
 
     // then
     arguments should have size 2
@@ -138,7 +140,7 @@ class SlotAllocationArgumentsTest extends CypherFunSuite with LogicalPlanningTes
     plan.assignIds()
 
     // when
-    val arguments = SlotAllocation.allocateSlots(plan).argumentSizes
+    val arguments = SlotAllocation.allocateSlots(plan, semanticTable).argumentSizes
 
     // then
     arguments should have size 3
@@ -164,7 +166,7 @@ class SlotAllocationArgumentsTest extends CypherFunSuite with LogicalPlanningTes
     plan.assignIds()
 
     // when
-    val arguments = SlotAllocation.allocateSlots(plan).argumentSizes
+    val arguments = SlotAllocation.allocateSlots(plan, semanticTable).argumentSizes
 
     // then
     arguments should have size 3
@@ -189,7 +191,7 @@ class SlotAllocationArgumentsTest extends CypherFunSuite with LogicalPlanningTes
     plan.assignIds()
 
     // when
-    val arguments = SlotAllocation.allocateSlots(plan).argumentSizes
+    val arguments = SlotAllocation.allocateSlots(plan, semanticTable).argumentSizes
 
     // then
     arguments should have size 2
@@ -213,7 +215,7 @@ class SlotAllocationArgumentsTest extends CypherFunSuite with LogicalPlanningTes
     plan.assignIds()
 
     // when
-    val arguments = SlotAllocation.allocateSlots(plan).argumentSizes
+    val arguments = SlotAllocation.allocateSlots(plan, semanticTable).argumentSizes
 
     // then
     arguments should have size 2
@@ -236,7 +238,7 @@ class SlotAllocationArgumentsTest extends CypherFunSuite with LogicalPlanningTes
     plan.assignIds()
 
     // when
-    val arguments = SlotAllocation.allocateSlots(plan).argumentSizes
+    val arguments = SlotAllocation.allocateSlots(plan, semanticTable).argumentSizes
 
     // then
     arguments should have size 3

--- a/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocationTest.scala
+++ b/enterprise/cypher/physical-planning/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocationTest.scala
@@ -20,6 +20,7 @@
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime
 
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport2
+import org.neo4j.cypher.internal.frontend.v3_4.semantics.SemanticTable
 import org.neo4j.cypher.internal.ir.v3_4.{CardinalityEstimation, IdName, PlannerQuery, VarPatternLength}
 import org.neo4j.cypher.internal.util.v3_4.LabelId
 import org.neo4j.cypher.internal.util.v3_4.symbols._
@@ -35,6 +36,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
   private val z = IdName("z")
   private val LABEL = LabelName("label")(pos)
   private val r = IdName("r")
+  private val semanticTable = SemanticTable()
 
   test("only single allnodes scan") {
     // given
@@ -42,7 +44,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     plan.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(plan).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(plan, semanticTable).slotConfigurations
 
     // then
     allocations should have size 1
@@ -56,7 +58,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     plan.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(plan).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(plan, semanticTable).slotConfigurations
 
     // then
     allocations should have size 2
@@ -70,7 +72,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     plan.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(plan).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(plan, semanticTable).slotConfigurations
 
     // then
     allocations should have size 1
@@ -84,7 +86,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     filter.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(filter).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(filter, semanticTable).slotConfigurations
 
     // then
     allocations should have size 2
@@ -99,7 +101,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     expand.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(expand).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(expand, semanticTable).slotConfigurations
 
     // then we'll end up with two pipelines
     allocations should have size 2
@@ -122,7 +124,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     expand.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(expand).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(expand, semanticTable).slotConfigurations
 
     // then we'll end up with two pipelines
     allocations should have size 2
@@ -143,7 +145,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     plan.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(plan).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(plan, semanticTable).slotConfigurations
 
     // then
     allocations should have size 2
@@ -157,7 +159,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     expand.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(expand).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(expand, semanticTable).slotConfigurations
 
     // then we'll end up with two pipelines
     allocations should have size 2
@@ -182,7 +184,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     expand.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(expand).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(expand, semanticTable).slotConfigurations
 
     // then we'll end up with two pipelines
     allocations should have size 2
@@ -209,7 +211,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     expand.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(expand).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(expand, semanticTable).slotConfigurations
 
     // then we'll end up with two pipelines
     allocations should have size 2
@@ -236,7 +238,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     skip.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(skip).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(skip, semanticTable).slotConfigurations
 
     // then
     allocations should have size 2
@@ -258,7 +260,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     apply.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(apply).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(apply, semanticTable).slotConfigurations
 
     // then
     allocations should have size 3
@@ -283,7 +285,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     distinct.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(distinct).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(distinct, semanticTable).slotConfigurations
 
     // then
     allocations should have size 2
@@ -302,7 +304,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     distinct.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(distinct).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(distinct, semanticTable).slotConfigurations
 
     // then
     allocations should have size 3
@@ -327,7 +329,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     countStar.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(countStar).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(countStar, semanticTable).slotConfigurations
 
     // then
     allocations should have size 3
@@ -350,7 +352,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     projection.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(projection).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(projection, semanticTable).slotConfigurations
 
     // then
     allocations should have size 2
@@ -369,7 +371,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     Xproduct.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(Xproduct).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(Xproduct, semanticTable).slotConfigurations
 
     // then
     allocations should have size 3
@@ -394,7 +396,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     hashJoin.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(hashJoin).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(hashJoin, semanticTable).slotConfigurations
 
     // then
     allocations should have size 3
@@ -422,7 +424,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     hashJoin.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(hashJoin).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(hashJoin, semanticTable).slotConfigurations
 
     // then
     allocations should have size 5
@@ -458,7 +460,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     hashJoin.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(hashJoin).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(hashJoin, semanticTable).slotConfigurations
 
     // then
     allocations should have size 5 // One for each label-scan and expand, and one after the join
@@ -491,7 +493,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     apply.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(apply).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(apply, semanticTable).slotConfigurations
 
     // then
     val lhsPipeline = SlotConfiguration(Map(
@@ -519,7 +521,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     produceResult.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(produceResult).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(produceResult, semanticTable).slotConfigurations
 
     // then
     allocations should have size 3
@@ -543,7 +545,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     produceResult.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(produceResult).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(produceResult, semanticTable).slotConfigurations
 
     // then
     allocations should have size 4
@@ -577,7 +579,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     val rhs = Expand(arg, x, SemanticDirection.INCOMING, Seq.empty, y, r, ExpandAll)(solved)
     val semiApply = semiApplyBuilder(lhs, rhs)(solved)
     semiApply.assignIds()
-    val allocations = SlotAllocation.allocateSlots(semiApply).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(semiApply, semanticTable).slotConfigurations
 
     val lhsPipeline = SlotConfiguration(Map(
       "x" -> LongSlot(0, nullable = false, CTNode)),
@@ -607,7 +609,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     apply.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(apply).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(apply, semanticTable).slotConfigurations
 
     // then
     allocations should have size 5
@@ -636,7 +638,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     aggregation.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(aggregation).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(aggregation, semanticTable).slotConfigurations
 
     allocations should have size 3
     allocations(expand.assignedId) should equal(
@@ -677,7 +679,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     rollUp.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(rollUp).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(rollUp, semanticTable).slotConfigurations
 
     // then
     allocations should have size 5
@@ -696,7 +698,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     plan.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(plan).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(plan, semanticTable).slotConfigurations
 
     // then
     allocations should have size 3
@@ -713,7 +715,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     plan.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(plan).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(plan, semanticTable).slotConfigurations
 
     // then
     allocations should have size 4
@@ -729,7 +731,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     plan.assignIds()
 
     // when
-    val allocations = SlotAllocation.allocateSlots(plan).slotConfigurations
+    val allocations = SlotAllocation.allocateSlots(plan, semanticTable).slotConfigurations
 
     // then
     allocations should have size 5
@@ -745,7 +747,7 @@ class SlotAllocationTest extends CypherFunSuite with LogicalPlanningTestSupport2
     plan.assignIds()
 
     // when
-    val physicalPlan = SlotAllocation.allocateSlots(plan)
+    val physicalPlan = SlotAllocation.allocateSlots(plan, semanticTable)
     val allocations = physicalPlan.slotConfigurations
 
     // then

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilder.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilder.scala
@@ -414,6 +414,10 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
         val refOffsets = refIds.map(e => slots.getReferenceOffsetFor(e.name))
         ConditionalApplySlottedPipe(lhs, rhs, longOffsets, refOffsets, negated = true, slots)(id)
 
+      case ForeachApply(_, _, variable, expression) =>
+        val innerVariableSlot = slots.get(variable).getOrElse(throw new InternalException(s"Foreach variable '$variable' has no slot"))
+        ForeachSlottedPipe(lhs, rhs, innerVariableSlot, convertExpressions(expression))(id)
+
       case Union(_, _) =>
         val lhsSlots = slotConfigs(lhs.id)
         val rhsSlots = slotConfigs(rhs.id)

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/helpers/NullChecker.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/helpers/NullChecker.scala
@@ -20,5 +20,5 @@
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers
 
 object NullChecker {
-  def entityIsNull(nodeId: Long): Boolean = nodeId == -1
+  def entityIsNull(entityId: Long): Boolean = entityId == -1L
 }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/helpers/SlottedPipeBuilderUtils.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/helpers/SlottedPipeBuilderUtils.scala
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers
+
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker.entityIsNull
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.{LongSlot, RefSlot, Slot}
+import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
+import org.neo4j.cypher.internal.util.v3_4.{InternalException, ParameterWrongTypeException}
+import org.neo4j.cypher.internal.util.v3_4.symbols.{CTNode, CTRelationship}
+import org.neo4j.values.AnyValue
+import org.neo4j.values.storable.Values
+import org.neo4j.values.virtual.{VirtualEdgeValue, VirtualNodeValue, VirtualValues}
+
+object SlottedPipeBuilderUtils {
+  /**
+    * Use this to make a specialized getter function for a slot,
+    * that given an ExecutionContext returns an AnyValue.
+    */
+  def makeGetValueFromSlotFunctionFor(slot: Slot): ExecutionContext => AnyValue =
+    slot match {
+      case LongSlot(offset, false, CTNode) =>
+        (context: ExecutionContext) =>
+          VirtualValues.node(context.getLongAt(offset))
+
+      case LongSlot(offset, false, CTRelationship) =>
+        (context: ExecutionContext) =>
+          VirtualValues.edge(context.getLongAt(offset))
+
+      case LongSlot(offset, true, CTNode) =>
+        (context: ExecutionContext) => {
+          val nodeId = context.getLongAt(offset)
+          if (entityIsNull(nodeId))
+            Values.NO_VALUE
+          else
+            VirtualValues.node(nodeId)
+        }
+      case LongSlot(offset, true, CTRelationship) =>
+        (context: ExecutionContext) => {
+          val relId = context.getLongAt(offset)
+          if (entityIsNull(relId))
+            Values.NO_VALUE
+          else
+            VirtualValues.edge(relId)
+        }
+      case RefSlot(offset, _, _) =>
+        (context: ExecutionContext) =>
+          context.getRefAt(offset)
+
+      case _ =>
+        throw new InternalException(s"Do not know how to make getter for slot $slot")
+    }
+
+  /**
+    * Use this to make a specialized setter function for a slot,
+    * that takes as input an ExecutionContext and an AnyValue.
+    */
+  def makeSetValueInSlotFunctionFor(slot: Slot): (ExecutionContext, AnyValue) => Unit =
+    slot match {
+      case LongSlot(offset, false, CTNode) =>
+        (context: ExecutionContext, value: AnyValue) =>
+          try {
+            context.setLongAt(offset, value.asInstanceOf[VirtualNodeValue].id())
+          } catch {
+            case _: java.lang.ClassCastException =>
+              throw new ParameterWrongTypeException(s"Expected to find a node at long slot $offset but found $value instead")
+          }
+
+      case LongSlot(offset, false, CTRelationship) =>
+        (context: ExecutionContext, value: AnyValue) =>
+          try {
+            context.setLongAt(offset, value.asInstanceOf[VirtualEdgeValue].id())
+          } catch {
+            case _: java.lang.ClassCastException =>
+              throw new ParameterWrongTypeException(s"Expected to find a relationship at long slot $offset but found $value instead")
+          }
+
+      case LongSlot(offset, true, CTNode) =>
+        (context: ExecutionContext, value: AnyValue) =>
+          if (value == Values.NO_VALUE)
+            context.setLongAt(offset, -1L)
+          else {
+            try {
+              context.setLongAt(offset, value.asInstanceOf[VirtualNodeValue].id())
+            } catch {
+              case _: java.lang.ClassCastException =>
+                throw new ParameterWrongTypeException(s"Expected to find a node at long slot $offset but found $value instead")
+            }
+          }
+
+      case LongSlot(offset, true, CTRelationship) =>
+        (context: ExecutionContext, value: AnyValue) =>
+          if (value == Values.NO_VALUE)
+            context.setLongAt(offset, -1L)
+          else {
+            try {
+              context.setLongAt(offset, value.asInstanceOf[VirtualEdgeValue].id())
+            } catch {
+              case _: java.lang.ClassCastException =>
+                throw new ParameterWrongTypeException(s"Expected to find a relationship at long slot $offset but found $value instead")
+            }
+          }
+
+      case RefSlot(offset, _, _) =>
+        (context: ExecutionContext, value: AnyValue) =>
+          context.setRefAt(offset, value)
+
+      case _ =>
+        throw new InternalException(s"Do not know how to make setter for slot $slot")
+    }
+}

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ForeachSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ForeachSlottedPipe.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
+
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.Slot
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.SlottedPipeBuilderUtils.makeSetValueInSlotFunctionFor
+import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Expression
+import org.neo4j.cypher.internal.runtime.interpreted.pipes.{Pipe, PipeWithSource, QueryState}
+import org.neo4j.cypher.internal.runtime.interpreted.{ExecutionContext, ListSupport}
+import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
+
+import scala.collection.JavaConverters._
+
+case class ForeachSlottedPipe(lhs: Pipe, rhs: Pipe, innerVariableSlot: Slot, expression: Expression)
+                             (val id: LogicalPlanId = LogicalPlanId.DEFAULT)
+  extends PipeWithSource(lhs) with Pipe with ListSupport {
+
+  val setVariableFun = makeSetValueInSlotFunctionFor(innerVariableSlot)
+
+  override protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
+    input.map {
+      (outerContext) =>
+        val values = makeTraversable(expression(outerContext, state))
+        values.iterator().asScala.foreach { v =>
+          setVariableFun(outerContext, v)
+          val innerState = state.withInitialContext(outerContext)
+          rhs.createResults(innerState).length // exhaust the iterator, in case there's a merge read increasing cardinality inside the foreach
+        }
+        outerContext
+    }
+  }
+}

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ProjectionSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ProjectionSlottedPipe.scala
@@ -39,11 +39,16 @@ case class ProjectionSlottedPipe(source: Pipe, introducedExpressions: Map[Int, E
         val result = expression(ctx, state)
         ctx.setRefAt(offset, result)
   }
+
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
-    input.map {
-      ctx =>
-        projectionFunctions.foreach(_(ctx, state))
-        ctx
+    if (projectionFunctions.isEmpty)
+      input
+    else {
+      input.map {
+        ctx =>
+          projectionFunctions.foreach(_ (ctx, state))
+          ctx
+      }
     }
   }
 }

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/helpers/SlottedPipeBuilderUtilsTest.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/helpers/SlottedPipeBuilderUtilsTest.scala
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers
+
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.SlottedPipeBuilderUtils._
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.{Slot, SlotConfiguration}
+import org.neo4j.cypher.internal.util.v3_4.ParameterWrongTypeException
+import org.neo4j.cypher.internal.util.v3_4.symbols._
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
+import org.neo4j.values.AnyValue
+import org.neo4j.values.storable.Values
+import org.neo4j.values.virtual.VirtualValues
+
+// If this test class gets in your way you can just delete it
+class SlottedPipeBuilderUtilsTest extends CypherFunSuite {
+  private val slots = SlotConfiguration.empty
+    .newLong("n1", false, CTNode)
+    .newLong("n2", true, CTNode)
+    .newLong("r1", false, CTRelationship)
+    .newLong("r2", true, CTRelationship)
+    .newReference("x", true, CTAny)
+
+  // GETTING
+
+  private def assertGetLong(slot: Slot, longValue: Long, expectedValue: AnyValue) = {
+    val context = PrimitiveExecutionContext(slots)
+    val getter = makeGetValueFromSlotFunctionFor(slot)
+
+    context.setLongAt(slot.offset, longValue)
+    val value = getter(context)
+    value should equal(expectedValue)
+  }
+
+  private def assertGetNode(slot: Slot, id: Long) = assertGetLong(slot, id, VirtualValues.node(id))
+  private def assertGetRelationship(slot: Slot, id: Long) = assertGetLong(slot, id, VirtualValues.edge(id))
+
+  test("getter for non-nullable node slot") {
+    assertGetNode(slots("n1"), 42L)
+  }
+
+  test("getter for nullable node slots with null") {
+    assertGetLong(slots("n2"), -1, Values.NO_VALUE)
+  }
+
+  test("getter for nullable node slot") {
+    assertGetNode(slots("n2"), 42L)
+  }
+
+  test("getter for non-nullable relationship slot") {
+    assertGetRelationship(slots("r1"), 42L)
+  }
+
+  test("getter for nullable relationship slots with null") {
+    assertGetLong(slots("r2"), -1, Values.NO_VALUE)
+  }
+
+  test("getter for nullable relationship slot") {
+    assertGetRelationship(slots("r2"), 42L)
+  }
+
+  test("getter for ref slot") {
+    val slot = slots("x")
+
+    val context = PrimitiveExecutionContext(slots)
+    val getter = makeGetValueFromSlotFunctionFor(slot)
+
+    val expectedValue = Values.stringValue("the value")
+    context.setRefAt(slot.offset, expectedValue)
+    val value = getter(context)
+    value should equal(expectedValue)
+  }
+
+  // SETTING
+
+  private def assertSetLong(slot: Slot, value: AnyValue, expected: Long): Unit = {
+    val context = PrimitiveExecutionContext(slots)
+    val setter = makeSetValueInSlotFunctionFor(slot)
+
+    setter(context, value)
+    context.getLongAt(slot.offset) should equal(expected)
+  }
+
+  private def assertSetNode(slot: Slot, id: Long) = assertSetLong(slot, VirtualValues.node(id), id)
+  private def assertSetRelationship(slot: Slot, id: Long) = assertSetLong(slot, VirtualValues.edge(id), id)
+
+  private def assertSetFails(slot: Slot, value: AnyValue): Unit = {
+    val context = PrimitiveExecutionContext(slots)
+    val setter = makeSetValueInSlotFunctionFor(slot)
+
+    a [ParameterWrongTypeException] should be thrownBy(setter(context, value))
+  }
+
+  test("setter for non-nullable node slot") {
+    assertSetNode(slots("n1"), 42L)
+  }
+
+  test("setter for nullable node slots with null") {
+    assertSetLong(slots("n2"), Values.NO_VALUE, -1)
+  }
+
+  test("setter for nullable node slot") {
+    assertSetNode(slots("n2"), 42L)
+  }
+
+  test("setter for non-nullable relationship slot") {
+    assertSetRelationship(slots("r1"), 42L)
+  }
+
+  test("setter for nullable relationship slots with null") {
+    assertSetLong(slots("r2"), Values.NO_VALUE, -1)
+  }
+
+  test("setter for nullable relationship slot") {
+    assertSetRelationship(slots("r2"), 42L)
+  }
+
+  test("setter for non-nullable node slot should throw") {
+    assertSetFails(slots("n1"), Values.stringValue("oops"))
+  }
+
+  test("setter for nullable node slot should throw") {
+    assertSetFails(slots("n2"), Values.stringValue("oops"))
+  }
+
+  test("setter for non-nullable relationship slot should throw") {
+    assertSetFails(slots("r1"), Values.stringValue("oops"))
+  }
+
+  test("setter for nullable relationship slot should throw") {
+    assertSetFails(slots("r2"), Values.stringValue("oops"))
+  }
+
+  test("setter for ref slot") {
+    val slot = slots("x")
+
+    val context = PrimitiveExecutionContext(slots)
+    val setter = makeSetValueInSlotFunctionFor(slot)
+
+    val expectedValue = Values.stringValue("the value")
+    setter(context, expectedValue)
+    val value = context.getRefAt(slot.offset)
+    value should equal(expectedValue)
+  }
+}


### PR DESCRIPTION
- Add ForeachSlottedPipe
- Allocate foreach inner variable on lhs before rhs allocation
- Pass SemanticTable to slot allocation so we can use long slots
for variables of lists of entities
- Add SlottedPipeBuilderUtils with helpers to make specialized
getter/setter functions for slots

- Minor optimization of empty projections
- Fix arguments for AbstractLetSemiApply

Update succeeding acceptance tests
