### PR TITLE
Improve ClusterSeedingIT to cover more scenarios

### DIFF
--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/BackupCoreIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/BackupCoreIT.java
@@ -24,28 +24,20 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.File;
-import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.neo4j.backup.OnlineBackupSettings;
-import org.neo4j.causalclustering.core.CausalClusteringSettings;
-import org.neo4j.causalclustering.core.CoreGraphDatabase;
 import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.CoreClusterMember;
-import org.neo4j.graphdb.Node;
-import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.collection.MapUtil;
-import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
-import org.neo4j.kernel.impl.store.format.standard.Standard;
 import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.causalclustering.ClusterRule;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.neo4j.backup.OnlineBackupCommandIT.runBackupToolFromOtherJvmToGetExitCode;
-import static org.neo4j.graphdb.Label.label;
+import static org.neo4j.causalclustering.helpers.BackupUtil.backupAddress;
+import static org.neo4j.causalclustering.helpers.BackupUtil.backupArguments;
+import static org.neo4j.causalclustering.helpers.BackupUtil.getConfig;
+import static org.neo4j.causalclustering.helpers.DataCreator.createSomeData;
 
 public class BackupCoreIT
 {
@@ -85,38 +77,5 @@ public class BackupCoreIT
             assertEquals( beforeChange, backupRepresentation );
             assertNotEquals( backupRepresentation, afterChange );
         }
