### PR TITLE
3.4 update cluster seed it

### DIFF
--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/ClusterSeedingIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/ClusterSeedingIT.java
@@ -26,7 +26,14 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.IntFunction;
 
+import org.neo4j.causalclustering.catchup.tx.FileCopyMonitor;
+import org.neo4j.causalclustering.catchup.tx.PullRequestMonitor;
 import org.neo4j.causalclustering.core.CoreGraphDatabase;
 import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.CoreClusterMember;
@@ -44,7 +51,9 @@ import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.neo4j.causalclustering.BackupCoreIT.backupAddress;
 import static org.neo4j.causalclustering.discovery.Cluster.dataMatchesEventually;
 import static org.neo4j.causalclustering.helpers.DataCreator.createEmptyNodes;
@@ -55,6 +64,8 @@ public class ClusterSeedingIT
     private Cluster backupCluster;
     private Cluster cluster;
     private FileSystemAbstraction fsa;
+    private DetectFileCopyMonitor detectFileCopyMonitor;
+    private PullRequestMonitor pullRequestMonitor;
 
     @Rule
     public TestDirectory testDir = TestDirectory.testDirectory();
@@ -66,16 +77,25 @@ public class ClusterSeedingIT
     public void setup() throws Exception
     {
         fsa = fileSystemRule.get();
-
+        Monitors monitors = new Monitors();
+        addMonitorListeners( monitors );
         backupCluster = new Cluster( testDir.directory( "cluster-for-backup" ), 3, 0,
-                new SharedDiscoveryService(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), Standard.LATEST_NAME,
-                IpFamily.IPV4, false, new Monitors() );
+                new SharedDiscoveryService(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), Standard
+                .LATEST_NAME, IpFamily.IPV4, false, new Monitors() );
 
         cluster = new Cluster( testDir.directory( "cluster-b" ), 3, 0,
                 new SharedDiscoveryService(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), Standard.LATEST_NAME,
-                IpFamily.IPV4, false, new Monitors() );
+                IpFamily.IPV4, false, monitors );
 
         baseBackupDir = testDir.directory( "backups" );
+    }
+
+    private void addMonitorListeners( Monitors monitors )
+    {
+        this.detectFileCopyMonitor = new DetectFileCopyMonitor();
+        this.pullRequestMonitor = new DetectPullRequestMonitor();
+        monitors.addMonitorListener( detectFileCopyMonitor );
+        monitors.addMonitorListener( pullRequestMonitor );
     }
 
     @After
@@ -125,19 +145,24 @@ public class ClusterSeedingIT
 
         // then
         dataMatchesEventually( before, cluster.coreMembers() );
+        assertFalse( detectFileCopyMonitor.fileCopyDetected.get() );
+        assertEquals( 4, pullRequestMonitor.numberOfRequests() );
     }
 
     @Test
     public void shouldSeedNewMemberFromEmptyIdleCluster() throws Throwable
     {
         // given
+        Monitors monitors = new Monitors();
         cluster = new Cluster( testDir.directory( "cluster-b" ), 3, 0,
                 new SharedDiscoveryService(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), Standard.LATEST_NAME,
-                IpFamily.IPV4, false, new Monitors() );
+                IpFamily.IPV4, false, monitors );
         cluster.start();
 
         // when: creating a backup
         File backupDir = createBackup( cluster, "the-backup" );
+        // we are only interested in monitoring the new instance
+        addMonitorListeners( monitors );
 
         // and: seeding new member with said backup
         CoreClusterMember newMember = cluster.addCoreMemberWithId( 3 );
@@ -147,21 +172,27 @@ public class ClusterSeedingIT
 
         // then
         dataMatchesEventually( DbRepresentation.of( newMember.database() ), cluster.coreMembers() );
