### PR TITLE
Define automatic module names for java 9 modules

### DIFF
--- a/community/bolt/pom.xml
+++ b/community/bolt/pom.xml
@@ -14,6 +14,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.bolt</moduleName>
   </properties>
 
   <artifactId>neo4j-bolt</artifactId>

--- a/community/codegen/pom.xml
+++ b/community/codegen/pom.xml
@@ -10,6 +10,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.codegen</moduleName>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>

--- a/community/collections/pom.xml
+++ b/community/collections/pom.xml
@@ -10,6 +10,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.collection</moduleName>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>

--- a/community/command-line/pom.xml
+++ b/community/command-line/pom.xml
@@ -17,6 +17,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.commandline</moduleName>
   </properties>
 
   <licenses>

--- a/community/common/pom.xml
+++ b/community/common/pom.xml
@@ -10,6 +10,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.common</moduleName>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>

--- a/community/configuration/pom.xml
+++ b/community/configuration/pom.xml
@@ -10,6 +10,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.configuration</moduleName>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>

--- a/community/consistency-check/pom.xml
+++ b/community/consistency-check/pom.xml
@@ -18,6 +18,7 @@
     <neo4j.version>${project.version}</neo4j.version>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.consistency</moduleName>
   </properties>
 
   <scm>

--- a/community/csv/pom.xml
+++ b/community/csv/pom.xml
@@ -10,6 +10,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.csv</moduleName>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>

--- a/community/cypher/cypher-logical-plans-3.4/pom.xml
+++ b/community/cypher/cypher-logical-plans-3.4/pom.xml
@@ -16,6 +16,10 @@
   <description>Cypher logical plans</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>
 
+  <properties>
+    <moduleName>org.neo4j.cypher.internal.v3_4.logical.plans</moduleName>
+  </properties>
+
   <scm>
     <connection>scm:git:git://github.com/neo4j/neo4j.git</connection>
     <developerConnection>scm:git:git@github.com:neo4j/neo4j.git</developerConnection>

--- a/community/cypher/cypher-planner-3.4/pom.xml
+++ b/community/cypher/cypher-planner-3.4/pom.xml
@@ -15,6 +15,10 @@
   <description>Planner for Cypher 3.4</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>
 
+  <properties>
+    <moduleName>org.neo4j.cypher.internal.compiler.v3_4</moduleName>
+  </properties>
+
   <scm>
     <connection>scm:git:git://github.com/neo4j/neo4j.git</connection>
     <developerConnection>scm:git:git@github.com:neo4j/neo4j.git</developerConnection>

--- a/community/cypher/cypher/pom.xml
+++ b/community/cypher/cypher/pom.xml
@@ -17,6 +17,10 @@
   <description>Neo4j query language</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>
 
+  <properties>
+    <moduleName>org.neo4j.cypher</moduleName>
+  </properties>
+
   <scm>
     <connection>scm:git:git://github.com/neo4j/neo4j.git</connection>
     <developerConnection>scm:git:git@github.com:neo4j/neo4j.git</developerConnection>

--- a/community/cypher/expressions-3.4/pom.xml
+++ b/community/cypher/expressions-3.4/pom.xml
@@ -25,6 +25,7 @@
   <properties>
     <licensing.prepend.text>notice-asl-prefix.txt</licensing.prepend.text>
     <license-text.header>${project.baseUri}/ASL-2-header.txt</license-text.header>
+    <moduleName>org.neo4j.cypher.internal.v3_4.expressions</moduleName>
   </properties>
 
   <licenses>

--- a/community/cypher/frontend-3.4/pom.xml
+++ b/community/cypher/frontend-3.4/pom.xml
@@ -25,6 +25,7 @@
   <properties>
     <licensing.prepend.text>notice-asl-prefix.txt</licensing.prepend.text>
     <license-text.header>${project.baseUri}/ASL-2-header.txt</license-text.header>
+    <moduleName>org.neo4j.cypher.internal.frontend.v3_4</moduleName>
   </properties>
 
   <licenses>

--- a/community/cypher/interpreted-runtime/pom.xml
+++ b/community/cypher/interpreted-runtime/pom.xml
@@ -22,6 +22,10 @@
     <url>https://github.com/neo4j/neo4j</url>
   </scm>
 
+  <properties>
+    <moduleName>org.neo4j.cypher.internal.runtime.interpreted</moduleName>
+  </properties>
+
   <licenses>
     <license>
       <name>GNU General Public License, Version 3</name>

--- a/community/cypher/ir-3.4/pom.xml
+++ b/community/cypher/ir-3.4/pom.xml
@@ -22,6 +22,10 @@
     <url>https://github.com/neo4j/neo4j</url>
   </scm>
 
