### PR TITLE
Forbidding unsupported planner/version/runtime options

### DIFF
--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/NotificationAcceptanceTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/NotificationAcceptanceTest.java
@@ -83,37 +83,6 @@ public class NotificationAcceptanceTest
     }
 
     @Test
-    public void shouldNotifyWhenUsingCypher3_1ForTheRulePlannerWhenCypherVersionIs3_4() throws Exception
-    {
-        // when
-        Result result = db().execute( "CYPHER 3.4 planner=rule RETURN 1" );
-        InputPosition position = new InputPosition( 24, 1, 25 );
-
-        // then
-        assertThat( result.getNotifications(), Matchers.contains( RULE_PLANNER_UNAVAILABLE_FALLBACK.notification( position ) ) );
-        Map<String,Object> arguments = result.getExecutionPlanDescription().getArguments();
-        assertThat( arguments.get( "version" ), equalTo( "CYPHER 3.1" ) );
-        assertThat( arguments.get( "planner" ), equalTo( "RULE" ) );
-        result.close();
-    }
-
-    //TODO unignore when support for 3.3 is added
-    @Ignore
-    public void shouldNotifyWhenUsingCypher3_1ForTheRulePlannerWhenCypherVersionIs3_3() throws Exception
-    {
-        // when
-        Result result = db().execute( "CYPHER 3.3 planner=rule RETURN 1" );
-        InputPosition position = new InputPosition( 24, 1, 25 );
-
-        // then
-        assertThat( result.getNotifications(), Matchers.contains( RULE_PLANNER_UNAVAILABLE_FALLBACK.notification( position ) ) );
-        Map<String,Object> arguments = result.getExecutionPlanDescription().getArguments();
-        assertThat( arguments.get( "version" ), equalTo( "CYPHER 3.1" ) );
-        assertThat( arguments.get( "planner" ), equalTo( "RULE" ) );
-        result.close();
-    }
-
-    @Test
     public void shouldWarnWhenRequestingCompiledRuntimeOnUnsupportedQuery() throws Exception
     {
         Stream.of( "CYPHER 3.1", "CYPHER 3.4" ).forEach(

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/HelpfulErrorMessagesTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/HelpfulErrorMessagesTest.scala
@@ -53,6 +53,18 @@ class HelpfulErrorMessagesTest extends ExecutionEngineFunSuite with CypherCompar
       "The given query is not currently supported in the selected cost-based planner"))
   }
 
+  test("should provide sensible error message for 3.4 rule planner") {
+    intercept[Exception](graph.execute("CYPHER 3.4 planner=rule RETURN 1")).getMessage should be("Unsupported PLANNER - VERSION combination: rule - 3.4")
+  }
+
+  test("should not fail for specifying rule planner if no version specified") {
+    graph.execute("CYPHER planner=rule RETURN 1") // should not fail
+  }
+
+  test("should provide sensible error message for rule planner and slotted") {
+    intercept[Exception](graph.execute("CYPHER planner=rule runtime=slotted RETURN 1")).getMessage should be("Unsupported PLANNER - RUNTIME combination: rule - slotted")
+  }
+
   test("should provide sensible error message for invalid regex syntax together with index") {
 
     graph.execute("CREATE (n:Person {text:'abcxxxdefyyyfff'})")


### PR DESCRIPTION
Specifying 3.3 rule / 3.4 rule / slotted rule / compiled rule
will fail now.