### PR TITLE
Fix regressions in Core API

### DIFF
--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Read.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Read.java
@@ -74,6 +74,13 @@ public interface Read
     void singleNode( long reference, NodeCursor cursor );
 
     /**
+     * Checks if a node exists in the database
+     * @param id The id of the node to check
+     * @return <tt>true</tt> if the node exists, otherwise <tt>false</tt>
+     */
+    boolean nodeExists( long id );
+
+    /**
      * @param reference
      *         a reference from {@link RelationshipDataAccessor#relationshipReference()}.
      * @param cursor

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/TransactionStateTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/TransactionStateTestBase.java
@@ -454,6 +454,66 @@ public abstract class TransactionStateTestBase<G extends KernelAPIWriteTestSuppo
         }
     }
 
+    @Test
+    public void shouldSeeExistingNode() throws Exception
+    {
+        // Given
+        long node;
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            node = tx.dataWrite().nodeCreate();
+            tx.success();
+        }
+
+        // Then
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            assertTrue( tx.dataRead().nodeExists( node ) );
+        }
+    }
+
+    @Test
+    public void shouldNotSeeNonExistingNode() throws Exception
+    {
+        // Given, empty db
+
+        // Then
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            assertFalse( tx.dataRead().nodeExists( 1337L ) );
+        }
+    }
+
+    @Test
+    public void shouldSeeNodeExistingInTxOnly() throws Exception
+    {
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            long node = tx.dataWrite().nodeCreate();
+            assertTrue( tx.dataRead().nodeExists( node ) );
+
+        }
+    }
+
+    @Test
+    public void shouldNotSeeDeletedNode() throws Exception
+    {
+        // Given
+        long node;
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            node = tx.dataWrite().nodeCreate();
+            tx.success();
+        }
+
+        // Then
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            tx.dataWrite().nodeDelete( node );
+            assertFalse( tx.dataRead().nodeExists( node ) );
+        }
+    }
+
     private void assertLabels( LabelSet labels, int... expected )
     {
         assertEquals( expected.length, labels.numberOfLabels() );

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
@@ -21,12 +21,10 @@ package org.neo4j.kernel.api;
 
 import java.util.Optional;
 
-import org.neo4j.internal.kernel.api.NodeCursor;
-import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.Transaction;
+import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.api.Kernel;
 
 /**
@@ -97,10 +95,6 @@ public interface KernelTransaction extends Transaction
      * @return a {@link Statement} with access to underlying database.
      */
     Statement acquireStatement();
-
-    NodeCursor nodeCursor();
-
-    PropertyCursor propertyCursor();
 
     /**
      * Closes this transaction, committing its changes if {@link #success()} has been called and neither

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
@@ -21,6 +21,8 @@ package org.neo4j.kernel.api;
 
 import java.util.Optional;
 
+import org.neo4j.internal.kernel.api.NodeCursor;
+import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.Transaction;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
@@ -95,6 +97,10 @@ public interface KernelTransaction extends Transaction
      * @return a {@link Statement} with access to underlying database.
      */
     Statement acquireStatement();
