### PR TITLE
Refactor reused ids arrays allocation

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdContainer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdContainer.java
@@ -250,6 +250,11 @@ public class IdContainer
         return freeIdKeeper.getId();
     }
 
+    public long[] getReusableIds( int numberOfIds )
+    {
+        return freeIdKeeper.getIds( numberOfIds );
+    }
+
     public IdRange getReusableIdBatch( int maxSize )
     {
         long[] tmpIdArr = new long[maxSize];

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGeneratorImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/id/IdGeneratorImpl.java
@@ -151,29 +151,11 @@ public class IdGeneratorImpl implements IdGenerator
     public synchronized IdRange nextIdBatch( int size )
     {
         assertStillOpen();
-
-        // Get from defrag list
-        int count = 0;
-        long[] defragIds = new long[size];
-        while ( count < size )
-        {
-            long id = idContainer.getReusableId();
-            if ( id == -1 )
-            {
-                break;
-            }
-            defragIds[count++] = id;
-        }
-
-        // Shrink the array to actual size
-        long[] tmpArray = defragIds;
-        defragIds = new long[count];
-        System.arraycopy( tmpArray, 0, defragIds, 0, count );
-
-        int sizeLeftForRange = size - count;
+        long[] reusableIds = idContainer.getReusableIds( size );
+        int sizeLeftForRange = size - reusableIds.length;
         long start = highId;
         setHighId( start + sizeLeftForRange );
-        return new IdRange( defragIds, start, sizeLeftForRange );
+        return new IdRange( reusableIds, start, sizeLeftForRange );
     }
 
     /**

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestCrashWithRebuildSlow.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/TestCrashWithRebuildSlow.java
@@ -57,7 +57,6 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-
 import static org.neo4j.kernel.configuration.Settings.FALSE;
 import static org.neo4j.test.mockito.matcher.Neo4jMatchers.hasProperty;
 import static org.neo4j.test.mockito.matcher.Neo4jMatchers.inTx;
@@ -67,7 +66,6 @@ import static org.neo4j.test.mockito.matcher.Neo4jMatchers.inTx;
  */
 public class TestCrashWithRebuildSlow
 {
-    // for dumping data about failing build
     @Rule
     public final TestDirectory testDir = TestDirectory.testDirectory();
     @Rule

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/id/HaIdGeneratorFactory.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/id/HaIdGeneratorFactory.java
@@ -215,8 +215,7 @@ public class HaIdGeneratorFactory implements IdGeneratorFactory
                 throw new IllegalStateException( state.name() );
             }
 
-            long result = delegate.nextId();
-            return result;
+            return delegate.nextId();
         }
 
         @Override


### PR DESCRIPTION
Avoid multiple arrays creation during id allocations.
Allow IdContainer and FreeIdKeeper to allocate and return precise array
with reusable ids.