### PR TITLE
Do not reconnect LDAP context after TLS negotiation

### DIFF
--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/LdapRealm.java
@@ -63,8 +63,8 @@ import javax.naming.ldap.StartTlsResponse;
 import org.neo4j.graphdb.security.AuthProviderFailedException;
 import org.neo4j.graphdb.security.AuthProviderTimeoutException;
 import org.neo4j.graphdb.security.AuthorizationExpiredException;
-import org.neo4j.kernel.api.security.AuthToken;
 import org.neo4j.internal.kernel.api.security.AuthenticationResult;
+import org.neo4j.kernel.api.security.AuthToken;
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.server.security.enterprise.configuration.SecuritySettings;
@@ -228,8 +228,6 @@ public class LdapRealm extends DefaultLdapRealm implements RealmLifecycle, Shiro
                     jndiLdapContextFactory.getAuthenticationMechanism() );
             ctx.addToEnvironment( Context.SECURITY_PRINCIPAL, principal );
             ctx.addToEnvironment( Context.SECURITY_CREDENTIALS, credentials );
-
-            ctx.reconnect( ctx.getConnectControls() );
 
             return ctx;
         }


### PR DESCRIPTION
Reconnecting after TLS negotiation in java 9 will create
separate connection/session that will not have TLS
enabled.
Updated behavior also matches to javadoc described usage pattern.