### PR TITLE
Unwind on arrays in compiled runtime

### DIFF
--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
@@ -29,6 +29,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
@@ -410,6 +411,31 @@ public abstract class CompiledConversionUtils
         else if ( iterable == null )
         {
             return Collections.emptyIterator();
+        }
+        else if ( iterable.getClass().isArray() )
+        {
+            int len = Array.getLength( iterable );
+
+            return new Iterator()
+            {
+                private int position = 0;
+
+                @Override
+                public boolean hasNext()
+                {
+                    return position < len;
+                }
+
+                @Override
+                public Object next()
+                {
+                    if ( position >= len )
+                    {
+                        throw new NoSuchElementException();
+                    }
+                    return Array.get( iterable, position++ );
+                }
+            };
         }
         else
         {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/UnwindAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/UnwindAcceptance.feature
@@ -209,3 +209,22 @@ Feature: UnwindAcceptance
       | [3] |
     And no side effects
 
+  Scenario: Unwind on array property
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (:L {array:['a', 'b', 'c']})
+      """
+    When executing query:
+      """
+      MATCH (n:L)
+      UNWIND n.array AS array
+      RETURN array
+      """
+    Then the result should be:
+      | array |
+      | 'a'   |
+      | 'b'   |
+      | 'c'   |
+    And no side effects
+


### PR DESCRIPTION
Fix bug where we were not properly handling `UNWIND` on arrays
coming from properties.

changelog: Handle UNWIND on matched array properties.