### PR TITLE
Compiled runtime should return String[] not Object[] for properties

### DIFF
--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledConversionUtils.java
@@ -370,6 +370,10 @@ public abstract class CompiledConversionUtils
                 System.arraycopy( anyValue, 0, copy, 0, length );
                 return copy;
             }
+            else if ( anyValue instanceof String[] )
+            {
+                return anyValue;
+            }
             else
             {
                 Object[] copy = new Object[length];

--- a/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionResultTest.java
+++ b/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionResultTest.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.cypher.internal.javacompat;
 
+import org.hamcrest.CoreMatchers;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -136,6 +137,19 @@ public class ExecutionResultTest
             // Then
             // just close result without consuming it
         }
+    }
+
+    @Test
+    public void shouldReturnCorrectArrayType()
+    {
+        // Given
+        db.execute( "CREATE (p:Person {names:['adsf', 'adf' ]})" );
+
+        // When
+        Object result = db.execute( "MATCH (n) RETURN n.names" ).next().get( "n.names" );
+
+        // Then
+        assertThat( result, CoreMatchers.instanceOf( String[].class ) );
     }
 
     private void createNode()


### PR DESCRIPTION
In embedded we need to preserve types so that when we return for

```
CREATE (p:Person {names:['adsf', 'adf' ]})
```

we should return a `String[]`

```
MATCH (n) RETURN n.names
```

changelog: Do not return Object[] when querying for array property in Cypher.