+        assertFalse( detectFileCopyMonitor.fileCopyDetected.get() );
+        assertEquals( 1, pullRequestMonitor.numberOfRequests() );
+        assertEquals( 1, pullRequestMonitor.lastRequestedTxId() );
     }
 
     @Test
     public void shouldSeedNewMemberFromNonEmptyIdleCluster() throws Throwable
     {
         // given
+        Monitors monitors = new Monitors();
         cluster = new Cluster( testDir.directory( "cluster-b" ), 3, 0,
                 new SharedDiscoveryService(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), Standard.LATEST_NAME,
-                IpFamily.IPV4, false, new Monitors() );
+                IpFamily.IPV4, false, monitors );
 
         cluster.start();
         createEmptyNodes( cluster, 100 );
 
         // when: creating a backup
         File backupDir = createBackup( cluster, "the-backup" );
+        // we are only interested in monitoring the new instance
+        addMonitorListeners( monitors );
 
         // and: seeding new member with said backup
         CoreClusterMember newMember = cluster.addCoreMemberWithId( 3 );
@@ -171,6 +202,8 @@ public class ClusterSeedingIT
 
         // then
         dataMatchesEventually( DbRepresentation.of( newMember.database() ), cluster.coreMembers() );
+        assertFalse( detectFileCopyMonitor.fileCopyDetected.get() );
+        assertEquals( 1, pullRequestMonitor.numberOfRequests() );
     }
 
     @Test
@@ -190,5 +223,54 @@ public class ClusterSeedingIT
 
         // then
         dataMatchesEventually( before, cluster.coreMembers() );
+    }
+
+    private class DetectPullRequestMonitor implements PullRequestMonitor
+    {
+
+        private final AtomicLong lastPullRequest = new AtomicLong();
+        private final AtomicInteger numberOfRequest = new AtomicInteger();
+
+        @Override
+        public void txPullRequest( long txId )
+        {
+            lastPullRequest.set( txId );
+            numberOfRequest.incrementAndGet();
+        }
+
+        @Override
+        public void txPullResponse( long txId )
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
+        public long lastRequestedTxId()
+        {
+            return lastPullRequest.get();
+        }
+
+        @Override
+        public long lastReceivedTxId()
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
+        public long numberOfRequests()
+        {
+            return numberOfRequest.get();
+        }
+    }
+
+    private class DetectFileCopyMonitor implements FileCopyMonitor
+    {
+        private final AtomicBoolean fileCopyDetected = new AtomicBoolean( false );
+
+        @Override
+        public void copyFile( File file )
+        {
+            fileCopyDetected.compareAndSet( false, true );
+        }
     }
 }

--- a/integrationtests/src/test/java/org/neo4j/causalclustering/scenarios/ConvertNonCausalClusteringStoreIT.java
+++ b/integrationtests/src/test/java/org/neo4j/causalclustering/scenarios/ConvertNonCausalClusteringStoreIT.java
@@ -35,10 +35,12 @@ import org.neo4j.causalclustering.discovery.CoreClusterMember;
 import org.neo4j.function.ThrowingSupplier;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.store.format.highlimit.HighLimit;
 import org.neo4j.kernel.impl.store.format.standard.Standard;
+import org.neo4j.restore.RestoreDatabaseCommand;
 import org.neo4j.test.causalclustering.ClusterRule;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -81,7 +83,8 @@ public class ConvertNonCausalClusteringStoreIT
         {
             for ( CoreClusterMember core : cluster.coreMembers() )
             {
-                fileSystem.copyRecursively( classicNeo4jStore, core.storeDir() );
+                new RestoreDatabaseCommand( fileSystem, classicNeo4jStore, core.getMemberConfig(), core.settingValue(
+                        GraphDatabaseSettings.active_database.name() ), true ).execute();
             }
         }
 


### PR DESCRIPTION
This should fix failing test:
ConvertNonCausalClusteringStoreIT.shouldReplicateTransactionToCoreMembers
ClusterSeedIT.shouldRestoreBySeedingAllMembers

ClusterSeedIT was moved and so the changes from 3.3 was never added. This adds the monitoring approach.

To solve the failing tests they now use RestoreDatabaseCommand instead of recursive file copy. This is because a in 3.4 these two are not the same anymore due to then new config: logical_logs_location