### PR TITLE
Properly handle STARTS WITH null

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_2/TransactionBoundQueryContext.scala
@@ -30,11 +30,11 @@ import org.neo4j.cypher.internal.compiler.v3_2._
 import org.neo4j.cypher.internal.compiler.v3_2.ast.convert.commands.DirectionConverter.toGraphDb
 import org.neo4j.cypher.internal.compiler.v3_2.commands.expressions
 import org.neo4j.cypher.internal.compiler.v3_2.commands.expressions.{KernelPredicate, OnlyDirectionExpander, TypeAndDirectionExpander, UserDefinedAggregator}
-import org.neo4j.cypher.internal.helpers.JavaConversionSupport
-import org.neo4j.cypher.internal.helpers.JavaConversionSupport._
 import org.neo4j.cypher.internal.compiler.v3_2.pipes.matching.PatternNode
 import org.neo4j.cypher.internal.compiler.v3_2.spi._
 import org.neo4j.cypher.internal.frontend.v3_2._
+import org.neo4j.cypher.internal.helpers.JavaConversionSupport
+import org.neo4j.cypher.internal.helpers.JavaConversionSupport._
 import org.neo4j.cypher.internal.spi.BeansAPIRelationshipIterator
 import org.neo4j.cypher.internal.spi.v3_2.TransactionBoundQueryContext.IndexSearchMonitor
 import org.neo4j.cypher.javacompat.internal.GraphDatabaseCypherService
@@ -145,6 +145,7 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
 
   override def indexSeekByRange(index: IndexDescriptor, value: Any) = value match {
 
+    case PrefixRange(null) => Iterator.empty
     case PrefixRange(prefix: String) =>
       indexSeekByPrefixRange(index, prefix)
     case range: InequalitySeekRange[Any] =>

--- a/enterprise/cypher/acceptance-spec-suite/src/test/java/cypher/AcceptanceSpecSuiteTest.java
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/java/cypher/AcceptanceSpecSuiteTest.java
@@ -24,7 +24,12 @@ import cucumber.api.junit.Cucumber;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 
-import static cypher.SpecSuiteConstants.*;
+import static cypher.SpecSuiteConstants.BLACKLIST_PLUGIN;
+import static cypher.SpecSuiteConstants.CYPHER_OPTION_PLUGIN;
+import static cypher.SpecSuiteConstants.DB_CONFIG;
+import static cypher.SpecSuiteConstants.GLUE_PATH;
+import static cypher.SpecSuiteConstants.HTML_REPORT;
+import static cypher.SpecSuiteConstants.JSON_REPORT;
 
 @RunWith( Enclosed.class )
 public class AcceptanceSpecSuiteTest

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
@@ -62,3 +62,6 @@ Ordering for lists, descending
 
 //SkipLimitAcceptance.feature - Unsupported limit syntax
 Negative parameter for LIMIT should not generate errors
+
+//IndexAcceptance.feature
+STARTS WITH should handle null prefix

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-31.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-31.txt
@@ -9,3 +9,6 @@ Ordering for lists, descending
 Shorthand case with filter should work as expected
 equality with boolean lists
 optional equality with boolean lists
+
+//IndexAcceptance.feature
+ STARTS WITH should handle null prefix

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -48,6 +48,7 @@ Works with indexed and unindexed property
 Works with two indexed properties
 Should be able to merge using property from match with index
 Merge with an index must properly handle multiple labels
+STARTS WITH should handle null prefix
 Filter on path nodes
 Using a single bound node
 Using a longer pattern

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/IndexAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/IndexAcceptance.feature
@@ -18,7 +18,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-Feature: ConstraintAcceptance
+Feature: IndexAcceptance
 
   Scenario: Handling numerical literal on the left when using an index
     Given an empty graph
@@ -167,4 +167,25 @@ Feature: ConstraintAcceptance
       | +nodes      | 1 |
       | +labels     | 2 |
       | +properties | 1 |
+
+  Scenario: STARTS WITH should handle null prefix
+    Given an empty graph
+    And having executed:
+      """
+      CREATE INDEX ON :Person(name)
+      """
+    And having executed:
+      """
+      CREATE (:Person {name: 'Jack'})
+      CREATE (:Person {name: 'Jill'})
+      """
+    When executing query:
+      """
+      MATCH (p:Person)
+      WHERE p.name STARTS WITH null
+      RETURN p
+      """
+    Then the result should be:
+      | p                             |
+    And no side effects
 


### PR DESCRIPTION
Queries like `MATCH (n:N) WHERE n.prop STARTS WITH null RETURN n`
should return empty and not throw a `NullPointerException`

changelog: `STARTS WITH null` should not throw an error