### PR TITLE
Passing whether method owner is Interface into "visitMethodInsn"

### DIFF
--- a/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeExpressionVisitor.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/bytecode/ByteCodeExpressionVisitor.java
@@ -158,7 +158,7 @@ class ByteCodeExpressionVisitor implements ExpressionVisitor
         }
         methodVisitor.visitMethodInsn( INVOKESTATIC,
                 byteCodeName( method.owner() ),
-                method.name(), desc( method ), false );
+                method.name(), desc( method ), Modifier.isInterface( method.owner().modifiers() ) );
     }
 
     @Override


### PR DESCRIPTION
Fixing java.lang.IncompatibleClassChangeError: Method _method in interface_ must
be InterfaceMethodref constant
Details: https://bugs.openjdk.java.net/browse/JDK-8145148