### PR TITLE
Backport cleanup HostnamePortTest URI creation assumptions.

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/helpers/HostnamePortTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/HostnamePortTest.java
@@ -19,19 +19,19 @@
  */
 package org.neo4j.helpers;
 
+import org.junit.Test;
+
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
-
-import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
 import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
 
 public class HostnamePortTest
 {
@@ -472,8 +472,6 @@ public class HostnamePortTest
     	// When & Then
     	
         assertFalse( hostnamePortSinglePort.matches( URI.create( "ha://" + unknownHost + ":1234" ) ) );
-        // no scheme means no ports and no host, so both null therefore comparison fails
-        assertFalse( hostnamePortSinglePort.matches( URI.create( unknownHost + ":1234" ) ) );
     }
 
     @Test
@@ -492,8 +490,6 @@ public class HostnamePortTest
         String host1 = InetAddress.getLocalHost().getHostName();
         
         assertFalse( hostnamePortSinglePort.matches( URI.create( "ha://" + host1 + ":1234" ) ) );
-        // no scheme means no ports and no host, so both null therefore comparison fails
-        assertFalse( hostnamePortSinglePort.matches( URI.create( host1 + ":1234" ) ) );
     }
     
     @Test


### PR DESCRIPTION
Cleanup incorrect assumption about ability to create URI for any host
and port if scheme is not specified.
Since URI should always have scheme defined and according to RFC 3986
it should be defined as "scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )"
And hosts that start with a digit will break that assumption.