### PR TITLE
Remove useless class parameter to Cluster (HA/CC) rules.

### DIFF
--- a/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandCcIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandCcIT.java
@@ -66,7 +66,7 @@ public class OnlineBackupCommandCcIT
     public final TestDirectory testDirectory = TestDirectory.testDirectory();
 
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( getClass() )
+    public ClusterRule clusterRule = new ClusterRule()
             .withNumberOfCoreMembers( 3 )
             .withNumberOfReadReplicas( 3 )
             .withSharedCoreParam( CausalClusteringSettings.cluster_topology_refresh, "5s" );

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/BackupCoreIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/BackupCoreIT.java
@@ -53,7 +53,7 @@ public class BackupCoreIT
     @Rule
     public final SuppressOutput suppressOutput = SuppressOutput.suppressAll();
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() )
+    public final ClusterRule clusterRule = new ClusterRule()
             .withNumberOfCoreMembers( 3 )
             .withNumberOfReadReplicas( 0 );
 

--- a/enterprise/backup/src/test/java/org/neo4j/causalclustering/BackupReadReplicaIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/causalclustering/BackupReadReplicaIT.java
@@ -47,7 +47,7 @@ import static org.neo4j.util.TestHelpers.runBackupToolFromOtherJvmToGetExitCode;
 public class BackupReadReplicaIT
 {
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( getClass() )
+    public ClusterRule clusterRule = new ClusterRule()
             .withNumberOfCoreMembers( 3 )
             .withSharedCoreParam( OnlineBackupSettings.online_backup_enabled, Settings.FALSE )
             .withNumberOfReadReplicas( 1 )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModuleIntegrationTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModuleIntegrationTest.java
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertTrue;
 public class EnterpriseCoreEditionModuleIntegrationTest
 {
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( getClass() );
+    public ClusterRule clusterRule = new ClusterRule();
 
     @Test
     public void createBufferedIdComponentsByDefault() throws Exception

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CausalClusteringProceduresIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CausalClusteringProceduresIT.java
@@ -41,7 +41,7 @@ import static org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext
 public class CausalClusteringProceduresIT
 {
     @ClassRule
-    public static final ClusterRule clusterRule = new ClusterRule( CausalClusteringProceduresIT.class )
+    public static final ClusterRule clusterRule = new ClusterRule()
             .withNumberOfCoreMembers( 2 )
             .withNumberOfReadReplicas( 1 );
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CausalClusteringRolesIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CausalClusteringRolesIT.java
@@ -32,7 +32,7 @@ import org.neo4j.test.causalclustering.ClusterRule;
 public class CausalClusteringRolesIT
 {
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() )
+    public final ClusterRule clusterRule = new ClusterRule()
             .withNumberOfCoreMembers( 3 )
             .withNumberOfReadReplicas( 1 );
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterBindingIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterBindingIT.java
@@ -59,7 +59,7 @@ import static org.neo4j.kernel.impl.store.MetaDataStore.Position.RANDOM_NUMBER;
 
 public class ClusterBindingIT
 {
-    private final ClusterRule clusterRule = new ClusterRule( ClusterBindingIT.class )
+    private final ClusterRule clusterRule = new ClusterRule()
                         .withNumberOfCoreMembers( 3 )
                         .withNumberOfReadReplicas( 0 )
                         .withSharedCoreParam( CausalClusteringSettings.raft_log_pruning_strategy, "3 entries" )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterCustomLogLocationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterCustomLogLocationIT.java
@@ -44,7 +44,7 @@ import static org.neo4j.kernel.impl.transaction.log.files.LogFilesBuilder.logFil
 public class ClusterCustomLogLocationIT
 {
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() )
+    public final ClusterRule clusterRule = new ClusterRule()
             .withNumberOfCoreMembers( 3 )
             .withNumberOfReadReplicas( 2 );
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterDiscoveryIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterDiscoveryIT.java
@@ -30,9 +30,9 @@ import java.util.List;
 import java.util.Map;
 
 import org.neo4j.causalclustering.discovery.Cluster;
+import org.neo4j.internal.kernel.api.Transaction.Type;
 import org.neo4j.kernel.api.InwardKernel;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.internal.kernel.api.Transaction.Type;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
@@ -73,7 +73,7 @@ public class ClusterDiscoveryIT
     }
 
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() ).withNumberOfCoreMembers( 3 );
+    public final ClusterRule clusterRule = new ClusterRule().withNumberOfCoreMembers( 3 );
 
     @Test
     public void shouldFindReadWriteAndRouteServers() throws Exception

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterFormationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterFormationIT.java
@@ -46,7 +46,7 @@ import static org.neo4j.values.virtual.VirtualValues.EMPTY_MAP;
 public class ClusterFormationIT
 {
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() )
+    public final ClusterRule clusterRule = new ClusterRule()
             .withNumberOfCoreMembers( 3 )
             .withNumberOfReadReplicas( 0 );
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterIdReuseIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterIdReuseIT.java
@@ -43,7 +43,7 @@ import static org.junit.Assume.assumeTrue;
 public class ClusterIdReuseIT
 {
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() )
+    public final ClusterRule clusterRule = new ClusterRule()
             .withNumberOfCoreMembers( 3 )
             // increased to decrease likelihood of unnecessary leadership changes
             .withSharedCoreParam( CausalClusteringSettings.leader_election_timeout, "2s" )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterIpFamilyIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterIpFamilyIT.java
@@ -86,7 +86,7 @@ public class ClusterIpFamilyIT
     }
 
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() )
+    public final ClusterRule clusterRule = new ClusterRule()
             .withNumberOfCoreMembers( 3 )
             .withNumberOfReadReplicas( 3 );
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterLeaderStepDownIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterLeaderStepDownIT.java
@@ -41,7 +41,7 @@ public class ClusterLeaderStepDownIT
 {
     @Rule
     public final ClusterRule clusterRule =
-            new ClusterRule( getClass() ).withNumberOfCoreMembers( 8 ).withNumberOfReadReplicas( 0 );
+            new ClusterRule().withNumberOfCoreMembers( 8 ).withNumberOfReadReplicas( 0 );
 
     @Test
     public void leaderShouldStepDownWhenFollowersAreGone() throws Throwable

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterOverviewIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterOverviewIT.java
@@ -45,10 +45,10 @@ import org.neo4j.causalclustering.discovery.SharedDiscoveryService;
 import org.neo4j.causalclustering.discovery.procedures.ClusterOverviewProcedure;
 import org.neo4j.causalclustering.discovery.procedures.Role;
 import org.neo4j.collection.RawIterator;
+import org.neo4j.internal.kernel.api.Transaction.Type;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.InwardKernel;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.internal.kernel.api.Transaction.Type;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
@@ -72,7 +72,7 @@ import static org.neo4j.test.assertion.Assert.assertEventually;
 public class ClusterOverviewIT
 {
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( getClass() )
+    public ClusterRule clusterRule = new ClusterRule()
             .withSharedCoreParam( CausalClusteringSettings.cluster_topology_refresh, "5s" );
 
     private enum DiscoveryService

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterShutdownIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterShutdownIT.java
@@ -48,7 +48,7 @@ public class ClusterShutdownIT
 {
     @Rule
     public final ClusterRule clusterRule =
-            new ClusterRule( getClass() ).withNumberOfCoreMembers( 3 ).withNumberOfReadReplicas( 0 );
+            new ClusterRule().withNumberOfCoreMembers( 3 ).withNumberOfReadReplicas( 0 );
 
     @Parameterized.Parameter()
     public Collection<Integer> shutdownOrder;

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ConnectionInfoIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ConnectionInfoIT.java
@@ -48,7 +48,7 @@ public class ConnectionInfoIT
 
     @Rule
     public final ClusterRule clusterRule =
-            new ClusterRule( getClass() ).withNumberOfCoreMembers( 3 ).withNumberOfReadReplicas( 0 );
+            new ClusterRule().withNumberOfCoreMembers( 3 ).withNumberOfReadReplicas( 0 );
 
     @After
     public void teardown() throws IOException

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CorePruningIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CorePruningIT.java
@@ -39,7 +39,7 @@ public class CorePruningIT
 {
     @Rule
     public final ClusterRule clusterRule =
-            new ClusterRule( getClass() ).withNumberOfCoreMembers( 3 ).withNumberOfReadReplicas( 0 )
+            new ClusterRule().withNumberOfCoreMembers( 3 ).withNumberOfReadReplicas( 0 )
                     .withSharedCoreParam( CausalClusteringSettings.state_machine_flush_window_size, "1" )
                     .withSharedCoreParam( raft_log_pruning_strategy, "keep_none" )
                     .withSharedCoreParam( CausalClusteringSettings.raft_log_rotation_size, "1K" )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreReplicationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreReplicationIT.java
@@ -60,7 +60,7 @@ import static org.neo4j.test.assertion.Assert.assertEventually;
 public class CoreReplicationIT
 {
     private final ClusterRule clusterRule =
-            new ClusterRule( getClass() ).withNumberOfCoreMembers( 3 ).withNumberOfReadReplicas( 0 );
+            new ClusterRule().withNumberOfCoreMembers( 3 ).withNumberOfReadReplicas( 0 );
     private final VerboseTimeout timeout = VerboseTimeout.builder()
             .withTimeout( 1000, SECONDS )
             .build();

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreToCoreCopySnapshotIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CoreToCoreCopySnapshotIT.java
@@ -58,7 +58,7 @@ public class CoreToCoreCopySnapshotIT
     protected static final int NR_CORE_MEMBERS = 3;
 
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() )
+    public final ClusterRule clusterRule = new ClusterRule()
             .withNumberOfCoreMembers( NR_CORE_MEMBERS )
             .withNumberOfReadReplicas( 0 );
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/PreElectionIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/PreElectionIT.java
@@ -45,7 +45,7 @@ import static org.junit.Assert.fail;
 public class PreElectionIT
 {
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( getClass() )
+    public ClusterRule clusterRule = new ClusterRule()
             .withNumberOfCoreMembers( 3 )
             .withNumberOfReadReplicas( 0 )
             .withSharedCoreParam( CausalClusteringSettings.leader_election_timeout, "10s" )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaHierarchicalCatchupIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaHierarchicalCatchupIT.java
@@ -35,12 +35,9 @@ import org.neo4j.causalclustering.discovery.ReadReplica;
 import org.neo4j.helpers.collection.Pair;
 import org.neo4j.test.causalclustering.ClusterRule;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
 import static org.neo4j.causalclustering.helpers.DataCreator.createLabelledNodesWithProperty;
 import static org.neo4j.causalclustering.scenarios.ReadReplicaToReadReplicaCatchupIT.checkDataHasReplicatedToReadReplicas;
 import static org.neo4j.graphdb.Label.label;
-import static org.neo4j.helpers.collection.Iterables.count;
 
 public class ReadReplicaHierarchicalCatchupIT
 {
@@ -62,7 +59,7 @@ public class ReadReplicaHierarchicalCatchupIT
 
     @Rule
     public ClusterRule clusterRule =
-            new ClusterRule( getClass() ).withNumberOfCoreMembers( 3 ).withNumberOfReadReplicas( 0 )
+            new ClusterRule().withNumberOfCoreMembers( 3 ).withNumberOfReadReplicas( 0 )
                     .withSharedCoreParam( CausalClusteringSettings.cluster_topology_refresh, "5s" )
                     .withSharedCoreParam( CausalClusteringSettings.multi_dc_license, "true" )
                     .withSharedReadReplicaParam( CausalClusteringSettings.multi_dc_license, "true" )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaReplicationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaReplicationIT.java
@@ -110,7 +110,7 @@ public class ReadReplicaReplicationIT
     protected static final int NR_READ_REPLICAS = 1;
 
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() ).withNumberOfCoreMembers( NR_CORE_MEMBERS )
+    public final ClusterRule clusterRule = new ClusterRule().withNumberOfCoreMembers( NR_CORE_MEMBERS )
             .withNumberOfReadReplicas( NR_READ_REPLICAS )
             .withSharedCoreParam( CausalClusteringSettings.cluster_topology_refresh, "5s" )
             .withDiscoveryServiceFactory( new HazelcastDiscoveryServiceFactory() );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaStoreCopyIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaStoreCopyIT.java
@@ -52,7 +52,7 @@ import static org.neo4j.test.assertion.Assert.assertEventually;
 public class ReadReplicaStoreCopyIT
 {
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() )
+    public final ClusterRule clusterRule = new ClusterRule()
             .withSharedCoreParam( GraphDatabaseSettings.keep_logical_logs, FALSE )
             .withNumberOfCoreMembers( 3 )
             .withNumberOfReadReplicas( 1 );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaToReadReplicaCatchupIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaToReadReplicaCatchupIT.java
@@ -56,7 +56,7 @@ public class ReadReplicaToReadReplicaCatchupIT
 {
     @Rule
     public final ClusterRule clusterRule =
-            new ClusterRule( getClass() ).withNumberOfCoreMembers( 3 ).withNumberOfReadReplicas( 0 )
+            new ClusterRule().withNumberOfCoreMembers( 3 ).withNumberOfReadReplicas( 0 )
                     .withSharedCoreParam( CausalClusteringSettings.cluster_topology_refresh, "5s" )
                     .withSharedCoreParam( CausalClusteringSettings.multi_dc_license, "true" )
                     .withSharedReadReplicaParam( CausalClusteringSettings.multi_dc_license, "true" )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/RecoveryIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/RecoveryIT.java
@@ -45,7 +45,7 @@ import static org.neo4j.test.assertion.Assert.assertEventually;
 public class RecoveryIT
 {
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() )
+    public final ClusterRule clusterRule = new ClusterRule()
             .withNumberOfCoreMembers( 3 )
             .withNumberOfReadReplicas( 0 );
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/RestartIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/RestartIT.java
@@ -50,7 +50,7 @@ import static org.neo4j.graphdb.Label.label;
 public class RestartIT
 {
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() )
+    public final ClusterRule clusterRule = new ClusterRule()
             .withNumberOfCoreMembers( 3 )
             .withNumberOfReadReplicas( 0 );
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/TransactionLogRecoveryIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/TransactionLogRecoveryIT.java
@@ -52,7 +52,7 @@ public class TransactionLogRecoveryIT
     public final PageCacheRule pageCache = new PageCacheRule();
 
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() )
+    public final ClusterRule clusterRule = new ClusterRule()
             .withNumberOfCoreMembers( 3 )
             .withNumberOfReadReplicas( 3 );
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/UnavailableIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/UnavailableIT.java
@@ -38,7 +38,7 @@ import static org.neo4j.kernel.api.exceptions.Status.statusCodeOf;
 public class UnavailableIT
 {
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() ).withNumberOfCoreMembers( 3 );
+    public final ClusterRule clusterRule = new ClusterRule().withNumberOfCoreMembers( 3 );
 
     private Cluster cluster;
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/WillNotBecomeLeaderIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/WillNotBecomeLeaderIT.java
@@ -40,7 +40,7 @@ public class WillNotBecomeLeaderIT
 {
     @Rule
     public final ClusterRule clusterRule =
-            new ClusterRule( getClass() ).withNumberOfCoreMembers( 3 ).withNumberOfReadReplicas( 0 )
+            new ClusterRule().withNumberOfCoreMembers( 3 ).withNumberOfReadReplicas( 0 )
                     .withDiscoveryServiceFactory( new HazelcastDiscoveryServiceFactory() )
                     .withSharedCoreParam( CausalClusteringSettings.multi_dc_license, "true" );
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/test/causalclustering/ClusterRule.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/test/causalclustering/ClusterRule.java
@@ -57,9 +57,9 @@ public class ClusterRule extends ExternalResource
     private IpFamily ipFamily = IPV4;
     private boolean useWildcard;
 
-    public ClusterRule( Class<?> testClass )
+    public ClusterRule()
     {
-        this.testDirectory = TestDirectory.testDirectory( testClass );
+        this.testDirectory = TestDirectory.testDirectory();
     }
 
     @Override

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/test/causalclustering/ClusterRuleIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/test/causalclustering/ClusterRuleIT.java
@@ -19,14 +19,12 @@
  */
 package org.neo4j.test.causalclustering;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import org.junit.Rule;
+import org.junit.Test;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.Rule;
-import org.junit.Test;
 import org.neo4j.causalclustering.core.CausalClusteringSettings;
 import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.ClusterMember;
@@ -36,13 +34,16 @@ import org.neo4j.kernel.configuration.BoltConnector;
 import org.neo4j.kernel.configuration.HttpConnector;
 import org.neo4j.kernel.impl.enterprise.configuration.OnlineBackupSettings;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 public class ClusterRuleIT
 {
     private static final int NumberOfPortsUsedByCoreMember = 6;
     private static final int NumberOfPortsUsedByReadReplica = 4;
 
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() );
+    public final ClusterRule clusterRule = new ClusterRule();
 
     @Test
     public void shouldAssignPortsToMembersAutomatically() throws Exception

--- a/enterprise/ha/src/test/java/jmx/HaBeanIT.java
+++ b/enterprise/ha/src/test/java/jmx/HaBeanIT.java
@@ -54,7 +54,7 @@ import static org.neo4j.test.ha.ClusterRule.stringWithIntBase;
 public class HaBeanIT
 {
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( HaBeanIT.class )
+    public final ClusterRule clusterRule = new ClusterRule()
             .withInstanceSetting( setting( "jmx.port", STRING, Settings.NO_DEFAULT ), intBase( 9912 ) )
             .withInstanceSetting( HaSettings.ha_server, stringWithIntBase( ":", 1136 ) )
             .withInstanceSetting( GraphDatabaseSettings.forced_kernel_id, stringWithIntBase( "kernel", 0 ) );

--- a/enterprise/ha/src/test/java/org/neo4j/ha/BackupHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/BackupHaIT.java
@@ -46,7 +46,7 @@ import static org.neo4j.util.TestHelpers.runBackupToolFromOtherJvmToGetExitCode;
 public class BackupHaIT
 {
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( getClass() )
+    public ClusterRule clusterRule = new ClusterRule()
             .withSharedSetting( OnlineBackupSettings.online_backup_enabled, Settings.TRUE )
             .withInstanceSetting( OnlineBackupSettings.online_backup_server, serverId -> ":" + PortAuthority.allocatePort() );
     @Rule

--- a/enterprise/ha/src/test/java/org/neo4j/ha/ClusterClientPaddingIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/ClusterClientPaddingIT.java
@@ -36,7 +36,7 @@ import static org.neo4j.kernel.impl.ha.ClusterManager.masterSeesMembers;
 public class ClusterClientPaddingIT
 {
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( getClass() )
+    public ClusterRule clusterRule = new ClusterRule()
             .withSharedSetting( ClusterSettings.heartbeat_interval, "1s" )
             .withSharedSetting( ClusterSettings.heartbeat_timeout, "10s" );
 

--- a/enterprise/ha/src/test/java/org/neo4j/ha/ClusterIndexDeletionIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/ClusterIndexDeletionIT.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertThat;
 public class ClusterIndexDeletionIT
 {
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( getClass() )
+    public ClusterRule clusterRule = new ClusterRule()
             .withSharedSetting( HaSettings.tx_push_factor, "2" )
             .withSharedSetting( OnlineBackupSettings.online_backup_enabled, Settings.FALSE );
 

--- a/enterprise/ha/src/test/java/org/neo4j/ha/ClusterTransactionIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/ClusterTransactionIT.java
@@ -46,7 +46,7 @@ import static org.neo4j.kernel.impl.ha.ClusterManager.clusterOfSize;
 public class ClusterTransactionIT
 {
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() );
+    public final ClusterRule clusterRule = new ClusterRule();
 
     private ClusterManager.ManagedCluster cluster;
 

--- a/enterprise/ha/src/test/java/org/neo4j/ha/ConstraintsInHAIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/ConstraintsInHAIT.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.fail;
 public class ConstraintsInHAIT
 {
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( getClass() );
+    public ClusterRule clusterRule = new ClusterRule();
 
     @Test
     public void creatingConstraintOnSlaveIsNotAllowed() throws Exception

--- a/enterprise/ha/src/test/java/org/neo4j/ha/PullUpdatesIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/PullUpdatesIT.java
@@ -74,7 +74,7 @@ public class PullUpdatesIT
     private static final int PULL_INTERVAL = 100;
 
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() );
+    public final ClusterRule clusterRule = new ClusterRule();
 
     @Test
     public void makeSureUpdatePullerGetsGoingAfterMasterSwitch() throws Throwable

--- a/enterprise/ha/src/test/java/org/neo4j/ha/SlaveOnlyClusterIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/SlaveOnlyClusterIT.java
@@ -46,7 +46,7 @@ import static org.neo4j.kernel.impl.ha.ClusterManager.allSeesAllAsAvailable;
 public class SlaveOnlyClusterIT
 {
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( SlaveOnlyClusterIT.class )
+    public ClusterRule clusterRule = new ClusterRule()
             .withInstanceSetting( HaSettings.slave_only,
                     value -> value == 1 || value == 2 ? Settings.TRUE : Settings.FALSE );
 

--- a/enterprise/ha/src/test/java/org/neo4j/ha/TransactionConstraintsIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/TransactionConstraintsIT.java
@@ -65,7 +65,7 @@ public class TransactionConstraintsIT
 
     @Rule
     public final ClusterRule clusterRule =
-            new ClusterRule( getClass() ).withSharedSetting( HaSettings.pull_interval, "0" )
+            new ClusterRule().withSharedSetting( HaSettings.pull_interval, "0" )
                     .withInstanceSetting( HaSettings.slave_only,
                             serverId -> serverId == SLAVE_ONLY_ID ? "true" : "false" );
 

--- a/enterprise/ha/src/test/java/org/neo4j/ha/UniquenessConstraintValidationHAIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/UniquenessConstraintValidationHAIT.java
@@ -48,7 +48,7 @@ public class UniquenessConstraintValidationHAIT
     @Rule
     public final OtherThreadRule<Void> otherThread = new OtherThreadRule<>();
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() )
+    public final ClusterRule clusterRule = new ClusterRule()
             .withInitialDataset( uniquenessConstraint( LABEL, PROPERTY_KEY ) );
 
     @Test

--- a/enterprise/ha/src/test/java/org/neo4j/ha/UpdatePullerSwitchIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/UpdatePullerSwitchIT.java
@@ -53,7 +53,7 @@ import static org.neo4j.kernel.impl.ha.ClusterManager.masterAvailable;
 public class UpdatePullerSwitchIT
 {
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() ).withCluster( clusterOfSize( 2 ) )
+    public final ClusterRule clusterRule = new ClusterRule().withCluster( clusterOfSize( 2 ) )
             .withSharedSetting( tx_push_factor, "0" )
             .withSharedSetting( HaSettings.pull_interval, "100s" )
             .withFirstInstanceId( 6 );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/HACountsPropagationIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/HACountsPropagationIT.java
@@ -42,7 +42,7 @@ public class HACountsPropagationIT
     private static final int PULL_INTERVAL = 100;
 
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( getClass() )
+    public ClusterRule clusterRule = new ClusterRule()
             .withSharedSetting( HaSettings.pull_interval, PULL_INTERVAL + "ms" );
 
     @Test

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/LabelIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/LabelIT.java
@@ -39,7 +39,7 @@ import static org.neo4j.graphdb.Label.label;
 public class LabelIT
 {
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() );
+    public final ClusterRule clusterRule = new ClusterRule();
 
     protected ClusterManager.ManagedCluster cluster;
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/ConstraintHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/ConstraintHaIT.java
@@ -212,7 +212,7 @@ public class ConstraintHaIT
     public abstract static class AbstractConstraintHaIT
     {
         @Rule
-        public ClusterRule clusterRule = new ClusterRule( getClass() )
+        public ClusterRule clusterRule = new ClusterRule()
                 .withSharedSetting( HaSettings.read_timeout, "4000s" );
 
         private static final String TYPE = "Type";

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/api/SchemaIndexHaIT.java
@@ -95,7 +95,7 @@ public class SchemaIndexHaIT
     @ClassRule
     public static DefaultFileSystemRule fileSystemRule = new DefaultFileSystemRule();
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( getClass() );
+    public ClusterRule clusterRule = new ClusterRule();
 
     @Test
     public void creatingIndexOnMasterShouldHaveSlavesBuildItAsWell() throws Throwable

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/BasicHaOperationsIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/BasicHaOperationsIT.java
@@ -42,7 +42,7 @@ public class BasicHaOperationsIT
     @ClassRule
     public static LoggerRule logger = new LoggerRule( Level.OFF );
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( getClass() ).withSharedSetting( HaSettings.tx_push_factor, "2" );
+    public ClusterRule clusterRule = new ClusterRule().withSharedSetting( HaSettings.tx_push_factor, "2" );
 
     @Test
     public void testBasicFailover() throws Throwable

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/BiggerThanLogTxIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/BiggerThanLogTxIT.java
@@ -42,7 +42,7 @@ public class BiggerThanLogTxIT
     private static final String ROTATION_THRESHOLD = "1M";
 
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( getClass() )
+    public ClusterRule clusterRule = new ClusterRule()
             .withSharedSetting( GraphDatabaseSettings.logical_log_rotation_threshold, ROTATION_THRESHOLD );
 
     protected ClusterManager.ManagedCluster cluster;

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterTopologyChangesIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/ClusterTopologyChangesIT.java
@@ -68,7 +68,7 @@ import static org.neo4j.kernel.impl.ha.ClusterManager.masterSeesSlavesAsAvailabl
 public class ClusterTopologyChangesIT
 {
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() );
+    public final ClusterRule clusterRule = new ClusterRule();
 
     @Rule
     public final CleanupRule cleanup = new CleanupRule();

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/DeletionIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/DeletionIT.java
@@ -54,7 +54,7 @@ import static org.neo4j.kernel.impl.ha.ClusterManager.clusterOfSize;
 public class DeletionIT
 {
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( DeletionIT.class ).withCluster( clusterOfSize( 2 ) );
+    public ClusterRule clusterRule = new ClusterRule().withCluster( clusterOfSize( 2 ) );
 
     /**
      * The problem would manifest even if the transaction was performed on the Master, it would then occur when the

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/HaCountsIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/HaCountsIT.java
@@ -28,8 +28,8 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.schema.IndexDefinition;
-import org.neo4j.kernel.api.Statement;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.impl.api.index.IndexingService;
@@ -51,7 +51,7 @@ public class HaCountsIT
     private static final String PROPERTY_VALUE = "value";
 
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( getClass() );
+    public ClusterRule clusterRule = new ClusterRule();
 
     private ManagedCluster cluster;
     private HighlyAvailableGraphDatabase master;

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/IdBufferingRoleSwitchIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/IdBufferingRoleSwitchIT.java
@@ -41,7 +41,7 @@ import static org.neo4j.kernel.impl.ha.ClusterManager.masterAvailable;
 public class IdBufferingRoleSwitchIT
 {
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( getClass() )
+    public ClusterRule clusterRule = new ClusterRule()
              // Disable automatic sync so that the test can control this itself
             .withSharedSetting( HaSettings.pull_interval, "0" )
             .withSharedSetting( HaSettings.tx_push_factor, "0" )

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/MeasureUpdatePullingRecordAndIndexGap.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/MeasureUpdatePullingRecordAndIndexGap.java
@@ -49,7 +49,7 @@ public class MeasureUpdatePullingRecordAndIndexGap
     private final int numberOfIndexes = 10;
 
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() )
+    public final ClusterRule clusterRule = new ClusterRule()
             .withSharedSetting( HaSettings.tx_push_factor, "0" );
 
     @Test

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/PropertyConstraintsStressIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/PropertyConstraintsStressIT.java
@@ -75,7 +75,7 @@ public class PropertyConstraintsStressIT
     @Rule
     public final SuppressOutput suppressOutput = SuppressOutput.suppressAll();
     @ClassRule
-    public static final ClusterRule clusterRule = new ClusterRule( PropertyConstraintsStressIT.class );
+    public static final ClusterRule clusterRule = new ClusterRule();
 
     @Rule
     public OtherThreadRule<Object> slaveWork = new OtherThreadRule<>();

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TwoInstanceClusterIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TwoInstanceClusterIT.java
@@ -37,7 +37,7 @@ import static org.neo4j.kernel.impl.ha.ClusterManager.memberSeesOtherMemberAsFai
 public class TwoInstanceClusterIT
 {
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() );
+    public final ClusterRule clusterRule = new ClusterRule();
 
     private ClusterManager.ManagedCluster cluster;
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TxPushStrategyConfigIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TxPushStrategyConfigIT.java
@@ -55,7 +55,7 @@ public class TxPushStrategyConfigIT
     @Rule
     public final SuppressOutput suppressOutput = SuppressOutput.suppressAll();
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() );
+    public final ClusterRule clusterRule = new ClusterRule();
 
     /**
      * These are _indexes_ of cluster members in machineIds

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/WhenToInitializeTransactionOnMasterFromSlaveIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/WhenToInitializeTransactionOnMasterFromSlaveIT.java
@@ -46,7 +46,7 @@ import static org.neo4j.helpers.collection.Iterables.count;
 public class WhenToInitializeTransactionOnMasterFromSlaveIT
 {
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( getClass() );
+    public ClusterRule clusterRule = new ClusterRule();
 
     private GraphDatabaseService slave;
     private ClusterManager.ManagedCluster cluster;

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SlaveWritingAfterStoreCopyIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/SlaveWritingAfterStoreCopyIT.java
@@ -38,7 +38,7 @@ import static org.neo4j.io.fs.FileUtils.deleteRecursively;
 public class SlaveWritingAfterStoreCopyIT
 {
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( this.getClass() );
+    public ClusterRule clusterRule = new ClusterRule();
 
     @Test
     public void shouldHandleSlaveWritingFirstAfterStoryCopy() throws Throwable

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/TerminationOfSlavesDuringPullUpdatesIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/cluster/TerminationOfSlavesDuringPullUpdatesIT.java
@@ -65,7 +65,7 @@ public class TerminationOfSlavesDuringPullUpdatesIT
     private static final int PROPERTY_KEY_CHAIN_LENGTH = 100;
 
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( getClass() )
+    public ClusterRule clusterRule = new ClusterRule()
             .withSharedSetting( HaSettings.pull_interval, "0" )
             .withSharedSetting( HaSettings.tx_push_factor, "0" );
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModuleIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModuleIT.java
@@ -46,7 +46,7 @@ import static org.junit.Assert.assertTrue;
 public class HighlyAvailableEditionModuleIT
 {
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( getClass() );
+    public ClusterRule clusterRule = new ClusterRule();
 
     @Test
     public void createBufferedIdComponentsByDefault() throws Exception

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/ClusterLocksIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/ClusterLocksIT.java
@@ -53,7 +53,7 @@ public class ClusterLocksIT
     private static final long TIMEOUT_MILLIS = 120_000;
 
     public final ExpectedException expectedException = ExpectedException.none();
-    public final ClusterRule clusterRule = new ClusterRule( getClass() );
+    public final ClusterRule clusterRule = new ClusterRule();
 
     @Rule
     public final RuleChain rules = RuleChain.outerRule( expectedException ).around( clusterRule );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveStatementLocksFactoryIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/lock/SlaveStatementLocksFactoryIT.java
@@ -50,7 +50,7 @@ public class SlaveStatementLocksFactoryIT
     private static final String testProperty = "testProperty";
 
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() )
+    public final ClusterRule clusterRule = new ClusterRule()
             .withSharedSetting( GraphDatabaseFacadeFactory.Configuration.tracer, "slaveLocksTracer" )
             .withSharedSetting( HaSettings.tx_push_factor, "2" );
     private ClusterManager.ManagedCluster managedCluster;

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/transaction/TransactionThroughMasterSwitchStressIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/transaction/TransactionThroughMasterSwitchStressIT.java
@@ -76,7 +76,7 @@ import static org.neo4j.kernel.impl.ha.ClusterManager.memberThinksItIsRole;
 public class TransactionThroughMasterSwitchStressIT
 {
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() )
+    public final ClusterRule clusterRule = new ClusterRule()
             .withInstanceSetting( HaSettings.slave_only,
                     value -> value == 1 || value == 2 ? Settings.TRUE : Settings.FALSE );
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/index/AutoIndexConfigIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/index/AutoIndexConfigIT.java
@@ -36,7 +36,7 @@ import static org.neo4j.kernel.impl.ha.ClusterManager.masterAvailable;
 public class AutoIndexConfigIT
 {
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( getClass() );
+    public ClusterRule clusterRule = new ClusterRule();
 
     @Test
     public void programmaticConfigShouldSurviveMasterSwitches() throws Throwable

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/index/IndexOperationsIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/index/IndexOperationsIT.java
@@ -49,7 +49,7 @@ import static org.junit.Assert.assertTrue;
 public class IndexOperationsIT
 {
     @Rule
-    public ClusterRule clusterRule = new ClusterRule( getClass() );
+    public ClusterRule clusterRule = new ClusterRule();
 
     protected ClusterManager.ManagedCluster cluster;
 

--- a/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterRule.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ha/ClusterRule.java
@@ -78,9 +78,9 @@ public class ClusterRule extends ExternalResource implements ClusterBuilder<Clus
     private final TestDirectory testDirectory;
     private ManagedCluster cluster;
 
-    public ClusterRule( Class<?> testClass )
+    public ClusterRule()
     {
-        this.testDirectory = TestDirectory.testDirectory( testClass );
+        this.testDirectory = TestDirectory.testDirectory();
         this.clusterManagerBuilder = new ClusterManager.Builder()
                 .withSharedSetting( store_internal_log_level, "DEBUG" )
                 .withSharedSetting( default_timeout, "1s" )

--- a/enterprise/ha/src/test/java/org/neo4j/test/ha/ReadOnlySlaveIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/test/ha/ReadOnlySlaveIT.java
@@ -44,7 +44,7 @@ import static org.neo4j.kernel.ha.HaSettings.tx_push_factor;
 public class ReadOnlySlaveIT
 {
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() )
+    public final ClusterRule clusterRule = new ClusterRule()
             .withSharedSetting( tx_push_factor, "2" )
             .withInstanceSetting( read_only, oneBasedServerId -> oneBasedServerId == 2 ? Settings.TRUE : null );
 

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/CoreEdgeMetricsIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/CoreEdgeMetricsIT.java
@@ -28,7 +28,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import org.neo4j.causalclustering.core.CoreGraphDatabase;
 import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.CoreClusterMember;
 import org.neo4j.causalclustering.discovery.ReadReplica;
@@ -63,7 +62,7 @@ public class CoreEdgeMetricsIT
     private static final int TIMEOUT = 15;
 
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() )
+    public final ClusterRule clusterRule = new ClusterRule()
             .withNumberOfCoreMembers( 3 )
             .withNumberOfReadReplicas( 1 )
             .withSharedCoreParam( MetricsSettings.metricsEnabled, Settings.TRUE )

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/MetricsKernelExtensionFactoryIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/MetricsKernelExtensionFactoryIT.java
@@ -70,7 +70,7 @@ import static org.neo4j.metrics.MetricsTestHelper.readLongValueAndAssert;
 public class MetricsKernelExtensionFactoryIT
 {
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() )
+    public final ClusterRule clusterRule = new ClusterRule()
             .withSharedSetting( GraphDatabaseSettings.record_id_batch_size, "1" );
 
     private HighlyAvailableGraphDatabase db;

--- a/integrationtests/src/test/java/org/neo4j/TransactionTerminationIT.java
+++ b/integrationtests/src/test/java/org/neo4j/TransactionTerminationIT.java
@@ -91,7 +91,7 @@ public class TransactionTerminationIT
     public String lockManagerName;
 
     private final CleanupRule cleanupRule = new CleanupRule();
-    private final ClusterRule clusterRule = new ClusterRule( getClass() )
+    private final ClusterRule clusterRule = new ClusterRule()
             .withCluster( clusterOfSize( 3 ) )
             .withSharedSetting( HaSettings.tx_push_factor, "2" )
             .withSharedSetting( HaSettings.lock_read_timeout, "1m" );

--- a/integrationtests/src/test/java/org/neo4j/causalclustering/scenarios/BoltCausalClusteringIT.java
+++ b/integrationtests/src/test/java/org/neo4j/causalclustering/scenarios/BoltCausalClusteringIT.java
@@ -76,7 +76,7 @@ public class BoltCausalClusteringIT
 {
     private static final long DEFAULT_TIMEOUT_MS = 15_000;
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() ).withNumberOfCoreMembers( 3 );
+    public final ClusterRule clusterRule = new ClusterRule().withNumberOfCoreMembers( 3 );
     @Rule
     public final SuppressOutput suppressOutput = SuppressOutput.suppressAll();
 

--- a/integrationtests/src/test/java/org/neo4j/causalclustering/scenarios/ConvertNonCausalClusteringStoreIT.java
+++ b/integrationtests/src/test/java/org/neo4j/causalclustering/scenarios/ConvertNonCausalClusteringStoreIT.java
@@ -56,7 +56,7 @@ import static org.neo4j.test.assertion.Assert.assertEventually;
 public class ConvertNonCausalClusteringStoreIT
 {
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() )
+    public final ClusterRule clusterRule = new ClusterRule()
             .withNumberOfCoreMembers( 3 )
             .withNumberOfReadReplicas( 0 );
 

--- a/integrationtests/src/test/java/org/neo4j/causalclustering/scenarios/ListQueriesProcedureInClusterIT.java
+++ b/integrationtests/src/test/java/org/neo4j/causalclustering/scenarios/ListQueriesProcedureInClusterIT.java
@@ -54,7 +54,7 @@ public class ListQueriesProcedureInClusterIT
 {
     private static final int THIRTY_SECONDS_TIMEOUT = 30;
     private final ClusterRule clusterRule =
-            new ClusterRule( getClass() ).withNumberOfCoreMembers( 3 ).withNumberOfReadReplicas( 1 );
+            new ClusterRule().withNumberOfCoreMembers( 3 ).withNumberOfReadReplicas( 1 );
     private final VerboseTimeout timeout = VerboseTimeout.builder().withTimeout( 1000, SECONDS ).build();
     @Rule
     public RuleChain ruleChain = RuleChain.outerRule( clusterRule ).around( timeout );

--- a/integrationtests/src/test/java/org/neo4j/ha/BoltHAIT.java
+++ b/integrationtests/src/test/java/org/neo4j/ha/BoltHAIT.java
@@ -19,11 +19,11 @@
  */
 package org.neo4j.ha;
 
-import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
-
 import org.junit.Rule;
 import org.junit.Test;
+
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 
 import org.neo4j.driver.v1.AuthTokens;
 import org.neo4j.driver.v1.Driver;
@@ -46,7 +46,7 @@ import static org.neo4j.kernel.impl.ha.ClusterManager.masterSeesMembers;
 public class BoltHAIT
 {
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() ).withBoltEnabled().withCluster( clusterOfSize( 3 ) );
+    public final ClusterRule clusterRule = new ClusterRule().withBoltEnabled().withCluster( clusterOfSize( 3 ) );
 
     @Test
     public void shouldContinueServingBoltRequestsBetweenInternalRestarts() throws Throwable

--- a/integrationtests/src/test/java/org/neo4j/ha/HAClusterStartupIT.java
+++ b/integrationtests/src/test/java/org/neo4j/ha/HAClusterStartupIT.java
@@ -59,7 +59,7 @@ public class HAClusterStartupIT
     public static class SimpleCluster
     {
         @Rule
-        public final ClusterRule clusterRule = new ClusterRule( getClass() ).withCluster( clusterOfSize( 3 ) );
+        public final ClusterRule clusterRule = new ClusterRule().withCluster( clusterOfSize( 3 ) );
         private HighlyAvailableGraphDatabase oldMaster;
         private HighlyAvailableGraphDatabase oldSlave1;
         private HighlyAvailableGraphDatabase oldSlave2;
@@ -179,7 +179,7 @@ public class HAClusterStartupIT
     public static class ClusterWithSeed
     {
         @Rule
-        public final ClusterRule clusterRule = new ClusterRule( getClass() ).withCluster( clusterOfSize( 3 ) )
+        public final ClusterRule clusterRule = new ClusterRule().withCluster( clusterOfSize( 3 ) )
                 .withSeedDir( dbWithOutLogs() );
 
         public ClusterWithSeed() throws IOException

--- a/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/IdReusabilityStressTesting.java
+++ b/stresstests/src/test/java/org/neo4j/causalclustering/stresstests/IdReusabilityStressTesting.java
@@ -79,7 +79,7 @@ public class IdReusabilityStressTesting
     private static final RelationshipType RELATIONSHIP_TYPE = RelationshipType.withName( "testType" );
 
     @Rule
-    public final ClusterRule clusterRule = new ClusterRule( getClass() );
+    public final ClusterRule clusterRule = new ClusterRule();
 
     private final DefaultFileSystemRule defaultFileSystemRule = new DefaultFileSystemRule();
     private DefaultFileSystemAbstraction fs;


### PR DESCRIPTION
Remove explicit getClass() parameter, rely on testDirectory
to correctly choose your test directory based on owning class
automatically instead.