### PR TITLE
Use new API from compiled code

### DIFF
--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledCursorUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledCursorUtils.java
@@ -29,7 +29,7 @@ import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
 
 /**
- * Utilities for working with cursor from within generated code
+ * Utilities for working with cursors from within generated code
  */
 public final class CompiledCursorUtils
 {
@@ -38,12 +38,12 @@ public final class CompiledCursorUtils
      */
     private CompiledCursorUtils()
     {
-        throw new UnsupportedOperationException(  );
+        throw new UnsupportedOperationException();
     }
-
 
     /**
      * Fetches a given property from a node
+     *
      * @param read The current Read instance
      * @param nodeCursor The node cursor to use
      * @param node The id of the node
@@ -52,7 +52,8 @@ public final class CompiledCursorUtils
      * @return The value of the given property
      * @throws EntityNotFoundException If the node cannot be find.
      */
-    public static Value nodeGetProperty(Read read, NodeCursor nodeCursor, long node, PropertyCursor propertyCursor, int prop) throws EntityNotFoundException
+    public static Value nodeGetProperty( Read read, NodeCursor nodeCursor, long node, PropertyCursor propertyCursor,
+            int prop ) throws EntityNotFoundException
     {
         if ( prop == StatementConstants.NO_SUCH_PROPERTY_KEY )
         {
@@ -73,6 +74,32 @@ public final class CompiledCursorUtils
         }
 
         return Values.NO_VALUE;
+    }
+
+    /**
+     * Checks if given node has a given label.
+     *
+     * @param read The current Read instance
+     * @param nodeCursor The node cursor to use
+     * @param node The id of the node
+     * @param label The id of the label
+     * @return <tt>true</tt> if the node has the label, otherwise <tt>false</tt>
+     * @throws EntityNotFoundException if the node is not there.
+     */
+    public static boolean nodeHasLabel( Read read, NodeCursor nodeCursor, long node, int label )
+            throws EntityNotFoundException
+    {
+        if ( label == StatementConstants.NO_SUCH_LABEL )
+        {
+            return false;
+        }
+        read.singleNode( node, nodeCursor );
+        if ( !nodeCursor.next() )
+        {
+            throw new EntityNotFoundException( EntityType.NODE, node );
+        }
+
+        return nodeCursor.labels().contains( label );
     }
 }
 

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledCursorUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledCursorUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.codegen;
+
+import org.neo4j.internal.kernel.api.NodeCursor;
+import org.neo4j.internal.kernel.api.PropertyCursor;
+import org.neo4j.internal.kernel.api.Read;
+import org.neo4j.kernel.api.StatementConstants;
+import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
+import org.neo4j.storageengine.api.EntityType;
+import org.neo4j.values.storable.Value;
+import org.neo4j.values.storable.Values;
+
+/**
+ * Utilities for working with cursor from within generated code
+ */
+public final class CompiledCursorUtils
+{
+    /**
+     * Do not instantiate this class
+     */
+    private CompiledCursorUtils()
+    {
+        throw new UnsupportedOperationException(  );
+    }
+
+
+    /**
+     * Fetches a given property from a node
+     * @param read The current Read instance
+     * @param nodeCursor The node cursor to use
+     * @param node The id of the node
+     * @param propertyCursor The property cursor to use
+     * @param prop The id of the property to find
+     * @return The value of the given property
+     * @throws EntityNotFoundException If the node cannot be find.
+     */
+    public static Value nodeGetProperty(Read read, NodeCursor nodeCursor, long node, PropertyCursor propertyCursor, int prop) throws EntityNotFoundException
+    {
+        if ( prop == StatementConstants.NO_SUCH_PROPERTY_KEY )
+        {
+            return Values.NO_VALUE;
+        }
+        read.singleNode( node, nodeCursor );
+        if ( !nodeCursor.next() )
+        {
+            throw new EntityNotFoundException( EntityType.NODE, node );
+        }
+        nodeCursor.properties( propertyCursor );
+        while ( propertyCursor.next() )
+        {
+            if ( propertyCursor.propertyKey() == prop )
+            {
+                return propertyCursor.propertyValue();
+            }
+        }
+
+        return Values.NO_VALUE;
+    }
+}
+

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/codegen/CompiledCursorUtilsTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/codegen/CompiledCursorUtilsTest.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.codegen
+
+import org.mockito.Mockito.when
+import org.neo4j.cypher.internal.codegen.CompiledCursorUtils.nodeGetProperty
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
+import org.neo4j.internal.kernel.api.{NodeCursor, PropertyCursor, Read}
+import org.neo4j.kernel.api.exceptions.EntityNotFoundException
+import org.neo4j.values.storable.Values.{NO_VALUE, stringValue}
+
+class CompiledCursorUtilsTest extends CypherFunSuite {
+
+  test("should find a property from a node cursor") {
+    val nodeCursor = mock[NodeCursor]
+    val propertyCursor = mock[PropertyCursor]
+    when(nodeCursor.next()).thenReturn(true)
+    when(propertyCursor.next()).thenReturn(true, true, true, false)
+    when(propertyCursor.propertyKey()).thenReturn(1336, 1337, 1338)
+    when(propertyCursor.propertyValue()).thenReturn(stringValue("hello"))
+
+    // When
+    val value = nodeGetProperty(mock[Read], nodeCursor, 42L, propertyCursor, 1337)
+
+    // Then
+    value should equal(stringValue("hello"))
+  }
+
+  test("should return NO_VALUE if the property not there") {
+    val nodeCursor = mock[NodeCursor]
+    val propertyCursor = mock[PropertyCursor]
+    when(nodeCursor.next()).thenReturn(true)
+    when(propertyCursor.next()).thenReturn(true, true, true, false)
+    when(propertyCursor.propertyKey()).thenReturn(1336, 1337, 1338)
+    when(propertyCursor.propertyValue()).thenReturn(stringValue("hello"))
+
+    // When
+    val value = nodeGetProperty(mock[Read], nodeCursor, 42L, propertyCursor, 1339)
+
+    // Then
+    value should equal(NO_VALUE)
+  }
+
+  test("should throw if node is missing") {
+    // Given
+    val read = mock[Read]
+    val nodeCursor = mock[NodeCursor]
+    when(nodeCursor.next()).thenReturn(false)
+
+    // Expect
+    an [EntityNotFoundException] shouldBe thrownBy(nodeGetProperty(read, nodeCursor, 42L, mock[PropertyCursor], 1337))
+  }
+}

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/DelegatingQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/DelegatingQueryContext.scala
@@ -27,6 +27,7 @@ import org.neo4j.cypher.internal.runtime._
 import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection
 import org.neo4j.cypher.internal.v3_4.logical.plans.QualifiedName
 import org.neo4j.graphdb.{Node, Path, PropertyContainer}
