### PR TITLE
Truncate log file non readable end

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/RecoveryCorruptedTransactionLogIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/RecoveryCorruptedTransactionLogIT.java
@@ -396,7 +396,6 @@ public class RecoveryCorruptedTransactionLogIT
         while ( logFiles.getHighestLogVersion() > 0 )
         {
             int bytesToTrim = 1 + random.nextInt( 100 );
-            System.out.println("Trim: " + bytesToTrim);
             truncateBytesFromLastLogFile( bytesToTrim );
             databaseFactory.newEmbeddedDatabase( storeDir ).shutdown();
             int numberOfRecoveredTransactions = recoveryMonitor.getNumberOfRecoveredTransactions();

--- a/community/kernel/src/test/java/org/neo4j/kernel/RecoveryCorruptedTransactionLogIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/RecoveryCorruptedTransactionLogIT.java
@@ -395,7 +395,31 @@ public class RecoveryCorruptedTransactionLogIT
 
         while ( logFiles.getHighestLogVersion() > 0 )
         {
-            truncateBytesFromLastLogFile( 1 + random.nextInt( 100 ) );
+            int bytesToTrim = 1 + random.nextInt( 100 );
+            System.out.println("Trim: " + bytesToTrim);
+            truncateBytesFromLastLogFile( bytesToTrim );
+            databaseFactory.newEmbeddedDatabase( storeDir ).shutdown();
+            int numberOfRecoveredTransactions = recoveryMonitor.getNumberOfRecoveredTransactions();
+            assertThat( numberOfRecoveredTransactions, Matchers.greaterThanOrEqualTo( 0 ) );
+        }
+
+        File corruptedLogArchives = new File( storeDir, CorruptedLogsTruncator.CORRUPTED_TX_LOGS_BASE_NAME );
+        assertThat( corruptedLogArchives.listFiles(), not( emptyArray() ) );
+    }
+
+    @Test
+    public void repetitiveRecoveryIfCorruptedLogsSmallTailsWithCheckpoints() throws IOException
+    {
+        GraphDatabaseAPI database = (GraphDatabaseAPI) databaseFactory.newEmbeddedDatabase( storeDir );
+        generateTransactionsAndRotate( database, 4, true );
+        database.shutdown();
+
+        byte[] trimSizes = new byte[]{4, 22};
+        int trimSize = 0;
+        while ( logFiles.getHighestLogVersion() > 0 )
+        {
+            byte bytesToTrim = trimSizes[trimSize++ % trimSizes.length];
+            truncateBytesFromLastLogFile( bytesToTrim );
             databaseFactory.newEmbeddedDatabase( storeDir ).shutdown();
             int numberOfRecoveredTransactions = recoveryMonitor.getNumberOfRecoveredTransactions();
             assertThat( numberOfRecoveredTransactions, Matchers.greaterThanOrEqualTo( 0 ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/recovery/LogTailScannerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/recovery/LogTailScannerTest.java
@@ -123,7 +123,7 @@ public class LogTailScannerTest
         LogTailInformation logTailInformation = tailScanner.getTailInformation();
 
         // then
-        assertLatestCheckPoint( false, false, NO_TRANSACTION_ID, endLogVersion, logTailInformation );
+        assertLatestCheckPoint( false, true, NO_TRANSACTION_ID, endLogVersion, logTailInformation );
     }
 
     @Test
@@ -150,7 +150,7 @@ public class LogTailScannerTest
         LogTailInformation logTailInformation = tailScanner.getTailInformation();
 
         // then
-        assertLatestCheckPoint( false, false, NO_TRANSACTION_ID, startLogVersion, logTailInformation );
+        assertLatestCheckPoint( false, true, NO_TRANSACTION_ID, startLogVersion, logTailInformation );
     }
 
     @Test
@@ -383,7 +383,7 @@ public class LogTailScannerTest
         LogTailInformation logTailInformation = tailScanner.getTailInformation();
 
         // then
-        assertLatestCheckPoint( true, false, NO_TRANSACTION_ID, startLogVersion, logTailInformation );
+        assertLatestCheckPoint( true, true, NO_TRANSACTION_ID, startLogVersion, logTailInformation );
     }
 
     @Test


### PR DESCRIPTION
It can be the case that on recovery log entry file reader will be not able
to read log file till the end because LogEntry was not written completely,
for example. In those cases, we need to trim those bytes because it can happen
that if we will start appending after that to a log file and will try to
re-read this half stored record again - we will be able to read it (since
bytes will be there), but the content of that record will be absolute gibberish.
To prevent that from happening we need to make sure that our log files are
always readable from a to z and trim anything that we can't read.