### PR TITLE
Upgrade scala to 2.11.12

### DIFF
--- a/community/cypher/acceptance-spec-suite/pom.xml
+++ b/community/cypher/acceptance-spec-suite/pom.xml
@@ -46,7 +46,7 @@
 
   <properties>
     <version-package>cypher.internal</version-package>
-    <scala.version>2.11.8</scala.version>
+    <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
   </properties>
 

--- a/community/cypher/compatibility-spec-suite/pom.xml
+++ b/community/cypher/compatibility-spec-suite/pom.xml
@@ -46,7 +46,7 @@
 
   <properties>
     <version-package>cypher.internal</version-package>
-    <scala.version>2.11.8</scala.version>
+    <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
   </properties>
 

--- a/community/cypher/cypher-compiler-3.1/pom.xml
+++ b/community/cypher/cypher-compiler-3.1/pom.xml
@@ -23,7 +23,7 @@
 
   <properties>
     <version-package>cypher.internal.compiler.v3_1</version-package>
-    <scala.version>2.11.8</scala.version>
+    <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
   </properties>
 
@@ -60,6 +60,7 @@
             <arg>-Xmax-classfile-name</arg>
             <arg>100</arg>
             <arg>-Xlint</arg>
+            <arg>-target:jvm-${maven.compiler.target}</arg>
           </args>
         </configuration>
       </plugin>

--- a/community/cypher/cypher/pom.xml
+++ b/community/cypher/cypher/pom.xml
@@ -45,7 +45,7 @@
 
   <properties>
     <version-package>cypher.internal</version-package>
-    <scala.version>2.11.8</scala.version>
+    <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
     <doclint-groups>none</doclint-groups>

--- a/community/cypher/frontend-3.1/pom.xml
+++ b/community/cypher/frontend-3.1/pom.xml
@@ -24,7 +24,7 @@
 
   <properties>
     <version-package>cypher.internal.frontend.v3_1</version-package>
-    <scala.version>2.11.8</scala.version>
+    <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
   </properties>
 
@@ -61,6 +61,7 @@
             <arg>-Xmax-classfile-name</arg>
             <arg>100</arg>
             <arg>-Xlint</arg>
+            <arg>-target:jvm-${maven.compiler.target}</arg>
           </args>
         </configuration>
       </plugin>

--- a/community/cypher/pom.xml
+++ b/community/cypher/pom.xml
@@ -79,6 +79,7 @@
           <args>
               <arg>-Xmax-classfile-name</arg>
               <arg>100</arg>
+              <arg>-target:jvm-${maven.compiler.target}</arg>
               <!-- arg>-deprecation</arg -->
           </args>
           <jvmArgs>

--- a/community/cypher/spec-suite-tools/pom.xml
+++ b/community/cypher/spec-suite-tools/pom.xml
@@ -46,7 +46,7 @@
 
   <properties>
     <version-package>cypher.internal</version-package>
-    <scala.version>2.11.8</scala.version>
+    <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <opencypher.version>1.0.0-M04</opencypher.version>
   </properties>

--- a/enterprise/kernel/pom.xml
+++ b/enterprise/kernel/pom.xml
@@ -21,7 +21,7 @@
   </scm>
 
   <properties>
-    <scala.version>2.11.8</scala.version>
+    <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
   </properties>
 
@@ -72,6 +72,7 @@
           <args>
             <arg>-Xmax-classfile-name</arg>
             <arg>100</arg>
+            <arg>-target:jvm-${maven.compiler.target}</arg>
             <!-- arg>-deprecation</arg -->
           </args>
           <jvmArgs>


### PR DESCRIPTION
Bump version to be able to generate correct bytecode for recent jvm versions (>= 9).
Error example: java.lang.IncompatibleClassChangeError:
Method org.neo4j.graphdb.RelationshipType.withName(Ljava/lang/String;)Lorg/neo4j/graphdb/RelationshipType; must be InterfaceMethodref constant