### PR TITLE
Update netty dependency

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportSelectionHandler.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportSelectionHandler.java
@@ -136,7 +136,7 @@ public class TransportSelectionHandler extends ByteToMessageDecoder
         p.addLast(
                 new HttpServerCodec(),
                 new HttpObjectAggregator( MAX_WEBSOCKET_HANDSHAKE_SIZE ),
-                new WebSocketServerProtocolHandler( "" ),
+                new WebSocketServerProtocolHandler( "/" ),
                 new WebSocketFrameTranslator(),
                 new SocketTransportHandler(
                         new SocketTransportHandler.ProtocolChooser( protocolVersions, isEncrypted ), logging ) );

--- a/pom.xml
+++ b/pom.xml
@@ -514,7 +514,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.0.28.Final</version>
+        <version>4.0.44.Final</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Some of our browser test cases started behaving flaky after we migrated browser tests to run on firefox. It turned out that netty had an issue (netty/netty#3687) that caused the websocket server not to send the close frame.