### PR TITLE
Don't depend on EntityNotFoundException in compiler module

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/helpers/JavaConversionSupport.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/helpers/JavaConversionSupport.scala
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compiler.v2_3.helpers
+package org.neo4j.cypher.internal.helpers
 
 import org.neo4j.collection.primitive.{PrimitiveIntIterator, PrimitiveLongIterator}
 import org.neo4j.cypher.internal.frontend.v2_3.EntityNotFoundException

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_2/TransactionBoundQueryContext.scala
@@ -24,8 +24,7 @@ import java.net.URL
 import org.neo4j.collection.primitive.PrimitiveLongIterator
 import org.neo4j.cypher.internal.compiler.v2_2.spi._
 import org.neo4j.cypher.internal.compiler.v2_2.{EntityNotFoundException, FailedIndexException}
-import org.neo4j.cypher.internal.compiler.v2_3.helpers.JavaConversionSupport
-import org.neo4j.cypher.internal.compiler.v2_3.helpers.JavaConversionSupport._
+import org.neo4j.cypher.internal.helpers.JavaConversionSupport._
 import org.neo4j.graphdb.DynamicRelationshipType._
 import org.neo4j.graphdb._
 import org.neo4j.kernel.GraphDatabaseAPI
@@ -113,13 +112,13 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
     statement.tokenWriteOperations().relationshipTypeGetOrCreateForName(relTypeName)
 
   def getLabelsForNode(node: Long) =
-    JavaConversionSupport.asScala(statement.readOperations().nodeGetLabels(node))
+    asScala(statement.readOperations().nodeGetLabels(node))
 
   def getPropertiesForNode(node: Long) =
-    JavaConversionSupport.mapToScala(statement.readOperations().nodeGetPropertyKeys(node))(_.toLong)
+    mapToScala(statement.readOperations().nodeGetPropertyKeys(node))(_.toLong)
 
   def getPropertiesForRelationship(relId: Long) =
-    JavaConversionSupport.mapToScala(statement.readOperations().relationshipGetPropertyKeys(relId))(_.toLong)
+    mapToScala(statement.readOperations().relationshipGetPropertyKeys(relId))(_.toLong)
 
   override def isLabelSetOnNode(label: Int, node: Long) =
     statement.readOperations().nodeHasLabel(node, label)
@@ -128,8 +127,8 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
     statement.tokenWriteOperations().labelGetOrCreateForName(labelName)
 
   def getRelationshipsForIds(node: Node, dir: Direction, types: Option[Seq[Int]]): Iterator[Relationship] = types match {
-    case None => JavaConversionSupport.asScala(statement.readOperations().nodeGetRelationships(node.getId, dir)).map(relationshipOps.getById)
-    case Some(typeIds) => JavaConversionSupport.asScala(statement.readOperations().nodeGetRelationships(node.getId, dir, typeIds: _* )).map(relationshipOps.getById)
+    case None => asScala(statement.readOperations().nodeGetRelationships(node.getId, dir)).map(relationshipOps.getById)
+    case Some(typeIds) => asScala(statement.readOperations().nodeGetRelationships(node.getId, dir, typeIds: _* )).map(relationshipOps.getById)
   }
 
   def exactIndexSearch(index: IndexDescriptor, value: Any) =

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v2_3/TransactionBoundQueryContext.scala
@@ -29,12 +29,11 @@ import org.neo4j.cypher.internal.compiler.v2_3._
 import org.neo4j.cypher.internal.compiler.v2_3.ast.convert.commands.DirectionConverter.toGraphDb
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions
 import org.neo4j.cypher.internal.compiler.v2_3.commands.expressions.{KernelPredicate, OnlyDirectionExpander, TypeAndDirectionExpander}
-import org.neo4j.cypher.internal.compiler.v2_3.helpers.JavaConversionSupport
-import org.neo4j.cypher.internal.compiler.v2_3.helpers.JavaConversionSupport._
 import org.neo4j.cypher.internal.compiler.v2_3.pipes.matching.PatternNode
 import org.neo4j.cypher.internal.compiler.v2_3.spi.SchemaTypes.{IndexDescriptor, NodePropertyExistenceConstraint, RelationshipPropertyExistenceConstraint, UniquenessConstraint}
 import org.neo4j.cypher.internal.compiler.v2_3.spi._
 import org.neo4j.cypher.internal.frontend.v2_3.{Bound, EntityNotFoundException, FailedIndexException, SemanticDirection}
+import org.neo4j.cypher.internal.helpers.JavaConversionSupport
 import org.neo4j.cypher.internal.spi.v2_3.TransactionBoundQueryContext.IndexSearchMonitor
 import org.neo4j.function.Predicate
 import org.neo4j.graphalgo.impl.path.ShortestPath
@@ -291,7 +290,7 @@ final class TransactionBoundQueryContext(graph: GraphDatabaseAPI,
   }
 
   def indexScan(index: IndexDescriptor) =
-    mapToScalaENFXSafe(statement.readOperations().nodesGetFromIndexScan(index))(nodeOps.getById)
+    JavaConversionSupport.mapToScalaENFXSafe(statement.readOperations().nodesGetFromIndexScan(index))(nodeOps.getById)
 
   def lockingExactUniqueIndexSearch(index: IndexDescriptor, value: Any): Option[Node] = {
     val nodeId: Long = statement.readOperations().nodeGetFromUniqueIndexSeek(index, value)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/helpers/JavaConversionSupportTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/helpers/JavaConversionSupportTest.scala
@@ -20,7 +20,7 @@
 package org.neo4j.cypher.internal.helpers
 
 import org.neo4j.collection.primitive.PrimitiveLongCollections
-import org.neo4j.cypher.internal.compiler.v2_3.helpers
+import org.neo4j.cypher.internal
 import org.neo4j.cypher.internal.frontend.v2_3.test_helpers.CypherFunSuite
 
 class JavaConversionSupportTest extends CypherFunSuite {
@@ -30,7 +30,7 @@ class JavaConversionSupportTest extends CypherFunSuite {
     val iterator = PrimitiveLongCollections.iterator( 12l, 14l )
 
     // when
-    val result = helpers.JavaConversionSupport.asScala(iterator)
+    val result = JavaConversionSupport.asScala(iterator)
 
     // then
     List(12l, 14l) should equal(result.toList)
@@ -42,7 +42,7 @@ class JavaConversionSupportTest extends CypherFunSuite {
     val iterator = PrimitiveLongCollections.iterator( 12l, 14l )
 
     // when
-    val result = helpers.JavaConversionSupport.mapToScala(iterator){ _ + 1l }
+    val result = internal.helpers.JavaConversionSupport.mapToScala(iterator){ _ + 1l }
 
     // then
     List(13l, 15l) should equal(result.toList)


### PR DESCRIPTION
We have a binary dependency on `EntityNotFoundException` from
`cypher-compiler-2.3` which makes it impossible to move the exception
in 3.4. We need to fix this binary dependency in all versions - or at
least 2.3 and 3.1 - and then do new releases and finally update the
dependencies in 3.4.