+  <properties>
+    <moduleName>org.neo4j.cypher.internal.ir.v3_4</moduleName>
+  </properties>
+
   <licenses>
     <license>
       <name>GNU General Public License, Version 3</name>

--- a/community/cypher/planner-spi-3.4/pom.xml
+++ b/community/cypher/planner-spi-3.4/pom.xml
@@ -22,6 +22,10 @@
     <url>https://github.com/neo4j/neo4j</url>
   </scm>
 
+  <properties>
+    <moduleName>org.neo4j.cypher.internal.planner.v3_4.spi</moduleName>
+  </properties>
+
   <licenses>
     <license>
       <name>GNU General Public License, Version 3</name>

--- a/community/cypher/runtime-util/pom.xml
+++ b/community/cypher/runtime-util/pom.xml
@@ -22,6 +22,10 @@
     <url>https://github.com/neo4j/neo4j</url>
   </scm>
 
+  <properties>
+    <moduleName>org.neo4j.cypher.internal.runtime.util</moduleName>
+  </properties>
+
   <licenses>
     <license>
       <name>GNU General Public License, Version 3</name>

--- a/community/cypher/util-3.4/pom.xml
+++ b/community/cypher/util-3.4/pom.xml
@@ -25,6 +25,7 @@
   <properties>
     <licensing.prepend.text>notice-asl-prefix.txt</licensing.prepend.text>
     <license-text.header>${project.baseUri}/ASL-2-header.txt</license-text.header>
+    <moduleName>org.neo4j.cypher.internal.util.v3_4</moduleName>
   </properties>
 
   <licenses>

--- a/community/dbms/pom.xml
+++ b/community/dbms/pom.xml
@@ -15,6 +15,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.dbms</moduleName>
   </properties>
 
   <description>

--- a/community/graph-algo/pom.xml
+++ b/community/graph-algo/pom.xml
@@ -13,6 +13,7 @@
     <test.runner.jvm.settings.additional>
       -Dorg.neo4j.kernel.impl.api.KernelStatement.trackStatements=false
     </test.runner.jvm.settings.additional>
+    <moduleName>org.neo4j.graphalgo</moduleName>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>

--- a/community/graphdb-api/pom.xml
+++ b/community/graphdb-api/pom.xml
@@ -10,6 +10,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.graphdb</moduleName>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>

--- a/community/import-tool/pom.xml
+++ b/community/import-tool/pom.xml
@@ -10,6 +10,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.tooling.import</moduleName>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>

--- a/community/index/pom.xml
+++ b/community/index/pom.xml
@@ -10,6 +10,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.index</moduleName>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>

--- a/community/io/pom.xml
+++ b/community/io/pom.xml
@@ -10,6 +10,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.io</moduleName>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>

--- a/community/jmx/pom.xml
+++ b/community/jmx/pom.xml
@@ -18,6 +18,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.jmx</moduleName>
   </properties>
 
   <packaging>jar</packaging>

--- a/community/kernel-api/pom.xml
+++ b/community/kernel-api/pom.xml
@@ -10,6 +10,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.internal.kernel.api</moduleName>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>

--- a/community/kernel/pom.xml
+++ b/community/kernel/pom.xml
@@ -42,6 +42,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.kernel</moduleName>
   </properties>
 
   <packaging>jar</packaging>

--- a/community/licensecheck-config/pom.xml
+++ b/community/licensecheck-config/pom.xml
@@ -18,6 +18,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.licensecheck</moduleName>
   </properties>
 
   <scm>

--- a/community/logging/pom.xml
+++ b/community/logging/pom.xml
@@ -10,6 +10,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.logging</moduleName>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>

--- a/community/lucene-index-upgrade/pom.xml
+++ b/community/lucene-index-upgrade/pom.xml
@@ -13,6 +13,7 @@
         <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
         <lucene4.version>4.10.4</lucene4.version>
         <lucene5.version>5.5.0</lucene5.version>
+        <moduleName>org.neo4j.upgrade.lucene</moduleName>
     </properties>
 
     <modelVersion>4.0.0</modelVersion>

--- a/community/lucene-index/pom.xml
+++ b/community/lucene-index/pom.xml
@@ -18,6 +18,7 @@ Integration layer between Neo4j and Lucene, providing one possible implementatio
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.index.lucene</moduleName>
   </properties>
 
   <packaging>jar</packaging>

--- a/community/neo4j-harness/LICENSES.txt
+++ b/community/neo4j-harness/LICENSES.txt
@@ -364,11 +364,9 @@ Common Development and Distribution License Version 1.1
   Java Servlet API
   jersey-client
   jersey-core
