### PR TITLE
Prometheus endpoint for metrics

### DIFF
--- a/enterprise/metrics/LICENSES.txt
+++ b/enterprise/metrics/LICENSES.txt
@@ -7,6 +7,11 @@ Apache Software License, Version 2.0
   Apache Commons Collections
   Graphite Integration for Metrics
   Metrics Core
+  Prometheus Java Simpleclient
+  Prometheus Java Simpleclient Common
+  Prometheus Java Simpleclient Dropwizard
+  Prometheus Java Simpleclient Hotspot
+  Prometheus Java Simpleclient Httpserver
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/enterprise/metrics/LICENSES.txt
+++ b/enterprise/metrics/LICENSES.txt
@@ -10,7 +10,6 @@ Apache Software License, Version 2.0
   Prometheus Java Simpleclient
   Prometheus Java Simpleclient Common
   Prometheus Java Simpleclient Dropwizard
-  Prometheus Java Simpleclient Hotspot
   Prometheus Java Simpleclient Httpserver
 ------------------------------------------------------------------------------
 

--- a/enterprise/metrics/NOTICE.txt
+++ b/enterprise/metrics/NOTICE.txt
@@ -29,6 +29,11 @@ Apache Software License, Version 2.0
   Apache Commons Collections
   Graphite Integration for Metrics
   Metrics Core
+  Prometheus Java Simpleclient
+  Prometheus Java Simpleclient Common
+  Prometheus Java Simpleclient Dropwizard
+  Prometheus Java Simpleclient Hotspot
+  Prometheus Java Simpleclient Httpserver
 
 MIT License
   SLF4J API Module

--- a/enterprise/metrics/NOTICE.txt
+++ b/enterprise/metrics/NOTICE.txt
@@ -32,7 +32,6 @@ Apache Software License, Version 2.0
   Prometheus Java Simpleclient
   Prometheus Java Simpleclient Common
   Prometheus Java Simpleclient Dropwizard
-  Prometheus Java Simpleclient Hotspot
   Prometheus Java Simpleclient Httpserver
 
 MIT License

--- a/enterprise/metrics/pom.xml
+++ b/enterprise/metrics/pom.xml
@@ -136,6 +136,29 @@
       <artifactId>metrics-graphite</artifactId>
     </dependency>
 
+    <!-- Prometheus.io endpoint-->
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient</artifactId>
+      <version>0.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_httpserver</artifactId>
+      <version>0.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_hotspot</artifactId>
+      <version>0.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_dropwizard</artifactId>
+      <version>0.1.0</version>
+    </dependency>
+
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/enterprise/metrics/pom.xml
+++ b/enterprise/metrics/pom.xml
@@ -149,11 +149,6 @@
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient_hotspot</artifactId>
-      <version>0.1.0</version>
-    </dependency>
-    <dependency>
-      <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_dropwizard</artifactId>
       <version>0.1.0</version>
     </dependency>

--- a/enterprise/metrics/pom.xml
+++ b/enterprise/metrics/pom.xml
@@ -16,6 +16,10 @@
   <name>Neo4j - Metrics Kernel Extension</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <prometheus.client.version>0.1.0</prometheus.client.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.neo4j</groupId>
@@ -140,19 +144,18 @@
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
-      <version>0.1.0</version>
+      <version>${prometheus.client.version}</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_httpserver</artifactId>
-      <version>0.1.0</version>
+      <version>${prometheus.client.version}</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_dropwizard</artifactId>
-      <version>0.1.0</version>
+      <version>${prometheus.client.version}</version>
     </dependency>
-
 
     <dependency>
       <groupId>junit</groupId>

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsSettings.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsSettings.java
@@ -153,4 +153,12 @@ public class MetricsSettings implements LoadableConfig
 
     @Description( "The reporting interval for Graphite. That is, how often to send updated metrics to Graphite." )
     public static Setting<Duration> graphiteInterval = setting( "metrics.graphite.interval", DURATION, "3s" );
+
+    // Prometheus settings
+    @Description( "Set to `true` to enable the Prometheus endpoint" )
+    public static Setting<Boolean> prometheusEnabled = setting( "metrics.prometheus.enabled", BOOLEAN, FALSE );
+
+    @Description( "The hostname and port to use as Prometheus endpoint" )
+    public static Setting<HostnamePort> prometheusEndpoint =
+            setting( "metrics.prometheus.endpoint", HOSTNAME_PORT, "localhost:8080" );
 }

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsSettings.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/MetricsSettings.java
@@ -160,5 +160,5 @@ public class MetricsSettings implements LoadableConfig
 
     @Description( "The hostname and port to use as Prometheus endpoint" )
     public static Setting<HostnamePort> prometheusEndpoint =
