### PR TITLE
Add eagerness before updating procedures

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
@@ -172,7 +172,7 @@ class EagerizationAcceptanceTest
     assertNumberOfEagerness(query, 1)
   }
 
-  test("should not introduce extra eagerness after CALL of writing procedure") {
+  test("should introduce extra eagerness after CALL of writing procedure") {
     // Given
     registerProcedure("user.mkRel") { builder =>
       builder.in("x", Neo4jTypes.NTNode)
@@ -203,11 +203,10 @@ class EagerizationAcceptanceTest
     val result = executeWithCostPlannerOnly(query)
     result.size should equal(4)
 
-    // Correct! Eagerization happens as part of query context operation
-    assertNumberOfEagerness(query, 0)
+    assertNumberOfEagerness(query, 1)
   }
 
-  test("should not introduce extra eagerness after CALL of writing void procedure") {
+  test("should introduce extra eagerness after CALL of writing void procedure") {
     // Given
     var counter = Counter(0)
 
@@ -242,8 +241,7 @@ class EagerizationAcceptanceTest
     result.size should equal(4)
     counter.counted should equal(4)
 
-    // Correct! Eagerization happens as part of query context operation
-    assertNumberOfEagerness(query, 0)
+    assertNumberOfEagerness(query, 1)
   }
 
   test("should not introduce extra eagerness after CALL of reading procedure") {

--- a/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/ResolvedCall.scala
+++ b/community/cypher/cypher-compiler-3.1/src/main/scala/org/neo4j/cypher/internal/compiler/v3_1/ast/ResolvedCall.scala
@@ -140,4 +140,6 @@ case class ResolvedCall(signature: ProcedureSignature,
     case ProcedureReadOnlyAccess(_) => true
     case _ => false
   }
+
+  def containsUpdates: Boolean = !containsNoUpdates
 }


### PR DESCRIPTION
Whenever a procedure is annotated with `@WRITE` we need to make the plan
eager.

changelog: Fixes #9055, user procedures fails to delete node.