-  jersey-multipart
   jersey-server
   jersey-servlet
   jsr311-api
-  MIME streaming extension
 ------------------------------------------------------------------------------
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1 

--- a/community/neo4j-harness/NOTICE.txt
+++ b/community/neo4j-harness/NOTICE.txt
@@ -83,11 +83,9 @@ Common Development and Distribution License Version 1.1
   Java Servlet API
   jersey-client
   jersey-core
-  jersey-multipart
   jersey-server
   jersey-servlet
   jsr311-api
-  MIME streaming extension
 
 GNU General Public License, version 2 with the Classpath Exception
   Java Servlet API

--- a/community/neo4j-harness/pom.xml
+++ b/community/neo4j-harness/pom.xml
@@ -22,6 +22,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.harness</moduleName>
   </properties>
 
   <scm>

--- a/community/neo4j-slf4j/pom.xml
+++ b/community/neo4j-slf4j/pom.xml
@@ -10,6 +10,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.logging.slf4j</moduleName>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>

--- a/community/neo4j/pom.xml
+++ b/community/neo4j/pom.xml
@@ -19,6 +19,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.community</moduleName>
   </properties>
 
   <scm>

--- a/community/primitive-collections/pom.xml
+++ b/community/primitive-collections/pom.xml
@@ -10,6 +10,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.collection.primitive</moduleName>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>

--- a/community/procedure-compiler/processor/pom.xml
+++ b/community/procedure-compiler/processor/pom.xml
@@ -17,6 +17,7 @@
     <properties>
         <license-text.header>GPL-3-header.txt</license-text.header>
         <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+        <moduleName>org.neo4j.tooling.procedure</moduleName>
     </properties>
 
     <licenses>

--- a/community/resource/pom.xml
+++ b/community/resource/pom.xml
@@ -10,6 +10,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.graphdb.resourse</moduleName>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>

--- a/community/security/pom.xml
+++ b/community/security/pom.xml
@@ -10,6 +10,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.server.security</moduleName>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>

--- a/community/server-api/pom.xml
+++ b/community/server-api/pom.xml
@@ -19,6 +19,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.server.api</moduleName>
   </properties>
 
   <scm>

--- a/community/server-plugin-test/LICENSES.txt
+++ b/community/server-plugin-test/LICENSES.txt
@@ -360,11 +360,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 Common Development and Distribution License Version 1.1
   Java Servlet API
   jersey-core
-  jersey-multipart
   jersey-server
   jersey-servlet
   jsr311-api
-  MIME streaming extension
 ------------------------------------------------------------------------------
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1 

--- a/community/server-plugin-test/NOTICE.txt
+++ b/community/server-plugin-test/NOTICE.txt
@@ -79,11 +79,9 @@ Bouncy Castle License
 Common Development and Distribution License Version 1.1
   Java Servlet API
   jersey-core
-  jersey-multipart
   jersey-server
   jersey-servlet
   jsr311-api
-  MIME streaming extension
 
 GNU General Public License, version 2 with the Classpath Exception
   Java Servlet API

--- a/community/server-plugin-test/pom.xml
+++ b/community/server-plugin-test/pom.xml
@@ -17,6 +17,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.server.plugins</moduleName>
   </properties>
 
   <packaging>jar</packaging>

--- a/community/server/LICENSES.txt
+++ b/community/server/LICENSES.txt
@@ -360,11 +360,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 Common Development and Distribution License Version 1.1
   Java Servlet API
   jersey-core
-  jersey-multipart
   jersey-server
   jersey-servlet
   jsr311-api
-  MIME streaming extension
 ------------------------------------------------------------------------------
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1 

--- a/community/server/NOTICE.txt
+++ b/community/server/NOTICE.txt
@@ -79,11 +79,9 @@ Bouncy Castle License
 Common Development and Distribution License Version 1.1
   Java Servlet API
   jersey-core
-  jersey-multipart
   jersey-server
   jersey-servlet
   jsr311-api
-  MIME streaming extension
 
 GNU General Public License, version 2 with the Classpath Exception
   Java Servlet API

--- a/community/server/pom.xml
+++ b/community/server/pom.xml
@@ -49,6 +49,7 @@
     <test.runner.jvm.settings.additional>
       -Dorg.neo4j.kernel.impl.api.KernelStatement.trackStatements=false
     </test.runner.jvm.settings.additional>
+    <moduleName>org.neo4j.server</moduleName>
   </properties>
 
   <scm>
