### PR TITLE
Configuration parameter for db.index.explicit.forNodes

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
@@ -468,7 +468,15 @@ public class BuiltInProcedures
             @Name( value = "config", defaultValue = "" ) Map<String,String> config )
     {
         IndexManager mgr = graphDatabaseAPI.index();
-        Index<Node> index = mgr.forNodes( explicitIndexName, config );
+        Index<Node> index;
+        if ( config.isEmpty() )
+        {
+            index = mgr.forNodes( explicitIndexName );
+        }
+        else
+        {
+            index = mgr.forNodes( explicitIndexName, config );
+        }
         return Stream.of( new ExplicitIndexInfo( "NODE", explicitIndexName, mgr.getConfiguration( index ) ) );
     }
 
@@ -478,7 +486,15 @@ public class BuiltInProcedures
             @Name( value = "config", defaultValue = "" ) Map<String,String> config )
     {
         IndexManager mgr = graphDatabaseAPI.index();
-        Index<Relationship> index = mgr.forRelationships( explicitIndexName, config );
+        Index<Relationship> index;
+        if ( config.isEmpty() )
+        {
+            index = mgr.forRelationships( explicitIndexName );
+        }
+        else
+        {
+            index = mgr.forRelationships( explicitIndexName, config );
+        }
         return Stream.of( new ExplicitIndexInfo( "RELATIONSHIP", explicitIndexName, mgr.getConfiguration( index ) ) );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
@@ -474,10 +474,11 @@ public class BuiltInProcedures
 
     @Description( "Get or create a relationship explicit index - YIELD type,name,config" )
     @Procedure( name = "db.index.explicit.forRelationships", mode = WRITE )
-    public Stream<ExplicitIndexInfo> relationshipManualIndex( @Name( "indexName" ) String explicitIndexName )
+    public Stream<ExplicitIndexInfo> relationshipManualIndex( @Name( "indexName" ) String explicitIndexName,
+            @Name( value = "config", defaultValue = "" ) Map<String,String> config )
     {
         IndexManager mgr = graphDatabaseAPI.index();
-        Index<Relationship> index = mgr.forRelationships( explicitIndexName );
+        Index<Relationship> index = mgr.forRelationships( explicitIndexName, config );
         return Stream.of( new ExplicitIndexInfo( "RELATIONSHIP", explicitIndexName, mgr.getConfiguration( index ) ) );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/builtinprocs/BuiltInProcedures.java
@@ -464,10 +464,11 @@ public class BuiltInProcedures
 
     @Description( "Get or create a node explicit index - YIELD type,name,config" )
     @Procedure( name = "db.index.explicit.forNodes", mode = WRITE )
-    public Stream<ExplicitIndexInfo> nodeManualIndex( @Name( "indexName" ) String explicitIndexName )
+    public Stream<ExplicitIndexInfo> nodeManualIndex( @Name( "indexName" ) String explicitIndexName,
+            @Name( value = "config", defaultValue = "" ) Map<String,String> config )
     {
         IndexManager mgr = graphDatabaseAPI.index();
-        Index<Node> index = mgr.forNodes( explicitIndexName );
+        Index<Node> index = mgr.forNodes( explicitIndexName, config );
         return Stream.of( new ExplicitIndexInfo( "NODE", explicitIndexName, mgr.getConfiguration( index ) ) );
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -284,7 +284,7 @@ public class BuiltInProceduresTest
                         "(type :: STRING?, name :: STRING?, config :: MAP?)",
                         "Get or create a node explicit index - YIELD type,name,config"),
                 record( "db.index.explicit.forRelationships",
-                        "db.index.explicit.forRelationships(indexName :: STRING?) :: " +
+                        "db.index.explicit.forRelationships(indexName :: STRING?, config = {} :: MAP?) :: " +
                         "(type :: STRING?, name :: STRING?, config :: MAP?)",
                         "Get or create a relationship explicit index - YIELD type,name,config"),
                 record( "db.index.explicit.existsForNodes",

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -280,7 +280,7 @@ public class BuiltInProceduresTest
                         "(type :: STRING?, name :: STRING?, config :: MAP?)",
                         "Remove an explicit index - YIELD type,name,config"),
                 record( "db.index.explicit.forNodes",
-                        "db.index.explicit.forNodes(indexName :: STRING?) :: " +
+                        "db.index.explicit.forNodes(indexName :: STRING?, config = {} :: MAP?) :: " +
                         "(type :: STRING?, name :: STRING?, config :: MAP?)",
                         "Get or create a node explicit index - YIELD type,name,config"),
                 record( "db.index.explicit.forRelationships",

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
@@ -214,7 +214,7 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
                         "(type :: STRING?, name :: STRING?, config :: MAP?)",
                         "Remove an explicit index - YIELD type,name,config"} ),
                 equalTo( new Object[]{ "db.index.explicit.forNodes",
-                        "db.index.explicit.forNodes(indexName :: STRING?) :: " +
+                        "db.index.explicit.forNodes(indexName :: STRING?, config = {} :: MAP?) :: " +
                         "(type :: STRING?, name :: STRING?, config :: MAP?)",
                         "Get or create a node explicit index - YIELD type,name,config"} ),
                 equalTo( new Object[]{ "db.index.explicit.forRelationships",

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
@@ -218,7 +218,7 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
                         "(type :: STRING?, name :: STRING?, config :: MAP?)",
                         "Get or create a node explicit index - YIELD type,name,config"} ),
                 equalTo( new Object[]{ "db.index.explicit.forRelationships",
-                        "db.index.explicit.forRelationships(indexName :: STRING?) :: " +
+                        "db.index.explicit.forRelationships(indexName :: STRING?, config = {} :: MAP?) :: " +
                         "(type :: STRING?, name :: STRING?, config :: MAP?)",
                         "Get or create a relationship explicit index - YIELD type,name,config"} ),
                 equalTo( new Object[]{ "db.index.explicit.existsForNodes",

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/IndexType.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/IndexType.java
@@ -209,6 +209,9 @@ public abstract class IndexType
                                LuceneDataSource.WHITESPACE_ANALYZER;
                 }
                 result = new CustomType( analyzer, toLowerCase, similarity );
+            } else {
+                throw new IllegalArgumentException( "The given type was not recognized: " + type +
+                        ". Known types are 'fulltext' and 'exact'");
             }
         }
         else

