### PR TITLE
Disable channel auto-read when bolt messages are queued up

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
@@ -36,6 +36,7 @@ import org.neo4j.bolt.transport.Netty4LoggerFactory;
 import org.neo4j.bolt.transport.NettyServer;
 import org.neo4j.bolt.transport.NettyServer.ProtocolInitializer;
 import org.neo4j.bolt.transport.SocketTransport;
+import org.neo4j.bolt.v1.runtime.BoltChannelAutoReadLimiter;
 import org.neo4j.bolt.v1.runtime.BoltConnectionDescriptor;
 import org.neo4j.bolt.v1.runtime.BoltFactory;
 import org.neo4j.bolt.v1.runtime.BoltFactoryImpl;
@@ -231,7 +232,9 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
                 {
                     BoltConnectionDescriptor descriptor = new BoltConnectionDescriptor(
                             channel.remoteAddress(), channel.localAddress() );
-                    BoltWorker worker = workerFactory.newWorker( descriptor, channel::close );
+                    BoltChannelAutoReadLimiter limiter =
+                            new BoltChannelAutoReadLimiter( channel, logging.getInternalLog( BoltChannelAutoReadLimiter.class ) );
+                    BoltWorker worker = workerFactory.newWorker( descriptor, limiter, channel::close );
                     return new BoltProtocolV1( worker, channel, logging );
                 }
         );

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltChannelAutoReadLimiter.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltChannelAutoReadLimiter.java
@@ -34,9 +34,6 @@ public class BoltChannelAutoReadLimiter implements BoltWorkerQueueMonitor
     protected static final String LOW_WATERMARK_NAME = "low_watermark";
     protected static final String HIGH_WATERMARK_NAME = "high_watermark";
 
-    private static final int defaultLowWatermark = FeatureToggles.getInteger( BoltChannelAutoReadLimiter.class, LOW_WATERMARK_NAME, 100 );
-    private static final int defaultHighWatermark = FeatureToggles.getInteger( BoltChannelAutoReadLimiter.class, HIGH_WATERMARK_NAME, 300 );
-
     private final AtomicInteger queueSize = new AtomicInteger( 0 );
     private final Channel channel;
     private final Log log;