+import org.neo4j.internal.kernel.api.{CursorFactory, Read, Write}
 import org.neo4j.kernel.api.ReadOperations
 import org.neo4j.kernel.api.dbms.DbmsOperations
 import org.neo4j.kernel.impl.api.store.RelationshipIterator
@@ -289,4 +290,10 @@ class DelegatingQueryTransactionalContext(val inner: QueryTransactionalContext) 
   override def kernelStatisticProvider: KernelStatisticProvider = inner.kernelStatisticProvider
 
   override def databaseInfo: DatabaseInfo = inner.databaseInfo
+
+  override def cursors: CursorFactory = inner.cursors
+
+  override def dataRead: Read = inner.dataRead
+
+  override def dataWrite: Write = inner.dataWrite
 }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
@@ -100,9 +100,8 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
     new TransactionBoundQueryContext(TransactionalContextWrapper(neo4jTransactionalContext))
   }
   //We cannot assign to value because of periodic commit
-  private def writes() = transactionalContext.kernelTransaction.dataWrite()
-  private def reads() = transactionalContext.kernelTransaction.dataRead()
-  private def cursors = transactionalContext.kernelTransaction.cursors()
+  private def writes() = transactionalContext.dataWrite
+  private def reads() = transactionalContext.dataRead
   private val nodeCursor = allocateAndTraceNodeCursor()
   private val propertyCursor = allocateAndTracePropertyCursor()
   private def tokenRead = transactionalContext.kernelTransaction.tokenRead()