@@ -216,12 +217,6 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
-    </dependency>
-
-    <!-- File uploads -->
-    <dependency>
-      <groupId>com.sun.jersey.contribs</groupId>
-      <artifactId>jersey-multipart</artifactId>
     </dependency>
 
     <!-- Test dependencies -->

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/ConcurrentTransactionAccessTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/ConcurrentTransactionAccessTest.java
@@ -33,7 +33,7 @@ import org.neo4j.server.rest.transactional.error.InvalidConcurrentTransactionAcc
 import org.neo4j.server.rest.web.TransactionUriScheme;
 import org.neo4j.test.DoubleLatch;
 
-import static javax.xml.bind.DatatypeConverter.parseLong;
+import static java.lang.Long.parseLong;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;

--- a/community/shell/pom.xml
+++ b/community/shell/pom.xml
@@ -28,6 +28,7 @@
     <jline.main.version>2.12</jline.main.version>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.shell</moduleName>
   </properties>
 
   <packaging>jar</packaging>

--- a/community/spatial-index/pom.xml
+++ b/community/spatial-index/pom.xml
@@ -30,6 +30,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.gis.spatial.index</moduleName>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>

--- a/community/ssl/pom.xml
+++ b/community/ssl/pom.xml
@@ -10,6 +10,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.ssl</moduleName>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>

--- a/community/udc/pom.xml
+++ b/community/udc/pom.xml
@@ -17,6 +17,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.ext.udc</moduleName>
   </properties>
 
   <packaging>jar</packaging>

--- a/community/unsafe/pom.xml
+++ b/community/unsafe/pom.xml
@@ -10,6 +10,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.unsafe</moduleName>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>

--- a/community/values/pom.xml
+++ b/community/values/pom.xml
@@ -11,6 +11,7 @@
   <properties>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
+    <moduleName>org.neo4j.values</moduleName>
   </properties>
 
   <modelVersion>4.0.0</modelVersion>

--- a/enterprise/auth-plugin-api/pom.xml
+++ b/enterprise/auth-plugin-api/pom.xml
@@ -14,6 +14,10 @@
   <description>Enterprise auth plugin API for adding custom auth providers to the Neo4j database</description>
   <packaging>jar</packaging>
 
+  <properties>
+    <moduleName>org.neo4j.server.security.enterprise.auth.plugin</moduleName>
+  </properties>
+
   <scm>
     <connection>scm:git:git://github.com/neo4j/neo4j.git</connection>
     <developerConnection>scm:git:git@github.com:neo4j/neo4j.git</developerConnection>

--- a/enterprise/backup/pom.xml
+++ b/enterprise/backup/pom.xml
@@ -14,6 +14,10 @@
   <packaging>jar</packaging>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>
 
+  <properties>
+    <moduleName>org.neo4j.backup</moduleName>
+  </properties>
+
   <scm>
     <connection>scm:git:git://github.com/neo4j/neo4j.git</connection>
     <developerConnection>scm:git:git@github.com:neo4j/neo4j.git</developerConnection>

--- a/enterprise/causal-clustering/pom.xml
+++ b/enterprise/causal-clustering/pom.xml
@@ -19,6 +19,10 @@
     <url>http://components.neo4j.org/${project.artifactId}/${project.version}/</url>
     <packaging>jar</packaging>
 
+    <properties>
+        <moduleName>org.neo4j.causalclustering</moduleName>
+    </properties>
+
     <scm>
         <url>https://github.com/neo4j/neo4j/tree/3.1/enterprise/causal-clustering</url>
     </scm>

--- a/enterprise/cluster/pom.xml
+++ b/enterprise/cluster/pom.xml
@@ -14,6 +14,10 @@
   <packaging>jar</packaging>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>
 
+  <properties>
+    <moduleName>org.neo4j.cluster</moduleName>
+  </properties>
+
   <scm>
     <connection>scm:git:git://github.com/neo4j/neo4j.git</connection>
     <developerConnection>scm:git:git@github.com:neo4j/neo4j.git</developerConnection>

--- a/enterprise/com/pom.xml
+++ b/enterprise/com/pom.xml
@@ -12,6 +12,10 @@
   <name>Neo4j - Communication Package</name>
   <packaging>jar</packaging>
 
+  <properties>
+    <moduleName>org.neo4j.com</moduleName>
+  </properties>
+
   <scm>
     <connection>scm:git:git://github.com/neo4j/neo4j.git</connection>
     <developerConnection>scm:git:git@github.com:neo4j/neo4j.git</developerConnection>

--- a/enterprise/cypher/acceptance-spec-suite/pom.xml
+++ b/enterprise/cypher/acceptance-spec-suite/pom.xml
@@ -24,6 +24,10 @@
     <url>https://github.com/neo4j/neo4j</url>
   </scm>
 
+  <properties>
+    <moduleName>org.neo4j.internal.cypher.acceptance.spec.suite</moduleName>
+  </properties>
+
   <licenses>
     <license>
       <name>GNU Affero General Public License, Version 3</name>

