### PR TITLE
Improve ClusterSeedingIT to cover more scenarios

### DIFF
--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/BackupCoreIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/BackupCoreIT.java
@@ -24,28 +24,20 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
-import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.neo4j.backup.OnlineBackupSettings;
-import org.neo4j.causalclustering.core.CausalClusteringSettings;
-import org.neo4j.causalclustering.core.CoreGraphDatabase;
 import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.CoreClusterMember;
-import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.collection.MapUtil;
-import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
-import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.causalclustering.ClusterRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.neo4j.backup.OnlineBackupCommandIT.runBackupToolFromOtherJvmToGetExitCode;
-import static org.neo4j.graphdb.Label.label;
+import static org.neo4j.causalclustering.helpers.BackupUtil.backupAddress;
+import static org.neo4j.causalclustering.helpers.BackupUtil.backupArguments;
+import static org.neo4j.causalclustering.helpers.BackupUtil.getConfig;
+import static org.neo4j.causalclustering.helpers.DataCreator.createSomeData;
 
 public class BackupCoreIT
 {
@@ -84,38 +76,5 @@ public class BackupCoreIT
             assertEquals( beforeChange, backupRepresentation );
             assertNotEquals( backupRepresentation, afterChange );
         }
-    }
-
-    static CoreGraphDatabase createSomeData( Cluster cluster ) throws Exception
-    {
-        return cluster.coreTx( ( db, tx ) ->
-        {
-            Node node = db.createNode( label( "boo" ) );
-            node.setProperty( "foobar", "baz_bat" );
-            tx.success();
-        } ).database();
-    }
-
-    static String backupAddress( GraphDatabaseFacade db )
-    {
-        InetSocketAddress inetSocketAddress = db.getDependencyResolver()
-                .resolveDependency( Config.class ).get( CausalClusteringSettings.transaction_advertised_address )
-                .socketAddress();
-        return inetSocketAddress.getHostName() + ":" + (inetSocketAddress.getPort() + 2000);
-    }
-
-    static String[] backupArguments( String from, File backupsDir, String name )
-    {
-        List<String> args = new ArrayList<>();
-        args.add( "--from=" + from );
-        args.add( "--cc-report-dir=" + backupsDir );
-        args.add( "--backup-dir=" + backupsDir );
-        args.add( "--name=" + name );
-        return args.toArray( new String[args.size()] );
-    }
-
-    static Config getConfig()
-    {
-        return new Config( MapUtil.stringMap( GraphDatabaseSettings.record_format.name(), StandardV3_0.NAME ) );
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/BackupReadReplicaIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/BackupReadReplicaIT.java
@@ -42,10 +42,10 @@ import org.neo4j.test.rule.SuppressOutput;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.neo4j.backup.OnlineBackupCommandIT.runBackupToolFromOtherJvmToGetExitCode;
-import static org.neo4j.causalclustering.backup.BackupCoreIT.backupAddress;
-import static org.neo4j.causalclustering.backup.BackupCoreIT.backupArguments;
-import static org.neo4j.causalclustering.backup.BackupCoreIT.createSomeData;
-import static org.neo4j.causalclustering.backup.BackupCoreIT.getConfig;
+import static org.neo4j.causalclustering.helpers.BackupUtil.backupAddress;
+import static org.neo4j.causalclustering.helpers.BackupUtil.backupArguments;
+import static org.neo4j.causalclustering.helpers.BackupUtil.getConfig;
+import static org.neo4j.causalclustering.helpers.DataCreator.createSomeData;
 import static org.neo4j.function.Predicates.awaitEx;
 import static org.neo4j.test.rule.SuppressOutput.suppress;
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/util/AbstractStoreGenerator.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/util/AbstractStoreGenerator.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.backup.util;
+
+import java.io.File;
+import java.util.UUID;
+
+import org.neo4j.causalclustering.core.CoreGraphDatabase;
+import org.neo4j.causalclustering.discovery.Cluster;
+
+import static org.neo4j.causalclustering.helpers.BackupUtil.createBackupFromCore;
+
+public abstract class AbstractStoreGenerator implements BackupStore
+{
+    private File backup;
+
+    abstract CoreGraphDatabase createData( Cluster cluster ) throws Exception;
+
+    abstract void modify( File backup );
+
+    private void generate( File backupDir, Cluster backupCluster ) throws Exception
+    {
+        CoreGraphDatabase db = createData( backupCluster );
+
+        this.backup = createBackupFromCore( db, backupName(), backupDir );
+        modify( backup );
+    }
+
+    @Override
+    public File get( File backupDir, Cluster backupCluster ) throws Exception
+    {
+        if ( backup == null )
+        {
+            generate( backupDir, backupCluster );
+        }
+        return backup;
+    }
+
+    private String backupName()
+    {
+        return "backup-" + UUID.randomUUID().toString().substring( 5 );
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/util/BackupStore.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/util/BackupStore.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.backup.util;
+
+import java.io.File;
+
+import org.neo4j.causalclustering.discovery.Cluster;
+
+public interface BackupStore
+{
+    File get(File backupDir, Cluster backupCluster) throws Exception;
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/util/BackupStoreWithSomeData.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/util/BackupStoreWithSomeData.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.backup.util;
+
+import java.io.File;
+
+import org.neo4j.causalclustering.core.CoreGraphDatabase;
+import org.neo4j.causalclustering.discovery.Cluster;
+
+import static org.neo4j.causalclustering.helpers.DataCreator.createNodes;
+
+public class BackupStoreWithSomeData extends AbstractStoreGenerator
+{
+    @Override
+    CoreGraphDatabase createData( Cluster cluster ) throws Exception
+    {
+        return createNodes( cluster, 15 ).database();
+    }
+
+    @Override
+    void modify( File backup )
+    {
+        // do nothing
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/util/BackupStoreWithSomeDataButNoTransactionLogs.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/util/BackupStoreWithSomeDataButNoTransactionLogs.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.backup.util;
+
+import java.io.File;
+
+import org.neo4j.causalclustering.core.CoreGraphDatabase;
+import org.neo4j.causalclustering.discovery.Cluster;
+
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.causalclustering.helpers.DataCreator.createNodes;
+
+public class BackupStoreWithSomeDataButNoTransactionLogs extends AbstractStoreGenerator
+{
+    @Override
+    CoreGraphDatabase createData( Cluster cluster ) throws Exception
+    {
+        return createNodes( cluster, 10 ).database();
+    }
+
+    @Override
+    void modify( File backup )
+    {
+        for ( File transaction : backup.listFiles( ( dir, name ) -> name.contains( "transaction" ) ) )
+        {
+            assertTrue( transaction.delete() );
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/util/EmptyBackupStore.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/util/EmptyBackupStore.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.backup.util;
+
+import java.io.File;
+
+import org.neo4j.causalclustering.core.CoreGraphDatabase;
+import org.neo4j.causalclustering.discovery.Cluster;
+
+public class EmptyBackupStore extends AbstractStoreGenerator
+{
+    @Override
+    CoreGraphDatabase createData( Cluster cluster )
+    {
+        return cluster.coreMembers().iterator().next().database();
+    }
+
+    @Override
+    void modify( File backup )
+    {
+        // do nothing
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreClusterMember.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreClusterMember.java
@@ -219,4 +219,9 @@ public class CoreClusterMember implements ClusterMember
     {
         return raftLogDir;
     }
+
+    public Config config()
+    {
+        return new Config( config );
+    }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helpers/BackupUtil.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helpers/BackupUtil.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.helpers;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
+import org.neo4j.causalclustering.core.CoreGraphDatabase;
+import org.neo4j.causalclustering.discovery.CoreClusterMember;
+import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
+import org.neo4j.restore.RestoreDatabaseCommand;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.backup.OnlineBackupCommandIT.runBackupToolFromOtherJvmToGetExitCode;
+
+public class BackupUtil
+{
+    public static String backupAddress( GraphDatabaseFacade db )
+    {
+        InetSocketAddress inetSocketAddress = db.getDependencyResolver()
+                .resolveDependency( Config.class ).get( CausalClusteringSettings.transaction_advertised_address )
+                .socketAddress();
+        return inetSocketAddress.getHostName() + ":" + (inetSocketAddress.getPort() + 2000);
+    }
+
+    public static String[] backupArguments( String from, File backupsDir, String name )
+    {
+        List<String> args = new ArrayList<>();
+        args.add( "--from=" + from );
+        args.add( "--cc-report-dir=" + backupsDir );
+        args.add( "--backup-dir=" + backupsDir );
+        args.add( "--name=" + name );
+        return args.toArray( new String[args.size()] );
+    }
+
+    public static File createBackupFromCore( CoreGraphDatabase db, String backupName, File baseBackupDir )
+            throws Exception
+    {
+        String[] args = backupArguments( backupAddress( db ), baseBackupDir, backupName );
+        assertEquals( 0, runBackupToolFromOtherJvmToGetExitCode( args ) );
+        return new File( baseBackupDir, backupName );
+    }
+
+    public static Config getConfig()
+    {
+        return new Config( MapUtil.stringMap( GraphDatabaseSettings.record_format.name(), StandardV3_0.NAME ) );
+    }
+
+    public static void restoreFromBackup( File backup, FileSystemAbstraction fsa, CoreClusterMember coreClusterMember )
+            throws IOException, CommandFailed
+    {
+        Config config = coreClusterMember.config();
+        RestoreDatabaseCommand restoreDatabaseCommand =
+                new RestoreDatabaseCommand( fsa, backup, config, "graph-db", true );
+        restoreDatabaseCommand.execute();
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helpers/DataCreator.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helpers/DataCreator.java
@@ -22,12 +22,24 @@ package org.neo4j.causalclustering.helpers;
 import org.neo4j.causalclustering.core.CoreGraphDatabase;
 import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.CoreClusterMember;
+import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 
+import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.helpers.collection.Iterables.count;
 
 public class DataCreator
 {
+    public static CoreGraphDatabase createSomeData( Cluster cluster ) throws Exception
+    {
+        return cluster.coreTx( ( db, tx ) ->
+        {
+            Node node = db.createNode( label( "boo" ) );
+            node.setProperty( "foobar", "baz_bat" );
+            tx.success();
+        } ).database();
+    }
+
     public static CoreClusterMember createNodes( Cluster cluster, int numberOfNodes ) throws Exception
     {
         CoreClusterMember last = null;


### PR DESCRIPTION
* Split up ClusterSeedingIT in two parameterized tests.
ClusterSeedingIT and SeedingNewMemberIt.
* Each test will seed with each type of BackupStore. EmptyBackup,
BackupContainingSomeData, BackupContainingSomeDataAndNoTransactionLogs