@@ -932,13 +931,13 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
     transactionalContext.statement.schemaWriteOperations()
 
   private def allocateAndTraceNodeCursor() = {
-    val cursor = cursors.allocateNodeCursor()
+    val cursor = transactionalContext.cursors.allocateNodeCursor()
     resources.trace(cursor)
     cursor
   }
 
   private def allocateAndTracePropertyCursor() = {
-    val cursor = cursors.allocatePropertyCursor()
+    val cursor = transactionalContext.cursors.allocatePropertyCursor()
     resources.trace(cursor)
     cursor
   }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionalContextWrapper.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionalContextWrapper.scala
@@ -23,6 +23,7 @@ import org.neo4j.cypher.internal.planner.v3_4.spi.KernelStatisticProvider
 import org.neo4j.cypher.internal.runtime.QueryTransactionalContext
 import org.neo4j.graphdb.{Lock, PropertyContainer}
 import org.neo4j.internal.kernel.api.security.SecurityContext
+import org.neo4j.internal.kernel.api.{CursorFactory, Read, Write}
 import org.neo4j.kernel.GraphDatabaseQueryService
 import org.neo4j.kernel.api.KernelTransaction.Revertable
 import org.neo4j.kernel.api.dbms.DbmsOperations
@@ -50,6 +51,13 @@ case class TransactionalContextWrapper(tc: TransactionalContext) extends QueryTr
 
   // needed only for compatibility with 2.3
   def acquireWriteLock(p: PropertyContainer): Lock = tc.acquireWriteLock(p)
