### PR TITLE
Add additional case to parse in inconsistency report

### DIFF
--- a/tools/src/main/java/org/neo4j/tools/dump/InconsistencyReportReader.java
+++ b/tools/src/main/java/org/neo4j/tools/dump/InconsistencyReportReader.java
@@ -61,7 +61,7 @@ public class InconsistencyReportReader
             line = line.trim();
             if ( state == 0 )
             {
-                if ( !line.contains( " ERROR " ) && !line.contains( " WARNING " ) )
+                if ( !line.contains( "ERROR" ) && !line.contains( " WARNING " ) )
                 {
                     continue;
                 }

--- a/tools/src/test/java/org/neo4j/tools/dump/InconsistencyReportReaderTest.java
+++ b/tools/src/test/java/org/neo4j/tools/dump/InconsistencyReportReaderTest.java
@@ -83,4 +83,20 @@ public class InconsistencyReportReaderTest
         assertTrue( inconsistencies.containsPropertyId( propertyId ) );
         assertTrue( inconsistencies.containsSchemaIndexId( indexId ) );
     }
+
+    @Test
+    public void shouldParseRelationshipGroupInconsistencies() throws Exception
+    {
+        // Given
+        ReportInconsistencies inconsistencies = new ReportInconsistencies();
+        String text =
+                "ERROR: The first outgoing relationship is not the first in its chain.\n" +
+                "\tRelationshipGroup[1337,type=1,out=2,in=-1,loop=-1,prev=-1,next=3,used=true,owner=4,secondaryUnitId=-1]";
+        // When
+        InconsistencyReportReader reader = new InconsistencyReportReader( inconsistencies );
+        reader.read( new BufferedReader( new StringReader( text ) ) );
+
+        // Then
+        assertTrue( inconsistencies.containsRelationshipGroupId( 1337 ) );
+    }
 }


### PR DESCRIPTION
The parse assumes the output comes from a timestamped log; however,
this is (apparently, because I got one which wasn't) not always the
case.

This broadens the parse just-so to parse reports without timestamps.