### PR TITLE
Reworked transaction batching during recovery

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexAccessor.java
@@ -67,6 +67,16 @@ public interface IndexAccessor extends Closeable
     void force() throws IOException;
 
     /**
+     * Refreshes this index, so that {@link #newReader() readers} created after completion of this call
+     * will see the latest updates. This happens automatically on closing {@link #newUpdater(IndexUpdateMode)}
+     * w/ {@link IndexUpdateMode#ONLINE}, but not guaranteed for {@link IndexUpdateMode#RECOVERY}.
+     * Therefore this call is complementary for updates that has taken place with {@link IndexUpdateMode#RECOVERY}.
+     *
+     * @throws IOException if there was a problem refreshing the index.
+     */
+    void refresh() throws IOException;
+
+    /**
      * Closes this index accessor. There will not be any interactions after this call.
      * After completion of this call there cannot be any essential state that hasn't been forced to disk.
      *
@@ -116,6 +126,11 @@ public interface IndexAccessor extends Closeable
 
         @Override
         public void force()
+        {
+        }
+
+        @Override
+        public void refresh()
         {
         }
 
@@ -192,6 +207,12 @@ public interface IndexAccessor extends Closeable
         public void force() throws IOException
         {
             delegate.force();
+        }
+
+        @Override
+        public void refresh() throws IOException
+        {
+            delegate.refresh();
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractDelegatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractDelegatingIndexProxy.java
@@ -91,6 +91,12 @@ public abstract class AbstractDelegatingIndexProxy implements IndexProxy
     }
 
     @Override
+    public void refresh() throws IOException
+    {
+        getDelegate().refresh();
+    }
+
+    @Override
     public Future<Void> close() throws IOException
     {
         return getDelegate().close();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractSwallowingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/AbstractSwallowingIndexProxy.java
@@ -76,6 +76,11 @@ public abstract class AbstractSwallowingIndexProxy implements IndexProxy
     }
 
     @Override
+    public void refresh()
+    {
+    }
+
+    @Override
     public IndexDescriptor getDescriptor()
     {
         return descriptor;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/FlippableIndexProxy.java
@@ -140,6 +140,20 @@ public class FlippableIndexProxy implements IndexProxy
         }
     }
 
+    @Override
+    public void refresh() throws IOException
+    {
+        lock.readLock();
+        try
+        {
+            delegate.refresh();
+        }
+        finally
+        {
+            lock.readLock().unlock();
+        }
+    }
+
     /**
      * Acquire the {@code ReadLock} in an <i>unfair</i> way, without waiting for queued up writers.
      * <p/>

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexProxy.java
@@ -80,6 +80,7 @@ public interface IndexProxy extends LabelSchemaSupplier
 
     IndexDescriptor getDescriptor();
 
+    @Override
     LabelSchemaDescriptor schema();
 
     SchemaIndexProvider.Descriptor getProviderDescriptor();
@@ -94,6 +95,8 @@ public interface IndexProxy extends LabelSchemaSupplier
     PopulationProgress getIndexPopulationProgress();
 
     void force() throws IOException;
+
+    void refresh() throws IOException;
 
     /**
      * @throws IndexNotFoundKernelException if the index isn't online yet.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexUpdateMode.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexUpdateMode.java
@@ -24,10 +24,34 @@ public enum IndexUpdateMode
     /**
      * Used when the db is online
      */
-    ONLINE,
+    ONLINE( false, true ),
+
+    /**
+     * Used when flipping from populating to online
+     */
+    ONLINE_IDEMPOTENT( true, true ),
 
     /**
      * Used when the db is recoverying
      */
