### PR TITLE
Checking parameter list explicitly

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
@@ -113,7 +113,7 @@ class ExecutionEngine(val queryService: GraphDatabaseQueryService,
   }
 
   def execute(query: String, mapParams: MapValue, context: TransactionalContext): Result = {
-    val (preparedPlanExecution: PreparedPlanExecution, wrappedContext, queryParamNames) = planQuery(context)
+    val (preparedPlanExecution, wrappedContext, queryParamNames) = planQuery(context)
     checkParameters(queryParamNames, mapParams, preparedPlanExecution.extractedParams)
     preparedPlanExecution.execute(wrappedContext, mapParams)
   }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
@@ -221,11 +221,18 @@ class ExecutionEngine(val queryService: GraphDatabaseQueryService,
   @throws(classOf[ParameterNotFoundException])
   private def checkParameters(queryParams: Seq[String], givenParams: MapValue, extractedParams: Map[String, Any]) {
     exceptionHandler.runSafely {
-      queryParams.foreach( key => {
+      val missingKeys = StringBuilder.newBuilder
+      queryParams.foreach(key => {
         if (!givenParams.containsKey(key) && !extractedParams.contains(key)) {
-          throw new ParameterNotFoundException("Expected a parameter named " + key)
+          if (missingKeys.size > 0) {
+            missingKeys.append(", ")
+          }
+          missingKeys.append(key)
         }
       })
+      if (missingKeys.size > 0) {
+        throw new ParameterNotFoundException("Expected parameter(s): " + missingKeys)
+      }
     }
   }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
@@ -114,7 +114,9 @@ class ExecutionEngine(val queryService: GraphDatabaseQueryService,
 
   def execute(query: String, mapParams: MapValue, context: TransactionalContext): Result = {
     val (preparedPlanExecution, wrappedContext, queryParamNames) = planQuery(context)
-    checkParameters(queryParamNames, mapParams, preparedPlanExecution.extractedParams)
+    if (preparedPlanExecution.executionMode.name != "explain") {
+      checkParameters(queryParamNames, mapParams, preparedPlanExecution.extractedParams)
+    }
     preparedPlanExecution.execute(wrappedContext, mapParams)
   }
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ExecutionEngine.scala
@@ -223,17 +223,9 @@ class ExecutionEngine(val queryService: GraphDatabaseQueryService,
   @throws(classOf[ParameterNotFoundException])
   private def checkParameters(queryParams: Seq[String], givenParams: MapValue, extractedParams: Map[String, Any]) {
     exceptionHandler.runSafely {
-      val missingKeys = StringBuilder.newBuilder
-      queryParams.foreach(key => {
-        if (!givenParams.containsKey(key) && !extractedParams.contains(key)) {
-          if (missingKeys.size > 0) {
-            missingKeys.append(", ")
-          }
-          missingKeys.append(key)
-        }
-      })
-      if (missingKeys.size > 0) {
-        throw new ParameterNotFoundException("Expected parameter(s): " + missingKeys)
+      val missingKeys = queryParams.filter(key => !(givenParams.containsKey(key) || extractedParams.contains(key)))
+      if (missingKeys.nonEmpty) {
+        throw new ParameterNotFoundException("Expected parameter(s): " + missingKeys.mkString(", "))
       }
     }
   }

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ParsedQuery.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/ParsedQuery.scala
@@ -26,7 +26,7 @@ import scala.util.Try
 
 trait ParsedQuery {
   protected def trier: Try[{ def isPeriodicCommit: Boolean }]
-  def plan(transactionContext: TransactionalContextWrapper, tracer: CompilationPhaseTracer): (ExecutionPlan, Map[String, Any])
+  def plan(transactionContext: TransactionalContextWrapper, tracer: CompilationPhaseTracer): (ExecutionPlan, Map[String, Any], Seq[String])
   final def isPeriodicCommit: Boolean = trier.map(_.isPeriodicCommit).getOrElse(false)
   final def hasErrors: Boolean = trier.isFailure
   final def onError[T](f: Throwable => T): Option[T] = trier.failed.toOption.map(f)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v2_3/Compatibility.scala
@@ -79,7 +79,7 @@ trait Compatibility {
                                 Some(as2_3(preParsedQuery.offset)), tracer))
     new ParsedQuery {
       def plan(transactionalContext: TransactionalContextWrapper,
-               tracer: v3_3.phases.CompilationPhaseTracer): (org.neo4j.cypher.internal.ExecutionPlan, Map[String, Any]) = exceptionHandler
+               tracer: v3_3.phases.CompilationPhaseTracer): (org.neo4j.cypher.internal.ExecutionPlan, Map[String, Any], Seq[String]) = exceptionHandler
         .runSafely {
           val planContext: PlanContext = new TransactionBoundPlanContext(transactionalContext)
           val (planImpl, extractedParameters) = compiler
@@ -88,7 +88,7 @@ trait Compatibility {
           // Log notifications/warnings from planning
           planImpl.notifications(planContext).foreach(notificationLogger += _)
 
-          (new ExecutionPlanWrapper(planImpl, preParsingNotifications, as2_3(preParsedQuery.offset)), extractedParameters)
+          (new ExecutionPlanWrapper(planImpl, preParsingNotifications, as2_3(preParsedQuery.offset)), extractedParameters, Seq.empty[String])
         }
 
       override protected val trier = preparedQueryForV_2_3

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_1/Compatibility.scala
@@ -77,7 +77,7 @@ trait Compatibility {
     new ParsedQuery {
       override def plan(transactionalContext: TransactionalContextWrapperV3_3,
                         tracer: frontend.v3_3.phases.CompilationPhaseTracer):
-      (ExecutionPlan, Map[String, Any]) =
+      (ExecutionPlan, Map[String, Any], Seq[String]) =
         exceptionHandler.runSafely {
           val tc = TransactionalContextWrapperV3_1(transactionalContext.tc)
           val planContext = new ExceptionTranslatingPlanContext(new TransactionBoundPlanContext(tc, notificationLogger))
@@ -89,7 +89,7 @@ trait Compatibility {
           // Log notifications/warnings from planning
           planImpl.notifications(planContext).foreach(notificationLogger += _)
 
-          (new ExecutionPlanWrapper(planImpl, preParsingNotifications, as3_1(preParsedQuery.offset)), extractedParameters)
+          (new ExecutionPlanWrapper(planImpl, preParsingNotifications, as3_1(preParsedQuery.offset)), extractedParameters, Seq.empty[String])
         }
 
       override protected val trier: Try[PreparedQuerySyntax] = preparedSyntacticQueryForV_3_1

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/Compatibility.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_2/Compatibility.scala
@@ -77,7 +77,7 @@ trait Compatibility[C <: CompilerContext] {
     new ParsedQuery {
       override def plan(transactionalContext: TransactionalContextWrapperV3_3,
                         tracer: frontend.v3_3.phases.CompilationPhaseTracer):
-      (ExecutionPlan, Map[String, Any]) = exceptionHandler.runSafely {
+      (ExecutionPlan, Map[String, Any], Seq[String]) = exceptionHandler.runSafely {
         val tc = TransactionalContextWrapperV3_2(transactionalContext.tc)
         val planContext = new ExceptionTranslatingPlanContext(new TransactionBoundPlanContext(tc, notificationLogger))
         val syntacticQuery = preparedSyntacticQueryForV_3_2.get
@@ -98,7 +98,7 @@ trait Compatibility[C <: CompilerContext] {
           pos3_2,
           searchMonitor,
           executionMonitor)
-        (executionPlanWrapper, extractedParameters)
+        (executionPlanWrapper, extractedParameters, Seq.empty[String])
       }
 
       override protected val trier: Try[BaseState] = preparedSyntacticQueryForV_3_2

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -84,7 +84,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
         |MATCH (rfq:Study_Dataset:RFQ) WHERE (rfq IN datasets)
         |OPTIONAL MATCH (wasi:Study_Dataset:WASI) WHERE (wasi IN datasets)
         |OPTIONAL MATCH (ypq:Study_Dataset:YPQ) WHERE (ypq IN datasets)
-        |RETURN DISTINCT derivedData AS DerivedData, subject , stai, pswq, pss, njre_q_r, iu, gad_7, fmps, bdi, wdq, treasurehunt, scid_v2, ybocs, bis, sdq, ehi, oci_r, pi_wsur, rfq, wasi, ypq""".stripMargin, Map.empty)
+        |RETURN DISTINCT derivedData AS DerivedData, subject , stai, pswq, pss, njre_q_r, iu, gad_7, fmps, bdi, wdq, treasurehunt, scid_v2, ybocs, bis, sdq, ehi, oci_r, pi_wsur, rfq, wasi, ypq""".stripMargin, Map("studyUUID" -> 1))
   }
 
   test("Should not use both pruning var expand and projections that need path info") {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekByRangeAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekByRangeAcceptanceTest.scala
@@ -1051,7 +1051,7 @@ class NodeIndexSeekByRangeAcceptanceTest extends ExecutionEngineFunSuite with Cy
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperators(IndexSeekByRange.name)
-      }, Configs.AllRulePlanners))
+      }, Configs.AllRulePlanners), params = Map("param" -> Array[Int](1, 2, 3)))
     result.toList should be(empty)
 
     an[IllegalArgumentException] should be thrownBy {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ParameterValuesAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ParameterValuesAcceptanceTest.scala
@@ -156,5 +156,14 @@ class ParameterValuesAcceptanceTest extends ExecutionEngineFunSuite with CypherC
     failWithError(config, "CREATE (n:Person) WITH n MATCH (n:Person {name:{name}}) RETURN n", Seq("Expected parameter(s): name"), params = "nam" -> "Neo")
   }
 
+  test("explain with missing parameter should NOT return error for empty db") {
+    val config = Configs.All
+    executeWith(config, "EXPLAIN MATCH (n:Person {name:{name}}) RETURN n")
+  }
+
+  test("explain with missing parameter should NOT return error for non-empty db") {
+    val config = Configs.Interpreted - Configs.Cost2_3
+    executeWith(config, "EXPLAIN CREATE (n:Person) WITH n MATCH (n:Person {name:{name}}) RETURN n")
+  }
 
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ParameterValuesAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ParameterValuesAcceptanceTest.scala
@@ -124,23 +124,37 @@ class ParameterValuesAcceptanceTest extends ExecutionEngineFunSuite with CypherC
     // all versions of 3.3
     val config = Configs.Version3_3 + Configs.Procs - Configs.AllRulePlanners
 
-    failWithError(config, "MATCH (n:Person {name:{name}}) RETURN n", Seq("Expected a parameter named name"))
+    failWithError(config, "MATCH (n:Person {name:{name}}) RETURN n", Seq("Expected parameter(s): name"))
   }
 
   test("match with missing parameter should return error for non-empty db") {
-    val config = Configs.AbsolutelyAll - Configs.Compiled - Configs.Cost2_3
-    failWithError(config, "CREATE (n:Person) WITH n MATCH (n:Person {name:{name}}) RETURN n", Seq("Expected a parameter named name"))
+    val config = Configs.Version3_3 + Configs.Procs - Configs.AllRulePlanners - Configs.Compiled
+    failWithError(config, "CREATE (n:Person) WITH n MATCH (n:Person {name:{name}}) RETURN n", Seq("Expected parameter(s): name"))
+  }
+
+  test("match with multiple missing parameters should return error for empty db") {
+    // all versions of 3.3
+    val config = Configs.Version3_3 + Configs.Procs - Configs.AllRulePlanners
+
+    failWithError(config, "MATCH (n:Person {name:{name}, age:{age}}) RETURN n", Seq("Expected parameter(s): name, age"))
+  }
+
+  test("match with multiple missing parameters should return error for non-empty db") {
+    val config = Configs.Version3_3 + Configs.Procs - Configs.AllRulePlanners - Configs.Compiled
+    failWithError(config, "CREATE (n:Person) WITH n MATCH (n:Person {name:{name}, age:{age}}) RETURN n", Seq("Expected parameter(s): name, age"))
   }
 
   test("match with misspelled parameter should return error for empty db") {
     // all versions of 3.3
     val config = Configs.Version3_3 + Configs.Procs - Configs.AllRulePlanners
 
-    failWithError(config, "MATCH (n:Person {name:{name}}) RETURN n", Seq("Expected a parameter named name"), params = "nam" -> "Neo")
+    failWithError(config, "MATCH (n:Person {name:{name}}) RETURN n", Seq("Expected parameter(s): name"), params = "nam" -> "Neo")
   }
 
   test("match with misspelled parameter should return error for non-empty db") {
-    val config = Configs.AbsolutelyAll - Configs.Compiled - Configs.Cost2_3
-    failWithError(config, "CREATE (n:Person) WITH n MATCH (n:Person {name:{name}}) RETURN n", Seq("Expected a parameter named name"), params = "nam" -> "Neo")
+    val config = Configs.Version3_3 + Configs.Procs - Configs.AllRulePlanners - Configs.Compiled
+    failWithError(config, "CREATE (n:Person) WITH n MATCH (n:Person {name:{name}}) RETURN n", Seq("Expected parameter(s): name"), params = "nam" -> "Neo")
   }
+
+
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ParameterValuesAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ParameterValuesAcceptanceTest.scala
@@ -119,4 +119,28 @@ class ParameterValuesAcceptanceTest extends ExecutionEngineFunSuite with CypherC
       r.hasProperty("name") should equal(false)
     }
   }
+
+  test("match with missing parameter should return error for empty db") {
+    // all versions of 3.3
+    val config = Configs.Version3_3 + Configs.Procs - Configs.AllRulePlanners
+
+    failWithError(config, "MATCH (n:Person {name:{name}}) RETURN n", Seq("Expected a parameter named name"))
+  }
+
+  test("match with missing parameter should return error for non-empty db") {
+    val config = Configs.AbsolutelyAll - Configs.Compiled - Configs.Cost2_3
+    failWithError(config, "CREATE (n:Person) WITH n MATCH (n:Person {name:{name}}) RETURN n", Seq("Expected a parameter named name"))
+  }
+
+  test("match with misspelled parameter should return error for empty db") {
+    // all versions of 3.3
+    val config = Configs.Version3_3 + Configs.Procs - Configs.AllRulePlanners
+
+    failWithError(config, "MATCH (n:Person {name:{name}}) RETURN n", Seq("Expected a parameter named name"), params = "nam" -> "Neo")
+  }
+
+  test("match with misspelled parameter should return error for non-empty db") {
+    val config = Configs.AbsolutelyAll - Configs.Compiled - Configs.Cost2_3
+    failWithError(config, "CREATE (n:Person) WITH n MATCH (n:Person {name:{name}}) RETURN n", Seq("Expected a parameter named name"), params = "nam" -> "Neo")
+  }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/QueryPlanCompactionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/QueryPlanCompactionAcceptanceTest.scala
@@ -792,7 +792,8 @@ class QueryPlanCompactionAcceptanceTest extends ExecutionEngineFunSuite with Que
         || +LoadCSV                |              1 | line                      |                       |
         |+-------------------------+----------------+---------------------------+-----------------------+
         |""".stripMargin
-    executeWith(expectedToSucceed - Configs.SlottedInterpreted, query, planComparisonStrategy = ComparePlansWithAssertion(_ should matchPlan(expectedPlan), expectPlansToFail = Configs.All - Configs.Cost3_3))
+    executeWith(expectedToSucceed - Configs.SlottedInterpreted, query, planComparisonStrategy = ComparePlansWithAssertion(_ should matchPlan(expectedPlan),
+                expectPlansToFail = Configs.All - Configs.Cost3_3), params = Map("csv_filename" -> "x"))
   }
 
   test("Don't compact query with consecutive expands due to presence of values in 'other' column") {

--- a/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/SpecSuiteErrorHandler.scala
+++ b/enterprise/cypher/spec-suite-tools/src/test/scala/cypher/feature/steps/SpecSuiteErrorHandler.scala
@@ -183,6 +183,8 @@ case class SpecSuiteErrorHandler(typ: String, phase: String, detail: String) ext
       detail should equal("InvalidNumberOfArguments")
     else if (msg.matches("Expected a parameter named .+"))
       detail should equal("MissingParameter")
+    else if (msg.matches("Expected parameter\\(s\\): .+"))
+      detail should equal("MissingParameter")
     else if (msg.startsWith("Procedure call cannot take an aggregating function as argument, please add a 'WITH' to your statement."))
       detail should equal("InvalidAggregation")
     else if (msg.startsWith("Procedure call inside a query does not support passing arguments implicitly (pass explicitly after procedure name instead)"))

--- a/integrationtests/src/test/java/org/neo4j/causalclustering/scenarios/BoltCausalClusteringIT.java
+++ b/integrationtests/src/test/java/org/neo4j/causalclustering/scenarios/BoltCausalClusteringIT.java
@@ -405,7 +405,7 @@ public class BoltCausalClusteringIT
                 try
                 {
                     switchLeader( leader );
-                    session.run( "CREATE (p:Person {name: {name} })" ).consume();
+                    session.run( "CREATE (p:Person {name: {name} })", Values.parameters( "name", "Mark" ) ).consume();
                     fail( "Should have thrown an exception as the leader went away mid session" );
                 }
                 catch ( SessionExpiredException sep )


### PR DESCRIPTION
If a parameters was missing in the parameter list, an error was only thrown if that parameter was used in the execution. This PR introduces to always check the parameter list during planning.

changelog: Fixes #10607 by explicitly checking that all parameters present in the query are also provided in the parameter list