### PR TITLE
Unflake RetrieveRelationshipsFromNodeIT

### DIFF
--- a/community/server/src/test/java/org/neo4j/server/rest/RetrieveRelationshipsFromNodeIT.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/RetrieveRelationshipsFromNodeIT.java
@@ -29,7 +29,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
@@ -60,7 +59,7 @@ public class RetrieveRelationshipsFromNodeIT extends AbstractRestFunctionalDocTe
     private long likes;
 
     @BeforeClass
-    public static void setupServer() throws IOException
+    public static void setupServer()
     {
         functionalTestHelper = new FunctionalTestHelper( server() );
         helper = functionalTestHelper.getGraphDbHelper();
@@ -74,7 +73,8 @@ public class RetrieveRelationshipsFromNodeIT extends AbstractRestFunctionalDocTe
         helper.createRelationship( "LIKES", helper.createNode(), nodeWithRelationships );
         helper.createRelationship( "HATES", nodeWithRelationships, helper.createNode() );
         nodeWithoutRelationships = helper.createNode();
-        nonExistingNode = nodeWithoutRelationships * 100;
+        nonExistingNode = helper.createNode();
+        helper.deleteNode( nonExistingNode );
     }
 
     private JaxRsResponse sendRetrieveRequestToServer( long nodeId, String path )
@@ -321,7 +321,7 @@ public class RetrieveRelationshipsFromNodeIT extends AbstractRestFunctionalDocTe
         return server().baseUri().toString();
     }
 
-    private void isLegalJson( String entity ) throws IOException, JsonParseException
+    private void isLegalJson( String entity ) throws JsonParseException
     {
         JsonHelper.jsonToMap( entity );
     }


### PR DESCRIPTION
By having the non-existent node be an actual node id which is deleted