--- a/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/IndexType.java
+++ b/community/lucene-index/src/main/java/org/neo4j/index/impl/lucene/explicit/IndexType.java
@@ -209,9 +209,11 @@ public abstract class IndexType
                                LuceneDataSource.WHITESPACE_ANALYZER;
                 }
                 result = new CustomType( analyzer, toLowerCase, similarity );
-            } else {
+            }
+            else
+            {
                 throw new IllegalArgumentException( "The given type was not recognized: " + type +
-                        ". Known types are 'fulltext' and 'exact'");
+                        ". Known types are 'fulltext' and 'exact'" );
             }
         }
         else

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ManualIndexProcsIT.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ManualIndexProcsIT.scala
@@ -479,6 +479,32 @@ class ManualIndexProcsIT extends ExecutionEngineFunSuite {
     assertNodeIndexExists("usernames", true)
   }
 
+  test("should be able to get an existing node index without specifying a configuration") {
+    //Given
+    assertNodeIndexExists("usernames", false)
+    execute("CALL db.index.explicit.forNodes('usernames') YIELD type, name").toList
+
+    //When
+    val result = execute("CALL db.index.explicit.forNodes('usernames') YIELD type, name").toList
+    result should equal(List(Map("name" -> "usernames", "type" -> "NODE")))
+
+    //Then
+    assertNodeIndexExists("usernames", true)
+  }
+
+  test("should be able to get an existing node index with specifying a configuration") {
+    //Given
+    assertNodeIndexExists("usernames", false)
+    execute("CALL db.index.explicit.forNodes('usernames') YIELD type, name").toList
+
+    //When
+    val result = execute("CALL db.index.explicit.forNodes('usernames', {type: 'exact', provider: 'lucene'}) YIELD type, name").toList
+    result should equal(List(Map("name" -> "usernames", "type" -> "NODE")))
+
+    //Then
+    assertNodeIndexExists("usernames", true)
+  }
+
   test("cannot get a node index with a different type if it exists already") {
     //Given
     assertNodeIndexExists("usernames", false)
@@ -525,6 +551,32 @@ class ManualIndexProcsIT extends ExecutionEngineFunSuite {
 
     //When
     val result = execute("CALL db.index.explicit.forRelationships('relIndex') YIELD type, name").toList
+    result should equal(List(Map("name" -> "relIndex", "type" -> "RELATIONSHIP")))
+
+    //Then
+    assertRelationshipIndexExists("relIndex", true)
+  }
+
+  test("should be able to get an existing relationship index without specifying a configuration") {
+    //Given
+    assertRelationshipIndexExists("relIndex", false)
+    execute("CALL db.index.explicit.forRelationships('relIndex') YIELD type, name").toList
+
+    //When
+    val result = execute("CALL db.index.explicit.forRelationships('relIndex') YIELD type, name").toList
+    result should equal(List(Map("name" -> "relIndex", "type" -> "RELATIONSHIP")))
+
+    //Then
+    assertRelationshipIndexExists("relIndex", true)
+  }
+
+  test("should be able to get an existing relationship index with specifying a configuration") {
+    //Given
+    assertRelationshipIndexExists("relIndex", false)
+    execute("CALL db.index.explicit.forRelationships('relIndex') YIELD type, name").toList
+
+    //When
+    val result = execute("CALL db.index.explicit.forRelationships('relIndex', {type: 'exact', provider: 'lucene'}) YIELD type, name").toList
     result should equal(List(Map("name" -> "relIndex", "type" -> "RELATIONSHIP")))
 
     //Then

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ManualIndexProcsIT.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ManualIndexProcsIT.scala
@@ -512,6 +512,13 @@ class ManualIndexProcsIT extends ExecutionEngineFunSuite {
     execute("CALL db.index.explicit.searchNodes('usernames', 'username:Satia') YIELD node RETURN node.prop").columnAs("node.prop").toList should be(List("x"))
   }
 
+  test("wrong index type does not lead to null-pointer-exception") {
+    val e = intercept[Exception](
+      execute("CALL db.index.explicit.forNodes('usernames', {type: 'does not exist', provider: 'lucene'}) YIELD type, name, config").toList
+    )
+    e.getCause.getCause.getMessage should equal("The given type was not recognized: does not exist. Known types are 'fulltext' and 'exact'")
+  }
+
   test("should be able to get or create a relationship index") {
     //Given
     graph.inTx {


### PR DESCRIPTION
db.index.explicit.forNodes now accepts a second paramater "configuration", that can be used to configure the index. This new parameter can be omitted.