-    RECOVERY
+    RECOVERY( true, false );
+
+    private final boolean idempotency;
+    private final boolean refresh;
+
+    IndexUpdateMode( boolean idempotency, boolean refresh )
+    {
+        this.idempotency = idempotency;
+        this.refresh = refresh;
+    }
+
+    public boolean requiresIdempotency()
+    {
+        return idempotency;
+    }
+
+    public boolean requiresRefresh()
+    {
+        return refresh;
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.function.BiConsumer;
 
+import org.neo4j.function.ThrowingConsumer;
 import org.neo4j.function.ThrowingFunction;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.collection.Iterators;
@@ -226,6 +227,10 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
     public void start() throws Exception
     {
         state = State.STARTING;
+
+        // Recovery will not do refresh (update read views) while applying recovered transactions and instead
+        // do it at one point after recovery... i.e. here
+        indexMapRef.indexMapSnapshot().forEachIndexProxy( indexProxyOperation( "refresh", proxy -> proxy.refresh() ) );
 
         final Map<Long,RebuildingIndexDescriptor> rebuildingDescriptors = new HashMap<>();
         indexMapRef.modify( indexMap ->
@@ -565,29 +570,28 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
 
     public void forceAll()
     {
-        indexMapRef.indexMapSnapshot().forEachIndexProxy( forceIndexProxy() );
+        indexMapRef.indexMapSnapshot().forEachIndexProxy( indexProxyOperation( "force", proxy -> proxy.force() ) );
     }
 
-    private BiConsumer<Long,IndexProxy> forceIndexProxy()
+    private BiConsumer<Long,IndexProxy> indexProxyOperation( String name, ThrowingConsumer<IndexProxy,Exception> operation )
     {
         return ( id, indexProxy ) ->
         {
             try
             {
-                indexProxy.force();
+                operation.accept( indexProxy );
             }
             catch ( Exception e )
             {
                 try
                 {
                     IndexProxy proxy = indexMapRef.getIndexProxy( id );
-                    throw new UnderlyingStorageException( "Unable to force " + proxy, e );
+                    throw new UnderlyingStorageException( "Unable to " + name + " " + proxy, e );
                 }
                 catch ( IndexNotFoundKernelException infe )
                 {
-                    // index was dropped while we where try to flush it, we can continue to flush other indexes
+                    // index was dropped while trying to operate on it, we can continue to other indexes
                 }
-
             }
         };
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
@@ -119,7 +119,13 @@ public class PopulatingIndexProxy implements IndexProxy
     @Override
     public void force()
     {
-        // Ignored... this isn't controlled from the outside while we're populating the index.
+        // Ignored... this isn't called from the outside while we're populating the index.
+    }
+
+    @Override
+    public void refresh()
+    {
+        // Ignored... this isn't called from the outside while we're populating the index.
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexAccessor.java
@@ -96,6 +96,12 @@ public class NativeSchemaNumberIndexAccessor<KEY extends SchemaNumberKey, VALUE 
     }
 
     @Override
+    public void refresh()
+    {
+        // not required in this implementation
+    }
+
+    @Override
     public void close() throws IOException
     {
         closeTree();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexAccessor.java
@@ -84,6 +84,13 @@ class FusionIndexAccessor implements IndexAccessor
     }
 
     @Override
+    public void refresh() throws IOException
+    {
+        nativeAccessor.refresh();
+        luceneAccessor.refresh();
+    }
+
+    @Override
     public void close() throws IOException
     {
         try

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageEngine.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/StorageEngine.java
@@ -140,5 +140,4 @@ public interface StorageEngine
 
     @Deprecated
     void clearBufferedIds();
-
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexProxyAdapter.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexProxyAdapter.java
@@ -66,6 +66,11 @@ public class IndexProxyAdapter implements IndexProxy
     }
 
     @Override
+    public void refresh()
+    {
+    }
+
+    @Override
     public Future<Void> close()
     {
         return VOID;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexingServiceTest.java
@@ -193,7 +193,7 @@ public class IndexingServiceTest
         InOrder order = inOrder( populator, accessor, updater);
         order.verify( populator ).create();
         order.verify( populator ).close( true );
-        order.verify( accessor ).newUpdater( IndexUpdateMode.RECOVERY );
+        order.verify( accessor ).newUpdater( IndexUpdateMode.ONLINE_IDEMPOTENT );
         order.verify( updater ).process( add( 10, "foo" ) );
         order.verify( updater ).close();
     }
@@ -400,6 +400,8 @@ public class IndexingServiceTest
                 .thenReturn( InternalIndexState.POPULATING );
         when( provider.getInitialState( failedIndex.getId(), failedIndex.getIndexDescriptor() ) )
                 .thenReturn( InternalIndexState.FAILED );
+        when( provider.getOnlineAccessor( anyLong(), any( IndexDescriptor.class ), any( IndexSamplingConfig.class ) ) ).thenAnswer(
+                invocation -> mock( IndexAccessor.class ) );
 
         indexingService.init();
 
@@ -1047,6 +1049,29 @@ public class IndexingServiceTest
         expectedException.expectMessage( "Unable to force" );
         expectedException.expect( UnderlyingStorageException.class );
         indexingService.forceAll();
+    }
+
+    @Test
+    public void shouldRefreshIndexesOnStart() throws Exception
+    {
+        // given
+        IndexRule rule = IndexRule.indexRule( 0, index, PROVIDER_DESCRIPTOR );
+        IndexingService indexing = newIndexingServiceWithMockedDependencies( populator, accessor, withData(), rule );
+
+        IndexAccessor accessor = mock( IndexAccessor.class );
+        IndexUpdater updater = mock( IndexUpdater.class );
+        when( accessor.newUpdater( any( IndexUpdateMode.class ) ) ).thenReturn( updater );
+        when( indexProvider.getOnlineAccessor( eq( rule.getId() ), any( IndexDescriptor.class ),
+                any( IndexSamplingConfig.class ) ) ).thenReturn( accessor );
+
+        life.init();
+
+        verify( accessor, times( 0 ) ).refresh();
+
+        life.start();
+
+        // Then
+        verify( accessor, times( 1 ) ).refresh();
     }
 
     private IndexProxy createIndexProxyMock()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndex.java
@@ -189,6 +189,11 @@ class InMemoryIndex
         }
 
         @Override
+        public void refresh()
+        {
+        }
+
+        @Override
         public void drop()
         {
             indexData.drop();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UpdateCapturingIndexAccessor.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UpdateCapturingIndexAccessor.java
@@ -72,6 +72,12 @@ public class UpdateCapturingIndexAccessor implements IndexAccessor
     }
 
     @Override
+    public void refresh() throws IOException
+    {
+        actual.refresh();
+    }
+
+    @Override
     public void close() throws IOException
     {
         actual.close();


### PR DESCRIPTION
Applies all transactions immediately instead of building up 100 at a time and apply
as batch. The upside of doing that was to do index refreshing less often,
one refresh per batch.

By avoiding refresh completely during recovery and instead do one refresh after recovery
completes avoids the need to do this batching (which can require a lot of heap for
large transactions) and also avoids refreshing entirely. This change results in
even faster recovery than before while at the same time using less memory.