### PR TITLE
Adds more configurability to import surface

### DIFF
--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
@@ -40,6 +40,7 @@ import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.util.Validators;
 import org.neo4j.server.configuration.ConfigLoader;
+import org.neo4j.unsafe.impl.batchimport.input.csv.Configuration;
 
 public class ImportCommand implements AdminCommand
 {
@@ -98,7 +99,9 @@ public class ImportCommand implements AdminCommand
             .withArgument( new OptionalBooleanArg( "ignore-duplicate-nodes", false,
                     "If duplicate nodes should be ignored during the import." ) )
             .withArgument( new OptionalBooleanArg( "ignore-missing-nodes", false,
-                    "If relationships referring to missing nodes should be ignored during the import." ) );
+                    "If relationships referring to missing nodes should be ignored during the import." ) )
+            .withArgument( new OptionalBooleanArg( "ignore-empty-arrays", Configuration.COMMAS.emptyArraysAsNull(),
+                    "If empty array properties should be ignored, or if 'false', stores as empty arrays." ) );
     private static final Arguments allArguments = new Arguments()
             .withDatabase()
             .withAdditionalConfig()
@@ -140,7 +143,9 @@ public class ImportCommand implements AdminCommand
             .withArgument( new OptionalBooleanArg( "ignore-duplicate-nodes", false,
                     "If duplicate nodes should be ignored during the import." ) )
             .withArgument( new OptionalBooleanArg( "ignore-missing-nodes", false,
-                    "If relationships referring to missing nodes should be ignored during the import." ) );
+                    "If relationships referring to missing nodes should be ignored during the import." ) )
+            .withArgument( new OptionalBooleanArg( "ignore-empty-arrays", Configuration.COMMAS.emptyArraysAsNull(),
+                    "If empty array properties should be ignored, or if 'false', stores as empty arrays." ) );
 
     public static Arguments databaseArguments()
     {

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/ImportCommand.java
@@ -101,7 +101,9 @@ public class ImportCommand implements AdminCommand
             .withArgument( new OptionalBooleanArg( "ignore-missing-nodes", false,
                     "If relationships referring to missing nodes should be ignored during the import." ) )
             .withArgument( new OptionalBooleanArg( "ignore-empty-arrays", Configuration.COMMAS.emptyArraysAsNull(),
-                    "If empty array properties should be ignored, or if 'false', stores as empty arrays." ) );
+                    "If empty array properties should be ignored, or if 'false', stores as empty arrays." ) )
+            .withArgument( new OptionalBooleanArg( "trim-strings", org.neo4j.csv.reader.Configuration.DEFAULT.trimStrings(),
+                    "If string values will be trimmed for whitespace." ) );
     private static final Arguments allArguments = new Arguments()
             .withDatabase()
             .withAdditionalConfig()
@@ -145,7 +147,9 @@ public class ImportCommand implements AdminCommand
             .withArgument( new OptionalBooleanArg( "ignore-missing-nodes", false,
                     "If relationships referring to missing nodes should be ignored during the import." ) )
             .withArgument( new OptionalBooleanArg( "ignore-empty-arrays", Configuration.COMMAS.emptyArraysAsNull(),
-                    "If empty array properties should be ignored, or if 'false', stores as empty arrays." ) );
+                    "If empty array properties should be ignored, or if 'false', stores as empty arrays." ) )
+            .withArgument( new OptionalBooleanArg( "trim-strings", org.neo4j.csv.reader.Configuration.DEFAULT.trimStrings(),
+                    "If string values will be trimmed for whitespace." ) );
 
     public static Arguments databaseArguments()
     {

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/config/WrappedCsvInputConfigurationForNeo4jAdmin.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/config/WrappedCsvInputConfigurationForNeo4jAdmin.java
@@ -40,12 +40,6 @@ public class WrappedCsvInputConfigurationForNeo4jAdmin extends Configuration.Ove
     }
 
     @Override