--- a/enterprise/cypher/compatibility-spec-suite/pom.xml
+++ b/enterprise/cypher/compatibility-spec-suite/pom.xml
@@ -24,6 +24,10 @@
     <url>https://github.com/neo4j/neo4j</url>
   </scm>
 
+  <properties>
+    <moduleName>org.neo4j.internal.cypher.compatibility.spec.suite</moduleName>
+  </properties>
+
   <licenses>
     <license>
       <name>GNU Affero General Public License, Version 3</name>

--- a/enterprise/cypher/cypher/pom.xml
+++ b/enterprise/cypher/cypher/pom.xml
@@ -23,6 +23,10 @@
     <url>https://github.com/neo4j/neo4j</url>
   </scm>
 
+  <properties>
+    <moduleName>org.neo4j.cypher.enterprise</moduleName>
+  </properties>
+
   <licenses>
     <license>
       <name>GNU Affero General Public License, Version 3</name>

--- a/enterprise/cypher/morsel-runtime/pom.xml
+++ b/enterprise/cypher/morsel-runtime/pom.xml
@@ -17,6 +17,10 @@
   <description>Parallel runtime for Cypher</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>
 
+  <properties>
+    <moduleName>org.neo4j.cypher.internal.runtime.vectorized</moduleName>
+  </properties>
+
   <scm>
     <connection>scm:git:git://github.com/neo4j/neo4j.git</connection>
     <developerConnection>scm:git:git@github.com:neo4j/neo4j.git</developerConnection>

--- a/enterprise/cypher/physical-planning/pom.xml
+++ b/enterprise/cypher/physical-planning/pom.xml
@@ -17,6 +17,10 @@
   <description>A runtime for Neo4j's query language</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>
 
+  <properties>
+    <moduleName>org.neo4j.cypher.internal.compatibility.v3_4.runtime</moduleName>
+  </properties>
+
   <scm>
     <connection>scm:git:git://github.com/neo4j/neo4j.git</connection>
     <developerConnection>scm:git:git@github.com:neo4j/neo4j.git</developerConnection>

--- a/enterprise/cypher/slotted-runtime/pom.xml
+++ b/enterprise/cypher/slotted-runtime/pom.xml
@@ -17,6 +17,10 @@
   <description>Planner for the physical query plans</description>
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>
 
+  <properties>
+    <moduleName>org.neo4j.cypher.internal.compatibility.v3_4.runtime.slotted</moduleName>
+  </properties>
+
   <scm>
     <connection>scm:git:git://github.com/neo4j/neo4j.git</connection>
     <developerConnection>scm:git:git@github.com:neo4j/neo4j.git</developerConnection>

--- a/enterprise/cypher/spec-suite-tools/pom.xml
+++ b/enterprise/cypher/spec-suite-tools/pom.xml
@@ -44,6 +44,10 @@
     </license>
   </licenses>
 
+  <properties>
+    <moduleName>org.neo4j.internal.cypher.spec.suite.tools</moduleName>
+  </properties>
+  
   <build>
     <plugins>
       <plugin>

--- a/enterprise/deferred-locks/pom.xml
+++ b/enterprise/deferred-locks/pom.xml
@@ -17,6 +17,10 @@
   <description>Enterprise locks deferred to commit time</description>
   <packaging>jar</packaging>
 
+  <properties>
+    <moduleName>org.neo4j.kernel.impl.locking.deferred</moduleName>
+  </properties>
+
   <scm>
     <url>https://github.com/neo4j/neo4j/tree/3.0/enterprise/deferred-locks</url>
   </scm>

--- a/enterprise/fulltext-addon/pom.xml
+++ b/enterprise/fulltext-addon/pom.xml
@@ -17,6 +17,10 @@
   <description>Fulltext index addon for neo4j</description>
   <packaging>jar</packaging>
 
+  <properties>
+    <moduleName>org.neo4j.kernel.api.impl.fulltext</moduleName>
+  </properties>
+
   <scm>
     <url>https://github.com/neo4j/neo4j/tree/3.3/enterprise/fulltext-addon</url>
   </scm>

--- a/enterprise/ha/pom.xml
+++ b/enterprise/ha/pom.xml
@@ -18,6 +18,10 @@
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}/</url>
   <packaging>jar</packaging>
 
+  <properties>
+    <moduleName>org.neo4j.kernel.ha</moduleName>
+  </properties>
+
   <scm>
     <connection>scm:git:git://github.com/neo4j/neo4j.git</connection>
     <developerConnection>scm:git:git@github.com:neo4j/neo4j.git</developerConnection>

