### PR TITLE
PropertiesFunction must do a copy

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/expressions/PropertiesFunction.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/expressions/PropertiesFunction.scala
@@ -24,11 +24,12 @@ import org.neo4j.cypher.internal.compatibility.v3_3.runtime.helpers.IsMap
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes.QueryState
 import org.neo4j.cypher.internal.frontend.v3_3.CypherTypeException
 import org.neo4j.values.AnyValue
+import org.neo4j.values.virtual.VirtualValues
 
 case class PropertiesFunction(a: Expression) extends NullInNullOutExpression(a) {
   override def compute(value: AnyValue, m: ExecutionContext, state: QueryState) =
     value match {
-      case IsMap(mapValue) => mapValue(state.query)
+      case IsMap(mapValue) => VirtualValues.copy(mapValue(state.query))
       case v =>
         throw new CypherTypeException(s"Expected a Node, Relationship, or Map, got: $v")
     }

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/expressions/PropertiesFunctionTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/commands/expressions/PropertiesFunctionTest.scala
@@ -21,7 +21,10 @@ package org.neo4j.cypher.internal.compatibility.v3_3.runtime.commands.expression
 
 import java.util
 
+import org.mockito.Matchers.any
 import org.mockito.Mockito
+import org.mockito.invocation.InvocationOnMock
+import org.mockito.stubbing.Answer
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.ExecutionContext
 import org.neo4j.cypher.internal.compatibility.v3_3.runtime.pipes.QueryStateHelper
 import org.neo4j.cypher.internal.frontend.v3_3.CypherTypeException
@@ -63,7 +66,9 @@ class PropertiesFunctionTest extends CypherFunSuite {
   test("should map nodes to maps") {
     val node = mock[Node]
     when(node.getId).thenReturn(0)
-    when(nodeOps.propertyKeyIds(0)).thenReturn(List(0,1).iterator)
+    when(nodeOps.propertyKeyIds(any())).thenAnswer(new Answer[Iterator[Int]] {
+      override def answer(invocationOnMock: InvocationOnMock): Iterator[Int] = List(0,1).iterator
+    })
     when(query.getPropertyKeyName(0)).thenReturn("a")
     when(query.getPropertyKeyName(1)).thenReturn("b")
     when(nodeOps.getProperty(0, 0)).thenReturn(stringValue("x"))
@@ -76,7 +81,9 @@ class PropertiesFunctionTest extends CypherFunSuite {
     val rel = mock[Relationship]
     when(rel.getId).thenReturn(0)
     when(rel.getId).thenReturn(0)
-    when(relOps.propertyKeyIds(0)).thenReturn(List(0,1).iterator)
+    when(relOps.propertyKeyIds(any())).thenAnswer(new Answer[Iterator[Int]] {
+      override def answer(invocationOnMock: InvocationOnMock): Iterator[Int] = List(0,1).iterator
+    })
     when(query.getPropertyKeyName(0)).thenReturn("a")
     when(query.getPropertyKeyName(1)).thenReturn("b")
     when(relOps.getProperty(0, 0)).thenReturn(stringValue("x"))

--- a/community/values/src/main/java/org/neo4j/values/virtual/VirtualValues.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/VirtualValues.java
@@ -156,6 +156,16 @@ public final class VirtualValues
         return new MapValue( map );
     }
 
+    public static MapValue copy( MapValue map )
+    {
+        HashMap<String,AnyValue> hashMap = new HashMap<>( map.size() );
+        for ( Map.Entry<String,AnyValue> entry : map.entrySet() )
+        {
+            hashMap.put( entry.getKey(), entry.getValue() );
+        }
+        return new MapValue( hashMap );
+    }
+
     public static NodeReference node( long id )
     {
         return new NodeReference( id );

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
@@ -70,3 +70,6 @@ max() over mixed values
 min() over mixed values
 max() over list values
 min() over list values
+
+//DeleteAcceptance.feature
+Return properties from deleted node

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -206,3 +206,6 @@ Should handle complex IS NOT NULL on node property when node is null
 
 //AggregationAcceptance.feature
 Multiple aggregations should work
+
+//DeleteAcceptance.feature
+Return properties from deleted node

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -117,3 +117,6 @@ difficult to plan query number 1
 difficult to plan query number 2
 difficult to plan query number 3
 Variable length path with both sides already bound
+
+//DeleteAcceptance.feature
+Return properties from deleted node

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/DeleteAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/DeleteAcceptance.feature
@@ -1,0 +1,43 @@
+#
+# Copyright (c) 2002-2017 "Neo Technology,"
+# Network Engine for Objects in Lund AB [http://neotechnology.com]
+#
+# This file is part of Neo4j.
+#
+# Neo4j is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+Feature: DeleteAcceptance
+
+  Scenario: Return properties from deleted node
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:L {prop1: 42, prop2: 1337})
+      """
+    When executing query:
+      """
+      MATCH (n:L)
+      WITH n, properties(n) AS props
+      DELETE n
+      RETURN props
+      """
+    Then the result should be:
+      | props                    |
+      | {prop1: 42, prop2: 1337} |
+    And the side effects should be:
+      | -nodes      | 1 |
+      | -labels     | 1 |
+      | -properties | 2 |
+


### PR DESCRIPTION
When doing the big AnyValue refactoring the copy in `PropertiesFunction`
was removed by mistake. This has the effect that the property map will see
changes coming after projection and wrong behavior for queries like
```
MATCH (n)
WITH n, properties(n) AS props
DELETE n
RETURN n
```

changelog: Fixed error when returning properties from deleted node