### PR TITLE
Keep Labels, Nodes, Relationship _STATE's in primitive maps in TxState

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/LabelState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/LabelState.java
@@ -36,14 +36,14 @@ public abstract class LabelState
     public static class Mutable extends LabelState
     {
         private DiffSets<Long> nodeDiffSets;
-        private final int labelId;
+        private final long labelId;
 
-        private Mutable( int labelId )
+        private Mutable( long labelId )
         {
             this.labelId = labelId;
         }
 
-        public int getLabelId()
+        public long getLabelId()
         {
             return labelId;
         }
@@ -64,10 +64,10 @@ public abstract class LabelState
         }
     }
 
-    abstract static class Defaults extends StateDefaults<Integer, LabelState, Mutable>
+    abstract static class Defaults extends StateDefaults<LabelState, Mutable>
     {
         @Override
-        Mutable createValue( Integer key, TxState state )
+        Mutable createValue( long key, TxState state )
         {
             return new Mutable( key );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/NodeStateImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/NodeStateImpl.java
@@ -231,10 +231,10 @@ public class NodeStateImpl extends PropertyContainerStateImpl implements NodeSta
             PrimitiveLongCollections.emptyIterator();
     }
 
-    public abstract static class Defaults extends StateDefaults<Long, NodeState, NodeStateImpl>
+    public abstract static class Defaults extends StateDefaults<NodeState, NodeStateImpl>
     {
         @Override
-        final NodeStateImpl createValue( Long id, TxState state )
+        final NodeStateImpl createValue( long id, TxState state )
         {
             return new NodeStateImpl( id, state );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/RelationshipStateImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/RelationshipStateImpl.java
@@ -57,10 +57,10 @@ public class RelationshipStateImpl extends PropertyContainerStateImpl implements
         return false;
     }
 
-    public abstract static class Defaults extends StateDefaults<Long, RelationshipState, RelationshipStateImpl>
+    public abstract static class Defaults extends StateDefaults<RelationshipState, RelationshipStateImpl>
     {
         @Override
-        RelationshipStateImpl createValue( Long id, TxState state )
+        RelationshipStateImpl createValue( long id, TxState state )
         {
             return new RelationshipStateImpl( id );
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/StateDefaults.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/StateDefaults.java
@@ -19,19 +19,17 @@
  */
 package org.neo4j.kernel.impl.api.state;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-
+import org.neo4j.collection.primitive.Primitive;
+import org.neo4j.collection.primitive.PrimitiveLongObjectMap;
 import org.neo4j.helpers.collection.Iterables;
 
 /**
- * Utility for {@linkplain #get(TxState, Object) retrieving} and
- * {@linkplain #getOrCreate(TxState, Object) initializing} lazy state held in maps in {@link TxState}.
+ * Utility for {@linkplain #get(TxState, long) retrieving} and
+ * {@linkplain #getOrCreate(TxState, long) initializing} lazy state held in maps in {@link TxState}.
  * <p>
- * {@linkplain #get(TxState, Object) Retrieving} state only guarantees that a readable object is returned, it does not
+ * {@linkplain #get(TxState, long) Retrieving} state only guarantees that a readable object is returned, it does not
  * guarantee a writable version. This allows us to return a read-only default value if the state has not been
- * initialized. Only when invoking {@link #getOrCreate(TxState, Object)} do we need to return a writable version, and
+ * initialized. Only when invoking {@link #getOrCreate(TxState, long)} do we need to return a writable version, and
  * at this point the state is initialized, if it has not been before, by creating a new instance and putting it in the
  * map.
  * <p>
@@ -65,15 +63,14 @@ import org.neo4j.helpers.collection.Iterables;
  * }
  * </pre></code>
  *
- * @param <KEY> The type of the key in the map for the state accessed by an instance of this class
  * @param <RO>  The read-only version of the value type stored in the state
  * @param <RW>  The read/write version of the value type stored in the state
  */
-abstract class StateDefaults<KEY, RO, RW extends RO>
+abstract class StateDefaults<RO, RW extends RO>
 {
-    final RO get( TxState state, KEY key )
+    final RO get( TxState state, long key )
     {
-        Map<KEY, RW> map = getMap( state );
+        PrimitiveLongObjectMap<RW> map = getMap( state );
         if ( map == null )
         {
             return defaultValue();
@@ -82,42 +79,44 @@ abstract class StateDefaults<KEY, RO, RW extends RO>
         return value == null ? defaultValue() : value;
     }
 
-    final RW getOrCreate( TxState state, KEY key )
+    final RW getOrCreate( TxState state, long key )
     {
-        Map<KEY, RW> map = getMap( state );
+        PrimitiveLongObjectMap<RW> map = getMap( state );
         if ( map == null )
         {
-            setMap( state, map = new HashMap<>() );
+            map = Primitive.longObjectMap();
+            setMap( state, map );
         }
         RW value = map.get( key );
         if ( value == null )
         {
-            map.put( key, value = createValue( key, state ) );
+            value = createValue( key, state );
+            map.put( key, value );
         }
         return value;
     }
 
     final Iterable<RO> values( TxState state )
     {
-        Map map = getMap( state );
+        PrimitiveLongObjectMap<RW> map = getMap( state );
         if ( map == null )
         {
             return Iterables.empty();
         }
         @SuppressWarnings( "unchecked" )
-        Collection<RO> values = map.values();
+        Iterable<RO> values = (Iterable<RO>) map.values();
         return values;
     }
 
     /** Implemented for the value holder - get the map from the state field. */
-    abstract Map<KEY, RW> getMap( TxState state );
+    abstract PrimitiveLongObjectMap<RW> getMap( TxState state );
 
     /** Implemented for the value holder - set the map to the state field. */
-    abstract void setMap( TxState state, Map<KEY, RW> map );
+    abstract void setMap( TxState state, PrimitiveLongObjectMap<RW> map );
 
     /** Implemented for the value type - initializes state by creating a new instance.
      * @param state */
-    abstract RW createValue( KEY key, TxState state );
+    abstract RW createValue( long key, TxState state );
 
     /** Implemented for the value type - returns a default read-only version of the value type. */
     abstract RO defaultValue();

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongObjectMap.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongObjectMap.java
@@ -33,4 +33,10 @@ public interface PrimitiveLongObjectMap<VALUE> extends PrimitiveLongCollection
      * Visit the entries of this map, until all have been visited or the visitor returns 'true'.
      */
     <E extends Exception> void visitEntries( PrimitiveLongObjectVisitor<VALUE, E> visitor ) throws E;
+
+    /**
+     * {@link Iterable} with all map values
+     * @return iterable with all map values
+     */
+    Iterable<VALUE> values();
 }

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/base/Empty.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/base/Empty.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.collection.primitive.base;
 
+import java.util.Collections;
+
 import org.neo4j.collection.primitive.PrimitiveCollection;
 import org.neo4j.collection.primitive.PrimitiveIntCollection;
 import org.neo4j.collection.primitive.PrimitiveIntCollections;
@@ -196,6 +198,12 @@ public class Empty
         @Override
         public <E extends Exception> void visitEntries( PrimitiveLongObjectVisitor<T,E> visitor ) throws E
         {   // No entries to visit
+        }
+
+        @Override
+        public Iterable<T> values()
+        {
+            return Collections.emptyList();
         }
 
         @Override

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongObjectHashMap.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongObjectHashMap.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.collection.primitive.hopscotch;
 
+import java.util.Iterator;
+
+import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.collection.primitive.PrimitiveLongObjectMap;
 import org.neo4j.collection.primitive.PrimitiveLongObjectVisitor;
 import org.neo4j.collection.primitive.hopscotch.HopScotchHashingAlgorithm.Monitor;
@@ -85,6 +88,12 @@ public class PrimitiveLongObjectHashMap<VALUE> extends AbstractLongHopScotchColl
                 return;
             }
         }
+    }
+
+    @Override
+    public Iterable<VALUE> values()
+    {
+        return new ValueIterable( this );
     }
 
     @SuppressWarnings( "EqualsWhichDoesntCheckParameterClass" ) // yes it does
@@ -163,6 +172,37 @@ public class PrimitiveLongObjectHashMap<VALUE> extends AbstractLongHopScotchColl
             }
             HashCodeComputer<?> that = (HashCodeComputer<?>) o;
             return hash == that.hash;
+        }
+    }
+
+    private class ValueIterable implements Iterable<VALUE>
+    {
+        private final PrimitiveLongObjectHashMap<VALUE> map;
+        private final PrimitiveLongIterator iterator;
+
+        ValueIterable( PrimitiveLongObjectHashMap<VALUE> map )
+        {
+            this.map = map;
+            this.iterator = map.iterator();
+        }
+
+        @Override
+        public Iterator<VALUE> iterator()
+        {
+            return new Iterator<VALUE>()
+            {
+                @Override
+                public boolean hasNext()
+                {
+                    return iterator.hasNext();
+                }
+
+                @Override
+                public VALUE next()
+                {
+                    return map.get( iterator.next() );
+                }
+            };
         }
     }
 }

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongObjectHashMap.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongObjectHashMap.java
@@ -178,12 +178,10 @@ public class PrimitiveLongObjectHashMap<VALUE> extends AbstractLongHopScotchColl
     private class ValueIterable implements Iterable<VALUE>
     {
         private final PrimitiveLongObjectHashMap<VALUE> map;
-        private final PrimitiveLongIterator iterator;
 
         ValueIterable( PrimitiveLongObjectHashMap<VALUE> map )
         {
             this.map = map;
-            this.iterator = map.iterator();
         }
 
         @Override
@@ -191,6 +189,8 @@ public class PrimitiveLongObjectHashMap<VALUE> extends AbstractLongHopScotchColl
         {
             return new Iterator<VALUE>()
             {
+                private final PrimitiveLongIterator iterator = map.iterator();
+
                 @Override
                 public boolean hasNext()
                 {

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongMapTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongMapTest.java
@@ -43,6 +43,7 @@ import org.neo4j.collection.primitive.PrimitiveLongObjectMap;
 import org.neo4j.collection.primitive.PrimitiveLongObjectVisitor;
 import org.neo4j.collection.primitive.PrimitiveLongVisitor;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1300,6 +1301,17 @@ public class PrimitiveLongMapTest
 
         // THEN
         assertThat( counter.get(), is( 3 ) );
+    }
+
+    @Test
+    public void longObjectMapValuesContainsAllValues()
+    {
+        PrimitiveLongObjectMap<String> map = Primitive.longObjectMap();
+        map.put( 1, "a" );
+        map.put( 2, "b" );
+        map.put( 3, "c" );
+
+        assertThat( map.values(), containsInAnyOrder( "a", "b", "c" ) );
     }
 
     @Test


### PR DESCRIPTION
Update LABEL_STATE, NODE_STATE, RELATIONSHIP_STATE to use primitive maps
and maps that keep underlying state.