### PR TITLE
Fix more acceptance tests in slotted runtime

### DIFF
--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/AllNodesScanPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/AllNodesScanPipe.scala
@@ -26,7 +26,7 @@ case class AllNodesScanPipe(ident: String)(val id: LogicalPlanId = LogicalPlanId
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
     val baseContext = state.createOrGetInitialContext(executionContextFactory)
-    state.query.nodeOps.all.map(n => baseContext.copyWith(ident, n))
+    state.query.nodeOps.all.map(n => executionContextFactory.copyWith(baseContext, ident, n))
   }
 
 }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/DirectedRelationshipByIdSeekPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/DirectedRelationshipByIdSeekPipe.scala
@@ -40,7 +40,15 @@ case class DirectedRelationshipByIdSeekPipe(ident: String, relIdExpr: SeekArgs, 
     val relIds = VirtualValues.filter(relIdExpr.expressions(ctx, state), new function.Function[AnyValue, java.lang.Boolean] {
       override def apply(t: AnyValue): lang.Boolean = t != Values.NO_VALUE
     })
-    new DirectedRelationshipIdSeekIterator(ident, fromNode, toNode, ctx, state.query.relationshipOps, relIds.iterator().asScala)
+    new DirectedRelationshipIdSeekIterator(
+      ident,
+      fromNode,
+      toNode,
+      ctx,
+      executionContextFactory,
+      state.query.relationshipOps,
+      relIds.iterator().asScala
+    )
   }
 
  }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ExpandAllPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ExpandAllPipe.scala