--- a/enterprise/kernel/pom.xml
+++ b/enterprise/kernel/pom.xml
@@ -13,6 +13,10 @@
   <description>Enterprise features for Neo4j</description>
   <packaging>jar</packaging>
 
+  <properties>
+    <moduleName>org.neo4j.kernel.enterprise</moduleName>
+  </properties>
+
   <scm>
     <connection>scm:git:git://github.com/neo4j/neo4j.git</connection>
     <developerConnection>scm:git:git@github.com:neo4j/neo4j.git</developerConnection>

--- a/enterprise/management/pom.xml
+++ b/enterprise/management/pom.xml
@@ -17,6 +17,10 @@
 
   <packaging>jar</packaging>
 
+  <properties>
+    <moduleName>org.neo4j.management</moduleName>
+  </properties>
+
   <scm>
     <connection>scm:git:git://github.com/neo4j/neo4j.git</connection>
     <developerConnection>scm:git:git@github.com:neo4j/neo4j.git</developerConnection>

--- a/enterprise/metrics/pom.xml
+++ b/enterprise/metrics/pom.xml
@@ -18,6 +18,7 @@
 
   <properties>
     <prometheus.client.version>0.1.0</prometheus.client.version>
+    <moduleName>org.neo4j.metrics</moduleName>
   </properties>
 
   <dependencies>

--- a/enterprise/neo4j-enterprise/pom.xml
+++ b/enterprise/neo4j-enterprise/pom.xml
@@ -17,6 +17,10 @@
   <description>A meta package containing the most used Neo4j Enterprise libraries. Intended use: as a Maven dependency.
   </description>
 
+  <properties>
+    <moduleName>org.neo4j.enterprise</moduleName>
+  </properties>
+
   <scm>
     <connection>scm:git:git://github.com/neo4j/neo4j.git</connection>
     <developerConnection>scm:git:git@github.com:neo4j/neo4j.git</developerConnection>

--- a/enterprise/neo4j-harness-enterprise/LICENSES.txt
+++ b/enterprise/neo4j-harness-enterprise/LICENSES.txt
@@ -382,11 +382,9 @@ Common Development and Distribution License Version 1.1
   Java Servlet API
   jersey-client
   jersey-core
-  jersey-multipart
   jersey-server
   jersey-servlet
   jsr311-api
-  MIME streaming extension
 ------------------------------------------------------------------------------
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1 

--- a/enterprise/neo4j-harness-enterprise/NOTICE.txt
+++ b/enterprise/neo4j-harness-enterprise/NOTICE.txt
@@ -100,11 +100,9 @@ Common Development and Distribution License Version 1.1
   Java Servlet API
   jersey-client
   jersey-core
-  jersey-multipart
   jersey-server
   jersey-servlet
   jsr311-api
-  MIME streaming extension
 
 GNU General Public License, version 2 with the Classpath Exception
   Java Servlet API

--- a/enterprise/neo4j-harness-enterprise/pom.xml
+++ b/enterprise/neo4j-harness-enterprise/pom.xml
@@ -21,6 +21,7 @@
 
     <properties>
         <licensing.prepend.text>notice-agpl-prefix.txt</licensing.prepend.text>
+        <moduleName>org.neo4j.harness.enterprise</moduleName>
     </properties>
 
     <scm>

--- a/enterprise/procedure-compiler-enterprise-tests/pom.xml
+++ b/enterprise/procedure-compiler-enterprise-tests/pom.xml
@@ -15,6 +15,10 @@
     <description>Neo4j Stored Procedure compile-time annotation processor</description>
     <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>
 
+    <properties>
+        <moduleName>org.neo4j.tooling.procedure.enterprise.tests</moduleName>
+    </properties>
+
     <licenses>
         <license>
             <name>GNU Affero General Public License, Version 3</name>

--- a/enterprise/query-logging/pom.xml
+++ b/enterprise/query-logging/pom.xml
@@ -21,6 +21,10 @@
     <url>https://github.com/neo4j/neo4j</url>
   </scm>
 
+  <properties>
+    <moduleName>org.neo4j.kernel.impl.query</moduleName>
+  </properties>
+
   <licenses>
     <license>
       <name>GNU Affero General Public License, Version 3</name>

--- a/enterprise/security/pom.xml
+++ b/enterprise/security/pom.xml
@@ -14,6 +14,10 @@
   <description>Enterprise security features for Neo4j</description>
   <packaging>jar</packaging>
 
+  <properties>
+    <moduleName>org.neo4j.server.security.enterprise</moduleName>
+  </properties>
+
   <scm>
     <connection>scm:git:git://github.com/neo4j/neo4j.git</connection>
     <developerConnection>scm:git:git@github.com:neo4j/neo4j.git</developerConnection>

