### PR TITLE
Diagnostics report tool, first iteration

### DIFF
--- a/community/bolt/LICENSES.txt
+++ b/community/bolt/LICENSES.txt
@@ -9,6 +9,8 @@ Apache Software License, Version 2.0
   ConcurrentLinkedHashMap
   Data Mapper for Jackson
   Jackson
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -18,6 +20,7 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
+  WMI4Java
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/community/bolt/NOTICE.txt
+++ b/community/bolt/NOTICE.txt
@@ -32,6 +32,8 @@ Apache Software License, Version 2.0
   ConcurrentLinkedHashMap
   Data Mapper for Jackson
   Jackson
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -41,6 +43,7 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
+  WMI4Java
 
 BSD - Scala License
   Scala Library

--- a/community/bolt/pom.xml
+++ b/community/bolt/pom.xml
@@ -81,6 +81,11 @@
       <artifactId>commons-codec</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>annotations</artifactId>
+    </dependency>
+
     <!--Test dependencies-->
     <dependency>
       <groupId>junit</groupId>

--- a/community/bolt/src/main/java/org/neo4j/bolt/diagnostics/BoltDiagnosticsOfflineReportProvider.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/diagnostics/BoltDiagnosticsOfflineReportProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/bolt/src/main/java/org/neo4j/bolt/diagnostics/BoltDiagnosticsOfflineReportProvider.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/diagnostics/BoltDiagnosticsOfflineReportProvider.java
@@ -23,7 +23,6 @@ import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import javax.annotation.Nonnull;
 
 import org.neo4j.diagnostics.DiagnosticsOfflineReportProvider;
 import org.neo4j.diagnostics.DiagnosticsReportSource;
@@ -50,7 +49,7 @@ public class BoltDiagnosticsOfflineReportProvider extends DiagnosticsOfflineRepo
         this.config = config;
     }
 
-    @Nonnull
+    @Override
     protected List<DiagnosticsReportSource> provideSources( Set<String> classifiers )
     {
         if ( classifiers.contains( "logs" ) )

--- a/community/bolt/src/main/java/org/neo4j/bolt/diagnostics/BoltDiagnosticsOfflineReportProvider.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/diagnostics/BoltDiagnosticsOfflineReportProvider.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.diagnostics;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nonnull;
+
+import org.neo4j.diagnostics.DiagnosticsOfflineReportProvider;
+import org.neo4j.diagnostics.DiagnosticsReportSource;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+
+import static org.neo4j.diagnostics.DiagnosticsReportSources.newDiagnosticsRotatingFile;
+
+public class BoltDiagnosticsOfflineReportProvider extends DiagnosticsOfflineReportProvider
+{
+    private FileSystemAbstraction fs;
+    private Config config;
+
+    public BoltDiagnosticsOfflineReportProvider()
+    {
+        super( "bolt", "logs" );
+    }
+
+    @Override
+    public void init( FileSystemAbstraction fs, Config config, File storeDirectory )
+    {
+        this.fs = fs;
+        this.config = config;
+    }
+
+    @Nonnull
+    protected List<DiagnosticsReportSource> provideSources( Set<String> classifiers )
+    {
+        if ( classifiers.contains( "logs" ) )
+        {
+            File boltLogFile = config.get( GraphDatabaseSettings.bolt_log_filename );
+            if ( fs.fileExists( boltLogFile ) )
+            {
+                return newDiagnosticsRotatingFile( "logs/bolt.log", fs, boltLogFile );
+            }
+        }
+        return Collections.emptyList();
+    }
+}

--- a/community/bolt/src/main/resources/META-INF/services/org.neo4j.diagnostics.DiagnosticsOfflineReportProvider
+++ b/community/bolt/src/main/resources/META-INF/services/org.neo4j.diagnostics.DiagnosticsOfflineReportProvider
@@ -1,0 +1,1 @@
+org.neo4j.bolt.diagnostics.BoltDiagnosticsOfflineReportProvider

--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/AdminTool.java
@@ -117,7 +117,7 @@ public class AdminTool
             if ( Args.parse( commandArgs ).has( "help" ) )
             {
                 outsideWorld.stdErrLine( "unknown argument: --help" );
-                usage.printUsageForCommand( commandLocator.findProvider( name ), outsideWorld::stdErrLine );
+                usage.printUsageForCommand( provider, outsideWorld::stdErrLine );
                 failure();
             }
             else

--- a/community/consistency-check/LICENSES.txt
+++ b/community/consistency-check/LICENSES.txt
@@ -6,12 +6,15 @@ Apache Software License, Version 2.0
   Apache Commons Compress
   Apache Commons Lang
   Apache Commons Text
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
+  WMI4Java
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/community/consistency-check/NOTICE.txt
+++ b/community/consistency-check/NOTICE.txt
@@ -29,12 +29,15 @@ Apache Software License, Version 2.0
   Apache Commons Compress
   Apache Commons Lang
   Apache Commons Text
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
+  WMI4Java
 
 Bouncy Castle License
   Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs

--- a/community/dbms/LICENSES.txt
+++ b/community/dbms/LICENSES.txt
@@ -5,12 +5,15 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 Apache Software License, Version 2.0
   Apache Commons Compress
   Apache Commons Text
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
+  WMI4Java
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/community/dbms/NOTICE.txt
+++ b/community/dbms/NOTICE.txt
@@ -28,12 +28,15 @@ Third-party licenses
 Apache Software License, Version 2.0
   Apache Commons Compress
   Apache Commons Text
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
+  WMI4Java
 
 Bouncy Castle License
   Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs

--- a/community/dbms/pom.xml
+++ b/community/dbms/pom.xml
@@ -50,14 +50,6 @@
   <!-- com.sun.tools is special prior to java 9... -->
   <profiles>
     <profile>
-      <id>jigsaw</id>
-      <activation>
-        <jdk>[1.9,)</jdk>
-      </activation>
-      <!-- No dependencies needed by Jigsaw -->
-      <dependencies />
-    </profile>
-    <profile>
       <id>default-jdk</id>
       <activation>
         <file>

--- a/community/dbms/pom.xml
+++ b/community/dbms/pom.xml
@@ -93,42 +93,7 @@
     </profile>
   </profiles>
 
-  <!--<build>-->
-    <!--<plugins>-->
-      <!--<plugin>-->
-        <!--<groupId>org.apache.maven.plugins</groupId>-->
-        <!--<artifactId>maven-shade-plugin</artifactId>-->
-        <!--<executions>-->
-          <!--<execution>-->
-            <!--<phase>package</phase>-->
-            <!--<goals><goal>shade</goal></goals>-->
-            <!--<configuration>-->
-              <!--<artifactSet>-->
-                <!--<includes>-->
-                  <!--<include>org.neo4j.driver:*</include>-->
-                <!--</includes>-->
-              <!--</artifactSet>-->
-              <!--<relocations>-->
-                <!--<relocation>-->
-                  <!--<pattern>org.neo4j.driver</pattern>-->
-                  <!--<shadedPattern>org.neo4j.not.driver</shadedPattern>-->
-                <!--</relocation>-->
-              <!--</relocations>-->
-              <!--<createDependencyReducedPom>false</createDependencyReducedPom>-->
-            <!--</configuration>-->
-          <!--</execution>-->
-        <!--</executions>-->
-      <!--</plugin>-->
-    <!--</plugins>-->
-  <!--</build>-->
-
   <dependencies>
-    <!--<dependency>-->
-      <!--<groupId>org.neo4j.driver</groupId>-->
-      <!--<artifactId>neo4j-java-driver</artifactId>-->
-      <!--<scope>provided</scope> &lt;!&ndash; shaded inside the jar file &ndash;&gt;-->
-    <!--</dependency>-->
-
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-kernel</artifactId>
@@ -161,6 +126,11 @@
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-import-tool</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-jmx</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/community/dbms/pom.xml
+++ b/community/dbms/pom.xml
@@ -165,6 +165,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jprocesses</groupId>
+      <artifactId>jProcesses</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
     </dependency>

--- a/community/dbms/pom.xml
+++ b/community/dbms/pom.xml
@@ -47,7 +47,88 @@
     </license>
   </licenses>
 
+  <!-- com.sun.tools is special prior to java 9... -->
+  <profiles>
+    <profile>
+      <id>jigsaw</id>
+      <activation>
+        <jdk>[1.9,)</jdk>
+      </activation>
+      <!-- No dependencies needed by Jigsaw -->
+      <dependencies />
+    </profile>
+    <profile>
+      <id>default-jdk</id>
+      <activation>
+        <file>
+          <exists>${java.home}/../lib/tools.jar</exists>
+        </file>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>jdk.tools</groupId>
+          <artifactId>jdk.tools</artifactId>
+          <scope>system</scope>
+          <version>1.6</version>
+          <systemPath>${java.home}/../lib/tools.jar</systemPath>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>osx-jdk</id>
+      <activation>
+        <file>
+          <exists>${java.home}/../Classes/classes.jar</exists>
+        </file>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>jdk.tools</groupId>
+          <artifactId>jdk.tools</artifactId>
+          <scope>system</scope>
+          <version>1.6</version>
+          <systemPath>${java.home}/../Classes/classes.jar</systemPath>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
+
+  <!--<build>-->
+    <!--<plugins>-->
+      <!--<plugin>-->
+        <!--<groupId>org.apache.maven.plugins</groupId>-->
+        <!--<artifactId>maven-shade-plugin</artifactId>-->
+        <!--<executions>-->
+          <!--<execution>-->
+            <!--<phase>package</phase>-->
+            <!--<goals><goal>shade</goal></goals>-->
+            <!--<configuration>-->
+              <!--<artifactSet>-->
+                <!--<includes>-->
+                  <!--<include>org.neo4j.driver:*</include>-->
+                <!--</includes>-->
+              <!--</artifactSet>-->
+              <!--<relocations>-->
+                <!--<relocation>-->
+                  <!--<pattern>org.neo4j.driver</pattern>-->
+                  <!--<shadedPattern>org.neo4j.not.driver</shadedPattern>-->
+                <!--</relocation>-->
+              <!--</relocations>-->
+              <!--<createDependencyReducedPom>false</createDependencyReducedPom>-->
+            <!--</configuration>-->
+          <!--</execution>-->
+        <!--</executions>-->
+      <!--</plugin>-->
+    <!--</plugins>-->
+  <!--</build>-->
+
   <dependencies>
+    <!--<dependency>-->
+      <!--<groupId>org.neo4j.driver</groupId>-->
+      <!--<artifactId>neo4j-java-driver</artifactId>-->
+      <!--<scope>provided</scope> &lt;!&ndash; shaded inside the jar file &ndash;&gt;-->
+    <!--</dependency>-->
+
     <dependency>
       <groupId>org.neo4j</groupId>
       <artifactId>neo4j-kernel</artifactId>

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommand.java
@@ -30,10 +30,10 @@ import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import org.neo4j.commandline.admin.AdminCommand;
@@ -125,7 +125,7 @@ public class DiagnosticsReportCommand implements AdminCommand
         }
 
         // Make sure 'all' is the only classifier if specified
