### PR TITLE
Lower memory requirement of recovery

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalTransactionCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/PhysicalTransactionCursor.java
@@ -57,6 +57,10 @@ public class PhysicalTransactionCursor<T extends ReadableClosablePositionAwareCh
     @Override
     public boolean next() throws IOException
     {
+        // Clear the previous deserialized transaction so that it won't have to be kept in heap while deserializing
+        // the next one. Could be problematic if both are really big.
+        current = null;
+
         while ( true )
         {
             if ( !logEntryCursor.next() )


### PR DESCRIPTION
By keeping only a single transaction in memory at any point in time. There was no performance benefit batching multiple transactions, mainly since the main benefactor of this batching would be indexing, but updates to indexes during recovery are batched in another way anyway.