+
+
+  override def cursors: CursorFactory = tc.kernelTransaction.cursors()
+
+  override def dataRead: Read = tc.kernelTransaction().dataRead()
+
+  override def dataWrite: Write = tc.kernelTransaction().dataWrite()
 
   override def readOperations: ReadOperations = tc.readOperations()
 

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryContext.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryContext.scala
@@ -26,6 +26,7 @@ import org.neo4j.cypher.internal.planner.v3_4.spi.{IdempotentResult, IndexDescri
 import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection
 import org.neo4j.cypher.internal.v3_4.logical.plans.QualifiedName
 import org.neo4j.graphdb.{Node, Path, PropertyContainer}
+import org.neo4j.internal.kernel.api.{CursorFactory, Read, Write}
 import org.neo4j.kernel.api.ReadOperations
 import org.neo4j.kernel.api.dbms.DbmsOperations
 import org.neo4j.kernel.impl.api.store.RelationshipIterator
@@ -236,6 +237,12 @@ trait Operations[T] {
 }
 
 trait QueryTransactionalContext extends CloseableResource {
+
+  def cursors : CursorFactory
+
+  def dataRead: Read
+
+  def dataWrite: Write
 
   def readOperations: ReadOperations
 

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/StubNodeCursor.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/StubNodeCursor.java
@@ -31,6 +31,23 @@ public class StubNodeCursor implements NodeCursor
     private int offset = -1;
     private List<Node> nodes = new ArrayList<>();
 
+    void single( long reference )
+    {
+        offset = Integer.MAX_VALUE;
+        for ( int i = 0; i < nodes.size(); i++ )
+        {
+            if ( reference == nodes.get( i ).id )
+            {
+                offset = i - 1;
+            }
+        }
+    }
+
+    void scan()
+    {
+        offset = -1;
+    }
+
     public StubNodeCursor withNode( long id )
     {
         nodes.add( new Node( id, new long[]{}, Collections.emptyMap() ) );

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/StubRead.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/StubRead.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.kernel.api;
+
+import org.neo4j.internal.kernel.api.exceptions.KernelException;
+
+public class StubRead implements Read
+{
+    @Override
+    public void nodeIndexSeek( IndexReference index, NodeValueIndexCursor cursor, IndexOrder indexOrder,
+            IndexQuery... query ) throws KernelException
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void nodeIndexScan( IndexReference index, NodeValueIndexCursor cursor, IndexOrder indexOrder )
+            throws KernelException
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void nodeLabelScan( int label, NodeLabelIndexCursor cursor )
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void nodeLabelUnionScan( NodeLabelIndexCursor cursor, int... labels )
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void nodeLabelIntersectionScan( NodeLabelIndexCursor cursor, int... labels )
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Scan<NodeLabelIndexCursor> nodeLabelScan( int label )
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void allNodesScan( NodeCursor cursor )
+    {
+        ((StubNodeCursor) cursor).scan();
+    }
+
+    @Override
+    public Scan<NodeCursor> allNodesScan()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void singleNode( long reference, NodeCursor cursor )
+    {
+        ((StubNodeCursor) cursor).single( reference );
+    }
+
+    @Override
+    public boolean nodeExists( long id )
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void singleRelationship( long reference, RelationshipScanCursor cursor )
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void allRelationshipsScan( RelationshipScanCursor cursor )
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Scan<RelationshipScanCursor> allRelationshipsScan()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void relationshipLabelScan( int label, RelationshipScanCursor cursor )
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Scan<RelationshipScanCursor> relationshipLabelScan( int label )
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void relationshipGroups( long nodeReference, long reference, RelationshipGroupCursor cursor )
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void relationships( long nodeReference, long reference, RelationshipTraversalCursor cursor )
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void nodeProperties( long reference, PropertyCursor cursor )
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void relationshipProperties( long reference, PropertyCursor cursor )
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void graphProperties( PropertyCursor cursor )
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void futureNodeReferenceRead( long reference )
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void futureRelationshipsReferenceRead( long reference )
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void futureNodePropertyReferenceRead( long reference )
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void futureRelationshipPropertyReferenceRead( long reference )
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Labels.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Labels.java
@@ -26,7 +26,7 @@ import org.neo4j.collection.primitive.PrimitiveIntSet;
 
 import org.neo4j.internal.kernel.api.LabelSet;
 
-class Labels implements LabelSet
+public class Labels implements LabelSet
 {
     /**
      * This really only needs to be {@code int[]}, but the underlying implementation uses {@code long[]} for some
@@ -34,7 +34,7 @@ class Labels implements LabelSet
      */
     private final long[] labels;
 
-    Labels( long[] labels )
+    public Labels( long[] labels )
     {
         this.labels = labels;
     }

--- a/enterprise/cypher/cypher/pom.xml
+++ b/enterprise/cypher/cypher/pom.xml
@@ -153,6 +153,13 @@
     </dependency>
     <dependency>
       <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-kernel-api</artifactId>
+      <version>3.4.0-SNAPSHOT</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.neo4j</groupId>
       <artifactId>neo4j-common</artifactId>
       <type>test-jar</type>
       <scope>test</scope>

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ScanAllNodes.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ScanAllNodes.scala
@@ -34,8 +34,8 @@ case class ScanAllNodes(opName: String) extends LoopDataGenerator {
   override def produceNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
                              (implicit context: CodeGenContext) = {
     generator.incrementDbHits()
-    generator.nextNode(nextVar.name, iterVar)
+    generator.nodeFromNodeCursor(nextVar.name, iterVar)
   }
 
-  override def hasNext[E](generator: MethodStructure[E], iterVar: String): E = generator.hasNextNode(iterVar)
+  override def hasNext[E](generator: MethodStructure[E], iterVar: String): E = generator.advanceNodeCursor(iterVar)
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/spi/MethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/spi/MethodStructure.scala
@@ -159,9 +159,11 @@ trait MethodStructure[E] {
   def connectingRelationships(iterVar: String, fromNode: String, fromNodeType: CodeGenType, dir: SemanticDirection, toNode:String, toNodeType: CodeGenType)
   def connectingRelationships(iterVar: String, fromNode: String, fromNodeType: CodeGenType, dir: SemanticDirection, types: Seq[String], toNode: String, toNodeType: CodeGenType)
   def nextNode(targetVar: String, iterVar: String): Unit
+  def nodeFromNodeCursor(targetVar: String, iterVar: String): Unit
   def nextRelationshipAndNode(toNodeVar: String, iterVar: String, direction: SemanticDirection, fromNodeVar: String, relVar: String): Unit
   def nextRelationship(iterVar: String, direction: SemanticDirection, relVar: String): Unit
   def hasNextNode(iterVar: String): E
+  def advanceNodeCursor(iterVar: String): E
   def hasNextRelationship(iterVar: String): E
   def nodeGetPropertyById(nodeVar: String, nodeVarType: CodeGenType, propId: Int, propValueVar: String): Unit
   def nodeGetPropertyForVar(nodeVar: String, nodeVarType: CodeGenType, propIdVar: String, propValueVar: String): Unit

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Fields.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Fields.scala
@@ -30,4 +30,8 @@ case class Fields(closer: FieldReference,
                   params: FieldReference,
                   closeable: FieldReference,
                   queryContext: FieldReference,
-                  skip: FieldReference)
+                  skip: FieldReference,
+                  cursors: FieldReference,
+                  nodeCursor: FieldReference,
+                  propertyCursor: FieldReference,
+                  dataRead: FieldReference)

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedMethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedMethodStructure.scala
@@ -1347,8 +1347,14 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
     val local = locals(predVar)
 
     handleEntityNotFound(generator, fields, _finalizers) { inner =>
-      val invoke = Expression.invoke(readOperations, nodeHasLabel, inner.load(nodeVar), inner.load(labelVar))
-      inner.assign(local, invoke)
+      val invoked =
+        invoke(
+          methodReference(typeRef[CompiledCursorUtils],
+                          typeRef[Boolean], "nodeHasLabel",
+                          typeRef[Read], typeRef[NodeCursor], typeRef[Long],
+                          typeRef[Int]),
+          dataRead, nodeCursor, inner.load(nodeVar), inner.load(labelVar))
+      inner.assign(local, invoked)
       generator.load(predVar)
     } { fail =>
       fail.assign(local, constant(false))

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedMethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedMethodStructure.scala
@@ -43,7 +43,7 @@ import org.neo4j.cypher.internal.util.v3_4.{ParameterNotFoundException, symbols}
 import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection
 import org.neo4j.cypher.internal.v3_4.logical.plans.LogicalPlanId
 import org.neo4j.graphdb.{Direction, Node, Relationship}
-import org.neo4j.internal.kernel.api.{CursorFactory, IndexQuery, NodeCursor, Read}
+import org.neo4j.internal.kernel.api._
 import org.neo4j.kernel.api.ReadOperations
 import org.neo4j.kernel.api.schema.LabelSchemaDescriptor
 import org.neo4j.kernel.api.schema.index.{IndexDescriptor, IndexDescriptorFactory}
@@ -558,6 +558,9 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
 
   private def nodeCursor: Expression =
     invoke(generator.self(), methodReference(generator.owner(), typeRef[NodeCursor], "nodeCursor"))
+
+  private def propertyCursor: Expression =
+    invoke(generator.self(), methodReference(generator.owner(), typeRef[PropertyCursor], "propertyCursor"))
 
   private def readOperations: Expression =
     invoke(generator.self(), getOrLoadReadOperations)
@@ -1388,7 +1391,12 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
       body.assign(local,
                   invoke(
                     reboxValue,
-                    invoke(readOperations, nodeGetProperty, forceLong(nodeVar, nodeVarType), body.load(propIdVar))
+                    invoke(
+                      methodReference(typeRef[CompiledCursorUtils],
+                                      typeRef[Value], "nodeGetProperty",
+                                      typeRef[Read], typeRef[NodeCursor], typeRef[Long],
+                                      typeRef[PropertyCursor], typeRef[Int]),
+                      dataRead, nodeCursor, forceLong(nodeVar, nodeVarType), propertyCursor, body.load(propIdVar))
                   ))
     } { fail =>
       fail.assign(local, constant(null))
@@ -1401,7 +1409,12 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
       body.assign(local,
                   invoke(
                     reboxValue,
-                    invoke(readOperations, nodeGetProperty, forceLong(nodeVar, nodeVarType), constant(propId))
+                    invoke(
+                      methodReference(typeRef[CompiledCursorUtils],
+                                      typeRef[Value], "nodeGetProperty",
+                                      typeRef[Read], typeRef[NodeCursor], typeRef[Long],
+                                      typeRef[PropertyCursor], typeRef[Int]),
+                      dataRead, nodeCursor, forceLong(nodeVar, nodeVarType),  propertyCursor, constant(propId))
                   ))
     }{ fail =>
       fail.assign(local, constant(null))

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_4/GeneratedMethodStructureTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_4/GeneratedMethodStructureTest.scala
@@ -201,8 +201,8 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
     Operation("expand from all node", (m) => {
       m.createRelExtractor("r")
       m.allNodesScan("nodeIter")
-      m.whileLoop(m.hasNextNode("nodeIter")) { b1 =>
-        b1.nextNode("node", "nodeIter")
+      m.whileLoop(m.advanceNodeCursor("nodeIter")) { b1 =>
+        b1.nodeFromNodeCursor("node", "nodeIter")
         b1.nodeGetRelationshipsWithDirection("relIter", "node", CodeGenType.primitiveInt, SemanticDirection.OUTGOING)
         b1.whileLoop(b1.hasNextRelationship("relIter")) { b2 =>
           b2.nextRelationshipAndNode("nextNode", "relIter", SemanticDirection.OUTGOING, "node", "r")
@@ -249,7 +249,9 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
       using(body.generate(MethodDeclaration.method(typeRef[Unit], "foo"))) { methodBody =>
         block(new GeneratedMethodStructure(fields, methodBody, new AuxGenerator(packageName, codeGen)))
       }
+      Templates.getOrLoadDataRead(body, fields)
       Templates.getOrLoadReadOperations(body, fields)
+      Templates.getOrLoadCursors(body, fields)
       Templates.nodeCursor(body, fields)
       Templates.propertyCursor(body, fields)
       body.handle()

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_4/GeneratedMethodStructureTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_4/GeneratedMethodStructureTest.scala
@@ -24,20 +24,21 @@ import java.util
 import org.neo4j.codegen.bytecode.ByteCode
 import org.neo4j.codegen.source.SourceCode
 import org.neo4j.codegen.{CodeGenerationStrategy, CodeGenerator, Expression, MethodDeclaration}
-import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.codegen.CodeGenContext
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.codegen.ir.expressions.{CodeGenType, CypherCodeGenType, ReferenceType}
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.codegen.spi._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan.{Completable, Provider}
 import org.neo4j.cypher.internal.frontend.v3_4.helpers._
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.SemanticTable
-import org.neo4j.cypher.internal.runtime.{ExecutionMode, QueryContext}
 import org.neo4j.cypher.internal.runtime.planDescription.InternalPlanDescription
-import org.neo4j.cypher.internal.util.v3_4.{TaskCloser, symbols}
+import org.neo4j.cypher.internal.runtime.{ExecutionMode, QueryContext}
 import org.neo4j.cypher.internal.spi.v3_4.codegen.GeneratedQueryStructure.typeRef
 import org.neo4j.cypher.internal.spi.v3_4.codegen.{GeneratedMethodStructure, Methods, _}
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.util.v3_4.{TaskCloser, symbols}
 import org.neo4j.cypher.internal.v3_4.codegen.QueryExecutionTracer
 import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection
+import org.neo4j.internal.kernel.api.{CursorFactory, NodeCursor, PropertyCursor, Read}
 import org.neo4j.kernel.api.ReadOperations
 import org.neo4j.kernel.impl.api.store.RelationshipIterator
 import org.neo4j.kernel.impl.core.NodeManager
@@ -237,13 +238,20 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
         params = body.field(typeRef[util.Map[String, Object]], "params"),
         closeable = body.field(typeRef[Completable], "closeable"),
         queryContext = body.field(typeRef[QueryContext], "queryContext"),
-        skip = body.field(typeRef[Boolean], "skip"))
+        skip = body.field(typeRef[Boolean], "skip"),
+        cursors = body.field(typeRef[CursorFactory], "cursors"),
+        nodeCursor = body.field(typeRef[NodeCursor], "nodeCursor"),
+        propertyCursor = body.field(typeRef[PropertyCursor], "propertyCursor"),
+        dataRead = body.field(typeRef[Read], "dataRead")
+      )
       // the "COLUMNS" static field
       body.staticField(typeRef[util.List[String]], "COLUMNS", Templates.asList[String](Seq.empty))
       using(body.generate(MethodDeclaration.method(typeRef[Unit], "foo"))) { methodBody =>
         block(new GeneratedMethodStructure(fields, methodBody, new AuxGenerator(packageName, codeGen)))
       }
       Templates.getOrLoadReadOperations(body, fields)
+      Templates.nodeCursor(body, fields)
+      Templates.propertyCursor(body, fields)
       body.handle()
     }
     clazz.newInstance()

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/ir/CompiledProfilingTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/v3_4/codegen/ir/CompiledProfilingTest.scala
@@ -21,7 +21,6 @@ package org.neo4j.cypher.internal.compiled_runtime.v3_4.codegen.ir
 
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.neo4j.collection.primitive.PrimitiveLongIterator
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.codegen.Variable
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.codegen.ir.expressions.{CodeGenType, NodeProjection}
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.codegen.ir.{AcceptVisitor, ScanAllNodes, WhileLoop}
@@ -40,8 +39,8 @@ import org.neo4j.cypher.internal.v3_4.expressions.SignedDecimalIntegerLiteral
 import org.neo4j.cypher.internal.v3_4.logical.plans
 import org.neo4j.cypher.internal.v3_4.logical.plans._
 import org.neo4j.internal.kernel.api.Transaction.Type
+import org.neo4j.internal.kernel.api.{CursorFactory, StubNodeCursor, StubRead}
 import org.neo4j.io.pagecache.tracing.cursor.DefaultPageCursorTracer
-import org.neo4j.kernel.api._
 import org.neo4j.kernel.api.security.AnonymousContext
 import org.neo4j.kernel.impl.core.{NodeManager, NodeProxy}
 import org.neo4j.test.TestGraphDatabaseFactory
@@ -59,25 +58,21 @@ class CompiledProfilingTest extends CypherFunSuite with CodeGenSugar {
       ScanAllNodes("OP1"), AcceptVisitor("OP2", Map("n" -> projectNode)))),
       Seq("n"), Map("OP1" -> id1, "OP2" -> id2, "X" -> LogicalPlanId.DEFAULT))
 
-    val readOps = mock[ReadOperations]
+    val cursors = mock[CursorFactory]
+    val dataRead = new StubRead
+    val nodeCursor = new StubNodeCursor
+    nodeCursor.withNode(1)
+    nodeCursor.withNode(2)
+    when(cursors.allocateNodeCursor()).thenReturn(nodeCursor)
     val entityAccessor = mock[NodeManager]
     val queryContext = mock[QueryContext]
     val transactionalContext = mock[TransactionalContextWrapper]
     when(queryContext.transactionalContext).thenReturn(transactionalContext.asInstanceOf[QueryTransactionalContext])
     when(transactionalContext.kernelStatisticProvider).thenReturn(new DelegatingKernelStatisticProvider(new DefaultPageCursorTracer))
-    when(transactionalContext.readOperations).thenReturn(readOps)
+    when(transactionalContext.cursors).thenReturn(cursors)
+    when(transactionalContext.dataRead).thenReturn(dataRead)
     when(entityAccessor.newNodeProxyById(anyLong())).thenReturn(mock[NodeProxy])
     when(queryContext.entityAccessor).thenReturn(entityAccessor)
-    when(readOps.nodesGetAll()).thenReturn(new PrimitiveLongIterator {
-      private var counter = 0
-
-      override def next(): Long = counter
-
-      override def hasNext: Boolean = {
-        counter += 1
-        counter < 3
-      }
-    })
 
     val provider = new Provider[InternalPlanDescription] {
       override def get(): InternalPlanDescription =


### PR DESCRIPTION
This PR changes to use the new API for:
- `AllNodesScan`
- `nodeGetProperty`
- `nodeHasLabel`

from the compiled runtime.