@@ -43,7 +43,7 @@ case class ExpandAllPipe(source: Pipe,
             val relationships: Iterator[EdgeValue] = state.query.getRelationshipsForIds(n.id(), dir, types.types(state.query))
             relationships.map { r =>
                 val other = r.otherNode(n)
-                row.copyWith(relName, r, toName, other)
+                executionContextFactory.copyWith(row, relName, r, toName, other)
             }
 
           case Values.NO_VALUE => None

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ExpandIntoPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ExpandIntoPipe.scala
@@ -64,7 +64,7 @@ case class ExpandIntoPipe(source: Pipe,
                   .getOrElse(findRelationships(state.query, fromNode, n, relCache, dir, lazyTypes.types(state.query)))
 
                 if (relationships.isEmpty) Iterator.empty
-                else relationships.map(r => row.copyWith(relName, r))
+                else relationships.map(r => executionContextFactory.copyWith(row, relName, r))
               case _ => throw new InternalException(s"$toNode must be node or null")
             }
 

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ForeachPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ForeachPipe.scala
@@ -35,7 +35,7 @@ case class ForeachPipe(source: Pipe, inner: Pipe, variable: String, expression: 
       (outerContext) =>
         val values = makeTraversable(expression(outerContext, state))
         values.iterator().asScala.foreach { v =>
-          val innerState = state.withInitialContext(outerContext.copyWith(variable, v))
+          val innerState = state.withInitialContext(executionContextFactory.copyWith(outerContext, variable, v))
           inner.createResults(innerState).length // exhaust the iterator, in case there's a merge read increasing cardinality inside the foreach
         }
         outerContext

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/FullPruningVarLengthExpandPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/FullPruningVarLengthExpandPipe.scala
@@ -294,7 +294,7 @@ case class FullPruningVarLengthExpandPipe(source: Pipe,
         inputRow = null
         null
       }
-      else inputRow.copyWith(self.toName, endNode)
+      else executionContextFactory.copyWith(inputRow, self.toName, endNode)
     }
 
     def push( pruningDFS: PruningDFS ): NodeValue = {

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/IdSeekIterator.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/IdSeekIterator.scala
@@ -57,6 +57,7 @@ abstract class IdSeekIterator[T]
 
 final class NodeIdSeekIterator(ident: String,
                                baseContext: ExecutionContext,
+                               executionContextFactory: ExecutionContextFactory,
                                protected val operations: Operations[NodeValue],
                                protected val entityIds: Iterator[AnyValue])
   extends IdSeekIterator[NodeValue] {
@@ -64,13 +65,14 @@ final class NodeIdSeekIterator(ident: String,
   def hasNext: Boolean = hasNextEntity
 
   def next(): ExecutionContext =
-    baseContext.copyWith(ident, nextEntity())
+    executionContextFactory.copyWith(baseContext, ident, nextEntity())
 }
 
 final class DirectedRelationshipIdSeekIterator(ident: String,
                                                fromNode: String,
                                                toNode: String,
                                                baseContext: ExecutionContext,
+                                               executionContextFactory: ExecutionContextFactory,
                                                protected val operations: Operations[EdgeValue],
                                                protected val entityIds: Iterator[AnyValue])
   extends IdSeekIterator[EdgeValue] {
@@ -79,7 +81,8 @@ final class DirectedRelationshipIdSeekIterator(ident: String,
 
   def next(): ExecutionContext = {
     val rel = nextEntity()
-    baseContext.copyWith(ident, rel, fromNode, rel.startNode(), toNode, rel.endNode())
+    executionContextFactory.copyWith(baseContext, ident, rel, fromNode, rel.startNode(), toNode, rel.endNode()
+    )
   }
 }
 
@@ -87,6 +90,7 @@ final class UndirectedRelationshipIdSeekIterator(ident: String,
                                                  fromNode: String,
                                                  toNode: String,
                                                  baseContext: ExecutionContext,
+                                                 executionContextFactory: ExecutionContextFactory,
                                                  protected val operations: Operations[EdgeValue],
                                                  protected val entityIds: Iterator[AnyValue])
   extends IdSeekIterator[EdgeValue] {
@@ -101,13 +105,13 @@ final class UndirectedRelationshipIdSeekIterator(ident: String,
   def next(): ExecutionContext = {
     if (emitSibling) {
       emitSibling = false
-      baseContext.copyWith(ident, lastEntity, fromNode, lastEnd, toNode, lastStart)
+      executionContextFactory.copyWith(baseContext, ident, lastEntity, fromNode, lastEnd, toNode, lastStart)
     } else {
       emitSibling = true
       lastEntity = nextEntity()
       lastStart = lastEntity.startNode()
       lastEnd = lastEntity.endNode()
-      baseContext.copyWith(ident, lastEntity, fromNode, lastStart, toNode, lastEnd)
+      executionContextFactory.copyWith(baseContext, ident, lastEntity, fromNode, lastStart, toNode, lastEnd)
     }
   }
 }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LoadCSVPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/LoadCSVPipe.scala
@@ -89,9 +89,8 @@ case class LoadCSVPipe(source: Pipe,
         //reference, e.g. EagerPipe
 
         val resultCopy = new util.HashMap[String, AnyValue](internalMap.size)
-        for (kv <- internalMap) {
-          val key = kv._1
-          val value = if (kv._2 == null) Values.NO_VALUE else kv._2
+        for ((key, maybeNull) <- internalMap) {
+          val value = if (maybeNull == null) Values.NO_VALUE else maybeNull
           resultCopy.put(key, value)
         }
         executionContextFactory.copyWith(context, variable, VirtualValues.map(resultCopy))

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeByIdSeekPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeByIdSeekPipe.scala
@@ -65,7 +65,7 @@ case class NodeByIdSeekPipe(ident: String, nodeIdsExpr: SeekArgs)
   nodeIdsExpr.registerOwningPipe(this)
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
-    val ctx = state.createOrGetInitialContext(executionContextFactory)
+    val ctx = state.newExecutionContext(executionContextFactory)
     val nodeIds = nodeIdsExpr.expressions(ctx, state)
     new NodeIdSeekIterator(ident, ctx, state.query.nodeOps, nodeIds.iterator().asScala)
   }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeByIdSeekPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeByIdSeekPipe.scala
@@ -67,6 +67,12 @@ case class NodeByIdSeekPipe(ident: String, nodeIdsExpr: SeekArgs)
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
     val ctx = state.newExecutionContext(executionContextFactory)
     val nodeIds = nodeIdsExpr.expressions(ctx, state)
-    new NodeIdSeekIterator(ident, ctx, state.query.nodeOps, nodeIds.iterator().asScala)
+    new NodeIdSeekIterator(
+      ident,
+      ctx,
+      executionContextFactory,
+      state.query.nodeOps,
+      nodeIds.iterator().asScala
+    )
   }
 }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeByLabelScanPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeByLabelScanPipe.scala
@@ -31,7 +31,7 @@ case class NodeByLabelScanPipe(ident: String, label: LazyLabel)
       case Some(labelId) =>
         val nodes = state.query.getNodesByLabel(labelId.id)
         val baseContext = state.createOrGetInitialContext(executionContextFactory)
-        nodes.map(n => baseContext.copyWith(ident, n))
+        nodes.map(n => executionContextFactory.copyWith(baseContext, ident, n))
       case None =>
         Iterator.empty
     }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeCountFromCountStorePipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeCountFromCountStorePipe.scala
@@ -28,7 +28,6 @@ case class NodeCountFromCountStorePipe(ident: String, labels: List[Option[LazyLa
                                       (val id: LogicalPlanId = LogicalPlanId.DEFAULT) extends Pipe {
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
-    val baseContext = state.createOrGetInitialContext(executionContextFactory)
     var count = 1L
     val it = labels.iterator
     while (it.hasNext) {
@@ -42,6 +41,8 @@ case class NodeCountFromCountStorePipe(ident: String, labels: List[Option[LazyLa
           count *= state.query.nodeCountByCountStore(NameId.WILDCARD)
       }
     }
-    Seq(baseContext.copyWith(ident, Values.longValue(count))).iterator
+
+    val baseContext = state.createOrGetInitialContext(executionContextFactory)
+    Seq(executionContextFactory.copyWith(baseContext, ident, Values.longValue(count))).iterator
   }
 }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeCountFromCountStorePipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeCountFromCountStorePipe.scala
@@ -43,6 +43,6 @@ case class NodeCountFromCountStorePipe(ident: String, labels: List[Option[LazyLa
     }
 
     val baseContext = state.createOrGetInitialContext(executionContextFactory)
-    Seq(executionContextFactory.copyWith(baseContext, ident, Values.longValue(count))).iterator
+    Iterator(executionContextFactory.copyWith(baseContext, ident, Values.longValue(count)))
   }
 }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexContainsScanPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexContainsScanPipe.scala
@@ -44,7 +44,7 @@ abstract class AbstractNodeIndexStringScanPipe(ident: String,
     val resultNodes = value match {
       case value: TextValue =>
         queryContextCall(state, descriptor, value.stringValue()).
-          map(node => baseContext.copyWith(ident, node))
+          map(node => executionContextFactory.copyWith(baseContext, ident, node))
       case Values.NO_VALUE =>
         Iterator.empty
       case x => throw new CypherTypeException(s"Expected a string value, but got $x")

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexScanPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexScanPipe.scala
@@ -34,6 +34,6 @@ case class NodeIndexScanPipe(ident: String,
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
     val baseContext = state.createOrGetInitialContext(executionContextFactory)
     val resultNodes = state.query.indexScan(descriptor)
-    resultNodes.map(node => baseContext.copyWith(ident, node))
+    resultNodes.map(node => executionContextFactory.copyWith(baseContext, ident, node))
   }
 }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexSeekPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/NodeIndexSeekPipe.scala
@@ -45,7 +45,7 @@ case class NodeIndexSeekPipe(ident: String,
     val index = indexFactory(state)
     val baseContext = state.createOrGetInitialContext(executionContextFactory)
     val resultNodes = indexQuery(valueExpr, baseContext, state, index, label.name, propertyKeys.map(_.name))
-    resultNodes.map(node => baseContext.copyWith(ident, node))
+    resultNodes.map(node => executionContextFactory.copyWith(baseContext, ident, node))
   }
 
 }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/OptionalExpandAllPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/OptionalExpandAllPipe.scala
@@ -44,7 +44,7 @@ case class OptionalExpandAllPipe(source: Pipe, fromName: String, relName: String
             val relationships = state.query.getRelationshipsForIds(n.id(), dir, types.types(state.query))
             val matchIterator = relationships.map { r =>
                 val other = r.otherNode(n)
-                row.copyWith(relName, r, toName, other)
+                executionContextFactory.copyWith(row, relName, r, toName, other)
             }.filter(ctx => predicate.isTrue(ctx, state))
 
             if (matchIterator.isEmpty) {

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/OptionalExpandIntoPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/OptionalExpandIntoPipe.scala
@@ -54,7 +54,7 @@ case class OptionalExpandIntoPipe(source: Pipe, fromName: String, relName: Strin
                 val it = relationships.toIterator
                 val filteredRows = ListBuffer.empty[ExecutionContext]
                 while (it.hasNext) {
-                  val candidateRow = row.copyWith(relName, it.next())
+                  val candidateRow = executionContextFactory.copyWith(row, relName, it.next())
                   if (predicate.isTrue(candidateRow, state)) {
                     filteredRows.append(candidateRow)
                   }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ProcedureCallPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ProcedureCallPipe.scala
@@ -72,7 +72,7 @@ case class ProcedureCallPipe(source: Pipe,
           builder += v -> javaValue
         }
         val rowEntries = builder.result()
-        val output = input.copyWith(rowEntries)
+        val output = executionContextFactory.copyWith(input, rowEntries)
         builder.clear()
         output
       }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ProjectEndpointsPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ProjectEndpointsPipe.scala
@@ -47,8 +47,8 @@ case class ProjectEndpointsPipe(source: Pipe, relName: String,
         )
       case Some((startNode, endNode, rels)) if !directed =>
         Iterator(
-          context.copyWith(start, startNode, end, endNode),
-          context.copyWith(start, endNode, end, startNode, relName, reverse(rels))
+          executionContextFactory.copyWith(context, start, startNode, end, endNode),
+          executionContextFactory.copyWith(context, start, endNode, end, startNode, relName, reverse(rels))
         )
       case None =>
         Iterator.empty
@@ -61,8 +61,8 @@ case class ProjectEndpointsPipe(source: Pipe, relName: String,
         Iterator(context.set(start, startNode, end, endNode))
       case Some((startNode, endNode)) if !directed =>
         Iterator(
-          context.copyWith(start, startNode, end, endNode),
-          context.copyWith(start, endNode, end, startNode)
+          executionContextFactory.copyWith(context, start, startNode, end, endNode),
+          executionContextFactory.copyWith(context, start, endNode, end, startNode)
         )
       case None =>
         Iterator.empty

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/PruningVarLengthExpandPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/PruningVarLengthExpandPipe.scala
@@ -220,7 +220,7 @@ case class PruningVarLengthExpandPipe(source: Pipe,
 
       updateMinFullExpandDepth(currentFullExpandDepth)
 
-      (whenEmptied, row.copyWith(self.toName, node))
+      (whenEmptied, executionContextFactory.copyWith(row, self.toName, node))
     }
 
     private def hasRelationships = idx < fullExpandDepths.rels.length

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/PruningVarLengthExpandPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/PruningVarLengthExpandPipe.scala
@@ -110,7 +110,7 @@ case class PruningVarLengthExpandPipe(source: Pipe,
       }
 
       if (pathLength >= self.min)
-        (whenEmptied, row.copyWith(self.toName, node))
+        (whenEmptied, executionContextFactory.copyWith(row, self.toName, node))
       else
         whenEmptied.next()
     }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/QueryState.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/QueryState.scala
@@ -101,7 +101,13 @@ trait ExecutionContextFactory {
   def newExecutionContext(m: mutable.Map[String, AnyValue] = MutableMaps.empty): ExecutionContext
   def newExecutionContext(): ExecutionContext
   def copyWith(init: ExecutionContext): ExecutionContext
+  def copyWith(row: ExecutionContext, newEntries: Seq[(String, AnyValue)]): ExecutionContext
   def copyWith(row: ExecutionContext, key: String, value: AnyValue): ExecutionContext
+  def copyWith(row: ExecutionContext, key1: String, value1: AnyValue, key2: String, value2: AnyValue): ExecutionContext
+  def copyWith(row: ExecutionContext,
+               key1: String, value1: AnyValue,
+               key2: String, value2: AnyValue,
+               key3: String, value3: AnyValue): ExecutionContext
 }
 
 case class CommunityExecutionContextFactory() extends ExecutionContextFactory {
@@ -113,6 +119,20 @@ case class CommunityExecutionContextFactory() extends ExecutionContextFactory {
   // As community execution ctxs are immutable, we can simply return init here.
   override def copyWith(init: ExecutionContext): ExecutionContext = init
 
+  override def copyWith(row: ExecutionContext, newEntries: Seq[(String, AnyValue)]): ExecutionContext =
+    row.copyWith(newEntries)
+
   override def copyWith(row: ExecutionContext, key: String, value: AnyValue): ExecutionContext =
     row.copyWith(key, value)
+
+  override def copyWith(row: ExecutionContext,
+                        key1: String, value1: AnyValue,
+                        key2: String, value2: AnyValue): ExecutionContext =
+    row.copyWith(key1, value1, key2, value2)
+
+  override def copyWith(row: ExecutionContext,
+                        key1: String, value1: AnyValue,
+                        key2: String, value2: AnyValue,
+                        key3: String, value3: AnyValue): ExecutionContext =
+    row.copyWith(key1, value1, key2, value2, key3, value3)
 }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/QueryState.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/QueryState.scala
@@ -50,7 +50,7 @@ class QueryState(val query: QueryContext,
 
   def newExecutionContext(factory: ExecutionContextFactory): ExecutionContext = {
     initialContext match {
-      case Some(init) => factory.newExecutionContext(init)
+      case Some(init) => factory.copyWith(init)
       case None => factory.newExecutionContext()
     }
   }
@@ -100,7 +100,8 @@ class TimeReader {
 trait ExecutionContextFactory {
   def newExecutionContext(m: mutable.Map[String, AnyValue] = MutableMaps.empty): ExecutionContext
   def newExecutionContext(): ExecutionContext
-  def newExecutionContext(init: ExecutionContext): ExecutionContext
+  def copyWith(init: ExecutionContext): ExecutionContext
+  def copyWith(row: ExecutionContext, key: String, value: AnyValue): ExecutionContext
 }
 
 case class CommunityExecutionContextFactory() extends ExecutionContextFactory {
@@ -110,5 +111,8 @@ case class CommunityExecutionContextFactory() extends ExecutionContextFactory {
   override def newExecutionContext(): ExecutionContext = ExecutionContext.empty
 
   // As community execution ctxs are immutable, we can simply return init here.
-  override def newExecutionContext(init: ExecutionContext): ExecutionContext = init
+  override def copyWith(init: ExecutionContext): ExecutionContext = init
+
+  override def copyWith(row: ExecutionContext, key: String, value: AnyValue): ExecutionContext =
+    row.copyWith(key, value)
 }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ShortestPathPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ShortestPathPipe.scala
@@ -51,13 +51,20 @@ case class ShortestPathPipe(source: Pipe, shortestPathCommand: ShortestPath, pre
       shortestPathCommand.relIterator match {
         case Some(relName) =>
           result.iterator().asScala.map {
-            case path: PathValue => ctx.copyWith(pathName, path, relName, VirtualValues.list(path.edges():_*))
-            case value => throw new InternalException(s"Expected path, got '$value'")
+            case path: PathValue =>
+              val relations = VirtualValues.list(path.edges(): _*)
+              executionContextFactory.copyWith(ctx, pathName, path, relName, relations)
+
+            case value =>
+              throw new InternalException(s"Expected path, got '$value'")
           }
         case None =>
           result.iterator().asScala.map {
-            case path: PathValue => ctx.copyWith(pathName, path)
-            case value => throw new InternalException(s"Expected path, got '$value'")
+            case path: PathValue =>
+              executionContextFactory.copyWith(ctx, pathName, path)
+
+            case value =>
+              throw new InternalException(s"Expected path, got '$value'")
           }
       }
     })

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/UndirectedRelationshipByIdSeekPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/UndirectedRelationshipByIdSeekPipe.scala
@@ -40,7 +40,15 @@ case class UndirectedRelationshipByIdSeekPipe(ident: String, relIdExpr: SeekArgs
     val relIds = VirtualValues.filter(relIdExpr.expressions(ctx, state), new function.Function[AnyValue, java.lang.Boolean] {
       override def apply(t: AnyValue): lang.Boolean = t != Values.NO_VALUE
     })
-    new UndirectedRelationshipIdSeekIterator(ident, fromNode, toNode, ctx, state.query.relationshipOps, relIds.iterator.asScala)
+    new UndirectedRelationshipIdSeekIterator(
+      ident,
+      fromNode,
+      toNode,
+      ctx,
+      executionContextFactory,
+      state.query.relationshipOps,
+      relIds.iterator.asScala
+    )
   }
 
 }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/UnwindPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/UnwindPipe.scala
@@ -39,9 +39,9 @@ case class UnwindPipe(source: Pipe, collection: Expression, variable: String)
   }
 
   private class UnwindIterator(input: Iterator[ExecutionContext], state: QueryState) extends Iterator[ExecutionContext] {
-    private var context: ExecutionContext = null
-    private var unwindIterator: Iterator[AnyValue] = null
-    private var nextItem: ExecutionContext = null
+    private var context: ExecutionContext = _
+    private var unwindIterator: Iterator[AnyValue] = _
+    private var nextItem: ExecutionContext = _
 
     prefetch()
 
@@ -59,7 +59,7 @@ case class UnwindPipe(source: Pipe, collection: Expression, variable: String)
     private def prefetch() {
       nextItem = null
       if (unwindIterator != null && unwindIterator.hasNext) {
-        nextItem = context.copyWith(variable, unwindIterator.next())
+        nextItem = executionContextFactory.copyWith(context, variable, unwindIterator.next())
       } else {
         if (input.hasNext) {
           context = input.next()

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/VarLengthExpandPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/VarLengthExpandPipe.scala
@@ -91,7 +91,7 @@ case class VarLengthExpandPipe(source: Pipe,
       val paths = varLengthExpand(n, state, max, row)
       paths.collect {
         case (node, rels) if rels.length >= min && isToNodeValid(row, state, node) =>
-          row.copyWith(relName, VirtualValues.list(rels: _*), toName, node)
+          executionContextFactory.copyWith(row, relName, VirtualValues.list(rels: _*), toName, node)
       }
     }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ForeachAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ForeachAcceptanceTest.scala
@@ -125,7 +125,7 @@ class ForeachAcceptanceTest extends ExecutionEngineFunSuite with CypherCompariso
         |FOREACH (r IN CASE WHEN rel IS NOT NULL THEN [rel] ELSE [] END | DELETE r )""".stripMargin
 
     // when
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
+    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query)
 
     // then
     assertStats(result, relationshipsDeleted = 1)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcQueries.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LdbcQueries.scala
@@ -623,7 +623,7 @@ object LdbcQueries {
 
     def expectedResult = List(Map("forumName" -> "forum1-ᚠさ丵פش", "postCount" -> 1), Map("forumName" -> "forum3-ᚠさ丵פش", "postCount" -> 1), Map("forumName" -> "forum1-ᚠさ丵פش", "postCount" -> 0))
 
-    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+    override def expectedToSucceedIn: TestConfiguration = Configs.Interpreted
 
   }
 
@@ -701,7 +701,7 @@ object LdbcQueries {
 
     def expectedResult = List(Map("tagName" -> "tag2-ᚠさ丵פش", "postCount" -> 2), Map("tagName" -> "tag5-ᚠさ丵פش", "postCount" -> 2), Map("tagName" -> "tag1-ᚠさ丵פش", "postCount" -> 1))
 
-    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+    override def expectedToSucceedIn: TestConfiguration = Configs.Interpreted
 
   }
 
@@ -1013,7 +1013,7 @@ object LdbcQueries {
       Map("personId" -> 2, "messageId" -> 311,
         "personLastName" -> "two-ᚠさ丵פش", "messageContent" -> "C311", "personFirstName" -> "friend", "messageCreationDate" -> 4))
 
-    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+    override def expectedToSucceedIn: TestConfiguration = Configs.Interpreted
 
   }
 
@@ -1209,7 +1209,7 @@ object LdbcQueries {
       Map("friendLastName" -> "one one-ᚠさ丵פش", "friendId" -> 11, "companyName" -> "company zero",
         "friendFirstName" -> "friend friend", "workFromYear" -> 3))
 
-    override def expectedToSucceedIn: TestConfiguration = Configs.CommunityInterpreted
+    override def expectedToSucceedIn: TestConfiguration = Configs.Interpreted
 
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -572,10 +572,8 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
         |RETURN project.p""".stripMargin
 
     //WHEN
-    val first = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
-      .length
-    val second = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
-      .length
+    val first = executeWith(Configs.Interpreted - Configs.Cost2_3, query).length
+    val second = executeWith(Configs.Interpreted - Configs.Cost2_3, query).length
     val check = executeWith(Configs.All, "MATCH (f:Folder) RETURN f.name").toSet
 
     //THEN
@@ -609,10 +607,8 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
 
     //WHEN
 
-    val first = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
-      .length
-    val second = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
-      .length
+    val first = executeWith(Configs.Interpreted - Configs.Cost2_3, query).length
+    val second = executeWith(Configs.Interpreted - Configs.Cost2_3, query).length
     val check = executeWith(Configs.All, "MATCH (f:Folder) RETURN f.name").toSet
 
     //THEN
@@ -637,7 +633,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     1.to(1000).foreach(_ => createNode())
 
     // when
-    val result = executeWith(Configs.CommunityInterpreted, s"profile WITH [$a,$b,$d] AS arr MATCH (n) WHERE id(n) IN arr return count(*)")
+    val result = executeWith(Configs.Interpreted, s"profile WITH [$a,$b,$d] AS arr MATCH (n) WHERE id(n) IN arr return count(*)")
 
     // then
     result.toList should equal(List(Map("count(*)" -> 3)))

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathExhaustiveForbiddenAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathExhaustiveForbiddenAcceptanceTest.scala
@@ -50,7 +50,7 @@ class ShortestPathExhaustiveForbiddenAcceptanceTest extends ExecutionEngineFunSu
 
   test("should warn if shortest path fallback is planned") {
     // when
-    val result = executeWith(Configs.CommunityInterpreted,
+    val result = executeWith(Configs.Interpreted,
       s"""EXPLAIN MATCH p = shortestPath((src:$topLeft)-[*0..]-(dst:$topLeft))
          |WHERE ANY(n in nodes(p) WHERE n:$topRight)
          |RETURN nodes(p) AS nodes""".stripMargin)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StartAcceptanceTest.scala
@@ -24,6 +24,8 @@ import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
 
 class StartAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with CypherComparisonSupport {
 
+  // START gets executed on legacy cypher, because it's deprecated and will be removes in 4.0. Therefore it is only
+  // executable on the community interpreted runtime.
   val expectedToSucceed = Configs.CommunityInterpreted - Configs.Version3_3
   val expectedToSucceedNoCost = Configs.CommunityInterpreted - Configs.Cost3_1 - Configs.Cost2_3 - Configs.Version3_3
 

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedExecutionContext.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedExecutionContext.scala
@@ -192,7 +192,7 @@ case class SlottedExecutionContext(slots: SlotConfiguration) extends ExecutionCo
   }
 
   override def copyWith(key1: String, value1: AnyValue): ExecutionContext = {
-    // This method should throw like it siblings below, as soon as reduce is changed to not use it.
+    // This method should throw like its siblings below as soon as reduce is changed to not use it.
     val newCopy = SlottedExecutionContext(slots)
     copyTo(newCopy)
     newCopy.setValue(key1, value1)
@@ -201,7 +201,7 @@ case class SlottedExecutionContext(slots: SlotConfiguration) extends ExecutionCo
 
   override def copyWith(key1: String, value1: AnyValue, key2: String, value2: AnyValue): ExecutionContext = {
     throw new UnsupportedOperationException(
-      "Use ExecutionContextFactory.copyWith instead, to get the correct slot configuration"
+      "Use ExecutionContextFactory.copyWith instead to get the correct slot configuration"
     )
   }
 
@@ -209,13 +209,13 @@ case class SlottedExecutionContext(slots: SlotConfiguration) extends ExecutionCo
                         key2: String, value2: AnyValue,
                         key3: String, value3: AnyValue): ExecutionContext = {
     throw new UnsupportedOperationException(
-      "Use ExecutionContextFactory.copyWith instead, to get the correct slot configuration"
+      "Use ExecutionContextFactory.copyWith instead to get the correct slot configuration"
     )
   }
 
   override def copyWith(newEntries: Seq[(String, AnyValue)]): ExecutionContext = {
     throw new UnsupportedOperationException(
-      "Use ExecutionContextFactory.copyWith instead, to get the correct slot configuration"
+      "Use ExecutionContextFactory.copyWith instead to get the correct slot configuration"
     )
   }
 

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedExecutionContext.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedExecutionContext.scala
@@ -191,9 +191,8 @@ case class SlottedExecutionContext(slots: SlotConfiguration) extends ExecutionCo
     this
   }
 
-  // This method is used instead of newWith1 from a ScopeExpression where the key in the new scope is overriding an existing key
-  // and it has to have the same name due to syntactic constraints. In this case we actually make a copy in order to not corrupt the existing slot.
   override def copyWith(key1: String, value1: AnyValue): ExecutionContext = {
+    // This method should throw like it siblings below, as soon as reduce is changed to not use it.
     val newCopy = SlottedExecutionContext(slots)
     copyTo(newCopy)
     newCopy.setValue(key1, value1)
@@ -201,32 +200,23 @@ case class SlottedExecutionContext(slots: SlotConfiguration) extends ExecutionCo
   }
 
   override def copyWith(key1: String, value1: AnyValue, key2: String, value2: AnyValue): ExecutionContext = {
-    val newCopy = SlottedExecutionContext(slots)
-    copyTo(newCopy)
-    newCopy.setValue(key1, value1)
-    newCopy.setValue(key2, value2)
-    newCopy
+    throw new UnsupportedOperationException(
+      "Use ExecutionContextFactory.copyWith instead, to get the correct slot configuration"
+    )
   }
 
   override def copyWith(key1: String, value1: AnyValue,
                         key2: String, value2: AnyValue,
                         key3: String, value3: AnyValue): ExecutionContext = {
-    val newCopy = SlottedExecutionContext(slots)
-    copyTo(newCopy)
-    newCopy.setValue(key1, value1)
-    newCopy.setValue(key2, value2)
-    newCopy.setValue(key3, value3)
-    newCopy
+    throw new UnsupportedOperationException(
+      "Use ExecutionContextFactory.copyWith instead, to get the correct slot configuration"
+    )
   }
 
   override def copyWith(newEntries: Seq[(String, AnyValue)]): ExecutionContext = {
-    val newCopy = SlottedExecutionContext(slots)
-    copyTo(newCopy)
-    for (t <- newEntries) {
-      val (key,value) = t
-      newCopy.setValue(key, value)
-    }
-    newCopy
+    throw new UnsupportedOperationException(
+      "Use ExecutionContextFactory.copyWith instead, to get the correct slot configuration"
+    )
   }
 
   private def setValue(key1: String, value1: AnyValue): Unit = {

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedQueryState.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedQueryState.scala
@@ -66,9 +66,16 @@ case class SlottedExecutionContextFactory(slots: SlotConfiguration) extends Exec
   override def newExecutionContext(): ExecutionContext =
     SlottedExecutionContext(slots)
 
-  override def newExecutionContext(init: ExecutionContext): ExecutionContext = {
+  override def copyWith(row: ExecutionContext): ExecutionContext = {
     val newCtx = SlottedExecutionContext(slots)
-    init.copyTo(newCtx)
+    row.copyTo(newCtx)
+    newCtx
+  }
+
+  override def copyWith(row: ExecutionContext, key: String, value: AnyValue): ExecutionContext = {
+    val newCtx = SlottedExecutionContext(slots)
+    row.copyTo(newCtx)
+    newCtx.set(key, value)
     newCtx
   }
 }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedQueryState.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedQueryState.scala
@@ -72,10 +72,42 @@ case class SlottedExecutionContextFactory(slots: SlotConfiguration) extends Exec
     newCtx
   }
 
+  override def copyWith(row: ExecutionContext, newEntries: Seq[(String, AnyValue)]): ExecutionContext = {
+    val newCopy = SlottedExecutionContext(slots)
+    row.copyTo(newCopy)
+    for (t <- newEntries) {
+      val (key,value) = t
+      newCopy.set(key, value)
+    }
+    newCopy
+  }
+
   override def copyWith(row: ExecutionContext, key: String, value: AnyValue): ExecutionContext = {
     val newCtx = SlottedExecutionContext(slots)
     row.copyTo(newCtx)
     newCtx.set(key, value)
     newCtx
+  }
+
+  override def copyWith(row: ExecutionContext,
+                        key1: String, value1: AnyValue,
+                        key2: String, value2: AnyValue): ExecutionContext = {
+    val newCopy = SlottedExecutionContext(slots)
+    row.copyTo(newCopy)
+    newCopy.set(key1, value1)
+    newCopy.set(key2, value2)
+    newCopy
+  }
+
+  override def copyWith(row: ExecutionContext,
+                        key1: String, value1: AnyValue,
+                        key2: String, value2: AnyValue,
+                        key3: String, value3: AnyValue): ExecutionContext = {
+    val newCopy = SlottedExecutionContext(slots)
+    row.copyTo(newCopy)
+    newCopy.set(key1, value1)
+    newCopy.set(key2, value2)
+    newCopy.set(key3, value3)
+    newCopy
   }
 }

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedQueryState.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedQueryState.scala
@@ -75,8 +75,7 @@ case class SlottedExecutionContextFactory(slots: SlotConfiguration) extends Exec
   override def copyWith(row: ExecutionContext, newEntries: Seq[(String, AnyValue)]): ExecutionContext = {
     val newCopy = SlottedExecutionContext(slots)
     row.copyTo(newCopy)
-    for (t <- newEntries) {
-      val (key,value) = t
+    for ((key,value) <- newEntries) {
       newCopy.set(key, value)
     }
     newCopy


### PR DESCRIPTION
Most failures cause by `ExecutionContext.copyWith` which creates a new
`ExecutionContext` with the slot configuration of the old one. This wrong
as new `ExecutionContext`s have to use the slot configuration of the
current operator, because these could be different. Creating
`ExecutionContext`s with the wrong slot configuration typically gives
bug with the error msg "Ouch, no suitable slot for key ...".

Builds on #10645, first commit is https://github.com/neo4j/neo4j/commit/812db816523a774d5777b399d850464712f1a7b8.