### PR TITLE
Fix cancellation of Timer

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/CatchupPollingProcess.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/tx/CatchupPollingProcess.java
@@ -53,6 +53,7 @@ import static org.neo4j.causalclustering.catchup.tx.CatchupPollingProcess.State.
 import static org.neo4j.causalclustering.catchup.tx.CatchupPollingProcess.State.TX_PULLING;
 import static org.neo4j.causalclustering.catchup.tx.CatchupPollingProcess.Timers.TX_PULLER_TIMER;
 import static org.neo4j.causalclustering.core.consensus.schedule.TimeoutFactory.fixedTimeout;
+import static org.neo4j.causalclustering.core.consensus.schedule.Timer.CancelMode.SYNC_WAIT;
 import static org.neo4j.kernel.impl.util.JobScheduler.Groups.pullUpdates;
 
 /**
@@ -131,7 +132,7 @@ public class CatchupPollingProcess extends LifecycleAdapter
     @Override
     public void stop() throws Throwable
     {
-        timer.cancel( false, true );
+        timer.cancel( SYNC_WAIT );
     }
 
     public State state()

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMachine.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/RaftMachine.java
@@ -59,6 +59,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.neo4j.causalclustering.core.consensus.roles.Role.LEADER;
 import static org.neo4j.causalclustering.core.consensus.schedule.TimeoutFactory.fixedTimeout;
 import static org.neo4j.causalclustering.core.consensus.schedule.TimeoutFactory.uniformRandomTimeout;
+import static org.neo4j.causalclustering.core.consensus.schedule.Timer.CancelMode.SYNC_WAIT;
 import static org.neo4j.kernel.impl.util.JobScheduler.*;
 
 /**
@@ -142,11 +143,11 @@ public class RaftMachine implements LeaderLocator, CoreMetaData
     {
         if ( electionTimer != null )
         {
-            electionTimer.cancel( false, true );
+            electionTimer.cancel( SYNC_WAIT );
         }
         if ( heartbeatTimer != null )
         {
-            heartbeatTimer.cancel( false, true );
+            heartbeatTimer.cancel( SYNC_WAIT );
         }
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/schedule/Timer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/schedule/Timer.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.causalclustering.core.consensus.schedule;
 
-import java.util.concurrent.CancellationException;
-
 import org.neo4j.causalclustering.core.consensus.schedule.TimerService.TimerName;
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.logging.Log;
@@ -124,10 +122,9 @@ public class Timer
      * then a subsequent cancel will not ensure that the first execution of the
      * handler was cancelled.
      *
-     * @param mayInterruptIfRunning Interrupt any currently running job.
-     * @param awaitTermination Await termination of cancelled job.
+     * @param cancelMode The mode of cancelling.
      */