--- a/enterprise/server-enterprise/LICENSES.txt
+++ b/enterprise/server-enterprise/LICENSES.txt
@@ -381,11 +381,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 Common Development and Distribution License Version 1.1
   Java Servlet API
   jersey-core
-  jersey-multipart
   jersey-server
   jersey-servlet
   jsr311-api
-  MIME streaming extension
 ------------------------------------------------------------------------------
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1 

--- a/enterprise/server-enterprise/NOTICE.txt
+++ b/enterprise/server-enterprise/NOTICE.txt
@@ -99,11 +99,9 @@ Bouncy Castle License
 Common Development and Distribution License Version 1.1
   Java Servlet API
   jersey-core
-  jersey-multipart
   jersey-server
   jersey-servlet
   jsr311-api
-  MIME streaming extension
 
 GNU General Public License, version 2 with the Classpath Exception
   Java Servlet API

--- a/enterprise/server-enterprise/pom.xml
+++ b/enterprise/server-enterprise/pom.xml
@@ -18,6 +18,10 @@
 
   <packaging>jar</packaging>
 
+  <properties>
+    <moduleName>org.neo4j.server.enterprise</moduleName>
+  </properties>
+
   <scm>
     <connection>scm:git:git://github.com/neo4j/neo4j.git</connection>
     <developerConnection>scm:git:git@github.com:neo4j/neo4j.git</developerConnection>

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -15,6 +15,10 @@
   <packaging>jar</packaging>
   <description>A package for cross-module integration tests.</description>
 
+  <properties>
+    <moduleName>org.neo4j.integrationtests</moduleName>
+  </properties>
+
   <scm>
     <connection>scm:git:git://github.com/neo4j/neo4j.git</connection>
     <developerConnection>scm:git:git@github.com:neo4j/neo4j.git</developerConnection>

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/LICENSES.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/LICENSES.txt
@@ -412,11 +412,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 Common Development and Distribution License Version 1.1
   Java Servlet API
   jersey-core
-  jersey-multipart
   jersey-server
   jersey-servlet
   jsr311-api
-  MIME streaming extension
 ------------------------------------------------------------------------------
 
 COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.1 

--- a/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
+++ b/packaging/standalone/standalone-community/src/main/distribution/text/community/NOTICE.txt
@@ -104,11 +104,9 @@ Bouncy Castle License
 Common Development and Distribution License Version 1.1
   Java Servlet API
   jersey-core
-  jersey-multipart
   jersey-server
   jersey-servlet
   jsr311-api
-  MIME streaming extension
 
 GNU General Public License, version 2 with the Classpath Exception
   Java Servlet API

--- a/pom.xml
+++ b/pom.xml
@@ -68,13 +68,14 @@
     <lucene.version>5.5.5</lucene.version>
     <bouncycastle.version>1.59</bouncycastle.version>
     <generate-config-docs-phase>prepare-package</generate-config-docs-phase>
+    <java9.exports/>
     <test.runner.jvm.settings.additional/>
     <test.runner.jvm.settings>-Xmx2G -XX:+UseG1GC -XX:-OmitStackTraceInFastThrow -XX:+HeapDumpOnOutOfMemoryError
       -XX:HeapDumpPath=target/test-data -Dorg.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.DIRTY_MEMORY=true
       -Dorg.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.CHECK_NATIVE_ACCESS=true
       -Dorg.neo4j.io.pagecache.impl.muninn.usePreciseCursorErrorStackTraces=true
       -Dorg.neo4j.kernel.impl.api.KernelStatement.trackStatements=true
-      -XX:+UnlockExperimentalVMOptions -XX:+TrustFinalNonStaticFields ${test.runner.jvm.settings.additional}
+      -XX:+UnlockExperimentalVMOptions -XX:+TrustFinalNonStaticFields ${java9.exports} ${test.runner.jvm.settings.additional}
     </test.runner.jvm.settings>
     <jetty.version>9.4.8.v20171121</jetty.version>
     <findbugs.version>3.0.1</findbugs.version>
@@ -89,7 +90,9 @@
     <scala.binary.version>2.11</scala.binary.version>
     <asm.version>6.0</asm.version>
     <metrics.version>4.0.2</metrics.version>
+    <scala.target.vm>1.8</scala.target.vm>
     <scala.java9.arg/>
+    <jersey.version>1.19.3</jersey.version>
     <checkstyle.strict>true</checkstyle.strict>
   </properties>
 
@@ -417,6 +420,7 @@
                   </manifest>
                   <manifestEntries>
                     <Url>${project.organization.url}</Url>
