### PR TITLE
Sensible error message/notification when running slotted/compiled with START/CREATE UNIQUE

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/ExecutionResultWrapper.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/ExecutionResultWrapper.scala
@@ -51,9 +51,9 @@ import scala.collection.JavaConverters._
 
 object ExecutionResultWrapper {
 
-  def unapply(v: Any): Option[(InternalExecutionResult, PlannerName, RuntimeName)] = v match {
+  def unapply(v: Any): Option[(InternalExecutionResult, PlannerName, RuntimeName, Set[org.neo4j.graphdb.Notification])] = v match {
     case closing: ClosingExecutionResult => unapply(closing.inner)
-    case wrapper: ExecutionResultWrapper => Some((wrapper.inner, wrapper.planner, wrapper.runtime))
+    case wrapper: ExecutionResultWrapper => Some((wrapper.inner, wrapper.planner, wrapper.runtime, wrapper.preParsingNotifications))
     case _ => None
   }
 
@@ -104,7 +104,7 @@ object ExecutionResultWrapper {
 }
 
 class ExecutionResultWrapper(val inner: InternalExecutionResult, val planner: PlannerName, val runtime: RuntimeName,
-                             preParsingNotifications: Set[org.neo4j.graphdb.Notification],
+                             val preParsingNotifications: Set[org.neo4j.graphdb.Notification],
                              offset : Option[v2_3.InputPosition])
   extends internal.runtime.InternalExecutionResult {
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/ExecutionResultWrapper.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/ExecutionResultWrapper.scala
@@ -51,7 +51,7 @@ import org.neo4j.values.AnyValue
 import scala.collection.JavaConverters._
 
 class ExecutionResultWrapper(val inner: InternalExecutionResult, val planner: PlannerName, val runtime: RuntimeName,
-                             preParsingNotification: Set[org.neo4j.graphdb.Notification],
+                             val preParsingNotification: Set[org.neo4j.graphdb.Notification],
                              offset : Option[frontend.v3_1.InputPosition])
   extends internal.runtime.InternalExecutionResult  {
 
@@ -171,9 +171,9 @@ class ExecutionResultWrapper(val inner: InternalExecutionResult, val planner: Pl
 }
 
 object ExecutionResultWrapper {
-  def unapply(v: Any): Option[(InternalExecutionResult, PlannerName, RuntimeName)] = v match {
+  def unapply(v: Any): Option[(InternalExecutionResult, PlannerName, RuntimeName, Set[org.neo4j.graphdb.Notification])] = v match {
     case closing: ClosingExecutionResult => unapply(closing.inner)
-    case wrapper: ExecutionResultWrapper => Some((wrapper.inner, wrapper.planner, wrapper.runtime))
+    case wrapper: ExecutionResultWrapper => Some((wrapper.inner, wrapper.planner, wrapper.runtime, wrapper.preParsingNotification))
     case _ => None
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NotificationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NotificationAcceptanceTest.scala
@@ -622,6 +622,21 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
       DEPRECATED_FUNCTION.notification(new graphdb.InputPosition(33, 1, 34),
                                        deprecatedName("rels", "relationships")))
   }
+
+  test("should warn when using START in newer runtimes") {
+    createNode()
+    val query = "EXPLAIN CYPHER runtime=slotted START n=node(0) RETURN n"
+    val result = innerExecuteDeprecated(query, Map.empty)
+    val notifications = result.notifications
+    notifications should contain(RUNTIME_UNSUPPORTED.notification(new graphdb.InputPosition(31,1,32)))
+  }
+
+  test("should warn when using CREATE UNIQUE in newer runtimes") {
+    val query = "EXPLAIN CYPHER runtime=slotted MATCH (root { name: 'root' }) CREATE UNIQUE (root)-[:LOVES]-(someone) RETURN someone"
+    val result = innerExecuteDeprecated(query, Map.empty)
+    val notifications = result.notifications
+    notifications should contain(RUNTIME_UNSUPPORTED.notification(new graphdb.InputPosition(61,1,62)))
+  }
 }
 
 object NotificationAcceptanceTest {


### PR DESCRIPTION
Instead of saying `Runtime is not supported in Cypher 3.1` we now say `The given query is not currently supported in the selected runtime`.