### PR TITLE
Minor optimizations of Kernel API implementation

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeCursor.java
@@ -62,7 +62,10 @@ class NodeCursor extends NodeRecord implements org.neo4j.internal.kernel.api.Nod
         this.next = 0;
         this.highMark = read.nodeHighMark();
         this.read = read;
-        this.labelCursor = read.labelCursor();
+        if ( labelCursor != null )
+        {
+            labelCursor = read.labelCursor();
+        }
     }
 
     void single( long reference, Read read )
@@ -79,7 +82,10 @@ class NodeCursor extends NodeRecord implements org.neo4j.internal.kernel.api.Nod
         //This marks the cursor as a "single cursor"
         this.highMark = NO_ID;
         this.read = read;
-        this.labelCursor = read.labelCursor();
+        if ( labelCursor != null )
+        {
+            labelCursor = read.labelCursor();
+        }
     }
 
     @Override
@@ -274,8 +280,11 @@ class NodeCursor extends NodeRecord implements org.neo4j.internal.kernel.api.Nod
             pageCursor = null;
         }
         read = null;
-        labelCursor = null;
-
+        if ( labelCursor != null )
+        {
+            labelCursor.close();
+            labelCursor = null;
+        }
         reset();
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeCursor.java
@@ -62,7 +62,7 @@ class NodeCursor extends NodeRecord implements org.neo4j.internal.kernel.api.Nod
         this.next = 0;
         this.highMark = read.nodeHighMark();
         this.read = read;
-        if ( labelCursor != null )
+        if ( labelCursor == null )
         {
             labelCursor = read.labelCursor();
         }
@@ -82,7 +82,7 @@ class NodeCursor extends NodeRecord implements org.neo4j.internal.kernel.api.Nod
         //This marks the cursor as a "single cursor"
         this.highMark = NO_ID;
         this.read = read;