-            setting( "metrics.prometheus.endpoint", HOSTNAME_PORT, "localhost:8080" );
+            setting( "metrics.prometheus.endpoint", HOSTNAME_PORT, "localhost:2004" );
 }

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/output/EventReporterBuilder.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/output/EventReporterBuilder.java
@@ -35,6 +35,8 @@ import static org.neo4j.metrics.MetricsSettings.csvEnabled;
 import static org.neo4j.metrics.MetricsSettings.graphiteEnabled;
 import static org.neo4j.metrics.MetricsSettings.graphiteInterval;
 import static org.neo4j.metrics.MetricsSettings.graphiteServer;
+import static org.neo4j.metrics.MetricsSettings.prometheusEnabled;
+import static org.neo4j.metrics.MetricsSettings.prometheusEndpoint;
 
 public class EventReporterBuilder
 {
@@ -76,6 +78,14 @@ public class EventReporterBuilder
             GraphiteOutput graphiteOutput = new GraphiteOutput( server, period, registry, logger, prefix );
             reporter.add( graphiteOutput );
             life.add( graphiteOutput );
+        }
+
+        if ( config.get( prometheusEnabled ) )
+        {
+            HostnamePort server = config.get( prometheusEndpoint );
+            PrometheusOutput prometheusOutput = new PrometheusOutput( server, registry, logger );
+            reporter.add( prometheusOutput );
+            life.add( prometheusOutput );
         }
 
         return reporter;

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/output/PrometheusOutput.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/output/PrometheusOutput.java
@@ -28,7 +28,6 @@ import com.codahale.metrics.Timer;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.dropwizard.DropwizardExports;
 import io.prometheus.client.exporter.HTTPServer;
-import io.prometheus.client.hotspot.DefaultExports;
 
 import java.util.Map;
 import java.util.SortedMap;
@@ -60,11 +59,8 @@ public class PrometheusOutput implements Lifecycle, EventReporter
     @Override
     public void init()
     {
-        // Setup neo4j prometheus collector
+        // Setup prometheus collector
         CollectorRegistry.defaultRegistry.register( new DropwizardExports( registry ) );
-
-        // Add additional JVM statistics
-        DefaultExports.initialize();
     }
 
     @Override

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/output/PrometheusOutputIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/output/PrometheusOutputIT.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.metrics.output;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Scanner;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.factory.EnterpriseGraphDatabaseFactory;
+import org.neo4j.kernel.configuration.Settings;
+import org.neo4j.ports.allocation.PortAuthority;
+import org.neo4j.test.rule.TestDirectory;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.neo4j.metrics.MetricsSettings.prometheusEnabled;
+import static org.neo4j.metrics.MetricsSettings.prometheusEndpoint;
+import static org.neo4j.metrics.source.db.EntityCountMetrics.COUNTS_NODE;
+import static org.neo4j.metrics.source.db.EntityCountMetrics.COUNTS_RELATIONSHIP_TYPE;
+
+public class PrometheusOutputIT
+{
+    @Rule
+    public TestDirectory testDirectory = TestDirectory.testDirectory();
+
+    private GraphDatabaseService database;
+    private String serverAddress;
+
+    @Before
+    public void setUp()
+    {
+        serverAddress = "localhost:" + PortAuthority.allocatePort();
+        database = new EnterpriseGraphDatabaseFactory().newEmbeddedDatabaseBuilder( testDirectory.graphDbDir() )
+                .setConfig( prometheusEnabled, Settings.TRUE )
+                .setConfig( prometheusEndpoint, serverAddress )
+                .newGraphDatabase();
+    }
+
+    @After
+    public void tearDown()
+    {
+        database.shutdown();
+    }
+
+    @Test
+    public void httpEndpointShouldBeAvailableAndResponsive() throws IOException
+    {
+        String url = "http://" + serverAddress + "/metrics";
+        URLConnection connection = new URL( url ).openConnection();
+        connection.setDoOutput( true );
+        connection.connect();
+        Scanner s = new Scanner( connection.getInputStream(), "UTF-8" ).useDelimiter( "\\A" );
+
+        assertTrue( s.hasNext() );
+        String response = s.next();
+        assertTrue( response.contains( COUNTS_NODE ) );
+        assertTrue( response.contains( COUNTS_RELATIONSHIP_TYPE ) );
+    }
+}

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/output/PrometheusOutputTest.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/output/PrometheusOutputTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.metrics.output;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.TreeMap;
+import java.util.function.LongConsumer;
+
+import org.neo4j.helpers.HostnamePort;
+import org.neo4j.logging.Log;
+
+import static java.util.Collections.emptySortedMap;
+import static org.junit.Assert.assertEquals;
+
+public class PrometheusOutputTest
+{
+    @Test
+    public void eventsShouldBeRedirectedToGauges()
+    {
+        String metricKey = "my.metric";
+        MetricRegistry registry = new MetricRegistry();
+        PrometheusOutput prometheusOutput =
+                new PrometheusOutput( new HostnamePort( "localhost:8080" ), registry, Mockito.mock( Log.class ) );
+
+        LongConsumer callback = durationMillis -> {
+            TreeMap<String,Gauge> gauges = new TreeMap<>();
+            gauges.put( metricKey, () -> durationMillis );
+            prometheusOutput.report( gauges, emptySortedMap(), emptySortedMap(), emptySortedMap(), emptySortedMap() );
+        };
+
+        assertEquals( 0, registry.getGauges().size() );
+
+        callback.accept( 10 );
+
+        assertEquals( 1, registry.getGauges().size() );
+        assertEquals( "10", registry.getGauges().get( metricKey ).getValue().toString() );
+
+        callback.accept( 20 );
+
+        assertEquals( 1, registry.getGauges().size() );
+        assertEquals( "20", registry.getGauges().get( metricKey ).getValue().toString() );
+    }
+}

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/output/PrometheusOutputTest.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/output/PrometheusOutputTest.java
@@ -43,7 +43,8 @@ public class PrometheusOutputTest
         PrometheusOutput prometheusOutput =
                 new PrometheusOutput( new HostnamePort( "localhost:8080" ), registry, Mockito.mock( Log.class ) );
 
