### PR TITLE
Ensure that the page cache events from the catchup client are published

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
@@ -209,9 +209,9 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
 
         LifeSupport txPulling = new LifeSupport();
         int maxBatchSize = config.get( CausalClusteringSettings.read_replica_transaction_applier_batch_size );
-        BatchingTxApplier batchingTxApplier =
-                new BatchingTxApplier( maxBatchSize, dependencies.provideDependency( TransactionIdStore.class ),
-                        writableCommitProcess, platformModule.monitors, logProvider );
+        BatchingTxApplier batchingTxApplier = new BatchingTxApplier(
+                maxBatchSize, dependencies.provideDependency( TransactionIdStore.class ), writableCommitProcess,
+                platformModule.monitors, platformModule.tracers.pageCursorTracerSupplier, logProvider );
 
         DelayedRenewableTimeoutService catchupTimeoutService =
                 new DelayedRenewableTimeoutService( Clocks.systemClock(), logProvider );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/BatchingTxApplierTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/tx/BatchingTxApplierTest.java
@@ -27,6 +27,7 @@ import org.mockito.ArgumentCaptor;
 import java.util.concurrent.CountDownLatch;
 
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.impl.api.TransactionCommitProcess;
 import org.neo4j.kernel.impl.api.TransactionToApply;
@@ -34,15 +35,11 @@ import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.TransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryCommit;
-import org.neo4j.kernel.internal.DatabaseHealth;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.NullLogProvider;
 
 import static org.junit.Assert.assertEquals;
-
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -53,13 +50,13 @@ public class BatchingTxApplierTest
 {
     private final TransactionIdStore idStore = mock( TransactionIdStore.class );
     private final TransactionCommitProcess commitProcess = mock( TransactionCommitProcess.class );
-    private final DatabaseHealth dbHealth = mock( DatabaseHealth.class );
 
     private final long startTxId = 31L;
     private final int maxBatchSize = 16;
 
-    private final BatchingTxApplier txApplier = new BatchingTxApplier( maxBatchSize, () -> idStore, () -> commitProcess,
-            new Monitors(), NullLogProvider.getInstance() );
+    private final BatchingTxApplier txApplier = new BatchingTxApplier(
+            maxBatchSize, () -> idStore, () -> commitProcess, new Monitors(), PageCursorTracerSupplier.NULL,
+            NullLogProvider.getInstance() );
 
     @Before
     public void before() throws Throwable

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaReplicationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaReplicationIT.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.causalclustering.scenarios;
 
+import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -28,6 +29,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedMap;
@@ -37,6 +39,7 @@ import java.util.function.BiConsumer;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import org.neo4j.causalclustering.catchup.tx.CatchupPollingProcess;
 import org.neo4j.causalclustering.catchup.tx.FileCopyMonitor;
@@ -61,6 +64,7 @@ import org.neo4j.graphdb.security.WriteOperationsNotAllowedException;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.io.pagecache.monitoring.PageCacheCounters;
 import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
@@ -88,6 +92,7 @@ import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
@@ -96,6 +101,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.neo4j.causalclustering.scenarios.SampleData.createData;
 import static org.neo4j.function.Predicates.awaitEx;
+import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.helpers.collection.Iterables.count;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.impl.store.MetaDataStore.Position.TIME;
@@ -592,6 +598,47 @@ public class ReadReplicaReplicationIT
             SortedMap<Long,File> logs = new FileNames( raftLogDir ).getAllFiles( fileSystem, mock( Log.class ) );
             return logs.keySet().stream().reduce( operator ).orElseThrow( IllegalStateException::new );
         }
+    }
+
+    @Test
+    public void pageFaultsFromReplicationMustCountInMetrics() throws Exception
+    {
+        // Given initial pin counts on all members
+        Cluster cluster = clusterRule.startCluster();
+        Function<ReadReplica,PageCacheCounters> getPageCacheCounters =
+                ccm -> ccm.database().getDependencyResolver().resolveDependency( PageCacheCounters.class );
+        List<PageCacheCounters> countersList =
+                cluster.readReplicas().stream().map( getPageCacheCounters ).collect( Collectors.toList() );
+        long[] initialPins = countersList.stream().mapToLong( PageCacheCounters::pins ).toArray();
+
+        // when the leader commits a write transaction,
+        cluster.coreTx( ( db, tx ) ->
+        {
+            Node node = db.createNode( label( "boo" ) );
+            node.setProperty( "foobar", "baz_bat" );
+            tx.success();
+        } );
+
+        // then the replication should cause pins on a majority of core members to increase.
+        // However, the commit returns as soon as the transaction has been replicated through the Raft log, which
+        // happens before the transaction is applied on the members, and then replicated to read-replicas.
+        // Therefor we are racing with the transaction application on the read-replicas, so we have to spin.
+        int minimumUpdatedMembersCount = countersList.size() / 2 + 1;
+        assertEventually( "Expected followers to eventually increase pin counts", () ->
+        {
+            long[] pinsAfterCommit = countersList.stream().mapToLong( PageCacheCounters::pins ).toArray();
+            int membersWithIncreasedPinCount = 0;
+            for ( int i = 0; i < initialPins.length; i++ )
+            {
+                long before = initialPins[i];
+                long after = pinsAfterCommit[i];
+                if ( before < after )
+                {
+                    membersWithIncreasedPinCount++;
+                }
+            }
+            return membersWithIncreasedPinCount;
+        }, Matchers.is( greaterThanOrEqualTo( minimumUpdatedMembersCount ) ), 10, SECONDS );
     }
 
     private final BiConsumer<CoreGraphDatabase,Transaction> createSomeData = ( db, tx ) ->


### PR DESCRIPTION
The catchup client is used by the Read Replicas to keep up to date with
the core replicas.

This is basically the same change as PR #10347, but for the Read
Replicas.