+
+    NodeCursor nodeCursor();
+
+    PropertyCursor propertyCursor();
 
     /**
      * Closes this transaction, committing its changes if {@link #success()} has been called and neither

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -478,7 +478,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         }
     }
 
-    private void assertOpen()
+    public void assertOpen()
     {
         Optional<Status> terminationReason = getReasonIfTerminated();
         if ( terminationReason.isPresent() )
@@ -724,7 +724,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     public Read dataRead()
     {
         currentStatement.assertAllows( AccessMode::allowsReads, "Read" );
-        return operations;
+        return operations.dataRead();
     }
 
     @Override
@@ -754,7 +754,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     @Override
     public ExplicitIndexRead indexRead()
     {
-        return operations;
+        return operations.indexRead();
     }
 
     @Override
@@ -766,7 +766,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     @Override
     public SchemaRead schemaRead()
     {
-        return operations;
+        return operations.schemaRead();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -37,12 +37,9 @@ import org.neo4j.graphdb.TransactionTerminatedException;
 import org.neo4j.internal.kernel.api.CursorFactory;
 import org.neo4j.internal.kernel.api.ExplicitIndexRead;
 import org.neo4j.internal.kernel.api.ExplicitIndexWrite;
-import org.neo4j.internal.kernel.api.NodeCursor;
-import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.Read;
 import org.neo4j.internal.kernel.api.SchemaRead;
 import org.neo4j.internal.kernel.api.SchemaWrite;
-import org.neo4j.internal.kernel.api.Token;
 import org.neo4j.internal.kernel.api.TokenRead;
 import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.Write;
@@ -367,18 +364,6 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         assertTransactionOpen();
         currentStatement.acquire();
         return currentStatement;
-    }
-
-    @Override
-    public NodeCursor nodeCursor()
-    {
-        return operations.nodeCursor();
-    }
-
-    @Override
-    public PropertyCursor propertyCursor()
-    {
-        return operations.propertyCursor();
     }
 
     ExecutingQueryList executingQueries()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -37,6 +37,8 @@ import org.neo4j.graphdb.TransactionTerminatedException;
 import org.neo4j.internal.kernel.api.CursorFactory;
 import org.neo4j.internal.kernel.api.ExplicitIndexRead;
 import org.neo4j.internal.kernel.api.ExplicitIndexWrite;
+import org.neo4j.internal.kernel.api.NodeCursor;
+import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.Read;
 import org.neo4j.internal.kernel.api.SchemaRead;
 import org.neo4j.internal.kernel.api.SchemaWrite;
@@ -365,6 +367,18 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         assertTransactionOpen();
         currentStatement.acquire();
         return currentStatement;
+    }
+
+    @Override
+    public NodeCursor nodeCursor()
+    {
+        return operations.nodeCursor();
+    }
+
+    @Override
+    public PropertyCursor propertyCursor()
+    {
+        return operations.propertyCursor();
     }
 
     ExecutingQueryList executingQueries()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -59,8 +59,6 @@ import org.neo4j.kernel.api.exceptions.schema.IllegalTokenNameException;
 import org.neo4j.kernel.api.exceptions.schema.TooManyLabelsException;
 import org.neo4j.kernel.impl.api.operations.KeyReadOperations;
 import org.neo4j.storageengine.api.EntityType;
-import org.neo4j.storageengine.api.NodeItem;
-import org.neo4j.storageengine.api.PropertyItem;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
 
@@ -543,6 +541,38 @@ public class NodeProxy implements Node
             }
             throw new NotFoundException( format( "No such property, '%s'.", key ) );
         }
+
+//        if ( null == key )
+//        {
+//            throw new IllegalArgumentException( "(null) property key is not allowed" );
+//        }
+//
+//        try ( Statement statement = actions.statement() )
+//        {
+//            try
+//            {
+//                int propertyKeyId = statement.readOperations().propertyKeyGetForName( key );
+//                if ( propertyKeyId == KeyReadOperations.NO_SUCH_PROPERTY_KEY )
+//                {
+//                    throw new NotFoundException( format( "No such property, '%s'.", key ) );
+//                }
+//
+//                Value value = statement.readOperations().nodeGetProperty( nodeId, propertyKeyId );
+//
+//                if ( value == Values.NO_VALUE )
+//                {
+//                    throw new PropertyNotFoundException( propertyKeyId, EntityType.NODE, nodeId );
+//                }
+//
+//                return value.asObjectCopy();
+//
+//            }
+//            catch ( EntityNotFoundException | PropertyNotFoundException e )
+//            {
+//                throw new NotFoundException(
+//                        e.getUserMessage( new StatementTokenNameLookup( statement.readOperations() ) ), e );
+//            }
+//        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -505,7 +505,7 @@ public class NodeProxy implements Node
         }
         NodeCursor nodes = transaction.nodeCursor();
         PropertyCursor properties = transaction.propertyCursor();
-        try ( Statement ignore = actions.statement())
+        try ( Statement ignore = actions.statement() )
         {
             transaction.dataRead().singleNode( nodeId, nodes );
             if ( !nodes.next() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -332,7 +332,7 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI
         }
 
         KernelTransaction ktx = spi.currentTransaction();
-        try ( Statement ignore = spi.currentStatement())
+        try ( Statement ignore = spi.currentStatement() )
         {
             if ( !ktx.dataRead().nodeExists( id ) )
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -332,12 +332,9 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI
         }
 
         KernelTransaction ktx = spi.currentTransaction();
-        try ( Statement ignore = spi.currentStatement();
-              NodeCursor nodeCursor = ktx.cursors().allocateNodeCursor()
-        )
+        try ( Statement ignore = spi.currentStatement())
         {
-            ktx.dataRead().singleNode( id, nodeCursor );
-            if ( !nodeCursor.next() )
+            if ( !ktx.dataRead().nodeExists( id ) )
             {
                 throw new NotFoundException( format( "Node %d not found", id ),
                         new EntityNotFoundException( EntityType.NODE, id ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -465,7 +465,7 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI
         {
             KernelTransaction ktx = spi.currentTransaction();
             Statement statement = ktx.acquireStatement();
-            NodeCursor cursor = ktx.nodeCursor();
+            NodeCursor cursor = ktx.cursors().allocateNodeCursor();
             ktx.dataRead().allNodesScan( cursor );
             return new PrefetchingResourceIterator<Node>()
             {
@@ -486,6 +486,7 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI
                 @Override
                 public void close()
                 {
+                    cursor.close();
                     statement.close();
                 }
             };

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -819,10 +818,10 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI
 
     private void assertTransactionOpen( KernelTransaction transaction )
     {
-        Optional<Status> terminationReason = transaction.getReasonIfTerminated();
-        if ( terminationReason.isPresent() )
+        if ( transaction.isTerminated() )
         {
-            throw new TransactionTerminatedException( terminationReason.get() );
+            Status terminationReason = transaction.getReasonIfTerminated().orElse( Status.Transaction.Terminated );
+            throw new TransactionTerminatedException( terminationReason );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -463,7 +463,7 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI
         {
             Statement statement = spi.currentStatement();
             KernelTransaction ktx = spi.currentTransaction();
-            NodeCursor cursor = ktx.cursors().allocateNodeCursor();
+            NodeCursor cursor = ktx.nodeCursor();
             ktx.dataRead().allNodesScan( cursor );
             return new PrefetchingResourceIterator<Node>()
             {
@@ -485,7 +485,6 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI
                 public void close()
                 {
                     statement.close();
-                    cursor.close();
                 }
             };
         };

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -265,9 +265,10 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI
     @Override
     public Node createNode()
     {
-        try ( Statement ignore = spi.currentStatement() )
+        KernelTransaction transaction = spi.currentTransaction();
+        try ( Statement ignore = transaction.acquireStatement() )
         {
-            return new NodeProxy( nodeActions, spi.currentTransaction().dataWrite().nodeCreate() );
+            return new NodeProxy( nodeActions, transaction.dataWrite().nodeCreate() );
         }
         catch ( InvalidTransactionTypeKernelException e )
         {
@@ -278,9 +279,10 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI
     @Override
     public Long createNodeId()
     {
-        try ( Statement ignore = spi.currentStatement() )
+        KernelTransaction transaction = spi.currentTransaction();
+        try ( Statement ignore = transaction.acquireStatement() )
         {
-            return spi.currentTransaction().dataWrite().nodeCreate();
+            return transaction.dataWrite().nodeCreate();
         }
         catch ( InvalidTransactionTypeKernelException e )
         {
@@ -332,7 +334,7 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI
         }
 
         KernelTransaction ktx = spi.currentTransaction();
-        try ( Statement ignore = spi.currentStatement() )
+        try ( Statement ignore = ktx.acquireStatement() )
         {
             if ( !ktx.dataRead().nodeExists( id ) )
             {
@@ -461,8 +463,8 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI
         assertTransactionOpen();
         return () ->
         {
-            Statement statement = spi.currentStatement();
             KernelTransaction ktx = spi.currentTransaction();
+            Statement statement = ktx.acquireStatement();
             NodeCursor cursor = ktx.nodeCursor();
             ktx.dataRead().allNodesScan( cursor );
             return new PrefetchingResourceIterator<Node>()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
@@ -152,6 +152,7 @@ public class AllStoreHolder extends Read implements Token
     @Override
     public CapableIndexReference index( int label, int... properties )
     {
+        assertOpen.assertOpen();
         IndexDescriptor indexDescriptor = storeReadLayer.indexGetForSchema( new LabelSchemaDescriptor( label, properties ) );
         if ( indexDescriptor == null )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
@@ -94,6 +94,8 @@ public class AllStoreHolder extends Read implements Token
     @Override
     public boolean nodeExists( long id )
     {
+        assertOpen.assertOpen();
+
         if ( hasTxStateWithChanges() )
         {
             TransactionState txState = txState();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeCursor.java
@@ -73,11 +73,6 @@ class NodeCursor extends NodeRecord implements org.neo4j.internal.kernel.api.Nod
         this.next = 0;
         this.highMark = read.nodeHighMark();
         this.read = read;
-        if ( labelCursor == null )
-        {
-            labelCursor = read.labelCursor();
-        }
-        this.labelCursor = read.labelCursor();
         this.hasChanges = HasChanges.MAYBE;
         this.addedNodes = null;
     }
@@ -96,10 +91,6 @@ class NodeCursor extends NodeRecord implements org.neo4j.internal.kernel.api.Nod
         //This marks the cursor as a "single cursor"
         this.highMark = NO_ID;
         this.read = read;
-        if ( labelCursor == null )
-        {
-            labelCursor = read.labelCursor();
-        }
         this.hasChanges = HasChanges.MAYBE;
         this.addedNodes = null;
     }
@@ -124,7 +115,7 @@ class NodeCursor extends NodeRecord implements org.neo4j.internal.kernel.api.Nod
             else
             {
                 //Get labels from store and put in intSet, unfortunately we get longs back
-                long[] longs = NodeLabelsField.get( this, labelCursor );
+                long[] longs = NodeLabelsField.get( this, labelCursor() );
                 PrimitiveIntSet labels = Primitive.intSet();
                 for ( long labelToken : longs )
                 {
@@ -138,7 +129,7 @@ class NodeCursor extends NodeRecord implements org.neo4j.internal.kernel.api.Nod
         else
         {
             //Nothing in tx state, just read the data.
-            return new Labels( NodeLabelsField.get( this, labelCursor ) );
+            return new Labels( NodeLabelsField.get( this, labelCursor()) );
         }
     }
 
@@ -345,6 +336,15 @@ class NodeCursor extends NodeRecord implements org.neo4j.internal.kernel.api.Nod
     {
         next = NO_ID;
         setId( NO_ID );
+    }
+
+    private RecordCursor<DynamicRecord> labelCursor()
+    {
+        if ( labelCursor == null )
+        {
+            labelCursor = read.labelCursor();
+        }
+        return labelCursor;
     }
 
     private boolean isSingle()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeCursor.java
@@ -336,6 +336,7 @@ class NodeCursor extends NodeRecord implements org.neo4j.internal.kernel.api.Nod
     {
         next = NO_ID;
         setId( NO_ID );
+        clear();
     }
 
     private RecordCursor<DynamicRecord> labelCursor()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.impl.newapi;
 
 import java.util.Map;
-import java.util.Optional;
 
 import org.neo4j.graphdb.TransactionTerminatedException;
 import org.neo4j.internal.kernel.api.CapableIndexReference;
@@ -665,5 +664,15 @@ public class Operations implements Read, ExplicitIndexRead, SchemaRead, Write, E
     private void acquireSharedLabelLock( int labelId )
     {
         ktx.locks().optimistic().acquireShared( ktx.lockTracer(), ResourceTypes.LABEL, labelId );
+    }
+
+    public NodeCursor nodeCursor()
+    {
+        return nodeCursor;
+    }
+
+    public PropertyCursor propertyCursor()
+    {
+        return propertyCursor;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
@@ -164,6 +164,13 @@ public class Operations implements Read, ExplicitIndexRead, SchemaRead, Write, E
     }
 
     @Override
+    public boolean nodeExists( long id )
+    {
+        assertOpen();
+        return allStoreHolder.nodeExists( id );
+    }
+
+    @Override
     public void singleRelationship( long reference, RelationshipScanCursor cursor )
     {
         assertOpen();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
@@ -21,32 +21,16 @@ package org.neo4j.kernel.impl.newapi;
 
 import java.util.Map;
 
-import org.neo4j.graphdb.TransactionTerminatedException;
-import org.neo4j.internal.kernel.api.CapableIndexReference;
 import org.neo4j.internal.kernel.api.CursorFactory;
 import org.neo4j.internal.kernel.api.ExplicitIndexRead;
 import org.neo4j.internal.kernel.api.ExplicitIndexWrite;
-import org.neo4j.internal.kernel.api.IndexOrder;
-import org.neo4j.internal.kernel.api.IndexQuery;
-import org.neo4j.internal.kernel.api.IndexReference;
-import org.neo4j.internal.kernel.api.NodeCursor;
-import org.neo4j.internal.kernel.api.NodeExplicitIndexCursor;
-import org.neo4j.internal.kernel.api.NodeLabelIndexCursor;
-import org.neo4j.internal.kernel.api.NodeValueIndexCursor;
 import org.neo4j.internal.kernel.api.Read;
-import org.neo4j.internal.kernel.api.RelationshipExplicitIndexCursor;
-import org.neo4j.internal.kernel.api.RelationshipGroupCursor;
-import org.neo4j.internal.kernel.api.RelationshipScanCursor;
-import org.neo4j.internal.kernel.api.RelationshipTraversalCursor;
-import org.neo4j.internal.kernel.api.Scan;
 import org.neo4j.internal.kernel.api.SchemaRead;
 import org.neo4j.internal.kernel.api.Token;
 import org.neo4j.internal.kernel.api.Write;
-import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.internal.kernel.api.exceptions.explicitindex.AutoIndexingKernelException;
 import org.neo4j.internal.kernel.api.exceptions.explicitindex.ExplicitIndexNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
-import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.explicitindex.AutoIndexing;
 import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
 import org.neo4j.kernel.impl.index.IndexEntityType;
@@ -62,7 +46,7 @@ import static org.neo4j.values.storable.Values.NO_VALUE;
 /**
  * Collects all Kernel API operations and guards them from being used outside of transaction.
  */