+                    <Automatic-Module-Name>${moduleName}</Automatic-Module-Name>
                   </manifestEntries>
                 </archive>
               </configuration>
@@ -512,7 +516,7 @@
               <arg>-Xmax-classfile-name</arg>
               <arg>100</arg>
               <arg>-Xlint</arg>
-              <arg>-target:jvm-${maven.compiler.target}</arg>
+              <arg>-target:jvm-${scala.target.vm}</arg>
               <arg>${scala.java9.arg}</arg>
             </args>
             <jvmArgs>
@@ -568,11 +572,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.7.0</version>
           <configuration>
             <showDeprecation>true</showDeprecation>
             <showWarnings>true</showWarnings>
+            <compilerArgument>${java9.exports}</compilerArgument>
           </configuration>
-          <version>3.7.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -905,6 +910,7 @@
         <jdk>9</jdk>
       </activation>
       <properties>
+        <java9.exports>--add-exports=java.base/sun.nio.ch=ALL-UNNAMED</java9.exports>
         <maven.javadoc.skip>true</maven.javadoc.skip>
         <scala.java9.arg>-nobootcp</scala.java9.arg>
       </properties>
@@ -1212,7 +1218,7 @@
       <dependency>
         <groupId>com.sun.jersey</groupId>
         <artifactId>jersey-client</artifactId>
-        <version>1.19</version>
+        <version>${jersey.version}</version>
         <exclusions>
           <exclusion>
             <groupId>javax.ws.rs</groupId>
@@ -1223,7 +1229,7 @@
       <dependency>
         <groupId>com.sun.jersey</groupId>
         <artifactId>jersey-server</artifactId>
-        <version>1.19</version>
+        <version>${jersey.version}</version>
         <exclusions>
           <exclusion>
             <groupId>javax.ws.rs</groupId>
@@ -1234,18 +1240,13 @@
       <dependency>
         <groupId>com.sun.jersey</groupId>
         <artifactId>jersey-servlet</artifactId>
-        <version>1.19</version>
+        <version>${jersey.version}</version>
         <exclusions>
           <exclusion>
             <groupId>javax.ws.rs</groupId>
             <artifactId>jsr311-api</artifactId>
           </exclusion>
         </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>com.sun.jersey.contribs</groupId>
-        <artifactId>jersey-multipart</artifactId>
-        <version>1.19</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.jackson</groupId>

--- a/stresstests/pom.xml
+++ b/stresstests/pom.xml
@@ -15,6 +15,10 @@
   <packaging>jar</packaging>
   <description>A package for stress tests.</description>
 
+  <properties>
+    <moduleName>org.neo4j.stresstests</moduleName>
+  </properties>
+
   <scm>
     <connection>scm:git:git://github.com/neo4j/neo4j.git</connection>
     <developerConnection>scm:git:git@github.com:neo4j/neo4j.git</developerConnection>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -17,6 +17,9 @@
     <name>Neo4j - Low Level Tools</name>
     <packaging>jar</packaging>
     <description>A package for low level tools.</description>
+    <properties>
+        <moduleName>org.neo4j.tools</moduleName>
+    </properties>
 
     <scm>
         <connection>scm:git:git://github.com/neo4j/neo4j.git</connection>

--- a/tools/src/main/java/org/neo4j/tools/rawstorereader/RsdrMain.java
+++ b/tools/src/main/java/org/neo4j/tools/rawstorereader/RsdrMain.java
@@ -26,7 +26,6 @@ import java.nio.ByteBuffer;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.xml.bind.DatatypeConverter;
 
 import org.neo4j.cursor.IOCursor;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
@@ -48,6 +47,7 @@ import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntry;
 import org.neo4j.logging.NullLogProvider;
+import org.neo4j.string.HexString;
 import org.neo4j.tools.util.TransactionLogUtils;
 
 import static org.neo4j.kernel.impl.pagecache.ConfigurableStandalonePageCacheFactory.createPageCache;
@@ -227,7 +227,7 @@ public class RsdrMain
                 byte[] bytes = new byte[count];
                 buf.clear();
                 buf.get( bytes );
-                String hex = DatatypeConverter.printHexBinary( bytes );
+                String hex = HexString.encodeHexString( bytes );
                 int paddingNeeded = (recordSize * 2 - Math.max( count * 2, 0 )) + 1;
                 String format = "%s %6s 0x%08X %s%" + paddingNeeded + "s%s%n";
                 String str;


### PR DESCRIPTION
Use unnamed modules for now; introduce separate property for
scala vm version since current version does not support have support
for -target:jvm-9
Use unnamed modules, export missed packages to unnamed modules.
Separate warm hugs to 'javax.xml.bind.DatatypeConverter' lovers.