@@ -45,7 +42,8 @@ public class BoltChannelAutoReadLimiter implements BoltWorkerQueueMonitor
 
     public BoltChannelAutoReadLimiter( Channel channel, Log log )
     {
-        this( channel, log, defaultLowWatermark, defaultHighWatermark );
+        this( channel, log, FeatureToggles.getInteger( BoltChannelAutoReadLimiter.class, LOW_WATERMARK_NAME, 100 ),
+                FeatureToggles.getInteger( BoltChannelAutoReadLimiter.class, HIGH_WATERMARK_NAME, 300 ) );
     }
 
     public BoltChannelAutoReadLimiter( Channel channel, Log log, int lowWatermark, int highWatermark)

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltChannelAutoReadLimiter.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltChannelAutoReadLimiter.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.v1.runtime;
+
+import io.netty.channel.Channel;
+
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.neo4j.logging.Log;
+
+import static java.util.Objects.requireNonNull;
+
+public class BoltChannelAutoReadLimiter implements BoltWorkerQueueMonitor
+{
+    private static final int defaultLowWatermark = Integer.getInteger( "org.neo4j.bolt.autoread.loWatermark", 100 );
+    private static final int defaultHighWatermark = Integer.getInteger( "org.neo4j.bolt.autoread.hiWatermark", 300 );
+
+    private final AtomicInteger queueSize = new AtomicInteger( 0 );
+    private final Channel channel;
+    private final Log log;
+    private final int lowWatermark;
+    private final int highWatermark;
+
+    public BoltChannelAutoReadLimiter( Channel channel, Log log )
+    {
+        this( channel, log, defaultLowWatermark, defaultHighWatermark );
+    }
+
+    public BoltChannelAutoReadLimiter( Channel channel, Log log, int lowWatermark, int highWatermark)
+    {
+        if ( highWatermark <= 0 )
+        {
+            throw new IllegalArgumentException( "invalid highWatermark value" );
+        }
+
+        if ( lowWatermark < 0 || lowWatermark >= highWatermark )
+        {
+            throw new IllegalArgumentException( "invalid lowWatermark value" );
+        }
+
+        this.channel = requireNonNull( channel );
+        this.log = log;
+        this.lowWatermark = lowWatermark;
+        this.highWatermark = highWatermark;
+    }
+
+    @Override
+    public void enqueued( Job job )
+    {
+        checkLimitsOnEnqueue( queueSize.incrementAndGet() );
+    }
+
+    @Override
+    public void dequeued( Job job )
+    {
+        checkLimitsOnDequeue( queueSize.decrementAndGet() );
+    }
+
+    @Override
+    public void drained( Collection<Job> jobs )
+    {
+        checkLimitsOnDequeue( queueSize.addAndGet( -jobs.size() ) );
+    }
+
+    private void checkLimitsOnEnqueue( int currentSize )
+    {
+        if (currentSize > highWatermark && channel.config().isAutoRead())
+        {
+            if (log != null)
+            {
+                log.warn( "Channel [%s]: client produced %d messages on the worker queue, auto-read is being disabled.", channel.id(), currentSize );
+            }
+
+            channel.config().setAutoRead( false );
+        }
+    }
+
+    private void checkLimitsOnDequeue( int currentSize )
+    {
+        if (currentSize <= lowWatermark && !channel.config().isAutoRead())
+        {
+            if (log != null)
+            {
+                log.warn( "Channel [%s]: consumed messages on the worker queue below %d, auto-read is being enabled.", channel.id(), currentSize );
+            }
+
+            channel.config().setAutoRead( true );
+        }
+    }
+
+}

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltChannelAutoReadLimiter.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltChannelAutoReadLimiter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.
@@ -25,13 +25,17 @@ import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.neo4j.logging.Log;
+import org.neo4j.unsafe.impl.internal.dragons.FeatureToggles;
 
 import static java.util.Objects.requireNonNull;
 
 public class BoltChannelAutoReadLimiter implements BoltWorkerQueueMonitor
 {
-    private static final int defaultLowWatermark = Integer.getInteger( "org.neo4j.bolt.autoread.loWatermark", 100 );
-    private static final int defaultHighWatermark = Integer.getInteger( "org.neo4j.bolt.autoread.hiWatermark", 300 );
+    protected static final String LOW_WATERMARK_NAME = "low_watermark";
+    protected static final String HIGH_WATERMARK_NAME = "high_watermark";
+
+    private static final int defaultLowWatermark = FeatureToggles.getInteger( BoltChannelAutoReadLimiter.class, LOW_WATERMARK_NAME, 100 );
+    private static final int defaultHighWatermark = FeatureToggles.getInteger( BoltChannelAutoReadLimiter.class, HIGH_WATERMARK_NAME, 300 );
 
     private final AtomicInteger queueSize = new AtomicInteger( 0 );
     private final Channel channel;
@@ -60,6 +64,16 @@ public class BoltChannelAutoReadLimiter implements BoltWorkerQueueMonitor
         this.log = log;
         this.lowWatermark = lowWatermark;
         this.highWatermark = highWatermark;
+    }
+
+    protected int getLowWatermark()
+    {
+        return lowWatermark;
+    }
+
+    protected int getHighWatermark()
+    {
+        return highWatermark;
     }
 
     @Override

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltWorkerQueueMonitor.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltWorkerQueueMonitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltWorkerQueueMonitor.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltWorkerQueueMonitor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.v1.runtime;
+
+import java.util.Collection;
+
+public interface BoltWorkerQueueMonitor
+{
+
+    void enqueued(Job job);
+
+    void dequeued(Job job);
+
+    void drained(Collection<Job> jobs);
+
+}

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/MonitoredWorkerFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/MonitoredWorkerFactory.java
@@ -45,13 +45,13 @@ public class MonitoredWorkerFactory implements WorkerFactory
     }
 
     @Override
