### PR TITLE
No offheap collection in birk

### DIFF
--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/Primitive.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/Primitive.java
@@ -24,6 +24,7 @@ import org.neo4j.collection.primitive.hopscotch.IntKeyObjectValueTable;
 import org.neo4j.collection.primitive.hopscotch.IntKeyTable;
 import org.neo4j.collection.primitive.hopscotch.IntKeyUnsafeTable;
 import org.neo4j.collection.primitive.hopscotch.LongKeyIntValueTable;
+import org.neo4j.collection.primitive.hopscotch.LongKeyLongValueTable;
 import org.neo4j.collection.primitive.hopscotch.LongKeyLongValueUnsafeTable;
 import org.neo4j.collection.primitive.hopscotch.LongKeyObjectValueTable;
 import org.neo4j.collection.primitive.hopscotch.LongKeyTable;
@@ -86,6 +87,16 @@ public class Primitive
     public static PrimitiveLongIntMap longIntMap( int initialCapacity )
     {
         return new PrimitiveLongIntHashMap( new LongKeyIntValueTable( initialCapacity ), NO_MONITOR );
+    }
+
+    public static PrimitiveLongLongMap longLongMap()
+    {
+        return longLongMap( DEFAULT_HEAP_CAPACITY );
+    }
+
+    public static PrimitiveLongLongMap longLongMap( int initialCapacity )
+    {
+        return new PrimitiveLongLongHashMap( new LongKeyLongValueTable( initialCapacity ), NO_MONITOR );
     }
 
     public static PrimitiveLongLongMap offHeapLongLongMap()

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/IntArrayBasedKeyTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/IntArrayBasedKeyTable.java
@@ -27,12 +27,15 @@ import static java.util.Arrays.fill;
  * Table implementation for handling primitive int/long keys and hop bits. The quantized unit is int so a
  * multiple of ints will be used for every entry.
  *