-        Set<String> orphans = new HashSet<>( args.orphans() );
+        Set<String> orphans = new TreeSet<>( args.orphans() );
         if ( orphans.contains( "all" ) )
         {
             if ( orphans.size() != 1 )

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommand.java
@@ -29,7 +29,6 @@ import java.io.PrintStream;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.text.SimpleDateFormat;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -72,7 +71,7 @@ public class DiagnosticsReportCommand implements AdminCommand
 
     private final Path homeDir;
     private final Path configDir;
-    static final String[] DEFAULT_CLASSIFIERS = new String[]{"logs", "config"};
+    static final String[] DEFAULT_CLASSIFIERS = new String[]{"logs", "config", "plugins", "tree", "metrics", "threads", "env", "sysprop", "ps"};
     private boolean verbose;
     private final PrintStream err;
     private final PrintStream out;
@@ -133,10 +132,16 @@ public class DiagnosticsReportCommand implements AdminCommand
         }
         else
         {
-            // Add default classifiers
+            // Add default classifiers that are available
             if ( orphans.size() == 0 )
             {
-                orphans.addAll( Arrays.asList( DEFAULT_CLASSIFIERS ) );
+                for ( String classifier : DEFAULT_CLASSIFIERS )
+                {
+                    if ( availableClassifiers.contains( classifier ) )
+                    {
+                        orphans.add( classifier );
+                    }
+                }
             }
 
             // Validate classifiers

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommand.java
@@ -65,9 +65,9 @@ public class DiagnosticsReportCommand implements AdminCommand
     private final Path homeDir;
     private final Path configDir;
     private final OutsideWorld outsideWorld;
-    private static final String[] DEFAULT_CLASSIFIERS = new String[]{"logs", "configs"};
+    static final String[] DEFAULT_CLASSIFIERS = new String[]{"logs", "configs"};
 
-    public DiagnosticsReportCommand( Path homeDir, Path configDir, OutsideWorld outsideWorld )
+    DiagnosticsReportCommand( Path homeDir, Path configDir, OutsideWorld outsideWorld )
     {
         this.homeDir = homeDir;
         this.configDir = configDir;
@@ -114,7 +114,7 @@ public class DiagnosticsReportCommand implements AdminCommand
         if ( jmxDump != null )
         {
             reporter.registerSource( "threads", jmxDump.threadDump() );
-            //reporter.registerSource( "heap", null );
+            reporter.registerSource( "heap", jmxDump.heapDump() );
             reporter.registerSource( "sysprop", jmxDump.systemProperties() );
             //reporter.registerSource( "env", null );
         }
@@ -206,10 +206,6 @@ public class DiagnosticsReportCommand implements AdminCommand
                         catch ( IOException e )
                         {
                             out.println( "Unable to communicate with JMX endpoint. Reason: " + e.getMessage() );
-                        }
-                        catch ( SecurityException e )
-                        {
-                            out.println( "Not allowed to connect for security reasons: " + e.getMessage() );
                         }
                     }
                     catch ( IOException e )

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommand.java
@@ -299,6 +299,8 @@ public class DiagnosticsReportCommand implements AdminCommand
             return "include a list of java system properties";
         case "raft":
             return "include the raft log";
+        case "ccstate":
+            return "include the current cluster state";
         case "activetxs":
             return "include the output of dbms.listTransactions()";
         case "ps":

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommand.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.dbms;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.neo4j.commandline.admin.AdminCommand;
+import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.commandline.admin.IncorrectUsage;
+import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.commandline.admin.Usage;
+import org.neo4j.commandline.arguments.Arguments;
+import org.neo4j.commandline.arguments.MandatoryNamedArg;
+import org.neo4j.commandline.arguments.OptionalNamedArg;
+import org.neo4j.commandline.arguments.PositionalArgument;
+import org.neo4j.commandline.arguments.common.OptionalCanonicalPath;
+import org.neo4j.dbms.report.jmx.JmxDump;
+import org.neo4j.dbms.report.jmx.LocalVirtualMachine;
+import org.neo4j.diagnostics.DiagnosticsOfflineReportProvider;
+import org.neo4j.diagnostics.DiagnosticsReportSources;
+import org.neo4j.diagnostics.DiagnosticsReporter;
+import org.neo4j.helpers.Args;
+import org.neo4j.helpers.Service;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.database_path;
+
+public class DiagnosticsReportCommand implements AdminCommand
+{
+    private static OptionalNamedArg destinationArgument =
+            new OptionalCanonicalPath( "to", "/tmp/", "reports/", "Destination directory for reports" );
+    private static final Arguments arguments =
+            new Arguments().withArgument( new OptionalListArgument() ).withArgument( destinationArgument )
+                    .withPositionalArgument( new ClassifierFiltersArgument() );
+    private final Path homeDir;
+    private final Path configDir;
+    private final OutsideWorld outsideWorld;
+    private static final String[] DEFAULT_CLASSIFIERS = new String[]{"logs", "configs"};
+
+    public DiagnosticsReportCommand( Path homeDir, Path configDir, OutsideWorld outsideWorld )
+    {
+        this.homeDir = homeDir;
+        this.configDir = configDir;
+        this.outsideWorld = outsideWorld;
+    }
+
+    public static Arguments allArguments()
+    {
+        return arguments;
+    }
+
+    @Override
+    public void execute( String[] stringArgs ) throws IncorrectUsage, CommandFailed
+    {
+        Args args = Args.withFlags( "list", "to" ).parse( stringArgs );
+        FileSystemAbstraction fs = outsideWorld.fileSystem();
+        PrintStream out = outsideWorld.outStream();
+
+        // Make sure we can access the configuration file
+        File configFile = configDir.resolve( Config.DEFAULT_CONFIG_FILE_NAME ).toFile();
+        if ( !fs.fileExists( configFile ) )
+        {
+            throw new CommandFailed( "Unable to find config file, tried: " + configFile.getAbsolutePath() );
+        }
+        Config config = Config.fromFile( configFile ).withHome( homeDir ).withConnectorsDisabled().build();
+
+        File storeDirectory = config.get( database_path );
+
+        DiagnosticsReporter reporter = new DiagnosticsReporter( out );
+
+        // Find all offline providers and register them
+        for ( DiagnosticsOfflineReportProvider provider : Service.load( DiagnosticsOfflineReportProvider.class ) )
+        {
+            provider.init( fs, config, storeDirectory );
+            reporter.registerOfflineProvider( provider );
+        }
+
+        // Register sources provided by this tool
+        reporter.registerSource( "config",
+                DiagnosticsReportSources.newDiagnosticsFile( "neo4j.conf", fs, configFile ) );
+
+        // Online connection
+        JmxDump jmxDump = connectToNeo4jInstance( fs, out );
+        if ( jmxDump != null )
+        {
+            reporter.registerSource( "threads", jmxDump.threadDump() );
+            //reporter.registerSource( "heap", null );
+            reporter.registerSource( "sysprop", jmxDump.systemProperties() );
+            //reporter.registerSource( "env", null );
+        }
+
+        Set<String> availableClassifiers = reporter.getAvailableClassifiers();
+
+        // Passing '--list' should print list and end execution
+        if ( args.has( "list" ) )
+        {
+            out.println( "All available classifiers:" );
+            for ( String classifier : availableClassifiers )
+            {
+                out.printf( "  %-10s %s\n", classifier, describeClassifier( classifier ) );
+            }
+            return;
+        }
+
+        // Make sure 'all' is the only classifier if specified
+        List<String> orphans = args.orphans();
+        if ( orphans.contains( "all" ) )
+        {
+            if ( orphans.size() != 1 )
+            {
+                orphans.remove( "all" );
+                throw new IncorrectUsage( "If you specify 'all' this has to be the only classifier. Found ['" +
+                        orphans.stream().collect( Collectors.joining( "','" ) ) + "'] as well." );
+            }
+        }
+        else
+        {
+            // Add default classifiers
+            if ( orphans.size() == 0 )
+            {
+                orphans.addAll( Arrays.asList( DEFAULT_CLASSIFIERS ) );
+            }
+
+            // Validate classifiers
+            for ( String classifier : orphans )
+            {
+                if ( !availableClassifiers.contains( classifier ) )
+                {
+                    throw new IncorrectUsage( "Unknown classifier: " + classifier );
+                }
+            }
+        }
+
+        // TODO: we should really guesstimate the size of the dump, in part not to fill up the disk and die in the
+        // TODO: middle, and part warn the user if it's larger than a given threshold
+
+        // Start dumping
+        Path destinationDir = new File( destinationArgument.parse( args ) ).toPath();
+        try
+        {
+            SimpleDateFormat dumpFormat = new SimpleDateFormat( "yyyy-MM-dd_HHmmss" );
+            Path reportFile = destinationDir.resolve( dumpFormat.format( new Date() ) + ".zip" );
+            out.println( "Writing report to " + reportFile.toAbsolutePath().toString() );
+            reporter.dump( new HashSet<>( orphans ), reportFile );
+        }
+        catch ( IOException e )
+        {
+            throw new CommandFailed( "Creating archive failed", e );
+        }
+    }
+
+    private JmxDump connectToNeo4jInstance( FileSystemAbstraction fs, PrintStream out )
+    {
+        out.println( "Trying to find running instance of neo4j" );
+        Path pidFile = homeDir.resolve( "run/neo4j.pid" );
+        if ( fs.fileExists( pidFile.toFile() ) )
+        {
+            try ( BufferedReader reader = new BufferedReader( fs.openAsReader( pidFile.toFile(), Charset.defaultCharset() ) ) )
+            {
+                String pidFileContent = reader.readLine();
+                try
+                {
+                    long pid = Long.parseLong( pidFileContent );
+
+                    try
+                    {
+                        LocalVirtualMachine vm = LocalVirtualMachine.from( pid );
+                        out.println( "Attached to running process with process id " + pid );
+                        try
+                        {
+                            JmxDump jmxDump = JmxDump.connectTo( vm.getJmxAddress() );
+                            jmxDump.attachSystemProperties( vm.getSystemProperties() );
+                            out.println( "Connected to JMX endpoint" );
+                            return jmxDump;
+                        }
+                        catch ( IOException e )
+                        {
+                            out.println( "Unable to communicate with JMX endpoint. Reason: " + e.getMessage() );
+                        }
+                        catch ( SecurityException e )
+                        {
+                            out.println( "Not allowed to connect for security reasons: " + e.getMessage() );
+                        }
+                    }
+                    catch ( IOException e )
+                    {
+                        out.println( "Unable to connect to process. Reason: " + e.getMessage() );
+                    }
+                }
+                catch ( NumberFormatException e )
+                {
+                    out.println( pidFile.toString() + " does not contain a valid id. Found: " + pidFileContent );
+                }
+            }
+            catch ( IOException e )
+            {
+                out.println( "Error reading the .pid file. Reason: " + e.getMessage() );
+            }
+        }
+        else
+        {
+            out.println( "No running instance of neo4j was found. Online reports will be omitted." );
+        }
+
+        return null;
+    }
+
+    private static String describeClassifier( String classifier )
+    {
+        switch ( classifier )
+        {
+        case "logs":
+            return "include log files";
+        case "config":
+            return "include configuration file";
+        case "plugins":
+            return "include a view of the plugin directory";
+        case "tree":
+            return "include a view of the tree structure of the data directory";
+        case "tx":
+            return "include transaction logs";
+        case "metrics":
+            return "include metrics";
+        case "threads":
+            return "include a thread dump of the running instance";
+        case "heap":
+            return "include a heap dump";
+        case "env":
+            return "include a list of all environment variables";
+        case "sysprop":
+            return "include a list of java system properties";
+        case "raft":
+            return "include the raft log";
+        case "queries":
+            return "include the output of dbms.listQueries()";
+        default:
+        }
+        throw new IllegalArgumentException( "Unknown classifier:" + classifier );
+    }
+
+    /**
+     * Helper class to format output of {@link Usage}. Parsing is done manually in this command module.
+     */
+    public static class OptionalListArgument extends MandatoryNamedArg
+    {
+        OptionalListArgument()
+        {
+            super( "list", "", "List all available classifiers" );
+        }
+
+        @Override
+        public String optionsListing()
+        {
+            return "--list";
+        }
+
+        @Override
+        public String usage()
+        {
+            return "[--list]";
+        }
+    }
+
+    /**
+     * Helper class to format output of {@link Usage}. Parsing is done manually in this command module.
+     */
+    public static class ClassifierFiltersArgument implements PositionalArgument
+    {
+        @Override
+        public int position()
+        {
+            return 1;
+        }
+
+        @Override
+        public String usage()
+        {
+            return "[all] [<classifier1> <classifier2> ...]";
+        }
+
+        @Override
+        public String parse( Args parsedArgs )
+        {
+            throw new UnsupportedOperationException( "no parser exists" );
+        }
+    }
+}

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandProvider.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandProvider.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandProvider.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.dbms;
+
+import java.nio.file.Path;
+import javax.annotation.Nonnull;
+
+import org.neo4j.commandline.admin.AdminCommand;
+import org.neo4j.commandline.admin.AdminCommandSection;
+import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.commandline.arguments.Arguments;
+
+public class DiagnosticsReportCommandProvider extends AdminCommand.Provider
+{
+    public DiagnosticsReportCommandProvider()
+    {
+        super( "report" );
+    }
+
+    @Nonnull
+    @Override
+    public Arguments allArguments()
+    {
+        return DiagnosticsReportCommand.allArguments();
+    }
+
+    @Nonnull
+    @Override
+    public String summary()
+    {
+        return "Produces a zip/tar of the most common information needed for remote assessments.";
+    }
+
+    @Nonnull
+    @Override
+    public AdminCommandSection commandSection()
+    {
+        return AdminCommandSection.general();
+    }
+
+    @Nonnull
+    @Override
+    public String description()
+    {
+        return "Will collect information about the system and package everything in an archive. If you specify 'all', " +
+                "everything will be included. You can also fine tune the selection by passing classifiers to the tool, " +
+                "e.g 'logs tx threads'. For a complete list of all available classifiers call the tool with " +
+                "the '--list' flag. If no classifiers are passed, the default list of `logs configs` will be used." ;// TODO: default classifiers
+    }
+
+    @Nonnull
+    @Override
+    public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
+    {
+        return new DiagnosticsReportCommand( homeDir, configDir, outsideWorld );
+    }
+}

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandProvider.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandProvider.java
@@ -27,6 +27,8 @@ import org.neo4j.commandline.admin.AdminCommandSection;
 import org.neo4j.commandline.admin.OutsideWorld;
 import org.neo4j.commandline.arguments.Arguments;
 
+import static org.neo4j.commandline.dbms.DiagnosticsReportCommand.DEFAULT_CLASSIFIERS;
+
 public class DiagnosticsReportCommandProvider extends AdminCommand.Provider
 {
     public DiagnosticsReportCommandProvider()
@@ -62,7 +64,8 @@ public class DiagnosticsReportCommandProvider extends AdminCommand.Provider
         return "Will collect information about the system and package everything in an archive. If you specify 'all', " +
                 "everything will be included. You can also fine tune the selection by passing classifiers to the tool, " +
                 "e.g 'logs tx threads'. For a complete list of all available classifiers call the tool with " +
-                "the '--list' flag. If no classifiers are passed, the default list of `logs configs` will be used." ;// TODO: default classifiers
+                "the '--list' flag. If no classifiers are passed, the default list of `" +
+                String.join( " ", DEFAULT_CLASSIFIERS ) + "` will be used." ;
     }
 
     @Nonnull

--- a/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/JMXDumper.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/JMXDumper.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.dbms.diagnostics.jmx;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+
+/**
+ * Facilitates JMX Dump for current running Neo4j instance.
+ */
+public class JMXDumper
+{
+    private final Path homeDir;
+    private final FileSystemAbstraction fs;
+    private final PrintStream err;
+    private final boolean verbose;
+    private PrintStream out;
+
+    public JMXDumper( Path homeDir, FileSystemAbstraction fs, PrintStream out, PrintStream err, boolean verbose )
+    {
+        this.homeDir = homeDir;
+        this.fs = fs;
+        this.err = err;
+        this.verbose = verbose;
+        this.out = out;
+    }
+
+    public Optional<JmxDump> getJMXDump()
+    {
+        out.println( "Finding running instance of neo4j" );
+
+        Optional<Long> pid = getPid();
+        if ( pid.isPresent() )
+        {
+            try
+            {
+                LocalVirtualMachine vm = LocalVirtualMachine.from( pid.get() );
+                out.println( "Attached to running process with process id " + pid.get() );
+                try
+                {
+                    JmxDump jmxDump = JmxDump.connectTo( vm.getJmxAddress() );
+                    jmxDump.attachSystemProperties( vm.getSystemProperties() );
+                    out.println( "Connected to JMX endpoint" );
+                    return Optional.of( jmxDump );
+                }
+                catch ( IOException e )
+                {
+                    printError( "Unable to communicate with JMX endpoint. Reason: " + e.getMessage(), e );
+                }
+            }
+            catch ( IOException e )
+            {
+                printError( "Unable to connect to process. Reason: " + e.getMessage(), e );
+            }
+        }
+        else
+        {
+            out.println( "No running instance of neo4j was found. Online reports will be omitted." );
+        }
+
+        return Optional.empty();
+    }
+
+    private void printError( String message, Throwable e )
+    {
+        err.println( message );
+        if ( verbose && e != null )
+        {
+            e.printStackTrace( err );
+        }
+    }
+
+    private void printError( String message )
+    {
+        printError( message, null );
+    }
+
+    private Optional<Long> getPid()
+    {
+        Path pidFile = this.homeDir.resolve( "run/neo4j.pid" );
+        if ( this.fs.fileExists( pidFile.toFile() ) )
+        {
+            try ( BufferedReader reader = new BufferedReader( this.fs.openAsReader( pidFile.toFile(), Charset
+                    .defaultCharset() ) ) )
+            {
+                String pidFileContent = reader.readLine();
+                try
+                {
+                    return Optional.of( Long.parseLong( pidFileContent ) );
+                }
+
+                catch ( NumberFormatException e )
+                {
+                    printError( pidFile.toString() + " does not contain a valid id. Found: " + pidFileContent );
+                }
+            }
+            catch ( IOException e )
+            {
+                printError( "Error reading the .pid file. Reason: " + e.getMessage(), e );
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/JmxDump.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/JmxDump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/JmxDump.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/JmxDump.java
@@ -254,7 +254,7 @@ public class JmxDump
         {
             try
             {
-                ObjectName name = new ObjectName( "org.neo4j:instance=kernel#0,name=Reports" ); // TODO: instance #0 ??
+                ObjectName name = new ObjectName( "org.neo4j:instance=kernel#0,name=Reports" );
                 Reports reportsBean = JMX.newMBeanProxy( mBeanServer, name, Reports.class );
                 return reportsInvoker.invoke( reportsBean );
             }

--- a/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/JmxDump.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/JmxDump.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.dbms.report.jmx;
+package org.neo4j.dbms.diagnostics.jmx;
 
 import com.sun.management.HotSpotDiagnosticMXBean;
 
@@ -193,8 +193,10 @@ public class JmxDump
                 monitor.info( "archiving..." );
                 long size = Files.size( tempFile );
                 InputStream in = Files.newInputStream( tempFile );
-                ProgressAwareInputStream inStream = new ProgressAwareInputStream( in, size, monitor::percentChanged );
-                Files.copy( inStream, archiveDestination );
+                try ( ProgressAwareInputStream inStream = new ProgressAwareInputStream( in, size, monitor::percentChanged ) )
+                {
+                    Files.copy( inStream, archiveDestination );
+                }
 
                 Files.delete( tempFile );
             }

--- a/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/LocalVirtualMachine.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/LocalVirtualMachine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/LocalVirtualMachine.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/LocalVirtualMachine.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.dbms.report.jmx;
+package org.neo4j.dbms.diagnostics.jmx;
 
 import com.sun.tools.attach.AttachNotSupportedException;
 import com.sun.tools.attach.VirtualMachine;

--- a/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/Reports.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/Reports.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.dbms.diagnostics.jmx;
+
+import org.neo4j.jmx.Description;
+import org.neo4j.jmx.ManagementInterface;
+
+@ManagementInterface( name = Reports.NAME )
+@Description( "Reports operations" )
+public interface Reports
+{
+    String NAME = "Reports";
+
+    @Description( "List all active transactions" )
+    String listTransactions();
+
+    @Description( "Returns a map if the current environment variables" )
+    String getEnvironmentVariables();
+}

--- a/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/ReportsBean.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/ReportsBean.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.dbms.diagnostics.jmx;
+
+import java.util.Map;
+
+import org.neo4j.graphdb.QueryExecutionException;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.jmx.impl.ManagementBeanProvider;
+import org.neo4j.jmx.impl.ManagementData;
+import org.neo4j.jmx.impl.Neo4jMBean;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+
+public class ReportsBean extends ManagementBeanProvider
+{
+    public ReportsBean()
+    {
+        super( Reports.class );
+    }
+
+    @Override
+    protected Neo4jMBean createMBean( ManagementData management )
+    {
+        return new ReportsImpl( management, false );
+    }
+
+    @Override
+    protected Neo4jMBean createMXBean( ManagementData management )
+    {
+        return new ReportsImpl( management, true );
+    }
+
+    private static class ReportsImpl extends Neo4jMBean implements Reports
+    {
+        private final GraphDatabaseAPI graphDatabaseAPI;
+
+        ReportsImpl( ManagementData management, boolean isMXBean )
+        {
+            super( management, isMXBean );
+            graphDatabaseAPI = management.getKernelData().graphDatabase();
+        }
+
+        @Override
+        public String listTransactions()
+        {
+            String res;
+            try ( Transaction tx = graphDatabaseAPI.beginTx() )
+            {
+                res = graphDatabaseAPI.execute( "CALL dbms.listTransactions()" ).resultAsString();
+
+                tx.success();
+            }
+            catch ( QueryExecutionException e )
+            {
+                res = "dbms.listTransactions() is not available";
+            }
+            return res;
+        }
+
+        @Override
+        public String getEnvironmentVariables()
+        {
+            StringBuilder sb = new StringBuilder();
+            for ( Map.Entry<String,String> env : System.getenv().entrySet() )
+            {
+                sb.append( env.getKey() ).append( '=' ).append( env.getValue() ).append( '\n' );
+            }
+            return sb.toString();
+        }
+    }
+}

--- a/community/dbms/src/main/java/org/neo4j/dbms/report/jmx/JmxDump.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/report/jmx/JmxDump.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.dbms.report.jmx;
+
+import com.sun.management.HotSpotDiagnosticMXBean;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MonitorInfo;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Properties;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.MBeanServerConnection;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+
+import org.neo4j.diagnostics.DiagnosticsReportSource;
+import org.neo4j.diagnostics.DiagnosticsReportSources;
+import org.neo4j.diagnostics.DiagnosticsReporterProgressCallback;
+
+/**
+ * Encapsulates remoting functionality for collecting diagnostics information on running instances.
+ */
+public class JmxDump
+{
+    private final MBeanServerConnection mBeanServer;
+    private Properties systemProperties;
+
+    private JmxDump( MBeanServerConnection mBeanServer )
+    {
+        this.mBeanServer = mBeanServer;
+    }
+
+    public static JmxDump connectTo( String jmxAddress ) throws IOException, SecurityException
+    {
+        JMXServiceURL url = new JMXServiceURL( jmxAddress );
+        JMXConnector connect = JMXConnectorFactory.connect( url );
+
+        return new JmxDump( connect.getMBeanServerConnection() );
+    }
+
+    public void attachSystemProperties( Properties systemProperties )
+    {
+        this.systemProperties = systemProperties;
+    }
+
+    /**
+     * Captures a thread dump of the running instance.
+     *
+     * @return a diagnostics source the will emmit a thread dump.
+     */
+    public DiagnosticsReportSource threadDump()
+    {
+        return DiagnosticsReportSources.newDiagnosticsString( "threaddump.txt", () ->
+        {
+            String result;
+            try
+            {
+                // Try to invoke real thread dump
+                result = (String) mBeanServer
+                        .invoke( new ObjectName( "com.sun.management:type=DiagnosticCommand" ), "threadPrint",
+                                new Object[]{null}, new String[]{String[].class.getName()} );
+            }
+            catch ( InstanceNotFoundException | ReflectionException | MBeanException | MalformedObjectNameException | IOException exception )
+            {
+                // Failed, do a poor mans attempt
+                result = getMXThreadDump();
+            }
+
+            return result;
+        } );
+    }
+
+    /**
+     * If "DiagnosticCommand" bean isn't available, for reasons unknown, try our best to reproduce the output. For obvious
+     * reasons we can't get everything, since it's not exposed in java.
+     *
+     * @return a thread dump.
+     */
+    private String getMXThreadDump()
+    {
+        ThreadMXBean threadMxBean;
+        try
+        {
+            threadMxBean =
+                    ManagementFactory.newPlatformMXBeanProxy( mBeanServer, "java.lang:type=Threading", ThreadMXBean.class );
+        }
+        catch ( IOException e )
+        {
+            return "ERROR: Unable to produce any thread dump";
+        }
+
+        ThreadInfo[] threadInfos = threadMxBean.dumpAllThreads( true, true );
+
+        // Reproduce JVM stack trace as far as possible to allow existing analytics tools to be used
+        String vmName = systemProperties.getProperty( "java.vm.name" );
+        String vmVersion = systemProperties.getProperty( "java.vm.version" );
+        String vmInfoString = systemProperties.getProperty( "java.vm.info" );
+
+        StringBuilder sb = new StringBuilder();
+        sb.append( String.format( "Full thread dump %s (%s %s):\n\n", vmName, vmVersion, vmInfoString ) );
+        for ( ThreadInfo threadInfo : threadInfos )
+        {
+            sb.append( String.format( "\"%s\" #%d\n", threadInfo.getThreadName(), threadInfo.getThreadId() ) );
+            sb.append( "   java.lang.Thread.State: " ).append( threadInfo.getThreadState() ).append( "\n" );
+
+            StackTraceElement[] stackTrace = threadInfo.getStackTrace();
+            for ( int i = 0; i < stackTrace.length; i++ )
+            {
+                StackTraceElement e = stackTrace[i];
+                sb.append( "\tat " ).append( e.toString() );
+
+                // First stack element info can be found in the thread state
+                if ( i == 0 && threadInfo.getLockInfo() != null )
+                {
+                    Thread.State ts = threadInfo.getThreadState();
+                    switch ( ts )
+                    {
+                    case BLOCKED:
+                        sb.append( "\t-  blocked on " ).append( threadInfo.getLockInfo() ).append( '\n' );
+                        break;
+                    case WAITING:
+                        sb.append( "\t-  waiting on " ).append( threadInfo.getLockInfo() ).append( '\n' );
+                        break;
+                    case TIMED_WAITING:
+                        sb.append( "\t-  waiting on " ).append( threadInfo.getLockInfo() ).append( '\n' );
+                        break;
+                    default:
+                    }
+                }
+                for ( MonitorInfo mi : threadInfo.getLockedMonitors() )
+                {
+                    if ( mi.getLockedStackDepth() == i )
+                    {
+                        sb.append( "\t-  locked ").append( mi ).append( '\n' );
+                    }
+                }
+            }
+        }
+
+        return sb.toString();
+    }
+
+    /**
+     * @param destination file path to send heap dump to, has to end with ".hprof"
+     */
+    public void heapDump( String destination ) throws IOException
+    {
+        HotSpotDiagnosticMXBean hotSpotDiagnosticMXBean = ManagementFactory
+                .newPlatformMXBeanProxy( mBeanServer, "com.sun.management:type=HotSpotDiagnostic",
+                        HotSpotDiagnosticMXBean.class );
+
+        hotSpotDiagnosticMXBean.dumpHeap( destination, false );
+    }
+
+    public DiagnosticsReportSource systemProperties()
+    {
+        return new DiagnosticsReportSource()
+        {
+            @Override
+            public String destinationPath()
+            {
+                return "vm.prop";
+            }
+
+            @Override
+            public void addToArchive( Path archiveDestination, DiagnosticsReporterProgressCallback monitor )
+                    throws IOException
+            {
+                try ( PrintStream printStream = new PrintStream( Files.newOutputStream( archiveDestination ) ) )
+                {
+                    systemProperties.list( printStream );
+                }
+            }
+        };
+    }
+}

--- a/community/dbms/src/main/java/org/neo4j/dbms/report/jmx/LocalVirtualMachine.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/report/jmx/LocalVirtualMachine.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.dbms.report.jmx;
+
+import com.sun.tools.attach.AttachNotSupportedException;
+import com.sun.tools.attach.VirtualMachine;
+
+import java.io.IOException;
+import java.util.Properties;
+
+public class LocalVirtualMachine
+{
+    private final String address;
+    private final Properties systemProperties;
+
+    private LocalVirtualMachine( String address, Properties systemProperties )
+    {
+        this.address = address;
+        this.systemProperties = systemProperties;
+    }
+
+    public String getJmxAddress()
+    {
+        return address;
+    }
+
+    public Properties getSystemProperties()
+    {
+        return systemProperties;
+    }
+
+    /**
+     * Get an instance from a process id and makes sure the a JMX agent is running on it.
+     *
+     * @param pid process id of the jvm to attach to.
+     * @return a virtual machine with a JMX endpoint available.
+     * @throws IOException if any operations failed.
+     */
+    public static LocalVirtualMachine from( long pid ) throws IOException
+    {
+        VirtualMachine vm = null;
+        try
+        {
+            // Try to attach to instance
+            vm = VirtualMachine.attach( String.valueOf( pid ) );
+
+            // Get local jmx address if management agent is already started
+            Properties agentProps = vm.getAgentProperties();
+            String address = (String) agentProps.get( "com.sun.management.jmxremote.localConnectorAddress" );
+
+            // Failed, we are the first one connecting, start agent
+            if ( address == null )
+            {
+                address = vm.startLocalManagementAgent();
+            }
+
+            return new LocalVirtualMachine( address, vm.getSystemProperties() );
+        }
+        catch ( AttachNotSupportedException x )
+        {
+            throw new IOException( x.getMessage(), x );
+        }
+        finally
+        {
+            if ( vm != null )
+            {
+                vm.detach();
+            }
+        }
+    }
+
+}

--- a/community/dbms/src/main/resources/META-INF/services/org.neo4j.commandline.admin.AdminCommand$Provider
+++ b/community/dbms/src/main/resources/META-INF/services/org.neo4j.commandline.admin.AdminCommand$Provider
@@ -2,3 +2,4 @@ org.neo4j.commandline.dbms.ImportCommandProvider
 org.neo4j.commandline.dbms.DumpCommandProvider
 org.neo4j.commandline.dbms.LoadCommandProvider
 org.neo4j.commandline.dbms.StoreInfoCommandProvider
+org.neo4j.commandline.dbms.DiagnosticsReportCommandProvider

--- a/community/dbms/src/main/resources/META-INF/services/org.neo4j.jmx.impl.ManagementBeanProvider
+++ b/community/dbms/src/main/resources/META-INF/services/org.neo4j.jmx.impl.ManagementBeanProvider
@@ -1,0 +1,1 @@
+org.neo4j.dbms.diagnostics.jmx.ReportsBean

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandIT.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandIT.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandIT.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.dbms;
+
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+
+import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.commandline.admin.IncorrectUsage;
+import org.neo4j.commandline.admin.RealOutsideWorld;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.test.rule.TestDirectory;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public class DiagnosticsReportCommandIT
+{
+    @Rule
+    public TestDirectory testDirectory = TestDirectory.testDirectory();
+
+    private GraphDatabaseService database;
+
+    @Before
+    public void setUp()
+    {
+        database = new GraphDatabaseFactory().newEmbeddedDatabaseBuilder( testDirectory.graphDbDir() )
+                .newGraphDatabase();
+    }
+
+    @After
+    public void tearDown()
+    {
+        database.shutdown();
+    }
+
+    @Test
+    public void shouldBeAbleToAttachToPidAndRunThreadDump() throws IOException, CommandFailed, IncorrectUsage
+    {
+        long pid = getPID();
+        Assume.assumeTrue( pid != 0 );
+
+        // Write config file
+        Files.createFile( testDirectory.file( "neo4j.conf" ).toPath() );
+
+        // write neo4j.pid file
+        File run = testDirectory.directory( "run" );
+        Files.write( Paths.get( run.getAbsolutePath(), "neo4j.pid" ), String.valueOf( pid ).getBytes() );
+
+        // Run command, should detect running instance
+        try ( RealOutsideWorld outsideWorld = new RealOutsideWorld() )
+        {
+            String[] args = {"threads", "--to=" + testDirectory.absolutePath().getAbsolutePath() + "/reports"};
+            Path homeDir = testDirectory.directory().toPath();
+            DiagnosticsReportCommand diagnosticsReportCommand =
+                    new DiagnosticsReportCommand( homeDir, homeDir, outsideWorld );
+            diagnosticsReportCommand.execute( args );
+        }
+
+        // Verify that we took a thread dump
+        File reports = testDirectory.directory( "reports" );
+        File[] files = reports.listFiles();
+        assertThat( files, notNullValue() );
+        assertThat( files.length, is( 1 ) );
+
+        Path report = files[0].toPath();
+        final URI uri = URI.create("jar:file:" + report.toUri().getPath());
+
+        try ( FileSystem fs = FileSystems.newFileSystem( uri, Collections.emptyMap() ) )
+        {
+            String threadDump = new String( Files.readAllBytes( fs.getPath( "threaddump.txt" ) ) );
+            assertThat( threadDump, containsString( DiagnosticsReportCommandIT.class.getCanonicalName() ) );
+        }
+    }
+
+    private static long getPID()
+    {
+        String processName = java.lang.management.ManagementFactory.getRuntimeMXBean().getName();
+        if ( processName != null && processName.length() > 0 )
+        {
+            try
+            {
+                return Long.parseLong( processName.split( "@" )[0] );
+            }
+            catch ( Exception ignored )
+            {
+            }
+        }
+
+        return 0;
+    }
+}

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandIT.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandIT.java
@@ -20,7 +20,6 @@
 package org.neo4j.commandline.dbms;
 
 import org.junit.After;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,6 +44,7 @@ import org.neo4j.test.rule.TestDirectory;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
@@ -74,7 +74,7 @@ public class DiagnosticsReportCommandIT
     public void shouldBeAbleToAttachToPidAndRunThreadDump() throws IOException, CommandFailed, IncorrectUsage
     {
         long pid = getPID();
-        Assume.assumeTrue( pid != 0 );
+        assertThat( pid, is( not( 0 ) ) );
 
         // Write config file
         Files.createFile( testDirectory.file( "neo4j.conf" ).toPath() );

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandIT.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandIT.java
@@ -40,6 +40,7 @@ import org.neo4j.commandline.admin.IncorrectUsage;
 import org.neo4j.commandline.admin.RealOutsideWorld;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
+import org.neo4j.test.rule.SuppressOutput;
 import org.neo4j.test.rule.TestDirectory;
 
 import static org.hamcrest.CoreMatchers.containsString;
@@ -49,6 +50,8 @@ import static org.junit.Assert.assertThat;
 
 public class DiagnosticsReportCommandIT
 {
+    @Rule
+    public SuppressOutput suppressOutput = SuppressOutput.suppressAll();
     @Rule
     public TestDirectory testDirectory = TestDirectory.testDirectory();
 

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandTest.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.commandline.dbms;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -69,6 +70,7 @@ public class DiagnosticsReportCommandTest
     private Path homeDir;
     private Path configDir;
     private Path configFile;
+    private String originalUserDir;
 
     public static class MyDiagnosticsOfflineReportProvider extends DiagnosticsOfflineReportProvider
     {
@@ -101,7 +103,14 @@ public class DiagnosticsReportCommandTest
         Files.createFile( configFile );
 
         // To make sure files are resolved from the working directory
-        System.setProperty( "user.dir", testDirectory.absolutePath().getAbsolutePath() );
+        originalUserDir = System.setProperty( "user.dir", testDirectory.absolutePath().getAbsolutePath() );
+    }
+
+    @After
+    public void tearDown()
+    {
+        // Restore directory
+        System.setProperty( "user.dir", originalUserDir );
     }
 
     @Test

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandTest.java
@@ -193,8 +193,11 @@ public class DiagnosticsReportCommandTest
             assertThat( baos.toString(), is(String.format(
                     "Trying to find running instance of neo4j%n" +
                             "No running instance of neo4j was found. Online reports will be omitted.%n" +
-                            "All available classifiers:%n" + "  config     include configuration file%n" +
-                            "  logs       include log files%n" + "  plugins    include a view of the plugin directory%n" +
+                            "All available classifiers:%n" +
+                            "  config     include configuration file%n" +
+                            "  logs       include log files%n" +
+                            "  plugins    include a view of the plugin directory%n" +
+                            "  ps         include a list of running processes%n" +
                             "  tree       include a view of the tree structure of the data directory%n" +
                             "  tx         include transaction logs%n" ) ) );
         }

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandTest.java
@@ -191,7 +191,7 @@ public class DiagnosticsReportCommandTest
             diagnosticsReportCommand.execute( args );
 
             assertThat( baos.toString(), is(String.format(
-                    "Trying to find running instance of neo4j%n" +
+                    "Finding running instance of neo4j%n" +
                             "No running instance of neo4j was found. Online reports will be omitted.%n" +
                             "All available classifiers:%n" +
                             "  config     include configuration file%n" +

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.dbms;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nonnull;
+
+import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.commandline.admin.IncorrectUsage;
+import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.commandline.admin.RealOutsideWorld;
+import org.neo4j.diagnostics.DiagnosticsOfflineReportProvider;
+import org.neo4j.diagnostics.DiagnosticsReportSource;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class DiagnosticsReportCommandTest
+{
+    @Rule
+    public TestDirectory testDirectory = TestDirectory.testDirectory();
+    @Rule
+    public ExpectedException expected = ExpectedException.none();
+    @Rule
+    public DefaultFileSystemRule fsRule = new DefaultFileSystemRule();
+
+    private Path homeDir;
+    private Path configDir;
+    private Path configFile;
+
+    public static class MyDiagnosticsOfflineReportProvider extends DiagnosticsOfflineReportProvider
+    {
+        public MyDiagnosticsOfflineReportProvider()
+        {
+            super( "my-provider", "logs", "tx" );
+        }
+
+        @Override
+        public void init( FileSystemAbstraction fs, Config config, File storeDirectory )
+        {
+        }
+
+        @Nonnull
+        @Override
+        protected List<DiagnosticsReportSource> provideSources( Set<String> classifiers )
+        {
+            return Collections.emptyList();
+        }
+    }
+
+    @Before
+    public void setUp() throws Exception
+    {
+        homeDir = testDirectory.directory( "home-dir" ).toPath();
+        configDir = testDirectory.directory( "config-dir" ).toPath();
+
+        // Touch config
+        configFile = configDir.resolve( "neo4j.conf" );
+        Files.createFile( configFile );
+
+        // To make sure files are resolved from the working directory
+        System.setProperty( "user.dir", testDirectory.absolutePath().getAbsolutePath() );
+    }
+
+    @Test
+    public void exitIfConfigFileIsMissing() throws IOException, CommandFailed, IncorrectUsage
+    {
+        Files.delete( configFile );
+        String[] args = {"--list"};
+        try ( RealOutsideWorld outsideWorld = new RealOutsideWorld() )
+        {
+            DiagnosticsReportCommand
+                    diagnosticsReportCommand = new DiagnosticsReportCommand( homeDir, configDir, outsideWorld );
+
+            expected.expect( CommandFailed.class );
+            expected.expectMessage( containsString( "Unable to find config file, tried: " ) );
+            diagnosticsReportCommand.execute( args );
+        }
+    }
+
+    @Test
+    public void allHasToBeOnlyClassifier() throws Exception
+    {
+        String[] args = {"all", "logs", "tx"};
+        try ( RealOutsideWorld outsideWorld = new RealOutsideWorld() )
+        {
+            DiagnosticsReportCommand
+                    diagnosticsReportCommand = new DiagnosticsReportCommand( homeDir, configDir, outsideWorld );
+
+            expected.expect( IncorrectUsage.class );
+            expected.expectMessage(
+                    "If you specify 'all' this has to be the only classifier. Found ['logs','tx'] as well." );
+            diagnosticsReportCommand.execute( args );
+        }
+    }
+
+    @Test
+    public void printUnrecognizedClassifiers() throws Exception
+    {
+        String[] args = {"logs", "tx", "invalid"};
+        try ( RealOutsideWorld outsideWorld = new RealOutsideWorld() )
+        {
+            DiagnosticsReportCommand
+                    diagnosticsReportCommand = new DiagnosticsReportCommand( homeDir, configDir, outsideWorld );
+
+            expected.expect( IncorrectUsage.class );
+            expected.expectMessage( "Unknown classifier: invalid" );
+            diagnosticsReportCommand.execute( args );
+        }
+    }
+
+    // TODO: test default classifiers
+
+    @Test
+    public void listShouldDisplayAllClassifiers() throws Exception
+    {
+        try ( ByteArrayOutputStream baos = new ByteArrayOutputStream() )
+        {
+            PrintStream ps = new PrintStream( baos );
+            String[] args = {"--list"};
+            OutsideWorld outsideWorld = mock( OutsideWorld.class );
+            when( outsideWorld.fileSystem() ).thenReturn( fsRule.get() );
+            when( outsideWorld.outStream() ).thenReturn( ps );
+
+            DiagnosticsReportCommand
+                    diagnosticsReportCommand = new DiagnosticsReportCommand( homeDir, configDir, outsideWorld );
+            diagnosticsReportCommand.execute( args );
+
+            assertThat( baos.toString(), is(String.format(
+                    "Trying to find running instance of neo4j%n" +
+                            "No running instance of neo4j was found. Online reports will be omitted.%n" +
+                            "All available classifiers:%n" + "  config     include configuration file%n" +
+                            "  logs       include log files%n" + "  plugins    include a view of the plugin directory%n" +
+                            "  tree       include a view of the tree structure of the data directory%n" +
+                            "  tx         include transaction logs%n" ) ) );
+        }
+    }
+
+    @Test
+    public void overrideDestination() throws Exception
+    {
+        String[] args = {"--to=other/", "all"};
+        try ( RealOutsideWorld outsideWorld = new RealOutsideWorld() )
+        {
+            DiagnosticsReportCommand
+                    diagnosticsReportCommand = new DiagnosticsReportCommand( homeDir, configDir, outsideWorld );
+            diagnosticsReportCommand.execute( args );
+
+            File other = testDirectory.directory( "other" );
+            FileSystemAbstraction fs = outsideWorld.fileSystem();
+            assertThat( fs.fileExists( other ), is( true ) );
+            assertThat( fs.listFiles( other ).length, is( 1 ) );
+
+            // Default should be empty
+            File reports = new File( testDirectory.directory(), "reports" );
+            assertThat( fs.fileExists( reports ), is( false ) );
+        }
+    }
+}

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DiagnosticsReportCommandTest.java
@@ -43,6 +43,7 @@ import org.neo4j.diagnostics.DiagnosticsOfflineReportProvider;
 import org.neo4j.diagnostics.DiagnosticsReportSource;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.test.rule.SuppressOutput;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 
@@ -51,9 +52,13 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.neo4j.commandline.dbms.DiagnosticsReportCommand.DEFAULT_CLASSIFIERS;
+import static org.neo4j.commandline.dbms.DiagnosticsReportCommand.describeClassifier;
 
 public class DiagnosticsReportCommandTest
 {
+    @Rule
+    public SuppressOutput suppressOutput = SuppressOutput.suppressAll();
     @Rule
     public TestDirectory testDirectory = TestDirectory.testDirectory();
     @Rule
@@ -146,7 +151,20 @@ public class DiagnosticsReportCommandTest
         }
     }
 
-    // TODO: test default classifiers
+    @SuppressWarnings( "ResultOfMethodCallIgnored" )
+    @Test
+    public void defaultValuesShouldBeValidClassifiers()
+    {
+        for ( String classifier : DEFAULT_CLASSIFIERS )
+        {
+            describeClassifier( classifier );
+        }
+
+        // Make sure the above actually catches bad classifiers
+        expected.expect( IllegalArgumentException.class );
+        expected.expectMessage( "Unknown classifier: invalid" );
+        describeClassifier( "invalid" );
+    }
 
     @Test
     public void listShouldDisplayAllClassifiers() throws Exception

--- a/community/dbms/src/test/resources/META-INF/services/org.neo4j.diagnostics.DiagnosticsOfflineReportProvider
+++ b/community/dbms/src/test/resources/META-INF/services/org.neo4j.diagnostics.DiagnosticsOfflineReportProvider
@@ -1,0 +1,1 @@
+org.neo4j.commandline.dbms.DiagnosticsReportCommandTest$MyDiagnosticsOfflineReportProvider

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsOfflineReportProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsOfflineReportProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsOfflineReportProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsOfflineReportProvider.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.diagnostics;
+
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.neo4j.helpers.Service;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+
+/**
+ * Base class for a provider of offline reports. Offline reports does not require a running instance of the database
+ * and is intended to be use as a way to gather information even if the database cannot be started. All implementing
+ * classes is service loaded and initialized through the
+ * {@link DiagnosticsOfflineReportProvider#init(FileSystemAbstraction, Config, File)} method.
+ */
+public abstract class DiagnosticsOfflineReportProvider extends Service
+{
+    private final Set<String> filterClassifiers;
+
+    /**
+     * A provider needs to know all the available classifiers in advance. A classifier is a group in the context of
+     * diagnostics reporting, e.g. 'logs', 'config' or 'threaddump'.
+     *
+     * @param identifier a unique identifier for tagging during service loading, used for useful debug information.
+     * @param classifier one
+     * @param classifiers or more classifiers have to be provided.
+     */
+    protected DiagnosticsOfflineReportProvider( String identifier, String classifier, String... classifiers )
+    {
+        super( identifier );
+        filterClassifiers = new HashSet<>( Arrays.asList( classifiers ) );
+        filterClassifiers.add( classifier );
+    }
+
+    /**
+     * Called after service loading to initialize the class.
+     *
+     * @param fs filesystem to use for file access.
+     * @param config configuration file in use.
+     * @param storeDirectory directory of the database files.
+     */
+    public abstract void init( FileSystemAbstraction fs, Config config, File storeDirectory );
+
+    /**
+     * Returns a list of source that matches the given classifiers.
+     *
+     * @param classifiers a set of classifiers to filter on.
+     * @return a list of sources, empty if nothing matches.
+     */
+    protected abstract List<DiagnosticsReportSource> provideSources( Set<String> classifiers );
+
+    final Set<String> getFilterClassifiers()
+    {
+        return filterClassifiers;
+    }
+
+    final List<DiagnosticsReportSource> getDiagnosticsSources( Set<String> classifiers )
+    {
+        if ( classifiers.contains( "all" ) )
+        {
+            return provideSources( filterClassifiers );
+        }
+        else
+        {
+            return provideSources( classifiers );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReportSource.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReportSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReportSource.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReportSource.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.diagnostics;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * A diagnostic source is a pair of a destination and a function to add data to mentioned destination.
+ * The destination has to be provided separately since the creation of the file is done outside of the method to
+ * make it more flexible in regards to where the file can be placed.
+ */
+public interface DiagnosticsReportSource
+{
+    /**
+     * The final path of the diagnostic source, it is relative to the archive base directory.
+     *
+     * @return a path as a string representation.
+     */
+    String destinationPath();
+
+    /**
+     * This method should output the diagnostics source to the provided destination.
+     *
+     * @param archiveDestination the target destination that should be written to.
+     * @param monitor a monitor that can track progress.
+     * @throws IOException if any file operations fail, exceptions should be handled by the caller for better error
+     * reporting to the user.
+     */
+    void addToArchive( Path archiveDestination, DiagnosticsReporterProgressCallback monitor ) throws IOException;
+}

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReportSources.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReportSources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReportSources.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReportSources.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.diagnostics;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.logging.RotatingFileOutputStreamSupplier;
+
+import static org.neo4j.logging.RotatingFileOutputStreamSupplier.getAllArchives;
+
+/**
+ * Contains helper methods to create create {@link DiagnosticsReportSource}.
+ */
+public class DiagnosticsReportSources
+{
+    private DiagnosticsReportSources()
+    {
+        throw new AssertionError( "No instances" );
+    }
+
+    /**
+     * Create a diagnostics source the will copy a file into the archive.
+     *
+     * @param destination final destination in archive.
+     * @param fs filesystem abstraction to use.
+     * @param source source file to archive
+     * @return a diagnostics source consuming a file.
+     */
+    public static DiagnosticsReportSource newDiagnosticsFile( String destination, FileSystemAbstraction fs,
+            File source )
+    {
+        return new DiagnosticsFileReportSource( destination, fs, source );
+    }
+
+    /**
+     * This is to be used by loggers that uses {@link RotatingFileOutputStreamSupplier}.
+     *
+     * @param destination final destination in archive.
+     * @param fs filesystem abstraction to use.
+     * @param file input log file, should be without rotation numbers.
+     * @return a list diagnostics sources consisting of the log file including all rotated away files.
+     */
+    public static List<DiagnosticsReportSource> newDiagnosticsRotatingFile( String destination,
+            FileSystemAbstraction fs, File file )
+    {
+        ArrayList<DiagnosticsReportSource> files = new ArrayList<>();
+
+        files.add( newDiagnosticsFile( destination, fs, file ) );
+
+        List<File> allArchives = getAllArchives( fs, file );
+        for ( File archive : allArchives )
+        {
+            String name = archive.getName();
+            String n = name.substring( name.lastIndexOf( '.' ) );
+            files.add( newDiagnosticsFile( destination + "." + n, fs, archive ) );
+        }
+        return files;
+    }
+
+    /**
+     * Create a diagnostics source from a string. Can be used to dump simple messages to a file in the archive. Files
+     * are opened with append option so this method can be used to accumulate messages from multiple source to a single
+     * file in the archive.
+     *
+     * @param destination final destination in archive.
+     * @param messageSupplier a string supplier with the final message.
+     * @return a diagnostics source consuming a string.
+     */
+    public static DiagnosticsReportSource newDiagnosticsString( String destination,
+            Supplier<String> messageSupplier )
+    {
+        return new DiagnosticsStringReportSource( destination, messageSupplier );
+    }
+
+    private static class DiagnosticsFileReportSource implements DiagnosticsReportSource
+    {
+        private final String destination;
+        private final FileSystemAbstraction fs;
+        private final File source;
+
+        DiagnosticsFileReportSource( String destination, FileSystemAbstraction fs, File source )
+        {
+            this.destination = destination;
+            this.fs = fs;
+            this.source = source;
+        }
+
+        @Override
+        public String destinationPath()
+        {
+            return destination;
+        }
+
+        @Override
+        public void addToArchive( Path archiveDestination, DiagnosticsReporterProgressCallback monitor )
+                throws IOException
+        {
+            long size = fs.getFileSize( source );
+            InputStream in = fs.openAsInputStream( source );
+
+            // Track progress of the file reading, source might be a very large file
+            ProgressAwareInputStream inStream = new ProgressAwareInputStream( in, size, monitor::percentChanged );
+            Files.copy( inStream, archiveDestination );
+        }
+    }
+
+    private static class DiagnosticsStringReportSource implements DiagnosticsReportSource
+    {
+        private final String destination;
+        private final Supplier<String> messageSupplier;
+
+        private DiagnosticsStringReportSource( String destination, Supplier<String> messageSupplier )
+        {
+            this.destination = destination;
+            this.messageSupplier = messageSupplier;
+        }
+
+        @Override
+        public String destinationPath()
+        {
+            return destination;
+        }
+
+        @Override
+        public void addToArchive( Path archiveDestination, DiagnosticsReporterProgressCallback monitor )
+                throws IOException
+        {
+            String message = messageSupplier.get();
+            Files.write( archiveDestination, message.getBytes( Charset.forName( "UTF8" ) ), StandardOpenOption.CREATE,
+                    StandardOpenOption.APPEND );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReportSources.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReportSources.java
@@ -22,7 +22,7 @@ package org.neo4j.diagnostics;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -126,8 +126,10 @@ public class DiagnosticsReportSources
             InputStream in = fs.openAsInputStream( source );
 
             // Track progress of the file reading, source might be a very large file
-            ProgressAwareInputStream inStream = new ProgressAwareInputStream( in, size, monitor::percentChanged );
-            Files.copy( inStream, archiveDestination );
+            try ( ProgressAwareInputStream inStream = new ProgressAwareInputStream( in, size, monitor::percentChanged ) )
+            {
+                Files.copy( inStream, archiveDestination );
+            }
         }
     }
 
@@ -153,7 +155,7 @@ public class DiagnosticsReportSources
                 throws IOException
         {
             String message = messageSupplier.get();
-            Files.write( archiveDestination, message.getBytes( Charset.forName( "UTF8" ) ), StandardOpenOption.CREATE,
+            Files.write( archiveDestination, message.getBytes( StandardCharsets.UTF_8 ), StandardOpenOption.CREATE,
                     StandardOpenOption.APPEND );
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporter.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporter.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporter.java
@@ -110,6 +110,7 @@ public class DiagnosticsReporter
         return availableClassifiers;
     }
 
+    // TODO:
     private static class Mon implements DiagnosticsReporterProgressCallback
     {
         private final String prefix;

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporter.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporter.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.diagnostics;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.FileSystem;
@@ -31,6 +32,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+
+import org.neo4j.helpers.Service;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
 
 
 public class DiagnosticsReporter
@@ -109,5 +114,14 @@ public class DiagnosticsReporter
     public Set<String> getAvailableClassifiers()
     {
         return availableClassifiers;
+    }
+
+    public void registerAllOfflineProviders( Config config, File storeDirectory, FileSystemAbstraction fs )
+    {
+        for ( DiagnosticsOfflineReportProvider provider : Service.load( DiagnosticsOfflineReportProvider.class ) )
+        {
+            provider.init( fs, config, storeDirectory );
+            registerOfflineProvider( provider );
+        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporter.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporter.java
@@ -27,6 +27,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +44,6 @@ public class DiagnosticsReporter
 
     public DiagnosticsReporter( PrintStream out )
     {
-
         this.out = out;
     }
 
@@ -115,6 +115,8 @@ public class DiagnosticsReporter
         private final String prefix;
         private final String suffix;
         private final PrintStream out;
+        private String info = "";
+        private int longestInfo;
 
         private Mon( String prefix, String suffix, PrintStream out )
         {
@@ -141,7 +143,7 @@ public class DiagnosticsReporter
                     out.print( ' ' );
                 }
             }
-            out.print( "] " + percent + "%" + suffix );
+            out.print( String.format( "] %3s%% %s %s", percent, suffix, info ) );
         }
 
         @Override
@@ -153,8 +155,21 @@ public class DiagnosticsReporter
         @Override
         public void finished()
         {
+            // Pad string to erase info string
+            info = String.join( "", Collections.nCopies( longestInfo, " " ) );
+
             percentChanged( 100 );
             out.println();
+        }
+
+        @Override
+        public void info( String info )
+        {
+            this.info = info;
+            if ( info.length() > longestInfo )
+            {
+                longestInfo = info.length();
+            }
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporter.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporter.java
@@ -99,6 +99,7 @@ public class DiagnosticsReporter
                 catch ( Throwable e )
                 {
                     progress.error( "Step failed", e );
+                    continue;
                 }
                 progress.finished();
             }

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporter.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporter.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.diagnostics;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+
+public class DiagnosticsReporter
+{
+    private final List<DiagnosticsOfflineReportProvider> providers = new ArrayList<>();
+    private final Set<String> availableClassifiers = new TreeSet<>();
+    private final Map<String,List<DiagnosticsReportSource>> additionalSources = new HashMap<>();
+    private final PrintStream out;
+
+    public DiagnosticsReporter( PrintStream out )
+    {
+
+        this.out = out;
+    }
+
+    public void registerOfflineProvider( DiagnosticsOfflineReportProvider provider )
+    {
+        providers.add( provider );
+        availableClassifiers.addAll( provider.getFilterClassifiers() );
+    }
+
+    public void registerSource( String classifier, DiagnosticsReportSource source )
+    {
+        availableClassifiers.add( classifier );
+        additionalSources.computeIfAbsent( classifier, c -> new ArrayList<>() ).add( source );
+    }
+
+    public void dump( Set<String> classifiers, Path destination ) throws IOException
+    {
+        // Collect sources
+        List<DiagnosticsReportSource> sources = new ArrayList<>();
+        for ( DiagnosticsOfflineReportProvider provider : providers )
+        {
+            sources.addAll( provider.getDiagnosticsSources( classifiers ) );
+        }
+
+        // Add additional sources
+        for ( String classifier : additionalSources.keySet() )
+        {
+            if ( classifiers.contains( "all" ) || classifiers.contains( classifier ) )
+            {
+                sources.addAll( additionalSources.get( classifier ) );
+            }
+        }
+
+        // Make sure target directory exists
+        Files.createDirectories( destination.getParent() );
+
+        // Compress all files to destination
+        Map<String,String> env = new HashMap<>();
+        env.put( "create", "true" );
+
+        URI uri = URI.create("jar:file:" + destination.toAbsolutePath());
+
+        try ( FileSystem fs = FileSystems.newFileSystem( uri, env ) )
+        {
+            for ( int i = 0; i < sources.size(); i++ )
+            {
+                DiagnosticsReportSource source = sources.get( i );
+                Path path = fs.getPath( source.destinationPath() );
+                if ( path.getParent() != null )
+                {
+                    Files.createDirectories( path.getParent() );
+                }
+
+                Mon monitor = new Mon( (i + 1) + "/" + sources.size(), "  " + path, out );
+                monitor.started();
+                source.addToArchive( path, monitor );
+                monitor.finished();
+            }
+        }
+    }
+
+    public Set<String> getAvailableClassifiers()
+    {
+        return availableClassifiers;
+    }
+
+    private static class Mon implements DiagnosticsReporterProgressCallback
+    {
+        private final String prefix;
+        private final String suffix;
+        private final PrintStream out;
+
+        private Mon( String prefix, String suffix, PrintStream out )
+        {
+            this.prefix = prefix;
+            this.suffix = suffix;
+            this.out = out;
+        }
+
+        @Override
+        public void percentChanged( int percent )
+        {
+            out.print( String.format( "\r%8s [", prefix ) );
+            int totalWidth = 20;
+
+            int numBars = totalWidth * percent / 100;
+            for ( int i = 0; i < totalWidth; i++ )
+            {
+                if ( i < numBars )
+                {
+                    out.print( '#' );
+                }
+                else
+                {
+                    out.print( ' ' );
+                }
+            }
+            out.print( "] " + percent + "%" + suffix );
+        }
+
+        @Override
+        public void started()
+        {
+            percentChanged( 0 );
+        }
+
+        @Override
+        public void finished()
+        {
+            percentChanged( 100 );
+            out.println();
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporterProgressCallback.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporterProgressCallback.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporterProgressCallback.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporterProgressCallback.java
@@ -43,7 +43,7 @@ public interface DiagnosticsReporterProgressCallback
     /**
      * @apiNote Called by dispatching class. Should not be called from diagnostics sources.
      */
-    void started();
+    void started( long currentFileIndex, String target );
 
     /**
      * @apiNote Called by dispatching class. Should not be called from diagnostics sources.

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporterProgressCallback.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporterProgressCallback.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.diagnostics;
+
+public interface DiagnosticsReporterProgressCallback
+{
+    void percentChanged( int percent );
+    void started();
+    void finished();
+}

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporterProgressCallback.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporterProgressCallback.java
@@ -19,9 +19,34 @@
  */
 package org.neo4j.diagnostics;
 
+/**
+ * Interface for handling feedback to the user. Implementations of this should be responsible of presenting the progress
+ * to the user. Some specialised implementations can choose to omit any of the information provided here.
+ */
 public interface DiagnosticsReporterProgressCallback
 {
+    /**
+     * Calling this will notify the user that the percentage has changed.
+     *
+     * @param percent to display to the user.
+     */
     void percentChanged( int percent );
+
+    /**
+     * Adds an additional information string to the output. Useful if the task has multiple steeps and the current step
+     * should be displayed.
+     *
+     * @param info string to present to the user.
+     */
+    void info( String info );
+
+    /**
+     * @apiNote Called by dispatching class. Should not be called from diagnostics sources.
+     */
     void started();
+
+    /**
+     * @apiNote Called by dispatching class. Should not be called from diagnostics sources.
+     */
     void finished();
 }

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporterProgressCallback.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporterProgressCallback.java
@@ -41,9 +41,22 @@ public interface DiagnosticsReporterProgressCallback
     void info( String info );
 
     /**
+     * Called if an internal error occurs with an optional exception.
+     *
+     * @param msg message to display to the user.
+     * @param throwable optional exception, used to include a stacktrace if applicable.
+     */
+    void error( String msg, Throwable throwable );
+
+    /**
      * @apiNote Called by dispatching class. Should not be called from diagnostics sources.
      */
-    void started( long currentFileIndex, String target );
+    void setTotalSteps( long steps );
+
+    /**
+     * @apiNote Called by dispatching class. Should not be called from diagnostics sources.
+     */
+    void started( long currentStepIndex, String target );
 
     /**
      * @apiNote Called by dispatching class. Should not be called from diagnostics sources.

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/InteractiveProgress.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/InteractiveProgress.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.diagnostics;
+
+import java.io.PrintStream;
+import java.util.Collections;
+
+/**
+ * Tracks progress in an interactive way, relies on the fact that the {@code PrintStream} echoes to a terminal that can
+ * interpret the carrier return to reset the current line.
+ */
+public class InteractiveProgress implements DiagnosticsReporterProgressCallback
+{
+    private String prefix;
+    private String suffix;
+    private String totalSteps = "?";
+    private final PrintStream out;
+    private final boolean verbose;
+    private String info = "";
+    private int longestInfo;
+
+    public InteractiveProgress( PrintStream out, boolean verbose )
+    {
+        this.out = out;
+        this.verbose = verbose;
+    }
+
+    @Override
+    public void percentChanged( int percent )
+    {
+        out.print( String.format( "\r%8s [", prefix ) );
+        int totalWidth = 20;
+
+        int numBars = totalWidth * percent / 100;
+        for ( int i = 0; i < totalWidth; i++ )
+        {
+            if ( i < numBars )
+            {
+                out.print( '#' );
+            }
+            else
+            {
+                out.print( ' ' );
+            }
+        }
+        out.print( String.format( "] %3s%%   %s %s", percent, suffix, info ) );
+    }
+
+    @Override
+    public void started( long currentStepIndex, String target )
+    {
+        this.prefix = currentStepIndex + "/" + totalSteps;
+        this.suffix = target;
+        percentChanged( 0 );
+    }
+
+    @Override
+    public void finished()
+    {
+        // Pad string to erase info string
+        info = String.join( "", Collections.nCopies( longestInfo, " " ) );
+
+        percentChanged( 100 );
+        out.println();
+    }
+
+    @Override
+    public void info( String info )
+    {
+        this.info = info;
+        if ( info.length() > longestInfo )
+        {
+            longestInfo = info.length();
+        }
+    }
+
+    @Override
+    public void error( String msg, Throwable throwable )
+    {
+        out.println();
+        out.println( "Error: " + msg );
+        if ( verbose )
+        {
+            throwable.printStackTrace( out );
+        }
+    }
+
+    @Override
+    public void setTotalSteps( long steps )
+    {
+        this.totalSteps = String.valueOf( steps );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/KernelDiagnosticsOfflineReportProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/KernelDiagnosticsOfflineReportProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/KernelDiagnosticsOfflineReportProvider.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/KernelDiagnosticsOfflineReportProvider.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.diagnostics;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nonnull;
+
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.info.DiagnosticsPhase;
+import org.neo4j.kernel.internal.KernelDiagnostics;
+import org.neo4j.logging.BufferingLog;
+
+import static org.neo4j.diagnostics.DiagnosticsReportSources.newDiagnosticsFile;
+import static org.neo4j.diagnostics.DiagnosticsReportSources.newDiagnosticsRotatingFile;
+import static org.neo4j.diagnostics.DiagnosticsReportSources.newDiagnosticsString;
+
+public class KernelDiagnosticsOfflineReportProvider extends DiagnosticsOfflineReportProvider
+{
+    private FileSystemAbstraction fs;
+    private Config config;
+    private File storeDirectory;
+
+    public KernelDiagnosticsOfflineReportProvider()
+    {
+        super( "kernel", "logs", "plugins", "tree" );
+    }
+
+    @Override
+    public void init( FileSystemAbstraction fs, Config config, File storeDirectory )
+    {
+        this.fs = fs;
+        this.config = config;
+        this.storeDirectory = storeDirectory;
+    }
+
+    @Nonnull
+    @Override
+    protected List<DiagnosticsReportSource> provideSources( Set<String> classifiers )
+    {
+        List<DiagnosticsReportSource> sources = new ArrayList<>();
+        if ( classifiers.contains( "logs" ) )
+        {
+            getLogFiles( sources );
+        }
+        if ( classifiers.contains( "plugins" ) )
+        {
+            listPlugins( sources );
+        }
+        if ( classifiers.contains( "tree" ) )
+        {
+            listDataDirectory( sources );
+        }
+
+        return sources;
+    }
+
+    /**
+     * Collect a list of all the files in the plugins directory.
+     *
+     * @param sources destination of the sources.
+     */
+    private void listPlugins( List<DiagnosticsReportSource> sources )
+    {
+        File pluginDirectory = config.get( GraphDatabaseSettings.plugin_dir );
+        if ( fs.fileExists( pluginDirectory ) )
+        {
+            StringBuilder sb = new StringBuilder();
+            sb.append( "List of plugin directory:" ).append( System.lineSeparator() );
+            listContentOfDirectory( pluginDirectory, "  ", sb );
+
+            sources.add( newDiagnosticsString( "plugins.txt", sb::toString ) );
+        }
+    }
+
+    private void listContentOfDirectory( File directory, String prefix, StringBuilder sb )
+    {
+        if ( !fs.isDirectory( directory ) )
+        {
+            return;
+        }
+
+        File[] files = fs.listFiles( directory );
+        for ( File file : files )
+        {
+            if ( fs.isDirectory( file ) )
+            {
+                listContentOfDirectory( file, prefix + File.separator + file.getName(), sb );
+            }
+            else
+            {
+                sb.append( prefix ).append( file.getName() ).append( System.lineSeparator() );
+            }
+        }
+    }
+
+    /**
+     * Print a tree view of all the files in the graph.db directory with files sizes.
+     *
+     * @param sources destination of the sources.
+     */
+    private void listDataDirectory( List<DiagnosticsReportSource> sources )
+    {
+        KernelDiagnostics.StoreFiles storeFiles = new KernelDiagnostics.StoreFiles( storeDirectory );
+
+        BufferingLog logger = new BufferingLog();
+        storeFiles.dump( DiagnosticsPhase.INITIALIZED, logger.debugLogger() );
+
+        sources.add( newDiagnosticsString( "tree.txt", logger::toString ) );
+    }
+
+    /**
+     * Add {@code debug.log}, {@code neo4j.log} and {@code gc.log}. All with all available rotated files.
+     *
+     * @param sources destination of the sources.
+     */
+    private void getLogFiles( List<DiagnosticsReportSource> sources )
+    {
+        // debug.log
+        File debugLogFile = config.get( GraphDatabaseSettings.store_internal_log_path );
+        if ( fs.fileExists( debugLogFile ) )
+        {
+            sources.addAll( newDiagnosticsRotatingFile( "logs/debug.log", fs, debugLogFile ) );
+        }
+
+        // neo4j.log
+        File logDirectory = config.get( GraphDatabaseSettings.logs_directory );
+        File neo4jLog = new File( logDirectory, "neo4j.log" );
+        if ( fs.fileExists( neo4jLog ) )
+        {
+            sources.add( newDiagnosticsFile( "logs/neo4j.log", fs, neo4jLog ) );
+        }
+
+        // gc.log
+        File gcLog = new File( logDirectory, "gc.log" );
+        if ( fs.fileExists( gcLog ) )
+        {
+            sources.add( newDiagnosticsFile( "logs/gc.log", fs, gcLog ) );
+        }
+        // we might have rotation activated, check
+        int i = 0;
+        while ( true )
+        {
+            File gcRotationLog = new File( logDirectory, "gc.log." + i );
+            if ( !fs.fileExists( gcRotationLog ) )
+            {
+                break;
+            }
+            sources.add( newDiagnosticsFile( "logs/gc.log." + i, fs, gcRotationLog ) );
+            i++;
+        }
+        // there are other rotation schemas but nothing we can predict...
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/NonInteractiveProgress.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/NonInteractiveProgress.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.diagnostics;
+
+import java.io.PrintStream;
+
+public class NonInteractiveProgress implements DiagnosticsReporterProgressCallback
+{
+    private String totalSteps = "?";
+    private final PrintStream out;
+    private final boolean verbose;
+    private int lastPercentage;
+
+    public NonInteractiveProgress( PrintStream out, boolean verbose )
+    {
+        this.out = out;
+        this.verbose = verbose;
+    }
+
+    @Override
+    public void percentChanged( int percent )
+    {
+        for ( int i = lastPercentage + 1; i <= percent; i++ )
+        {
+            out.print( '.' );
+            if ( i % 20 == 0 )
+            {
+                out.printf( " %3d%%%n", i );
+            }
+        }
+        lastPercentage = percent;
+        out.flush();
+    }
+
+    @Override
+    public void started( long currentStepIndex, String target )
+    {
+        out.println( currentStepIndex + "/" + totalSteps + " " + target );
+        lastPercentage = 0;
+    }
+
+    @Override
+    public void finished()
+    {
+        percentChanged( 100 );
+        out.println();
+    }
+
+    @Override
+    public void info( String info )
+    {
+        // Ignore info message
+    }
+
+    @Override
+    public void error( String msg, Throwable throwable )
+    {
+        out.println();
+        out.println( "Error: " + msg );
+        if ( verbose )
+        {
+            throwable.printStackTrace( out );
+        }
+    }
+
+    @Override
+    public void setTotalSteps( long steps )
+    {
+        this.totalSteps = String.valueOf( steps );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/ProgressAwareInputStream.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/ProgressAwareInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/ProgressAwareInputStream.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/ProgressAwareInputStream.java
@@ -34,7 +34,7 @@ public class ProgressAwareInputStream extends InputStream
     private long totalRead;
     private int lastReportedPercent;
 
-    ProgressAwareInputStream( InputStream wrappedInputStream, long size, OnProgressListener listener )
+    public ProgressAwareInputStream( InputStream wrappedInputStream, long size, OnProgressListener listener )
     {
         this.wrappedInputStream = wrappedInputStream;
         this.size = size;

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/ProgressAwareInputStream.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/ProgressAwareInputStream.java
@@ -80,6 +80,14 @@ public class ProgressAwareInputStream extends InputStream
     private void recalculatePercent()
     {
         int percent = (int) (totalRead * 100 / size);
+        if ( percent > 100 )
+        {
+            percent = 100;
+        }
+        if ( percent < 0 )
+        {
+            percent = 0;
+        }
         if ( percent > lastReportedPercent )
         {
             lastReportedPercent = percent;

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/ProgressAwareInputStream.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/ProgressAwareInputStream.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.diagnostics;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Implements an {@link InputStream} that keeps track of the progress. This assumes that the total size is available
+ * before reading starts.
+ */
+public class ProgressAwareInputStream extends InputStream
+{
+    private final OnProgressListener listener;
+    private final InputStream wrappedInputStream;
+    private final long size;
+    private long totalRead;
+    private int lastReportedPercent;
+
+    ProgressAwareInputStream( InputStream wrappedInputStream, long size, OnProgressListener listener )
+    {
+        this.wrappedInputStream = wrappedInputStream;
+        this.size = size;
+        this.listener = listener;
+    }
+
+    @Override
+    public int read() throws IOException
+    {
+        int data = wrappedInputStream.read();
+        if ( data >= 0 )
+        {
+            totalRead += 1;
+            recalculatePercent();
+        }
+        return data;
+    }
+
+    @Override
+    public int read( byte[] b ) throws IOException
+    {
+        int n = wrappedInputStream.read( b );
+        if ( n > 0 )
+        {
+            totalRead += n;
+            recalculatePercent();
+        }
+        return n;
+    }
+
+    @Override
+    public int read( byte[] b, int offset, int length ) throws IOException
+    {
+        int n = wrappedInputStream.read( b, offset, length );
+        if ( n > 0 )
+        {
+            totalRead += n;
+            recalculatePercent();
+        }
+        return n;
+    }
+
+    private void recalculatePercent()
+    {
+        int percent = (int) (totalRead * 100 / size);
+        if ( percent > lastReportedPercent )
+        {
+            lastReportedPercent = percent;
+            listener.onProgress( percent );
+        }
+    }
+
+    @Override
+    public long skip( long n ) throws IOException
+    {
+        return wrappedInputStream.skip( n );
+    }
+
+    @Override
+    public int available() throws IOException
+    {
+        return wrappedInputStream.available();
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        wrappedInputStream.close();
+    }
+
+    @Override
+    public void mark( int readLimit )
+    {
+        wrappedInputStream.mark( readLimit );
+    }
+
+    @Override
+    public void reset() throws IOException
+    {
+        wrappedInputStream.reset();
+    }
+
+    @Override
+    public boolean markSupported()
+    {
+        return wrappedInputStream.markSupported();
+    }
+
+    /**
+     * Interface for classes that want to monitor this input stream
+     */
+    public interface OnProgressListener
+    {
+        void onProgress( int percentage );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/helpers/Args.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Args.java
@@ -462,11 +462,7 @@ public class Args
     private void put( Function<String,Option<String>> optionParser, String key, String value )
     {
         Option<String> option = optionParser.apply( key );
-        List<Option<String>> values = map.get( option.value() );
-        if ( values == null )
-        {
-            map.put( option.value(), values = new ArrayList<>() );
-        }
+        List<Option<String>> values = map.computeIfAbsent( option.value(), k -> new ArrayList<>() );
         values.add( new Option<>( value, option.metadata() ) );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ReflectiveProcedureCompiler.java
@@ -36,8 +36,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.neo4j.collection.RawIterator;
-import org.neo4j.kernel.api.exceptions.ComponentInjectionException;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
+import org.neo4j.kernel.api.exceptions.ComponentInjectionException;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.proc.CallableProcedure;
@@ -604,7 +604,7 @@ class ReflectiveProcedureCompiler
                 }
                 else
                 {
-                    return new MappingIterator( ((Stream<?>) rs).iterator(), () -> ((Stream<?>) rs).close() );
+                    return new MappingIterator( ((Stream<?>) rs).iterator(), ((Stream<?>) rs)::close );
                 }
             }
             catch ( Throwable throwable )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/LogFilesBuilder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/LogFilesBuilder.java
@@ -102,7 +102,7 @@ public class LogFilesBuilder
     }
 
     /**
-     * Build log files that will be able to perform only operations on a lgo files directly.
+     * Build log files that will be able to perform only operations on a log files directly.
      * Any operation that will require access to a store or other parts of runtime will fail.
      * Should be mainly used only for testing purposes or when only file based operations will be performed
      * @param logsDirectory log files directory

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/KernelDiagnostics.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/KernelDiagnostics.java
@@ -22,7 +22,6 @@ package org.neo4j.kernel.internal;
 import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
@@ -99,7 +98,7 @@ public abstract class KernelDiagnostics implements DiagnosticsProvider
 
             // Sort by name
             List<File> fileList = Arrays.asList( files );
-            Collections.sort( fileList, ( o1, o2 ) -> o1.getName().compareTo( o2.getName() ) );
+            fileList.sort( Comparator.comparing( File::getName ) );
 
             for ( File file : fileList )
             {

--- a/community/kernel/src/main/resources/META-INF/services/org.neo4j.diagnostics.DiagnosticsOfflineReportProvider
+++ b/community/kernel/src/main/resources/META-INF/services/org.neo4j.diagnostics.DiagnosticsOfflineReportProvider
@@ -1,0 +1,1 @@
+org.neo4j.diagnostics.KernelDiagnosticsOfflineReportProvider

--- a/community/kernel/src/test/java/org/neo4j/diagnostics/DiagnosticsReporterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/diagnostics/DiagnosticsReporterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/kernel/src/test/java/org/neo4j/diagnostics/DiagnosticsReporterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/diagnostics/DiagnosticsReporterTest.java
@@ -34,7 +34,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import javax.annotation.Nonnull;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
@@ -73,7 +72,6 @@ public class DiagnosticsReporterTest
         {
         }
 
-        @Nonnull
         @Override
         public List<DiagnosticsReportSource> provideSources( Set<String> classifiers )
         {

--- a/community/kernel/src/test/java/org/neo4j/diagnostics/DiagnosticsReporterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/diagnostics/DiagnosticsReporterTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.PrintStream;
 import java.net.URI;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -87,7 +86,7 @@ public class DiagnosticsReporterTest
     @Test
     public void dumpFiles() throws Exception
     {
-        DiagnosticsReporter reporter = new DiagnosticsReporter( mock( PrintStream.class ) );
+        DiagnosticsReporter reporter = new DiagnosticsReporter(  );
         MyProvider myProvider = new MyProvider( fileSystemRule.get() );
         reporter.registerOfflineProvider( myProvider );
 
@@ -96,7 +95,7 @@ public class DiagnosticsReporterTest
 
         Path destination = testDirectory.file( "logs.zip" ).toPath();
 
-        reporter.dump( Collections.singleton( "logs" ), destination );
+        reporter.dump( Collections.singleton( "logs" ), destination, mock( DiagnosticsReporterProgressCallback.class ) );
 
         // Verify content
         URI uri = URI.create("jar:file:" + destination.toAbsolutePath().toUri().getPath() );

--- a/community/kernel/src/test/java/org/neo4j/diagnostics/DiagnosticsReporterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/diagnostics/DiagnosticsReporterTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.diagnostics;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nonnull;
+
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.neo4j.diagnostics.DiagnosticsReportSources.newDiagnosticsFile;
+
+public class DiagnosticsReporterTest
+{
+    @Rule
+    public final TestDirectory testDirectory = TestDirectory.testDirectory();
+    @Rule
+    public final DefaultFileSystemRule fileSystemRule = new DefaultFileSystemRule();
+
+    static class MyProvider extends DiagnosticsOfflineReportProvider
+    {
+        private final FileSystemAbstraction fs;
+        private List<DiagnosticsReportSource> logFiles = new ArrayList<>();
+
+        MyProvider( FileSystemAbstraction fs )
+        {
+            super( "my-provider", "logs" );
+            this.fs = fs;
+        }
+
+        void addFile( String destination, File file )
+        {
+            logFiles.add( newDiagnosticsFile( destination, fs, file ) );
+        }
+
+        @Override
+        public void init( FileSystemAbstraction fs, Config config, File storeDirectory )
+        {
+        }
+
+        @Nonnull
+        @Override
+        public List<DiagnosticsReportSource> provideSources( Set<String> classifiers )
+        {
+            if ( classifiers.contains( "logs" ) )
+            {
+                return logFiles;
+            }
+
+            return Collections.emptyList();
+        }
+    }
+
+    @Test
+    public void dumpFiles() throws Exception
+    {
+        DiagnosticsReporter reporter = new DiagnosticsReporter( mock( PrintStream.class ) );
+        MyProvider myProvider = new MyProvider( fileSystemRule.get() );
+        reporter.registerOfflineProvider( myProvider );
+
+        myProvider.addFile( "logs/a.txt", createNewFileWithContent( "a.txt", "file a") );
+        myProvider.addFile( "logs/b.txt", createNewFileWithContent( "b.txt", "file b") );
+
+        Path destination = testDirectory.file( "logs.zip" ).toPath();
+
+        reporter.dump( Collections.singleton( "logs" ), destination );
+
+        // Verify content
+        URI uri = URI.create("jar:file:" + destination.toAbsolutePath());
+
+        try ( FileSystem fs = FileSystems.newFileSystem( uri, Collections.emptyMap() ) )
+        {
+            List<String> fileA = Files.readAllLines( fs.getPath( "logs/a.txt" ) );
+            assertEquals( 1, fileA.size() );
+            assertEquals( "file a", fileA.get( 0 ) );
+
+            List<String> fileB = Files.readAllLines( fs.getPath( "logs/b.txt" ) );
+            assertEquals( 1, fileB.size() );
+            assertEquals( "file b", fileB.get( 0 ) );
+        }
+    }
+
+    private File createNewFileWithContent( String name, String content ) throws IOException
+    {
+        Path file = testDirectory.file( name ).toPath();
+        Files.write( file, content.getBytes() );
+        return file.toFile();
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/diagnostics/DiagnosticsReporterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/diagnostics/DiagnosticsReporterTest.java
@@ -101,7 +101,7 @@ public class DiagnosticsReporterTest
         reporter.dump( Collections.singleton( "logs" ), destination );
 
         // Verify content
-        URI uri = URI.create("jar:file:" + destination.toAbsolutePath());
+        URI uri = URI.create("jar:file:" + destination.toAbsolutePath().toUri().getPath() );
 
         try ( FileSystem fs = FileSystems.newFileSystem( uri, Collections.emptyMap() ) )
         {

--- a/community/licensecheck-config/src/main/resources/licensing-requirements-base.xml
+++ b/community/licensecheck-config/src/main/resources/licensing-requirements-base.xml
@@ -80,6 +80,7 @@
       <aka>Apache Software Licenses</aka>
       <aka>Apache 2</aka>
       <aka>Apache License, Version 2.0</aka>
+      <aka>Apache License, Version 2</aka>
       <aka>Apache License 2.0</aka>
       <aka>Apache 2.0</aka>
       <aka>Apache</aka>

--- a/community/neo4j-community/LICENSES.txt
+++ b/community/neo4j-community/LICENSES.txt
@@ -10,6 +10,8 @@ Apache Software License, Version 2.0
   ConcurrentLinkedHashMap
   Data Mapper for Jackson
   Jackson
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -19,6 +21,7 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
+  WMI4Java
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/community/neo4j-community/NOTICE.txt
+++ b/community/neo4j-community/NOTICE.txt
@@ -33,6 +33,8 @@ Apache Software License, Version 2.0
   ConcurrentLinkedHashMap
   Data Mapper for Jackson
   Jackson
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -42,6 +44,7 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
+  WMI4Java
 
 BSD - Scala License
   Scala Library

--- a/community/neo4j-harness/LICENSES.txt
+++ b/community/neo4j-harness/LICENSES.txt
@@ -26,6 +26,8 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -35,6 +37,7 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
+  WMI4Java
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/community/neo4j-harness/NOTICE.txt
+++ b/community/neo4j-harness/NOTICE.txt
@@ -49,6 +49,8 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -58,6 +60,7 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
+  WMI4Java
 
 BSD - Scala License
   Scala Library

--- a/community/neo4j/LICENSES.txt
+++ b/community/neo4j/LICENSES.txt
@@ -8,6 +8,8 @@ Apache Software License, Version 2.0
   Apache Commons Text
   Caffeine cache
   ConcurrentLinkedHashMap
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -17,6 +19,7 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
+  WMI4Java
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/community/neo4j/NOTICE.txt
+++ b/community/neo4j/NOTICE.txt
@@ -31,6 +31,8 @@ Apache Software License, Version 2.0
   Apache Commons Text
   Caffeine cache
   ConcurrentLinkedHashMap
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -40,6 +42,7 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
+  WMI4Java
 
 BSD - Scala License
   Scala Library

--- a/community/security/LICENSES.txt
+++ b/community/security/LICENSES.txt
@@ -6,12 +6,15 @@ Apache Software License, Version 2.0
   Apache Commons Compress
   Apache Commons Lang
   Apache Commons Text
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
+  WMI4Java
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/community/security/NOTICE.txt
+++ b/community/security/NOTICE.txt
@@ -29,12 +29,15 @@ Apache Software License, Version 2.0
   Apache Commons Compress
   Apache Commons Lang
   Apache Commons Text
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
+  WMI4Java
 
 Bouncy Castle License
   Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs

--- a/community/server-plugin-test/LICENSES.txt
+++ b/community/server-plugin-test/LICENSES.txt
@@ -23,6 +23,8 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -32,6 +34,7 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
+  WMI4Java
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/community/server-plugin-test/NOTICE.txt
+++ b/community/server-plugin-test/NOTICE.txt
@@ -46,6 +46,8 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -55,6 +57,7 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
+  WMI4Java
 
 BSD - Scala License
   Scala Library

--- a/community/server/LICENSES.txt
+++ b/community/server/LICENSES.txt
@@ -23,6 +23,8 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -32,6 +34,7 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
+  WMI4Java
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/community/server/NOTICE.txt
+++ b/community/server/NOTICE.txt
@@ -46,6 +46,8 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -55,6 +57,7 @@ Apache Software License, Version 2.0
   opencsv
   parboiled-core
   parboiled-scala
+  WMI4Java
 
 BSD - Scala License
   Scala Library

--- a/community/server/src/main/java/org/neo4j/server/diagnostics/ServerDiagnosticsOfflineReportProvider.java
+++ b/community/server/src/main/java/org/neo4j/server/diagnostics/ServerDiagnosticsOfflineReportProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/server/src/main/java/org/neo4j/server/diagnostics/ServerDiagnosticsOfflineReportProvider.java
+++ b/community/server/src/main/java/org/neo4j/server/diagnostics/ServerDiagnosticsOfflineReportProvider.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.diagnostics;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.neo4j.diagnostics.DiagnosticsOfflineReportProvider;
+import org.neo4j.diagnostics.DiagnosticsReportSource;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.server.configuration.ServerSettings;
+
+import static org.neo4j.diagnostics.DiagnosticsReportSources.newDiagnosticsRotatingFile;
+
+public class ServerDiagnosticsOfflineReportProvider extends DiagnosticsOfflineReportProvider
+{
+    private FileSystemAbstraction fs;
+    private Config config;
+
+    public ServerDiagnosticsOfflineReportProvider()
+    {
+        super( "server", "logs" );
+    }
+    @Override
+    public void init( FileSystemAbstraction fs, Config config, File storeDirectory )
+    {
+        this.fs = fs;
+        this.config = config;
+    }
+
+    @Override
+    protected List<DiagnosticsReportSource> provideSources( Set<String> classifiers )
+    {
+        if ( classifiers.contains( "logs" ) )
+        {
+            File httpLog = config.get( ServerSettings.http_log_path );
+            if ( fs.fileExists( httpLog ) )
+            {
+                return newDiagnosticsRotatingFile( "logs/http.log", fs, httpLog );
+            }
+        }
+        return Collections.emptyList();
+    }
+}

--- a/community/server/src/main/resources/META-INF/services/org.neo4j.diagnostics.DiagnosticsOfflineReportProvider
+++ b/community/server/src/main/resources/META-INF/services/org.neo4j.diagnostics.DiagnosticsOfflineReportProvider
@@ -1,0 +1,1 @@
+org.neo4j.server.diagnostics.ServerDiagnosticsOfflineReportProvider

--- a/enterprise/backup/LICENSES.txt
+++ b/enterprise/backup/LICENSES.txt
@@ -19,10 +19,13 @@ Apache Software License, Version 2.0
   Apache Shiro :: Lang
   Caffeine cache
   hazelcast-all
+  jPowerShell
+  jProcesses
   Lucene Core
   Lucene Memory
   Netty
   Netty/All-in-One
+  WMI4Java
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/enterprise/backup/NOTICE.txt
+++ b/enterprise/backup/NOTICE.txt
@@ -41,10 +41,13 @@ Apache Software License, Version 2.0
   Apache Shiro :: Lang
   Caffeine cache
   hazelcast-all
+  jPowerShell
+  jProcesses
   Lucene Core
   Lucene Memory
   Netty
   Netty/All-in-One
+  WMI4Java
 
 Bouncy Castle License
   Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs

--- a/enterprise/causal-clustering/LICENSES.txt
+++ b/enterprise/causal-clustering/LICENSES.txt
@@ -18,6 +18,8 @@ Apache Software License, Version 2.0
   Apache Shiro :: Lang
   Caffeine cache
   hazelcast-all
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -25,6 +27,7 @@ Apache Software License, Version 2.0
   Lucene QueryParsers
   Netty
   Netty/All-in-One
+  WMI4Java
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/enterprise/causal-clustering/NOTICE.txt
+++ b/enterprise/causal-clustering/NOTICE.txt
@@ -40,6 +40,8 @@ Apache Software License, Version 2.0
   Apache Shiro :: Lang
   Caffeine cache
   hazelcast-all
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -47,6 +49,7 @@ Apache Software License, Version 2.0
   Lucene QueryParsers
   Netty
   Netty/All-in-One
+  WMI4Java
 
 Bouncy Castle License
   Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/diagnostics/ClusterDiagnosticsOfflineReportProvider.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/diagnostics/ClusterDiagnosticsOfflineReportProvider.java
@@ -108,13 +108,8 @@ public class ClusterDiagnosticsOfflineReportProvider extends DiagnosticsOfflineR
             return;
         }
 
-        for ( File file : fs.listFiles( clusterStateDirectory ) )
+        for ( File file : fs.listFiles( clusterStateDirectory, ( dir, name ) -> !name.equals( RAFT_LOG_DIRECTORY_NAME ) ) )
         {
-            if ( file.getName().equals( RAFT_LOG_DIRECTORY_NAME ) )
-            {
-                continue; // include everything except raft log
-            }
-
             addDirectory( "ccstate", file, sources );
         }
     }
@@ -128,7 +123,7 @@ public class ClusterDiagnosticsOfflineReportProvider extends DiagnosticsOfflineR
      */
     private void addDirectory( String path, File dir, List<DiagnosticsReportSource> sources )
     {
-        String currentLevel = path + "/" + dir.getName();
+        String currentLevel = path + File.separator + dir.getName();
         if ( fs.isDirectory( dir ) )
         {
             File[] files = fs.listFiles( dir );

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/diagnostics/ClusterDiagnosticsOfflineReportProvider.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/diagnostics/ClusterDiagnosticsOfflineReportProvider.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.diagnostics;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedMap;
+
+import org.neo4j.causalclustering.core.consensus.log.segmented.FileNames;
+import org.neo4j.causalclustering.core.state.ClusterStateDirectory;
+import org.neo4j.causalclustering.core.state.ClusterStateException;
+import org.neo4j.diagnostics.DiagnosticsOfflineReportProvider;
+import org.neo4j.diagnostics.DiagnosticsReportSource;
+import org.neo4j.diagnostics.DiagnosticsReportSources;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.logging.NullLog;
+
+import static org.neo4j.causalclustering.core.consensus.log.RaftLog.RAFT_LOG_DIRECTORY_NAME;
+
+public class ClusterDiagnosticsOfflineReportProvider extends DiagnosticsOfflineReportProvider
+{
+    private FileSystemAbstraction fs;
+    private File clusterStateDirectory;
+    private ClusterStateException clusterStateException;
+
+    public ClusterDiagnosticsOfflineReportProvider()
+    {
+        super( "cc", "raft", "ccstate" );
+    }
+
+    @Override
+    public void init( FileSystemAbstraction fs, Config config, File storeDirectory )
+    {
+        this.fs = fs;
+        final File dataDir = config.get( GraphDatabaseSettings.data_directory );
+        try
+        {
+            clusterStateDirectory = new ClusterStateDirectory( dataDir, storeDirectory, true ).initialize( fs ).get();
+        }
+        catch ( ClusterStateException e )
+        {
+            clusterStateException = e;
+        }
+    }
+
+    @Override
+    protected List<DiagnosticsReportSource> provideSources( Set<String> classifiers )
+    {
+        List<DiagnosticsReportSource> sources = new ArrayList<>();
+        if ( classifiers.contains( "raft" ) )
+        {
+            getRaftLogs( sources );
+        }
+        if ( classifiers.contains( "ccstate" ) )
+        {
+            getClusterState( sources );
+        }
+
+        return sources;
+    }
+
+    private void getRaftLogs( List<DiagnosticsReportSource> sources )
+    {
+        if ( clusterStateDirectory == null )
+        {
+            sources.add( DiagnosticsReportSources.newDiagnosticsString( "raft.txt",
+                    () -> "error creating ClusterStateDirectory: " + clusterStateException.getMessage() ) );
+            return;
+        }
+
+        File raftLogDirectory = new File( clusterStateDirectory, RAFT_LOG_DIRECTORY_NAME );
+        FileNames fileNames = new FileNames( raftLogDirectory );
+        SortedMap<Long,File> allFiles = fileNames.getAllFiles( fs, NullLog.getInstance() );
+
+        for ( File logFile : allFiles.values() )
+        {
+            sources.add( DiagnosticsReportSources.newDiagnosticsFile( "raft/" + logFile.getName(), fs, logFile ) );
+        }
+    }
+
+    private void getClusterState( List<DiagnosticsReportSource> sources )
+    {
+        if ( clusterStateDirectory == null )
+        {
+            sources.add( DiagnosticsReportSources.newDiagnosticsString( "ccstate.txt",
+                    () -> "error creating ClusterStateDirectory: " + clusterStateException.getMessage() ) );
+            return;
+        }
+
+        for ( File file : fs.listFiles( clusterStateDirectory ) )
+        {
+            if ( file.getName().equals( RAFT_LOG_DIRECTORY_NAME ) )
+            {
+                continue; // include everything except raft log
+            }
+
+            addDirectory( "ccstate", file, sources );
+        }
+    }
+
+    /**
+     * Add all files in a directory recursively.
+     *
+     * @param path current relative path for destination.
+     * @param dir current directory or file.
+     * @param sources list of source that will be accumulated.
+     */
+    private void addDirectory( String path, File dir, List<DiagnosticsReportSource> sources )
+    {
+        String currentLevel = path + "/" + dir.getName();
+        if ( fs.isDirectory( dir ) )
+        {
+            File[] files = fs.listFiles( dir );
+            if ( files != null )
+            {
+                for ( File file : files )
+                {
+                    addDirectory( currentLevel, file, sources );
+                }
+            }
+        }
+        else // File
+        {
+            sources.add( DiagnosticsReportSources.newDiagnosticsFile( currentLevel, fs, dir ) );
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/main/resources/META-INF/services/org.neo4j.diagnostics.DiagnosticsOfflineReportProvider
+++ b/enterprise/causal-clustering/src/main/resources/META-INF/services/org.neo4j.diagnostics.DiagnosticsOfflineReportProvider
@@ -1,0 +1,1 @@
+org.neo4j.causalclustering.diagnostics.ClusterDiagnosticsOfflineReportProvider

--- a/enterprise/fulltext-addon/LICENSES.txt
+++ b/enterprise/fulltext-addon/LICENSES.txt
@@ -6,12 +6,15 @@ Apache Software License, Version 2.0
   Apache Commons Compress
   Apache Commons Lang
   Apache Commons Text
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
+  WMI4Java
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/enterprise/fulltext-addon/NOTICE.txt
+++ b/enterprise/fulltext-addon/NOTICE.txt
@@ -28,12 +28,15 @@ Apache Software License, Version 2.0
   Apache Commons Compress
   Apache Commons Lang
   Apache Commons Text
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
+  WMI4Java
 
 Bouncy Castle License
   Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs

--- a/enterprise/ha/LICENSES.txt
+++ b/enterprise/ha/LICENSES.txt
@@ -19,6 +19,8 @@ Apache Software License, Version 2.0
   Apache Shiro :: Lang
   Caffeine cache
   hazelcast-all
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -26,6 +28,7 @@ Apache Software License, Version 2.0
   Lucene QueryParsers
   Netty
   Netty/All-in-One
+  WMI4Java
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/enterprise/ha/NOTICE.txt
+++ b/enterprise/ha/NOTICE.txt
@@ -41,6 +41,8 @@ Apache Software License, Version 2.0
   Apache Shiro :: Lang
   Caffeine cache
   hazelcast-all
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -48,6 +50,7 @@ Apache Software License, Version 2.0
   Lucene QueryParsers
   Netty
   Netty/All-in-One
+  WMI4Java
 
 Bouncy Castle License
   Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/diagnostics/MetricsDiagnosticsOfflineReportProvider.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/diagnostics/MetricsDiagnosticsOfflineReportProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/diagnostics/MetricsDiagnosticsOfflineReportProvider.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/diagnostics/MetricsDiagnosticsOfflineReportProvider.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.metrics.diagnostics;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.neo4j.diagnostics.DiagnosticsOfflineReportProvider;
+import org.neo4j.diagnostics.DiagnosticsReportSource;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.metrics.MetricsSettings;
+
+import static org.neo4j.diagnostics.DiagnosticsReportSources.newDiagnosticsFile;
+
+public class MetricsDiagnosticsOfflineReportProvider extends DiagnosticsOfflineReportProvider
+{
+    private FileSystemAbstraction fs;
+    private Config config;
+
+    public MetricsDiagnosticsOfflineReportProvider()
+    {
+        super( "metrics", "metrics" );
+    }
+
+    @Override
+    public void init( FileSystemAbstraction fs, Config config, File storeDirectory )
+    {
+        this.fs = fs;
+        this.config = config;
+    }
+
+    @Override
+    protected List<DiagnosticsReportSource> provideSources( Set<String> classifiers )
+    {
+        File metricsDirectory = config.get( MetricsSettings.csvPath );
+        if ( fs.fileExists( metricsDirectory ) && fs.isDirectory( metricsDirectory ) )
+        {
+            List<DiagnosticsReportSource> files = new ArrayList<>();
+            for ( File file : fs.listFiles( metricsDirectory ) )
+            {
+                files.add( newDiagnosticsFile( "metrics/" + file.getName(), fs, file ) );
+            }
+            return files;
+        }
+        return Collections.emptyList();
+    }
+}

--- a/enterprise/metrics/src/main/resources/META-INF/services/org.neo4j.diagnostics.DiagnosticsOfflineReportProvider
+++ b/enterprise/metrics/src/main/resources/META-INF/services/org.neo4j.diagnostics.DiagnosticsOfflineReportProvider
@@ -1,0 +1,1 @@
+org.neo4j.metrics.diagnostics.MetricsDiagnosticsOfflineReportProvider

--- a/enterprise/neo4j-enterprise/LICENSES.txt
+++ b/enterprise/neo4j-enterprise/LICENSES.txt
@@ -23,6 +23,8 @@ Apache Software License, Version 2.0
   Graphite Integration for Metrics
   hazelcast-all
   Jackson
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -38,6 +40,7 @@ Apache Software License, Version 2.0
   Prometheus Java Simpleclient Common
   Prometheus Java Simpleclient Dropwizard
   Prometheus Java Simpleclient Httpserver
+  WMI4Java
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/enterprise/neo4j-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-enterprise/NOTICE.txt
@@ -45,6 +45,8 @@ Apache Software License, Version 2.0
   Graphite Integration for Metrics
   hazelcast-all
   Jackson
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -60,6 +62,7 @@ Apache Software License, Version 2.0
   Prometheus Java Simpleclient Common
   Prometheus Java Simpleclient Dropwizard
   Prometheus Java Simpleclient Httpserver
+  WMI4Java
 
 BSD - Scala License
   Scala Library

--- a/enterprise/neo4j-harness-enterprise/LICENSES.txt
+++ b/enterprise/neo4j-harness-enterprise/LICENSES.txt
@@ -38,6 +38,8 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -53,6 +55,7 @@ Apache Software License, Version 2.0
   Prometheus Java Simpleclient Common
   Prometheus Java Simpleclient Dropwizard
   Prometheus Java Simpleclient Httpserver
+  WMI4Java
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/enterprise/neo4j-harness-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-harness-enterprise/NOTICE.txt
@@ -60,6 +60,8 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -75,6 +77,7 @@ Apache Software License, Version 2.0
   Prometheus Java Simpleclient Common
   Prometheus Java Simpleclient Dropwizard
   Prometheus Java Simpleclient Httpserver
+  WMI4Java
 
 BSD - Scala License
   Scala Library

--- a/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLoggerDiagnosticsOfflineReportProvider.java
+++ b/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLoggerDiagnosticsOfflineReportProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLoggerDiagnosticsOfflineReportProvider.java
+++ b/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/QueryLoggerDiagnosticsOfflineReportProvider.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.query;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.neo4j.diagnostics.DiagnosticsOfflineReportProvider;
+import org.neo4j.diagnostics.DiagnosticsReportSource;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+
+import static org.neo4j.diagnostics.DiagnosticsReportSources.newDiagnosticsRotatingFile;
+
+public class QueryLoggerDiagnosticsOfflineReportProvider extends DiagnosticsOfflineReportProvider
+{
+    private FileSystemAbstraction fs;
+    private Config config;
+
+    public QueryLoggerDiagnosticsOfflineReportProvider()
+    {
+        super( "query-logger", "logs" );
+    }
+
+    @Override
+    public void init( FileSystemAbstraction fs, Config config, File storeDirectory )
+    {
+        this.fs = fs;
+        this.config = config;
+    }
+
+    @Override
+    protected List<DiagnosticsReportSource> provideSources( Set<String> classifiers )
+    {
+        if ( classifiers.contains( "logs" ) )
+        {
+            File queryLog = config.get( GraphDatabaseSettings.log_queries_filename );
+            if ( fs.fileExists( queryLog ) )
+            {
+                return newDiagnosticsRotatingFile( "logs/query.log", fs, queryLog );
+            }
+        }
+        return Collections.emptyList();
+    }
+}

--- a/enterprise/query-logging/src/main/resources/META-INF/services/org.neo4j.diagnostics.DiagnosticsOfflineReportProvider
+++ b/enterprise/query-logging/src/main/resources/META-INF/services/org.neo4j.diagnostics.DiagnosticsOfflineReportProvider
@@ -1,0 +1,1 @@
+org.neo4j.kernel.impl.query.QueryLoggerDiagnosticsOfflineReportProvider

--- a/enterprise/security/LICENSES.txt
+++ b/enterprise/security/LICENSES.txt
@@ -17,12 +17,15 @@ Apache Software License, Version 2.0
   Apache Shiro :: Event
   Apache Shiro :: Lang
   Caffeine cache
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
+  WMI4Java
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/enterprise/security/NOTICE.txt
+++ b/enterprise/security/NOTICE.txt
@@ -39,12 +39,15 @@ Apache Software License, Version 2.0
   Apache Shiro :: Event
   Apache Shiro :: Lang
   Caffeine cache
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
+  WMI4Java
 
 Bouncy Castle License
   Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/diagnostics/SecurityLogDiagnosticsOfflineReportProvider.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/diagnostics/SecurityLogDiagnosticsOfflineReportProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/diagnostics/SecurityLogDiagnosticsOfflineReportProvider.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/diagnostics/SecurityLogDiagnosticsOfflineReportProvider.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.security.enterprise.diagnostics;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.neo4j.diagnostics.DiagnosticsOfflineReportProvider;
+import org.neo4j.diagnostics.DiagnosticsReportSource;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.server.security.enterprise.configuration.SecuritySettings;
+
+import static org.neo4j.diagnostics.DiagnosticsReportSources.newDiagnosticsRotatingFile;
+
+public class SecurityLogDiagnosticsOfflineReportProvider extends DiagnosticsOfflineReportProvider
+{
+    private FileSystemAbstraction fs;
+    private Config config;
+
+    public SecurityLogDiagnosticsOfflineReportProvider()
+    {
+        super( "enterprise-security", "logs" );
+    }
+
+    @Override
+    public void init( FileSystemAbstraction fs, Config config, File storeDirectory )
+    {
+        this.fs = fs;
+        this.config = config;
+    }
+
+    @Override
+    protected List<DiagnosticsReportSource> provideSources( Set<String> classifiers )
+    {
+        if ( classifiers.contains( "logs" ) )
+        {
+            File securityLog = config.get( SecuritySettings.security_log_filename );
+            if ( fs.fileExists( securityLog ) )
+            {
+                return newDiagnosticsRotatingFile( "logs/security.log", fs, securityLog );
+            }
+        }
+        return Collections.emptyList();
+    }
+}

--- a/enterprise/security/src/main/resources/META-INF/services/org.neo4j.diagnostics.DiagnosticsOfflineReportProvider
+++ b/enterprise/security/src/main/resources/META-INF/services/org.neo4j.diagnostics.DiagnosticsOfflineReportProvider
@@ -1,0 +1,1 @@
+org.neo4j.server.security.enterprise.diagnostics.SecurityLogDiagnosticsOfflineReportProvider

--- a/enterprise/server-enterprise/LICENSES.txt
+++ b/enterprise/server-enterprise/LICENSES.txt
@@ -38,6 +38,8 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -53,6 +55,7 @@ Apache Software License, Version 2.0
   Prometheus Java Simpleclient Common
   Prometheus Java Simpleclient Dropwizard
   Prometheus Java Simpleclient Httpserver
+  WMI4Java
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/enterprise/server-enterprise/NOTICE.txt
+++ b/enterprise/server-enterprise/NOTICE.txt
@@ -60,6 +60,8 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -75,6 +77,7 @@ Apache Software License, Version 2.0
   Prometheus Java Simpleclient Common
   Prometheus Java Simpleclient Dropwizard
   Prometheus Java Simpleclient Httpserver
+  WMI4Java
 
 BSD - Scala License
   Scala Library

--- a/integrationtests/src/test/java/org/neo4j/commandline/admin/Neo4jAdminUsageTest.java
+++ b/integrationtests/src/test/java/org/neo4j/commandline/admin/Neo4jAdminUsageTest.java
@@ -35,7 +35,7 @@ public class Neo4jAdminUsageTest
     }
 
     @Test
-    public void verifyUsageMatchesExpectedCommands() throws Exception
+    public void verifyUsageMatchesExpectedCommands()
     {
         final StringBuilder sb = new StringBuilder();
         usageCmd.print( s -> sb.append( s ).append( "\n" ) );
@@ -58,6 +58,8 @@ public class Neo4jAdminUsageTest
                         "        Check the consistency of a database.\n" +
                         "    import\n" +
                         "        Import from a collection of CSV files or a pre-3.0 database.\n" +
+                        "    report\n" +
+                        "        Produces a zip/tar of the most common information needed for remote assessments.\n" +
                         "    store-info\n" +
                         "        Prints information about a Neo4j database store.\n" +
                         "\n" +

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -58,6 +58,12 @@ setup_heap() {
 
 build_classpath() {
   CLASSPATH="${NEO4J_PLUGINS}:${NEO4J_CONF}:${NEO4J_LIB}/*:${NEO4J_PLUGINS}/*"
+
+  # augment with tools.jar, will need JDK
+  JAVA_TOOLS="${JAVA_HOME}/lib/tools.jar"
+  if [ -e $JAVA_TOOLS ]; then
+    CLASSPATH="${JAVA_TOOLS}:${CLASSPATH}"
+  fi
 }
 
 detect_os() {

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -62,7 +62,7 @@ build_classpath() {
   # augment with tools.jar, will need JDK
   JAVA_TOOLS="${JAVA_HOME}/lib/tools.jar"
   if [ -e $JAVA_TOOLS ]; then
-    CLASSPATH="${JAVA_TOOLS}:${CLASSPATH}"
+    CLASSPATH="${CLASSPATH}:${JAVA_TOOLS}"
   fi
 }
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-admin
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-admin
@@ -34,6 +34,12 @@ setup_heap() {
 
 build_classpath() {
   CLASSPATH="${NEO4J_PLUGINS}:${NEO4J_CONF}:${NEO4J_LIB}/*:${NEO4J_PLUGINS}/*"
+
+  # augment with tools.jar, will need JDK
+  JAVA_TOOLS="${JAVA_HOME}/lib/tools.jar"
+  if [ -e $JAVA_TOOLS ]; then
+    CLASSPATH="${JAVA_TOOLS}:${CLASSPATH}"
+  fi
 }
 
 detect_os() {

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-admin
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-admin
@@ -38,7 +38,7 @@ build_classpath() {
   # augment with tools.jar, will need JDK
   JAVA_TOOLS="${JAVA_HOME}/lib/tools.jar"
   if [ -e $JAVA_TOOLS ]; then
-    CLASSPATH="${JAVA_TOOLS}:${CLASSPATH}"
+    CLASSPATH="${CLASSPATH}:${JAVA_TOOLS}"
   fi
 }
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-backup
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-backup
@@ -34,6 +34,12 @@ setup_heap() {
 
 build_classpath() {
   CLASSPATH="${NEO4J_PLUGINS}:${NEO4J_CONF}:${NEO4J_LIB}/*:${NEO4J_PLUGINS}/*"
+
+  # augment with tools.jar, will need JDK
+  JAVA_TOOLS="${JAVA_HOME}/lib/tools.jar"
+  if [ -e $JAVA_TOOLS ]; then
+    CLASSPATH="${JAVA_TOOLS}:${CLASSPATH}"
+  fi
 }
 
 detect_os() {

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-backup
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-backup
@@ -38,7 +38,7 @@ build_classpath() {
   # augment with tools.jar, will need JDK
   JAVA_TOOLS="${JAVA_HOME}/lib/tools.jar"
   if [ -e $JAVA_TOOLS ]; then
-    CLASSPATH="${JAVA_TOOLS}:${CLASSPATH}"
+    CLASSPATH="${CLASSPATH}:${JAVA_TOOLS}"
   fi
 }
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-import
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-import
@@ -34,6 +34,12 @@ setup_heap() {
 
 build_classpath() {
   CLASSPATH="${NEO4J_PLUGINS}:${NEO4J_CONF}:${NEO4J_LIB}/*:${NEO4J_PLUGINS}/*"
+
+  # augment with tools.jar, will need JDK
+  JAVA_TOOLS="${JAVA_HOME}/lib/tools.jar"
+  if [ -e $JAVA_TOOLS ]; then
+    CLASSPATH="${JAVA_TOOLS}:${CLASSPATH}"
+  fi
 }
 
 detect_os() {

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-import
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-import
@@ -38,7 +38,7 @@ build_classpath() {
   # augment with tools.jar, will need JDK
   JAVA_TOOLS="${JAVA_HOME}/lib/tools.jar"
   if [ -e $JAVA_TOOLS ]; then
-    CLASSPATH="${JAVA_TOOLS}:${CLASSPATH}"
+    CLASSPATH="${CLASSPATH}:${JAVA_TOOLS}"
   fi
 }
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shared.m4
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shared.m4
@@ -32,6 +32,12 @@ setup_heap() {
 
 build_classpath() {
   CLASSPATH="${NEO4J_PLUGINS}:${NEO4J_CONF}:${NEO4J_LIB}/*:${NEO4J_PLUGINS}/*"
+
+  # augment with tools.jar, will need JDK
+  JAVA_TOOLS="${JAVA_HOME}/lib/tools.jar"
+  if [ -e $JAVA_TOOLS ]; then
+    CLASSPATH="${JAVA_TOOLS}:${CLASSPATH}"
+  fi
 }
 
 detect_os() {

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shared.m4
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shared.m4
@@ -36,7 +36,7 @@ build_classpath() {
   # augment with tools.jar, will need JDK
   JAVA_TOOLS="${JAVA_HOME}/lib/tools.jar"
   if [ -e $JAVA_TOOLS ]; then
-    CLASSPATH="${JAVA_TOOLS}:${CLASSPATH}"
+    CLASSPATH="${CLASSPATH}:${JAVA_TOOLS}"
   fi
 }
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shell
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shell
@@ -34,6 +34,12 @@ setup_heap() {
 
 build_classpath() {
   CLASSPATH="${NEO4J_PLUGINS}:${NEO4J_CONF}:${NEO4J_LIB}/*:${NEO4J_PLUGINS}/*"
+
+  # augment with tools.jar, will need JDK
+  JAVA_TOOLS="${JAVA_HOME}/lib/tools.jar"
+  if [ -e $JAVA_TOOLS ]; then
+    CLASSPATH="${JAVA_TOOLS}:${CLASSPATH}"
+  fi
 }
 
 detect_os() {

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shell
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shell
@@ -38,7 +38,7 @@ build_classpath() {
   # augment with tools.jar, will need JDK
   JAVA_TOOLS="${JAVA_HOME}/lib/tools.jar"
   if [ -e $JAVA_TOOLS ]; then
-    CLASSPATH="${JAVA_TOOLS}:${CLASSPATH}"
+    CLASSPATH="${CLASSPATH}:${JAVA_TOOLS}"
   fi
 }
 

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/LICENSES.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/LICENSES.txt
@@ -27,6 +27,8 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -37,6 +39,7 @@ Apache Software License, Version 2.0
   parboiled-core
   parboiled-scala
   rxjs.js
+  WMI4Java
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
@@ -50,6 +50,8 @@ Apache Software License, Version 2.0
   Jetty :: Utilities
   Jetty :: Webapp Application Support
   Jetty :: XML utilities
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -60,6 +62,7 @@ Apache Software License, Version 2.0
   parboiled-core
   parboiled-scala
   rxjs.js
+  WMI4Java
 
 BSD - Scala License
   Scala Library

--- a/pom.xml
+++ b/pom.xml
@@ -1174,6 +1174,11 @@
         <artifactId>metrics-graphite</artifactId>
         <version>3.1.2</version>
       </dependency>
+      <dependency>
+        <groupId>org.jprocesses</groupId>
+        <artifactId>jProcesses</artifactId>
+        <version>1.6.4</version>
+      </dependency>
 
       <dependency>
         <groupId>com.google.code.findbugs</groupId>

--- a/tools/LICENSES.txt
+++ b/tools/LICENSES.txt
@@ -9,6 +9,8 @@ Apache Software License, Version 2.0
   Apache Commons Text
   Guava: Google Core Libraries for Java
   javax.inject
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -16,6 +18,7 @@ Apache Software License, Version 2.0
   Lucene QueryParsers
   Netty
   Netty/All-in-One
+  WMI4Java
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/tools/NOTICE.txt
+++ b/tools/NOTICE.txt
@@ -31,6 +31,8 @@ Apache Software License, Version 2.0
   Apache Commons Text
   Guava: Google Core Libraries for Java
   javax.inject
+  jPowerShell
+  jProcesses
   Lucene codecs
   Lucene Common Analyzers
   Lucene Core
@@ -38,6 +40,7 @@ Apache Software License, Version 2.0
   Lucene QueryParsers
   Netty
   Netty/All-in-One
+  WMI4Java
 
 Bouncy Castle License
   Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs


### PR DESCRIPTION
This introduces `neo4j-admin report` that can be used to collect information useful for support cases.

The first iteration includes a way to gather files offline, for startup troubleshooting, and a limited number of online information that can be accessed through the standard JMX interface.

You can pass `--list` to the command to get a view of available classifiers, e.g.
```
/bin> ./neo4j-admin report --list
Trying to find running instance of neo4j
Attached to running process with process id 6439
Connected to JMX endpoint
All available classifiers:
  config     include configuration file
  logs       include log files
  plugins    include a view of the plugin directory
  sysprop    include a list of java system properties
  threads    include a thread dump of the running instance
  tree       include a view of the tree structure of the data directory
```

A sample output follows:
```
/bin> ./neo4j-admin report all   
Trying to find running instance of neo4j
Attached to running process with process id 6439
Connected to JMX endpoint
Writing report to /home/klaren/Desktop/neo4j-community-3.4.0-SNAPSHOT/bin/reports/2017-12-14_132858.zip
     1/7 [####################] 100%  logs/debug.log
     2/7 [####################] 100%  logs/neo4j.log
     3/7 [####################] 100%  plugins.txt
     4/7 [####################] 100%  tree.txt
     5/7 [####################] 100%  vm.prop
     6/7 [####################] 100%  threaddump.txt
     7/7 [####################] 100%  neo4j.conf
```

  Known issues:
-----------------------
* Online sources does not work on Windows due to the way we start neo4j with `prunsrv`