### PR TITLE
Correct log statement when stopping servers

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupServer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/CatchupServer.java
@@ -226,7 +226,7 @@ public class CatchupServer extends LifecycleAdapter
         }
 
         if ( workerGroup != null &&
-                workerGroup.shutdownGracefully( 2, 5, TimeUnit.SECONDS ).awaitUninterruptibly( 10, TimeUnit.SECONDS ) )
+             !workerGroup.shutdownGracefully( 2, 5, TimeUnit.SECONDS ).awaitUninterruptibly( 10, TimeUnit.SECONDS ) )
         {
             log.warn( "Worker group not shutdown within 10 seconds." );
         }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftServer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftServer.java
@@ -104,7 +104,7 @@ public class RaftServer extends LifecycleAdapter implements Inbound<RaftMessages
             log.warn( "Interrupted while closing channel." );
         }
 
-        if ( workerGroup.shutdownGracefully( 2, 5, TimeUnit.SECONDS ).awaitUninterruptibly( 10, TimeUnit.SECONDS ) )
+        if ( !workerGroup.shutdownGracefully( 2, 5, TimeUnit.SECONDS ).awaitUninterruptibly( 10, TimeUnit.SECONDS ) )
         {
             log.warn( "Worker group not shutdown within 10 seconds." );
         }


### PR DESCRIPTION
The log statement should correctly warn when worker group was not shutdown
within time limit. It was doing the opposite before.