### PR TITLE
Full coverage of slotted runtime

### DIFF
--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/convert/plannerQuery/ClauseConverters.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/convert/plannerQuery/ClauseConverters.scala
@@ -246,7 +246,7 @@ object ClauseConverters {
     case e => throw new InternalException(s"Expected MapExpression, got $e")
   }
 
-  private def toPropertySelection(identifier: Variable,  map:Map[PropertyKeyName, Expression]): Seq[Expression] = map.map {
+  private def toPropertySelection(identifier: LogicalVariable,  map:Map[PropertyKeyName, Expression]): Seq[Expression] = map.map {
     case (k, e) => In(Property(identifier, k)(k.position), ListLiteral(Seq(e))(e.position))(identifier.position)
   }.toIndexedSeq
 

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/InliningContext.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/InliningContext.scala
@@ -49,7 +49,7 @@ case class InliningContext(projections: Map[LogicalVariable, Expression] = Map.e
     copy(projections = resultProjections, seenVariables = seenVariables ++ newProjections.keys)
   }
 
-  def spoilVariable(variable: Variable): InliningContext =
+  def spoilVariable(variable: LogicalVariable): InliningContext =
     copy(projections = projections - variable)
 
   def variableRewriter: Rewriter = bottomUp(Rewriter.lift {
@@ -74,9 +74,9 @@ case class InliningContext(projections: Map[LogicalVariable, Expression] = Map.e
       }
   })
 
-  def isAliasedVarible(variable: Variable) = alias(variable).nonEmpty
+  def isAliasedVarible(variable: LogicalVariable) = alias(variable).nonEmpty
 
-  def alias(variable: Variable): Option[Variable] = projections.get(variable) match {
+  def alias(variable: LogicalVariable): Option[LogicalVariable] = projections.get(variable) match {
     case Some(other: Variable) => Some(other.copyId)
     case _                       => None
   }

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/inliningContextCreator.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/ast/rewriters/inliningContextCreator.scala
@@ -57,7 +57,7 @@ object inliningContextCreator extends (ast.Statement => InliningContext) {
     }
   }
 
-  private def spoilVariableIfNotAliased(variable: Variable, context: InliningContext): InliningContext =
+  private def spoilVariableIfNotAliased(variable: LogicalVariable, context: InliningContext): InliningContext =
     if (context.isAliasedVarible(variable)) context
     else context.spoilVariable(variable)
 

--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/planShortestPaths.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/planShortestPaths.scala
@@ -90,7 +90,7 @@ case object planShortestPaths {
     val lhsArgument = lpp.planArgumentFrom(inner)
     val lhsSp = lpp.planShortestPath(lhsArgument, shortestPath, predicates, withFallBack = true,
                                      disallowSameNode = context.errorIfShortestPathHasCommonNodesAtRuntime)
-    val lhsOption = lpp.planOptional(lhsSp, Set.empty)
+    val lhsOption = lpp.planOptional(lhsSp, lhsArgument.availableSymbols)
     val lhs = lpp.planApply(inner, lhsOption)
 
     val rhsArgument = lpp.planArgumentFrom(lhs)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/LatestRuntimeVariablePlannerCompatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/LatestRuntimeVariablePlannerCompatibility.scala
@@ -87,7 +87,7 @@ STATEMENT <: AnyRef](configV3_4: CypherCompilerConfiguration,
 
   protected def createExecPlan: Transformer[CONTEXT3_4, LogicalPlanState, CompilationState] = {
     ProcedureCallOrSchemaCommandExecutionPlanBuilder andThen
-      If((s: CompilationState) => s.maybeExecutionPlan.isEmpty) {
+      If((s: CompilationState) => s.maybeExecutionPlan.isFailure) {
         val maybeRuntimeName: Option[RuntimeName] = runtime match {
           case CypherRuntime.default => None
           case CypherRuntime.interpreted => Some(InterpretedRuntimeName)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/CheckForLoadCsvAndMatchOnLargeLabel.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/CheckForLoadCsvAndMatchOnLargeLabel.scala
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan
+package org.neo4j.cypher.internal.compatibility.v3_4
 
 import org.neo4j.cypher.internal.frontend.v3_4.notification.{InternalNotification, LargeLabelWithLoadCsvNotification}
 import org.neo4j.cypher.internal.planner.v3_4.spi.PlanContext

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/CheckForLoadCsvAndMatchOnLargeLabel.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/CheckForLoadCsvAndMatchOnLargeLabel.scala
@@ -30,7 +30,7 @@ case class CheckForLoadCsvAndMatchOnLargeLabel(planContext: PlanContext,
 
   private val threshold = Cardinality(nonIndexedLabelWarningThreshold)
 
-  def apply(plan: LogicalPlan) = {
+  def apply(plan: LogicalPlan): Option[InternalNotification] = {
     import org.neo4j.cypher.internal.util.v3_4.Foldable._
 
     sealed trait SearchState
@@ -55,7 +55,5 @@ case class CheckForLoadCsvAndMatchOnLargeLabel(planContext: PlanContext,
   }
 
   private def cardinality(labelName: String): Cardinality =
-    cardinality(planContext.getOptLabelId(labelName).getOrElse(NameId.WILDCARD))
-
-  private def cardinality(id: Int) = planContext.statistics.nodesWithLabelCardinality(Some(LabelId(id)))
+    planContext.statistics.nodesWithLabelCardinality(planContext.getOptLabelId(labelName).map(LabelId))
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/Compatibility.scala
@@ -81,7 +81,6 @@ case class Compatibility[CONTEXT <: CommunityRuntimeContext,
     new CypherCompilerFactory().costBasedCompiler(configV3_4, clock, monitors, rewriterSequencer,
       maybePlannerNameV3_4, maybeUpdateStrategy, contextCreatorV3_4)
 
-
   private def queryGraphSolver = LatestRuntimeVariablePlannerCompatibility.
     createQueryGraphSolver(maybePlannerNameV3_4.getOrElse(CostBasedPlannerName.default), monitors, configV3_4)
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/Compatibility.scala
@@ -44,7 +44,7 @@ import org.neo4j.logging.Log
 import scala.util.Try
 
 case class Compatibility[CONTEXT <: CommunityRuntimeContext,
-                    T <: Transformer[CONTEXT, LogicalPlanState, CompilationState]](configV3_4: CypherCompilerConfiguration,
+                    T <: Transformer[CONTEXT, LogicalPlanState, CompilationState]](config: CypherCompilerConfiguration,
                                                                                    clock: Clock,
                                                                                    kernelMonitors: KernelMonitors,
                                                                                    log: Log,
@@ -53,7 +53,7 @@ case class Compatibility[CONTEXT <: CommunityRuntimeContext,
                                                                                    updateStrategy: CypherUpdateStrategy,
                                                                                    runtimeBuilder: RuntimeBuilder[T],
                                                                                    contextCreatorV3_4: ContextCreator[CONTEXT])
-  extends LatestRuntimeVariablePlannerCompatibility[CONTEXT, T, Statement](configV3_4, clock, kernelMonitors, log, planner, runtime, updateStrategy, runtimeBuilder, contextCreatorV3_4) {
+  extends LatestRuntimeVariablePlannerCompatibility[CONTEXT, T, Statement](config, clock, kernelMonitors, log, planner, runtime, updateStrategy, runtimeBuilder, contextCreatorV3_4) {
 
   val monitors: Monitors = WrappedMonitors(kernelMonitors)
   val cacheMonitor: AstCacheMonitor[Statement] = monitors.newMonitor[AstCacheMonitor[Statement]]("cypher3.4")
@@ -78,11 +78,11 @@ case class Compatibility[CONTEXT <: CommunityRuntimeContext,
   }
 
   protected val compiler: v3_4.CypherCompiler[CONTEXT] =
-    new CypherCompilerFactory().costBasedCompiler(configV3_4, clock, monitors, rewriterSequencer,
+    new CypherCompilerFactory().costBasedCompiler(config, clock, monitors, rewriterSequencer,
       maybePlannerNameV3_4, maybeUpdateStrategy, contextCreatorV3_4)
 
   private def queryGraphSolver = LatestRuntimeVariablePlannerCompatibility.
-    createQueryGraphSolver(maybePlannerNameV3_4.getOrElse(CostBasedPlannerName.default), monitors, configV3_4)
+    createQueryGraphSolver(maybePlannerNameV3_4.getOrElse(CostBasedPlannerName.default), monitors, config)
 
   def produceParsedQuery(preParsedQuery: PreParsedQuery, tracer: CompilationPhaseTracer,
                          preParsingNotifications: Set[org.neo4j.graphdb.Notification]): ParsedQuery = {
@@ -106,7 +106,7 @@ case class Compatibility[CONTEXT <: CommunityRuntimeContext,
                                                         syntacticQuery.queryText, preParsedQuery.debugOptions,
                                                         Some(preParsedQuery.offset), monitors,
                                                         CachedMetricsFactory(SimpleMetricsFactory), queryGraphSolver,
-                                                        configV3_4, maybeUpdateStrategy.getOrElse(defaultUpdateStrategy),
+                                                        config, maybeUpdateStrategy.getOrElse(defaultUpdateStrategy),
                                                         clock, simpleExpressionEvaluator)
         //Prepare query for caching
         val preparedQuery = compiler.normalizeQuery(syntacticQuery, context)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/LogicalPlanNotifications.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/LogicalPlanNotifications.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compatibility.v3_4
+
+import org.neo4j.cypher.internal.compiler.v3_4.CypherCompilerConfiguration
+import org.neo4j.cypher.internal.frontend.v3_4.notification.InternalNotification
+import org.neo4j.cypher.internal.planner.v3_4.spi.PlanContext
+import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlan
+
+object LogicalPlanNotifications {
+  def checkForNotifications(logicalPlan: LogicalPlan,
+                            planContext: PlanContext,
+                            config: CypherCompilerConfiguration): Seq[InternalNotification] = {
+    val notificationCheckers = Seq(checkForEagerLoadCsv,
+      CheckForLoadCsvAndMatchOnLargeLabel(planContext, config.nonIndexedLabelWarningThreshold))
+
+    notificationCheckers.flatMap(_ (logicalPlan))
+  }
+}

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/checkForEagerLoadCsv.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/checkForEagerLoadCsv.scala
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan
+package org.neo4j.cypher.internal.compatibility.v3_4
 
 import org.neo4j.cypher.internal.frontend.v3_4.notification.{EagerLoadCsvNotification, InternalNotification}
 import org.neo4j.cypher.internal.v3_4.logical.plans.{Eager, LoadCSV, LogicalPlan}

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/BuildInterpretedExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/BuildInterpretedExecutionPlan.scala
@@ -70,11 +70,13 @@ object BuildInterpretedExecutionPlan extends Phase[CommunityRuntimeContext, Logi
     new CompilationState(from, Success(execPlan))
   }
 
-  def checkForNotifications(pipe: Pipe, planContext: PlanContext, config: CypherCompilerConfiguration): Seq[InternalNotification] = {
+  def checkForNotifications(logicalPlan: LogicalPlan,
+                            planContext: PlanContext,
+                            config: CypherCompilerConfiguration): Seq[InternalNotification] = {
     val notificationCheckers = Seq(checkForEagerLoadCsv,
       CheckForLoadCsvAndMatchOnLargeLabel(planContext, config.nonIndexedLabelWarningThreshold))
 
-    notificationCheckers.flatMap(_ (pipe))
+    notificationCheckers.flatMap(_ (logicalPlan))
   }
 
   def getExecutionPlanFunction(periodicCommit: Option[PeriodicCommitInfo],
@@ -123,7 +125,8 @@ object BuildInterpretedExecutionPlan extends Phase[CommunityRuntimeContext, Logi
 
     override def runtimeUsed: RuntimeName = InterpretedRuntimeName
 
-    override def notifications(planContext: PlanContext): Seq[InternalNotification] = checkForNotifications(pipe, planContext, config)
+    override def notifications(planContext: PlanContext): Seq[InternalNotification] =
+      checkForNotifications(logicalPlan, planContext, config)
 
     override def plannedIndexUsage: Seq[IndexUsage] = logicalPlan.indexUsage
   }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/BuildInterpretedExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/BuildInterpretedExecutionPlan.scala
@@ -37,6 +37,8 @@ import org.neo4j.cypher.internal.runtime.{ExecutionMode, InternalExecutionResult
 import org.neo4j.cypher.internal.v3_4.logical.plans.{IndexUsage, LogicalPlan}
 import org.neo4j.values.virtual.MapValue
 
+import scala.util.Success
+
 object BuildInterpretedExecutionPlan extends Phase[CommunityRuntimeContext, LogicalPlanState, CompilationState] {
   override def phase = PIPE_BUILDING
 
@@ -65,7 +67,7 @@ object BuildInterpretedExecutionPlan extends Phase[CommunityRuntimeContext, Logi
       context.createFingerprintReference(fp),
       context.config)
 
-    new CompilationState(from, Some(execPlan))
+    new CompilationState(from, Success(execPlan))
   }
 
   def checkForNotifications(pipe: Pipe, planContext: PlanContext, config: CypherCompilerConfiguration): Seq[InternalNotification] = {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/CommunityPipeBuilder.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/CommunityPipeBuilder.scala
@@ -317,7 +317,7 @@ case class CommunityPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe
   private def varLengthPredicate(predicates: Seq[(LogicalVariable, ASTExpression)]): VarLengthPredicate  = {
     //Creates commands out of the predicates
     def asCommand(predicates: Seq[(LogicalVariable, ASTExpression)]) = {
-      val (keys: Seq[Variable], exprs) = predicates.unzip
+      val (keys: Seq[LogicalVariable], exprs) = predicates.unzip
 
       val commands = exprs.map(buildPredicate)
       (context: ExecutionContext, state: QueryState, entity: AnyValue) => {

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/ExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/ExecutionPlan.scala
@@ -21,9 +21,8 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan
 
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.RuntimeName
 import org.neo4j.cypher.internal.frontend.v3_4.PlannerName
-import org.neo4j.cypher.internal.frontend.v3_4.notification.InternalNotification
 import org.neo4j.cypher.internal.frontend.v3_4.phases.CacheCheckResult
-import org.neo4j.cypher.internal.planner.v3_4.spi.{GraphStatistics, PlanContext}
+import org.neo4j.cypher.internal.planner.v3_4.spi.GraphStatistics
 import org.neo4j.cypher.internal.runtime.{ExecutionMode, InternalExecutionResult, QueryContext}
 import org.neo4j.cypher.internal.v3_4.logical.plans.IndexUsage
 import org.neo4j.values.virtual.MapValue
@@ -34,6 +33,5 @@ abstract class ExecutionPlan {
   def plannerUsed: PlannerName
   def isStale(lastTxId: () => Long, statistics: GraphStatistics): CacheCheckResult
   def runtimeUsed: RuntimeName
-  def notifications(planContext: PlanContext): Seq[InternalNotification]
   def plannedIndexUsage: Seq[IndexUsage] = Seq.empty
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/checkForEagerLoadCsv.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/checkForEagerLoadCsv.scala
@@ -20,11 +20,11 @@
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan
 
 import org.neo4j.cypher.internal.frontend.v3_4.notification.{EagerLoadCsvNotification, InternalNotification}
-import org.neo4j.cypher.internal.runtime.interpreted.pipes.{EagerPipe, LoadCSVPipe, Pipe}
+import org.neo4j.cypher.internal.v3_4.logical.plans.{Eager, LoadCSV, LogicalPlan}
 
-object checkForEagerLoadCsv extends (Pipe => Option[InternalNotification]) {
+object checkForEagerLoadCsv extends (LogicalPlan => Option[InternalNotification]) {
 
-  def apply(pipe: Pipe) = {
+  def apply(plan: LogicalPlan) = {
     import org.neo4j.cypher.internal.util.v3_4.Foldable._
     sealed trait SearchState
     case object NoEagerFound extends SearchState
@@ -32,12 +32,12 @@ object checkForEagerLoadCsv extends (Pipe => Option[InternalNotification]) {
     case object EagerWithLoadCsvFound extends SearchState
 
     // Walk over the pipe tree and check if an Eager is to be executed after a LoadCsv
-    val resultState = pipe.treeFold[SearchState](NoEagerFound) {
-      case _: LoadCSVPipe => {
+    val resultState = plan.treeFold[SearchState](NoEagerFound) {
+      case _: LoadCSV => {
         case EagerFound => (EagerWithLoadCsvFound, None)
         case e => (e, None)
       }
-      case _: EagerPipe =>
+      case _: Eager =>
         acc =>
           (EagerFound, Some(identity))
     }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/procs/ProcedureCallExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/procs/ProcedureCallExecutionPlan.scala
@@ -22,9 +22,8 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan.procs
 import org.neo4j.cypher.CypherVersion
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan.ExecutionPlan
-import org.neo4j.cypher.internal.frontend.v3_4.notification.InternalNotification
 import org.neo4j.cypher.internal.frontend.v3_4.phases.CacheCheckResult
-import org.neo4j.cypher.internal.planner.v3_4.spi.{GraphStatistics, PlanContext, ProcedurePlannerName}
+import org.neo4j.cypher.internal.planner.v3_4.spi.{GraphStatistics, ProcedurePlannerName}
 import org.neo4j.cypher.internal.runtime._
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.commands.convert.ExpressionConverters
@@ -136,8 +135,6 @@ case class ProcedureCallExecutionPlan(signature: ProcedureSignature,
 
   private def createSignatureArgument: Argument =
     Signature(signature.name, Seq.empty, resultSymbols)
-
-  override def notifications(planContext: PlanContext): Seq[InternalNotification] = Seq.empty
 
   override def isPeriodicCommit: Boolean = false
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/procs/PureSideEffectExecutionPlan.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/procs/PureSideEffectExecutionPlan.scala
@@ -23,9 +23,8 @@ import org.neo4j.cypher.CypherVersion
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan.ExecutionPlan
 import org.neo4j.cypher.internal.frontend.v3_4.PlannerName
-import org.neo4j.cypher.internal.frontend.v3_4.notification.InternalNotification
 import org.neo4j.cypher.internal.frontend.v3_4.phases.CacheCheckResult
-import org.neo4j.cypher.internal.planner.v3_4.spi.{GraphStatistics, PlanContext, ProcedurePlannerName}
+import org.neo4j.cypher.internal.planner.v3_4.spi.{GraphStatistics, ProcedurePlannerName}
 import org.neo4j.cypher.internal.runtime._
 import org.neo4j.cypher.internal.runtime.interpreted.UpdateCountingQueryContext
 import org.neo4j.cypher.internal.runtime.planDescription.InternalPlanDescription.Arguments._
@@ -72,8 +71,6 @@ case class PureSideEffectExecutionPlan(name: String, queryType: InternalQueryTyp
   override def isStale(lastTxId: () => Long, statistics: GraphStatistics) = CacheCheckResult.empty
 
   override def plannerUsed: PlannerName = ProcedurePlannerName
-
-  override def notifications(planContext: PlanContext): Seq[InternalNotification] = Seq.empty
 
   override def isPeriodicCommit: Boolean = false
 }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/phases/CompilationState.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/phases/CompilationState.scala
@@ -22,10 +22,10 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime.phases
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan.ExecutionPlan
 import org.neo4j.cypher.internal.compiler.v3_4.phases.LogicalPlanState
 
+import scala.util.{Failure, Try}
+
 class CompilationState(ls: LogicalPlanState,
-                           val maybeExecutionPlan: Option[ExecutionPlan] = None)
+                           val maybeExecutionPlan: Try[ExecutionPlan] = Failure(new UnsupportedOperationException))
   extends LogicalPlanState(ls.queryText, ls.startPosition, ls.plannerName, ls.maybeStatement, ls.maybeSemantics,
                            ls.maybeExtractedParams, ls.maybeSemanticTable, ls.maybeUnionQuery, ls.maybeLogicalPlan,
-                           ls.maybePeriodicCommit, ls.accumulatedConditions) {
-  def withMaybeExecutionPlan(e: Option[ExecutionPlan]): CompilationState = new CompilationState(ls, e)
-}
+                           ls.maybePeriodicCommit, ls.accumulatedConditions)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/CheckForEagerLoadCsvTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/CheckForEagerLoadCsvTest.scala
@@ -17,12 +17,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan
+package org.neo4j.cypher.internal.compatibility.v3_4
 
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport
 import org.neo4j.cypher.internal.frontend.v3_4.notification.EagerLoadCsvNotification
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.ir.v3_4.{IdName, NoHeaders}
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.v3_4.expressions.StringLiteral
 import org.neo4j.cypher.internal.v3_4.logical.plans.{AllNodesScan, Eager, LoadCSV}
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/CheckForLoadCsvAndMatchOnLargeLabelTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/CheckForLoadCsvAndMatchOnLargeLabelTest.scala
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan
+package org.neo4j.cypher.internal.compatibility.v3_4
 
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
@@ -25,7 +25,7 @@ import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.neo4j.cypher.internal.compiler.v3_4.planner.LogicalPlanningTestSupport
 import org.neo4j.cypher.internal.frontend.v3_4.notification.LargeLabelWithLoadCsvNotification
-import org.neo4j.cypher.internal.ir.v3_4.{HasHeaders, IdName, NoHeaders}
+import org.neo4j.cypher.internal.ir.v3_4.{HasHeaders, IdName}
 import org.neo4j.cypher.internal.planner.v3_4.spi.{GraphStatistics, PlanContext}
 import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.util.v3_4.{Cardinality, LabelId}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/CheckForLoadCsvAndMatchOnLargeLabelTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/CheckForLoadCsvAndMatchOnLargeLabelTest.scala
@@ -58,7 +58,7 @@ class CheckForLoadCsvAndMatchOnLargeLabelTest
   test("should notify when doing LoadCsv on top of large label scan") {
     val loadCsv =
       LoadCSV(
-        Argument()(solved)(),
+        Argument()(solved),
         url,
         IdName("foo"),
         HasHeaders,
@@ -77,7 +77,7 @@ class CheckForLoadCsvAndMatchOnLargeLabelTest
   test("should not notify when doing LoadCsv on top of a small label scan") {
     val loadCsv =
       LoadCSV(
-        Argument()(solved)(),
+        Argument()(solved),
         url,
         IdName("foo"),
         HasHeaders,

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/CypherReductionSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/CypherReductionSupport.scala
@@ -111,7 +111,7 @@ trait CypherReductionSupport extends CypherTestSupport with GraphIcing {
   private val rewriting = PreparatoryRewriting andThen
     SemanticAnalysis(warn = true).adds(BaseContains[SemanticState])
   private val createExecPlan = ProcedureCallOrSchemaCommandExecutionPlanBuilder andThen
-    If((s: CompilationState) => s.maybeExecutionPlan.isEmpty)(
+    If((s: CompilationState) => s.maybeExecutionPlan.isFailure)(
       CommunityRuntimeBuilder.create(None, CypherReductionSupport.config.useErrorsOverWarnings).adds(CompilationContains[ExecutionPlan]))
 
 

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/IterableExpressions.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/IterableExpressions.scala
@@ -109,7 +109,7 @@ case class AllIterablePredicate(scope: FilterScope, expression: Expression)(val 
 }
 
 object AllIterablePredicate {
-  def apply(variable: Variable, expression: Expression, innerPredicate: Option[Expression])(position: InputPosition): AllIterablePredicate =
+  def apply(variable: LogicalVariable, expression: Expression, innerPredicate: Option[Expression])(position: InputPosition): AllIterablePredicate =
     AllIterablePredicate(FilterScope(variable, innerPredicate)(position), expression)(position)
 }
 
@@ -118,7 +118,7 @@ case class AnyIterablePredicate(scope: FilterScope, expression: Expression)(val 
 }
 
 object AnyIterablePredicate {
-  def apply(variable: Variable, expression: Expression, innerPredicate: Option[Expression])(position: InputPosition): AnyIterablePredicate =
+  def apply(variable: LogicalVariable, expression: Expression, innerPredicate: Option[Expression])(position: InputPosition): AnyIterablePredicate =
     AnyIterablePredicate(FilterScope(variable, innerPredicate)(position), expression)(position)
 }
 
@@ -127,7 +127,7 @@ case class NoneIterablePredicate(scope: FilterScope, expression: Expression)(val
 }
 
 object NoneIterablePredicate {
-  def apply(variable: Variable, expression: Expression, innerPredicate: Option[Expression])(position: InputPosition): NoneIterablePredicate =
+  def apply(variable: LogicalVariable, expression: Expression, innerPredicate: Option[Expression])(position: InputPosition): NoneIterablePredicate =
     NoneIterablePredicate(FilterScope(variable, innerPredicate)(position), expression)(position)
 }
 
@@ -136,7 +136,7 @@ case class SingleIterablePredicate(scope: FilterScope, expression: Expression)(v
 }
 
 object SingleIterablePredicate {
-  def apply(variable: Variable, expression: Expression, innerPredicate: Option[Expression])(position: InputPosition): SingleIterablePredicate =
+  def apply(variable: LogicalVariable, expression: Expression, innerPredicate: Option[Expression])(position: InputPosition): SingleIterablePredicate =
     SingleIterablePredicate(FilterScope(variable, innerPredicate)(position), expression)(position)
 }
 

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Pattern.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Pattern.scala
@@ -40,10 +40,10 @@ object Pattern {
     }
   }
 
-  object findDuplicateRelationships extends (Pattern => Set[Seq[Variable]]) {
+  object findDuplicateRelationships extends (Pattern => Set[Seq[LogicalVariable]]) {
 
-    def apply(pattern: Pattern): Set[Seq[Variable]] = {
-      val (seen, duplicates) = pattern.fold((Set.empty[Variable], Seq.empty[Variable])) {
+    def apply(pattern: Pattern): Set[Seq[LogicalVariable]] = {
+      val (seen, duplicates) = pattern.fold((Set.empty[LogicalVariable], Seq.empty[LogicalVariable])) {
         case RelationshipChain(_, RelationshipPattern(Some(rel), _, None, _, _, _), _) =>
           (acc) =>
             val (seen, duplicates) = acc
@@ -57,7 +57,7 @@ object Pattern {
           identity
       }
 
-      val m0: Map[String, Seq[Variable]] = duplicates.groupBy(_.name)
+      val m0: Map[String, Seq[LogicalVariable]] = duplicates.groupBy(_.name)
 
       val resultMap = seen.foldLeft(m0) {
         case (m, ident @ Variable(name)) if m.contains(name) => m.updated(name, Seq(ident) ++ m(name))
@@ -104,8 +104,8 @@ case class ShortestPaths(element: PatternElement, single: Boolean)(val position:
 }
 
 sealed abstract class PatternElement extends ASTNode {
-  def allVariables: Set[Variable]
-  def variable: Option[Variable]
+  def allVariables: Set[LogicalVariable]
+  def variable: Option[LogicalVariable]
 
   def isSingleNode = false
 }
@@ -117,9 +117,9 @@ case class RelationshipChain(
                             )(val position: InputPosition)
   extends PatternElement {
 
-  def variable: Option[Variable] = relationship.variable
+  def variable: Option[LogicalVariable] = relationship.variable
 
-  override def allVariables: Set[Variable] = element.allVariables ++ relationship.variable ++ rightNode.variable
+  override def allVariables: Set[LogicalVariable] = element.allVariables ++ relationship.variable ++ rightNode.variable
 
 }
 
@@ -129,7 +129,7 @@ object InvalidNodePattern {
 }
 
 class InvalidNodePattern(
-                          val id: Variable
+                          val id: LogicalVariable
                         )(
                           position: InputPosition
 ) extends NodePattern(Some(id), Seq.empty, None)(position) {
@@ -145,22 +145,22 @@ class InvalidNodePattern(
 
   override def hashCode(): Int = 31 * id.hashCode()
 
-  override def allVariables: Set[Variable] = Set.empty
+  override def allVariables: Set[LogicalVariable] = Set.empty
 }
 
-case class NodePattern(variable: Option[Variable],
+case class NodePattern(variable: Option[LogicalVariable],
                        labels: Seq[LabelName],
                        properties: Option[Expression])(val position: InputPosition)
   extends PatternElement {
 
-  override def allVariables: Set[Variable] = variable.toSet
+  override def allVariables: Set[LogicalVariable] = variable.toSet
 
   override def isSingleNode = true
 }
 
 
 case class RelationshipPattern(
-                                variable: Option[Variable],
+                                variable: Option[LogicalVariable],
                                 types: Seq[RelTypeName],
                                 length: Option[Option[Range]],
                                 properties: Option[Expression],

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ProcedureResultItem.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ProcedureResultItem.scala
@@ -20,7 +20,7 @@ import org.neo4j.cypher.internal.util.v3_4.{ASTNode, InputPosition}
 import org.neo4j.cypher.internal.frontend.v3_4._
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.SemanticAnalysisTooling
 import org.neo4j.cypher.internal.util.v3_4.symbols._
-import org.neo4j.cypher.internal.v3_4.expressions.{ProcedureOutput, Variable}
+import org.neo4j.cypher.internal.v3_4.expressions.{LogicalVariable, ProcedureOutput, Variable}
 
 object ProcedureResultItem {
   def apply(output: ProcedureOutput, variable: Variable)(position: InputPosition): ProcedureResultItem =
@@ -30,7 +30,7 @@ object ProcedureResultItem {
     ProcedureResultItem(None, variable)(position)
 }
 
-case class ProcedureResultItem(output: Option[ProcedureOutput], variable: Variable)(val position: InputPosition)
+case class ProcedureResultItem(output: Option[ProcedureOutput], variable: LogicalVariable)(val position: InputPosition)
   extends ASTNode with SemanticAnalysisTooling {
 
   val outputName: String = output.map(_.name).getOrElse(variable.name)

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/connectedComponents.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/connectedComponents.scala
@@ -16,7 +16,7 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_4.ast
 
-import org.neo4j.cypher.internal.v3_4.expressions.{NodePattern, PatternPart, Variable}
+import org.neo4j.cypher.internal.v3_4.expressions.{LogicalVariable, NodePattern, PatternPart}
 
 import scala.annotation.tailrec
 import scala.collection.immutable
@@ -26,7 +26,7 @@ import scala.collection.immutable
  */
 object connectedComponents {
 
-  type ComponentPart = Set[Variable]
+  type ComponentPart = Set[LogicalVariable]
   type ConnectedComponent = Set[ComponentPart]
 
   //enable using the companion objects of the type aliases,
@@ -35,7 +35,7 @@ object connectedComponents {
   val ConnectedComponent = Set
 
   def apply(patternParts: Seq[PatternPart]): IndexedSeq[ConnectedComponent] = {
-    val parts: immutable.IndexedSeq[ComponentPart] = patternParts.map(_.fold(Set.empty[Variable]) {
+    val parts: immutable.IndexedSeq[ComponentPart] = patternParts.map(_.fold(Set.empty[LogicalVariable]) {
       case NodePattern(Some(id), _, _) => list => list + id
     }).toIndexedSeq
 
@@ -64,6 +64,6 @@ object connectedComponents {
 
     def connectedTo(part: ComponentPart) = connectedComponent.exists(c => (c intersect part).nonEmpty)
 
-    def variables: Set[Variable] = connectedComponent.flatten
+    def variables: Set[LogicalVariable] = connectedComponent.flatten
   }
 }

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/PropertyPredicateNormalizer.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/PropertyPredicateNormalizer.scala
@@ -41,7 +41,7 @@ object PropertyPredicateNormalizer extends MatchPredicateNormalizer {
     case _            => false
   }
 
-  private def propertyPredicates(id: Variable, props: Expression): IndexedSeq[Expression] = props match {
+  private def propertyPredicates(id: LogicalVariable, props: Expression): IndexedSeq[Expression] = props match {
     case mapProps: MapExpression =>
       mapProps.items.map {
         // MATCH (a {a: 1, b: 2}) => MATCH (a) WHERE a.a = 1 AND a.b = 2
@@ -53,7 +53,7 @@ object PropertyPredicateNormalizer extends MatchPredicateNormalizer {
       Vector.empty
   }
 
-  private def varLengthPropertyPredicates(id: Variable, props: Expression, patternPosition: InputPosition): Expression = {
+  private def varLengthPropertyPredicates(id: LogicalVariable, props: Expression, patternPosition: InputPosition): Expression = {
     val idName = FreshIdNameGenerator.name(patternPosition)
     val newId = Variable(idName)(id.position)
     val expressions = propertyPredicates(newId, props)

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/addUniquenessPredicates.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/addUniquenessPredicates.scala
@@ -85,7 +85,7 @@ case object addUniquenessPredicates extends Rewriter {
       }
     }
 
-  case class UniqueRel(variable: Variable, types: Set[RelTypeName], singleLength: Boolean) {
+  case class UniqueRel(variable: LogicalVariable, types: Set[RelTypeName], singleLength: Boolean) {
     def name = variable.name
 
     def isAlwaysDifferentFrom(other: UniqueRel) =

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/calculateUsingGetDegree.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/helpers/calculateUsingGetDegree.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.v3_4.expressions._
  */
 object calculateUsingGetDegree {
 
-  def apply(expr: Expression, node: Variable, types: Seq[RelTypeName], dir: SemanticDirection): Expression = {
+  def apply(expr: Expression, node: LogicalVariable, types: Seq[RelTypeName], dir: SemanticDirection): Expression = {
       types
         .map(typ => GetDegree(node.copyId, Some(typ), dir)(typ.position))
         .reduceOption[Expression](Add(_, _)(expr.position))

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticAnalysisTooling.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticAnalysisTooling.scala
@@ -180,7 +180,7 @@ trait SemanticAnalysisTooling {
                      ): (SemanticState) => Either[SemanticError, SemanticState] =
     (s: SemanticState) => s.declareVariable(v, typeGen(s), positions)
 
-  def implicitVariable(v:Variable, possibleType: CypherType): (SemanticState) => Either[SemanticError, SemanticState] =
+  def implicitVariable(v:LogicalVariable, possibleType: CypherType): (SemanticState) => Either[SemanticError, SemanticState] =
     (_: SemanticState).implicitVariable(v, possibleType)
 
   def declareGraph(v:Variable): (SemanticState) => Either[SemanticError, SemanticState] =

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticState.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticState.scala
@@ -408,7 +408,7 @@ case class SemanticState(currentScope: ScopeLocation,
         Left(SemanticError(s"`${variable.name}` already declared as variable", variable.position, symbol.positions.toSeq: _*))
     }
 
-  def implicitVariable(variable: Variable, possibleTypes: TypeSpec): Either[SemanticError, SemanticState] =
+  def implicitVariable(variable: LogicalVariable, possibleTypes: TypeSpec): Either[SemanticError, SemanticState] =
     this.symbol(variable.name) match {
       case None =>
         Right(updateVariable(variable, possibleTypes, Set(variable.position)))

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ConnectedComponentsTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/ConnectedComponentsTest.scala
@@ -17,7 +17,7 @@
 package org.neo4j.cypher.internal.frontend.v3_4.ast
 
 import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
-import org.neo4j.cypher.internal.v3_4.expressions.Variable
+import org.neo4j.cypher.internal.v3_4.expressions.{LogicalVariable, Variable}
 
 class ConnectedComponentsTest extends CypherFunSuite {
   import connectedComponents._
@@ -72,5 +72,5 @@ class ConnectedComponentsTest extends CypherFunSuite {
     ))
   }
 
-  private def varFor(name: String): Variable = Variable(name)(null)
+  private def varFor(name: String): LogicalVariable = Variable(name)(null)
 }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ExecutionContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ExecutionContext.scala
@@ -55,6 +55,8 @@ trait ExecutionContext extends MutableMap[String, AnyValue] {
     * Like newWith1 but guarantees that we will never overwrite the value of an existing key
     */
   def newScopeWith1(key1: String, value1: AnyValue): ExecutionContext
+
+  def newScopeWith2(key1: String, value1: AnyValue, key2: String, value2: AnyValue): ExecutionContext
 }
 
 case class MapExecutionContext(m: MutableMap[String, AnyValue])
@@ -109,6 +111,10 @@ case class MapExecutionContext(m: MutableMap[String, AnyValue])
 
   override def newScopeWith1(key1: String, value1: AnyValue): MapExecutionContext.this.type =
     newWith1(key1, value1)
+
+  override def newScopeWith2(key1: String, value1: AnyValue, key2: String, value2: AnyValue): MapExecutionContext.this.type = {
+    newWith2(key1, value1, key2, value2)
+  }
 
   override def newWith2(key1: String, value1: AnyValue, key2: String, value2: AnyValue): MapExecutionContext.this.type = {
     val newMap = m.clone()

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/InList.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/InList.scala
@@ -30,6 +30,9 @@ import org.neo4j.values.virtual.ListValue
 
 import scala.collection.Seq
 
+/**
+  * These classes solve List Predicates.
+  */
 abstract class InList(collectionExpression: Expression, id: String, predicate: Predicate)
   extends Predicate
   with ListSupport
@@ -45,10 +48,11 @@ abstract class InList(collectionExpression: Expression, id: String, predicate: P
     if (list == Values.NO_VALUE) None
     else {
       val seq = makeTraversable(list)
+      val innerContext = m.createClone()
 
       seqMethod(seq)(item =>
         // Since we can override an existing id here we use a method that guarantees that we do not overwrite an existing variable
-        predicate.isMatch(m.newScopeWith1(id, item), state))
+        predicate.isMatch(innerContext.newWith1(id, item), state))
     }
   }
 
@@ -73,7 +77,7 @@ case class AllInList(collection: Expression, symbolName: String, inner: Predicat
 
     val iterator = collectionValue.iterator()
     while(iterator.hasNext) {
-      predicate(iterator.next())  match {
+      predicate(iterator.next()) match {
         case Some(false) => return Some(false)
         case None        => result = None
         case _           =>

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ExtractFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ExtractFunction.scala
@@ -31,8 +31,9 @@ case class ExtractFunction(collection: Expression, id: String, expression: Expre
   with Closure {
   override def compute(value: AnyValue, m: ExecutionContext, state: QueryState): ListValue = {
     val list = makeTraversable(value)
+    val innerContext = m.createClone()
     VirtualValues.transform(list, new java.util.function.Function[AnyValue, AnyValue]() {
-      override def apply(v1: AnyValue): AnyValue = expression(m.newWith1(id, v1), state)
+      override def apply(v1: AnyValue): AnyValue = expression(innerContext.newWith1(id, v1), state)
     })
   }
 

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/FilterFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/FilterFunction.scala
@@ -33,8 +33,9 @@ case class FilterFunction(collection: Expression, id: String, predicate: Predica
 
   override def compute(value: AnyValue, m: ExecutionContext, state: QueryState) = {
     val traversable = makeTraversable(value)
+    val innerContext = m.createClone()
     VirtualValues.filter(traversable, new java.util.function.Function[AnyValue, java.lang.Boolean]() {
-      override def apply(v1: AnyValue): java.lang.Boolean =  predicate.isTrue(m.newWith1(id, v1), state)
+      override def apply(v1: AnyValue): java.lang.Boolean =  predicate.isTrue(innerContext.newWith1(id, v1), state)
     })
   }
 

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ReduceFunction.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ReduceFunction.scala
@@ -29,16 +29,14 @@ case class ReduceFunction(collection: Expression, id: String, expression: Expres
   extends NullInNullOutExpression(collection) with ListSupport {
 
   override def compute(value: AnyValue, m: ExecutionContext, state: QueryState) = {
-    val initMap = m.newWith1(acc, init(m, state))
     val list = makeTraversable(value)
     val iterator = list.iterator()
-    var computed = initMap
+    var contextWithAcc = m.newScopeWith1(acc, init(m, state))
     while(iterator.hasNext) {
-      val innerMap = computed.newWith1(id, iterator.next())
-      computed = innerMap.newWith1(acc, expression(innerMap, state))
+      val innerMap = contextWithAcc.newWith1(id, iterator.next())
+      contextWithAcc = contextWithAcc.newWith1(acc, expression(innerMap, state))
     }
-
-    computed(acc)
+    contextWithAcc(acc)
   }
 
   def rewrite(f: (Expression) => Expression) =

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ProjectEndpointsPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ProjectEndpointsPipe.scala
@@ -61,8 +61,8 @@ case class ProjectEndpointsPipe(source: Pipe, relName: String,
         Iterator(context.newWith2(start, startNode, end, endNode))
       case Some((startNode, endNode)) if !directed =>
         Iterator(
-          context.newWith2(start, startNode, end, endNode),
-          context.newWith2(start, endNode, end, startNode)
+          context.newScopeWith2(start, startNode, end, endNode),
+          context.newScopeWith2(start, endNode, end, startNode)
         )
       case None =>
         Iterator.empty

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ShortestPathPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ShortestPathPipe.scala
@@ -51,13 +51,13 @@ case class ShortestPathPipe(source: Pipe, shortestPathCommand: ShortestPath, pre
       shortestPathCommand.relIterator match {
         case Some(relName) =>
           result.iterator().asScala.map {
-            case(path: PathValue) => ctx.newWith2(pathName, path, relName, VirtualValues.list(path.edges():_*))
-            case _ => throw new InternalException("We expect only paths here")
+            case (path: PathValue) => ctx.newScopeWith2(pathName, path, relName, VirtualValues.list(path.edges():_*))
+            case value => throw new InternalException(s"Expected path, got '$value'")
           }
         case None =>
           result.iterator().asScala.map {
-            case path: PathValue => ctx.newWith1(pathName, path)
-            case _ => throw new InternalException("We expect only paths here")
+            case path: PathValue => ctx.newScopeWith1(pathName, path)
+            case value => throw new InternalException(s"Expected path, got '$value'")
           }
       }
     })

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -1,10 +1,2 @@
-Should fail on merge using multiple unique indexes using same key if found different nodes
-Should fail on merge using multiple unique indexes if found different nodes
-Should fail on merge using multiple unique indexes if it found a node matching single property only
-Should fail on merge using multiple unique indexes if it found a node matching single property only flipped order
-Should fail on merge using multiple unique indexes and labels if found different nodes
-Merge with uniqueness constraints must properly handle multiple labels
-Failing when creation would violate constraint
-
-//SkipLimitAcceptance.feature
+//Broken because of bug in IR rewriting
 Using a optional match after aggregation and before an aggregation

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -5,14 +5,6 @@ Should fail on merge using multiple unique indexes if it found a node matching s
 Should fail on merge using multiple unique indexes and labels if found different nodes
 Merge with uniqueness constraints must properly handle multiple labels
 Failing when creation would violate constraint
-Explanation of in-query procedure call
-In-query call to procedure that takes no arguments
-Calling the same procedure twice using the same outputs in each call
-In-query call to procedure with explicit arguments
-In-query call to procedure with argument of type NUMBER accepts value of type INTEGER
-In-query call to procedure with argument of type NUMBER accepts value of type FLOAT
-In-query call to procedure with argument of type FLOAT accepts value of type INTEGER
-In-query call to procedure with null argument
 
 //SkipLimitAcceptance.feature
 Using a optional match after aggregation and before an aggregation

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -1,4 +1,3 @@
-Shorthand case with filter should work as expected
 Should fail on merge using multiple unique indexes using same key if found different nodes
 Should fail on merge using multiple unique indexes if found different nodes
 Should fail on merge using multiple unique indexes if it found a node matching single property only
@@ -7,11 +6,6 @@ Should fail on merge using multiple unique indexes and labels if found different
 Merge with uniqueness constraints must properly handle multiple labels
 Failing when creation would violate constraint
 Explanation of in-query procedure call
-Returning a pattern expression with bound nodes
-Using a variable-length pattern expression in a WITH
-Pattern expression inside list comprehension
-Using a pattern predicate after aggregation 1
-Using a pattern predicate after aggregation 2
 In-query call to procedure that takes no arguments
 Calling the same procedure twice using the same outputs in each call
 In-query call to procedure with explicit arguments
@@ -19,17 +13,6 @@ In-query call to procedure with argument of type NUMBER accepts value of type IN
 In-query call to procedure with argument of type NUMBER accepts value of type FLOAT
 In-query call to procedure with argument of type FLOAT accepts value of type INTEGER
 In-query call to procedure with null argument
-Find a shortest path among paths that fulfill a predicate on all nodes
-Find a shortest path among paths that fulfill a predicate on all relationships
-Find a shortest path among paths that fulfill a predicate
-Find a shortest path without loosing context information at runtime
-Optionally finds shortest path
-Optionally finds shortest path using previously bound nodes
-Returns null when not finding a shortest path during an OPTIONAL MATCH
-Find a combination of a shortest path and a pattern expression
 
 //SkipLimitAcceptance.feature
 Using a optional match after aggregation and before an aggregation
-
-//MatchAcceptance.feature
-Variable length path with both sides already bound

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -10,17 +10,10 @@ Explanation of in-query procedure call
 Returning a pattern expression with bound nodes
 Using a variable-length pattern expression in a WITH
 Pattern expression inside list comprehension
-Filter using a pattern predicate that is a logical OR between two subqueries
-Filter using a pattern predicate that is a logical OR between one negated subquery, two subqueries, and an equality expression
-Filter using a pattern predicate that is a logical OR between one negated subquery, two subqueries, and an equality expression 2
 Using a pattern predicate after aggregation 1
 Using a pattern predicate after aggregation 2
-Returning a relationship from a pattern predicate
-Matching with complex composite pattern predicate
 In-query call to procedure that takes no arguments
 Calling the same procedure twice using the same outputs in each call
-In-query call to VOID procedure that takes no arguments
-In-query call to VOID procedure does not consume rows
 In-query call to procedure with explicit arguments
 In-query call to procedure with argument of type NUMBER accepts value of type INTEGER
 In-query call to procedure with argument of type NUMBER accepts value of type FLOAT
@@ -28,23 +21,15 @@ In-query call to procedure with argument of type FLOAT accepts value of type INT
 In-query call to procedure with null argument
 Find a shortest path among paths that fulfill a predicate on all nodes
 Find a shortest path among paths that fulfill a predicate on all relationships
-Find a shortest path among paths that fulfill a predicate on all relationships 2
 Find a shortest path among paths that fulfill a predicate
 Find a shortest path without loosing context information at runtime
-Find a shortest path in an expression context
-Finds shortest path
 Optionally finds shortest path
 Optionally finds shortest path using previously bound nodes
 Returns null when not finding a shortest path during an OPTIONAL MATCH
-Find relationships of a shortest path
-Find no shortest path when a length limit prunes all candidates
-Find no shortest path when the start node is null
-Find all shortest paths
 Find a combination of a shortest path and a pattern expression
 
 //SkipLimitAcceptance.feature
 Using a optional match after aggregation and before an aggregation
 
 //MatchAcceptance.feature
-difficult to plan query number 3
 Variable length path with both sides already bound

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/AggregationAcceptanceTest.scala
@@ -21,7 +21,6 @@ package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.ExecutionEngineFunSuite
 import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
-import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Versions.V2_3
 
 
 class AggregationAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
@@ -73,7 +72,7 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
     val node2 = createLabeledNode("Person")
     val node3 = createNode()
     // CountStore not supported by sloted
-    val result = executeWith(Configs.AllExceptSlotted, "MATCH (a:Person) WITH count(a) as c RETURN c")
+    val result = executeWith(Configs.All, "MATCH (a:Person) WITH count(a) as c RETURN c")
     result.toList should equal(List(Map("c" -> 2L)))
   }
 
@@ -123,7 +122,7 @@ class AggregationAcceptanceTest extends ExecutionEngineFunSuite with CypherCompa
   test("combine simple aggregation with sorting (can use node count store)") {
     val node1 = createNode()
     val node2 = createNode()
-    val result = executeWith(Configs.AllExceptSlotted, "MATCH (a) RETURN count(a) ORDER BY count(a)")
+    val result = executeWith(Configs.All, "MATCH (a) RETURN count(a) ORDER BY count(a)")
     result.toList should equal(List(Map("count(a)" -> 2)))
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/BuiltInProcedureAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/BuiltInProcedureAcceptanceTest.scala
@@ -27,7 +27,7 @@ import scala.collection.JavaConversions._
 
 class BuiltInProcedureAcceptanceTest extends ProcedureCallAcceptanceTest with CypherComparisonSupport {
 
-  private val combinedCallconfiguration = Configs.CommunityInterpreted - Configs.AllRulePlanners - Configs.Version2_3
+  private val combinedCallconfiguration = Configs.Interpreted - Configs.AllRulePlanners - Configs.Version2_3
 
   test("should be able to filter as part of call") {
     // Given

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeIndexAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeIndexAcceptanceTest.scala
@@ -392,7 +392,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
     val b = createLabeledNode(Map("p1" -> 1, "p2" -> 1), "X")
 
     // 2.3 excluded because the params syntax was not supported in that version
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Version2_3, "match (a), (b:X) where id(a) = $id AND b.p1 = a.p1 AND b.p2 = 1 return b",
+    val result = executeWith(Configs.Interpreted - Configs.Version2_3, "match (a), (b:X) where id(a) = $id AND b.p1 = a.p1 AND b.p2 = 1 return b",
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperatorWithText("NodeIndexSeek", ":X(p1,p2)")

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateAcceptanceTest.scala
@@ -81,7 +81,7 @@ class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
   test("should have bound node recognized after projection with WITH + CALL") {
     val query = "CREATE (a:L) WITH a CALL db.labels() YIELD label CREATE (b) CREATE (a)<-[:T]-(b)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Version2_3 - Configs.AllRulePlanners, query)
+    val result = executeWith(Configs.Interpreted - Configs.Version2_3 - Configs.AllRulePlanners, query)
 
     assertStats(result, nodesCreated = 2, relationshipsCreated = 1, labelsAdded = 1)
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateAcceptanceTest.scala
@@ -72,7 +72,7 @@ class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
 
     val query = s"CREATE (a) WITH a LOAD CSV FROM '$url' AS line CREATE (b) CREATE (a)<-[:T]-(b)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query)
 
     assertStats(result, nodesCreated = 2, relationshipsCreated = 1)
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
@@ -310,7 +310,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (x), (y) CALL user.expand(x, y) YIELD relId RETURN x, y, relId"
 
     // Correct! No eagerization necessary
-    val result = executeWith(Configs.CommunityInterpreted - Configs.AllRulePlanners - Configs.Version2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.AllRulePlanners - Configs.Version2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
 
     result.size should equal(2)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
@@ -261,7 +261,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (a), (b) CALL user.mkRel(a, b) MATCH (a)-[rel]->(b) RETURN rel.foo"
 
     // Correct! Eagerization happens as part of query context operation
-    val result = executeWith(Configs.CommunityInterpreted - Configs.AllRulePlanners - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.AllRulePlanners - Configs.Cost2_3, query,
       executeBefore = () => counter.reset(),
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
 
@@ -358,7 +358,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (x), (y) CALL user.expand(x, y) WITH * MATCH (x)-[rel]->(y) RETURN *"
 
     // Correct! No eagerization necessary
-    val result = executeWith(Configs.CommunityInterpreted - Configs.AllRulePlanners - Configs.Version2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.AllRulePlanners - Configs.Version2_3, query,
       executeBefore = () => counter.reset(),
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
 
@@ -2533,7 +2533,7 @@ class EagerizationAcceptanceTest
   test("should not be eager for LOAD CSV followed by MERGE") {
     val query = "LOAD CSV FROM 'file:///something' AS line MERGE (b:B {p:line[0]}) RETURN b"
     val config =
-      TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Default)) +
+      TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Slotted, Runtimes.Default)) +
       TestConfiguration(Versions.Default, Planners.Rule, Runtimes(Runtimes.Interpreted, Runtimes.Default)) +
       TestConfiguration(Versions.V2_3 -> Versions.V3_1, Planners.Rule, Runtimes.Default) +
       Configs.Cost3_1 + Configs.Version3_3
@@ -2553,7 +2553,7 @@ class EagerizationAcceptanceTest
 
     val query = s"MATCH (a)-[t:T]-(b) LOAD CSV FROM '$url' AS line DELETE t RETURN count(*) as count"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsDeleted = 1)
@@ -2572,7 +2572,7 @@ class EagerizationAcceptanceTest
 
     val query = s"CREATE () WITH * MATCH (a)-[t:T]-(b) LOAD CSV FROM '$url' AS line DELETE t RETURN count(*) as count"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, nodesCreated = 1, relationshipsDeleted = 1)
@@ -2590,7 +2590,7 @@ class EagerizationAcceptanceTest
 
     val query = s"MATCH () LOAD CSV FROM '$url' AS i MATCH () UNWIND [0] as j CREATE () RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next() should equal(4)
     assertStats(result, nodesCreated = 4)
@@ -2607,7 +2607,7 @@ class EagerizationAcceptanceTest
 
     val query = s"MERGE () WITH * LOAD CSV FROM '$url' AS line MATCH () LOAD CSV FROM '$url' AS line2 CREATE () RETURN count(*)"
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, optimalEagerCount = 1, expectPlansToFailPredicate = Configs.AllRulePlanners))
     result.columnAs[Long]("count(*)").next() should equal(4)
     assertStats(result, nodesCreated = 4)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionEngineTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionEngineTest.scala
@@ -514,7 +514,7 @@ order by a.COL1""".format(a, b))
 
     val q = "match (n)-[f]->() where id(n)= 0 with n, max(f.age) as age match (n)-[f]->(m) where f.age = age return m"
 
-    executeWith(Configs.CommunityInterpreted, q).toList should equal(List(Map("m" -> c)))
+    executeWith(Configs.Interpreted, q).toList should equal(List(Map("m" -> c)))
   }
 
   test("issue 432") {
@@ -832,7 +832,7 @@ order by a.COL1""".format(a, b))
     val n = createNode("n")
     val m = createNode("m")
     relate(n,m,"link")
-    val result = executeWith(Configs.CommunityInterpreted, "match (n) where id(n) = 0 with coalesce(n,n) as n match (n)--() return n")
+    val result = executeWith(Configs.Interpreted, "match (n) where id(n) = 0 with coalesce(n,n) as n match (n)--() return n")
 
     result.toList should equal(List(Map("n" -> n)))
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionEngineTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionEngineTest.scala
@@ -55,7 +55,7 @@ class ExecutionEngineTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     val n = createNode()
     val r = relate(n, createNode(), "KNOWS")
 
-    val result = executeWith(Configs.CommunityInterpreted, "match ()-[r]->() where id(r) = 0 return r")
+    val result = executeWith(Configs.Interpreted, "match ()-[r]->() where id(r) = 0 return r")
 
     result.columnAs[Relationship]("r").toList should equal(List(r))
   }
@@ -89,7 +89,7 @@ class ExecutionEngineTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     val node: Node = createNode()
     val rel: Relationship = relate(createNode(), node, "yo")
 
-    val result = executeWith(Configs.CommunityInterpreted, s"match ()-[rel]->() where id(rel) = ${rel.getId} return rel")
+    val result = executeWith(Configs.Interpreted, s"match ()-[rel]->() where id(rel) = ${rel.getId} return rel")
 
     result.columnAs[Relationship]("rel").toList should equal(List(rel))
   }
@@ -253,7 +253,7 @@ class ExecutionEngineTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     relate("B" -> "FRIEND" -> "C")
 
 
-    val result = executeWith(Configs.CommunityInterpreted, "match (a)-[:CONTAINS*0..1]->(b)-[:FRIEND*0..1]->(c) where id(a) = 0 return a,b,c")
+    val result = executeWith(Configs.Interpreted, "match (a)-[:CONTAINS*0..1]->(b)-[:FRIEND*0..1]->(c) where id(a) = 0 return a,b,c")
 
     result.toSet should equal(
       Set(
@@ -279,7 +279,7 @@ class ExecutionEngineTest extends ExecutionEngineFunSuite with QueryStatisticsTe
         |return pA, pB, pC, pD, pE
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted, query, params = Map(
+    val result = executeWith(Configs.Interpreted, query, params = Map(
       "a" -> Seq[Long](a),
       "b" -> b.toInt,
       "c" -> Seq(c).asJava,
@@ -451,7 +451,7 @@ order by a.COL1""".format(a, b))
     val a = createNode()
     val b = createNode()
     val r = relate(a, b)
-    val result = executeWith(Configs.CommunityInterpreted, "match (a), ()-[r]->() where id(a) = 0 and id(r) = 0 return a,r")
+    val result = executeWith(Configs.Interpreted, "match (a), ()-[r]->() where id(a) = 0 and id(r) = 0 return a,r")
 
     result.toList should equal(List(Map("a" -> a, "r" -> r)))
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExplainAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExplainAcceptanceTest.scala
@@ -68,7 +68,7 @@ class ExplainAcceptanceTest extends ExecutionEngineFunSuite with CypherCompariso
                   |
                   |RETURN count(*), count(distinct bknEnd), avg(size(bookings)),avg(size(perDays));""".stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted, query)
+    val result = executeWith(Configs.Interpreted, query)
     val plan = result.executionPlanDescription().toString
     result.close()
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExpressionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExpressionAcceptanceTest.scala
@@ -74,7 +74,7 @@ class ExpressionAcceptanceTest extends ExecutionEngineFunSuite with CypherCompar
 
   test("projecting from a null identifier produces a null value") {
 
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Version2_3, "OPTIONAL MATCH (n) RETURN n{.foo, .bar}")
+    val result = executeWith(Configs.Interpreted - Configs.Version2_3, "OPTIONAL MATCH (n) RETURN n{.foo, .bar}")
 
     result.toList should equal(List(Map("n" -> null)))
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ForeachAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ForeachAcceptanceTest.scala
@@ -154,7 +154,7 @@ class ForeachAcceptanceTest extends ExecutionEngineFunSuite with CypherCompariso
         |FOREACH (x IN CASE WHEN condition THEN nodes ELSE [] END | CREATE (a)-[:X]->(x) );""".stripMargin
 
     // when
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query)
 
     // then
     assertStats(result, nodesCreated = 2, relationshipsCreated = 1)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcAcceptanceTest.scala
@@ -95,7 +95,7 @@ class LdbcAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSu
 
     val result =
     // when
-      executeWith(Configs.CommunityInterpreted, ldbcQuery, params = params)
+      executeWith(Configs.Interpreted, ldbcQuery, params = params)
 
     // then
     result should not be empty

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcQueries.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcQueries.scala
@@ -1534,7 +1534,7 @@ object LdbcQueries {
       Map("weight" -> 4.0, "pathNodeIds" -> List(0, 1, 2, 4, 8, 5)),
       Map("weight" -> 3.0, "pathNodeIds" -> List(0, 1, 2, 4, 6, 5)))
 
-    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+    override def expectedToSucceedIn: TestConfiguration = Configs.Interpreted
 
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcQueries.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcQueries.scala
@@ -199,7 +199,7 @@ object LdbcQueries {
       )
     }
 
-    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+    override def expectedToSucceedIn: TestConfiguration = Configs.Interpreted
 
   }
 
@@ -431,7 +431,7 @@ object LdbcQueries {
       Map("friendLastName" -> "last2-ᚠさ丵פش", "friendId" -> 2, "friendFirstName" -> "f2", "yCount" -> 1, "xyCount" -> 2, "xCount" -> 1),
       Map("friendLastName" -> "last6-ᚠさ丵פش", "friendId" -> 6, "friendFirstName" -> "ff6", "yCount" -> 1, "xyCount" -> 2, "xCount" -> 1))
 
-    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+    override def expectedToSucceedIn: TestConfiguration = Configs.Interpreted
 
   }
 
@@ -817,7 +817,7 @@ object LdbcQueries {
       Map("isNew" -> true, "likeTime" -> 946681800000L, "personId" -> 8, "latencyAsMilli" -> 480000, "messageId" -> 2,
         "personLastName" -> "last8-ᚠさ丵פش", "messageContent" -> "person1post2", "personFirstName" -> "s8"))
 
-    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+    override def expectedToSucceedIn: TestConfiguration = Configs.Interpreted
 
   }
 
@@ -1137,7 +1137,7 @@ object LdbcQueries {
         "personLastName" -> "two one-ᚠさ丵פش", "commonInterestScore" -> -1, "personFirstName" -> "friendfriend",
         "personCityName" -> "city0"))
 
-    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+    override def expectedToSucceedIn: TestConfiguration = Configs.Interpreted
 
   }
 
@@ -1353,7 +1353,7 @@ object LdbcQueries {
       Map("friendLastName" -> "3", "tagNames" -> Seq.empty, "friendId" -> 3, "count" -> 0, "friendFirstName" -> "f"),
       Map("friendLastName" -> "4", "tagNames" -> Seq.empty, "friendId" -> 4, "count" -> 0, "friendFirstName" -> "f"))
 
-    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+    override def expectedToSucceedIn: TestConfiguration = Configs.Interpreted
 
   }
 
@@ -1397,7 +1397,7 @@ object LdbcQueries {
 
     def expectedResult = List(Map("pathLength" -> 5))
 
-    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+    override def expectedToSucceedIn: TestConfiguration = Configs.Interpreted
 
   }
 
@@ -1503,7 +1503,7 @@ object LdbcQueries {
       Map("weight" -> 4.0, "pathNodeIds" -> List(0, 1, 2, 4, 8, 5)),
       Map("weight" -> 3.0, "pathNodeIds" -> List(0, 1, 2, 4, 6, 5)))
 
-    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+    override def expectedToSucceedIn: TestConfiguration = Configs.Interpreted
 
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceTest.scala
@@ -42,8 +42,8 @@ class LoadCsvAcceptanceTest
   extends ExecutionEngineFunSuite with BeforeAndAfterAll
   with QueryStatisticsTestSupport with CreateTempFileTestSupport with CypherComparisonSupport{
 
-  val expectedToSucceed = Configs.CommunityInterpreted - Configs.Cost2_3
-  val expectedToFail = Configs.CommunityInterpreted - Configs.Cost2_3 + TestConfiguration(Versions.Default, Planners.Default,
+  val expectedToSucceed = Configs.Interpreted - Configs.Cost2_3
+  val expectedToFail = Configs.Interpreted - Configs.Cost2_3 + TestConfiguration(Versions.Default, Planners.Default,
     Runtimes(Runtimes.Default, Runtimes.ProcedureOrSchema, Runtimes.CompiledSource, Runtimes.CompiledBytecode))
 
   def csvUrls(f: PrintWriter => Unit) = Seq(
@@ -73,7 +73,7 @@ class LoadCsvAcceptanceTest
 
     // when & then
     for (url <- urls) {
-      val result = executeWith(Configs.CommunityInterpreted - Configs.Version2_3,
+      val result = executeWith(Configs.Interpreted - Configs.Version2_3,
         s"""LOAD CSV WITH HEADERS FROM '$url' AS row
             | MATCH (user:User{userID: row.USERID}) USING INDEX user:User(userID)
             | MATCH (order:Order{orderID: row.OrderId})
@@ -218,7 +218,7 @@ class LoadCsvAcceptanceTest
         writer.println("5,'Emerald',")
     })
     for (url <- urls) {
-      val result = executeWith(expectedToSucceed, s"LOAD CSV WITH HEADERS FROM '$url' AS line WITH line WHERE line.x IS NOT NULL RETURN line.name")
+      val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, s"LOAD CSV WITH HEADERS FROM '$url' AS line WITH line WHERE line.x IS NOT NULL RETURN line.name")
       assert(result.toList === List(
         Map("line.name" -> "'Aardvark'"),
         Map("line.name" -> "'Cash'"),

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceTest.scala
@@ -218,7 +218,7 @@ class LoadCsvAcceptanceTest
         writer.println("5,'Emerald',")
     })
     for (url <- urls) {
-      val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, s"LOAD CSV WITH HEADERS FROM '$url' AS line WITH line WHERE line.x IS NOT NULL RETURN line.name")
+      val result = executeWith(expectedToSucceed + Configs.SlottedInterpreted, s"LOAD CSV WITH HEADERS FROM '$url' AS line WITH line WHERE line.x IS NOT NULL RETURN line.name")
       assert(result.toList === List(
         Map("line.name" -> "'Aardvark'"),
         Map("line.name" -> "'Cash'"),

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceUserAgentTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceUserAgentTest.scala
@@ -29,7 +29,7 @@ import sun.net.www.protocol.http.HttpURLConnection
 class LoadCsvAcceptanceUserAgentTest
   extends ExecutionEngineFunSuite with BeforeAndAfterAll with CypherComparisonSupport {
 
-  val expectedToSucceed: TestConfiguration = Configs.CommunityInterpreted - Configs.Version2_3
+  val expectedToSucceed: TestConfiguration = Configs.Interpreted - Configs.Version2_3
 
   test("should be able to download data from the web") {
     val url = s"http://127.0.0.1:$port/test.csv".cypherEscape

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -30,6 +30,34 @@ import scala.collection.mutable.ArrayBuffer
 
 class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with CypherComparisonSupport {
 
+//  test("APA") {
+//    val query = "CYPHER runtime=slotted MATCH (a) RETURN a ORDER BY id(a)"
+//    val result = innerExecuteDeprecated(query)
+//
+//    println(result.toList)
+//  }
+//
+//  test("Should work when doing union with alias on one side used as value on another") {
+//    val node = createLabeledNode("A")
+//
+//    val query1 =
+//      """
+//        |MATCH (n)
+//        |WITH n AS X
+//        |WITH X as A, X
+//        |RETURN A, X
+//        |UNION
+//        |MATCH (m)
+//        |WITH m as A, "foo" AS X
+//        |RETURN A, X
+//      """.stripMargin
+//
+//    val result1 = executeWith(Configs.Interpreted, query1)
+//    val expected1 = List(Map("A" -> node, "X" -> node), Map("A" -> node, "X" -> "foo"))
+//
+//    result1.toList should equal(expected1)
+//  }
+
   test("Do not count null elements in nodes without labels") {
 
     createNode("name" -> "a")
@@ -162,7 +190,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     createNodes("A", "B")
     val r1 = relate("A" -> "KNOWS" -> "B")
 
-    val result = executeWith(Configs.CommunityInterpreted, "match p = shortestPath((a {name:'A'})-[*..15]-(b {name:'B'})) return p").
+    val result = executeWith(Configs.Interpreted, "match p = shortestPath((a {name:'A'})-[*..15]-(b {name:'B'})) return p").
 
       toList.head("p").asInstanceOf[Path]
 
@@ -180,7 +208,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     relate("A" -> "KNOWS" -> "B")
 
     //Checking that we don't get an exception
-    executeWith(Configs.CommunityInterpreted, "match p = shortestPath((a {name:'A'})-[*]-(b {name:'B'})) return p").toList
+    executeWith(Configs.Interpreted, "match p = shortestPath((a {name:'A'})-[*]-(b {name:'B'})) return p").toList
   }
 
   test("should not traverse same relationship twice in shortest path") {
@@ -189,7 +217,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     relate("A" -> "KNOWS" -> "B")
 
     // when
-    val result = executeWith(Configs.CommunityInterpreted, "MATCH (a{name:'A'}), (b{name:'B'}) MATCH p=allShortestPaths((a)-[:KNOWS|KNOWS*]->(b)) RETURN p").
+    val result = executeWith(Configs.Interpreted, "MATCH (a{name:'A'}), (b{name:'B'}) MATCH p=allShortestPaths((a)-[:KNOWS|KNOWS*]->(b)) RETURN p").
       toList
 
     // then
@@ -234,7 +262,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
   test("should handle all shortest paths") {
     val (a, b, c, d) = createDiamond()
 
-    val result = executeWith(Configs.CommunityInterpreted,
+    val result = executeWith(Configs.Interpreted,
       """
     match (a), (d) where id(a) = %d and id(d) = %d
     match p = allShortestPaths( (a)-[*]->(d) )
@@ -247,7 +275,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     val a = createNode()
     val b = createNode()
     relate(a, b)
-    val result = executeWith(Configs.CommunityInterpreted, "match (a), (b) where id(a) = 0 and id(b) = 1 match p=shortestPath((b)<-[*]-(a)) return p").toList.head("p").asInstanceOf[Path]
+    val result = executeWith(Configs.Interpreted, "match (a), (b) where id(a) = 0 and id(b) = 1 match p=shortestPath((b)<-[*]-(a)) return p").toList.head("p").asInstanceOf[Path]
 
     result.startNode() should equal(b)
     result.endNode() should equal(a)
@@ -258,7 +286,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     val b = createLabeledNode("B")
     val r1 = relate(a, b)
 
-    val result = executeWith(Configs.CommunityInterpreted, "match (a:A) match p = shortestPath( (a)-[*]->(b:B) ) return p").toList.head("p").asInstanceOf[Path]
+    val result = executeWith(Configs.Interpreted, "match (a:A) match p = shortestPath( (a)-[*]->(b:B) ) return p").toList.head("p").asInstanceOf[Path]
 
 
     graph.inTx {
@@ -905,7 +933,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
         |  RETURN DISTINCT req.eid, y.eid
       """.stripMargin
 
-    val result = executeWith(Configs.CommunityInterpreted, query)
+    val result = executeWith(Configs.Interpreted, query)
 
     result.toList should equal(List(Map("req.eid" -> null, "y.eid" -> null)))
   }
@@ -947,7 +975,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
       """.stripMargin
 
 
-    val configuration = Configs.CommunityInterpreted - Configs.Version2_3
+    val configuration = Configs.Interpreted - Configs.Version2_3
     val result = executeWith(configuration, query, params = Map("position" -> "2", "folderId" -> 0, "videoId" -> 0))
 
     result.toList should equal(List.empty)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -247,7 +247,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     val c = createNode("C")
     val r = relate(a, b, "X")
 
-    val result = executeWith(Configs.CommunityInterpreted,
+    val result = executeWith(Configs.Interpreted,
       """
     match (a {name:'A'}), (x) where x.name in ['B', 'C']
     optional match p = shortestPath((a)-[*]->(x))
@@ -749,7 +749,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
 
     // When
     val res =
-      executeWith(Configs.AllExceptSlotted, "UNWIND {p} AS n MATCH (n)<-[:PING_DAY]-(p:Ping) RETURN count(p) as c", params = Map("p" -> List(node1, node2)))
+      executeWith(Configs.All, "UNWIND {p} AS n MATCH (n)<-[:PING_DAY]-(p:Ping) RETURN count(p) as c", params = Map("p" -> List(node1, node2)))
 
     //Then
     res.toList should equal(List(Map("c" -> 2)))
@@ -766,7 +766,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
 
     // When
     val res =
-      executeWith(Configs.AllExceptSlotted,
+      executeWith(Configs.All,
         """UNWIND {p1} AS n1
           |UNWIND {p2} AS n2
           |MATCH (n1)<-[:PING_DAY]-(n2) RETURN n1.prop, n2.prop""".stripMargin,

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -30,34 +30,6 @@ import scala.collection.mutable.ArrayBuffer
 
 class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with CypherComparisonSupport {
 
-//  test("APA") {
-//    val query = "CYPHER runtime=slotted MATCH (a) RETURN a ORDER BY id(a)"
-//    val result = innerExecuteDeprecated(query)
-//
-//    println(result.toList)
-//  }
-//
-//  test("Should work when doing union with alias on one side used as value on another") {
-//    val node = createLabeledNode("A")
-//
-//    val query1 =
-//      """
-//        |MATCH (n)
-//        |WITH n AS X
-//        |WITH X as A, X
-//        |RETURN A, X
-//        |UNION
-//        |MATCH (m)
-//        |WITH m as A, "foo" AS X
-//        |RETURN A, X
-//      """.stripMargin
-//
-//    val result1 = executeWith(Configs.Interpreted, query1)
-//    val expected1 = List(Map("A" -> node, "X" -> node), Map("A" -> node, "X" -> "foo"))
-//
-//    result1.toList should equal(expected1)
-//  }
-
   test("Do not count null elements in nodes without labels") {
 
     createNode("name" -> "a")

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAggregationsBackedByCountStoreAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAggregationsBackedByCountStoreAcceptanceTest.scala
@@ -20,15 +20,13 @@
 package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.internal.runtime.InternalExecutionResult
-import org.neo4j.cypher.internal.runtime.planDescription.InternalPlanDescription
 import org.neo4j.cypher.{ExecutionEngineFunSuite, QueryPlanTestSupport, QueryStatisticsTestSupport}
-import org.scalatest.matchers.{MatchResult, Matcher}
 import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.{ComparePlansWithAssertion, Configs, TestConfiguration}
 
 class MatchAggregationsBackedByCountStoreAcceptanceTest
   extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with CypherComparisonSupport with QueryPlanTestSupport {
 
-  val defaultConfig = Configs.AllExceptSlotted
+  val defaultConfig = Configs.All
   val expectOtherPlan = Configs.AllRulePlanners + Configs.Cost2_3
 
   test("do not plan counts store lookup for loop matches") {
@@ -95,8 +93,8 @@ class MatchAggregationsBackedByCountStoreAcceptanceTest
     val query = "MATCH (n:User) RETURN count(n) > 0"
 
     // Then
-    compareCount(query, false, Configs.AllExceptSlotted - Configs.Compiled)
-    compareCount(query, true, Configs.AllExceptSlotted - Configs.Compiled, executeBefore = executeBefore)
+    compareCount(query, false, Configs.All - Configs.Compiled)
+    compareCount(query, true, Configs.All - Configs.Compiled, executeBefore = executeBefore)
   }
 
   test("counts nodes using count store and projection expression with variable") {
@@ -105,8 +103,8 @@ class MatchAggregationsBackedByCountStoreAcceptanceTest
     val query = "MATCH (n) RETURN count(n)/2.0*5 as someNum"
 
     // Then
-    compareCount(query, 0, Configs.AllExceptSlotted - Configs.Compiled)
-    compareCount(query, 7.5, Configs.AllExceptSlotted - Configs.Compiled, executeBefore = executeBefore)
+    compareCount(query, 0, Configs.All - Configs.Compiled)
+    compareCount(query, 7.5, Configs.All - Configs.Compiled, executeBefore = executeBefore)
   }
 
   test("counts relationships with unspecified type using count store") {
@@ -321,9 +319,9 @@ class MatchAggregationsBackedByCountStoreAcceptanceTest
     val query = "MATCH (n:User) RETURN count(n) > 1"
 
     // Then
-    compareCount(query, false, Configs.AllExceptSlotted - Configs.Compiled)
+    compareCount(query, false, Configs.All - Configs.Compiled)
     setupBigModel(label1 = "Admin")
-    compareCount(query, true, Configs.AllExceptSlotted - Configs.Compiled, assertCountInTransaction = true, executeBefore = executeBefore)
+    compareCount(query, true, Configs.All - Configs.Compiled, assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts nodes using count store and projection expression with variable considering transaction state") {
@@ -332,9 +330,9 @@ class MatchAggregationsBackedByCountStoreAcceptanceTest
     val query = "MATCH (n) RETURN count(n)/3*5 as someNum"
 
     // Then
-    compareCount(query, 0, Configs.AllExceptSlotted - Configs.Compiled)
+    compareCount(query, 0, Configs.All - Configs.Compiled)
     setupBigModel()
-    compareCount(query, 5, Configs.AllExceptSlotted - Configs.Compiled, assertCountInTransaction = true, executeBefore = executeBefore)
+    compareCount(query, 5, Configs.All - Configs.Compiled, assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts relationships using count store considering transaction state") {
@@ -376,9 +374,9 @@ class MatchAggregationsBackedByCountStoreAcceptanceTest
     val query = "MATCH ()-[r]->() RETURN count(r) > 2"
 
     // Then
-    compareCount(query, false, Configs.AllExceptSlotted - Configs.Compiled, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    compareCount(query, false, Configs.All - Configs.Compiled, expectedLogicalPlan = "RelationshipCountFromCountStore")
     setupBigModel()
-    compareCount(query, true, Configs.AllExceptSlotted - Configs.Compiled, expectedLogicalPlan = "RelationshipCountFromCountStore", assertCountInTransaction = true, executeBefore = executeBefore)
+    compareCount(query, true, Configs.All - Configs.Compiled, expectedLogicalPlan = "RelationshipCountFromCountStore", assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts relationships using count store and projection with expression and variable considering transaction state") {
@@ -387,9 +385,9 @@ class MatchAggregationsBackedByCountStoreAcceptanceTest
     val query = "MATCH ()-[r]->() RETURN count(r)/3*5 as someNum"
 
     // Then
-    compareCount(query, 0, Configs.AllExceptSlotted - Configs.Compiled, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    compareCount(query, 0, Configs.All - Configs.Compiled, expectedLogicalPlan = "RelationshipCountFromCountStore")
     setupBigModel()
-    compareCount(query, 5, Configs.AllExceptSlotted - Configs.Compiled, expectedLogicalPlan = "RelationshipCountFromCountStore", assertCountInTransaction = true, executeBefore = executeBefore)
+    compareCount(query, 5, Configs.All - Configs.Compiled, expectedLogicalPlan = "RelationshipCountFromCountStore", assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts relationships using count store and horizon with further query") {
@@ -400,7 +398,7 @@ class MatchAggregationsBackedByCountStoreAcceptanceTest
                   |MATCH (n)-[r:KNOWS]->() WITH count(r) as otherKnows, n, userKnows WHERE otherKnows <> userKnows
                   |RETURN userKnows, otherKnows
                 """.stripMargin
-    val expectSucceed = Configs.AllExceptSlotted - Configs.Compiled
+    val expectSucceed = Configs.All - Configs.Compiled
 
     // Then
     val resultOnEmpty = executeWith(

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MutatingIntegrationTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MutatingIntegrationTest.scala
@@ -245,7 +245,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
 
     executeWith(createConf, "match (root) where id(root) = 0 match (root)-->(other) create (new {name:other.name}), (root)-[:REL]->(new)")
 
-    val result = executeWith(Configs.AllExceptSlotted, "match (root) where id(root) = 0 match (root)-->(other) return other.name order by other.name").columnAs[String]("other.name").toList
+    val result = executeWith(Configs.All, "match (root) where id(root) = 0 match (root)-->(other) return other.name order by other.name").columnAs[String]("other.name").toList
     result should equal(List("Alfa", "Alfa", "Beta", "Beta", "Gamma", "Gamma"))
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexContainsScanAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexContainsScanAcceptanceTest.scala
@@ -28,7 +28,7 @@ import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
  * [[org.neo4j.cypher.internal.compiler.v3_4.planner.logical.LeafPlanningIntegrationTest]]
  */
 class NodeIndexContainsScanAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport{
-  val expectedToSucceed = Configs.CommunityInterpreted
+  val expectedToSucceed = Configs.Interpreted
   val expectPlansToFail = Configs.AllRulePlanners + Configs.Cost2_3
 
   test("should be case sensitive for CONTAINS with indexes") {
@@ -183,7 +183,7 @@ class NodeIndexContainsScanAcceptanceTest extends ExecutionEngineFunSuite with C
 
     val query = "MATCH (l:Location) WHERE l.name CONTAINS {param} RETURN l"
 
-    failWithError(TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.ProcedureOrSchema, Runtimes.Interpreted)) +
+    failWithError(TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.ProcedureOrSchema, Runtimes.Interpreted, Runtimes.Slotted)) +
       TestConfiguration(Versions.all, Planners.Cost, Runtimes(Runtimes.Interpreted, Runtimes.Default)) +
       TestConfiguration(Versions.V2_3, Planners.Rule, Runtimes(Runtimes.Interpreted, Runtimes.Default)),
       query, message = List("Expected a string value, but got 42","Expected a string value, but got Long(42)","Expected two strings, but got London and 42"),

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexEndsWithScanAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexEndsWithScanAcceptanceTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.internal.cypher.acceptance
 
-import org.neo4j.cypher.{CypherTypeException, ExecutionEngineFunSuite}
+import org.neo4j.cypher.ExecutionEngineFunSuite
 import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
 
 /**
@@ -28,7 +28,7 @@ import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
  * [[org.neo4j.cypher.internal.compiler.v3_4.planner.logical.LeafPlanningIntegrationTest]]
  */
 class NodeIndexEndsWithScanAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport{
-  val expectedToSucceed = Configs.CommunityInterpreted
+  val expectedToSucceed = Configs.Interpreted
   val expectPlansToFail = Configs.AllRulePlanners + Configs.Cost2_3
 
   test("should be case sensitive for ENDS WITH with indexes") {
@@ -184,7 +184,7 @@ class NodeIndexEndsWithScanAcceptanceTest extends ExecutionEngineFunSuite with C
 
     val query = "MATCH (l:Location) WHERE l.name ENDS WITH {param} RETURN l"
 
-    failWithError(TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.ProcedureOrSchema, Runtimes.Interpreted)) +
+    failWithError(TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.ProcedureOrSchema, Runtimes.Interpreted, Runtimes.Slotted)) +
       TestConfiguration(Versions.all, Planners.Cost, Runtimes(Runtimes.Interpreted, Runtimes.Default)) +
       TestConfiguration(Versions.V2_3, Planners.Rule, Runtimes(Runtimes.Interpreted, Runtimes.Default)),
       query, message = List("Expected a string value, but got 42","Expected a string value, but got Long(42)","Expected two strings, but got London and 42"),

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NotificationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NotificationAcceptanceTest.scala
@@ -135,7 +135,7 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
       RUNTIME_UNSUPPORTED.notification(graphdb.InputPosition.empty)))
   }
 
-  test("Warn unsupported runtime with explain and runtime=slotted") {
+  ignore("Warn unsupported runtime with explain and runtime=slotted") {
     val result = innerExecuteDeprecated(
       """explain cypher runtime=slotted
          RETURN reduce(y=0, x IN [0] | x) AS z""", Map.empty)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NotificationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NotificationAcceptanceTest.scala
@@ -135,9 +135,9 @@ class NotificationAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
       RUNTIME_UNSUPPORTED.notification(graphdb.InputPosition.empty)))
   }
 
-  ignore("Warn unsupported runtime with explain and runtime=slotted") {
+  test("Warn unsupported runtime with explain and runtime=compiled") {
     val result = innerExecuteDeprecated(
-      """explain cypher runtime=slotted
+      """explain cypher runtime=compiled
          RETURN reduce(y=0, x IN [0] | x) AS z""", Map.empty)
 
     result.notifications.toList should equal(List(

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
@@ -388,7 +388,7 @@ class PatternComprehensionAcceptanceTest extends ExecutionEngineFunSuite with Cy
   test("pattern comprehension in RETURN following a WITH") {
     val query = """MATCH (e:X) WITH e LIMIT 5 RETURN [(e) --> (t) | t { .amount }]"""
 
-    executeWith(expectedToSucceedRestricted, query).toList //does not throw
+    executeWith(expectedToSucceedIncludingSlottedRestricted, query).toList //does not throw
   }
 
   test("pattern comprehension play nice with map projections") {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
@@ -109,7 +109,7 @@ class PatternComprehensionAcceptanceTest extends ExecutionEngineFunSuite with Cy
                |WITH collect(t) AS tweets
                |RETURN test.toSet([ tweet IN tweets | [ (tweet)<-[:POSTED]-(user) | user] ]) AS users""".stripMargin
 
-    val result = executeWith(expectedToSucceedRestricted, query)
+    val result = executeWith(expectedToSucceedIncludingSlottedRestricted, query)
     result.toList should equal(List(Map("users" -> List(List(n2)))))
   }
 
@@ -125,7 +125,7 @@ class PatternComprehensionAcceptanceTest extends ExecutionEngineFunSuite with Cy
                   |WITH [ tweet IN tweets | [ (tweet)<-[:POSTED]-(user) | user] ] AS pattern
                   |RETURN test.toSet(pattern) AS users""".stripMargin
 
-    val result = executeWith(expectedToSucceedRestricted, query)
+    val result = executeWith(expectedToSucceedIncludingSlottedRestricted, query)
     result.toList should equal(List(Map("users" -> List(List(n2)))))
   }
 
@@ -363,6 +363,7 @@ class PatternComprehensionAcceptanceTest extends ExecutionEngineFunSuite with Cy
     result.toList should equal(List(Map("size" -> 3)))
   }
 
+  // FAIL: Ouch, no suitable slot for key   UNNAMED58 = -[0]-
   test("pattern comprehension inside list comprehension") {
     val a = createLabeledNode("X", "A")
     val m1 = createLabeledNode("Y")
@@ -376,9 +377,9 @@ class PatternComprehensionAcceptanceTest extends ExecutionEngineFunSuite with Cy
     relate(m2, createLabeledNode("Y"))
     relate(m2, createNode())
 
-    val query = """MATCH p = (n:X)-->() RETURN n, [x IN nodes(p) | size([(x)-->(y:Y) | 1])] AS list"""
+    val query = """MATCH p = (n:X)-[s]->(apa) RETURN n, [x IN nodes(p) | size([(x)-[r]->(y:Y) | 1])] AS list"""
 
-    val result = executeWith(expectedToSucceedRestricted, query)
+    val result = executeWith(expectedToSucceedIncludingSlottedRestricted, query)
     result.toSet should equal(Set(
       Map("n" -> a, "list" -> Seq(1, 2)),
       Map("n" -> b, "list" -> Seq(0, 1))

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternExpressionImplementationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternExpressionImplementationAcceptanceTest.scala
@@ -295,11 +295,12 @@ class PatternExpressionImplementationAcceptanceTest extends ExecutionEngineFunSu
     val b = createLabeledNode("End")
     relate(a, b)
 
-    executeWith(Configs.CommunityInterpreted, "match (a:Start), (b:End) with (a)-[*]->(b) as path, count(a) as c return path, c",
+    executeWith(Configs.Interpreted, "match (a:Start), (b:End) with (a)-[*]->(b) as path, count(a) as c return path, c",
       planComparisonStrategy = ComparePlansWithAssertion(_ should useOperators("VarLengthExpand(Into)"),
         expectPlansToFail = Configs.AllRulePlanners + Configs.Version2_3))
   }
 
+  // FAIL: <default version> <default planner> runtime=slotted returned different results than <default version> <default planner> runtime=interpreted List() did not contain the same elements as List(Map("r" -> (20000)-[T,0]->(20001)))
   test("should not use a label scan as starting point when statistics are bad") {
     graph.inTx {
       (1 to 10000).foreach { i =>

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternExpressionImplementationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternExpressionImplementationAcceptanceTest.scala
@@ -309,7 +309,7 @@ class PatternExpressionImplementationAcceptanceTest extends ExecutionEngineFunSu
     }
     relate(createNode(), createLabeledNode("A"), "T")
 
-    executeWith(Configs.CommunityInterpreted, "PROFILE MATCH ()-[r]->() WHERE ()-[r]-(:A) RETURN r",
+    executeWith(Configs.Interpreted, "PROFILE MATCH ()-[r]->() WHERE ()-[r]-(:A) RETURN r",
       planComparisonStrategy = ComparePlansWithAssertion(_ shouldNot useOperators("NodeByLabelScan")))
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProfilerAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProfilerAcceptanceTest.scala
@@ -193,7 +193,7 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
         // due to the cost model, we need a bunch of nodes for the planner to pick a plan that does lookup by id
         (1 to 100).foreach(_ => createNode())
 
-        val result = profileWithExecute(Configs.AllExceptSlotted, "match (n) where id(n) = 0 RETURN n")
+        val result = profileWithExecute(Configs.All, "match (n) where id(n) = 0 RETURN n")
 
         //WHEN THEN
         assertRows(1)(result)("NodeByIdSeek")
@@ -204,7 +204,7 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
         // due to the cost model, we need a bunch of nodes for the planner to pick a plan that does lookup by id
         (1 to 100).foreach(_ => createNode("foo" -> "bar"))
 
-        val result = profileWithExecute(Configs.AllExceptSlotted, "match (n) where id(n) = 0 RETURN n.foo")
+        val result = profileWithExecute(Configs.All, "match (n) where id(n) = 0 RETURN n.foo")
 
         //WHEN THEN
         assertRows(1)(result)("ProduceResults", "Projection", "NodeByIdSeek")
@@ -352,7 +352,7 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
         val query = s"USING PERIODIC COMMIT 10 LOAD CSV FROM '$url' AS line CREATE()"
 
         // given
-        executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query).toList
+        executeWith(Configs.Interpreted - Configs.Cost2_3, query).toList
         deleteAllEntities()
         val initialTxCounts = graph.txCounts
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProfilerAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProfilerAcceptanceTest.scala
@@ -646,7 +646,7 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
         relate(anotherNode, createNode(), "HAS_CATEGORY")
 
         // WHEN
-        val result = profileWithExecute(Configs.CommunityInterpreted,
+        val result = profileWithExecute(Configs.Interpreted,
           """MATCH (cat:Category)
             |WITH collect(cat) as categories
             |MATCH (m:Entity)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/QueryPlanCompactionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/QueryPlanCompactionAcceptanceTest.scala
@@ -792,7 +792,7 @@ class QueryPlanCompactionAcceptanceTest extends ExecutionEngineFunSuite with Que
         || +LoadCSV                |              1 | line                      |                       |
         |+-------------------------+----------------+---------------------------+-----------------------+
         |""".stripMargin
-    executeWith(expectedToSucceed - Configs.SlottedInterpreted, query, planComparisonStrategy = ComparePlansWithAssertion(_ should matchPlan(expectedPlan), expectPlansToFail = Configs.All - Configs.Version3_3 - Configs.Cost3_4))
+    executeWith(expectedToSucceed, query, planComparisonStrategy = ComparePlansWithAssertion(_ should matchPlan(expectedPlan), expectPlansToFail = Configs.All - Configs.Version3_3 - Configs.Cost3_4))
   }
 
   test("Don't compact query with consecutive expands due to presence of values in 'other' column") {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
@@ -127,7 +127,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
 
     val queryWithComplexPredicate = "MATCH shortestPath((src:A)-[r*]->(dst:D)) WHERE ALL (x IN tail(r) WHERE x.foo = (head(r)).bar) RETURN r AS rels"
 
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, queryWithComplexPredicate).columnAs[List[Node]]("rels").toList
+    val result = executeWith(expectedToSucceed, queryWithComplexPredicate).columnAs[List[Node]]("rels").toList
 
     result should equal(List(List(r1, r4)))
   }
@@ -143,7 +143,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
     relate(nodeA, nodeX)
     relate(nodeX, nodeD)
 
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted,
+    val result = executeWith(expectedToSucceed,
       """MATCH p = shortestPath((src:A)-[*]->(dst:D))
         | WHERE NONE(n in nodes(p) WHERE n:X)
         |RETURN nodes(p) AS nodes""".stripMargin)
@@ -163,7 +163,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
     relate(nodeA, nodeX, "blocked" -> true)
     relate(nodeX, nodeD, "blocked" -> true)
 
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted,
+    val result = executeWith(expectedToSucceed,
       """MATCH p = shortestPath((src:A)-[*]->(dst:D))
         | WHERE NONE(r in rels(p) WHERE exists(r.blocked))
         |RETURN nodes(p) AS nodes""".stripMargin)
@@ -202,7 +202,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
     relate(nodeA, nodeX)
     relate(nodeX, nodeD)
 
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted,
+    val result = executeWith(expectedToSucceed,
       """MATCH p = shortestPath((src:A)-[rs*]->(dst:D))
         | WHERE length(p) % 2 = 1 // Only uneven paths wanted!
         |RETURN nodes(p) AS nodes""".stripMargin)
@@ -220,7 +220,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
         |RETURN p
       """.stripMargin
 
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
+    val result = executeWith(expectedToSucceed, query)
   }
 
   test("should still be able to return shortest path expression") {
@@ -252,7 +252,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
     relate(nodeA, nodeX, "A")
     relate(nodeX, nodeD, "B")
 
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted,
+    val result = executeWith(expectedToSucceed,
       """MATCH p = shortestPath((src:A)-[rs*]->(dst:D))
         | WHERE ALL(r in rs WHERE type(rs[0]) = type(r) )
         |RETURN nodes(p) AS nodes""".stripMargin)
@@ -286,7 +286,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
     relate(nodeC, nodeD)
     relate(nodeB, nodeD)
 
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, "OPTIONAL MATCH p = shortestPath((src:A)-[*]->(dst:D)) RETURN nodes(p) AS nodes").columnAs[List[Node]]("nodes").toList
+    val result = executeWith(expectedToSucceed, "OPTIONAL MATCH p = shortestPath((src:A)-[*]->(dst:D)) RETURN nodes(p) AS nodes").columnAs[List[Node]]("nodes").toList
 
     result should equal(List(List(nodeA, nodeB, nodeD)))
   }
@@ -301,13 +301,13 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
     relate(nodeC, nodeD)
     relate(nodeB, nodeD)
 
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, "MATCH (a:A), (d:D) OPTIONAL MATCH p = shortestPath((a)-[*]->(d)) RETURN nodes(p) AS nodes").toList
+    val result = executeWith(expectedToSucceed, "MATCH (a:A), (d:D) OPTIONAL MATCH p = shortestPath((a)-[*]->(d)) RETURN nodes(p) AS nodes").toList
 
     result should equal(List(Map("nodes" -> List(nodeA, nodeB, nodeD))))
   }
 
   test("returns null when no shortest path is found") {
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, "MATCH (a:A), (b:B) OPTIONAL MATCH p = shortestPath( (a)-[*]->(b) ) RETURN p").toList
+    val result = executeWith(expectedToSucceed, "MATCH (a:A), (b:B) OPTIONAL MATCH p = shortestPath( (a)-[*]->(b) ) RETURN p").toList
 
     result should equal(List(Map("p" -> null)))
   }
@@ -395,7 +395,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p) AS nodes
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
+    val result = executeWith(expectedToSucceed, query)
 
     result.toList should equal(List(Map("nodes" -> List(nodes("source"), nodes("node3"), nodes("node4"), nodes("target")))))
   }
@@ -410,7 +410,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p) as nodes
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
+    val result = executeWith(expectedToSucceed, query)
 
     result.toList should equal(List(Map("nodes" -> List(nodes("Donald"), nodes("Huey"), nodes("Dewey"), nodes("Louie"), nodes("Daisy")))))
   }
@@ -426,7 +426,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p) as nodes
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
+    val result = executeWith(expectedToSucceed, query)
 
     result.toList should equal(List(
       Map("nodes" -> List(nodes("Donald"), nodes("Huey"), nodes("Dewey"), nodes("Louie"), nodes("Daisy"))),
@@ -446,7 +446,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p1) AS nodes1, nodes(p2) as nodes2
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query, expectedDifferentResults = Configs.AllRulePlanners)
+    val result = executeWith(expectedToSucceed, query, expectedDifferentResults = Configs.AllRulePlanners)
 
     result.toList should equal(List(Map("nodes1" -> List(nodes("source"), nodes("node3"), nodes("node4"), nodes("target")),
       "nodes2" -> List(nodes("source"), nodes("target")))))
@@ -463,7 +463,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p1) AS nodes1, nodes(p2) as nodes2
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
+    val result = executeWith(expectedToSucceed, query)
 
     result.toList should equal(List(Map("nodes1" -> List(nodes("Donald"), nodes("Goofy"), nodes("Daisy")),
       "nodes2" -> List(nodes("Donald"), nodes("Huey"), nodes("Dewey"), nodes("Louie"), nodes("Daisy")))))
@@ -481,7 +481,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p1) AS nodes1, nodes(p2) as nodes2
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query, expectedDifferentResults = Configs.AllRulePlanners)
+    val result = executeWith(expectedToSucceed, query, expectedDifferentResults = Configs.AllRulePlanners)
 
     result.toList should equal(List(Map("nodes1" -> List(nodes("Donald"), nodes("Huey"), nodes("Dewey"), nodes("Louie"), nodes("Daisy")),
       "nodes2" -> List(nodes("Donald"), nodes("Huey"), nodes("Dewey"), nodes("Louie"), nodes("Daisy")))))
@@ -547,7 +547,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p) AS nodes
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
+    val result = executeWith(expectedToSucceed, query)
 
     result.toList should equal(List(Map("nodes" -> List(nodes("source"), nodes("node3"), nodes("node4"), nodes("target")))))
   }
@@ -562,7 +562,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p) AS nodes
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
+    val result = executeWith(expectedToSucceed, query)
 
     result.toList should equal(List(Map("nodes" -> List(nodes("Donald"), nodes("Huey"), nodes("Dewey"), nodes("Louie"), nodes("Daisy")))))
   }
@@ -579,7 +579,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p) AS nodes
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
+    val result = executeWith(expectedToSucceed, query)
 
     result.toList should equal(List(Map("nodes" -> List(nodes("Donald"), nodes("Huey"), nodes("Dewey"), nodes("Louie"), nodes("Daisy")))))
   }
@@ -593,7 +593,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p) AS nodes
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
+    val result = executeWith(expectedToSucceed, query)
 
     result.toList should equal(List(Map("nodes" -> List(nodes("source"), nodes("node3"), nodes("node4"), nodes("target")))))
   }
@@ -607,7 +607,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p) AS nodes
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
+    val result = executeWith(expectedToSucceed, query)
 
     result.toList should equal(List(Map("nodes" -> List(nodes("source"), nodes("node3"), nodes("node4"), nodes("target")))))
   }
@@ -734,7 +734,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
     relate(intermediate, p2, "KNOWS", Map("prop" -> 42))
 
     // When
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted - Configs.Cost2_3,
+    val result = executeWith(expectedToSucceed - Configs.Cost2_3,
       """MATCH (person1:Person {id:1}), (person2:Person {id:2})
         |OPTIONAL MATCH path = shortestPath((person1)-[k:KNOWS*0..]-(person2))
         |WHERE all(r in k WHERE r.prop IN [42])

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
@@ -29,7 +29,7 @@ import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
 
 class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
 
-  val expectedToSucceed = Configs.CommunityInterpreted
+  val expectedToSucceed = Configs.Interpreted
 
   var nodeA: Node = _
   var nodeB: Node = _
@@ -127,7 +127,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
 
     val queryWithComplexPredicate = "MATCH shortestPath((src:A)-[r*]->(dst:D)) WHERE ALL (x IN tail(r) WHERE x.foo = (head(r)).bar) RETURN r AS rels"
 
-    val result = executeWith(expectedToSucceed, queryWithComplexPredicate).columnAs[List[Node]]("rels").toList
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, queryWithComplexPredicate).columnAs[List[Node]]("rels").toList
 
     result should equal(List(List(r1, r4)))
   }
@@ -143,7 +143,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
     relate(nodeA, nodeX)
     relate(nodeX, nodeD)
 
-    val result = executeWith(expectedToSucceed,
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted,
       """MATCH p = shortestPath((src:A)-[*]->(dst:D))
         | WHERE NONE(n in nodes(p) WHERE n:X)
         |RETURN nodes(p) AS nodes""".stripMargin)
@@ -163,7 +163,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
     relate(nodeA, nodeX, "blocked" -> true)
     relate(nodeX, nodeD, "blocked" -> true)
 
-    val result = executeWith(expectedToSucceed,
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted,
       """MATCH p = shortestPath((src:A)-[*]->(dst:D))
         | WHERE NONE(r in rels(p) WHERE exists(r.blocked))
         |RETURN nodes(p) AS nodes""".stripMargin)
@@ -202,7 +202,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
     relate(nodeA, nodeX)
     relate(nodeX, nodeD)
 
-    val result = executeWith(expectedToSucceed,
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted,
       """MATCH p = shortestPath((src:A)-[rs*]->(dst:D))
         | WHERE length(p) % 2 = 1 // Only uneven paths wanted!
         |RETURN nodes(p) AS nodes""".stripMargin)
@@ -220,7 +220,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
         |RETURN p
       """.stripMargin
 
-    val result = executeWith(expectedToSucceed, query)
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
   }
 
   test("should still be able to return shortest path expression") {
@@ -252,7 +252,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
     relate(nodeA, nodeX, "A")
     relate(nodeX, nodeD, "B")
 
-    val result = executeWith(expectedToSucceed,
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted,
       """MATCH p = shortestPath((src:A)-[rs*]->(dst:D))
         | WHERE ALL(r in rs WHERE type(rs[0]) = type(r) )
         |RETURN nodes(p) AS nodes""".stripMargin)
@@ -286,7 +286,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
     relate(nodeC, nodeD)
     relate(nodeB, nodeD)
 
-    val result = executeWith(expectedToSucceed, "OPTIONAL MATCH p = shortestPath((src:A)-[*]->(dst:D)) RETURN nodes(p) AS nodes").columnAs[List[Node]]("nodes").toList
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, "OPTIONAL MATCH p = shortestPath((src:A)-[*]->(dst:D)) RETURN nodes(p) AS nodes").columnAs[List[Node]]("nodes").toList
 
     result should equal(List(List(nodeA, nodeB, nodeD)))
   }
@@ -301,13 +301,13 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
     relate(nodeC, nodeD)
     relate(nodeB, nodeD)
 
-    val result = executeWith(expectedToSucceed, "MATCH (a:A), (d:D) OPTIONAL MATCH p = shortestPath((a)-[*]->(d)) RETURN nodes(p) AS nodes").toList
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, "MATCH (a:A), (d:D) OPTIONAL MATCH p = shortestPath((a)-[*]->(d)) RETURN nodes(p) AS nodes").toList
 
     result should equal(List(Map("nodes" -> List(nodeA, nodeB, nodeD))))
   }
 
   test("returns null when no shortest path is found") {
-    val result = executeWith(expectedToSucceed, "MATCH (a:A), (b:B) OPTIONAL MATCH p = shortestPath( (a)-[*]->(b) ) RETURN p").toList
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, "MATCH (a:A), (b:B) OPTIONAL MATCH p = shortestPath( (a)-[*]->(b) ) RETURN p").toList
 
     result should equal(List(Map("p" -> null)))
   }
@@ -395,7 +395,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p) AS nodes
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed, query)
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
 
     result.toList should equal(List(Map("nodes" -> List(nodes("source"), nodes("node3"), nodes("node4"), nodes("target")))))
   }
@@ -410,7 +410,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p) as nodes
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed, query)
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
 
     result.toList should equal(List(Map("nodes" -> List(nodes("Donald"), nodes("Huey"), nodes("Dewey"), nodes("Louie"), nodes("Daisy")))))
   }
@@ -426,7 +426,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p) as nodes
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed, query)
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
 
     result.toList should equal(List(
       Map("nodes" -> List(nodes("Donald"), nodes("Huey"), nodes("Dewey"), nodes("Louie"), nodes("Daisy"))),
@@ -446,7 +446,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p1) AS nodes1, nodes(p2) as nodes2
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed, query, expectedDifferentResults = Configs.AllRulePlanners)
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query, expectedDifferentResults = Configs.AllRulePlanners)
 
     result.toList should equal(List(Map("nodes1" -> List(nodes("source"), nodes("node3"), nodes("node4"), nodes("target")),
       "nodes2" -> List(nodes("source"), nodes("target")))))
@@ -463,7 +463,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p1) AS nodes1, nodes(p2) as nodes2
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed, query)
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
 
     result.toList should equal(List(Map("nodes1" -> List(nodes("Donald"), nodes("Goofy"), nodes("Daisy")),
       "nodes2" -> List(nodes("Donald"), nodes("Huey"), nodes("Dewey"), nodes("Louie"), nodes("Daisy")))))
@@ -481,7 +481,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p1) AS nodes1, nodes(p2) as nodes2
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed, query, expectedDifferentResults = Configs.AllRulePlanners)
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query, expectedDifferentResults = Configs.AllRulePlanners)
 
     result.toList should equal(List(Map("nodes1" -> List(nodes("Donald"), nodes("Huey"), nodes("Dewey"), nodes("Louie"), nodes("Daisy")),
       "nodes2" -> List(nodes("Donald"), nodes("Huey"), nodes("Dewey"), nodes("Louie"), nodes("Daisy")))))
@@ -497,7 +497,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p) AS nodes
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed, query)
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
 
     result.toList should equal(List(Map("nodes" -> List(nodes("source"), nodes("node3"), nodes("node4"), nodes("target")))))
   }
@@ -512,7 +512,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p) as nodes
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed, query)
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
 
     result.toList should equal(List(Map("nodes" -> List(nodes("Donald"), nodes("Mickey"))),
       Map("nodes" -> List(nodes("Donald"), nodes("Mickey"), nodes("Minnie"))),
@@ -530,7 +530,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p) as nodes
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed, query)
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
 
     result.toList should equal(List(Map("nodes" -> List(nodes("Donald"), nodes("Mickey"))),
       Map("nodes" -> List(nodes("Donald"), nodes("Mickey"), nodes("Minnie"))),
@@ -547,7 +547,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p) AS nodes
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed, query)
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
 
     result.toList should equal(List(Map("nodes" -> List(nodes("source"), nodes("node3"), nodes("node4"), nodes("target")))))
   }
@@ -562,7 +562,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p) AS nodes
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed, query)
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
 
     result.toList should equal(List(Map("nodes" -> List(nodes("Donald"), nodes("Huey"), nodes("Dewey"), nodes("Louie"), nodes("Daisy")))))
   }
@@ -579,7 +579,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p) AS nodes
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed, query)
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
 
     result.toList should equal(List(Map("nodes" -> List(nodes("Donald"), nodes("Huey"), nodes("Dewey"), nodes("Louie"), nodes("Daisy")))))
   }
@@ -593,7 +593,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p) AS nodes
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed, query)
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
 
     result.toList should equal(List(Map("nodes" -> List(nodes("source"), nodes("node3"), nodes("node4"), nodes("target")))))
   }
@@ -607,7 +607,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p) AS nodes
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed, query)
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
 
     result.toList should equal(List(Map("nodes" -> List(nodes("source"), nodes("node3"), nodes("node4"), nodes("target")))))
   }
@@ -734,7 +734,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
     relate(intermediate, p2, "KNOWS", Map("prop" -> 42))
 
     // When
-    val result = executeWith(expectedToSucceed - Configs.Cost2_3,
+    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted - Configs.Cost2_3,
       """MATCH (person1:Person {id:1}), (person2:Person {id:2})
         |OPTIONAL MATCH path = shortestPath((person1)-[k:KNOWS*0..]-(person2))
         |WHERE all(r in k WHERE r.prop IN [42])

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathComplexQueryAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathComplexQueryAcceptanceTest.scala
@@ -28,7 +28,7 @@ class ShortestPathComplexQueryAcceptanceTest extends ExecutionEngineFunSuite wit
 
   test("allShortestPaths with complex LHS should be planned with exhaustive fallback and include predicate") {
     setupModel()
-    val result = executeWith(Configs.CommunityInterpreted,
+    val result = executeWith(Configs.Interpreted,
       """
         |PROFILE MATCH (charles:Pixie { fname : 'Charles'}),(joey:Pixie { fname : 'Joey'}),(kim:Pixie { fname : 'Kim'})
         |WITH kim AS kimDeal, collect(charles) AS charlesT, collect(joey) AS joeyS
@@ -47,7 +47,7 @@ class ShortestPathComplexQueryAcceptanceTest extends ExecutionEngineFunSuite wit
 
   test("shortestPath with complex LHS should be planned with exhaustive fallback and include predicate") {
     setupModel()
-    val result = executeWith(Configs.CommunityInterpreted,
+    val result = executeWith(Configs.Interpreted,
       """
         |PROFILE MATCH (charles:Pixie { fname : 'Charles'}),(joey:Pixie { fname : 'Joey'}),(kim:Pixie { fname : 'Kim'})
         |WITH kim AS kimDeal, collect(charles) AS charlesT, collect(joey) AS joeyS

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathEdgeCasesAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathEdgeCasesAcceptanceTest.scala
@@ -103,7 +103,7 @@ class ShortestPathEdgeCasesAcceptanceTest extends ExecutionEngineFunSuite with C
                   |WHERE ALL(id IN wps WHERE id IN EXTRACT(n IN nodes(p) | n.id))
                   |WITH p, size(nodes(p)) as length order by length limit 1
                   |RETURN size(nodes(p)) as size""".stripMargin
-    val results = executeWith(Configs.CommunityInterpreted, query)
+    val results = executeWith(Configs.Interpreted, query)
     results.toList should equal(List(Map("size" -> 7)))
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathLongerAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathLongerAcceptanceTest.scala
@@ -21,13 +21,12 @@ package org.neo4j.internal.cypher.acceptance
 
 import java.util
 
-import org.neo4j.cypher.internal.util.v3_4.InternalException
-import org.neo4j.cypher.internal.RewindableExecutionResult
-import org.neo4j.cypher.internal.compatibility.ClosingExecutionResult
 import org.neo4j.cypher.ExecutionEngineFunSuite
+import org.neo4j.cypher.internal.RewindableExecutionResult
 import org.neo4j.cypher.internal.runtime.InternalExecutionResult
 import org.neo4j.cypher.internal.runtime.planDescription.InternalPlanDescription
 import org.neo4j.cypher.internal.runtime.planDescription.InternalPlanDescription.Arguments.Rows
+import org.neo4j.cypher.internal.util.v3_4.InternalException
 import org.neo4j.graphalgo.impl.path.ShortestPath
 import org.neo4j.graphalgo.impl.path.ShortestPath.DataMonitor
 import org.neo4j.graphdb.factory.GraphDatabaseSettings
@@ -110,6 +109,7 @@ class ShortestPathLongerAcceptanceTest extends ExecutionEngineFunSuite with Cyph
     results shouldNot executeShortestPathFallbackWith(minRows = 1)
   }
 
+  // FAIL: head of empty list
   test("shortestPath with same start and end node as well as predicates should resort to fallback") {
     val start = System.currentTimeMillis
     val results = executeUsingCostPlannerOnly(
@@ -129,6 +129,7 @@ class ShortestPathLongerAcceptanceTest extends ExecutionEngineFunSuite with Cyph
     results should executeShortestPathFallbackWith(minRows = 1)
   }
 
+  // FAIL: head of empty list
   test("Shortest path from first to first node via top right (reverts to exhaustive)") {
     val start = System.currentTimeMillis
     val results = executeUsingCostPlannerOnly(
@@ -168,7 +169,7 @@ class ShortestPathLongerAcceptanceTest extends ExecutionEngineFunSuite with Cyph
 
   test("Shortest path from first to last node via top right") {
     val start = System.currentTimeMillis
-    val results = executeWith(Configs.CommunityInterpreted,
+    val results = executeWith(Configs.Interpreted,
       s"""PROFILE MATCH p = shortestPath((src:$topLeft)-[*]-(dst:$bottomRight))
          |WHERE ANY(n in nodes(p) WHERE n:$topRight)
          |RETURN nodes(p) AS nodes""".stripMargin,
@@ -188,7 +189,7 @@ class ShortestPathLongerAcceptanceTest extends ExecutionEngineFunSuite with Cyph
 
   test("Shortest path from first to last node via bottom left") {
     val start = System.currentTimeMillis
-    val results = executeWith(Configs.CommunityInterpreted,
+    val results = executeWith(Configs.Interpreted,
       s"""PROFILE MATCH p = shortestPath((src:$topLeft)-[*]-(dst:$bottomRight))
          |WHERE ANY(n in nodes(p) WHERE n:$bottomLeft)
          |RETURN nodes(p) AS nodes""".stripMargin,
@@ -208,7 +209,7 @@ class ShortestPathLongerAcceptanceTest extends ExecutionEngineFunSuite with Cyph
 
   test("Fallback expander should take on rel-type predicates") {
     val start = System.currentTimeMillis
-    val results = executeWith(Configs.CommunityInterpreted,
+    val results = executeWith(Configs.Interpreted,
       s"""PROFILE MATCH p = shortestPath((src:$topLeft)-[rels*]-(dst:$bottomRight))
          |WHERE ALL(r in rels WHERE type(r) = "DOWN")
          |  AND ANY(n in nodes(p) WHERE n:$bottomLeft)
@@ -244,6 +245,7 @@ class ShortestPathLongerAcceptanceTest extends ExecutionEngineFunSuite with Cyph
     results should executeShortestPathFallbackWith(minRows = 0, maxRows = 0)
   }
 
+  // FAIL: head of empty list
   test("Shortest path from first to last node via top right and bottom left (reverts to exhaustive)") {
     val start = System.currentTimeMillis
     val query =
@@ -353,6 +355,7 @@ class ShortestPathLongerAcceptanceTest extends ExecutionEngineFunSuite with Cyph
     ))
   }
 
+  // FAIL: expected row count 0 was not equal to 8
   test("All shortest paths from first to last node via top right and bottom left (needs to be with fallback)") {
     val start = System.currentTimeMillis
     val result = executeUsingCostPlannerOnly(
@@ -613,7 +616,7 @@ class ShortestPathLongerAcceptanceTest extends ExecutionEngineFunSuite with Cyph
                   |WHERE ALL(id IN wps WHERE id IN EXTRACT(n IN nodes(p) | n.id))
                   |WITH p, size(nodes(p)) as length order by length DESC limit 1
                   |RETURN EXTRACT(n IN nodes(p) | n.id) as nodes""".stripMargin
-    val result = executeWith(Configs.CommunityInterpreted, query,
+    val result = executeWith(Configs.Interpreted, query,
       expectedDifferentResults = Configs.AllRulePlanners + Configs.Cost2_3)
 
     result.toList should equal(List(Map("nodes" -> List(3, 2, 1, 11, 12, 13, 26, 27, 14))))

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathSameNodeAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathSameNodeAcceptanceTest.scala
@@ -34,7 +34,7 @@ class ShortestPathSameNodeAcceptanceTest extends ExecutionEngineFunSuite with Ru
   val expectedToFail = TestConfiguration(
     Versions(Versions.Default, V3_1, V3_3),
     Planners(Planners.Cost, Planners.Rule, Planners.Default),
-    Runtimes(Runtimes.Interpreted, Runtimes.Default, Runtimes.ProcedureOrSchema))
+    Runtimes(Runtimes.Interpreted, Runtimes.Slotted, Runtimes.Default, Runtimes.ProcedureOrSchema))
 
   def setupModel(db: GraphDatabaseCypherService) {
     db.inTx {
@@ -97,7 +97,7 @@ class ShortestPathSameNodeAcceptanceTest extends ExecutionEngineFunSuite with Ru
   test("shortest paths with min length 0 that discover at runtime that the start and end nodes are the same should not throw exception by default") {
     setupModel(graph)
     val query = "MATCH (a), (b) MATCH p=shortestPath((a)-[*0..]-(b)) RETURN p"
-    executeWith(Configs.CommunityInterpreted, query).toList.length should be(9)
+    executeWith(Configs.Interpreted, query).toList.length should be(9)
   }
 
   test("shortest paths with min length 0 that discover at runtime that the start and end nodes are the same should throw exception even when when configured to do so") {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartPointFindingAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartPointFindingAcceptanceTest.scala
@@ -74,14 +74,14 @@ class StartPointFindingAcceptanceTest extends ExecutionEngineFunSuite with Cyphe
   test("Seek relationship by id given on the left") {
     val rel = relate(createNode("a"), createNode("b"))
 
-    val result = executeWith(Configs.CommunityInterpreted, s"match ()-[r]->() where ${rel.getId} = id(r) return r")
+    val result = executeWith(Configs.Interpreted, s"match ()-[r]->() where ${rel.getId} = id(r) return r")
     result.columnAs[Node]("r").toList should equal(List(rel))
   }
 
   test("Seek relationship by id given on the right") {
     val rel = relate(createNode("a"), createNode("b"))
 
-    val result = executeWith(Configs.CommunityInterpreted, s"match ()-[r]->() where id(r) = ${rel.getId} return r")
+    val result = executeWith(Configs.Interpreted, s"match ()-[r]->() where id(r) = ${rel.getId} return r")
     result.columnAs[Node]("r").toList should equal(List(rel))
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UsingAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UsingAcceptanceTest.scala
@@ -730,7 +730,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
         |RETURN count(p)
         |""".stripMargin
 
-    executeWith(Configs.CommunityInterpreted  - Configs.Cost3_1 - Configs.Cost2_3, query,
+    executeWith(Configs.Interpreted  - Configs.Cost3_1 - Configs.Cost2_3, query,
       planComparisonStrategy = ComparePlansWithAssertion(planDescription => {
         planDescription should includeAtLeastOne(classOf[NodeIndexSeek], withVariable = "k")
         planDescription should includeAtLeastOne(classOf[NodeIndexSeek], withVariable = "t")

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/VarLengthExpandQueryPlanAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/VarLengthExpandQueryPlanAcceptanceTest.scala
@@ -52,7 +52,7 @@ class VarLengthExpandQueryPlanAcceptanceTest extends ExecutionEngineFunSuite wit
 
   test("Plan pruning var expand on distinct var-length match") {
     val query = "MATCH (a)-[*1..2]->(c) RETURN DISTINCT c"
-    executeWith(expectedToSucceed - Configs.SlottedInterpreted, query, planComparisonStrategy =
+    executeWith(expectedToSucceed, query, planComparisonStrategy =
       ComparePlansWithAssertion( plan => {
         plan should useOperators("VarLengthExpand(Pruning)")
       }, expectPlansToFail = ignoreConfiguration))
@@ -60,7 +60,7 @@ class VarLengthExpandQueryPlanAcceptanceTest extends ExecutionEngineFunSuite wit
 
   test("Plan pruning var expand on distinct var-length match with projection and aggregation") {
     val query = "MATCH (a)-[*1..2]->(c) WITH DISTINCT c RETURN count(*)"
-    executeWith(expectedToSucceed - Configs.SlottedInterpreted, query, planComparisonStrategy =
+    executeWith(expectedToSucceed, query, planComparisonStrategy =
       ComparePlansWithAssertion( plan => {
         plan should useOperators("VarLengthExpand(Pruning)")
       }, expectPlansToFail = ignoreConfiguration))
@@ -68,7 +68,7 @@ class VarLengthExpandQueryPlanAcceptanceTest extends ExecutionEngineFunSuite wit
 
   test("query with distinct aggregation") {
     val query = "MATCH (from)-[*1..3]->(to) RETURN count(DISTINCT to)"
-    executeWith(expectedToSucceed - Configs.SlottedInterpreted, query, planComparisonStrategy =
+    executeWith(expectedToSucceed, query, planComparisonStrategy =
       ComparePlansWithAssertion( plan => {
         plan should useOperators("VarLengthExpand(Pruning)")
       }, expectPlansToFail = ignoreConfiguration))
@@ -76,7 +76,7 @@ class VarLengthExpandQueryPlanAcceptanceTest extends ExecutionEngineFunSuite wit
 
   test("Simple query that filters between expand and distinct") {
     val query = "MATCH (a)-[*1..3]->(b:X) RETURN DISTINCT b"
-    executeWith(expectedToSucceed - Configs.SlottedInterpreted, query, planComparisonStrategy =
+    executeWith(expectedToSucceed, query, planComparisonStrategy =
       ComparePlansWithAssertion( plan => {
         plan should useOperators("VarLengthExpand(Pruning)")
       }, expectPlansToFail = ignoreConfiguration))
@@ -93,7 +93,7 @@ class VarLengthExpandQueryPlanAcceptanceTest extends ExecutionEngineFunSuite wit
 
   test("Double var expand with distinct result") {
     val query = "MATCH (a)-[:R*1..3]->(b)-[:T*1..3]->(c) RETURN DISTINCT c"
-    executeWith(expectedToSucceed - Configs.SlottedInterpreted, query, planComparisonStrategy =
+    executeWith(expectedToSucceed, query, planComparisonStrategy =
       ComparePlansWithAssertion( plan => {
         plan should useOperators("VarLengthExpand(Pruning)")
       }, expectPlansToFail = ignoreConfiguration))
@@ -101,7 +101,7 @@ class VarLengthExpandQueryPlanAcceptanceTest extends ExecutionEngineFunSuite wit
 
   test("var expand followed by normal expand") {
     val query = "MATCH (a)-[:R*1..3]->(b)-[:T]->(c) RETURN DISTINCT c"
-    executeWith(expectedToSucceed - Configs.SlottedInterpreted, query, planComparisonStrategy =
+    executeWith(expectedToSucceed, query, planComparisonStrategy =
       ComparePlansWithAssertion( plan => {
         plan should useOperators("VarLengthExpand(Pruning)")
       }, expectPlansToFail = ignoreConfiguration))
@@ -109,7 +109,7 @@ class VarLengthExpandQueryPlanAcceptanceTest extends ExecutionEngineFunSuite wit
 
   test("optional match can be solved with PruningVarExpand") {
     val query = "MATCH (a) OPTIONAL MATCH (a)-[:R*1..3]->(b)-[:T]->(c) RETURN DISTINCT c"
-    executeWith(expectedToSucceed - Configs.SlottedInterpreted, query, planComparisonStrategy =
+    executeWith(expectedToSucceed, query, planComparisonStrategy =
       ComparePlansWithAssertion( plan => {
         plan should useOperators("VarLengthExpand(Pruning)")
       }, expectPlansToFail = ignoreConfiguration))
@@ -126,7 +126,7 @@ class VarLengthExpandQueryPlanAcceptanceTest extends ExecutionEngineFunSuite wit
 
   test("on longer var-lengths, we use FullPruningVarExpand") {
     val query = "MATCH (a)-[*4..5]->(b) RETURN DISTINCT b"
-    executeWith(expectedToSucceed - Configs.SlottedInterpreted, query, planComparisonStrategy =
+    executeWith(expectedToSucceed, query, planComparisonStrategy =
       ComparePlansWithAssertion( plan => {
         plan should useOperators("VarLengthExpand(FullPruning)")
       }, expectPlansToFail = ignoreConfiguration))

--- a/enterprise/cypher/compatibility-spec-suite/src/test/java/cypher/CompatibilitySpecSuiteTest.java
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/java/cypher/CompatibilitySpecSuiteTest.java
@@ -44,8 +44,6 @@ public class CompatibilitySpecSuiteTest
     // If you want to run only a single feature, put the name of the feature file in `FEATURE_TO_RUN` (including .feature)
     // If you want to run only a single scenario, put (part of) its name in the `SCENARIO_NAME_REQUIRED` constant
     // Do not forget to clear these strings to empty strings before you commit!!
-//    public static final String FEATURE_TO_RUN = "MatchAcceptance2.feature";
-//    public static final String SCENARIO_NAME_REQUIRED = "Matching and optionally matching with bound nodes in reverse direction";
     public static final String FEATURE_TO_RUN = "";
     public static final String SCENARIO_NAME_REQUIRED = "";
 

--- a/enterprise/cypher/compatibility-spec-suite/src/test/java/cypher/CompatibilitySpecSuiteTest.java
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/java/cypher/CompatibilitySpecSuiteTest.java
@@ -44,9 +44,9 @@ public class CompatibilitySpecSuiteTest
     // If you want to run only a single feature, put the name of the feature file in `FEATURE_TO_RUN` (including .feature)
     // If you want to run only a single scenario, put (part of) its name in the `SCENARIO_NAME_REQUIRED` constant
     // Do not forget to clear these strings to empty strings before you commit!!
-    @SuppressWarnings( "WeakerAccess" )
+//    public static final String FEATURE_TO_RUN = "MatchAcceptance2.feature";
+//    public static final String SCENARIO_NAME_REQUIRED = "Matching and optionally matching with bound nodes in reverse direction";
     public static final String FEATURE_TO_RUN = "";
-    @SuppressWarnings( "WeakerAccess" )
     public static final String SCENARIO_NAME_REQUIRED = "";
 
     private CompatibilitySpecSuiteTest()

--- a/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -4,36 +4,17 @@ Fail at runtime when trying to index into a map with a non-string
 Fail at runtime when attempting to index with a String into a Collection
 Fail at runtime when trying to index into a list with a list
 Fail at runtime when trying to index something which is not a map or collection
-Functions should return null if they get path containing unbound
-`exists()` with literal maps
-IS NOT NULL with literal maps
 `percentileCont()` failing on bad arguments
 `percentileDisc()` failing on bad arguments
 `percentileDisc()` failing in more involved query
 `type()` failing on invalid arguments
-Optionally matching named paths with single and variable length patterns
-Optionally matching named paths with variable length patterns
-Variable length relationship in OPTIONAL MATCH
-Matching and optionally matching with bound nodes in reverse direction
-Matching and optionally matching with unbound nodes and equality predicate in reverse direction
 Fail when using property access on primitive type
-Variable length pattern checking labels on endnodes
-Variable length patterns and nulls
 Failing on merging node with null property
 Failing when setting a list of maps as a property
-MATCH after OPTIONAL MATCH
-Variable length optional relationships
-Variable length optional relationships with length predicates
-Variable length optional relationships with bound nodes
-Variable length optional relationships with bound nodes, no matches
-Returning a pattern comprehension with bound nodes
-Using a variable-length pattern comprehension in a WITH
-Pattern comprehension inside list comprehension
 Fail when returning properties of deleted nodes
 Fail when returning labels of deleted nodes
 Fail when returning properties of deleted relationships
 Fail when sorting on variable removed by DISTINCT
-Arithmetic expressions inside aggregation
 Concatenating and returning the size of literal lists
 Failing when performing property access on a non-map 1
 Failing when performing property access on a non-map 2
@@ -44,7 +25,6 @@ Using `rand()` in aggregations
 `toFloat()` failing on invalid arguments
 `toString()` failing on invalid arguments
 Creating nodes from an unwound parameter list
-Unwind does not remove variables from scope
 Fail when asterisk operator is missing
 Fail on negative bound
 Fail at compile time when attempting to index with a non-integer into a list

--- a/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -77,17 +77,11 @@ Fail when trying to create using an undirected relationship pattern
 Many CREATE clauses
 
 `labels()` failing on invalid arguments
-In-query call to procedure that takes no arguments
-Calling the same procedure twice using the same outputs in each call
 In-query call to procedure that takes no arguments and yields no results
 In-query call to procedure with explicit arguments
 In-query call to procedure with explicit arguments that drops all result fields
-In-query call to procedure with argument of type NUMBER accepts value of type INTEGER
-In-query call to procedure with argument of type NUMBER accepts value of type FLOAT
-In-query call to procedure with argument of type FLOAT accepts value of type INTEGER
 Standalone call to procedure with argument of type INTEGER accepts value of type FLOAT
 In-query call to procedure with argument of type INTEGER accepts value of type FLOAT
-In-query call to procedure with null argument
 
 // TCK side effects are incorrectly specified -- need update
 Standalone call to procedure with explicit arguments

--- a/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -1,87 +1,14 @@
-Aggregates in aggregates
-Fail at runtime when attempting to index with an Int into a Map
-Fail at runtime when trying to index into a map with a non-string
-Fail at runtime when attempting to index with a String into a Collection
-Fail at runtime when trying to index into a list with a list
-Fail at runtime when trying to index something which is not a map or collection
-`percentileCont()` failing on bad arguments
-`percentileDisc()` failing on bad arguments
-`percentileDisc()` failing in more involved query
-`type()` failing on invalid arguments
-Fail when using property access on primitive type
-Failing on merging node with null property
-Failing when setting a list of maps as a property
-Fail when returning properties of deleted nodes
-Fail when returning labels of deleted nodes
-Fail when returning properties of deleted relationships
-Fail when sorting on variable removed by DISTINCT
-Concatenating and returning the size of literal lists
-Failing when performing property access on a non-map 1
-Failing when performing property access on a non-map 2
-Bad arguments for `range()`
-Using `rand()` in aggregations
-`toBoolean()` on invalid types
-`toInteger()` failing on invalid arguments
-`toFloat()` failing on invalid arguments
-`toString()` failing on invalid arguments
-Creating nodes from an unwound parameter list
-Fail when asterisk operator is missing
-Fail on negative bound
-Fail at compile time when attempting to index with a non-integer into a list
-`properties()` failing on an integer literal
-`properties()` failing on a string literal
-`properties()` failing on a list of booleans
-Fail when adding a new label predicate on a node that is already bound 1
-Fail when adding new label predicate on a node that is already bound 2
-Fail when adding new label predicate on a node that is already bound 3
-Fail when adding new label predicate on a node that is already bound 4
-Fail when adding new label predicate on a node that is already bound 5
-Failing on incorrect unicode literal
-Failing on aggregation in WHERE
-Failing when not aliasing expressions in WITH
-Failing when using undefined variable in pattern
-Failing when using undefined variable in SET
-Failing when using undefined variable in DELETE
-Failing when using a variable that is already bound in CREATE
-
-// Updating queries
-Fail when imposing new predicates on a variable that is already bound
-Create a relationship with the correct direction
-Deleting connected nodes
-Detach deleting connected nodes and relationships
-Detach deleting paths
-Create and delete in same query
-Delete nodes from a map
-Delete paths from nested map/list
-Delete relationship with bidirectional matching
-Updating one property with ON CREATE
-Null-setting one property with ON CREATE
-Copying properties from literal map with ON CREATE
-Copying properties from literal map with ON MATCH
-Copying properties from node with ON CREATE
-Copying properties from node with ON MATCH
-Should be able to use properties from match in ON MATCH and ON CREATE
-Merges should not be able to match on deleted nodes
-UNWIND with multiple merges
-Do not match on deleted entities
-Do not match on deleted relationships
-Set a property
-Set a property to an expression
-Concatenate elements onto a list property
-Concatenate elements in reverse onto a list property
-Overwrite values when using +=
-Non-existent values in a property map are removed with SET =
-Unwind with merge
-Fail when trying to create using an undirected relationship pattern
-
-Many CREATE clauses
-
-`labels()` failing on invalid arguments
+// unsupported YIELD -
 In-query call to procedure that takes no arguments and yields no results
-In-query call to procedure with explicit arguments
 In-query call to procedure with explicit arguments that drops all result fields
+
+// type hierarchy bugs/coercion rules
 Standalone call to procedure with argument of type INTEGER accepts value of type FLOAT
 In-query call to procedure with argument of type INTEGER accepts value of type FLOAT
+
+// TODO tck enforces specific order of `keys`, remove from blacklist when tck has been updated.
+Copying properties from literal map with ON CREATE
+Copying properties from literal map with ON MATCH
 
 // TCK side effects are incorrectly specified -- need update
 Standalone call to procedure with explicit arguments

--- a/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -1,12 +1,4 @@
-Directed match of a simple relationship, count
-Directed match on self-relationship graph, count
-
-Keeping used expression 1
-Simple counting of nodes
-Support column renaming for aggregates as well
-Support multiple divisions in aggregate function
 Aggregates in aggregates
-Aggregates with arithmetics
 Fail at runtime when attempting to index with an Int into a Map
 Fail at runtime when trying to index into a map with a non-string
 Fail at runtime when attempting to index with a String into a Collection
@@ -22,22 +14,9 @@ IS NOT NULL with literal maps
 Optionally matching named paths with single and variable length patterns
 Optionally matching named paths with variable length patterns
 Variable length relationship in OPTIONAL MATCH
-Matching using a relationship that is already bound
-Matching using a relationship that is already bound, in conjunction with aggregation
-Matching using a relationship that is already bound, in conjunction with aggregation and ORDER BY
-Matching with LIMIT and optionally matching using a relationship that is already bound
-Matching with LIMIT and optionally matching using a relationship and node that are both already bound
-Matching with LIMIT, then matching again using a relationship and node that are both already bound along with an additional predicate
-Matching with LIMIT and predicates, then matching again using a relationship and node that are both already bound along with a duplicate predicate
-Matching twice with conflicting relationship types on same relationship
-Matching twice with duplicate relationship types on same relationship
-Matching relationships into a list and matching variable length using the list
-Matching relationships into a list and matching variable length using the list, with bound nodes
-Matching relationships into a list and matching variable length using the list, with bound nodes, wrong direction
 Matching and optionally matching with bound nodes in reverse direction
 Matching and optionally matching with unbound nodes and equality predicate in reverse direction
 Fail when using property access on primitive type
-Counting an empty graph
 Variable length pattern checking labels on endnodes
 Variable length patterns and nulls
 Failing on merging node with null property
@@ -68,8 +47,6 @@ Creating nodes from an unwound parameter list
 Unwind does not remove variables from scope
 Fail when asterisk operator is missing
 Fail on negative bound
-Handling relationships that are already bound in variable length paths
-A simple pattern with one bound endpoint
 Fail at compile time when attempting to index with a non-integer into a list
 `properties()` failing on an integer literal
 `properties()` failing on a string literal
@@ -122,8 +99,6 @@ Many CREATE clauses
 `labels()` failing on invalid arguments
 In-query call to procedure that takes no arguments
 Calling the same procedure twice using the same outputs in each call
-In-query call to VOID procedure that takes no arguments
-In-query call to VOID procedure does not consume rows
 In-query call to procedure that takes no arguments and yields no results
 In-query call to procedure with explicit arguments
 In-query call to procedure with explicit arguments that drops all result fields

--- a/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/compatibility-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -11,10 +11,31 @@ Copying properties from literal map with ON CREATE
 Copying properties from literal map with ON MATCH
 
 // TCK side effects are incorrectly specified -- need update
+In-query call to procedure with explicit arguments
 Standalone call to procedure with explicit arguments
+Detach deleting connected nodes and relationships
+Detach deleting paths
+Create and delete in same query
+Delete nodes from a map
+Delete paths from nested map/list
+Delete relationship with bidirectional matching
 Generate the movie graph correctly
+Many CREATE clauses
 Merge node should create when it doesn't match, properties and label
 Should work when finding multiple elements
+Should be able to use properties from match in ON MATCH and ON CREATE
 Should support updates while merging
 Merge must properly handle multiple labels
+UNWIND with multiple merges
+Do not match on deleted entities
+Do not match on deleted relationships
+Set a property
+Set a property to an expression
+Concatenate elements onto a list property
+Concatenate elements in reverse onto a list property
+Overwrite values when using +=
+Non-existent values in a property map are removed with SET =
+Creating nodes from an unwound parameter list
+Unwind with merge
 Should be able to merge using property from match
+Merges should not be able to match on deleted nodes

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildSlottedExecutionPlan.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildSlottedExecutionPlan.scala
@@ -101,7 +101,7 @@ object BuildSlottedExecutionPlan extends Phase[EnterpriseRuntimeContext, Logical
       val fingerprint = context.createFingerprintReference(fp)
       val periodicCommit = periodicCommitInfo.isDefined
       val indexes = logicalPlan.indexUsage
-      val execPlan = SlottedExecutionPlan(fingerprint, periodicCommit, planner, indexes, func, pipe, context.config)
+      val execPlan = SlottedExecutionPlan(fingerprint, periodicCommit, planner, indexes, func, logicalPlan, context.config)
 
       if (ENABLE_DEBUG_PRINTS) {
         if (!PRINT_PLAN_INFO_EARLY) {
@@ -138,7 +138,7 @@ object BuildSlottedExecutionPlan extends Phase[EnterpriseRuntimeContext, Logical
                                   plannerUsed: PlannerName,
                                   override val plannedIndexUsage: Seq[IndexUsage],
                                   runFunction: (QueryContext, ExecutionMode, MapValue) => InternalExecutionResult,
-                                  pipe: Pipe,
+                                  logicalPlan: LogicalPlan,
                                   config: CypherCompilerConfiguration) extends executionplan.ExecutionPlan {
 
     override def run(queryContext: QueryContext, planType: ExecutionMode,
@@ -150,6 +150,6 @@ object BuildSlottedExecutionPlan extends Phase[EnterpriseRuntimeContext, Logical
     override def runtimeUsed: RuntimeName = SlottedRuntimeName
 
     override def notifications(planContext: PlanContext): Seq[InternalNotification] =
-      BuildInterpretedExecutionPlan.checkForNotifications(pipe, planContext, config)
+      BuildInterpretedExecutionPlan.checkForNotifications(logicalPlan, planContext, config)
   }
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildSlottedExecutionPlan.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildSlottedExecutionPlan.scala
@@ -42,6 +42,8 @@ import org.neo4j.cypher.internal.util.v3_4.CypherException
 import org.neo4j.cypher.internal.v3_4.logical.plans.{IndexUsage, LogicalPlan}
 import org.neo4j.values.virtual.MapValue
 
+import scala.util.{Failure, Success}
+
 object BuildSlottedExecutionPlan extends Phase[EnterpriseRuntimeContext, LogicalPlanState, CompilationState] with DebugPrettyPrinter {
   val ENABLE_DEBUG_PRINTS = false // NOTE: false toggles all debug prints off, overriding the individual settings below
 
@@ -110,7 +112,7 @@ object BuildSlottedExecutionPlan extends Phase[EnterpriseRuntimeContext, Logical
         printPipeInfo(physicalPlan.slotConfigurations, pipeInfo)
       }
 
-      new CompilationState(from, Some(execPlan))
+      new CompilationState(from, Success(execPlan))
     } catch {
       case e: CypherException =>
         if (ENABLE_DEBUG_PRINTS) {
@@ -120,7 +122,7 @@ object BuildSlottedExecutionPlan extends Phase[EnterpriseRuntimeContext, Logical
           }
         }
         runtimeSuccessRateMonitor.unableToHandlePlan(from.logicalPlan, new CantCompileQueryException(cause = e))
-        new CompilationState(from, None)
+        new CompilationState(from, Failure(e))
     }
   }
 

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildSlottedExecutionPlan.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildSlottedExecutionPlan.scala
@@ -43,7 +43,7 @@ import org.neo4j.values.virtual.MapValue
 import scala.util.{Failure, Success}
 
 object BuildSlottedExecutionPlan extends Phase[EnterpriseRuntimeContext, LogicalPlanState, CompilationState] with DebugPrettyPrinter {
-  val ENABLE_DEBUG_PRINTS = true // NOTE: false toggles all debug prints off, overriding the individual settings below
+  val ENABLE_DEBUG_PRINTS = false // NOTE: false toggles all debug prints off, overriding the individual settings below
 
   // Should we print query text and logical plan before we see any exceptions from execution plan building?
   // Setting this to true is useful if you want to see the query and logical plan while debugging a failure

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildVectorizedExecutionPlan.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildVectorizedExecutionPlan.scala
@@ -48,6 +48,8 @@ import org.neo4j.cypher.result.QueryResult.QueryResultVisitor
 import org.neo4j.graphdb._
 import org.neo4j.values.virtual.MapValue
 
+import scala.util.{Failure, Success}
+
 object BuildVectorizedExecutionPlan extends Phase[EnterpriseRuntimeContext, LogicalPlanState, CompilationState] {
   override def phase: CompilationPhaseTracer.CompilationPhase = CompilationPhase.PIPE_BUILDING
 
@@ -72,11 +74,11 @@ object BuildVectorizedExecutionPlan extends Phase[EnterpriseRuntimeContext, Logi
       val execPlan = VectorizedExecutionPlan(from.plannerName, operators, pipelines, physicalPlan, fieldNames,
                                              dispatcher, context.notificationLogger)
       runtimeSuccessRateMonitor.newPlanSeen(from.logicalPlan)
-      new CompilationState(from, Some(execPlan))
+      new CompilationState(from, Success(execPlan))
     } catch {
       case e: CantCompileQueryException =>
         runtimeSuccessRateMonitor.unableToHandlePlan(from.logicalPlan, e)
-        new CompilationState(from, None)
+        new CompilationState(from, Failure(e))
     }
   }
 

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildVectorizedExecutionPlan.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildVectorizedExecutionPlan.scala
@@ -31,11 +31,11 @@ import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.expressions.
 import org.neo4j.cypher.internal.compiler.v3_4.phases.LogicalPlanState
 import org.neo4j.cypher.internal.compiler.v3_4.planner.CantCompileQueryException
 import org.neo4j.cypher.internal.frontend.v3_4.PlannerName
-import org.neo4j.cypher.internal.frontend.v3_4.notification.{ExperimentalFeatureNotification, InternalNotification}
+import org.neo4j.cypher.internal.frontend.v3_4.notification.ExperimentalFeatureNotification
 import org.neo4j.cypher.internal.frontend.v3_4.phases.CompilationPhaseTracer.CompilationPhase
 import org.neo4j.cypher.internal.frontend.v3_4.phases._
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.SemanticTable
-import org.neo4j.cypher.internal.planner.v3_4.spi.{GraphStatistics, PlanContext}
+import org.neo4j.cypher.internal.planner.v3_4.spi.GraphStatistics
 import org.neo4j.cypher.internal.runtime.interpreted.commands.convert.{CommunityExpressionConverter, ExpressionConverters}
 import org.neo4j.cypher.internal.runtime.planDescription.InternalPlanDescription.Arguments.{Runtime, RuntimeImpl}
 import org.neo4j.cypher.internal.runtime.planDescription.{InternalPlanDescription, LogicalPlan2PlanDescription}
@@ -122,10 +122,7 @@ object BuildVectorizedExecutionPlan extends Phase[EnterpriseRuntimeContext, Logi
     override def isStale(lastTxId: () => Long, statistics: GraphStatistics): CacheCheckResult = CacheCheckResult.empty
 
     override def runtimeUsed: RuntimeName = MorselRuntimeName
-
-    override def notifications(planContext: PlanContext): Seq[InternalNotification] = Seq.empty
   }
-
 }
 
 class VectorizedOperatorExecutionResult(operators: Pipeline,

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/EnterpriseRuntimeBuilder.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/EnterpriseRuntimeBuilder.scala
@@ -27,63 +27,64 @@ import org.neo4j.cypher.internal.frontend.v3_4.notification.RuntimeUnsupportedNo
 import org.neo4j.cypher.internal.frontend.v3_4.phases.{Do, If, Transformer}
 import org.neo4j.cypher.internal.util.v3_4.InvalidArgumentException
 
+import scala.util.{Failure, Success}
+
 object EnterpriseRuntimeBuilder extends RuntimeBuilder[Transformer[EnterpriseRuntimeContext, LogicalPlanState, CompilationState]] {
+
+  type CompilationStateTransformer = Transformer[EnterpriseRuntimeContext, CompilationState, CompilationState]
+
+  private val AssertExecutionPlan: CompilationStateTransformer = AssertExecutionPlan(false)
+  private val AssertExecutionPlanAndWrapException: CompilationStateTransformer = AssertExecutionPlan(true)
+  private def AssertExecutionPlan(wrapException: Boolean): CompilationStateTransformer =
+    Do((state, ctx) => state.maybeExecutionPlan match {
+      case Success(_) => state
+      case Failure(t) =>
+        if (wrapException)
+          throw new InvalidArgumentException("The given query is not currently supported in the selected runtime", t)
+        else throw t
+    })
+
+  private def Fallback(fallback: Transformer[EnterpriseRuntimeContext, LogicalPlanState, CompilationState]
+                      ): CompilationStateTransformer =
+    If[EnterpriseRuntimeContext, LogicalPlanState, CompilationState](_.maybeExecutionPlan.isFailure) { fallback }
+
+  private def FallbackWithNotification(fallback: Transformer[EnterpriseRuntimeContext, LogicalPlanState, CompilationState]
+                                      ): CompilationStateTransformer =
+    Fallback(
+      Do((_: EnterpriseRuntimeContext).notificationLogger.log(RuntimeUnsupportedNotification))
+        andThen fallback
+    )
+
   def create(runtimeName: Option[RuntimeName], useErrorsOverWarnings: Boolean): Transformer[EnterpriseRuntimeContext, LogicalPlanState, CompilationState] = {
 
     def pickInterpretedExecutionPlan() =
-      BuildSlottedExecutionPlan andThen
-        If[EnterpriseRuntimeContext, LogicalPlanState, CompilationState](_.maybeExecutionPlan.isEmpty) {
-          BuildInterpretedExecutionPlan
-        }
+      BuildSlottedExecutionPlan andThen Fallback(BuildInterpretedExecutionPlan)
 
     runtimeName match {
       case None =>
-        BuildCompiledExecutionPlan andThen
-          If[EnterpriseRuntimeContext, LogicalPlanState, CompilationState](_.maybeExecutionPlan.isEmpty) {
-            pickInterpretedExecutionPlan()
-          }
+        BuildCompiledExecutionPlan andThen Fallback(pickInterpretedExecutionPlan())
 
       case Some(InterpretedRuntimeName) =>
-        BuildInterpretedExecutionPlan
+        BuildInterpretedExecutionPlan andThen AssertExecutionPlan
 
-      case Some(MorselRuntimeName)if useErrorsOverWarnings =>
-        BuildVectorizedExecutionPlan andThen
-          If[EnterpriseRuntimeContext, LogicalPlanState, CompilationState](_.maybeExecutionPlan.isEmpty)(
-            Do((_, _) => throw new InvalidArgumentException("The given query is not currently supported in the selected runtime"))
-          )
+      case Some(MorselRuntimeName) if useErrorsOverWarnings =>
+        BuildVectorizedExecutionPlan andThen AssertExecutionPlanAndWrapException
 
       case Some(MorselRuntimeName) =>
-        BuildVectorizedExecutionPlan andThen
-          If[EnterpriseRuntimeContext, LogicalPlanState, CompilationState](_.maybeExecutionPlan.isEmpty)(
-            Do((_: EnterpriseRuntimeContext).notificationLogger.log(RuntimeUnsupportedNotification)) andThen
-              pickInterpretedExecutionPlan()
-          )
+        BuildVectorizedExecutionPlan andThen FallbackWithNotification(pickInterpretedExecutionPlan())
 
       case Some(SlottedRuntimeName) if useErrorsOverWarnings =>
-        BuildSlottedExecutionPlan andThen
-          If[EnterpriseRuntimeContext, LogicalPlanState, CompilationState](_.maybeExecutionPlan.isEmpty) {
-            Do((_, _) => throw new InvalidArgumentException("The given query is not currently supported in the selected runtime"))
-          }
+        BuildSlottedExecutionPlan andThen AssertExecutionPlan
 
       case Some(SlottedRuntimeName) =>
         BuildSlottedExecutionPlan andThen
-          If[EnterpriseRuntimeContext, LogicalPlanState, CompilationState](_.maybeExecutionPlan.isEmpty) {
-            Do((_: EnterpriseRuntimeContext).notificationLogger.log(RuntimeUnsupportedNotification)) andThen
-              BuildInterpretedExecutionPlan
-          }
+          FallbackWithNotification(BuildInterpretedExecutionPlan)
 
       case Some(CompiledRuntimeName) if useErrorsOverWarnings =>
-        BuildCompiledExecutionPlan andThen
-          If[EnterpriseRuntimeContext, LogicalPlanState, CompilationState](_.maybeExecutionPlan.isEmpty)(
-            Do((_, _) => throw new InvalidArgumentException("The given query is not currently supported in the selected runtime"))
-          )
+        BuildCompiledExecutionPlan andThen AssertExecutionPlanAndWrapException
 
       case Some(CompiledRuntimeName) =>
-        BuildCompiledExecutionPlan andThen
-          If[EnterpriseRuntimeContext, LogicalPlanState, CompilationState](_.maybeExecutionPlan.isEmpty)(
-            Do((_: EnterpriseRuntimeContext).notificationLogger.log(RuntimeUnsupportedNotification)) andThen
-              pickInterpretedExecutionPlan()
-          )
+        BuildCompiledExecutionPlan andThen FallbackWithNotification(pickInterpretedExecutionPlan())
 
       case Some(x) =>
         throw new InvalidArgumentException(s"This version of Neo4j does not support requested runtime: $x")

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/BuildCompiledExecutionPlan.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/BuildCompiledExecutionPlan.scala
@@ -19,22 +19,21 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled
 
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.ExecutionPlanBuilder.DescriptionProvider
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.codegen._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.helpers.InternalWrapping.asKernelNotification
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.phases.CompilationState
-import org.neo4j.cypher.internal.runtime.planDescription.InternalPlanDescription.Arguments
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime._
 import org.neo4j.cypher.internal.compiler.v3_4.phases.LogicalPlanState
 import org.neo4j.cypher.internal.compiler.v3_4.planner.CantCompileQueryException
 import org.neo4j.cypher.internal.frontend.v3_4.PlannerName
-import org.neo4j.cypher.internal.frontend.v3_4.notification.InternalNotification
 import org.neo4j.cypher.internal.frontend.v3_4.phases.CompilationPhaseTracer.CompilationPhase.CODE_GENERATION
 import org.neo4j.cypher.internal.frontend.v3_4.phases.Phase
-import org.neo4j.cypher.internal.planner.v3_4.spi.{GraphStatistics, PlanContext}
+import org.neo4j.cypher.internal.planner.v3_4.spi.GraphStatistics
 import org.neo4j.cypher.internal.runtime._
 import org.neo4j.cypher.internal.runtime.planDescription.InternalPlanDescription
+import org.neo4j.cypher.internal.runtime.planDescription.InternalPlanDescription.Arguments
 import org.neo4j.cypher.internal.util.v3_4.TaskCloser
 import org.neo4j.cypher.internal.v3_4.codegen.profiling.ProfilingTracer
 import org.neo4j.cypher.internal.v3_4.logical.plans.IndexUsage
@@ -122,8 +121,6 @@ object BuildCompiledExecutionPlan extends Phase[EnterpriseRuntimeContext, Logica
     override def isStale(lastTxId: () => Long, statistics: GraphStatistics) = fingerprint.isStale(lastTxId, statistics)
 
     override def runtimeUsed: RuntimeName = CompiledRuntimeName
-
-    override def notifications(planContext: PlanContext): Seq[InternalNotification] = Seq.empty
 
     override def plannedIndexUsage: Seq[IndexUsage] = compiled.plannedIndexUsage
 

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/BuildCompiledExecutionPlan.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/BuildCompiledExecutionPlan.scala
@@ -41,6 +41,8 @@ import org.neo4j.cypher.internal.v3_4.logical.plans.IndexUsage
 import org.neo4j.graphdb.Notification
 import org.neo4j.values.virtual.MapValue
 
+import scala.util.{Failure, Success}
+
 object BuildCompiledExecutionPlan extends Phase[EnterpriseRuntimeContext, LogicalPlanState, CompilationState] {
 
   override def phase = CODE_GENERATION
@@ -59,11 +61,11 @@ object BuildCompiledExecutionPlan extends Phase[EnterpriseRuntimeContext, Logica
                                   context.createFingerprintReference(compiled.fingerprint),
                                   notifications(context))
       runtimeSuccessRateMonitor.newPlanSeen(from.logicalPlan)
-      new CompilationState(from, Some(executionPlan))
+      new CompilationState(from, Success(executionPlan))
     } catch {
       case e: CantCompileQueryException =>
         runtimeSuccessRateMonitor.unableToHandlePlan(from.logicalPlan, e)
-        new CompilationState(from, None)
+        new CompilationState(from, Failure(e))
     }
   }
 

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/CompiledRuntimeBuilder.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/CompiledRuntimeBuilder.scala
@@ -32,7 +32,7 @@ class CompiledRuntimeBuilder extends RuntimeBuilder[Transformer[EnterpriseRuntim
     runtimeName match {
       case None =>
         BuildCompiledExecutionPlan andThen
-          If[EnterpriseRuntimeContext, LogicalPlanState, CompilationState](_.maybeExecutionPlan.isEmpty)(
+          If[EnterpriseRuntimeContext, LogicalPlanState, CompilationState](_.maybeExecutionPlan.isFailure)(
             BuildInterpretedExecutionPlan
           )
 
@@ -41,13 +41,13 @@ class CompiledRuntimeBuilder extends RuntimeBuilder[Transformer[EnterpriseRuntim
 
       case Some(CompiledRuntimeName) if useErrorsOverWarnings =>
         BuildCompiledExecutionPlan andThen
-          If[EnterpriseRuntimeContext, LogicalPlanState, CompilationState](_.maybeExecutionPlan.isEmpty)(
+          If[EnterpriseRuntimeContext, LogicalPlanState, CompilationState](_.maybeExecutionPlan.isFailure)(
             Do[EnterpriseRuntimeContext, LogicalPlanState, CompilationState]((_, _) => throw new InvalidArgumentException("The given query is not currently supported in the selected runtime"))
           )
 
       case Some(CompiledRuntimeName) =>
         BuildCompiledExecutionPlan andThen
-          If[EnterpriseRuntimeContext, LogicalPlanState, CompilationState](_.maybeExecutionPlan.isEmpty)(
+          If[EnterpriseRuntimeContext, LogicalPlanState, CompilationState](_.maybeExecutionPlan.isFailure)(
             Do((ctx: EnterpriseRuntimeContext) => warnThatCompiledRuntimeDoesNotYetSupportQuery(ctx)) andThen
               BuildInterpretedExecutionPlan
           )

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/MorselExecutionContext.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/MorselExecutionContext.scala
@@ -66,4 +66,6 @@ class MorselExecutionContext(morsel: Morsel, longsPerRow: Int, refsPerRow: Int, 
   override def iterator: Iterator[(String, AnyValue)] = ???
 
   override def newScopeWith1(key1: String, value1: AnyValue) = ???
+
+  override def newScopeWith2(key1: String, value1: AnyValue, key2: String, value2: AnyValue) = ???
 }

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/Slot.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/Slot.scala
@@ -26,7 +26,7 @@ sealed trait Slot {
   def nullable: Boolean
   def typ: CypherType
   def isTypeCompatibleWith(other: Slot): Boolean
-  def isLongSlot(): Boolean
+  def isLongSlot: Boolean
 }
 
 case class LongSlot(offset: Int, nullable: Boolean, typ: CypherType) extends Slot {
@@ -36,7 +36,7 @@ case class LongSlot(offset: Int, nullable: Boolean, typ: CypherType) extends Slo
     case _ => false
   }
 
-  override def isLongSlot(): Boolean = true
+  override def isLongSlot: Boolean = true
 }
 
 case class RefSlot(offset: Int, nullable: Boolean, typ: CypherType) extends Slot {
@@ -46,7 +46,7 @@ case class RefSlot(offset: Int, nullable: Boolean, typ: CypherType) extends Slot
     case _ => false
   }
 
-  override def isLongSlot(): Boolean = false
+  override def isLongSlot: Boolean = false
 }
 
 sealed trait SlotWithAliases {

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
@@ -370,7 +370,7 @@ object SlotAllocation {
                        IdName(to),
                        IdName(edge),
                        _,
-                       ExpandAll,
+                       expansionMode,
                        IdName(tempNode),
                        IdName(tempEdge),
                        _,
@@ -384,7 +384,9 @@ object SlotAllocation {
         source.newLong(tempNode, nullable = false, CTNode)
         source.newLong(tempEdge, nullable = false, CTRelationship)
 
-        result.newLong(to, nullable, CTNode)
+        if (expansionMode == ExpandAll) {
+          result.newLong(to, nullable, CTNode)
+        }
         result.newReference(edge, nullable, CTList(CTRelationship))
         result
 

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
@@ -458,17 +458,17 @@ object SlotAllocation {
 
       case ProjectEndpoints(_, _, start, startInScope, end, endInScope, _, _, _) =>
         if (!startInScope)
-          source.newLong(start.name, nullable = false, CTNode)
+          source.newLong(start.name, nullable, CTNode)
         if (!endInScope)
-          source.newLong(end.name, nullable = false, CTNode)
+          source.newLong(end.name, nullable, CTNode)
         source
 
       case LoadCSV(_, _, variableName, NoHeaders, _, _) =>
-        source.newReference(variableName.name, false, CTList(CTAny))
+        source.newReference(variableName.name, nullable, CTList(CTAny))
         source
 
       case LoadCSV(_, _, variableName, HasHeaders, _, _) =>
-        source.newReference(variableName.name, false, CTMap)
+        source.newReference(variableName.name, nullable, CTMap)
         source
 
       case ProcedureCall(_, ResolvedCall(_, _, callResults, _, _)) =>

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriter.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlottedRewriter.scala
@@ -21,7 +21,6 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime
 
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.ast._
 import org.neo4j.cypher.internal.compiler.v3_4.planner.CantCompileQueryException
-import org.neo4j.cypher.internal.frontend.v3_4.ast.rewriters.DesugaredMapProjection
 import org.neo4j.cypher.internal.planner.v3_4.spi.TokenContext
 import org.neo4j.cypher.internal.util.v3_4.AssertionUtils.ifAssertionsEnabled
 import org.neo4j.cypher.internal.util.v3_4.Foldable._
@@ -227,17 +226,17 @@ class SlottedRewriter(tokenContext: TokenContext) {
       case e @ IsNull(prop @ Property(Variable(key), PropertyKeyName(propKey))) =>
         Not(checkIfPropertyExists(slotConfiguration, key, propKey, prop))(e.position)
 
-      case _: ReduceExpression =>
-        throw new CantCompileQueryException(s"Expressions with reduce are not yet supported in slot allocation")
-
-      case _: DesugaredMapProjection =>
-        throw new CantCompileQueryException(s"Expressions with map projections are not yet supported in slot allocation")
-
-      case _: ShortestPathExpression =>
-        throw new CantCompileQueryException(s"Expressions with shortestPath functions not yet supported in slot allocation")
-
-      case _: PatternExpression =>
-        throw new CantCompileQueryException(s"Pattern expressions not yet supported in the slotted runtime")
+//      case _: ReduceExpression =>
+//        throw new CantCompileQueryException(s"Expressions with reduce are not yet supported in slot allocation")
+//
+//      case _: DesugaredMapProjection =>
+//        throw new CantCompileQueryException(s"Expressions with map projections are not yet supported in slot allocation")
+//
+//      case _: ShortestPathExpression =>
+//        throw new CantCompileQueryException(s"Expressions with shortestPath functions not yet supported in slot allocation")
+//
+//      case _: PatternExpression =>
+//        throw new CantCompileQueryException(s"Pattern expressions not yet supported in the slotted runtime")
     }
     topDown(rewriter = innerRewriter, stopper = stopAtOtherLogicalPlans(thisPlan))
   }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/PrimitiveExecutionContext.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/PrimitiveExecutionContext.scala
@@ -200,6 +200,14 @@ case class PrimitiveExecutionContext(slots: SlotConfiguration) extends Execution
     scopeContext
   }
 
+  override def newScopeWith2(key1: String, value1: AnyValue, key2: String, value2: AnyValue): ExecutionContext = {
+    val scopeContext = PrimitiveExecutionContext(slots)
+    copyTo(scopeContext)
+    scopeContext.setValue(key1, value1)
+    scopeContext.setValue(key2, value2)
+    scopeContext
+  }
+
   private def setValue(key1: String, value1: AnyValue): Unit = {
     (slots.get(key1), value1) match {
       case (Some(RefSlot(offset, _, _)), _) =>

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilder.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilder.scala
@@ -160,9 +160,9 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
 
       case Optional(inner, symbols) =>
         val nullableKeys = inner.availableSymbols -- symbols
-        val nullableOffsets = nullableKeys.map(k => slots.getLongOffsetFor(k.name))
+        val nullableSlots = nullableKeys.map(k => slots.get(k.name).get)
         val argumentSize = physicalPlan.argumentSizes(plan.assignedId)
-        OptionalSlottedPipe(source, nullableOffsets.toSeq, slots, argumentSize)(id)
+        OptionalSlottedPipe(source, nullableSlots.toSeq, slots, argumentSize)(id)
 
       case Projection(_, expressions) =>
         val expressionsWithSlots: Map[Int, Expression] = expressions collect {

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilder.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilder.scala
@@ -25,7 +25,6 @@ import org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan.builde
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.pipes.DropResultPipe
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.{expressions => slottedExpressions}
-import org.neo4j.cypher.internal.compiler.v3_4.planner.CantCompileQueryException
 import org.neo4j.cypher.internal.frontend.v3_4.phases.Monitors
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.SemanticTable
 import org.neo4j.cypher.internal.ir.v3_4.{IdName, VarPatternLength}
@@ -87,7 +86,8 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
         ArgumentSlottedPipe(slots, argumentSize)(id)
 
       case _ =>
-        throw new CantCompileQueryException(s"Unsupported logical plan operator: $plan")
+        fallback.build(plan)
+        //throw new CantCompileQueryException(s"Unsupported logical plan operator: $plan")
 
     }
     pipe.setExecutionContextFactory(SlottedExecutionContextFactory(slots))
@@ -279,7 +279,8 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
         fallback.build(plan, source)
 
       case _ =>
-        throw new CantCompileQueryException(s"Unsupported logical plan operator: $plan")
+        fallback.build(plan, source)
+        //throw new CantCompileQueryException(s"Unsupported logical plan operator: $plan")
     }
     pipe.setExecutionContextFactory(SlottedExecutionContextFactory(slots))
     pipe
@@ -429,7 +430,8 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
         fallback.build(plan, lhs, rhs)
 
       case _ =>
-        throw new CantCompileQueryException(s"Unsupported logical plan operator: $plan")
+        fallback.build(plan, lhs, rhs)
+        //throw new CantCompileQueryException(s"Unsupported logical plan operator: $plan")
     }
     pipe.setExecutionContextFactory(SlottedExecutionContextFactory(slots))
     pipe

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilder.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilder.scala
@@ -200,7 +200,7 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
       case Aggregation(_, groupingExpressions, aggregationExpression) =>
         val grouping = groupingExpressions.map {
           case (key, expression) =>
-            slots.getReferenceOffsetFor(key) -> convertExpressions(expression)
+            slots(key) -> convertExpressions(expression)
         }
         val aggregation = aggregationExpression.map {
           case (key, expression) =>
@@ -212,9 +212,8 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
       case Distinct(_, groupingExpressions) =>
         val grouping = groupingExpressions.map {
           case (key, expression) =>
-            slots.getReferenceOffsetFor(key) -> convertExpressions(expression)
+            slots(key) -> convertExpressions(expression)
         }
-
         DistinctSlottedPipe(source, slots, grouping)(id)
 
       case CreateRelationship(_, idName, IdName(startNode), typ, IdName(endNode), props) =>

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilder.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilder.scala
@@ -87,8 +87,6 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
 
       case _ =>
         fallback.build(plan)
-        //throw new CantCompileQueryException(s"Unsupported logical plan operator: $plan")
-
     }
     pipe.setExecutionContextFactory(SlottedExecutionContextFactory(slots))
     pipe

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilder.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilder.scala
@@ -157,9 +157,9 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
 
       case Optional(inner, symbols) =>
         val nullableKeys = inner.availableSymbols -- symbols
-        val nullableSlots = nullableKeys.map(k => slots.get(k.name).get)
+        val nullableSlots: Array[Slot] = nullableKeys.map(k => slots.get(k.name).get).toArray
         val argumentSize = physicalPlan.argumentSizes(plan.assignedId)
-        OptionalSlottedPipe(source, nullableSlots.toArray, slots, argumentSize)(id)
+        OptionalSlottedPipe(source, nullableSlots, slots, argumentSize)(id)
 
       case Projection(_, expressions) =>
         val expressionsWithSlots: Map[Int, Expression] = expressions collect {

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilder.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilder.scala
@@ -159,7 +159,7 @@ class SlottedPipeBuilder(fallback: PipeBuilder,
         val nullableKeys = inner.availableSymbols -- symbols
         val nullableSlots = nullableKeys.map(k => slots.get(k.name).get)
         val argumentSize = physicalPlan.argumentSizes(plan.assignedId)
-        OptionalSlottedPipe(source, nullableSlots.toSeq, slots, argumentSize)(id)
+        OptionalSlottedPipe(source, nullableSlots.toArray, slots, argumentSize)(id)
 
       case Projection(_, expressions) =>
         val expressionsWithSlots: Map[Int, Expression] = expressions collect {

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ExpandIntoSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/ExpandIntoSlottedPipe.scala
@@ -20,10 +20,11 @@
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
 import org.neo4j.collection.primitive.PrimitiveLongIterator
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.{Slot, SlotConfiguration}
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.helpers.PrimitiveLongHelper
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker.entityIsNull
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.SlottedPipeBuilderUtils.makeGetPrimitiveNodeFromSlotFunctionFor
 import org.neo4j.cypher.internal.runtime.interpreted.pipes._
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
@@ -39,25 +40,34 @@ import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection
   * This pipe also caches relationship information between nodes for the duration of the query
   */
 case class ExpandIntoSlottedPipe(source: Pipe,
-                                 fromOffset: Int,
+                                 fromSlot: Slot,
                                  relOffset: Int,
-                                 toOffset: Int,
+                                 toSlot: Slot,
                                  dir: SemanticDirection,
                                  lazyTypes: LazyTypes,
                                  slots: SlotConfiguration)
                                 (val id: LogicalPlanId = LogicalPlanId.DEFAULT)
   extends PipeWithSource(source) with PrimitiveCachingExpandInto {
   self =>
-  private final val CACHE_SIZE = 100000
 
+  //===========================================================================
+  // Compile-time initializations
+  //===========================================================================
+  private final val CACHE_SIZE = 100000
+  private val getFromNodeFunction = makeGetPrimitiveNodeFromSlotFunctionFor(fromSlot)
+  private val getToNodeFunction = makeGetPrimitiveNodeFromSlotFunctionFor(toSlot)
+
+  //===========================================================================
+  // Runtime code
+  //===========================================================================
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     //cache of known connected nodes
     val relCache = new PrimitiveRelationshipsCache(CACHE_SIZE)
 
     input.flatMap {
       inputRow =>
-        val fromNode = inputRow.getLongAt(fromOffset)
-        val toNode = inputRow.getLongAt(toOffset)
+        val fromNode = getFromNodeFunction(inputRow)
+        val toNode = getToNodeFunction(inputRow)
 
         if (entityIsNull(fromNode) || entityIsNull(toNode))
           Iterator.empty

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalExpandAllSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalExpandAllSlottedPipe.scala
@@ -19,10 +19,11 @@
  */
 package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
-import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.{Slot, SlotConfiguration}
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.helpers.PrimitiveLongHelper
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.SlottedPipeBuilderUtils.makeGetPrimitiveNodeFromSlotFunctionFor
 import org.neo4j.cypher.internal.util.v3_4.InternalException
 import org.neo4j.cypher.internal.runtime.interpreted.commands.predicates.Predicate
 import org.neo4j.cypher.internal.runtime.interpreted.pipes._
@@ -33,7 +34,7 @@ import org.neo4j.kernel.impl.api.RelationshipVisitor
 import org.neo4j.kernel.impl.api.store.RelationshipIterator
 
 case class OptionalExpandAllSlottedPipe(source: Pipe,
-                                        fromOffset: Int,
+                                        fromSlot: Slot,
                                         relOffset: Int,
                                         toOffset: Int,
                                         dir: SemanticDirection,
@@ -42,10 +43,18 @@ case class OptionalExpandAllSlottedPipe(source: Pipe,
                                         slots: SlotConfiguration)
                                        (val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends PipeWithSource(source) with Pipe {
 
+  //===========================================================================
+  // Compile-time initializations
+  //===========================================================================
+  private val getFromNodeFunction = makeGetPrimitiveNodeFromSlotFunctionFor(fromSlot)
+
+  //===========================================================================
+  // Runtime code
+  //===========================================================================
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     input.flatMap {
       (inputRow: ExecutionContext) =>
-        val fromNode = inputRow.getLongAt(fromOffset)
+        val fromNode = getFromNodeFunction(inputRow)
 
         if (NullChecker.entityIsNull(fromNode)) {
           Iterator(withNulls(inputRow))

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalSlottedPipe.scala
@@ -33,7 +33,10 @@ case class OptionalSlottedPipe(source: Pipe,
                               (val id: LogicalPlanId = LogicalPlanId.DEFAULT)
   extends PipeWithSource(source) with Pipe {
 
-  val setNullableSlotToNullFunctions =
+  //===========================================================================
+  // Compile-time initializations
+  //===========================================================================
+  private val setNullableSlotToNullFunctions =
     nullableSlots.map {
       case LongSlot(offset, _, _) =>
         (context: ExecutionContext) => context.setLongAt(offset, -1L)
@@ -41,7 +44,10 @@ case class OptionalSlottedPipe(source: Pipe,
         (context: ExecutionContext) => context.setRefAt(offset, Values.NO_VALUE)
     }
 
-  def setNullableSlotsToNull(context: ExecutionContext) =
+  //===========================================================================
+  // Runtime code
+  //===========================================================================
+  private def setNullableSlotsToNull(context: ExecutionContext) =
     setNullableSlotToNullFunctions.foreach { f =>
       f(context)
     }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalSlottedPipe.scala
@@ -27,7 +27,7 @@ import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 import org.neo4j.values.storable.Values
 
 case class OptionalSlottedPipe(source: Pipe,
-                               nullableSlots: Array[Slot],
+                               nullableSlots: Seq[Slot],
                                slots: SlotConfiguration,
                                argumentSize: SlotConfiguration.Size)
                               (val id: LogicalPlanId = LogicalPlanId.DEFAULT)

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/OptionalSlottedPipe.scala
@@ -27,7 +27,7 @@ import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 import org.neo4j.values.storable.Values
 
 case class OptionalSlottedPipe(source: Pipe,
-                               nullableSlots: Seq[Slot],
+                               nullableSlots: Array[Slot],
                                slots: SlotConfiguration,
                                argumentSize: SlotConfiguration.Size)
                               (val id: LogicalPlanId = LogicalPlanId.DEFAULT)

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/VarLengthExpandSlottedPipe.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/pipes/VarLengthExpandSlottedPipe.scala
@@ -21,6 +21,7 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.pipes
 
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.SlotConfiguration
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.PrimitiveExecutionContext
+import org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted.helpers.NullChecker.entityIsNull
 import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
 import org.neo4j.cypher.internal.runtime.interpreted.commands.predicates.Predicate
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.{LazyTypes, Pipe, PipeWithSource, QueryState}
@@ -31,6 +32,7 @@ import org.neo4j.kernel.impl.api.RelationshipVisitor
 import org.neo4j.kernel.impl.api.store.RelationshipIterator
 import org.neo4j.values.storable.Values
 import org.neo4j.values.virtual.{EdgeValue, VirtualValues}
+import org.neo4j.values.storable.Values
 
 import scala.collection.mutable
 
@@ -111,7 +113,7 @@ case class VarLengthExpandSlottedPipe(source: Pipe,
     input.flatMap {
       inputRow =>
         val fromNode = inputRow.getLongAt(fromOffset)
-        if (fromNode == -1) {
+        if (entityIsNull(fromNode)) {
           val resultRow = PrimitiveExecutionContext(slots)
           resultRow.copyFrom(inputRow, argumentSize.nLongs, argumentSize.nReferences)
           resultRow.setRefAt(relOffset, Values.NO_VALUE)

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilderTest.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilderTest.scala
@@ -197,7 +197,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
     val zNodeSlot = LongSlot(2, nullable = false, CTNode)
     pipe should equal(ExpandAllSlottedPipe(
       AllNodesScanSlottedPipe("x", X_NODE_SLOTS, Size.zero)(),
-      xNodeSlot.offset, rRelSlot.offset, zNodeSlot.offset,
+      xNodeSlot, rRelSlot.offset, zNodeSlot.offset,
       SemanticDirection.INCOMING,
       LazyTypes.empty,
       SlotConfiguration(Map(
@@ -220,7 +220,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
     val relSlot = LongSlot(1, nullable = false, CTRelationship)
     pipe should equal(ExpandIntoSlottedPipe(
       AllNodesScanSlottedPipe("x", X_NODE_SLOTS, Size.zero)(),
-      nodeSlot.offset, relSlot.offset, nodeSlot.offset, SemanticDirection.INCOMING, LazyTypes.empty,
+      nodeSlot, relSlot.offset, nodeSlot, SemanticDirection.INCOMING, LazyTypes.empty,
       SlotConfiguration(Map("x" -> nodeSlot, "r" -> relSlot), numberOfLongs = 2, numberOfReferences = 0)
     )())
   }
@@ -252,7 +252,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
           allNodeScanSlots,
           Size.zero
         )(),
-        xNodeSlot.offset, rRelSlot.offset, zNodeSlot.offset,
+        xNodeSlot, rRelSlot.offset, zNodeSlot.offset,
         SemanticDirection.INCOMING,
         LazyTypes.empty,
         expandSlots
@@ -282,7 +282,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
           allNodeScanSlots,
           Size.zero
         )(),
-        nodeSlot.offset, relSlot.offset, nodeSlot.offset, SemanticDirection.INCOMING, LazyTypes.empty,
+        nodeSlot, relSlot.offset, nodeSlot, SemanticDirection.INCOMING, LazyTypes.empty,
         expandSlots)()
     )
   }
@@ -340,7 +340,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
     // then
     pipe should equal(OptionalExpandAllSlottedPipe(
       AllNodesScanSlottedPipe("x", X_NODE_SLOTS, Size.zero)(),
-      0, 1, 2, SemanticDirection.INCOMING, LazyTypes.empty, predicates.True(),
+      X_NODE_SLOTS("x"), 1, 2, SemanticDirection.INCOMING, LazyTypes.empty, predicates.True(),
       SlotConfiguration(Map(
         "x" -> LongSlot(0, nullable = false, CTNode),
         "r" -> LongSlot(1, nullable = true, CTRelationship),
@@ -359,7 +359,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
     // then
     pipe should equal(OptionalExpandIntoSlottedPipe(
       AllNodesScanSlottedPipe("x", X_NODE_SLOTS, Size.zero)(),
-      0, 1, 0, SemanticDirection.INCOMING, LazyTypes.empty, predicates.True(),
+      X_NODE_SLOTS("x"), 1, X_NODE_SLOTS("x"), SemanticDirection.INCOMING, LazyTypes.empty, predicates.True(),
       SlotConfiguration(Map(
         "x" -> LongSlot(0, nullable = false, CTNode),
         "r" -> LongSlot(1, nullable = true, CTRelationship)), numberOfLongs = 2, numberOfReferences = 0)
@@ -397,7 +397,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
 
     pipe should equal(VarLengthExpandSlottedPipe(
       AllNodesScanSlottedPipe("x", allNodeScanSlots, Size.zero)(),
-      xNodeSlot.offset, rRelSlot.offset, zNodeSlot.offset,
+      xNodeSlot, rRelSlot.offset, zNodeSlot,
       SemanticDirection.INCOMING, SemanticDirection.INCOMING,
       LazyTypes.empty, varLength.min, varLength.max, shouldExpandAll = true,
       varExpandSlots,
@@ -453,11 +453,11 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
       VarLengthExpandSlottedPipe(
         ExpandAllSlottedPipe(
           AllNodesScanSlottedPipe("x", allNodeScanSlots, Size.zero)(),
-          xNodeSlot.offset, rRelSlot.offset, zNodeSlot.offset,
+          xNodeSlot, rRelSlot.offset, zNodeSlot.offset,
           SemanticDirection.OUTGOING,
           LazyTypes.empty,
           expandSlots)(),
-        xNodeSlot.offset, r2RelSlot.offset, zNodeSlot.offset,
+        xNodeSlot, r2RelSlot.offset, zNodeSlot,
         SemanticDirection.INCOMING, SemanticDirection.INCOMING,
         LazyTypes.empty, varLength.min, varLength.max, shouldExpandAll = false,
         varExpandSlots,
@@ -500,7 +500,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
 
     pipe should equal(VarLengthExpandSlottedPipe(
       AllNodesScanSlottedPipe("x", allNodeScanSlots, Size.zero)(),
-      xNodeSlot.offset, rRelSlot.offset, zNodeSlot.offset,
+      xNodeSlot, rRelSlot.offset, zNodeSlot,
       SemanticDirection.INCOMING, SemanticDirection.INCOMING,
       LazyTypes.empty, varLength.min, varLength.max, shouldExpandAll = true,
       varExpandSlots,
@@ -694,7 +694,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
       NodesByLabelScanSlottedPipe("x", LazyLabel(LABEL), lhsSlots, Size.zero)(),
       ExpandAllSlottedPipe(
         ArgumentSlottedPipe(lhsSlots, Size(1, 0))(),
-        0, 1, 2, SemanticDirection.INCOMING, LazyTypes.empty, rhsSlots
+        rhsSlots("x"), 1, 2, SemanticDirection.INCOMING, LazyTypes.empty, rhsSlots
       )()
     )())
   }

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilderTest.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilderTest.scala
@@ -309,7 +309,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
 
   test("optional refslot value") {
     // given
-    val arg = Argument(Set.empty)(solved)()
+    val arg = Argument(Set.empty)(solved)
     val project = Projection(arg, Map("x" -> literalInt(1)))(solved)
     val plan = Optional(project)(solved)
 

--- a/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilderTest.scala
+++ b/enterprise/cypher/slotted-runtime/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedPipeBuilderTest.scala
@@ -48,6 +48,7 @@ import org.neo4j.cypher.internal.v3_4.expressions._
 import org.neo4j.cypher.internal.v3_4.logical.plans
 import org.neo4j.cypher.internal.v3_4.logical.plans._
 
+//noinspection NameBooleanParameters
 class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupport2 {
 
   implicit private val table = SemanticTable()
@@ -248,7 +249,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
       ExpandAllSlottedPipe(
         OptionalSlottedPipe(
           AllNodesScanSlottedPipe("x", allNodeScanSlots, Size.zero)(),
-          Seq(xNodeSlot),
+          Array(xNodeSlot),
           allNodeScanSlots,
           Size.zero
         )(),
@@ -278,7 +279,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
       ExpandIntoSlottedPipe(
         OptionalSlottedPipe(
           AllNodesScanSlottedPipe("x", allNodeScanSlots, Size.zero)(),
-          Seq(nodeSlot),
+          Array(nodeSlot),
           allNodeScanSlots,
           Size.zero
         )(),
@@ -300,7 +301,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
     val expectedSlots = SlotConfiguration(Map("x" -> nodeSlot), numberOfLongs = 1, numberOfReferences = 0)
     pipe should equal(OptionalSlottedPipe(
       AllNodesScanSlottedPipe("x", expectedSlots, Size.zero)(),
-      Seq(nodeSlot),
+      Array(nodeSlot),
       expectedSlots,
       Size.zero
     )())
@@ -323,7 +324,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
         ArgumentSlottedPipe(expectedSlots, Size.zero)(),
         Map(0 -> Literal(1))
       )(),
-      Seq(refSlot),
+      Array(refSlot),
       expectedSlots,
       Size.zero
     )())
@@ -578,7 +579,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
 
     // then
     val labelScan = NodesByLabelScanSlottedPipe("x", LazyLabel("label"), X_NODE_SLOTS, Size.zero)()
-    val optionalPipe = OptionalSlottedPipe(labelScan, Seq(X_NODE_SLOTS("x")), X_NODE_SLOTS, Size.zero)()
+    val optionalPipe = OptionalSlottedPipe(labelScan, Array(X_NODE_SLOTS("x")), X_NODE_SLOTS, Size.zero)()
     pipe should equal(DistinctPipe(
       optionalPipe,
       Map("x" -> Variable("x"), "x.propertyKey" -> Property(Variable("x"), KeyToken.Resolved("propertyKey", 0, PropertyKey)))
@@ -603,7 +604,7 @@ class SlottedPipeBuilderTest extends CypherFunSuite with LogicalPlanningTestSupp
       "x.propertyKey" -> Property(Variable("x"), KeyToken.Resolved("propertyKey", 0, PropertyKey))
     )
     pipe should equal(EagerAggregationPipe(
-      OptionalSlottedPipe(nodeByLabelScan, Seq(X_NODE_SLOTS("x")), X_NODE_SLOTS, Size.zero)(),
+      OptionalSlottedPipe(nodeByLabelScan, Array(X_NODE_SLOTS("x")), X_NODE_SLOTS, Size.zero)(),
       keyExpressions = grouping,
       aggregations = Map("count" -> commands.expressions.CountStar())
     )())


### PR DESCRIPTION
This PR bumps the slotted runtime to cover all Cypher queries which interpreted handles. 

That feat is completed by 
 * implementing slot allocation for the remaining operators
 * enabling fallback to interpreted pipes for operators which are not yet slotted
 * fixing some remaining minor bugs and issues in the slotted pipe implementations

Falling back to interpreted pipes in some cases is expected to have worse performance that making these pipes slotted, but it will still improve over interpreted as we reduce copying of execution contexts and improve slot cache locality. Once every query can run with slotted, we can perform benchmarking and profiling to detect which optimization we should pursue, and possibly implement slotted version of additional pipes.

This PR also changes several slotted pipes to handle nodes and relationships regardless of whether these are in `LongSlot`s or `RefSlot`s. This is done by making getter and setter functions for these slots on `Pipe` construction. Possibly we can get away with having any nodes and relationship in `RefSlot`s later, but for now this seems like the safe thing.
