### PR TITLE
Forbidding unsupported planner/version/runtime options

### DIFF
--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/NotificationAcceptanceTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/NotificationAcceptanceTest.java
@@ -34,6 +34,7 @@ import java.util.stream.Stream;
 
 import org.neo4j.graphdb.InputPosition;
 import org.neo4j.graphdb.Notification;
+import org.neo4j.graphdb.QueryExecutionException;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.SeverityLevel;
 import org.neo4j.graphdb.Transaction;
@@ -50,6 +51,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.graphdb.impl.notification.NotificationCode.CREATE_UNIQUE_UNAVAILABLE_FALLBACK;
 import static org.neo4j.graphdb.impl.notification.NotificationCode.EAGER_LOAD_CSV;
@@ -82,33 +84,35 @@ public class NotificationAcceptanceTest
     }
 
     @Test
-    public void shouldNotifyWhenUsingCypher3_1ForTheRulePlannerWhenCypherVersionIs3_3() throws Exception
+    public void shouldFailWhenSpecifyingCypher3_3ForTheRulePlanner() throws Exception
     {
-        // when
-        Result result = db().execute( "CYPHER 3.3 planner=rule RETURN 1" );
-        InputPosition position = new InputPosition( 24, 1, 25 );
-
-        // then
-        assertThat( result.getNotifications(), Matchers.contains( RULE_PLANNER_UNAVAILABLE_FALLBACK.notification( position ) ) );
-        Map<String,Object> arguments = result.getExecutionPlanDescription().getArguments();
-        assertThat( arguments.get( "version" ), equalTo( "CYPHER 3.1" ) );
-        assertThat( arguments.get( "planner" ), equalTo( "RULE" ) );
-        result.close();
+        try
+        {
+            // when
+            db().execute( "CYPHER 3.3 planner=rule RETURN 1" );
+            fail();
+        }
+        catch ( QueryExecutionException e )
+        {
+            // then
+            assertThat( e.getMessage(), equalTo( "Unsupported PLANNER - VERSION combination: rule - 3.3" ) );
+        }
     }
 
     @Test
-    public void shouldNotifyWhenUsingCypher3_1ForTheRulePlannerWhenCypherVersionIs3_2() throws Exception
+    public void shouldFailWhenSpecifyingCypher3_2ForTheRulePlanner() throws Exception
     {
-        // when
-        Result result = db().execute( "CYPHER 3.2 planner=rule RETURN 1" );
-        InputPosition position = new InputPosition( 24, 1, 25 );
-
-        // then
-        assertThat( result.getNotifications(), Matchers.contains( RULE_PLANNER_UNAVAILABLE_FALLBACK.notification( position ) ) );
-        Map<String,Object> arguments = result.getExecutionPlanDescription().getArguments();
-        assertThat( arguments.get( "version" ), equalTo( "CYPHER 3.1" ) );
-        assertThat( arguments.get( "planner" ), equalTo( "RULE" ) );
-        result.close();
+        try
+        {
+            // when
+            db().execute( "CYPHER 3.2 planner=rule RETURN 1" );
+            fail();
+        }
+        catch ( QueryExecutionException e )
+        {
+            // then
+            assertThat( e.getMessage(), equalTo( "Unsupported PLANNER - VERSION combination: rule - 3.2" ) );
+        }
     }
 
     @Test

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
@@ -524,12 +524,14 @@ object CypherComparisonSupport {
 
     def Interpreted: TestConfiguration =
       TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Slotted)) +
-        TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default) +
-        TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
+        TestConfiguration(Versions.V2_3 -> Versions.V3_1, Planners.all, Runtimes.Default) +
+        TestScenario(Versions.V3_2, Planners.Cost, Runtimes.Default) +
+        TestConfiguration(Versions.Default, Planners.Rule, Runtimes.Default)
 
     def CommunityInterpreted: TestConfiguration =
       TestScenario(Versions.Default, Planners.Default, Runtimes.Interpreted) +
-        TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default) +
+        TestConfiguration(Versions.V2_3 -> Versions.V3_1, Planners.all, Runtimes.Default) +
+        TestScenario(Versions.V3_2, Planners.Cost, Runtimes.Default) +
         TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
 
     def SlottedInterpreted: TestConfiguration = TestScenario(Versions.Default, Planners.Default, Runtimes.Slotted)
@@ -548,28 +550,26 @@ object CypherComparisonSupport {
 
     def Rule3_1: TestConfiguration = TestScenario(Versions.V3_1, Planners.Rule, Runtimes.Default)
 
-    def Rule3_2: TestConfiguration = TestScenario(Versions.V3_2, Planners.Rule, Runtimes.Default)
-
-    def CurrentRulePlanner: TestConfiguration = TestScenario(Versions.latest, Planners.Rule, Runtimes.Default)
-
     def Version2_3: TestConfiguration = TestConfiguration(Versions.V2_3, Planners.all, Runtimes.Default)
 
     def Version3_1: TestConfiguration = TestConfiguration(Versions.V3_1, Planners.all, Runtimes.Default)
 
-    def Version3_2: TestConfiguration = TestConfiguration(Versions.V3_2, Planners.all, Runtimes.Default)
+    def Version3_2: TestConfiguration = TestConfiguration(Versions.V3_2, Planners.Cost, Runtimes.Default)
 
     def Version3_3: TestConfiguration =
       TestConfiguration(Versions.V3_3, Planners.Cost, Runtimes(Runtimes.CompiledSource, Runtimes.CompiledBytecode)) +
         TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Slotted)) +
         TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
 