-    public boolean trimStrings()
-    {
-        return true;
-    }
-
-    @Override
     public boolean emptyQuotedStringsAsNull()
     {
         return false;

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/config/WrappedCsvInputConfigurationForNeo4jAdmin.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/config/WrappedCsvInputConfigurationForNeo4jAdmin.java
@@ -26,44 +26,17 @@ import org.neo4j.unsafe.impl.batchimport.input.csv.Configuration;
  * Import emptyQuotedStrings as empty Strings
  * Buffer size is set to 4MB
  */
-
-public class WrappedCsvInputConfigurationForNeo4jAdmin implements Configuration
+public class WrappedCsvInputConfigurationForNeo4jAdmin extends Configuration.Overridden
 {
-    private Configuration defaults;
-
-    public WrappedCsvInputConfigurationForNeo4jAdmin( Configuration defaults)
+    public WrappedCsvInputConfigurationForNeo4jAdmin( Configuration defaults )
     {
-        this.defaults = defaults;
-    }
-
-    @Override
-    public char delimiter()
-    {
-        return defaults.delimiter();
-    }
-
-    @Override
-    public char arrayDelimiter()
-    {
-        return defaults.arrayDelimiter();
-    }
-
-    @Override
-    public char quotationCharacter()
-    {
-        return defaults.quotationCharacter();
+        super( defaults );
     }
 
     @Override
     public int bufferSize()
     {
         return DEFAULT_BUFFER_SIZE_4MB;
-    }
-
-    @Override
-    public boolean multilineFields()
-    {
-        return defaults.multilineFields();
     }
 
     @Override

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
@@ -208,6 +208,7 @@ public class ImportCommandTest
                             "                          [--ignore-extra-columns[=<true|false>]]%n" +
                             "                          [--ignore-duplicate-nodes[=<true|false>]]%n" +
                             "                          [--ignore-missing-nodes[=<true|false>]]%n" +
+                            "                          [--ignore-empty-arrays[=<true|false>]]%n" +
                             "usage: neo4j-admin import --mode=database [--database=<name>]%n" +
                             "                          [--additional-config=<config-file-path>]%n" +
                             "                          [--from=<source-directory>]%n" +
@@ -258,7 +259,10 @@ public class ImportCommandTest
                             "      If duplicate nodes should be ignored during the import. [default:false]%n" +
                             "  --ignore-missing-nodes=<true|false>%n" +
                             "      If relationships referring to missing nodes should be ignored during the%n" +
-                            "      import. [default:false]%n" ),
+                            "      import. [default:false]%n" +
+                            "  --ignore-empty-arrays=<true|false>%n" +
+                            "      If empty array properties should be ignored, or if 'false', stores as%n" +
+                            "      empty arrays. [default:true]%n" ),
                     baos.toString() );
         }
     }

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
@@ -189,6 +189,42 @@ public class ImportCommandTest
     }
 
     @Test
+    public void acceptsIgnoreEmptyArraysConfiguration() throws Exception
+    {
+        File homeDir = testDir.directory( "home" );
+        ImporterFactory mockImporterFactory = mock( ImporterFactory.class );
+        when( mockImporterFactory
+                .getImporterForMode( eq( "csv" ), any( Args.class ), any( Config.class ), any( OutsideWorld.class ) ) )
+                .thenReturn( mock( Importer.class ) );
+
+        ImportCommand importCommand =
+                new ImportCommand( homeDir.toPath(), testDir.directory( "conf" ).toPath(), new RealOutsideWorld(),
+                        mockImporterFactory );
+
+        String[] arguments = {"--database=foo", "--from=bar", "--ignore-empty-arrays=false"};
+
+        importCommand.execute( arguments );
+    }
+
+    @Test
+    public void acceptsTrimStringsConfiguration() throws Exception
+    {
+        File homeDir = testDir.directory( "home" );
+        ImporterFactory mockImporterFactory = mock( ImporterFactory.class );
+        when( mockImporterFactory
+                .getImporterForMode( eq( "csv" ), any( Args.class ), any( Config.class ), any( OutsideWorld.class ) ) )
+        .thenReturn( mock( Importer.class ) );
+
+        ImportCommand importCommand =
+                new ImportCommand( homeDir.toPath(), testDir.directory( "conf" ).toPath(), new RealOutsideWorld(),
+                        mockImporterFactory );
+
+        String[] arguments = {"--database=foo", "--from=bar", "--trim-strings=false"};
+
+        importCommand.execute( arguments );
+    }
+
+    @Test
     public void shouldPrintNiceHelp() throws Throwable
     {
         try ( ByteArrayOutputStream baos = new ByteArrayOutputStream() )
@@ -209,6 +245,7 @@ public class ImportCommandTest
                             "                          [--ignore-duplicate-nodes[=<true|false>]]%n" +
                             "                          [--ignore-missing-nodes[=<true|false>]]%n" +
                             "                          [--ignore-empty-arrays[=<true|false>]]%n" +
+                            "                          [--trim-strings[=<true|false>]]%n" +
                             "usage: neo4j-admin import --mode=database [--database=<name>]%n" +
                             "                          [--additional-config=<config-file-path>]%n" +
                             "                          [--from=<source-directory>]%n" +
@@ -262,7 +299,9 @@ public class ImportCommandTest
                             "      import. [default:false]%n" +
                             "  --ignore-empty-arrays=<true|false>%n" +
                             "      If empty array properties should be ignored, or if 'false', stores as%n" +
-                            "      empty arrays. [default:true]%n" ),
+                            "      empty arrays. [default:true]%n" +
+                            "  --trim-strings=<true|false>%n" +
+                            "      If string values will be trimmed for whitespace. [default:false]%n" ),
                     baos.toString() );
         }
     }