+ * In this class, <code>index</code> refers to the index of an entry (key + value + hop bits), while
+ * <code>address</code> refers to the position of an int word in the internal <code>table</code>.
+ *
  * @param <VALUE> essentially ignored, since no values are stored in this table. Although subclasses can.
  */
 public abstract class IntArrayBasedKeyTable<VALUE> extends PowerOfTwoQuantizedTable<VALUE>
 {
     protected int[] table;
-    protected final VALUE singleValue;
+    protected final VALUE singleValue; // used as a pointer to pass around a primitive value in concrete subclasses
     private final int itemsPerEntry;
 
     protected IntArrayBasedKeyTable( int capacity, int itemsPerEntry, int h, VALUE singleValue )
@@ -72,17 +75,17 @@ public abstract class IntArrayBasedKeyTable<VALUE> extends PowerOfTwoQuantizedTa
     @Override
     public void put( int index, long key, VALUE value )
     {
-        int actualIndex = index( index );
-        internalPut( actualIndex, key, value );
+        int address = address( index );
+        internalPut( address, key, value );
         size++;
     }
 
     @Override
     public VALUE remove( int index )
     {
-        int actualIndex = index( index );
+        int address = address( index );
         VALUE value = value( index );
-        internalRemove( actualIndex );
+        internalRemove( address );
         size--;
         return value;
     }
@@ -91,13 +94,13 @@ public abstract class IntArrayBasedKeyTable<VALUE> extends PowerOfTwoQuantizedTa
     public long move( int fromIndex, int toIndex )
     {
         long key = key( fromIndex );
-        int actualFromIndex = index( fromIndex );
-        int actualToIndex = index( toIndex );
+        int fromAddress = address( fromIndex );
+        int toAddress = address( toIndex );
         for ( int i = 0; i < itemsPerEntry - 1; i++ )
         {
-            int tempValue = table[actualFromIndex + i];
-            table[actualFromIndex + i] = table[actualToIndex + i];
-            table[actualToIndex + i] = tempValue;
+            int tempValue = table[fromAddress + i];
+            table[fromAddress + i] = table[toAddress + i];
+            table[toAddress + i] = tempValue;
         }
         return key;
     }
@@ -124,7 +127,7 @@ public abstract class IntArrayBasedKeyTable<VALUE> extends PowerOfTwoQuantizedTa
     @Override
     public long hopBits( int index )
     {
-        return ~(table[index( index ) + itemsPerEntry - 1] | 0xFFFFFFFF00000000L);
+        return ~(table[address( index ) + itemsPerEntry - 1] | 0xFFFFFFFF00000000L);
     }
 
     private int hopBit( int hd )
@@ -135,22 +138,22 @@ public abstract class IntArrayBasedKeyTable<VALUE> extends PowerOfTwoQuantizedTa
     @Override
     public void putHopBit( int index, int hd )
     {
-        table[index( index ) + itemsPerEntry - 1] &= ~hopBit( hd );
+        table[address( index ) + itemsPerEntry - 1] &= ~hopBit( hd );
     }
 
     @Override
     public void moveHopBit( int index, int hd, int delta )
     {
-        table[index( index ) + itemsPerEntry - 1] ^= hopBit( hd ) | hopBit( hd + delta );
+        table[address( index ) + itemsPerEntry - 1] ^= hopBit( hd ) | hopBit( hd + delta );
     }
 
     @Override
     public void removeHopBit( int index, int hd )
     {
-        table[index( index ) + itemsPerEntry - 1] |= hopBit( hd );
+        table[address( index ) + itemsPerEntry - 1] |= hopBit( hd );
     }
 
-    protected int index( int index )
+    protected int address( int index )
     {
         return index * itemsPerEntry;
     }

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/IntArrayBasedKeyTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/IntArrayBasedKeyTable.java
@@ -35,11 +35,6 @@ public abstract class IntArrayBasedKeyTable<VALUE> extends PowerOfTwoQuantizedTa
     protected final VALUE singleValue;
     private final int itemsPerEntry;
 
-    protected IntArrayBasedKeyTable( int itemsPerEntry, int h, VALUE singleValue )
-    {
-        this( baseCapacity( h ), itemsPerEntry, h, singleValue );
-    }
-
     protected IntArrayBasedKeyTable( int capacity, int itemsPerEntry, int h, VALUE singleValue )
     {
         super( capacity, h );

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/IntKeyLongValueTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/IntKeyLongValueTable.java
@@ -31,7 +31,7 @@ public class IntKeyLongValueTable extends IntArrayBasedKeyTable<long[]>
     @Override
     public long key( int index )
     {
-        return table[index( index )];
+        return table[address( index )];
     }
 
     @Override
@@ -44,14 +44,14 @@ public class IntKeyLongValueTable extends IntArrayBasedKeyTable<long[]>
     @Override
     public long[] value( int index )
     {
-        singleValue[0] = getLong( index( index ) + 1 );
+        singleValue[0] = getLong( address( index ) + 1 );
         return singleValue;
     }
 
     @Override
     public long[] putValue( int index, long[] value )
     {
-        singleValue[0] = putLong( index( index ) + 1, value[0] );
+        singleValue[0] = putLong( address( index ) + 1, value[0] );
         return singleValue;
     }
 

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/IntKeyTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/IntKeyTable.java
@@ -29,7 +29,7 @@ public class IntKeyTable<VALUE> extends IntArrayBasedKeyTable<VALUE>
     @Override
     public long key( int index )
     {
-        return table[index( index )];
+        return table[address( index )];
     }
 
     @Override

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyIntValueTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyIntValueTable.java
@@ -31,7 +31,7 @@ public class LongKeyIntValueTable extends IntArrayBasedKeyTable<int[]>
     @Override
     public long key( int index )
     {
-        return getLong( index( index ) );
+        return getLong( address( index ) );
     }
 
     @Override
@@ -44,7 +44,7 @@ public class LongKeyIntValueTable extends IntArrayBasedKeyTable<int[]>
     @Override
     public int[] putValue( int index, int[] value )
     {
-        int actualIndex = index( index ) + 2;
+        int actualIndex = address( index ) + 2;
         int previous = table[actualIndex];
         table[actualIndex] = value[0];
         return pack( previous );
@@ -53,7 +53,7 @@ public class LongKeyIntValueTable extends IntArrayBasedKeyTable<int[]>
     @Override
     public int[] value( int index )
     {
-        return pack( table[index( index ) + 2] );
+        return pack( table[address( index ) + 2] );
     }
 
     @Override

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyLongValueTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyLongValueTable.java
@@ -32,7 +32,7 @@ public class LongKeyLongValueTable
     @Override
     public long key( int index )
     {
-        return getLong( index( index ) );
+        return getLong( address( index ) );
     }
 
     @Override
@@ -45,7 +45,7 @@ public class LongKeyLongValueTable
     @Override
     public long[] putValue( int index, long[] value )
     {
-        int actualValueIndex = index( index ) + 2;
+        int actualValueIndex = address( index ) + 2;
         long previous = getLong( actualValueIndex );
         putLong( actualValueIndex, value[0] );
         return pack( previous );
@@ -54,7 +54,7 @@ public class LongKeyLongValueTable
     @Override
     public long[] value( int index )
     {
-        return pack( getLong( index( index ) + 2 ) );
+        return pack( getLong( address( index ) + 2 ) );
     }
 
     @Override

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyLongValueTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyLongValueTable.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.collection.primitive.hopscotch;
+
+public class LongKeyLongValueTable
+        extends IntArrayBasedKeyTable<long[]>
+{
+    public static final long NULL = -1;
+
+    public LongKeyLongValueTable( int capacity )
+    {
+        super( capacity, 5, 32, new long[]{ NULL } );
+    }
+
+    @Override
+    public long key( int index )
+    {
+        return getLong( index( index ) );
+    }
+
+    @Override
+    protected void internalPut( int actualIndex, long key, long[] value )
+    {
+        putLong( actualIndex, key );
+        putLong( actualIndex + 2, value[0] );
+    }
+
+    @Override
+    public long[] putValue( int index, long[] value )
+    {
+        int actualValueIndex = index( index ) + 2;
+        long previous = getLong( actualValueIndex );
+        putLong( actualValueIndex, value[0] );
+        return pack( previous );
+    }
+
+    @Override
+    public long[] value( int index )
+    {
+        return pack( getLong( index( index ) + 2 ) );
+    }
+
+    @Override
+    protected LongKeyLongValueTable newInstance( int newCapacity )
+    {
+        return new LongKeyLongValueTable( newCapacity );
+    }
+
+    private long[] pack( long value )
+    {
+        singleValue[0] = value;
+        return singleValue;
+    }
+}

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyTable.java
@@ -30,7 +30,7 @@ public class LongKeyTable<VALUE>
     @Override
     public long key( int index )
     {
-        return getLong( index( index ) );
+        return getLong( address( index ) );
     }
 
     @Override

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/BasicTableTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/BasicTableTest.java
@@ -153,6 +153,26 @@ public class BasicTableTest
             @Override
             public Table newTable( int capacity )
             {
+                return new LongKeyLongValueTable( capacity );
+            }
+
+            @Override
+            public boolean supportsLongs()
+            {
+                return true;
+            }
+
+            @Override
+            public Object sampleValue()
+            {
+                return new long[] {Math.abs( random.nextLong() )};
+            }
+        } } );
+        result.add( new Object[] { new TableFactory()
+        {
+            @Override
+            public Table newTable( int capacity )
+            {
                 return new LongKeyObjectValueTable( capacity );
             }
 

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveCollectionEqualityTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveCollectionEqualityTest.java
@@ -302,6 +302,13 @@ public class PrimitiveCollectionEqualityTest
     public static Factory<PrimitiveLongIntMap> longIntMapWithCapacity = () -> Primitive.longIntMap( randomCapacity() );
 
     @DataPoint
+    public static Factory<PrimitiveLongLongMap> longLongMap = Primitive::longLongMap;
+
+    @DataPoint
+    public static Factory<PrimitiveLongLongMap> longLongMapWithCapacity =
+            () -> Primitive.longLongMap( randomCapacity() );
+
+    @DataPoint
     public static Factory<PrimitiveLongLongMap> offheapLongLongMap = Primitive::offHeapLongLongMap;
 
     @DataPoint

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongMapTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongMapTest.java
@@ -939,7 +939,7 @@ public class PrimitiveLongMapTest
     {
         // GIVEN
         PrimitiveLongLongVisitor<RuntimeException> visitor;
-        try ( PrimitiveLongLongMap map = Primitive.offHeapLongLongMap() )
+        try ( PrimitiveLongLongMap map = Primitive.longLongMap() )
         {
             map.put( 1, 100 );
             map.put( 2, 200 );
@@ -959,6 +959,50 @@ public class PrimitiveLongMapTest
 
     @Test
     public void longLongEntryVisitorShouldNotSeeEntriesAfterRequestingBreakOut()
+    {
+        // GIVEN
+        AtomicInteger counter = new AtomicInteger();
+        try ( PrimitiveLongLongMap map = Primitive.longLongMap() )
+        {
+            map.put( 1, 100 );
+            map.put( 2, 200 );
+            map.put( 3, 300 );
+            map.put( 4, 400 );
+
+            // WHEN
+            map.visitEntries( ( key, value ) -> counter.incrementAndGet() > 2 );
+        }
+
+        // THEN
+        assertThat( counter.get(), is( 3 ) );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    @Test
+    public void longLongOffHeapEntryVisitorShouldSeeAllEntriesIfItDoesNotBreakOut()
+    {
+        // GIVEN
+        PrimitiveLongLongVisitor<RuntimeException> visitor;
+        try ( PrimitiveLongLongMap map = Primitive.offHeapLongLongMap() )
+        {
+            map.put( 1, 100 );
+            map.put( 2, 200 );
+            map.put( 3, 300 );
+            visitor = mock( PrimitiveLongLongVisitor.class );
+
+            // WHEN
+            map.visitEntries( visitor );
+        }
+
+        // THEN
+        verify( visitor ).visited( 1, 100 );
+        verify( visitor ).visited( 2, 200 );
+        verify( visitor ).visited( 3, 300 );
+        verifyNoMoreInteractions( visitor );
+    }
+
+    @Test
+    public void longLongOffHeapEntryVisitorShouldNotSeeEntriesAfterRequestingBreakOut()
     {
         // GIVEN
         AtomicInteger counter = new AtomicInteger();
@@ -1100,7 +1144,7 @@ public class PrimitiveLongMapTest
     {
         // GIVEN
         PrimitiveLongVisitor<RuntimeException> visitor = mock( PrimitiveLongVisitor.class );
-        try ( PrimitiveLongLongMap map = Primitive.offHeapLongLongMap() )
+        try ( PrimitiveLongLongMap map = Primitive.longLongMap() )
         {
             map.put( 1, 100 );
             map.put( 2, 200 );
@@ -1119,6 +1163,49 @@ public class PrimitiveLongMapTest
 
     @Test
     public void longLongKeyVisitorShouldNotSeeEntriesAfterRequestingBreakOut()
+    {
+        // GIVEN
+        AtomicInteger counter = new AtomicInteger();
+        try ( PrimitiveLongLongMap map = Primitive.longLongMap() )
+        {
+            map.put( 1, 100 );
+            map.put( 2, 200 );
+            map.put( 3, 300 );
+            map.put( 4, 400 );
+
+            // WHEN
+            map.visitKeys( value -> counter.incrementAndGet() > 2 );
+        }
+
+        // THEN
+        assertThat( counter.get(), is( 3 ) );
+    }
+
+    @SuppressWarnings( "unchecked" )
+    @Test
+    public void longLongOffHeapKeyVisitorShouldSeeAllEntriesIfItDoesNotBreakOut()
+    {
+        // GIVEN
+        PrimitiveLongVisitor<RuntimeException> visitor = mock( PrimitiveLongVisitor.class );
+        try ( PrimitiveLongLongMap map = Primitive.offHeapLongLongMap() )
+        {
+            map.put( 1, 100 );
+            map.put( 2, 200 );
+            map.put( 3, 300 );
+
+            // WHEN
+            map.visitKeys( visitor );
+        }
+
+        // THEN
+        verify( visitor ).visited( 1 );
+        verify( visitor ).visited( 2 );
+        verify( visitor ).visited( 3 );
+        verifyNoMoreInteractions( visitor );
+    }
+
+    @Test
+    public void longLongOffHeapKeyVisitorShouldNotSeeEntriesAfterRequestingBreakOut()
     {
         // GIVEN
         AtomicInteger counter = new AtomicInteger();

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/codegen/GeneratedMethodStructure.scala
@@ -624,7 +624,7 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
   override def newDistinctSet(name: String, codeGenTypes: Iterable[CodeGenType]) = {
     if (codeGenTypes.size == 1 && codeGenTypes.head.repr == LongType) {
       generator.assign(generator.declare(typeRef[PrimitiveLongSet], name),
-                       invoke(method[Primitive, PrimitiveLongSet]("offHeapLongSet")))
+                       invoke(method[Primitive, PrimitiveLongSet]("longSet")))
       _finalizers.append((_: Boolean) => (block) =>
                            block.expression(
                              invoke(block.load(name), method[PrimitiveLongSet, Unit]("close"))))
@@ -722,7 +722,7 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
   override def newAggregationMap(name: String, keyTypes: IndexedSeq[CodeGenType]) = {
     if (keyTypes.size == 1 && keyTypes.head.repr == LongType) {
       generator.assign(generator.declare(typeRef[PrimitiveLongLongMap], name),
-                       invoke(method[Primitive, PrimitiveLongLongMap]("offHeapLongLongMap")))
+                       invoke(method[Primitive, PrimitiveLongLongMap]("longLongMap")))
       _finalizers.append((_: Boolean) => (block) =>
                            block.expression(
                              invoke(block.load(name), method[PrimitiveLongLongMap, Unit]("close"))))


### PR DESCRIPTION
Stop compiled runtime from using off heap data structures. This was a remnant from the compiled runtime prototyping that should have been removed, now it is.

Also added an on-heap primitive long-long map, which the lack of was probably the reason for the off-heaping.