-    }
-
-    static CoreGraphDatabase createSomeData( Cluster cluster ) throws Exception
-    {
-        return cluster.coreTx( ( db, tx ) ->
-        {
-            Node node = db.createNode( label( "boo" ) );
-            node.setProperty( "foobar", "baz_bat" );
-            tx.success();
-        } ).database();
-    }
-
-    static String backupAddress( GraphDatabaseFacade db )
-    {
-        InetSocketAddress inetSocketAddress = db.getDependencyResolver()
-                .resolveDependency( Config.class ).get( CausalClusteringSettings.transaction_advertised_address )
-                .socketAddress();
-        return inetSocketAddress.getHostName() + ":" + (inetSocketAddress.getPort() + 2000);
-    }
-
-    static String[] backupArguments( String from, File backupsDir, String name )
-    {
-        List<String> args = new ArrayList<>();
-        args.add( "--from=" + from );
-        args.add( "--cc-report-dir=" + backupsDir );
-        args.add( "--backup-dir=" + backupsDir );
-        args.add( "--name=" + name );
-        return args.toArray( new String[args.size()] );
-    }
-
-    static Config getConfig()
-    {
-        return Config.embeddedDefaults( MapUtil.stringMap( GraphDatabaseSettings.record_format.name(), Standard.LATEST_NAME ) );
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/BackupReadReplicaIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/BackupReadReplicaIT.java
@@ -43,14 +43,14 @@ import org.neo4j.test.causalclustering.ClusterRule;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.neo4j.backup.OnlineBackupCommandIT.runBackupToolFromOtherJvmToGetExitCode;
-import static org.neo4j.causalclustering.backup.BackupCoreIT.backupArguments;
-import static org.neo4j.causalclustering.backup.BackupCoreIT.createSomeData;
-import static org.neo4j.causalclustering.backup.BackupCoreIT.getConfig;
+import static org.neo4j.causalclustering.helpers.BackupUtil.backupArguments;
+import static org.neo4j.causalclustering.helpers.BackupUtil.getConfig;
+import static org.neo4j.causalclustering.helpers.DataCreator.createSomeData;
 import static org.neo4j.function.Predicates.awaitEx;
 
 public class BackupReadReplicaIT
 {
-    private int backupPort = findFreePort( 22000, 23000);
+    private int backupPort = findFreePort( 22000, 23000 );
 
     @Rule
     public ClusterRule clusterRule = new ClusterRule( BackupReadReplicaIT.class ).withNumberOfCoreMembers( 3 )

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/FileCopyDetector.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/FileCopyDetector.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.backup;
+
+import java.io.File;
+
+import org.neo4j.causalclustering.catchup.tx.FileCopyMonitor;
+
+public class FileCopyDetector implements FileCopyMonitor
+{
+    private volatile boolean hasCopiedFile = false;
+
+    @Override
+    public void copyFile( File file )
+    {
+        hasCopiedFile = true;
+    }
+
+    public boolean hasDetectedAnyFileCopied()
+    {
+        return hasCopiedFile;
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/NewMemberSeedingIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/NewMemberSeedingIT.java
@@ -40,11 +40,9 @@ import org.neo4j.causalclustering.discovery.Cluster;
 import org.neo4j.causalclustering.discovery.CoreClusterMember;
 import org.neo4j.causalclustering.discovery.IpFamily;
 import org.neo4j.causalclustering.discovery.SharedDiscoveryService;
-import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.kernel.impl.store.format.standard.Standard;
-import org.neo4j.test.DbRepresentation;
 import org.neo4j.test.rule.TestDirectory;
-import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
@@ -53,11 +51,10 @@ import static org.neo4j.causalclustering.discovery.Cluster.dataMatchesEventually
 import static org.neo4j.causalclustering.helpers.BackupUtil.restoreFromBackup;
 
 @RunWith( Parameterized.class )
-public class ClusterSeedingIT
+public class NewMemberSeedingIT
 {
-    private Cluster backupCluster;
     private Cluster cluster;
-    private FileSystemAbstraction fsa;
+    private DefaultFileSystemAbstraction fsa = new DefaultFileSystemAbstraction();
     private FileCopyDetector fileCopyDetector;
 
     @Parameterized.Parameters( name = "{0}" )
@@ -68,33 +65,25 @@ public class ClusterSeedingIT
 
     private static Iterable<BackupStore> stores()
     {
-        return Arrays.asList(
-                new EmptyBackupStore(),
-                new BackupStoreWithSomeData(),
-                new BackupStoreWithSomeDataButNoTransactionLogs() );
+        return Arrays
+                .asList( new EmptyBackupStore(), new BackupStoreWithSomeData(),
+                        new BackupStoreWithSomeDataButNoTransactionLogs() );
     }
 
     @Parameterized.Parameter()
-    public BackupStore initialStore;
+    public BackupStore seedStore;
 
     @Rule
     public TestDirectory testDir = TestDirectory.testDirectory();
-    public DefaultFileSystemRule fileSystemRule = new DefaultFileSystemRule();
     private File baseBackupDir;
 
     @Before
     public void setup() throws Exception
     {
         this.fileCopyDetector = new FileCopyDetector();
-        fsa = fileSystemRule.get();
-        backupCluster = new Cluster( testDir.directory( "cluster-for-backup" ), 3, 0,
-                new SharedDiscoveryService(), emptyMap(), backupParams(), emptyMap(), emptyMap(), Standard
-                .LATEST_NAME, IpFamily.IPV4, false );
-
         cluster = new Cluster( testDir.directory( "cluster-b" ), 3, 0,
-                new SharedDiscoveryService(), emptyMap(), emptyMap(), emptyMap(), emptyMap(), Standard.LATEST_NAME,
+                new SharedDiscoveryService(), emptyMap(), backupParams(), emptyMap(), emptyMap(), Standard.LATEST_NAME,
                 IpFamily.IPV4, false );
-
         baseBackupDir = testDir.directory( "backups" );
     }
 
@@ -108,10 +97,6 @@ public class ClusterSeedingIT
     @After
     public void after() throws Exception
     {
-        if ( backupCluster != null )
-        {
-            backupCluster.shutdown();
-        }
         if ( cluster != null )
         {
             cluster.shutdown();
@@ -119,26 +104,21 @@ public class ClusterSeedingIT
     }
 
     @Test
-    public void shouldSeedNewCluster() throws Exception
+    public void shouldSeedNewMemberToCluster() throws Exception
     {
         // given
-        backupCluster.start();
-        File backup = initialStore.get( baseBackupDir, backupCluster );
-        backupCluster.shutdown();
-
-        for ( CoreClusterMember coreClusterMember : cluster.coreMembers() )
-        {
-            restoreFromBackup( backup, fsa, coreClusterMember );
-        }
-
-        // we want the cluster to seed from backup. No instance should delete and re-copy the store.
-        cluster.coreMembers().forEach( ccm -> ccm.monitors().addMonitorListener( fileCopyDetector ) );
-
-        // when
         cluster.start();
 
-        //then
-        dataMatchesEventually( DbRepresentation.of( backup ), cluster.coreMembers() );
+        // when
+        File backup = seedStore.get( baseBackupDir, cluster );
+        CoreClusterMember newCoreClusterMember = cluster.addCoreMemberWithId( 3 );
+        restoreFromBackup( backup, fsa, newCoreClusterMember );
+        // we want the new instance to seed from backup and not delete and re-download the store
+        newCoreClusterMember.monitors().addMonitorListener( fileCopyDetector );
+        newCoreClusterMember.start();
+
+        // then
+        dataMatchesEventually( newCoreClusterMember, cluster.coreMembers() );
         assertFalse( fileCopyDetector.hasDetectedAnyFileCopied() );
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/backup_stores/AbstractStoreGenerator.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/backup_stores/AbstractStoreGenerator.java
@@ -20,6 +20,7 @@
 package org.neo4j.causalclustering.backup.backup_stores;
 
 import java.io.File;
+import java.util.Optional;
 import java.util.UUID;
 
 import org.neo4j.causalclustering.core.CoreGraphDatabase;
@@ -29,27 +30,17 @@ import static org.neo4j.causalclustering.helpers.BackupUtil.createBackupFromCore
 
 public abstract class AbstractStoreGenerator implements BackupStore
 {
-    private File backup;
-
     abstract CoreGraphDatabase createData( Cluster cluster ) throws Exception;
 
     abstract void modify( File backup );
 
-    private void generate( File backupDir, Cluster backupCluster ) throws Exception
+    @Override
+    public Optional<File> generate( File backupDir, Cluster backupCluster ) throws Exception
     {
         CoreGraphDatabase db = createData( backupCluster );
-        this.backup = createBackupFromCore( db, backupName(), backupDir );
-        modify( backup );
-    }
-
-    @Override
-    public File get( File backupDir, Cluster backupCluster ) throws Exception
-    {
-        if ( backup == null )
-        {
-            generate( backupDir, backupCluster );
-        }
-        return backup;
+        File backupFromCore = createBackupFromCore( db, backupName(), backupDir );
+        modify( backupFromCore );
+        return Optional.of( backupFromCore );
     }
 
     private String backupName()

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/backup_stores/AbstractStoreGenerator.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/backup_stores/AbstractStoreGenerator.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.backup.backup_stores;
+
+import java.io.File;
+import java.util.UUID;
+
+import org.neo4j.causalclustering.core.CoreGraphDatabase;
+import org.neo4j.causalclustering.discovery.Cluster;
+
+import static org.neo4j.causalclustering.helpers.BackupUtil.createBackupFromCore;
+
+public abstract class AbstractStoreGenerator implements BackupStore
+{
+    private File backup;
+
+    abstract CoreGraphDatabase createData( Cluster cluster ) throws Exception;
+
+    abstract void modify( File backup );
+
+    private void generate( File backupDir, Cluster backupCluster ) throws Exception
+    {
+        CoreGraphDatabase db = createData( backupCluster );
+        this.backup = createBackupFromCore( db, backupName(), backupDir );
+        modify( backup );
+    }
+
+    @Override
+    public File get( File backupDir, Cluster backupCluster ) throws Exception
+    {
+        if ( backup == null )
+        {
+            generate( backupDir, backupCluster );
+        }
+        return backup;
+    }
+
+    private String backupName()
+    {
+        return "backup-" + UUID.randomUUID().toString().substring( 5 );
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/backup_stores/BackupStore.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/backup_stores/BackupStore.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.backup.backup_stores;
+
+import java.io.File;
+
+import org.neo4j.causalclustering.discovery.Cluster;
+
+public interface BackupStore
+{
+    File get(File backupDir, Cluster backupCluster) throws Exception;
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/backup_stores/BackupStoreWithSomeData.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/backup_stores/BackupStoreWithSomeData.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.backup.backup_stores;
+
+import java.io.File;
+
+import org.neo4j.causalclustering.core.CoreGraphDatabase;
+import org.neo4j.causalclustering.discovery.Cluster;
+
+import static org.neo4j.causalclustering.helpers.DataCreator.createEmptyNodes;
+
+public class BackupStoreWithSomeData extends AbstractStoreGenerator
+{
+    @Override
+    CoreGraphDatabase createData( Cluster cluster ) throws Exception
+    {
+        return createEmptyNodes( cluster, 15 ).database();
+    }
+
+    @Override
+    void modify( File backup )
+    {
+        // do nothing
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/backup_stores/BackupStoreWithSomeDataButNoTransactionLogs.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/backup_stores/BackupStoreWithSomeDataButNoTransactionLogs.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.backup.backup_stores;
+
+import java.io.File;
+
+import org.neo4j.causalclustering.core.CoreGraphDatabase;
+import org.neo4j.causalclustering.discovery.Cluster;
+
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.causalclustering.helpers.DataCreator.createEmptyNodes;
+
+public class BackupStoreWithSomeDataButNoTransactionLogs extends AbstractStoreGenerator
+{
+    @Override
+    CoreGraphDatabase createData( Cluster cluster ) throws Exception
+    {
+        return createEmptyNodes( cluster, 10 ).database();
+    }
+
+    @Override
+    void modify( File backup )
+    {
+        for ( File transaction : backup.listFiles( ( dir, name ) -> name.contains( "transaction" ) ) )
+        {
+            assertTrue( transaction.delete() );
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/backup_stores/EmptyBackupStore.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/backup_stores/EmptyBackupStore.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.backup.backup_stores;
+
+import java.io.File;
+
+import org.neo4j.causalclustering.core.CoreGraphDatabase;
+import org.neo4j.causalclustering.discovery.Cluster;
+
+public class EmptyBackupStore extends AbstractStoreGenerator
+{
+    @Override
+    CoreGraphDatabase createData( Cluster cluster )
+    {
+        return cluster.coreMembers().iterator().next().database();
+    }
+
+    @Override
+    void modify( File backup )
+    {
+        // do nothing
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/backup_stores/NoStore.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/backup_stores/NoStore.java
@@ -24,7 +24,11 @@ import java.util.Optional;
 
 import org.neo4j.causalclustering.discovery.Cluster;
 
-public interface BackupStore
+public class NoStore implements BackupStore
 {
-    Optional<File> generate(File backupDir, Cluster backupCluster) throws Exception;
+    @Override
+    public Optional<File> generate( File backupDir, Cluster backupCluster ) throws Exception
+    {
+        return Optional.empty();
+    }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/cluster_load/ClusterLoad.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/cluster_load/ClusterLoad.java
@@ -17,14 +17,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.causalclustering.backup.backup_stores;
-
-import java.io.File;
-import java.util.Optional;
+package org.neo4j.causalclustering.backup.cluster_load;
 
 import org.neo4j.causalclustering.discovery.Cluster;
 
-public interface BackupStore
+public interface ClusterLoad
 {
-    Optional<File> generate(File backupDir, Cluster backupCluster) throws Exception;
+    void start(Cluster cluster) throws Exception;
+
+    void stop();
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/cluster_load/NoLoad.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/cluster_load/NoLoad.java
@@ -17,14 +17,21 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.causalclustering.backup.backup_stores;
-
-import java.io.File;
-import java.util.Optional;
+package org.neo4j.causalclustering.backup.cluster_load;
 
 import org.neo4j.causalclustering.discovery.Cluster;
 
-public interface BackupStore
+public class NoLoad implements ClusterLoad
 {
-    Optional<File> generate(File backupDir, Cluster backupCluster) throws Exception;
+    @Override
+    public void start(Cluster cluster)
+    {
+        // do nothing
+    }
+
+    @Override
+    public void stop()
+    {
+        // do nothing
+    }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/cluster_load/SmallBurst.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/backup/cluster_load/SmallBurst.java
@@ -17,14 +17,22 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.causalclustering.backup.backup_stores;
-
-import java.io.File;
-import java.util.Optional;
+package org.neo4j.causalclustering.backup.cluster_load;
 
 import org.neo4j.causalclustering.discovery.Cluster;
+import org.neo4j.causalclustering.helpers.DataCreator;
 
-public interface BackupStore
+public class SmallBurst implements ClusterLoad
 {
-    Optional<File> generate(File backupDir, Cluster backupCluster) throws Exception;
+    @Override
+    public void start( Cluster cluster ) throws Exception
+    {
+        DataCreator.createSomeData( cluster );
+    }
+
+    @Override
+    public void stop()
+    {
+        // do nothing
+    }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreClusterMember.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/CoreClusterMember.java
@@ -44,6 +44,7 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.configuration.HttpConnector;
 import org.neo4j.kernel.configuration.HttpConnector.Encryption;
 import org.neo4j.kernel.configuration.Settings;
+import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.Level;
 
 import static java.lang.String.format;
@@ -64,6 +65,7 @@ public class CoreClusterMember implements ClusterMember
     private final int serverId;
     private final String boltAdvertisedSocketAddress;
     private CoreGraphDatabase database;
+    private final Monitors monitors = new Monitors();
 
     public CoreClusterMember( int serverId, int clusterSize,
                               List<AdvertisedSocketAddress> addresses,
@@ -146,7 +148,7 @@ public class CoreClusterMember implements ClusterMember
     public void start()
     {
         database = new CoreGraphDatabase( storeDir, Config.embeddedDefaults( config ),
-                GraphDatabaseDependencies.newDependencies(), discoveryServiceFactory );
+                GraphDatabaseDependencies.newDependencies().monitors( monitors ), discoveryServiceFactory );
     }
 
     @Override
@@ -216,6 +218,11 @@ public class CoreClusterMember implements ClusterMember
         return ClientConnectorAddresses.extractFromConfig( Config.embeddedDefaults( this.config ) );
     }
 
+    public Monitors monitors()
+    {
+        return monitors;
+    }
+
     public File clusterStateDirectory()
     {
         return clusterStateDir;
@@ -228,6 +235,11 @@ public class CoreClusterMember implements ClusterMember
 
     public void stopCatchupServer() throws Throwable
     {
-        database.getDependencyResolver().resolveDependency( CatchupServer.class).stop();
+        database.getDependencyResolver().resolveDependency( CatchupServer.class ).stop();
+    }
+
+    public Config config()
+    {
+        return Config.embeddedDefaults( config );
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helpers/BackupUtil.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helpers/BackupUtil.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.helpers;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.neo4j.causalclustering.backup.BackupCoreIT;
+import org.neo4j.causalclustering.core.CausalClusteringSettings;
+import org.neo4j.causalclustering.core.CoreGraphDatabase;
+import org.neo4j.causalclustering.discovery.Cluster;
+import org.neo4j.causalclustering.discovery.CoreClusterMember;
+import org.neo4j.commandline.admin.CommandFailed;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.collection.MapUtil;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+import org.neo4j.kernel.impl.store.format.standard.Standard;
+import org.neo4j.kernel.impl.store.format.standard.StandardV3_0;
+import org.neo4j.restore.RestoreDatabaseCommand;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.backup.OnlineBackupCommandIT.runBackupToolFromOtherJvmToGetExitCode;
+import static org.neo4j.graphdb.Label.label;
+
+public class BackupUtil
+{
+    public static String backupAddress( GraphDatabaseFacade db )
+    {
+        InetSocketAddress inetSocketAddress = db.getDependencyResolver()
+                .resolveDependency( Config.class ).get( CausalClusteringSettings.transaction_advertised_address )
+                .socketAddress();
+        return inetSocketAddress.getHostName() + ":" + (inetSocketAddress.getPort() + 2000);
+    }
+
+    public static String[] backupArguments( String from, File backupsDir, String name )
+    {
+        List<String> args = new ArrayList<>();
+        args.add( "--from=" + from );
+        args.add( "--cc-report-dir=" + backupsDir );
+        args.add( "--backup-dir=" + backupsDir );
+        args.add( "--name=" + name );
+        return args.toArray( new String[args.size()] );
+    }
+
+    public static Config getConfig()
+    {
+        return Config.embeddedDefaults( MapUtil.stringMap( GraphDatabaseSettings.record_format.name(), Standard.LATEST_NAME ) );
+    }
+
+    public static File createBackupFromCore( CoreGraphDatabase db, String backupName, File baseBackupDir ) throws Exception
+    {
+        String[] args = backupArguments( backupAddress( db ), baseBackupDir, backupName );
+        assertEquals( 0, runBackupToolFromOtherJvmToGetExitCode( baseBackupDir, args ) );
+        return new File( baseBackupDir, backupName );
+    }
+
+    public static void restoreFromBackup( File backup, FileSystemAbstraction fsa, CoreClusterMember coreClusterMember )
+            throws IOException, CommandFailed
+    {
+        Config config = coreClusterMember.config();
+        RestoreDatabaseCommand restoreDatabaseCommand =
+                new RestoreDatabaseCommand( fsa, backup, config, "graph-db", true );
+        restoreDatabaseCommand.execute();
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helpers/DataCreator.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/helpers/DataCreator.java
@@ -29,10 +29,21 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.Pair;
 
+import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.helpers.collection.Iterables.count;
 
 public class DataCreator
 {
+    public static CoreGraphDatabase createSomeData( Cluster cluster ) throws Exception
+    {
+        return cluster.coreTx( ( db, tx ) ->
+        {
+            Node node = db.createNode( label( "boo" ) );
+            node.setProperty( "foobar", "baz_bat" );
+            tx.success();
+        } ).database();
+    }
+
     public static CoreClusterMember createLabelledNodesWithProperty( Cluster cluster, int numberOfNodes,
             Label label, Supplier<Pair<String,Object>> supplier ) throws Exception
     {


### PR DESCRIPTION
* Split up ClusterSeedingIT in two parameterized tests.
ClusterSeedingIT and SeedingNewMemberIt.
* Each test will seed with each type of BackupStore. EmptyBackup,
BackupContainingSomeData, BackupContainingSomeDataAndNoTransactionLogs
* Added monitors to be able to track and assert on store copy.