### PR TITLE
Deduplicate blacklists in 3.1

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/community/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -117,7 +117,6 @@ Find a shortest path among paths that fulfill a predicate on all relationships 2
 Find a shortest path among paths that fulfill a predicate
 Find a shortest path without loosing context information at runtime
 Find a shortest path in an expression context
-Find a shortest path among paths that fulfill a predicate on all relationships
 Finds shortest path
 Optionally finds shortest path
 Optionally finds shortest path using previously bound nodes

--- a/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/compatibility-23.txt
+++ b/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/compatibility-23.txt
@@ -10,7 +10,6 @@ Remove multiple relationship properties
 Absolute function
 Return collection size
 Setting and returning the size of a list property
-Setting and returning the size of a list property
 Arithmetic expressions inside aggregation
 Concatenating and returning the size of literal lists
 
@@ -50,7 +49,6 @@ LIMIT with an expression that does not depend on variables
 `type()` handling Any type
 `type()` failing on invalid arguments
 `labels()` should accept type Any
-`labels()` should accept type Any
 Handling property access on the Any type
 Failing when performing property access on a non-map 1
 `toFloat()` handling Any type
@@ -89,7 +87,6 @@ IN should work with literal list slices
 
 // new parameter syntax $
 Delete node from a list
-Delete node from a list
 Delete relationship from a list
 Use dynamic property lookup based on parameters when there is no type information
 Use dynamic property lookup based on parameters when there is lhs type information
@@ -103,9 +100,6 @@ Fail at runtime when trying to index into a list with a list
 Fail at runtime when trying to index something which is not a map or collection
 `percentileDisc()`
 `percentileCont()`
-`percentileCont()` failing on bad arguments
-`percentileDisc()` failing on bad arguments
-`percentileDisc()` failing in more involved query
 Using `keys()` on a parameter map
 Use params in pattern matching predicates
 Matching with many predicates and larger pattern

--- a/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/community/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -82,8 +82,6 @@ IS NOT NULL with literal maps
 `type()` handling Any type
 `type()` failing on invalid arguments
 `labels()` should accept type Any
-`labels()` should accept type Any
-`labels()` should accept type Any
 `exists()` is case insensitive
 Find friends of others
 Should only join when matching
@@ -258,7 +256,6 @@ Remove multiple labels
 Remove a single node property
 Remove multiple node properties
 Remove a single relationship property
-Remove a single relationship property
 Remove multiple relationship properties
 Remove a missing property should be a valid operation
 Start the result from the second row
@@ -281,12 +278,10 @@ Ordering with aggregation
 DISTINCT on nullable values
 Return all variables
 Setting and returning the size of a list property
-Setting and returning the size of a list property
 `sqrt()` returning float values
 Arithmetic expressions inside aggregation
 Matching and disregarding output, then matching again
 Returning an expression
-Concatenating and returning the size of literal lists
 Concatenating and returning the size of literal lists
 Limiting amount of rows when there are fewer left than the LIMIT argument
 `substring()` with default second argument
@@ -518,7 +513,6 @@ Delete optionally matched relationship
 Delete on null node
 Detach delete on null node
 Delete on null path
-Delete node from a list
 Delete node from a list
 Delete relationship from a list
 Delete nodes from a map


### PR DESCRIPTION
This PR is a part of a sequence of 4 PRs, where we deduplicate all blacklists in `3.1`-`3.4`. They should all be null-merged forward. The PRs are #10585, #10586, #10587, and #10588.