### PR TITLE
Do not trim checkpoints position after last transaction during recovery

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalTransactionCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalTransactionCursor.java
@@ -44,6 +44,7 @@ public class PhysicalTransactionCursor<T extends ReadableClosablePositionAwareCh
     public PhysicalTransactionCursor( T channel, LogEntryReader<T> entryReader ) throws IOException
     {
         this.channel = channel;
+        channel.getCurrentPosition( lastGoodPositionMarker );
         this.logEntryCursor =
                 new LogEntryCursor( (LogEntryReader<ReadableClosablePositionAwareChannel>) entryReader, channel );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/Recovery.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/Recovery.java
@@ -111,6 +111,7 @@ public class Recovery extends LifecycleAdapter
                     recoveryToPosition = transactionsToRecover.position();
                     reportProgress();
                 }
+                recoveryToPosition = transactionsToRecover.position();
             }
         }
         catch ( Throwable t )

--- a/community/kernel/src/test/java/org/neo4j/kernel/RecoveryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/RecoveryTest.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel;
 
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,6 +54,7 @@ import org.neo4j.kernel.impl.transaction.log.entry.LogEntryCommit;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryStart;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryWriter;
+import org.neo4j.kernel.impl.transaction.log.entry.LogHeader;
 import org.neo4j.kernel.impl.transaction.log.entry.VersionAwareLogEntryReader;
 import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
 import org.neo4j.kernel.impl.transaction.log.files.LogFilesBuilder;
@@ -305,6 +307,29 @@ public class RecoveryTest
 
         // THEN
         assertTrue( recoveryRequired );
+        assertEquals( marker.getByteOffset(), file.length() );
+    }
+
+    @Test
+    public void doNotTruncateCheckpointsAfterLastTransaction() throws IOException
+    {
+        File file = logFiles.getLogFileForVersion( logVersion );
+        LogPositionMarker marker = new LogPositionMarker();
+        writeSomeData( file, pair ->
+        {
+            LogEntryWriter writer = pair.first();
+            writer.writeStartEntry( 1, 1, 1L, 1L, ArrayUtils.EMPTY_BYTE_ARRAY );
+            writer.writeCommitEntry( 1L, 2L );
+            writer.writeCheckPointEntry( new LogPosition( logVersion, LogHeader.LOG_HEADER_SIZE ) );
+            writer.writeCheckPointEntry( new LogPosition( logVersion, LogHeader.LOG_HEADER_SIZE ) );
+            writer.writeCheckPointEntry( new LogPosition( logVersion, LogHeader.LOG_HEADER_SIZE ) );
+            writer.writeCheckPointEntry( new LogPosition( logVersion, LogHeader.LOG_HEADER_SIZE ) );
+            Consumer<LogPositionMarker> other = pair.other();
+            other.accept( marker );
+            return true;
+        } );
+        assertTrue( recover( storeDir, logFiles ) );
+
         assertEquals( marker.getByteOffset(), file.length() );
     }
 


### PR DESCRIPTION
Previously transaction log truncation was using position after last transaction
commit entry. In a cases when there were checkpoint entries it meant that
they were removed after recovery completion.
Now we will use position till which cursor was able to read transaction
log file - and that includes all the checkpoint entries.