### PR TITLE
Only count the locks acquired by the current query

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/kernel/api/query/ExecutingQueryStatusTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/query/ExecutingQueryStatusTest.java
@@ -100,7 +100,7 @@ public class ExecutingQueryStatusTest
                                 null,
                                 null,
                                 null,
-                                null,
+                                (/*activeLockCount:*/) -> 0,
                                 PageCursorTracer.NULL,
                                 Thread.currentThread().getId(),
                                 Thread.currentThread().getName(),


### PR DESCRIPTION
Previously the active lock count from `dbms.listQueries()` would return the lock count of the current transaction. This makes it so that it only returns the lock count from the current query.

It might, however, not count locks that have been re-entered from a previous query in the same transaction.