-    def AllRulePlanners: TestConfiguration = TestConfiguration(Versions(Versions.V2_3, Versions.V3_1, Versions.V3_2, Versions.Default), Planners.Rule, Runtimes.Default)
+    def AllRulePlanners: TestConfiguration = TestConfiguration(Versions(Versions.V2_3, Versions.V3_1, Versions.Default), Planners.Rule, Runtimes.Default)
 
     def Cost: TestConfiguration =
       TestConfiguration(Versions.V3_3, Planners.Cost, Runtimes(Runtimes.CompiledSource, Runtimes.CompiledBytecode)) +
         TestConfiguration(Versions(Versions.V2_3, Versions.V3_1, Versions.Default), Planners.Cost, Runtimes.Default)
 
-    def BackwardsCompatibility: TestConfiguration = TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default)
+    def BackwardsCompatibility: TestConfiguration =
+      TestConfiguration(Versions.V2_3 -> Versions.V3_1, Planners.all, Runtimes.Default) +
+        TestScenario(Versions.V3_2, Planners.Cost, Runtimes.Default)
 
     def Procs: TestConfiguration = TestScenario(Versions.Default, Planners.Default, Runtimes.ProcedureOrSchema)
 
@@ -580,19 +580,22 @@ object CypherComparisonSupport {
     def All: TestConfiguration =
       TestConfiguration(Versions.V3_3, Planners.Cost, Runtimes(Runtimes.CompiledSource, Runtimes.CompiledBytecode)) +
         TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Slotted)) +
-        TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default) +
+        TestConfiguration(Versions.V2_3 -> Versions.V3_1, Planners.all, Runtimes.Default) +
+        TestScenario(Versions.V3_2, Planners.Cost, Runtimes.Default) +
         TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
 
     def AllExceptSlotted: TestConfiguration =
       TestConfiguration(Versions.V3_3, Planners.Cost, Runtimes(Runtimes.CompiledSource, Runtimes.CompiledBytecode)) +
         TestConfiguration(Versions.Default, Planners.Default, Runtimes.Interpreted) +
-        TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default) +
+        TestConfiguration(Versions.V2_3 -> Versions.V3_1, Planners.all, Runtimes.Default) +
+        TestScenario(Versions.V3_2, Planners.Cost, Runtimes.Default) +
         TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
 
     def AbsolutelyAll: TestConfiguration =
       TestConfiguration(Versions.V3_3, Planners.Cost, Runtimes(Runtimes.CompiledSource, Runtimes.CompiledBytecode)) +
         TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Slotted, Runtimes.ProcedureOrSchema)) +
-        TestConfiguration(Versions.V2_3 -> Versions.V3_2, Planners.all, Runtimes.Default) +
+        TestConfiguration(Versions.V2_3 -> Versions.V3_1, Planners.all, Runtimes.Default) +
+        TestScenario(Versions.V3_2, Planners.Cost, Runtimes.Default) +
         TestScenario(Versions.Default, Planners.Rule, Runtimes.Default)
 
     def Empty: TestConfiguration = TestConfiguration.empty

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/HelpfulErrorMessagesTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/HelpfulErrorMessagesTest.scala
@@ -56,6 +56,10 @@ class HelpfulErrorMessagesTest extends ExecutionEngineFunSuite with CypherCompar
     intercept[Exception](graph.execute("CYPHER 3.3 planner=rule RETURN 1")).getMessage should be("Unsupported PLANNER - VERSION combination: rule - 3.3")
   }
 
+  test("should provide sensible error message for 3.2 rule planner") {
+    intercept[Exception](graph.execute("CYPHER 3.2 planner=rule RETURN 1")).getMessage should be("Unsupported PLANNER - VERSION combination: rule - 3.2")
+  }
+
   test("should not fail for specifying rule planner if no version specified") {
     graph.execute("CYPHER planner=rule RETURN 1") // should not fail
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/HelpfulErrorMessagesTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/HelpfulErrorMessagesTest.scala
@@ -52,6 +52,18 @@ class HelpfulErrorMessagesTest extends ExecutionEngineFunSuite with CypherCompar
       "The given query is not currently supported in the selected cost-based planner"))
   }
 
+  test("should provide sensible error message for 3.3 rule planner") {
+    intercept[Exception](graph.execute("CYPHER 3.3 planner=rule RETURN 1")).getMessage should be("Unsupported PLANNER - VERSION combination: rule - 3.3")
+  }
+
+  test("should not fail for specifying rule planner if no version specified") {
+    graph.execute("CYPHER planner=rule RETURN 1") // should not fail
+  }
+
+  test("should provide sensible error message for rule planner and slotted") {
+    intercept[Exception](graph.execute("CYPHER planner=rule runtime=slotted RETURN 1")).getMessage should be("Unsupported PLANNER - RUNTIME combination: rule - slotted")
+  }
+
   test("should provide sensible error message for invalid regex syntax together with index") {
 
     graph.execute("CREATE (n:Person {text:'abcxxxdefyyyfff'})")


### PR DESCRIPTION
Specifying 3.2 rule / 3.3 rule / slotted rule / compiled rule will fail now. Back port of #10552