--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -158,6 +158,9 @@ public class ImportTool
         IGNORE_EMPTY_STRINGS( "ignore-empty-strings", org.neo4j.csv.reader.Configuration.DEFAULT.emptyQuotedStringsAsNull(),
                 "<true/false>",
                 "Whether or not empty string fields, i.e. \"\" from input source are ignored, i.e. treated as null." ),
+        IGNORE_EMPTY_ARRAYS( "ignore-empty-arrays", Configuration.COMMAS.emptyArraysAsNull(),
+                "<true/false>",
+                "Whether or not empty array fields from input source are ignored, i.e. treated as null." ),
         ID_TYPE( "id-type", IdType.STRING,
                 "<id-type>",
                 "One out of " + Arrays.toString( IdType.values() )
@@ -861,6 +864,7 @@ public class ImportTool
                 CHARACTER_CONVERTER );
         final Boolean multiLineFields = args.getBoolean( Options.MULTILINE_FIELDS.key(), null );
         final Boolean emptyStringsAsNull = args.getBoolean( Options.IGNORE_EMPTY_STRINGS.key(), null );
+        final Boolean emptyArraysAsNull = args.getBoolean( Options.IGNORE_EMPTY_ARRAYS.key(), null );
         final Boolean trimStrings = args.getBoolean( Options.TRIM_STRINGS.key(), null);
         final Boolean legacyStyleQuoting = args.getBoolean( Options.LEGACY_STYLE_QUOTING.key(), null );
         final Number bufferSize = args.has( Options.READ_BUFFER_SIZE.key() )
@@ -906,6 +910,14 @@ public class ImportTool
                 return emptyStringsAsNull != null
                         ? emptyStringsAsNull.booleanValue()
                         : defaultConfiguration.emptyQuotedStringsAsNull();
+            }
+
+            @Override
+            public boolean emptyArraysAsNull()
+            {
+                return emptyArraysAsNull != null
+                        ? emptyArraysAsNull.booleanValue()
+                                : defaultConfiguration.emptyArraysAsNull();
             }
 
             @Override

--- a/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/ImportToolTest.java
@@ -74,6 +74,7 @@ import static java.lang.System.currentTimeMillis;
 import static java.util.Arrays.asList;
 import static org.apache.commons.lang3.StringUtils.repeat;
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -1930,6 +1931,29 @@ public class ImportToolTest
 
             List<String> errorLines = suppressOutput.getErrorVoice().lines();
             assertContains( errorLines, "Starting a database on these store files will likely fail or observe inconsistent records" );
+        }
+    }
+
+    @Test
+    public void shouldStoreEmptyArraysIfToldTo() throws Exception
+    {
+        List<String> lines = new ArrayList<>();
+        lines.add( ":ID,strings:String[],longs:long[]" );
+        lines.add( "1,," );
+
+        // WHEN
+        importTool(
+                "--into", dbRule.getStoreDirAbsolutePath(),
+                "--nodes", data( lines.toArray( new String[lines.size()] ) ).getAbsolutePath(),
+                "--ignore-empty-arrays", "false" );
+
+        // THEN
+        GraphDatabaseService db = dbRule.getGraphDatabaseAPI();
+        try ( Transaction tx = db.beginTx() )
+        {
+            Node node = db.getAllNodes().iterator().next();
+            assertArrayEquals( new String[0], (String[]) node.getProperty( "strings" ) );
+            assertArrayEquals( new long[0], (long[]) node.getProperty( "longs" ) );
         }
     }
 

