### PR TITLE
Fix selection regression in compiled runtime

### DIFF
--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/ast/rewriters/NamespacerTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/ast/rewriters/NamespacerTest.scala
@@ -24,62 +24,61 @@ import org.neo4j.cypher.internal.compiler.v3_3.parser.ParserFixture.parser
 import org.neo4j.cypher.internal.compiler.v3_3.phases.LogicalPlanState
 import org.neo4j.cypher.internal.compiler.v3_3.test_helpers.ContextHelper
 import org.neo4j.cypher.internal.frontend.v3_3._
-import org.neo4j.cypher.internal.frontend.v3_3.ast.rewriters._
 import org.neo4j.cypher.internal.frontend.v3_3.ast._
+import org.neo4j.cypher.internal.frontend.v3_3.ast.rewriters._
 import org.neo4j.cypher.internal.frontend.v3_3.helpers.StatementHelper._
 import org.neo4j.cypher.internal.frontend.v3_3.helpers.rewriting.RewriterStepSequencer
-import org.neo4j.cypher.internal.frontend.v3_3.phases.BaseState
 import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.CypherFunSuite
 
 class NamespacerTest extends CypherFunSuite with AstConstructionTestSupport {
 
   val tests = Seq(
     "match (n) return n as n" ->
-      ("match (n) return n as n", List.empty)
+      ("match (n) return n as n" -> List.empty)
     ,
     "match (n), (x) with n as n match (x) return n as n, x as x" ->
-      ("match (n), (`  x@12`) with n as n match (`  x@34`) return n as n, `  x@34` as x", List(varFor("  x@12"), varFor("  x@34")))
+      ("match (n), (`  x@12`) with n as n match (`  x@34`) return n as n, `  x@34` as x" -> List(varFor("  x@12"), varFor("  x@34")))
     ,
     "match (n), (x) where [x in n.prop where x = 2] return x as x" ->
-      ("match (n), (`  x@12`) where [`  x@22` in n.prop where `  x@22` = 2] return `  x@12` as x",
+      ("match (n), (`  x@12`) where [`  x@22` in n.prop where `  x@22` = 2] return `  x@12` as x" ->
         List(varFor("  x@12"), varFor("  x@22"), Equals(varFor("  x@22"), SignedDecimalIntegerLiteral("2")(pos))(pos),
           ListComprehension(ExtractScope(varFor("  x@22"),Some(Equals(varFor("  x@22"),SignedDecimalIntegerLiteral("2")(pos))(pos)),None)(pos),
             Property(varFor("n"),PropertyKeyName("prop")(pos))(pos))(pos)))
     ,
     "MATCH (a) WITH a.bar as bars WHERE 1 = 2 RETURN *" ->
-      ("MATCH (a) WITH a.bar as bars WHERE 1 = 2 RETURN *", List.empty)
+      ("MATCH (a) WITH a.bar as bars WHERE 1 = 2 RETURN *" -> List.empty)
     ,
     "match (n) where id(n) = 0 WITH collect(n) as coll where length(coll)={id} RETURN coll" ->
-      ("match (n) where id(n) = 0 WITH collect(n) as coll where length(coll)={id} RETURN coll", List.empty)
+      ("match (n) where id(n) = 0 WITH collect(n) as coll where length(coll)={id} RETURN coll" -> List.empty)
     ,
     "match (me)-[r1]->(you) with 1 AS x match (me)-[r1]->(food)<-[r2]-(you) return r1.times as `r1.times`" ->
-      ("match (`  me@7`)-[`  r1@12`]->(`  you@18`) with 1 AS x match (`  me@42`)-[`  r1@47`]->(food)<-[r2]-(`  you@66`) return `  r1@47`.times as `r1.times`",
+      ("match (`  me@7`)-[`  r1@12`]->(`  you@18`) with 1 AS x match (`  me@42`)-[`  r1@47`]->(food)<-[r2]-(`  you@66`) return `  r1@47`.times as `r1.times`" ->
         List(varFor("  me@7"), varFor("  r1@12"), varFor("  you@18"), varFor("  me@42"), varFor("  r1@47"), varFor("  you@66")))
     ,
     "MATCH (a:A)-[r1:T1]->(b:B)-[r2:T1]->(c:C) RETURN *" ->
-      ("MATCH (a:A)-[r1:T1]->(b:B)-[r2:T1]->(c:C) RETURN *", List.empty)
+      ("MATCH (a:A)-[r1:T1]->(b:B)-[r2:T1]->(c:C) RETURN *" -> List.empty)
     ,
     "match (a:Party) return a as a union match (a:Animal) return a as a" ->
-      ("match (`  a@7`:Party) return `  a@7` as a union match (`  a@43`:Animal) return `  a@43` as a", List(varFor("  a@7"), varFor("  a@43")))
+      ("match (`  a@7`:Party) return `  a@7` as a union match (`  a@43`:Animal) return `  a@43` as a" -> List(varFor("  a@7"), varFor("  a@43")))
     ,
     "match p=(a:Start)-->(b) return *" ->
-      ("match p=(a:Start)-->(b) return *", List.empty)
+      ("match p=(a:Start)-->(b) return *" -> List.empty)
     ,
     "match (n) return n, count(*) as c order by c" ->
       ("""match (`  n@7`)
       |with `  n@7` as `  FRESHID17`, count(*) as `  FRESHID20` ORDER BY `  FRESHID20`
-      |return `  FRESHID17` as n, `  FRESHID20` as c""".stripMargin,
+      |return `  FRESHID17` as n, `  FRESHID20` as c""".stripMargin ->
         List(varFor("  n@7")))
     ,
     "WITH 1 AS p, count(*) AS rng RETURN p ORDER BY rng" ->
-      ("WITH 1 AS `  p@10`, count(*) AS rng WITH `  p@10`  AS `  FRESHID36` ORDER BY rng RETURN `  FRESHID36` AS p", List(varFor("  p@10")))
+      ("WITH 1 AS `  p@10`, count(*) AS rng WITH `  p@10`  AS `  FRESHID36` ORDER BY rng RETURN `  FRESHID36` AS p" -> List(varFor("  p@10")))
     ,
     "CALL db.labels() YIELD label WITH count(*) AS c CALL db.labels() YIELD label RETURN *" ->
-      ("CALL db.labels() YIELD label AS `  label@23` WITH count(*) AS c CALL db.labels() YIELD label AS `  label@71` RETURN c AS c, `  label@71` AS label",
+      ("CALL db.labels() YIELD label AS `  label@23` WITH count(*) AS c CALL db.labels() YIELD label AS `  label@71` RETURN c AS c, `  label@71` AS label" ->
         List(varFor("  label@23"), varFor("  label@71")))
     ,
     "MATCH (a),(b) WITH a as a, a.prop as AG1, collect(b.prop) as AG2 RETURN a{prop: AG1, k: AG2} as X" ->
-      ("MATCH (a),(b) WITH a as a, a.prop as AG1, collect(b.prop) as AG2 RETURN a{prop: AG1, k: AG2} as X", List.empty)
+      ("MATCH (a),(b) WITH a as a, a.prop as AG1, collect(b.prop) as AG2 RETURN a{prop: AG1, k: AG2} as X" -> List.empty)
     ,
 
     """ |MATCH (video)
@@ -87,7 +86,7 @@ class NamespacerTest extends CypherFunSuite with AstConstructionTestSupport {
         |RETURN video.key AS x""".stripMargin ->
       ("""|MATCH (`  video@7`)
           |WITH {key:`  video@7`} AS `  video@34`
-          |RETURN `  video@34`.key AS x""".stripMargin,
+          |RETURN `  video@34`.key AS x""".stripMargin ->
         List(varFor("  video@7"), varFor("  video@34"), Property(varFor("  video@34"), PropertyKeyName("key")(pos))(pos)))
   )
 

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
@@ -35,12 +35,12 @@ import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
-import org.neo4j.cypher.internal.compatibility.v3_3.runtime.helpers.ValueConversion;
 import org.neo4j.cypher.internal.compiler.v3_3.spi.NodeIdWrapper;
 import org.neo4j.cypher.internal.compiler.v3_3.spi.RelationshipIdWrapper;
 import org.neo4j.cypher.internal.frontend.v3_3.CypherTypeException;
 import org.neo4j.cypher.internal.frontend.v3_3.IncomparableValuesException;
 import org.neo4j.kernel.impl.core.NodeManager;
+import org.neo4j.kernel.impl.util.ValueUtils;
 import org.neo4j.values.AnyValue;
 
 import static java.lang.String.format;
@@ -197,24 +197,21 @@ public abstract class CompiledConversionUtils
         }
 
         boolean lhsNodeIdWrapper = lhs instanceof NodeIdWrapper;
-        boolean rhsNodeIdWrapper = rhs instanceof NodeIdWrapper;
-        boolean lhsRelIdWrapper = lhs instanceof RelationshipIdWrapper;
-        boolean rhsRelIdWrapper = rhs instanceof RelationshipIdWrapper;
-
-        if ( lhsNodeIdWrapper || rhsNodeIdWrapper || lhsRelIdWrapper || rhsRelIdWrapper )
+        if ( lhsNodeIdWrapper || rhs instanceof NodeIdWrapper || lhs instanceof RelationshipIdWrapper ||
+             rhs instanceof RelationshipIdWrapper )
         {
-            if ( (lhsNodeIdWrapper && !rhsNodeIdWrapper) ||
-                 (rhsNodeIdWrapper && !lhsNodeIdWrapper) ||
-                 (lhsRelIdWrapper && !rhsRelIdWrapper) ||
-                 (rhsRelIdWrapper && !lhsRelIdWrapper) )
+            if ( (lhsNodeIdWrapper && !(rhs instanceof NodeIdWrapper)) ||
+                 (rhs instanceof NodeIdWrapper && !lhsNodeIdWrapper) ||
+                 (lhs instanceof RelationshipIdWrapper && !(rhs instanceof RelationshipIdWrapper)) ||
+                 (rhs instanceof RelationshipIdWrapper && !(lhs instanceof RelationshipIdWrapper)) )
             {
                 throw new IncomparableValuesException( lhs.getClass().getSimpleName(), rhs.getClass().getSimpleName() );
             }
             return lhs.equals( rhs );
         }
 
-        AnyValue lhsValue = lhs instanceof AnyValue ? (AnyValue) lhs : ValueConversion.asValue( lhs );
-        AnyValue rhsValue = rhs instanceof AnyValue ? (AnyValue) rhs : ValueConversion.asValue( rhs );
+        AnyValue lhsValue = lhs instanceof AnyValue ? (AnyValue) lhs : ValueUtils.of( lhs );
+        AnyValue rhsValue = rhs instanceof AnyValue ? (AnyValue) rhs : ValueUtils.of( rhs );
 
         return lhsValue.ternaryEquals( rhsValue );
     }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_2/CompatibilityTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_2/CompatibilityTest.scala
@@ -59,7 +59,7 @@ class CompatibilityTest extends CypherFunSuite {
     txClosed = true
 
     // then does not fail
-    executionPlanWrapper.plannerInfo
+    executionPlanWrapper.plannerInfo should not be null
   }
 
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ApocAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ApocAcceptanceTest.scala
@@ -49,13 +49,11 @@ class ApocAcceptanceTest extends ExecutionEngineFunSuite with NewPlannerTestSupp
   }
 
   def testResult(db: GraphDatabaseService, call: String, onResult: Result => Unit): Unit = {
-    try {
       val tx: Transaction = db.beginTx
       try {
         onResult(db.execute(call, Collections.emptyMap[String, AnyRef]))
         tx.success()
       } finally if (tx != null) tx.close()
-    }
   }
 
   val movies = """


### PR DESCRIPTION
We have seen a regression in the compiled runtime for selections since https://github.com/neo4j/neo4j/pull/10411. Turns out it is due to the extra `instance_of` checks introduced in that PR. This PR fixes that regression, plus removes some compiler warnings from the cypher codebase.