-    public BoltWorker newWorker( BoltConnectionDescriptor connectionDescriptor, Runnable onClose )
+    public BoltWorker newWorker( BoltConnectionDescriptor connectionDescriptor, BoltWorkerQueueMonitor queueMonitor,  Runnable onClose )
     {
         if ( monitors.hasListeners( SessionMonitor.class ) )
         {
-            return new MonitoredBoltWorker( monitor, delegate.newWorker( connectionDescriptor, onClose ), clock );
+            return new MonitoredBoltWorker( monitor, delegate.newWorker( connectionDescriptor, queueMonitor, onClose ), clock );
         }
-        return delegate.newWorker( connectionDescriptor, onClose );
+        return delegate.newWorker( connectionDescriptor, queueMonitor, onClose );
     }
 
     static class MonitoredBoltWorker implements BoltWorker

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/WorkerFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/WorkerFactory.java
@@ -27,13 +27,14 @@ public interface WorkerFactory
 {
     default BoltWorker newWorker( BoltConnectionDescriptor connectionDescriptor )
     {
-        return newWorker( connectionDescriptor, null );
+        return newWorker( connectionDescriptor, null, null );
     }
 
     /**
      * @param connectionDescriptor describes the underlying medium (TCP, HTTP, ...)
+     * @param queueMonitor         object that will be notified of changes (enqueue, dequeue, drain) in worker job queue
      * @param onClose              callback for closing the underlying connection in case of protocol violation.
      * @return a new job queue
      */
-    BoltWorker newWorker( BoltConnectionDescriptor connectionDescriptor, Runnable onClose );
+    BoltWorker newWorker( BoltConnectionDescriptor connectionDescriptor, BoltWorkerQueueMonitor queueMonitor, Runnable onClose );
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/concurrent/RunnableBoltWorker.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/concurrent/RunnableBoltWorker.java
@@ -20,9 +20,11 @@
 package org.neo4j.bolt.v1.runtime.concurrent;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import org.neo4j.bolt.v1.runtime.BoltConnectionAuthFatality;
@@ -30,6 +32,7 @@ import org.neo4j.bolt.v1.runtime.BoltConnectionFatality;
 import org.neo4j.bolt.v1.runtime.BoltProtocolBreachFatality;
 import org.neo4j.bolt.v1.runtime.BoltStateMachine;
 import org.neo4j.bolt.v1.runtime.BoltWorker;
+import org.neo4j.bolt.v1.runtime.BoltWorkerQueueMonitor;
 import org.neo4j.bolt.v1.runtime.Job;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.logging.Log;
@@ -39,21 +42,28 @@ import org.neo4j.logging.Log;
  */
 class RunnableBoltWorker implements Runnable, BoltWorker
 {
-    private static final int workQueueSize = Integer.getInteger( "org.neo4j.bolt.workQueueSize", 100 );
+    private static final int workQueueMaxBatchSize = Integer.getInteger( "org.neo4j.bolt.workQueueMaxBatchSize", 100 );
     static final int workQueuePollDuration =  Integer.getInteger( "org.neo4j.bolt.workQueuePollDuration", 10 );
 
-    private final BlockingQueue<Job> jobQueue = new ArrayBlockingQueue<>( workQueueSize );
+    private final BlockingQueue<Job> jobQueue = new LinkedBlockingQueue<>();
     private final BoltStateMachine machine;
     private final Log log;
     private final Log userLog;
+    private final BoltWorkerQueueMonitor queueMonitor;
 
     private volatile boolean keepRunning = true;
 
     RunnableBoltWorker( BoltStateMachine machine, LogService logging )
     {
+        this( machine, logging, null );
+    }
+
+    RunnableBoltWorker( BoltStateMachine machine, LogService logging, BoltWorkerQueueMonitor queueMonitor )
+    {
         this.machine = machine;
         this.log = logging.getInternalLog( getClass() );
         this.userLog = logging.getUserLog( getClass() );
+        this.queueMonitor = queueMonitor;
     }
 
     /**
@@ -68,6 +78,7 @@ class RunnableBoltWorker implements Runnable, BoltWorker
         try
         {
             jobQueue.put( job );
+            notifyEnqueued( job );
         }
         catch ( InterruptedException e )
         {
@@ -80,7 +91,7 @@ class RunnableBoltWorker implements Runnable, BoltWorker
     @Override
     public void run()
     {
-        List<Job> batch = new ArrayList<>( workQueueSize );
+        List<Job> batch = new ArrayList<>( workQueueMaxBatchSize );
 
         try
         {
@@ -89,11 +100,13 @@ class RunnableBoltWorker implements Runnable, BoltWorker
                 Job job = jobQueue.poll( workQueuePollDuration, TimeUnit.SECONDS );
                 if ( job != null )
                 {
+                    notifyDequeued( job );
                     execute( job );
 
-                    for ( int jobCount = jobQueue.drainTo( batch ); keepRunning && jobCount > 0;
-                          jobCount = jobQueue.drainTo( batch ) )
+                    for ( int jobCount = jobQueue.drainTo( batch, workQueueMaxBatchSize ); keepRunning && jobCount > 0;
+                          jobCount = jobQueue.drainTo( batch, workQueueMaxBatchSize ) )
                     {
+                        notifyDrained( batch );
                         executeBatch( batch );
                     }
                 }
@@ -169,4 +182,29 @@ class RunnableBoltWorker implements Runnable, BoltWorker
             log.error( "Unable to close Bolt session '" + machine.key() + "'", t );
         }
     }
+
+    private void notifyEnqueued( Job job )
+    {
+        if ( queueMonitor != null )
+        {
+            queueMonitor.enqueued( job );
+        }
+    }
+
+    private void notifyDequeued( Job job )
+    {
+        if ( queueMonitor != null )
+        {
+            queueMonitor.dequeued( job );
+        }
+    }
+
+    private void notifyDrained( List<Job> jobs )
+    {
+        if ( queueMonitor != null )
+        {
+            queueMonitor.drained( jobs );
+        }
+    }
+
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/concurrent/ThreadedWorkerFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/concurrent/ThreadedWorkerFactory.java
@@ -25,6 +25,7 @@ import org.neo4j.bolt.v1.runtime.BoltConnectionDescriptor;
 import org.neo4j.bolt.v1.runtime.BoltFactory;
 import org.neo4j.bolt.v1.runtime.BoltStateMachine;
 import org.neo4j.bolt.v1.runtime.BoltWorker;
+import org.neo4j.bolt.v1.runtime.BoltWorkerQueueMonitor;
 import org.neo4j.bolt.v1.runtime.WorkerFactory;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.util.JobScheduler;
@@ -60,10 +61,10 @@ public class ThreadedWorkerFactory implements WorkerFactory
     }
 
     @Override
-    public BoltWorker newWorker( BoltConnectionDescriptor connectionDescriptor, Runnable onClose )
+    public BoltWorker newWorker( BoltConnectionDescriptor connectionDescriptor, BoltWorkerQueueMonitor queueMonitor, Runnable onClose )
     {
         BoltStateMachine machine = connector.newMachine( connectionDescriptor, onClose, clock );
-        RunnableBoltWorker worker = new RunnableBoltWorker( machine, logging );
+        RunnableBoltWorker worker = new RunnableBoltWorker( machine, logging, queueMonitor );
 
         scheduler.schedule( sessionWorker, worker, stringMap( THREAD_ID, machine.key() ) );
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltChannelAutoReadLimiterTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltChannelAutoReadLimiterTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.v1.runtime;
+
+import io.netty.channel.Channel;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.neo4j.logging.Log;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.contains;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class BoltChannelAutoReadLimiterTest
+{
+    private static final Job job = s -> s.run( "INIT", null, null );
+    private Channel channel;
+    private Log log;
+
+    @Before
+    public void setup()
+    {
+        this.channel = new EmbeddedChannel();
+        this.log = mock( Log.class );
+    }
+
+    @Test
+    public void shouldNotDisableAutoReadBelowHighWatermark()
+    {
+        BoltChannelAutoReadLimiter limiter = newLimiter( 1, 2 );
+
+        assertTrue( channel.config().isAutoRead() );
+
+        limiter.enqueued( job );
+
+        assertTrue( channel.config().isAutoRead() );
+        verify( log, never() ).warn( anyString(), any(), any() );
+    }
+
+    @Test
+    public void shouldDisableAutoReadWhenAtHighWatermark()
+    {
+        BoltChannelAutoReadLimiter limiter = newLimiter( 1, 2 );
+
+        assertTrue( channel.config().isAutoRead() );
+
+        limiter.enqueued( job );
+        limiter.enqueued( job );
+        limiter.enqueued( job );
+
+        assertFalse( channel.config().isAutoRead() );
+        verify( log ).warn( contains( "disabled" ), eq( channel.id() ), eq( 3 ) );
+    }
+
+    @Test
+    public void shouldDisableAutoReadOnlyOnceWhenAboveHighWatermark()
+    {
+        BoltChannelAutoReadLimiter limiter = newLimiter( 1, 2 );
+
+        assertTrue( channel.config().isAutoRead() );
+
+        limiter.enqueued( job );
+        limiter.enqueued( job );
+        limiter.enqueued( job );
+        limiter.enqueued( job );
+        limiter.enqueued( job );
+
+        assertFalse( channel.config().isAutoRead() );
+        verify( log, times( 1 ) ).warn( contains( "disabled" ), eq( channel.id() ), eq( 3 ) );
+    }
+
+    @Test
+    public void shouldEnableAutoReadWhenAtLowWatermark()
+    {
+        BoltChannelAutoReadLimiter limiter = newLimiter( 1, 2 );
+
+        assertTrue( channel.config().isAutoRead() );
+
+        limiter.enqueued( job );
+        limiter.enqueued( job );
+        limiter.enqueued( job );
+        limiter.dequeued( job );
+        limiter.dequeued( job );
+
+        assertTrue( channel.config().isAutoRead() );
+        verify( log, times( 1 ) ).warn( contains( "disabled" ), eq( channel.id() ), eq( 3 ) );
+        verify( log, times( 1 ) ).warn( contains( "enabled" ), eq( channel.id() ), eq( 1 ) );
+    }
+
+    @Test
+    public void shouldEnableAutoReadOnlyOnceWhenBelowLowWatermark()
+    {
+        BoltChannelAutoReadLimiter limiter = newLimiter( 1, 2 );
+
+        assertTrue( channel.config().isAutoRead() );
+
+        limiter.enqueued( job );
+        limiter.enqueued( job );
+        limiter.enqueued( job );
+        limiter.dequeued( job );
+        limiter.dequeued( job );
+        limiter.dequeued( job );
+
+        assertTrue( channel.config().isAutoRead() );
+        verify( log, times( 1 ) ).warn( contains( "disabled" ), eq( channel.id() ), eq( 3 ) );
+        verify( log, times( 1 ) ).warn( contains( "enabled" ), eq( channel.id() ), eq( 1 ) );
+    }
+
+    @Test
+    public void shouldNotAcceptNegativeLowWatermark()
+    {
+        try
+        {
+            newLimiter( -1, 5 );
+            fail( "exception expected" );
+        }
+        catch ( IllegalArgumentException exc )
+        {
+            assertThat( exc.getMessage(), startsWith( "invalid lowWatermark value" )  );
+        }
+    }
+
+    @Test
+    public void shouldNotAcceptLowWatermarkEqualToHighWatermark()
+    {
+        try
+        {
+            newLimiter( 5, 5 );
+            fail( "exception expected" );
+        }
+        catch ( IllegalArgumentException exc )
+        {
+            assertThat( exc.getMessage(), startsWith( "invalid lowWatermark value" )  );
+        }
+    }
+
+    @Test
+    public void shouldNotAcceptLowWatermarkLargerThanHighWatermark()
+    {
+        try
+        {
+            newLimiter( 6, 5 );
+            fail( "exception expected" );
+        }
+        catch ( IllegalArgumentException exc )
+        {
+            assertThat( exc.getMessage(), startsWith( "invalid lowWatermark value" )  );
+        }
+    }
+
+    @Test
+    public void shouldNotAcceptZeroHighWatermark()
+    {
+        try
+        {
+            newLimiter( 1, 0 );
+            fail( "exception expected" );
+        }
+        catch ( IllegalArgumentException exc )
+        {
+            assertThat( exc.getMessage(), startsWith( "invalid highWatermark value" )  );
+        }
+    }
+
+    @Test
+    public void shouldNotAcceptNegativeHighWatermark()
+    {
+        try
+        {
+            newLimiter( 1, -1 );
+            fail( "exception expected" );
+        }
+        catch ( IllegalArgumentException exc )
+        {
+            assertThat( exc.getMessage(), startsWith( "invalid highWatermark value" )  );
+        }
+    }
+
+    private BoltChannelAutoReadLimiter newLimiter( int low, int high )
+    {
+        return new BoltChannelAutoReadLimiter( channel, log, low, high );
+    }
+
+}

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/MonitoredBoltWorkerFactoryTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/MonitoredBoltWorkerFactoryTest.java
@@ -54,7 +54,7 @@ public class MonitoredBoltWorkerFactoryTest
 
         WorkerFactory delegate = mock( WorkerFactory.class );
         BoltStateMachine machine = mock( BoltStateMachine.class );
-        when( delegate.newWorker( anyObject(), anyObject() ) )
+        when( delegate.newWorker( anyObject(), anyObject(), anyObject() ) )
                 .thenReturn( new BoltWorker()
                 {
                     @Override
@@ -115,7 +115,7 @@ public class MonitoredBoltWorkerFactoryTest
         monitors.addMonitorListener( monitor );
 
         WorkerFactory mockWorkers = mock( WorkerFactory.class );
-        when( mockWorkers.newWorker( anyObject(), any() ) ).thenReturn( mock( BoltWorker.class ) );
+        when( mockWorkers.newWorker( anyObject(), anyObject(), any() ) ).thenReturn( mock( BoltWorker.class ) );
 
         MonitoredWorkerFactory workerFactory = new MonitoredWorkerFactory( monitors, mockWorkers, systemClock() );
 
@@ -137,7 +137,7 @@ public class MonitoredBoltWorkerFactoryTest
         // after monitor listeners are added
         WorkerFactory workerFactory = mock( WorkerFactory.class );
         BoltWorker innerSession = mock( BoltWorker.class );
-        when( workerFactory.newWorker( anyObject(), anyObject() ) )
+        when( workerFactory.newWorker( anyObject(), anyObject(), anyObject() ) )
                 .thenReturn( innerSession );
 
         Monitors monitors = new Monitors();

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/concurrent/RunnableBoltWorkerTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/concurrent/RunnableBoltWorkerTest.java
@@ -22,25 +22,43 @@ package org.neo4j.bolt.v1.runtime.concurrent;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import org.neo4j.bolt.v1.runtime.BoltConnectionAuthFatality;
 import org.neo4j.bolt.v1.runtime.BoltProtocolBreachFatality;
 import org.neo4j.bolt.v1.runtime.BoltStateMachine;
+import org.neo4j.bolt.v1.runtime.BoltWorkerQueueMonitor;
+import org.neo4j.bolt.v1.runtime.Job;
+import org.neo4j.cypher.internal.frontend.v3_2.ast.functions.Collect;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.logging.AssertableLogProvider;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyCollection;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -283,6 +301,85 @@ public class RunnableBoltWorkerTest
         workerFuture.get();
 
         verify( machine, atLeastOnce() ).validateTransaction();
+    }
+
+    @Test
+    public void shouldNotNotifyMonitorWhenNothingEnqueued() throws Exception
+    {
+        BoltWorkerQueueMonitor monitor = mock( BoltWorkerQueueMonitor.class );
+        RunnableBoltWorker worker = new RunnableBoltWorker( machine, logService, monitor );
+
+        verify( monitor, never() ).enqueued( any( Job.class ) );
+        verify( monitor, never() ).dequeued( any( Job.class ) );
+        verify( monitor, never() ).drained( any( Collection.class ) );
+    }
+
+    @Test
+    public void shouldNotifyMonitorWhenQueued() throws Exception
+    {
+        BoltWorkerQueueMonitor monitor = mock( BoltWorkerQueueMonitor.class );
+        RunnableBoltWorker worker = new RunnableBoltWorker( machine, logService, monitor );
+        Job job = s -> s.run( "Hello world", null, null );
+
+        worker.enqueue( job );
+
+        verify( monitor ).enqueued( job );
+    }
+
+    @Test
+    public void shouldNotifyMonitorWhenDequeued() throws Exception
+    {
+        BoltWorkerQueueMonitor monitor = mock( BoltWorkerQueueMonitor.class );
+        RunnableBoltWorker worker = new RunnableBoltWorker( machine, logService, monitor );
+        Job job = s -> s.run( "Hello world", null, null );
+
+        worker.enqueue( job );
+        worker.enqueue( s -> worker.halt() );
+        worker.run();
+
+        verify( monitor ).enqueued( job );
+        verify( monitor ).dequeued( job );
+    }
+
+    @Test
+    public void shouldNotifyMonitorWhenDrained() throws Exception
+    {
+        List<Job> drainedJobs = new ArrayList<>();
+        BoltWorkerQueueMonitor monitor = newMonitor( drainedJobs );
+        RunnableBoltWorker worker = new RunnableBoltWorker( machine, logService, monitor );
+        Job job1 = s -> s.run( "Hello world 1", null, null );
+        Job job2 = s -> s.run( "Hello world 1", null, null );
+        Job job3 = s -> s.run( "Hello world 1", null, null );
+        Job haltJob = s -> worker.halt();
+
+        worker.enqueue( job1 );
+        worker.enqueue( job2 );
+        worker.enqueue( job3 );
+        worker.enqueue( haltJob );
+        worker.run();
+
+        verify( monitor ).enqueued( job1 );
+        verify( monitor ).enqueued( job2 );
+        verify( monitor ).enqueued( job3 );
+        verify( monitor ).dequeued( job1 );
+        verify( monitor ).drained( anyCollection() );
+
+        assertThat( drainedJobs, hasSize( 3 ) );
+        assertThat( drainedJobs, contains( job2, job3, haltJob ) );
+    }
+
+    private static BoltWorkerQueueMonitor newMonitor( final List<Job> drained )
+    {
+        BoltWorkerQueueMonitor monitor = mock( BoltWorkerQueueMonitor.class );
+
+        doAnswer( invocation ->
+        {
+            final Collection<Job> jobs = invocation.getArgumentAt( 0, Collection.class );
+            drained.addAll( jobs );
+            return null;
+        } ).when( monitor ).drained( anyListOf( Job.class ) );
+
+        return monitor;
     }
 
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/BoltChannelAutoReadLimiterIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/BoltChannelAutoReadLimiterIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.
@@ -52,7 +52,6 @@ import org.neo4j.kernel.api.proc.Neo4jTypes;
 import org.neo4j.kernel.api.proc.ProcedureSignature;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
-import org.neo4j.kernel.internal.Version;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
@@ -71,23 +70,20 @@ import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
 @RunWith( Parameterized.class )
 public class BoltChannelAutoReadLimiterIT
 {
-    protected EphemeralFileSystemRule fsRule = new EphemeralFileSystemRule();
-    protected Neo4jWithSocket server = new Neo4jWithSocket( getClass(), getTestGraphDatabaseFactory(),
+    private AssertableLogProvider logProvider;
+    private EphemeralFileSystemRule fsRule = new EphemeralFileSystemRule();
+    private Neo4jWithSocket server = new Neo4jWithSocket( getClass(), getTestGraphDatabaseFactory(),
             fsRule::get, getSettingsFunction() );
+    private TransportConnection client;
 
     @Rule
     public RuleChain ruleChain = RuleChain.outerRule( fsRule ).around( server );
-
-    public AssertableLogProvider logProvider;
 
     @Parameterized.Parameter( 0 )
     public Factory<TransportConnection> cf;
 
     @Parameterized.Parameter( 1 )
     public HostnamePort address;
-
-    protected TransportConnection client;
-    private final String version = "Neo4j/" + Version.getNeo4jVersion();
 
     @Parameterized.Parameters
     public static Collection<Object[]> transports()

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/BoltChannelAutoReadLimiterIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/BoltChannelAutoReadLimiterIT.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.v1.transport.integration;
+
+import org.apache.commons.lang.StringUtils;
+import org.hamcrest.CoreMatchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.neo4j.bolt.v1.runtime.BoltChannelAutoReadLimiter;
+import org.neo4j.bolt.v1.transport.socket.client.SecureSocketConnection;
+import org.neo4j.bolt.v1.transport.socket.client.SecureWebSocketConnection;
+import org.neo4j.bolt.v1.transport.socket.client.SocketConnection;
+import org.neo4j.bolt.v1.transport.socket.client.TransportConnection;
+import org.neo4j.bolt.v1.transport.socket.client.WebSocketConnection;
+import org.neo4j.collection.RawIterator;
+import org.neo4j.function.Factory;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.HostnamePort;
+import org.neo4j.kernel.api.exceptions.ProcedureException;
+import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.api.proc.CallableProcedure;
+import org.neo4j.kernel.api.proc.Context;
+import org.neo4j.kernel.api.proc.Neo4jTypes;
+import org.neo4j.kernel.api.proc.ProcedureSignature;
+import org.neo4j.kernel.impl.proc.Procedures;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.kernel.internal.Version;
+import org.neo4j.logging.AssertableLogProvider;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.neo4j.bolt.v1.messaging.message.DiscardAllMessage.discardAll;
+import static org.neo4j.bolt.v1.messaging.message.InitMessage.init;
+import static org.neo4j.bolt.v1.messaging.message.RunMessage.run;
+import static org.neo4j.bolt.v1.messaging.util.MessageMatchers.msgSuccess;
+import static org.neo4j.bolt.v1.transport.integration.TransportTestUtil.eventuallyReceives;
+import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
+
+@RunWith( Parameterized.class )
+public class BoltChannelAutoReadLimiterIT
+{
+    protected EphemeralFileSystemRule fsRule = new EphemeralFileSystemRule();
+    protected Neo4jWithSocket server = new Neo4jWithSocket( getClass(), getTestGraphDatabaseFactory(),
+            fsRule::get, getSettingsFunction() );
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule( fsRule ).around( server );
+
+    public AssertableLogProvider logProvider;
+
+    @Parameterized.Parameter( 0 )
+    public Factory<TransportConnection> cf;
+
+    @Parameterized.Parameter( 1 )
+    public HostnamePort address;
+
+    protected TransportConnection client;
+    private final String version = "Neo4j/" + Version.getNeo4jVersion();
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> transports()
+    {
+        return asList(
+                new Object[]{
+                        (Factory<TransportConnection>) SocketConnection::new,
+                        new HostnamePort( "localhost:7687" )
+                },
+                new Object[]{
+                        (Factory<TransportConnection>) WebSocketConnection::new,
+                        new HostnamePort( "localhost:7687" )
+                },
+                new Object[]{
+                        (Factory<TransportConnection>) SecureSocketConnection::new,
+                        new HostnamePort( "localhost:7687" )
+                },
+                new Object[]{
+                        (Factory<TransportConnection>) SecureWebSocketConnection::new,
+                        new HostnamePort( "localhost:7687" )
+                } );
+    }
+
+    protected TestGraphDatabaseFactory getTestGraphDatabaseFactory()
+    {
+        TestGraphDatabaseFactory factory = new TestGraphDatabaseFactory();
+
+        logProvider = new AssertableLogProvider();
+
+        factory.setInternalLogProvider( logProvider );
+
+        return factory;
+
+    }
+
+    protected Consumer<Map<String, String>> getSettingsFunction()
+    {
+        return settings -> settings.put( GraphDatabaseSettings.auth_enabled.name(), "false" );
+    }
+
+    @Before
+    public void setup() throws Exception
+    {
+        installSleepProcedure( server.graphDatabaseService() );
+
+        this.client = cf.newInstance();
+    }
+
+    @After
+    public void after() throws Exception
+    {
+        this.client.disconnect();
+    }
+
+    @Test
+    public void largeNumberOfSlowRunningJobsShouldChangeAutoReadState() throws Exception
+    {
+        int numberOfRunDiscardPairs = 1000;
+        String largeString = StringUtils.repeat( " ", 8 * 1024  );
+
+        client.connect( address )
+            .send( TransportTestUtil.acceptedVersions( 1, 0, 0, 0 ) )
+            .send( TransportTestUtil.chunk(
+                    init( "TestClient/1.1", emptyMap() ) ) );
+
+        assertThat( client, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
+        assertThat( client, eventuallyReceives( msgSuccess() ) );
+
+        // when
+        for ( int i = 0; i < numberOfRunDiscardPairs; i++ )
+        {
+            client.send( TransportTestUtil.chunk(
+                    run( "CALL boltissue.sleep( $data )", singletonMap( "data", largeString ) ),
+                    discardAll()
+            ) );
+        }
+
+        // expect
+        for ( int i = 0; i < numberOfRunDiscardPairs; i++ )
+        {
+            assertThat( client, eventuallyReceives( msgSuccess(), msgSuccess() ) );
+        }
+
+        logProvider.assertAtLeastOnce(
+                AssertableLogProvider.inLog( BoltChannelAutoReadLimiter.class ).warn( CoreMatchers.containsString( "disabled" ), CoreMatchers.anything(),
+                        CoreMatchers.anything() ) );
+        logProvider.assertAtLeastOnce(
+                AssertableLogProvider.inLog( BoltChannelAutoReadLimiter.class ).warn( CoreMatchers.containsString( "enabled" ), CoreMatchers.anything(),
+                        CoreMatchers.anything() ) );
+    }
+
+    private static void installSleepProcedure( GraphDatabaseService db ) throws ProcedureException
+    {
+        GraphDatabaseAPI dbApi = (GraphDatabaseAPI) db;
+
+        dbApi.getDependencyResolver().resolveDependency( Procedures.class ).register(
+                new CallableProcedure.BasicProcedure(
+                        procedureSignature("boltissue", "sleep")
+                                .in( "data", Neo4jTypes.NTString )
+                                .out( ProcedureSignature.VOID )
+                                .build())
+                {
+                    @Override
+                    public RawIterator<Object[],ProcedureException> apply( Context context, Object[] objects ) throws ProcedureException
+                    {
+                        try
+                        {
+                            Thread.sleep( 50 );
+                        }
+                        catch ( InterruptedException e )
+                        {
+                            throw new ProcedureException( Status.General.UnknownError, e, "Interrupted" );
+                        }
+                        return RawIterator.empty();
+                    }
+                } );
+    }
+
+}

--- a/integrationtests/src/test/java/org/neo4j/bolt/BoltFailuresIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/BoltFailuresIT.java
@@ -82,7 +82,7 @@ public class BoltFailuresIT
     public void throwsWhenWorkerCreationFails()
     {
         WorkerFactory workerFactory = mock( WorkerFactory.class );
-        when( workerFactory.newWorker( anyObject(), any() ) ).thenThrow( new IllegalStateException( "Oh!" ) );
+        when( workerFactory.newWorker( anyObject(), anyObject(), any() ) ).thenThrow( new IllegalStateException( "Oh!" ) );
 
         BoltKernelExtension extension = new BoltKernelExtensionWithWorkerFactory( workerFactory );
 


### PR DESCRIPTION
When bolt messages are queued up in Bolt Worker Thread's job queue by continuous submission of messages (in an intent of batch queries or not waiting previous time-consuming queries to complete), job queue may start blocking IO threads which in turn starts blocking other client connections that are served by that specific IO thread.

This PR changes blocking job queue to a non-blocking one and sets channel's auto-read property based on job queue size. When job queue size gets over a pre-defined high water mark (`300`), channel's auto-read property is disabled and when it gets below a pre-defined low water mark (`100`) it is enabled back.