-    public synchronized void cancel( boolean mayInterruptIfRunning, boolean awaitTermination )
+    public synchronized void cancel( CancelMode cancelMode )
     {
         activeJobId++;
 
@@ -135,16 +132,14 @@ public class Timer
         {
             try
             {
-                job.cancel( mayInterruptIfRunning );
-
-                if ( awaitTermination )
+                if ( cancelMode == CancelMode.SYNC_WAIT )
                 {
                     job.waitTermination();
                 }
-            }
-            catch ( CancellationException ignored )
-            {
-                // expected if a cancelled job was awaited
+                else if ( cancelMode == CancelMode.ASYNC_INTERRUPT )
+                {
+                    job.cancel( true );
+                }
             }
             catch ( Exception e )
             {
@@ -175,5 +170,28 @@ public class Timer
     private String canonicalName()
     {
         return name.getClass().getCanonicalName() + "." + name.name();
+    }
+
+    public enum CancelMode
+    {
+        /**
+         * Asynchronously cancels.
+         */
+        ASYNC,
+
+        /**
+         * Asynchronously cancels and interrupts the handler.
+         */
+        ASYNC_INTERRUPT,
+
+        /**
+         * Synchronously cancels and waits for the handler to finish.
+         */
+        SYNC_WAIT,
+
+        /*
+         * Note that SYNC_INTERRUPT cannot be supported, since the underlying
+         * primitive is a future which cannot be cancelled/interrupted and awaited.
+         */
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/shipping/RaftLogShipper.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/shipping/RaftLogShipper.java
@@ -40,6 +40,7 @@ import static java.lang.Long.min;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.neo4j.causalclustering.core.consensus.schedule.TimeoutFactory.fixedTimeout;
+import static org.neo4j.causalclustering.core.consensus.schedule.Timer.CancelMode.SYNC_WAIT;
 import static org.neo4j.causalclustering.core.consensus.shipping.RaftLogShipper.Mode.CATCHUP;
 import static org.neo4j.causalclustering.core.consensus.shipping.RaftLogShipper.Mode.PIPELINE;
 import static org.neo4j.causalclustering.core.consensus.shipping.RaftLogShipper.Timeouts.RESEND;
@@ -344,7 +345,7 @@ public class RaftLogShipper
     {
         if ( timer != null )
         {
-            timer.cancel( false, true );
+            timer.cancel( SYNC_WAIT );
         }
         timeoutAbsoluteMillis = TIMER_INACTIVE;
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/schedule/TimerServiceTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/core/consensus/schedule/TimerServiceTest.java
@@ -21,13 +21,18 @@ package org.neo4j.causalclustering.core.consensus.schedule;
 
 import org.junit.Test;
 
+import java.util.concurrent.CountDownLatch;
+
 import org.neo4j.kernel.impl.util.JobScheduler;
 import org.neo4j.kernel.impl.util.JobScheduler.Group;
+import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
+import org.neo4j.logging.FormattedLogProvider;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.test.FakeClockJobScheduler;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -35,6 +40,7 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.neo4j.causalclustering.core.consensus.schedule.TimeoutFactory.fixedTimeout;
+import static org.neo4j.causalclustering.core.consensus.schedule.Timer.CancelMode.SYNC_WAIT;
 import static org.neo4j.causalclustering.core.consensus.schedule.TimerServiceTest.Timers.TIMER_A;
 import static org.neo4j.causalclustering.core.consensus.schedule.TimerServiceTest.Timers.TIMER_B;
 
@@ -219,11 +225,53 @@ public class TimerServiceTest
         scheduler.forward( 900, MILLISECONDS );
 
         // when
-        timerA.cancel( true, true );
+        timerA.cancel( SYNC_WAIT );
         scheduler.forward( 100, MILLISECONDS );
 
         // then
         verify( handlerA, never() ).onTimeout( any() );
+    }
+
+    @Test
+    public void shouldAwaitCancellationUnderRealScheduler() throws Throwable
+    {
+        // given
+        Neo4jJobScheduler scheduler = new Neo4jJobScheduler();
+        scheduler.init();
+        scheduler.start();
+
+        TimerService timerService = new TimerService( scheduler, FormattedLogProvider.toOutputStream( System.out ) );
+
+        CountDownLatch started = new CountDownLatch( 1 );
+        CountDownLatch finished = new CountDownLatch( 1 );
+
+        TimeoutHandler handlerA = timer ->
+        {
+            started.countDown();
+            finished.await();
+        };
+
+        TimeoutHandler handlerB = timer ->
+        {
+            finished.countDown();
+        };
+
+        Timer timerA = timerService.create( Timers.TIMER_A, group, handlerA );
+        timerA.set( fixedTimeout( 0, SECONDS ) );
+        started.await();
+
+        Timer timerB = timerService.create( Timers.TIMER_B, group, handlerB );
+        timerB.set( fixedTimeout( 2, SECONDS ) );
+
+        // when
+        timerA.cancel( SYNC_WAIT );
+
+        // then
+        assertEquals( 0, finished.getCount() );
+
+        // cleanup
+        scheduler.stop();
+        scheduler.shutdown();
     }
 
     enum Timers implements TimerService.TimerName


### PR DESCRIPTION
JobHandle is a wrapper on top of a future. If you cancel a future
you cannot wait for it, no matter what. Thus the abstraction now
disallows cancelling if waiting is required.