### PR TITLE
Unflake WorksyncTest#mustCombineWork

### DIFF
--- a/community/primitive-collections/src/test/java/org/neo4j/concurrent/WorkSyncTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/concurrent/WorkSyncTest.java
@@ -205,8 +205,8 @@ public class WorkSyncTest
             @Override
             public void apply( Adder adder )
             {
-                startLatch.release();
                 super.apply( adder );
+                startLatch.release();
                 blockLatch.await();
             }
         } ) );


### PR DESCRIPTION
By making sure that we apply at least one unit of work before starting the
other appliers.