-        if ( labelCursor != null )
+        if ( labelCursor == null )
         {
             labelCursor = read.labelCursor();
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
@@ -322,10 +322,10 @@ public class Operations implements Read, ExplicitIndexRead, SchemaRead, Write, E
 
     private void assertOpen()
     {
-        Optional<Status> terminationReason = ktx.getReasonIfTerminated();
-        if ( terminationReason.isPresent() )
+        if ( ktx.isTerminated() )
         {
-            throw new TransactionTerminatedException( terminationReason.get() );
+            Status terminationReason = ktx.getReasonIfTerminated().orElse( Status.Transaction.Terminated );
+            throw new TransactionTerminatedException( terminationReason );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/StoreStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/StoreStatement.java
@@ -40,6 +40,8 @@ import org.neo4j.kernel.impl.api.store.StoreSingleRelationshipCursor;
 import org.neo4j.kernel.impl.locking.Lock;
 import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.store.AbstractDynamicStore;
+import org.neo4j.kernel.impl.store.DynamicArrayStore;
+import org.neo4j.kernel.impl.store.DynamicStringStore;
 import org.neo4j.kernel.impl.store.InvalidRecordException;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.NodeStore;
@@ -95,6 +97,8 @@ public class StoreStatement implements StorageStatement
     private final RecordCursors recordCursors;
     private final Supplier<LabelScanReader> labelScanStore;
     private final RecordStorageCommandCreationContext commandCreationContext;
+    private final DynamicArrayStore propertyArrayStore;
+    private final DynamicStringStore propertyStringStore;
 
     private IndexReaderFactory indexReaderFactory;
     private LabelScanReader labelScanReader;
@@ -120,6 +124,8 @@ public class StoreStatement implements StorageStatement
         this.relationshipStore = neoStores.getRelationshipStore();
         this.relationshipGroupStore = neoStores.getRelationshipGroupStore();
         this.propertyStore = neoStores.getPropertyStore();
+        this.propertyArrayStore = propertyStore.getArrayStore();
+        this.propertyStringStore = propertyStore.getStringStore();
         this.recordCursors = new RecordCursors( neoStores );
 
         singleNodeCursor = new InstanceCache<StoreSingleNodeCursor>()
@@ -432,13 +438,13 @@ public class StoreStatement implements StorageStatement
         @Override
         public PageCursor openStringPageCursor( long reference )
         {
-            return propertyStore.getStringStore().openPageCursorForReading( reference );
+            return propertyStringStore.openPageCursorForReading( reference );
         }
 
         @Override
         public PageCursor openArrayPageCursor( long reference )
         {
-            return propertyStore.getArrayStore().openPageCursorForReading( reference );
+            return propertyArrayStore.openPageCursorForReading( reference );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/StoreStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/StoreStatement.java
@@ -43,9 +43,11 @@ import org.neo4j.kernel.impl.store.AbstractDynamicStore;
 import org.neo4j.kernel.impl.store.InvalidRecordException;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.store.NodeStore;
+import org.neo4j.kernel.impl.store.PropertyStore;
 import org.neo4j.kernel.impl.store.RecordCursor;
 import org.neo4j.kernel.impl.store.RecordCursors;
 import org.neo4j.kernel.impl.store.RecordStore;
+import org.neo4j.kernel.impl.store.RelationshipGroupStore;
 import org.neo4j.kernel.impl.store.RelationshipStore;
 import org.neo4j.kernel.impl.store.StoreType;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
@@ -82,13 +84,16 @@ public class StoreStatement implements StorageStatement
     private final InstanceCache<StoreNodeRelationshipCursor> nodeRelationshipsCursor;
     private final InstanceCache<StoreSinglePropertyCursor> singlePropertyCursorCache;
     private final InstanceCache<StorePropertyCursor> propertyCursorCache;
+
     private final NeoStores neoStores;
     private final NodeStore nodeStore;
     private final RelationshipStore relationshipStore;
+    private final RelationshipGroupStore relationshipGroupStore;
+    private final PropertyStore propertyStore;
+
     private final Supplier<IndexReaderFactory> indexReaderFactorySupplier;
     private final RecordCursors recordCursors;
     private final Supplier<LabelScanReader> labelScanStore;
-    private final RecordStore<RelationshipGroupRecord> relationshipGroupStore;
     private final RecordStorageCommandCreationContext commandCreationContext;
 
     private IndexReaderFactory indexReaderFactory;
@@ -110,9 +115,11 @@ public class StoreStatement implements StorageStatement
         this.indexReaderFactorySupplier = indexReaderFactory;
         this.labelScanStore = labelScanReaderSupplier;
         this.commandCreationContext = commandCreationContext;
+
         this.nodeStore = neoStores.getNodeStore();
         this.relationshipStore = neoStores.getRelationshipStore();
         this.relationshipGroupStore = neoStores.getRelationshipGroupStore();
+        this.propertyStore = neoStores.getPropertyStore();
         this.recordCursors = new RecordCursors( neoStores );
 
         singleNodeCursor = new InstanceCache<StoreSingleNodeCursor>()
@@ -331,123 +338,119 @@ public class StoreStatement implements StorageStatement
 
     class Nodes implements StorageStatement.Nodes
     {
-
         @Override
         public PageCursor openPageCursor( long reference )
         {
-            return neoStores.getNodeStore().openPageCursorForReading( reference );
+            return nodeStore.openPageCursorForReading( reference );
         }
 
         @Override
         public void loadRecordByCursor( long reference, NodeRecord nodeRecord, RecordLoad mode, PageCursor cursor )
                 throws InvalidRecordException
         {
-            neoStores.getNodeStore().getRecordByCursor( reference, nodeRecord, mode, cursor );
+            nodeStore.getRecordByCursor( reference, nodeRecord, mode, cursor );
         }
 
         @Override
         public long getHighestPossibleIdInUse()
         {
-            return neoStores.getNodeStore().getHighestPossibleIdInUse();
+            return nodeStore.getHighestPossibleIdInUse();
         }
 
         @Override
         public RecordCursor<DynamicRecord> newLabelCursor()
         {
-            return newCursor( neoStores.getNodeStore().getDynamicLabelStore() );
+            return newCursor( nodeStore.getDynamicLabelStore() );
         }
     }
 
     class Relationships implements StorageStatement.Relationships
     {
-
         @Override
         public PageCursor openPageCursor( long reference )
         {
-            return neoStores.getRelationshipStore().openPageCursorForReading( reference );
+            return relationshipStore.openPageCursorForReading( reference );
         }
 
         @Override
         public void loadRecordByCursor( long reference, RelationshipRecord relationshipRecord, RecordLoad mode,
                 PageCursor cursor ) throws InvalidRecordException
         {
-            neoStores.getRelationshipStore().getRecordByCursor( reference, relationshipRecord, mode, cursor );
+            relationshipStore.getRecordByCursor( reference, relationshipRecord, mode, cursor );
         }
 
         @Override
         public long getHighestPossibleIdInUse()
         {
-            return neoStores.getRelationshipStore().getHighestPossibleIdInUse();
+            return relationshipStore.getHighestPossibleIdInUse();
         }
     }
 
     class Groups implements StorageStatement.Groups
     {
-
         @Override
         public PageCursor openPageCursor( long reference )
         {
-            return neoStores.getRelationshipGroupStore().openPageCursorForReading( reference );
+            return relationshipGroupStore.openPageCursorForReading( reference );
         }
 
         @Override
         public void loadRecordByCursor( long reference, RelationshipGroupRecord relationshipGroupRecord,
                 RecordLoad mode, PageCursor cursor ) throws InvalidRecordException
         {
-            neoStores.getRelationshipGroupStore().getRecordByCursor( reference, relationshipGroupRecord, mode, cursor );
+            relationshipGroupStore.getRecordByCursor( reference, relationshipGroupRecord, mode, cursor );
         }
 
         @Override
         public long getHighestPossibleIdInUse()
         {
-            return neoStores.getRelationshipGroupStore().getHighestPossibleIdInUse();
+            return relationshipGroupStore.getHighestPossibleIdInUse();
         }
     }
 
     class Properties implements StorageStatement.Properties
     {
-
         @Override
         public PageCursor openPageCursor( long reference )
         {
-            return neoStores.getPropertyStore().openPageCursorForReading( reference );
+            return propertyStore.openPageCursorForReading( reference );
         }
 
         @Override
         public void loadRecordByCursor( long reference, PropertyRecord propertyBlocks, RecordLoad mode,
                 PageCursor cursor ) throws InvalidRecordException
         {
-            neoStores.getPropertyStore().getRecordByCursor( reference, propertyBlocks, mode, cursor );
+            propertyStore.getRecordByCursor( reference, propertyBlocks, mode, cursor );
         }
 
         @Override
         public long getHighestPossibleIdInUse()
         {
-            return neoStores.getPropertyStore().getHighestPossibleIdInUse();
+            return propertyStore.getHighestPossibleIdInUse();
         }
 
         @Override
         public PageCursor openStringPageCursor( long reference )
         {
-            return neoStores.getPropertyStore().getStringStore().openPageCursorForReading( reference );
+            return propertyStore.getStringStore().openPageCursorForReading( reference );
         }
 
         @Override
         public PageCursor openArrayPageCursor( long reference )
         {
-            return neoStores.getPropertyStore().getArrayStore().openPageCursorForReading( reference );
+            return propertyStore.getArrayStore().openPageCursorForReading( reference );
         }
 
         @Override
         public ByteBuffer loadString( long reference, ByteBuffer buffer, PageCursor page )
         {
-            return readDynamic( neoStores.getPropertyStore().getStringStore(), reference, buffer, page );
+            return readDynamic( propertyStore.getStringStore(), reference, buffer, page );
         }
 
         @Override
         public ByteBuffer loadArray( long reference, ByteBuffer buffer, PageCursor page )
         {
-            return readDynamic( neoStores.getPropertyStore().getArrayStore(), reference, buffer, page );
+            return readDynamic( propertyStore.getArrayStore(), reference, buffer, page );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageStatement.java
@@ -229,7 +229,7 @@ public interface StorageStatement extends AutoCloseable
     interface Nodes extends RecordReads<NodeRecord>
     {
         /**
-         * @return a new Record cursor for accessing DynamicRecords containing labels.
+         * @return a new Record cursor for accessing DynamicRecords containing labels. This comes acquired.
          */
         RecordCursor<DynamicRecord> newLabelCursor();
     }


### PR DESCRIPTION
Improves performance of most basic Kernel API reads by some cheap profile driven optimizations:

 - Fetch stores once in `StoreStatement`
 - Reuse the `LabelCursor` in `NodeCursor` between initializations
 - Faster happy path transaction termination checks (without `Optional`).