### PR TITLE
Move downloader service last again

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
@@ -140,8 +140,7 @@ public class EnterpriseCoreEditionModule extends EditionModule
     public void registerEditionSpecificProcedures( Procedures procedures ) throws KernelException
     {
         procedures.registerProcedure( EnterpriseBuiltInDbmsProcedures.class, true );
-        procedures.register(
-                new LegacyGetServersProcedure( topologyService, consensusModule.raftMachine(), config, logProvider ) );
+        procedures.register( new LegacyGetServersProcedure( topologyService, consensusModule.raftMachine(), config, logProvider ) );
 
         if ( config.get( CausalClusteringSettings.multi_dc_license ) )
         {
@@ -244,11 +243,11 @@ public class EnterpriseCoreEditionModule extends EditionModule
         this.commitProcessFactory = coreStateMachinesModule.commitProcessFactory;
         this.accessCapability = new LeaderCanWrite( consensusModule.raftMachine() );
 
-        RaftServerModule raftServerModule = new RaftServerModule( platformModule, consensusModule, identityModule, localDatabase, clusterSslPolicy, monitors,
-                messageLogger );
-
         CoreServerModule coreServerModule = new CoreServerModule( identityModule, platformModule, consensusModule, coreStateMachinesModule, clusteringModule,
-                replicationModule, raftServerModule, localDatabase, databaseHealthSupplier, clusterSslPolicy, clusterStateDirectory.get() );
+                replicationModule, localDatabase, databaseHealthSupplier, clusterSslPolicy, clusterStateDirectory.get() );
+
+        new RaftServerModule( platformModule, consensusModule, identityModule, coreServerModule, localDatabase, clusterSslPolicy, monitors,
+                messageLogger );
 
         editionInvariants( platformModule, dependencies, config, logging, life );
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/RaftServerModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/RaftServerModule.java
@@ -55,8 +55,8 @@ public class RaftServerModule
     private final MessageLogger<MemberId> messageLogger;
     private final LogProvider logProvider;
 
-    RaftServerModule( PlatformModule platformModule, ConsensusModule consensusModule, IdentityModule identityModule, LocalDatabase localDatabase,
-            SslPolicy sslPolicy, Monitors monitors, MessageLogger<MemberId> messageLogger )
+    RaftServerModule( PlatformModule platformModule, ConsensusModule consensusModule, IdentityModule identityModule, CoreServerModule coreServerModule,
+            LocalDatabase localDatabase, SslPolicy sslPolicy, Monitors monitors, MessageLogger<MemberId> messageLogger )
     {
         this.platformModule = platformModule;
         this.consensusModule = consensusModule;
@@ -66,10 +66,7 @@ public class RaftServerModule
         this.monitors = monitors;
         this.messageLogger = messageLogger;
         this.logProvider = platformModule.logging.getInternalLogProvider();
-    }
 
-    public void create( CoreServerModule coreServerModule )
-    {
         LifecycleMessageHandler<ReceivedInstantClusterIdAwareMessage> messageHandlerChain = createMessageHandlerChain( coreServerModule );
 
         createRaftServer( coreServerModule, messageHandlerChain );
@@ -87,6 +84,7 @@ public class RaftServerModule
         platformModule.life.add( raftServer ); // must start before core state so that it can trigger snapshot downloads when necessary
         platformModule.life.add( coreServerModule.createCoreLife( messageHandlerChain ) );
         platformModule.life.add( coreServerModule.catchupServer() ); // must start last and stop first, since it handles external requests
+        platformModule.life.add( coreServerModule.downloadService() );
     }
 
     private LifecycleMessageHandler<ReceivedInstantClusterIdAwareMessage> createMessageHandlerChain( CoreServerModule coreServerModule )


### PR DESCRIPTION
It was moved by mistake in a merge conflict.

Also removed a circular dependency between Raft and CoreServer
modules.