--- a/community/import-tool/src/test/java/org/neo4j/tooling/QuickImport.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/QuickImport.java
@@ -102,7 +102,7 @@ public class QuickImport
         };
 
         SimpleDataGenerator generator = new SimpleDataGenerator( nodeHeader, relationshipHeader, randomSeed,
-                nodeCount, labelCount, relationshipTypeCount, idType );
+                nodeCount, labelCount, relationshipTypeCount, idType, config );
         Input input = new DataGeneratorInput(
                 nodeCount, relationshipCount,
                 generator.nodes(), generator.relationships(),

--- a/community/import-tool/src/test/java/org/neo4j/tooling/SimpleDataGenerator.java
+++ b/community/import-tool/src/test/java/org/neo4j/tooling/SimpleDataGenerator.java
@@ -26,6 +26,7 @@ import org.neo4j.unsafe.impl.batchimport.IdRangeInput.Range;
 import org.neo4j.unsafe.impl.batchimport.input.Groups;
 import org.neo4j.unsafe.impl.batchimport.input.InputNode;
 import org.neo4j.unsafe.impl.batchimport.input.InputRelationship;
+import org.neo4j.unsafe.impl.batchimport.input.csv.Configuration;
 import org.neo4j.unsafe.impl.batchimport.input.csv.Header;
 import org.neo4j.unsafe.impl.batchimport.input.csv.IdType;
 import org.neo4j.unsafe.impl.batchimport.input.csv.InputNodeDeserialization;
@@ -42,15 +43,17 @@ public class SimpleDataGenerator extends SourceTraceability.Adapter
     private final Groups groups = new Groups();
     private final IdType idType;
     private final String className = getClass().getSimpleName();
+    private final Configuration config;
 
     public SimpleDataGenerator( Header nodeHeader, Header relationshipHeader, long randomSeed,
-            long nodeCount, int labelCount, int relationshipTypeCount, IdType idType )
+            long nodeCount, int labelCount, int relationshipTypeCount, IdType idType, Configuration config )
     {
         this.nodeHeader = nodeHeader;
         this.relationshipHeader = relationshipHeader;
         this.randomSeed = randomSeed;
         this.nodeCount = nodeCount;
         this.idType = idType;
+        this.config = config;
         this.labels = new Distribution<>( tokens( "Label", labelCount ) );
         this.relationshipTypes = new Distribution<>( tokens( "TYPE", relationshipTypeCount ) );
     }
@@ -59,7 +62,7 @@ public class SimpleDataGenerator extends SourceTraceability.Adapter
     {
         return batch -> new SimpleDataGeneratorBatch<>( nodeHeader, batch.getStart(), randomSeed + batch.getStart(),
                 nodeCount, labels, relationshipTypes,
-                new InputNodeDeserialization( nodeHeader, SimpleDataGenerator.this, groups, idType.idsAreExternal() ),
+                new InputNodeDeserialization( nodeHeader, SimpleDataGenerator.this, groups, idType.idsAreExternal(), config ),
                 new InputNode[batch.getSize()] ).get();
     }
 
