### PR TITLE
Do not override UDC settings with default values on startup

### DIFF
--- a/community/udc/src/main/filtered-resources/org/neo4j/ext/udc/udc.properties
+++ b/community/udc/src/main/filtered-resources/org/neo4j/ext/udc/udc.properties
@@ -1,3 +1,0 @@
-unsupported.dbms.udc.source=${neo4j-source-distribution}
-unsupported.dbms.udc.reg=unreg
-

--- a/community/udc/src/main/java/org/neo4j/ext/udc/UdcSettings.java
+++ b/community/udc/src/main/java/org/neo4j/ext/udc/UdcSettings.java
@@ -26,7 +26,6 @@ import org.neo4j.configuration.Internal;
 import org.neo4j.configuration.LoadableConfig;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.helpers.HostnamePort;
-import org.neo4j.kernel.configuration.Settings;
 
 import static org.neo4j.kernel.configuration.Settings.ANY;
 import static org.neo4j.kernel.configuration.Settings.FALSE;
@@ -65,7 +64,8 @@ public class UdcSettings implements LoadableConfig
 
     /** Configuration key for overriding the source parameter in UDC */
     @Internal
-    public static final Setting<String> udc_source = buildSetting( "unsupported.dbms.udc.source", STRING, Settings.NO_DEFAULT ).constraint(
+    public static final Setting<String> udc_source = buildSetting( "unsupported.dbms.udc.source", STRING, "maven" )
+            .constraint(
             illegalValueMessage( "Must be a valid source", matches( ANY ) ) ).build();
 
     /** Unique registration id */

--- a/community/udc/src/main/java/org/neo4j/ext/udc/impl/UdcKernelExtensionFactory.java
+++ b/community/udc/src/main/java/org/neo4j/ext/udc/impl/UdcKernelExtensionFactory.java
@@ -19,12 +19,9 @@
  */
 package org.neo4j.ext.udc.impl;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Timer;
 
 import org.neo4j.helpers.Service;
-import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.core.StartupStatistics;
@@ -67,7 +64,6 @@ public class UdcKernelExtensionFactory extends KernelExtensionFactory<UdcKernelE
             throws Throwable
     {
         Config config = dependencies.config();
-        config.augment( loadUdcProperties() );
         return new UdcKernelExtension(
                 config,
                 dependencies.dataSourceManager(),
@@ -80,17 +76,5 @@ public class UdcKernelExtensionFactory extends KernelExtensionFactory<UdcKernelE
     private boolean isAlwaysDaemon()
     {
         return true;
-    }
-
-    private Map<String, String> loadUdcProperties()
-    {
-        try
-        {
-            return MapUtil.load( getClass().getResourceAsStream( "/org/neo4j/ext/udc/udc.properties" ) );
-        }
-        catch ( Exception e )
-        {
-            return new HashMap<>();
-        }
     }
 }

--- a/integrationtests/src/test/java/org/neo4j/ext/udc/impl/UdcExtensionImplTest.java
+++ b/integrationtests/src/test/java/org/neo4j/ext/udc/impl/UdcExtensionImplTest.java
@@ -48,7 +48,6 @@ import org.neo4j.ext.udc.UdcConstants;
 import org.neo4j.ext.udc.UdcSettings;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
-import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
 import org.neo4j.test.TestGraphDatabaseFactory;
@@ -84,7 +83,9 @@ import static org.neo4j.ext.udc.UdcConstants.VERSION;
  */
 public class UdcExtensionImplTest extends LocalServerTestBase
 {
-    private static final String VersionPattern = "(\\d\\.\\d+((\\.|\\-).*)?)|(dev)";
+    private static final String VersionPattern = "(\\d\\.\\d+(([.-]).*)?)|(dev)";
+    private static final Condition<Integer> IS_ZERO = value -> value == 0;
+    private static final Condition<Integer> IS_GREATER_THAN_ZERO = value -> value > 0;
 
     @Rule
     public TestDirectory path = TestDirectory.testDirectory();
@@ -241,20 +242,6 @@ public class UdcExtensionImplTest extends LocalServerTestBase
         assertTrue( latch.await( 1000, TimeUnit.MILLISECONDS ) );
 
         t.join();
-    }
-
-    @Test
-    public void shouldNotBeAbleToSpecifyRegistrationIdWithConfig() throws Exception
-    {
-        // Given
-        config.put( UdcSettings.udc_registration_key.name(), "marketoid" );
-
-        // When
-        graphdb = createDatabase( config );
-
-        // Then
-        assertGotSuccessWithRetry( IS_GREATER_THAN_ZERO );
-        assertEquals( "test-reg", handler.getQueryMap().get( REGISTRATION ) );
     }
 
     @Test
@@ -434,15 +421,6 @@ public class UdcExtensionImplTest extends LocalServerTestBase
     }
 
     @Test
-    public void testUdcPropertyFileKeysMatchSettings() throws Exception
-    {
-        Map<String,String> config =
-                MapUtil.load( getClass().getResourceAsStream( "/org/neo4j/ext/udc/udc" + ".properties" ) );
-        assertEquals( "test-reg", config.get( UdcSettings.udc_registration_key.name() ) );
-        assertEquals( "unit-testing", config.get( UdcSettings.udc_source.name() ) );
-    }
-
-    @Test
     public void shouldFilterPlusBuildNumbers() throws Exception
     {
         assertThat( DefaultUdcInformationCollector.filterVersionForUDC( "1.9.0-M01+00001" ),
@@ -467,10 +445,6 @@ public class UdcExtensionImplTest extends LocalServerTestBase
     {
         boolean isTrue( T value );
     }
-
-    private static final Condition<Integer> IS_ZERO = value -> value == 0;
-
-    private static final Condition<Integer> IS_GREATER_THAN_ZERO = value -> value > 0;
 
     private void assertGotSuccessWithRetry( Condition<Integer> condition ) throws Exception
     {

--- a/integrationtests/src/test/java/org/neo4j/ext/udc/impl/UdcExtensionImplTest.java
+++ b/integrationtests/src/test/java/org/neo4j/ext/udc/impl/UdcExtensionImplTest.java
@@ -48,6 +48,7 @@ import org.neo4j.ext.udc.UdcConstants;
 import org.neo4j.ext.udc.UdcSettings;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
 import org.neo4j.test.TestGraphDatabaseFactory;
@@ -439,6 +440,23 @@ public class UdcExtensionImplTest extends LocalServerTestBase
     public void shouldNotFilterReleaseBuildNumbers() throws Exception
     {
         assertThat( DefaultUdcInformationCollector.filterVersionForUDC( "1.9" ), is( equalTo( "1.9" ) ) );
+    }
+
+    @Test
+    public void shouldUseTheCustomConfiguration() throws Exception
+    {
+        // Given
+        config.put( UdcSettings.udc_source.name(), "my_source" );
+        config.put( UdcSettings.udc_registration_key.name(), "my_key" );
+
+        // When
+        graphdb = createDatabase( config );
+
+        // Then
+        Config config = ((GraphDatabaseAPI) graphdb).getDependencyResolver().resolveDependency(Config.class);
+
+        assertEquals("my_source",config.get(UdcSettings.udc_source));
+        assertEquals("my_key",config.get(UdcSettings.udc_registration_key));
     }
 
     private interface Condition<T>


### PR DESCRIPTION
Do not override UDC settings that specified in neo4j instance config
with default values.
Cleanup re-invented default property values loading.
Use settings default values instead.