### PR TITLE
Moved OptionalHostnamePort to non-public package

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Converters.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Converters.java
@@ -29,9 +29,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 
-import org.neo4j.helpers.HostnamePort;
-import org.neo4j.helpers.OptionalHostnamePort;
-
 public class Converters
 {
     private Converters()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/OptionalHostnamePort.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/OptionalHostnamePort.java
@@ -17,10 +17,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.helpers;
+package org.neo4j.kernel.impl.util;
 
 import java.util.Optional;
 import javax.annotation.Nullable;
+
+import org.neo4j.helpers.HostnamePort;
 
 public class OptionalHostnamePort
 {

--- a/enterprise/backup/src/main/java/org/neo4j/backup/AddressResolutionHelper.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/AddressResolutionHelper.java
@@ -23,7 +23,7 @@ import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.helpers.HostnamePort;
 import org.neo4j.helpers.ListenSocketAddress;
-import org.neo4j.helpers.OptionalHostnamePort;
+import org.neo4j.kernel.impl.util.OptionalHostnamePort;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.enterprise.configuration.OnlineBackupSettings;
 
@@ -45,12 +45,12 @@ class AddressResolutionHelper
 
     private HostnamePort readDefaultConfigAddressHA( Config config )
     {
-        return OnlineBackupSettings.online_backup_server.from( config );
+        return config.get( OnlineBackupSettings.online_backup_server );
     }
 
     private AdvertisedSocketAddress readDefaultConfigAddressCC( Config config )
     {
-        return advertisedFromListenAddress( CausalClusteringSettings.transaction_listen_address.from( config ) );
+        return advertisedFromListenAddress( config.get( CausalClusteringSettings.transaction_listen_address ) );
     }
 
     private AdvertisedSocketAddress advertisedFromListenAddress( ListenSocketAddress listenSocketAddress )

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupCommandArgumentHandler.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupCommandArgumentHandler.java
@@ -31,7 +31,7 @@ import org.neo4j.commandline.arguments.common.MandatoryCanonicalPath;
 import org.neo4j.commandline.arguments.common.OptionalCanonicalPath;
 import org.neo4j.consistency.ConsistencyCheckSettings;
 import org.neo4j.consistency.checking.full.ConsistencyFlags;
-import org.neo4j.helpers.OptionalHostnamePort;
+import org.neo4j.kernel.impl.util.OptionalHostnamePort;
 import org.neo4j.helpers.TimeUtil;
 import org.neo4j.kernel.configuration.Config;
 

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupStrategy.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupStrategy.java
@@ -21,7 +21,7 @@ package org.neo4j.backup;
 
 import java.io.File;
 
-import org.neo4j.helpers.OptionalHostnamePort;
+import org.neo4j.kernel.impl.util.OptionalHostnamePort;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupStrategyWrapper.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupStrategyWrapper.java
@@ -22,7 +22,7 @@ package org.neo4j.backup;
 import java.io.File;
 
 import org.neo4j.commandline.admin.CommandFailed;
-import org.neo4j.helpers.OptionalHostnamePort;
+import org.neo4j.kernel.impl.util.OptionalHostnamePort;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.lifecycle.LifeSupport;

--- a/enterprise/backup/src/main/java/org/neo4j/backup/CausalClusteringBackupStrategy.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/CausalClusteringBackupStrategy.java
@@ -26,7 +26,7 @@ import org.neo4j.causalclustering.catchup.storecopy.StoreCopyFailedException;
 import org.neo4j.causalclustering.catchup.storecopy.StoreIdDownloadFailedException;
 import org.neo4j.causalclustering.identity.StoreId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
-import org.neo4j.helpers.OptionalHostnamePort;
+import org.neo4j.kernel.impl.util.OptionalHostnamePort;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 

--- a/enterprise/backup/src/main/java/org/neo4j/backup/HaBackupStrategy.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/HaBackupStrategy.java
@@ -23,7 +23,7 @@ import java.io.File;
 
 import org.neo4j.com.ComException;
 import org.neo4j.helpers.HostnamePort;
-import org.neo4j.helpers.OptionalHostnamePort;
+import org.neo4j.kernel.impl.util.OptionalHostnamePort;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.store.MismatchingStoreIdException;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupRequiredArguments.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupRequiredArguments.java
@@ -23,7 +23,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.Optional;
 
-import org.neo4j.helpers.OptionalHostnamePort;
+import org.neo4j.kernel.impl.util.OptionalHostnamePort;
 
 public class OnlineBackupRequiredArguments
 {

--- a/enterprise/backup/src/test/java/org/neo4j/backup/AddressResolutionHelperTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/AddressResolutionHelperTest.java
@@ -23,7 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.neo4j.helpers.HostnamePort;
-import org.neo4j.helpers.OptionalHostnamePort;
+import org.neo4j.kernel.impl.util.OptionalHostnamePort;
 import org.neo4j.kernel.configuration.Config;
 
 import static org.junit.Assert.assertEquals;
@@ -45,7 +45,9 @@ public class AddressResolutionHelperTest
     @Test
     public void noPortResolvesToDefault_ha()
     {
+        // given
         Integer portIsNotSupplied = null;
+
         // when
         HostnamePort resolved = subject.resolveCorrectHAAddress( defaultConfig, new OptionalHostnamePort( "localhost", portIsNotSupplied, null ) );
 

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupProtocolServiceStrategyTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupProtocolServiceStrategyTest.java
@@ -26,7 +26,7 @@ import java.io.File;
 
 import org.neo4j.com.ComException;
 import org.neo4j.helpers.HostnamePort;
-import org.neo4j.helpers.OptionalHostnamePort;
+import org.neo4j.kernel.impl.util.OptionalHostnamePort;
 import org.neo4j.kernel.configuration.Config;
 
 import static org.junit.Assert.assertEquals;

--- a/enterprise/backup/src/test/java/org/neo4j/backup/BackupStrategyWrapperTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/BackupStrategyWrapperTest.java
@@ -28,7 +28,7 @@ import java.io.File;
 
 import org.neo4j.commandline.admin.CommandFailed;
 import org.neo4j.commandline.admin.OutsideWorld;
-import org.neo4j.helpers.OptionalHostnamePort;
+import org.neo4j.kernel.impl.util.OptionalHostnamePort;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.configuration.Config;

--- a/enterprise/backup/src/test/java/org/neo4j/backup/CausalClusteringBackupStrategyTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/CausalClusteringBackupStrategyTest.java
@@ -31,7 +31,7 @@ import org.neo4j.causalclustering.catchup.storecopy.StoreCopyFailedException;
 import org.neo4j.causalclustering.catchup.storecopy.StoreIdDownloadFailedException;
 import org.neo4j.causalclustering.identity.StoreId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
-import org.neo4j.helpers.OptionalHostnamePort;
+import org.neo4j.kernel.impl.util.OptionalHostnamePort;
 import org.neo4j.kernel.configuration.Config;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
OptionalHostnamePort was declared as a public class in the public
org.neo4j.helpers public package. This is really an implementation
detail and doesn't need to be public.
The class has been moved to org.neo4j.kernel.impl.util which isn't
public.