### PR TITLE
Checkpoint duration expectations in MetricsKernelExtensionFactoryIT

### DIFF
--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/MetricsKernelExtensionFactoryIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/MetricsKernelExtensionFactoryIT.java
@@ -204,7 +204,7 @@ public class MetricsKernelExtensionFactoryIT
         // wait for the file to be written before shutting down the cluster
         File metricFile = metricsCsv( outputPath, CheckPointingMetrics.CHECK_POINT_DURATION );
 
-        long result = readLongValueAndAssert( metricFile, ( newValue, currentValue ) -> newValue > 0 );
+        long result = readLongValueAndAssert( metricFile, ( newValue, currentValue ) -> newValue >= 0 );
 
         // THEN
         assertThat( result, greaterThanOrEqualTo( 0L ) );


### PR DESCRIPTION
One of the observed checkpoints duration can be 0