### PR TITLE
Removes accidental limitation of number of reltypes to 64K for high_limit format

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/RelationshipTypeTokenRecordFormat.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/format/standard/RelationshipTypeTokenRecordFormat.java
@@ -25,7 +25,12 @@ public class RelationshipTypeTokenRecordFormat extends TokenRecordFormat<Relatio
 {
     public RelationshipTypeTokenRecordFormat()
     {
-        super( BASE_RECORD_SIZE, StandardFormatSettings.RELATIONSHIP_TYPE_TOKEN_MAXIMUM_ID_BITS );
+        this( StandardFormatSettings.RELATIONSHIP_TYPE_TOKEN_MAXIMUM_ID_BITS );
+    }
+
+    public RelationshipTypeTokenRecordFormat( int maxIdBits )
+    {
+        super( BASE_RECORD_SIZE, maxIdBits );
     }
 
     @Override

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/store/format/highlimit/HighLimit.java
@@ -48,6 +48,8 @@ public class HighLimit extends BaseRecordFormats
      * Default maximum number of bits that can be used to represent id
      */
     static final int DEFAULT_MAXIMUM_BITS_PER_ID = 50;
+    static final int RELATIONSHIP_TYPE_TOKEN_MAXIMUM_ID_BITS = 24;
+    // id limits for property key and label tokens are already quite high
 
     public static final String STORE_VERSION = StoreVersion.HIGH_LIMIT_V3_1_0.versionString();
 
@@ -99,7 +101,7 @@ public class HighLimit extends BaseRecordFormats
     @Override
     public RecordFormat<RelationshipTypeTokenRecord> relationshipTypeToken()
     {
-        return new RelationshipTypeTokenRecordFormat();
+        return new RelationshipTypeTokenRecordFormat( RELATIONSHIP_TYPE_TOKEN_MAXIMUM_ID_BITS );
     }
 
     @Override

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipTypeTokenRecordFormatTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/store/format/highlimit/RelationshipTypeTokenRecordFormatTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.store.format.highlimit;
+
+import org.junit.Test;
+
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.io.pagecache.StubPageCursor;
+import org.neo4j.kernel.impl.store.format.RecordFormat;
+import org.neo4j.kernel.impl.store.id.IdSequence;
+import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import static org.neo4j.io.ByteUnit.kibiBytes;
+import static org.neo4j.kernel.impl.store.NoStoreHeader.NO_STORE_HEADER;
+import static org.neo4j.kernel.impl.store.record.RecordLoad.NORMAL;
+
+public class RelationshipTypeTokenRecordFormatTest
+{
+    @Test
+    public void shouldHandleRelationshipTypesBeyond2Bytes() throws Exception
+    {
+        // given
+        RecordFormat<RelationshipTypeTokenRecord> format = HighLimit.RECORD_FORMATS.relationshipTypeToken();
+        int typeId = 1 << (Short.SIZE + Byte.SIZE) - 1;
+        RelationshipTypeTokenRecord record = new RelationshipTypeTokenRecord( typeId );
+        int recordSize = format.getRecordSize( NO_STORE_HEADER );
+        record.initialize( true, 10 );
+        IdSequence doubleUnits = mock( IdSequence.class );
+        PageCursor cursor = new StubPageCursor( 0, (int) kibiBytes( 8 ) );
+
+        // when
+        format.prepare( record, recordSize, doubleUnits );
+        format.write( record, cursor, recordSize );
+        verifyNoMoreInteractions( doubleUnits );
+
+        // then
+        RelationshipTypeTokenRecord read = new RelationshipTypeTokenRecord( typeId );
+        format.read( record, cursor, NORMAL, recordSize );
+        assertEquals( record, read );
+    }
+
+    @Test
+    public void shouldReport3BytesMaxIdForRelationshipTypes() throws Exception
+    {
+        // given
+        RecordFormat<RelationshipTypeTokenRecord> format = HighLimit.RECORD_FORMATS.relationshipTypeToken();
+
+        // when
+        long maxId = format.getMaxId();
+
+        // then
+        assertEquals( (1 << HighLimit.RELATIONSHIP_TYPE_TOKEN_MAXIMUM_ID_BITS) - 1, maxId );
+    }
+}


### PR DESCRIPTION
The format itself already supports 3B, i.e. ~16M relationship types, but the format
was accidentally limited to 2B from outside upon its construction.
This removes that limit and will not incur any format change.