-public class Operations implements Read, ExplicitIndexRead, SchemaRead, Write, ExplicitIndexWrite
+public class Operations implements Write, ExplicitIndexWrite
 {
     private final KernelTransactionImplementation ktx;
     private final AllStoreHolder allStoreHolder;
@@ -94,253 +78,10 @@ public class Operations implements Read, ExplicitIndexRead, SchemaRead, Write, E
         this.propertyCursor = cursors.allocatePropertyCursor();
     }
 
-    // READ
-
-    @Override
-    public void nodeIndexSeek( IndexReference index, NodeValueIndexCursor cursor,
-            IndexOrder order, IndexQuery... query )
-            throws KernelException
-    {
-        assertOpen();
-        allStoreHolder.nodeIndexSeek( index, cursor, order, query );
-    }
-
-    @Override
-    public void nodeIndexScan( IndexReference index, NodeValueIndexCursor cursor, IndexOrder order )
-            throws KernelException
-    {
-        assertOpen();
-        allStoreHolder.nodeIndexScan( index, cursor, order );
-    }
-
-    @Override
-    public void nodeLabelScan( int label, NodeLabelIndexCursor cursor )
-    {
-        assertOpen();
-        allStoreHolder.nodeLabelScan( label, cursor );
-    }
-
-    @Override
-    public void nodeLabelUnionScan( NodeLabelIndexCursor cursor, int... labels )
-    {
-        assertOpen();
-        allStoreHolder.nodeLabelUnionScan( cursor, labels );
-    }
-
-    @Override
-    public void nodeLabelIntersectionScan( NodeLabelIndexCursor cursor, int... labels )
-    {
-        assertOpen();
-        allStoreHolder.nodeLabelIntersectionScan( cursor, labels );
-    }
-
-    @Override
-    public Scan<NodeLabelIndexCursor> nodeLabelScan( int label )
-    {
-        assertOpen();
-        return allStoreHolder.nodeLabelScan( label );
-    }
-
-    @Override
-    public void allNodesScan( NodeCursor cursor )
-    {
-        assertOpen();
-        allStoreHolder.allNodesScan( cursor );
-    }
-
-    @Override
-    public Scan<NodeCursor> allNodesScan()
-    {
-        assertOpen();
-        return allStoreHolder.allNodesScan();
-    }
-
-    @Override
-    public void singleNode( long reference, NodeCursor cursor )
-    {
-        assertOpen();
-        allStoreHolder.singleNode( reference, cursor );
-    }
-
-    @Override
-    public boolean nodeExists( long id )
-    {
-        assertOpen();
-        return allStoreHolder.nodeExists( id );
-    }
-
-    @Override
-    public void singleRelationship( long reference, RelationshipScanCursor cursor )
-    {
-        assertOpen();
-        allStoreHolder.singleRelationship( reference, cursor );
-    }
-
-    @Override
-    public void allRelationshipsScan( RelationshipScanCursor cursor )
-    {
-        assertOpen();
-        allStoreHolder.allRelationshipsScan( cursor );
-    }
-
-    @Override
-    public Scan<RelationshipScanCursor> allRelationshipsScan()
-    {
-        assertOpen();
-        return allStoreHolder.allRelationshipsScan();
-    }
-
-    @Override
-    public void relationshipLabelScan( int label, RelationshipScanCursor cursor )
-    {
-        assertOpen();
-        allStoreHolder.relationshipLabelScan( label, cursor );
-    }
-
-    @Override
-    public Scan<RelationshipScanCursor> relationshipLabelScan( int label )
-    {
-        assertOpen();
-        return allStoreHolder.relationshipLabelScan( label );
-    }
-
-    @Override
-    public void relationshipGroups( long nodeReference, long reference, RelationshipGroupCursor cursor )
-    {
-        assertOpen();
-        allStoreHolder.relationshipGroups( nodeReference, reference, cursor );
-    }
-
-    @Override
-    public void relationships( long nodeReference, long reference, RelationshipTraversalCursor cursor )
-    {
-        assertOpen();
-        allStoreHolder.relationships( nodeReference, reference, cursor );
-    }
-
-    @Override
-    public void nodeProperties( long reference, org.neo4j.internal.kernel.api.PropertyCursor cursor )
-    {
-        assertOpen();
-        allStoreHolder.nodeProperties( reference, cursor );
-    }
-
-    @Override
-    public void relationshipProperties( long reference, org.neo4j.internal.kernel.api.PropertyCursor cursor )
-    {
-        assertOpen();
-        allStoreHolder.relationshipProperties( reference, cursor );
-    }
-
-    @Override
-    public void graphProperties( org.neo4j.internal.kernel.api.PropertyCursor cursor )
-    {
-        assertOpen();
-        allStoreHolder.graphProperties( cursor );
-    }
-
-    @Override
-    public void futureNodeReferenceRead( long reference )
-    {
-        assertOpen();
-        allStoreHolder.futureNodeReferenceRead( reference );
-    }
-
-    @Override
-    public void futureRelationshipsReferenceRead( long reference )
-    {
-        assertOpen();
-        allStoreHolder.futureRelationshipsReferenceRead( reference );
-    }
-
-    @Override
-    public void futureNodePropertyReferenceRead( long reference )
-    {
-        assertOpen();
-        allStoreHolder.futureNodePropertyReferenceRead( reference );
-    }
-
-    @Override
-    public void futureRelationshipPropertyReferenceRead( long reference )
-    {
-        assertOpen();
-        allStoreHolder.futureRelationshipPropertyReferenceRead( reference );
-    }
-
-    // EXPLICIT INDEX READ
-
-    @Override
-    public void nodeExplicitIndexLookup( NodeExplicitIndexCursor cursor, String index, String key, Value value )
-            throws KernelException
-    {
-        assertOpen();
-        allStoreHolder.nodeExplicitIndexLookup( cursor, index, key, value );
-    }
-
-    @Override
-    public void nodeExplicitIndexQuery( NodeExplicitIndexCursor cursor, String index, Object query )
-            throws KernelException
-    {
-        assertOpen();
-        allStoreHolder.nodeExplicitIndexQuery( cursor, index, query );
-    }
-
-    @Override
-    public void nodeExplicitIndexQuery( NodeExplicitIndexCursor cursor, String index, String key, Object query )
-            throws KernelException
-    {
-        assertOpen();
-        allStoreHolder.nodeExplicitIndexQuery( cursor, index, key, query );
-    }
-
-    @Override
-    public void relationshipExplicitIndexGet( RelationshipExplicitIndexCursor cursor, String index, String key,
-            Value value, long source, long target ) throws KernelException
-    {
-        assertOpen();
-        allStoreHolder.relationshipExplicitIndexGet( cursor, index, key, value, source, target );
-    }
-
-    @Override
-    public void relationshipExplicitIndexQuery( RelationshipExplicitIndexCursor cursor, String index, Object query,
-            long source, long target ) throws KernelException
-    {
-        assertOpen();
-        allStoreHolder.relationshipExplicitIndexQuery( cursor, index, query, source, target );
-    }
-
-    @Override
-    public void relationshipExplicitIndexQuery( RelationshipExplicitIndexCursor cursor, String index, String key,
-            Object query, long source, long target ) throws KernelException
-    {
-        assertOpen();
-        allStoreHolder.relationshipExplicitIndexQuery( cursor, index, key, query, source, target );
-    }
-
-    // SCHEMA READ
-
-    @Override
-    public CapableIndexReference index( int label, int... properties )
-    {
-        assertOpen();
-        return allStoreHolder.index( label, properties );
-    }
-
-    private void assertOpen()
-    {
-        if ( ktx.isTerminated() )
-        {
-            Status terminationReason = ktx.getReasonIfTerminated().orElse( Status.Transaction.Terminated );
-            throw new TransactionTerminatedException( terminationReason );
-        }
-    }
-
-    // WRITE
-
     @Override
     public long nodeCreate()
     {
-        assertOpen();
+        ktx.assertOpen();
         long nodeId = statement.reserveNode();
         ktx.txState().nodeDoCreate( nodeId );
         return nodeId;
@@ -349,7 +90,7 @@ public class Operations implements Read, ExplicitIndexRead, SchemaRead, Write, E
     @Override
     public boolean nodeDelete( long node ) throws AutoIndexingKernelException
     {
-        assertOpen();
+        ktx.assertOpen();
 
         if ( ktx.hasTxStateWithChanges() )
         {
@@ -381,14 +122,14 @@ public class Operations implements Read, ExplicitIndexRead, SchemaRead, Write, E
     @Override
     public long relationshipCreate( long sourceNode, int relationshipLabel, long targetNode )
     {
-        assertOpen();
+        ktx.assertOpen();
         throw new UnsupportedOperationException();
     }
 
     @Override
     public void relationshipDelete( long relationship )
     {
-        assertOpen();
+        ktx.assertOpen();
         throw new UnsupportedOperationException();
     }
 
@@ -398,7 +139,7 @@ public class Operations implements Read, ExplicitIndexRead, SchemaRead, Write, E
         acquireSharedLabelLock( nodeLabel );
         acquireExclusiveNodeLock( node );
 
-        assertOpen();
+        ktx.assertOpen();
         allStoreHolder.singleNode( node, nodeCursor );
         if ( !nodeCursor.next() )
         {
@@ -421,7 +162,7 @@ public class Operations implements Read, ExplicitIndexRead, SchemaRead, Write, E
     public boolean nodeRemoveLabel( long node, int nodeLabel ) throws EntityNotFoundException
     {
         acquireExclusiveNodeLock( node );
-        assertOpen();
+        ktx.assertOpen();
 
         allStoreHolder.singleNode( node, nodeCursor );
         if ( !nodeCursor.next() )
@@ -445,7 +186,7 @@ public class Operations implements Read, ExplicitIndexRead, SchemaRead, Write, E
             throws EntityNotFoundException, AutoIndexingKernelException
     {
         acquireExclusiveNodeLock( node );
-        assertOpen();
+        ktx.assertOpen();
 
         Value existingValue = readNodeProperty( node, propertyKey );
 
@@ -475,7 +216,7 @@ public class Operations implements Read, ExplicitIndexRead, SchemaRead, Write, E
             throws EntityNotFoundException, AutoIndexingKernelException
     {
         acquireExclusiveNodeLock( node );
-        assertOpen();
+        ktx.assertOpen();
         Value existingValue = readNodeProperty( node, propertyKey );
 
         if ( existingValue != NO_VALUE )
@@ -492,28 +233,28 @@ public class Operations implements Read, ExplicitIndexRead, SchemaRead, Write, E
     @Override
     public Value relationshipSetProperty( long relationship, int propertyKey, Value value )
     {
-        assertOpen();
+        ktx.assertOpen();
         throw new UnsupportedOperationException();
     }
 
     @Override
     public Value relationshipRemoveProperty( long node, int propertyKey )
     {
-        assertOpen();
+        ktx.assertOpen();
         throw new UnsupportedOperationException();
     }
 
     @Override
     public Value graphSetProperty( int propertyKey, Value value )
     {
-        assertOpen();
+        ktx.assertOpen();
         throw new UnsupportedOperationException();
     }
 
     @Override
     public Value graphRemoveProperty( int propertyKey )
     {
-        assertOpen();
+        ktx.assertOpen();
         throw new UnsupportedOperationException();
     }
 
@@ -521,14 +262,14 @@ public class Operations implements Read, ExplicitIndexRead, SchemaRead, Write, E
     public void nodeAddToExplicitIndex( String indexName, long node, String key, Object value )
             throws EntityNotFoundException, ExplicitIndexNotFoundKernelException
     {
-        assertOpen();
+        ktx.assertOpen();
         ktx.explicitIndexTxState().nodeChanges( indexName ).addNode( node, key, value );
     }
 
     @Override
     public void nodeRemoveFromExplicitIndex( String indexName, long node ) throws ExplicitIndexNotFoundKernelException
     {
-        assertOpen();
+        ktx.assertOpen();
         ktx.explicitIndexTxState().nodeChanges( indexName ).remove( node );
     }
 
@@ -536,7 +277,7 @@ public class Operations implements Read, ExplicitIndexRead, SchemaRead, Write, E
     public void nodeRemoveFromExplicitIndex( String indexName, long node, String key, Object value )
             throws ExplicitIndexNotFoundKernelException
     {
-        assertOpen();
+        ktx.assertOpen();
         ktx.explicitIndexTxState().nodeChanges( indexName ).remove( node, key, value );
     }
 
@@ -544,21 +285,21 @@ public class Operations implements Read, ExplicitIndexRead, SchemaRead, Write, E
     public void nodeRemoveFromExplicitIndex( String indexName, long node, String key )
             throws ExplicitIndexNotFoundKernelException
     {
-        assertOpen();
+        ktx.assertOpen();
         ktx.explicitIndexTxState().nodeChanges( indexName ).remove( node, key );
     }
 
     @Override
     public void nodeExplicitIndexCreate( String indexName, Map<String,String> customConfig )
     {
-        assertOpen();
+        ktx.assertOpen();
         ktx.explicitIndexTxState().createIndex( IndexEntityType.Node, indexName, customConfig );
     }
 
     @Override
     public void nodeExplicitIndexCreateLazily( String indexName, Map<String,String> customConfig )
     {
-        assertOpen();
+        ktx.assertOpen();
         allStoreHolder.getOrCreateNodeIndexConfig( indexName, customConfig );
     }
 
@@ -573,7 +314,7 @@ public class Operations implements Read, ExplicitIndexRead, SchemaRead, Write, E
     public void relationshipRemoveFromExplicitIndex( String indexName, long relationship, String key, Object value )
             throws ExplicitIndexNotFoundKernelException, EntityNotFoundException
     {
-        assertOpen();
+        ktx.assertOpen();
         ktx.explicitIndexTxState().relationshipChanges( indexName ).remove( relationship, key, value );
     }
 
@@ -595,14 +336,14 @@ public class Operations implements Read, ExplicitIndexRead, SchemaRead, Write, E
     @Override
     public void relationshipExplicitIndexCreate( String indexName, Map<String,String> customConfig )
     {
-        assertOpen();
+        ktx.assertOpen();
         ktx.explicitIndexTxState().createIndex( IndexEntityType.Relationship, indexName, customConfig );
     }
 
     @Override
     public void relationshipExplicitIndexCreateLazily( String indexName, Map<String,String> customConfig )
     {
-        assertOpen();
+        ktx.assertOpen();
         allStoreHolder.getOrCreateRelationshipIndexConfig( indexName, customConfig );
     }
 
@@ -674,5 +415,20 @@ public class Operations implements Read, ExplicitIndexRead, SchemaRead, Write, E
     public PropertyCursor propertyCursor()
     {
         return propertyCursor;
+    }
+
+    public ExplicitIndexRead indexRead()
+    {
+        return allStoreHolder;
+    }
+
+    public SchemaRead schemaRead()
+    {
+        return allStoreHolder;
+    }
+
+    public Read dataRead()
+    {
+        return allStoreHolder;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
@@ -407,16 +407,6 @@ public class Operations implements Write, ExplicitIndexWrite
         ktx.locks().optimistic().acquireShared( ktx.lockTracer(), ResourceTypes.LABEL, labelId );
     }
 
-    public NodeCursor nodeCursor()
-    {
-        return nodeCursor;
-    }
-
-    public PropertyCursor propertyCursor()
-    {
-        return propertyCursor;
-    }
-
     public ExplicitIndexRead indexRead()
     {
         return allStoreHolder;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Read.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Read.java
@@ -61,7 +61,7 @@ abstract class Read implements TxStateHolder,
 {
     private final Cursors cursors;
     private final TxStateHolder txStateHolder;
-    private final AssertOpen assertOpen;
+    protected final AssertOpen assertOpen;
 
     Read( Cursors cursors, TxStateHolder txStateHolder, AssertOpen assertOpen )
     {
@@ -77,6 +77,8 @@ abstract class Read implements TxStateHolder,
             IndexOrder indexOrder,
             IndexQuery... query ) throws KernelException
     {
+        assertOpen.assertOpen();
+
         ((NodeValueIndexCursor) cursor).setRead( this );
         IndexProgressor.NodeValueClient target = (NodeValueIndexCursor) cursor;
         IndexReader reader = indexReader( index );
@@ -123,6 +125,8 @@ abstract class Read implements TxStateHolder,
             org.neo4j.internal.kernel.api.NodeValueIndexCursor cursor,
             IndexOrder indexOrder ) throws KernelException
     {
+        assertOpen.assertOpen();
+
         // for a scan, we simply query for existence of the first property, which covers all entries in an index
         int firstProperty = index.properties()[0];
         ((NodeValueIndexCursor) cursor).setRead( this );
@@ -132,6 +136,8 @@ abstract class Read implements TxStateHolder,
     @Override
     public final void nodeLabelScan( int label, org.neo4j.internal.kernel.api.NodeLabelIndexCursor cursor )
     {
+        assertOpen.assertOpen();
+
         ((NodeLabelIndexCursor) cursor).setRead( this );
         labelScan( (NodeLabelIndexCursor) cursor, labelScanReader().nodesWithLabel( label ) );
     }
@@ -139,6 +145,8 @@ abstract class Read implements TxStateHolder,
     @Override
     public void nodeLabelUnionScan( org.neo4j.internal.kernel.api.NodeLabelIndexCursor cursor, int... labels )
     {
+        assertOpen.assertOpen();
+
         ((NodeLabelIndexCursor) cursor).setRead( this );
         labelScan( (NodeLabelIndexCursor) cursor, labelScanReader().nodesWithAnyOfLabels( labels ) );
     }
@@ -146,6 +154,8 @@ abstract class Read implements TxStateHolder,
     @Override
     public void nodeLabelIntersectionScan( org.neo4j.internal.kernel.api.NodeLabelIndexCursor cursor, int... labels )
     {
+        assertOpen.assertOpen();
+
         ((NodeLabelIndexCursor) cursor).setRead( this );
         labelScan( (NodeLabelIndexCursor) cursor, labelScanReader().nodesWithAllLabels( labels ) );
     }
@@ -158,54 +168,63 @@ abstract class Read implements TxStateHolder,
     @Override
     public final Scan<org.neo4j.internal.kernel.api.NodeLabelIndexCursor> nodeLabelScan( int label )
     {
+        assertOpen.assertOpen();
         throw new UnsupportedOperationException( "not implemented" );
     }
 
     @Override
     public final void allNodesScan( org.neo4j.internal.kernel.api.NodeCursor cursor )
     {
+        assertOpen.assertOpen();
         ((NodeCursor) cursor).scan( this );
     }
 
     @Override
     public final Scan<org.neo4j.internal.kernel.api.NodeCursor> allNodesScan()
     {
+        assertOpen.assertOpen();
         throw new UnsupportedOperationException( "not implemented" );
     }
 
     @Override
     public final void singleNode( long reference, org.neo4j.internal.kernel.api.NodeCursor cursor )
     {
+        assertOpen.assertOpen();
         ((NodeCursor) cursor).single( reference, this );
     }
 
     @Override
     public final void singleRelationship( long reference, org.neo4j.internal.kernel.api.RelationshipScanCursor cursor )
     {
+        assertOpen.assertOpen();
         ((RelationshipScanCursor) cursor).single( reference, this );
     }
 
     @Override
     public final void allRelationshipsScan( org.neo4j.internal.kernel.api.RelationshipScanCursor cursor )
     {
+        assertOpen.assertOpen();
         ((RelationshipScanCursor) cursor).scan( -1/*include all labels*/, this );
     }
 
     @Override
     public final Scan<org.neo4j.internal.kernel.api.RelationshipScanCursor> allRelationshipsScan()
     {
+        assertOpen.assertOpen();
         throw new UnsupportedOperationException( "not implemented" );
     }
 
     @Override
     public final void relationshipLabelScan( int label, org.neo4j.internal.kernel.api.RelationshipScanCursor cursor )
     {
+        assertOpen.assertOpen();
         ((RelationshipScanCursor) cursor).scan( label, this );
     }
 
     @Override
     public final Scan<org.neo4j.internal.kernel.api.RelationshipScanCursor> relationshipLabelScan( int label )
     {
+        assertOpen.assertOpen();
         throw new UnsupportedOperationException( "not implemented" );
     }
 
@@ -213,6 +232,7 @@ abstract class Read implements TxStateHolder,
     public final void relationshipGroups(
             long nodeReference, long reference, org.neo4j.internal.kernel.api.RelationshipGroupCursor cursor )
     {
+        assertOpen.assertOpen();
         if ( reference == NO_ID ) // there are no relationships for this node
         {
             cursor.close();
@@ -258,6 +278,7 @@ abstract class Read implements TxStateHolder,
          *
          * This means that we need reference encodings (flags) for cases: 1, 3, 4, 5
          */
+        assertOpen.assertOpen();
         if ( reference == NO_ID ) // there are no relationships for this node
         {
             cursor.close();
@@ -279,18 +300,21 @@ abstract class Read implements TxStateHolder,
     @Override
     public final void nodeProperties( long reference, org.neo4j.internal.kernel.api.PropertyCursor cursor )
     {
+        assertOpen.assertOpen();
         ((PropertyCursor) cursor).init( reference, this, assertOpen );
     }
 
     @Override
     public final void relationshipProperties( long reference, org.neo4j.internal.kernel.api.PropertyCursor cursor )
     {
+        assertOpen.assertOpen();
         ((PropertyCursor) cursor).init( reference, this, assertOpen );
     }
 
     @Override
     public final void graphProperties( org.neo4j.internal.kernel.api.PropertyCursor cursor )
     {
+        assertOpen.assertOpen();
         ((PropertyCursor) cursor).init( graphPropertiesReference(), this, assertOpen );
     }
 
@@ -300,6 +324,7 @@ abstract class Read implements TxStateHolder,
     public final void nodeExplicitIndexLookup(
             org.neo4j.internal.kernel.api.NodeExplicitIndexCursor cursor, String index, String key, Value value ) throws KernelException
     {
+        assertOpen.assertOpen();
         ((NodeExplicitIndexCursor) cursor).setRead( this );
         explicitIndex( (org.neo4j.kernel.impl.newapi.NodeExplicitIndexCursor) cursor, explicitNodeIndex( index ).get( key, value.asObject() ) );
     }
@@ -308,6 +333,7 @@ abstract class Read implements TxStateHolder,
     public final void nodeExplicitIndexQuery(
             org.neo4j.internal.kernel.api.NodeExplicitIndexCursor cursor, String index, Object query ) throws KernelException
     {
+        assertOpen.assertOpen();
         ((NodeExplicitIndexCursor) cursor).setRead( this );
         explicitIndex( (org.neo4j.kernel.impl.newapi.NodeExplicitIndexCursor) cursor, explicitNodeIndex( index ).query(
                 query instanceof Value ? ((Value) query).asObject() : query ) );
@@ -317,6 +343,7 @@ abstract class Read implements TxStateHolder,
     public final void nodeExplicitIndexQuery(
             org.neo4j.internal.kernel.api.NodeExplicitIndexCursor cursor, String index, String key, Object query ) throws KernelException
     {
+        assertOpen.assertOpen();
         ((NodeExplicitIndexCursor) cursor).setRead( this );
         explicitIndex( (NodeExplicitIndexCursor) cursor, explicitNodeIndex( index ).query(
                 key, query instanceof Value ? ((Value) query).asObject() : query ) );
@@ -331,6 +358,7 @@ abstract class Read implements TxStateHolder,
             long source,
             long target ) throws KernelException
     {
+        assertOpen.assertOpen();
         ((RelationshipExplicitIndexCursor) cursor).setRead( this );
         explicitIndex(
                 (RelationshipExplicitIndexCursor) cursor,
@@ -345,6 +373,7 @@ abstract class Read implements TxStateHolder,
             long source,
             long target ) throws KernelException
     {
+        assertOpen.assertOpen();
         ((RelationshipExplicitIndexCursor) cursor).setRead( this );
         explicitIndex(
                 (RelationshipExplicitIndexCursor) cursor,
@@ -361,6 +390,7 @@ abstract class Read implements TxStateHolder,
             long source,
             long target ) throws KernelException
     {
+        assertOpen.assertOpen();
         ((RelationshipExplicitIndexCursor) cursor).setRead( this );
         explicitIndex(
                 (RelationshipExplicitIndexCursor) cursor,
@@ -376,21 +406,25 @@ abstract class Read implements TxStateHolder,
     @Override
     public final void futureNodeReferenceRead( long reference )
     {
+        assertOpen.assertOpen();
     }
 
     @Override
     public final void futureRelationshipsReferenceRead( long reference )
     {
+        assertOpen.assertOpen();
     }
 
     @Override
     public final void futureNodePropertyReferenceRead( long reference )
     {
+        assertOpen.assertOpen();
     }
 
     @Override
     public final void futureRelationshipPropertyReferenceRead( long reference )
     {
+        assertOpen.assertOpen();
     }
 
     abstract IndexReader indexReader( org.neo4j.internal.kernel.api.IndexReference index );

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/StubKernelTransaction.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/StubKernelTransaction.java
@@ -25,12 +25,9 @@ import org.neo4j.internal.kernel.api.CursorFactory;
 import org.neo4j.internal.kernel.api.ExplicitIndexRead;
 import org.neo4j.internal.kernel.api.ExplicitIndexWrite;
 import org.neo4j.internal.kernel.api.Locks;
-import org.neo4j.internal.kernel.api.NodeCursor;
-import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.Read;
 import org.neo4j.internal.kernel.api.SchemaRead;
 import org.neo4j.internal.kernel.api.SchemaWrite;
-import org.neo4j.internal.kernel.api.Token;
 import org.neo4j.internal.kernel.api.TokenRead;
 import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.Write;
@@ -54,18 +51,6 @@ public class StubKernelTransaction implements KernelTransaction
     public Statement acquireStatement()
     {
         return new StubStatement( readOperations );
-    }
-
-    @Override
-    public NodeCursor nodeCursor()
-    {
-        throw new UnsupportedOperationException( "not implemented" );
-    }
-
-    @Override
-    public PropertyCursor propertyCursor()
-    {
-        throw new UnsupportedOperationException( "not implemented" );
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/StubKernelTransaction.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/StubKernelTransaction.java
@@ -25,6 +25,8 @@ import org.neo4j.internal.kernel.api.CursorFactory;
 import org.neo4j.internal.kernel.api.ExplicitIndexRead;
 import org.neo4j.internal.kernel.api.ExplicitIndexWrite;
 import org.neo4j.internal.kernel.api.Locks;
+import org.neo4j.internal.kernel.api.NodeCursor;
+import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.Read;
 import org.neo4j.internal.kernel.api.SchemaRead;
 import org.neo4j.internal.kernel.api.SchemaWrite;
@@ -52,6 +54,18 @@ public class StubKernelTransaction implements KernelTransaction
     public Statement acquireStatement()
     {
         return new StubStatement( readOperations );
+    }
+
+    @Override
+    public NodeCursor nodeCursor()
+    {
+        throw new UnsupportedOperationException( "not implemented" );
+    }
+
+    @Override
+    public PropertyCursor propertyCursor()
+    {
+        throw new UnsupportedOperationException( "not implemented" );
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
@@ -29,13 +29,10 @@ import org.neo4j.internal.kernel.api.CursorFactory;
 import org.neo4j.internal.kernel.api.ExplicitIndexRead;
 import org.neo4j.internal.kernel.api.ExplicitIndexWrite;
 import org.neo4j.internal.kernel.api.Locks;
-import org.neo4j.internal.kernel.api.NodeCursor;
-import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.Read;
 import org.neo4j.internal.kernel.api.SchemaRead;
 import org.neo4j.internal.kernel.api.SchemaWrite;
 import org.neo4j.internal.kernel.api.Session;
-import org.neo4j.internal.kernel.api.Token;
 import org.neo4j.internal.kernel.api.TokenRead;
 import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.Write;
@@ -461,18 +458,6 @@ public class ConstraintIndexCreatorTest
             public Statement acquireStatement()
             {
                 return remember( mockedState() );
-            }
-
-            @Override
-            public NodeCursor nodeCursor()
-            {
-                throw new UnsupportedOperationException( "not implemented" );
-            }
-
-            @Override
-            public PropertyCursor propertyCursor()
-            {
-                throw new UnsupportedOperationException( "not implemented" );
             }
 
             private Statement remember( KernelStatement mockedState )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
@@ -29,6 +29,8 @@ import org.neo4j.internal.kernel.api.CursorFactory;
 import org.neo4j.internal.kernel.api.ExplicitIndexRead;
 import org.neo4j.internal.kernel.api.ExplicitIndexWrite;
 import org.neo4j.internal.kernel.api.Locks;
+import org.neo4j.internal.kernel.api.NodeCursor;
+import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.Read;
 import org.neo4j.internal.kernel.api.SchemaRead;
 import org.neo4j.internal.kernel.api.SchemaWrite;
@@ -459,6 +461,18 @@ public class ConstraintIndexCreatorTest
             public Statement acquireStatement()
             {
                 return remember( mockedState() );
+            }
+
+            @Override
+            public NodeCursor nodeCursor()
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            public PropertyCursor propertyCursor()
+            {
+                throw new UnsupportedOperationException( "not implemented" );
             }
 
             private Statement remember( KernelStatement mockedState )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/MockStore.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/MockStore.java
@@ -186,6 +186,12 @@ public class MockStore extends Read implements TestRule
         };
     }
 
+    @Override
+    public boolean nodeExists( long id )
+    {
+        throw new UnsupportedOperationException( "not implemented" );
+    }
+
     private abstract static class Record<R extends AbstractBaseRecord>
     {
         abstract void initialize( R record );

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/StubKernelTransaction.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/StubKernelTransaction.java
@@ -27,12 +27,9 @@ import org.neo4j.internal.kernel.api.CursorFactory;
 import org.neo4j.internal.kernel.api.ExplicitIndexRead;
 import org.neo4j.internal.kernel.api.ExplicitIndexWrite;
 import org.neo4j.internal.kernel.api.Locks;
-import org.neo4j.internal.kernel.api.NodeCursor;
-import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.Read;
 import org.neo4j.internal.kernel.api.SchemaRead;
 import org.neo4j.internal.kernel.api.SchemaWrite;
-import org.neo4j.internal.kernel.api.Token;
 import org.neo4j.internal.kernel.api.TokenRead;
 import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.Write;
@@ -51,18 +48,6 @@ class StubKernelTransaction implements KernelTransaction
     public Statement acquireStatement()
     {
         return null;
-    }
-
-    @Override
-    public NodeCursor nodeCursor()
-    {
-        throw new UnsupportedOperationException( "not implemented" );
-    }
-
-    @Override
-    public PropertyCursor propertyCursor()
-    {
-        throw new UnsupportedOperationException( "not implemented" );
     }
 
     @Override

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/StubKernelTransaction.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/StubKernelTransaction.java
@@ -27,6 +27,8 @@ import org.neo4j.internal.kernel.api.CursorFactory;
 import org.neo4j.internal.kernel.api.ExplicitIndexRead;
 import org.neo4j.internal.kernel.api.ExplicitIndexWrite;
 import org.neo4j.internal.kernel.api.Locks;
+import org.neo4j.internal.kernel.api.NodeCursor;
+import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.Read;
 import org.neo4j.internal.kernel.api.SchemaRead;
 import org.neo4j.internal.kernel.api.SchemaWrite;
@@ -49,6 +51,18 @@ class StubKernelTransaction implements KernelTransaction
     public Statement acquireStatement()
     {
         return null;
+    }
+
+    @Override
+    public NodeCursor nodeCursor()
+    {
+        throw new UnsupportedOperationException( "not implemented" );
+    }
+
+    @Override
+    public PropertyCursor propertyCursor()
+    {
+        throw new UnsupportedOperationException( "not implemented" );
     }
 
     @Override


### PR DESCRIPTION
After merging https://github.com/neo4j/neo4j/pull/10495 we have seen a couple of regressions in the Core API benchmarks. This PR addresses these regression. Fixes include:

- Don't be stupid in `NodeProxy::getProperties(String[])`
- Add `nodeExists` to API to get more efficient `nodeGetById`
- ~Reuse node cursors and property cursors.~
- Load label cursor lazily
- Make `Read` monomorphic