-        LongConsumer callback = durationMillis -> {
+        LongConsumer callback = durationMillis ->
+        {
             TreeMap<String,Gauge> gauges = new TreeMap<>();
             gauges.put( metricKey, () -> durationMillis );
             prometheusOutput.report( gauges, emptySortedMap(), emptySortedMap(), emptySortedMap(), emptySortedMap() );

--- a/enterprise/neo4j-enterprise/LICENSES.txt
+++ b/enterprise/neo4j-enterprise/LICENSES.txt
@@ -34,6 +34,11 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
+  Prometheus Java Simpleclient
+  Prometheus Java Simpleclient Common
+  Prometheus Java Simpleclient Dropwizard
+  Prometheus Java Simpleclient Hotspot
+  Prometheus Java Simpleclient Httpserver
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/enterprise/neo4j-enterprise/LICENSES.txt
+++ b/enterprise/neo4j-enterprise/LICENSES.txt
@@ -37,7 +37,6 @@ Apache Software License, Version 2.0
   Prometheus Java Simpleclient
   Prometheus Java Simpleclient Common
   Prometheus Java Simpleclient Dropwizard
-  Prometheus Java Simpleclient Hotspot
   Prometheus Java Simpleclient Httpserver
 ------------------------------------------------------------------------------
 

--- a/enterprise/neo4j-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-enterprise/NOTICE.txt
@@ -56,6 +56,11 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
+  Prometheus Java Simpleclient
+  Prometheus Java Simpleclient Common
+  Prometheus Java Simpleclient Dropwizard
+  Prometheus Java Simpleclient Hotspot
+  Prometheus Java Simpleclient Httpserver
 
 BSD - Scala License
   Scala Library

--- a/enterprise/neo4j-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-enterprise/NOTICE.txt
@@ -59,7 +59,6 @@ Apache Software License, Version 2.0
   Prometheus Java Simpleclient
   Prometheus Java Simpleclient Common
   Prometheus Java Simpleclient Dropwizard
-  Prometheus Java Simpleclient Hotspot
   Prometheus Java Simpleclient Httpserver
 
 BSD - Scala License

--- a/enterprise/neo4j-harness-enterprise/LICENSES.txt
+++ b/enterprise/neo4j-harness-enterprise/LICENSES.txt
@@ -52,7 +52,6 @@ Apache Software License, Version 2.0
   Prometheus Java Simpleclient
   Prometheus Java Simpleclient Common
   Prometheus Java Simpleclient Dropwizard
-  Prometheus Java Simpleclient Hotspot
   Prometheus Java Simpleclient Httpserver
 ------------------------------------------------------------------------------
 

--- a/enterprise/neo4j-harness-enterprise/LICENSES.txt
+++ b/enterprise/neo4j-harness-enterprise/LICENSES.txt
@@ -49,6 +49,11 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
+  Prometheus Java Simpleclient
+  Prometheus Java Simpleclient Common
+  Prometheus Java Simpleclient Dropwizard
+  Prometheus Java Simpleclient Hotspot
+  Prometheus Java Simpleclient Httpserver
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/enterprise/neo4j-harness-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-harness-enterprise/NOTICE.txt
@@ -74,7 +74,6 @@ Apache Software License, Version 2.0
   Prometheus Java Simpleclient
   Prometheus Java Simpleclient Common
   Prometheus Java Simpleclient Dropwizard
-  Prometheus Java Simpleclient Hotspot
   Prometheus Java Simpleclient Httpserver
 
 BSD - Scala License

--- a/enterprise/neo4j-harness-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-harness-enterprise/NOTICE.txt
@@ -71,6 +71,11 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
+  Prometheus Java Simpleclient
+  Prometheus Java Simpleclient Common
+  Prometheus Java Simpleclient Dropwizard
+  Prometheus Java Simpleclient Hotspot
+  Prometheus Java Simpleclient Httpserver
 
 BSD - Scala License
   Scala Library

--- a/enterprise/server-enterprise/LICENSES.txt
+++ b/enterprise/server-enterprise/LICENSES.txt
@@ -52,7 +52,6 @@ Apache Software License, Version 2.0
   Prometheus Java Simpleclient
   Prometheus Java Simpleclient Common
   Prometheus Java Simpleclient Dropwizard
-  Prometheus Java Simpleclient Hotspot
   Prometheus Java Simpleclient Httpserver
 ------------------------------------------------------------------------------
 

--- a/enterprise/server-enterprise/LICENSES.txt
+++ b/enterprise/server-enterprise/LICENSES.txt
@@ -49,6 +49,11 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
+  Prometheus Java Simpleclient
+  Prometheus Java Simpleclient Common
+  Prometheus Java Simpleclient Dropwizard
+  Prometheus Java Simpleclient Hotspot
+  Prometheus Java Simpleclient Httpserver
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/enterprise/server-enterprise/NOTICE.txt
+++ b/enterprise/server-enterprise/NOTICE.txt
@@ -74,7 +74,6 @@ Apache Software License, Version 2.0
   Prometheus Java Simpleclient
   Prometheus Java Simpleclient Common
   Prometheus Java Simpleclient Dropwizard
-  Prometheus Java Simpleclient Hotspot
   Prometheus Java Simpleclient Httpserver
 
 BSD - Scala License

--- a/enterprise/server-enterprise/NOTICE.txt
+++ b/enterprise/server-enterprise/NOTICE.txt
@@ -71,6 +71,11 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
+  Prometheus Java Simpleclient
+  Prometheus Java Simpleclient Common
+  Prometheus Java Simpleclient Dropwizard
+  Prometheus Java Simpleclient Hotspot
+  Prometheus Java Simpleclient Httpserver
 
 BSD - Scala License
   Scala Library


### PR DESCRIPTION
[Prometheus](https://prometheus.io/) is monitoring and alerting toolkit maintained by the [Cloud Native Computing Foundation](https://www.cncf.io/).

To enable the Prometheus HTTP endpoint you have to set `metrics.prometheus.enabled=true` in your `neo4j.conf`. The setting `metrics.prometheus.endpoint=<ip:port>` can be used to change the listening ip and port, default one is `localhost:2004`.

For example, adding the following to your configuration file:
```
metrics.prometheus.enabled=true
metrics.prometheus.endpoint=localhost:2004
```
will start a Prometheus endpoint at port 2004 accepting connections from the local machine.

Security wise, Prometheus states the following:
>It is presumed that untrusted users have access to the Prometheus HTTP endpoint and logs. They have access to all time series information contained in the database, plus a variety of operational/debugging information.

and should thus be managed at a firewall/OS level. If authentication is a requirement, a reverse proxy can be used on the local machine to expose the information.