@@ -67,7 +70,7 @@ public class SimpleDataGenerator extends SourceTraceability.Adapter
     {
         return batch -> new SimpleDataGeneratorBatch<>( relationshipHeader, batch.getStart(),
                 randomSeed + batch.getStart(), nodeCount, labels, relationshipTypes,
-                new InputRelationshipDeserialization( relationshipHeader, SimpleDataGenerator.this, groups ),
+                new InputRelationshipDeserialization( relationshipHeader, SimpleDataGenerator.this, groups, config ),
                 new InputRelationship[batch.getSize()] ).get();
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Configuration.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/Configuration.java
@@ -35,8 +35,18 @@ public interface Configuration extends org.neo4j.csv.reader.Configuration
      */
     char arrayDelimiter();
 
+    /**
+     * @return {@code true} for treating empty arrays, i.e. {@code []} as null, instead of an empty array.
+     */
+    boolean emptyArraysAsNull();
+
     abstract class Default extends org.neo4j.csv.reader.Configuration.Default implements Configuration
     {
+        @Override
+        public boolean emptyArraysAsNull()
+        {
+            return true;
+        }
     }
 
     Configuration COMMAS = new Default()
@@ -89,6 +99,12 @@ public interface Configuration extends org.neo4j.csv.reader.Configuration
         public char arrayDelimiter()
         {
             return defaults.arrayDelimiter();
+        }
+
+        @Override
+        public boolean emptyArraysAsNull()
+        {
+            return defaults.emptyArraysAsNull();
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DeserializerFactories.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/DeserializerFactories.java
@@ -36,7 +36,7 @@ public class DeserializerFactories
         return (header,stream,decorator,validator) ->
         {
             InputNodeDeserialization deserialization =
-                    new InputNodeDeserialization( header, stream, groups, idType.idsAreExternal() );
+                    new InputNodeDeserialization( header, stream, groups, idType.idsAreExternal(), config );
             return new InputEntityDeserializer<>( header, stream, config.delimiter(),
                     deserialization, decorator, validator, badCollector );
         };
@@ -48,7 +48,7 @@ public class DeserializerFactories
         return (header,stream,decorator,validator) ->
         {
                 InputRelationshipDeserialization deserialization =
-                        new InputRelationshipDeserialization( header, stream, groups );
+                        new InputRelationshipDeserialization( header, stream, groups, config );
                 return new InputEntityDeserializer<>( header, stream, config.delimiter(),
                         deserialization, decorator, validator, badCollector );
         };

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecorator.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/ExternalPropertiesDecorator.java
@@ -69,7 +69,7 @@ public class ExternalPropertiesDecorator implements Decorator<InputNode>
         CharSeeker dataStream = charSeeker( data.create( config ).stream(), config, true );
         Header header = headerFactory.create( dataStream, config, idType );
         this.deserializer = new InputEntityDeserializer<>( header, dataStream, config.delimiter(),
-                new InputNodeDeserialization( header, dataStream, new Groups(), idType.idsAreExternal() ),
+                new InputNodeDeserialization( header, dataStream, new Groups(), idType.idsAreExternal(), config ),
                 NO_NODE_DECORATOR, Validators.<InputNode>emptyValidator(), badCollector );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputEntityDeserialization.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputEntityDeserialization.java
@@ -34,13 +34,15 @@ import org.neo4j.unsafe.impl.batchimport.input.csv.Header.Entry;
 public abstract class InputEntityDeserialization<ENTITY extends InputEntity> implements Deserialization<ENTITY>
 {
     protected final SourceTraceability source;
+    private final boolean emptyArraysAsNull;
 
     private Object[] properties = new Object[10 * 2];
     private int propertiesCursor;
 
-    public InputEntityDeserialization( SourceTraceability source )
+    public InputEntityDeserialization( SourceTraceability source, Configuration config )
     {
         this.source = source;
+        this.emptyArraysAsNull = config.emptyArraysAsNull();
     }
 
     public void addProperty( String name, Object value )
@@ -67,7 +69,7 @@ public abstract class InputEntityDeserialization<ENTITY extends InputEntity> imp
         switch ( entry.type() )
         {
         case PROPERTY:
-            if ( value != null && value.getClass().isArray() && Array.getLength( value ) == 0 )
+            if ( emptyArraysAsNull && value != null && value.getClass().isArray() && Array.getLength( value ) == 0 )
             {
                 // Extractor will return empty arrays for fields that are empty. We don't need to
                 // store empty arrays as properties on entities since queries handle this while reading

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputNodeDeserialization.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputNodeDeserialization.java
@@ -44,9 +44,10 @@ public class InputNodeDeserialization extends InputEntityDeserialization<InputNo
     private String[] labels = new String[10];
     private int labelsCursor;
 
-    public InputNodeDeserialization( Header header, SourceTraceability source, Groups groups, boolean idsAreExternal )
+    public InputNodeDeserialization( Header header, SourceTraceability source, Groups groups, boolean idsAreExternal,
+            Configuration config )
     {
-        super( source );
+        super( source, config );
         this.header = header;
         this.groups = groups;
         this.idsAreExternal = idsAreExternal;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputRelationshipDeserialization.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/csv/InputRelationshipDeserialization.java
@@ -39,9 +39,9 @@ public class InputRelationshipDeserialization extends InputEntityDeserialization
     private Object startNode;
     private Object endNode;
 
-    public InputRelationshipDeserialization( Header header, SourceTraceability source, Groups groups )
+    public InputRelationshipDeserialization( Header header, SourceTraceability source, Groups groups, Configuration config )
     {
-        super( source );
+        super( source, config );
         this.header = header;
         this.groups = groups;
     }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/csv/ParallelInputEntityDeserializerTest.java
@@ -83,7 +83,7 @@ public class ParallelInputEntityDeserializerTest
             }
             while ( !allThreadsStarted );
             return new InputEntityDeserializer<>( header, chunk, config.delimiter(),
-                    new InputNodeDeserialization( header, chunk, groups, idType.idsAreExternal() ), decorator,
+                    new InputNodeDeserialization( header, chunk, groups, idType.idsAreExternal(), config ), decorator,
                     validator, badCollector );
         };
         try ( ParallelInputEntityDeserializer<InputNode> deserializer = new ParallelInputEntityDeserializer<>( data,


### PR DESCRIPTION
Allows importer to be configured for storing empty arrays as property values, instead of ignoring them. Also adds `trim-strings` configuration option to `neo4j-admin import`.