### PR TITLE
Simplifies property access in new kernel API

### DIFF
--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Read.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Read.java
@@ -119,20 +119,24 @@ public interface Read
     void relationships( long nodeReference, long reference, RelationshipTraversalCursor cursor );
 
     /**
+     * @param nodeReference
+     *         the owner of the properties.
      * @param reference
      *         a reference from {@link NodeCursor#propertiesReference()}.
      * @param cursor
      *         the cursor to use for consuming the results.
      */
-    void nodeProperties( long reference, PropertyCursor cursor );
+    void nodeProperties( long nodeReference, long reference, PropertyCursor cursor );
 
     /**
+     * @param relationshipReference
+     *         the owner of the properties.
      * @param reference
      *         a reference from {@link RelationshipDataAccessor#propertiesReference()}.
      * @param cursor
      *         the cursor to use for consuming the results.
      */
-    void relationshipProperties( long reference, PropertyCursor cursor );
+    void relationshipProperties( long relationshipReference, long reference, PropertyCursor cursor );
 
     void graphProperties( PropertyCursor cursor );
 

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/PropertyCursorTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/PropertyCursorTestBase.java
@@ -175,7 +175,7 @@ public abstract class PropertyCursorTestBase<G extends KernelAPIReadTestSupport>
             node.properties( props );
             assertFalse( "no properties by direct method", props.next() );
 
-            read.nodeProperties( node.propertiesReference(), props );
+            read.nodeProperties( node.nodeReference(), node.propertiesReference(), props );
             assertFalse( "no properties via property ref", props.next() );
 
             assertFalse( "only one node", node.next() );
@@ -268,7 +268,7 @@ public abstract class PropertyCursorTestBase<G extends KernelAPIReadTestSupport>
             assertEquals( "correct value", expectedValue, props.propertyValue() );
             assertFalse( "single property", props.next() );
 
-            read.nodeProperties( node.propertiesReference(), props );
+            read.nodeProperties( node.nodeReference(), node.propertiesReference(), props );
             assertTrue( "has properties via property ref", props.next() );
             assertEquals( "correct value", expectedValue, props.propertyValue() );
             assertFalse( "single property", props.next() );

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/StubRead.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/StubRead.java
@@ -128,13 +128,13 @@ public class StubRead implements Read
     }
 
     @Override
-    public void nodeProperties( long reference, PropertyCursor cursor )
+    public void nodeProperties( long nodeReference, long reference, PropertyCursor cursor )
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void relationshipProperties( long reference, PropertyCursor cursor )
+    public void relationshipProperties( long relationshipReference, long reference, PropertyCursor cursor )
     {
         throw new UnsupportedOperationException();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionState.java
@@ -23,7 +23,6 @@ import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.internal.kernel.api.schema.constraints.ConstraintDescriptor;
 import org.neo4j.kernel.api.schema.constaints.IndexBackedConstraintDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
-import org.neo4j.storageengine.api.txstate.PropertyContainerState;
 import org.neo4j.storageengine.api.txstate.ReadableTransactionState;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.ValueTuple;
@@ -67,8 +66,6 @@ public interface TransactionState extends ReadableTransactionState
     void nodeDoAddLabel( int labelId, long nodeId );
 
     void nodeDoRemoveLabel( int labelId, long nodeId );
-
-    void registerProperties( long ref, PropertyContainerState state );
 
     // TOKEN RELATED
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
@@ -114,8 +114,6 @@ public final class TxState implements TransactionState, RelationshipVisitor.Home
     // Tracks added and removed relationships, not modified relationships
     private RelationshipDiffSets<Long> relationships;
 
-    private PrimitiveLongObjectMap<PropertyContainerState> propertiesMap = Primitive.longObjectMap();
-
     /**
      * These two sets are needed because create-delete in same transaction is a no-op in {@link DiffSets}
      * but we still need to provide correct answer in {@link #nodeIsDeletedInThisTx(long)} and
@@ -604,12 +602,6 @@ public final class TxState implements TransactionState, RelationshipVisitor.Home
     }
 
     @Override
-    public void registerProperties( long ref, PropertyContainerState state )
-    {
-        propertiesMap.put( ref, state );
-    }
-
-    @Override
     public void labelDoCreateForName( String labelName, int id )
     {
         if ( createdLabelTokens == null )
@@ -652,12 +644,6 @@ public final class TxState implements TransactionState, RelationshipVisitor.Home
     public RelationshipState getRelationshipState( long id )
     {
         return RELATIONSHIP_STATE.get( this, id );
-    }
-
-    @Override
-    public PropertyContainerState getPropertiesState( long reference )
-    {
-        return propertiesMap.get( reference );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeCursor.java
@@ -33,8 +33,6 @@ import org.neo4j.kernel.impl.store.NodeLabelsField;
 import org.neo4j.kernel.impl.store.RecordCursor;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
-import org.neo4j.storageengine.api.txstate.NodeState;
-
 import static org.neo4j.kernel.impl.newapi.References.setDirectFlag;
 import static org.neo4j.kernel.impl.newapi.References.setGroupFlag;
 
@@ -136,7 +134,7 @@ class NodeCursor extends NodeRecord implements org.neo4j.internal.kernel.api.Nod
     @Override
     public boolean hasProperties()
     {
-        return nextProp != (long) NO_ID;
+        return nextProp != NO_ID;
     }
 
     @Override
@@ -154,7 +152,7 @@ class NodeCursor extends NodeRecord implements org.neo4j.internal.kernel.api.Nod
     @Override
     public void properties( PropertyCursor cursor )
     {
-        read.nodeProperties( propertiesReference(), cursor );
+        read.nodeProperties( nodeReference(), propertiesReference(), cursor );
     }
 
     @Override
@@ -172,45 +170,7 @@ class NodeCursor extends NodeRecord implements org.neo4j.internal.kernel.api.Nod
     @Override
     public long propertiesReference()
     {
-        //In the case where there hasn't been any changes in the transaction state this method simply returns the
-        // property reference.
-        //
-        //However if there has been changes we can have two cases:
-        //
-        //   i: The node had no prior properties, in this case we simply encode the node id in the reference
-        //      which allows the property cursor to probe tx state for properties.
-        //   ii: The node has properties, in this case we mark the actual property reference as having tx state
-        //
-        //in both cases we need to store a mapping from the computed reference to the state in the transaction state
-        //so we can retrieve it later in the property cursor.
-        long propertiesReference = getNextProp();
-
-        if ( hasChanges() )
-        {
-            TransactionState txState = read.txState();
-            NodeState nodeState = txState.getNodeState( nodeReference() );
-            if ( nodeState.hasPropertyChanges() )
-            {
-                long ref;
-                if ( propertiesReference == NO_ID )
-                {
-                    //Current node has no properties before the start of this transaction,
-                    //store the node id in the reference.
-                    ref = References.setNodeFlag( nodeReference() );
-                }
-                else
-                {
-                    //Mark the reference so that property cursor checks both
-                    //tx state as well as disk.
-                    ref = References.setTxStateFlag( propertiesReference );
-                    //stores the node state mapped to the current property
-                    //reference so that property cursor is able to retrieve the state later.
-                    txState.registerProperties( ref, nodeState );
-                }
-                return ref;
-            }
-        }
-        return propertiesReference;
+        return getNextProp();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Read.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Read.java
@@ -299,24 +299,25 @@ abstract class Read implements TxStateHolder,
     }
 
     @Override
-    public final void nodeProperties( long reference, org.neo4j.internal.kernel.api.PropertyCursor cursor )
+    public final void nodeProperties( long nodeReference, long reference, org.neo4j.internal.kernel.api.PropertyCursor cursor )
     {
         ktx.assertOpen();
-        ((PropertyCursor) cursor).init( reference, this, ktx );
+        ((PropertyCursor) cursor).init( References.setNodeFlag( nodeReference ), reference, this, ktx );
     }
 
     @Override
-    public final void relationshipProperties( long reference, org.neo4j.internal.kernel.api.PropertyCursor cursor )
+    public final void relationshipProperties( long relationshipReference, long reference,
+            org.neo4j.internal.kernel.api.PropertyCursor cursor )
     {
         ktx.assertOpen();
-        ((PropertyCursor) cursor).init( reference, this, ktx );
+        ((PropertyCursor) cursor).init( References.setRelationshipFlag( relationshipReference ), reference, this, ktx );
     }
 
     @Override
     public final void graphProperties( org.neo4j.internal.kernel.api.PropertyCursor cursor )
     {
         ktx.assertOpen();
-        ((PropertyCursor) cursor).init( graphPropertiesReference(), this, ktx );
+        ((PropertyCursor) cursor).init( NO_ID, graphPropertiesReference(), this, ktx );
     }
 
     abstract long graphPropertiesReference();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/References.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/References.java
@@ -58,7 +58,6 @@ class References
     private static final long DIRECT_FLAG = 0x2000_0000_0000_0000L;
 
     // Use node reference as property reference
-    private static final long STATE_MARKER = 0x1000_0000_0000_0000L;
     private static final long NODE_MARKER = 0x2000_0000_0000_0000L;
     private static final long RELATIONSHIP_MARKER = 0x4000_0000_0000_0000L;
 
@@ -189,30 +188,5 @@ class References
     {
         assert reference != NO_ID;
         return (reference & RELATIONSHIP_MARKER) != 0L;
-    }
-
-    /**
-     * Marks the property reference as having changes in the transaction state.
-     * <p>
-     * Setting this flag tells us that the value on disk is not the only source of truth, the transaction state must
-     * also be checked.
-     *
-     * @param reference The reference to set as having tx state
-     * @return The encoded reference.
-     */
-    static long setTxStateFlag( long reference )
-    {
-        return reference | STATE_MARKER | FLAG_MARKER;
-    }
-
-    /**
-     * Checks if the property reference has been marked as having changes in the transaction state.
-     * @param reference The reference to check
-     * @return <tt>true</tt>if the reference has been marked as having changes otherwise <tt>false</tt>
-     */
-    static boolean hasTxStateFlag( long reference )
-    {
-        assert reference != NO_ID;
-        return (reference & STATE_MARKER) != 0L;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
@@ -46,7 +46,7 @@ abstract class RelationshipCursor extends RelationshipRecord implements Relation
     @Override
     public boolean hasProperties()
     {
-        return nextProp != (long) PropertyCursor.NO_ID;
+        return nextProp != PropertyCursor.NO_ID;
     }
 
     @Override
@@ -64,7 +64,7 @@ abstract class RelationshipCursor extends RelationshipRecord implements Relation
     @Override
     public void properties( org.neo4j.internal.kernel.api.PropertyCursor cursor )
     {
-        read.nodeProperties( propertiesReference(), cursor );
+        read.relationshipProperties( relationshipReference(), propertiesReference(), cursor );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/ReadableTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/ReadableTransactionState.java
@@ -142,8 +142,6 @@ public interface ReadableTransactionState
 
     RelationshipState getRelationshipState( long id );
 
-    PropertyContainerState getPropertiesState( long propertyReference );
-
     Cursor<NodeItem> augmentSingleNodeCursor( Cursor<NodeItem> cursor, long nodeId );
 
     Cursor<PropertyItem> augmentPropertyCursor( Cursor<PropertyItem> cursor,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/TxStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/TxStateTest.java
@@ -46,10 +46,7 @@ import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
 import org.neo4j.kernel.api.txstate.TransactionState;
 import org.neo4j.storageengine.api.Direction;
 import org.neo4j.storageengine.api.RelationshipItem;
-import org.neo4j.storageengine.api.txstate.NodeState;
-import org.neo4j.storageengine.api.txstate.PropertyContainerState;
 import org.neo4j.storageengine.api.txstate.ReadableDiffSets;
-import org.neo4j.storageengine.api.txstate.RelationshipState;
 import org.neo4j.storageengine.api.txstate.TxStateVisitor;
 import org.neo4j.test.rule.RandomRule;
 import org.neo4j.test.rule.RepeatRule;
@@ -1471,36 +1468,6 @@ public class TxStateTest
             assertTrue( "Augmented cursor didn't return some expected relationships: " + expectedRelationships,
                     expectedRelationships.isEmpty() );
         }
-    }
-
-    @Test
-    public void shouldGetNodeStateFromPropertyReference() throws Exception
-    {
-        // GIVEN
-        state.nodeDoCreate( 1337L );
-        NodeState nodeState = state.getNodeState( 1337L );
-        state.registerProperties( 42L, nodeState );
-
-        // WHEN
-        PropertyContainerState propertiesState = state.getPropertiesState( 42L );
-
-        // Then
-        assertThat( propertiesState, equalTo( nodeState ) );
-    }
-
-    @Test
-    public void shouldGetRelationshipStateFromPropertyReference() throws Exception
-    {
-        // GIVEN
-        state.relationshipDoCreate( 1337L, 0, 1L, 2L );
-        RelationshipState relState = state.getRelationshipState( 1337L );
-        state.registerProperties( 42L, relState );
-
-        // WHEN
-        PropertyContainerState propertiesState = state.getPropertiesState( 42L );
-
-        // Then
-        assertThat( propertiesState, equalTo( relState ) );
     }
 
     private Map<Long,RelationshipItem> relationshipsForNode( long nodeId, Map<Long,RelationshipItem> allRelationships,

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/ReferencesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/ReferencesTest.java
@@ -33,13 +33,11 @@ import static org.neo4j.kernel.impl.newapi.References.hasFilterFlag;
 import static org.neo4j.kernel.impl.newapi.References.hasGroupFlag;
 import static org.neo4j.kernel.impl.newapi.References.hasNodeFlag;
 import static org.neo4j.kernel.impl.newapi.References.hasRelationshipFlag;
-import static org.neo4j.kernel.impl.newapi.References.hasTxStateFlag;
 import static org.neo4j.kernel.impl.newapi.References.setDirectFlag;
 import static org.neo4j.kernel.impl.newapi.References.setFilterFlag;
 import static org.neo4j.kernel.impl.newapi.References.setGroupFlag;
 import static org.neo4j.kernel.impl.newapi.References.setNodeFlag;
 import static org.neo4j.kernel.impl.newapi.References.setRelationshipFlag;
-import static org.neo4j.kernel.impl.newapi.References.setTxStateFlag;
 import static org.neo4j.kernel.impl.store.record.AbstractBaseRecord.NO_ID;
 
 public class ReferencesTest
@@ -101,18 +99,6 @@ public class ReferencesTest
             long reference = random.nextLong( MAX_ID_LIMIT );
             assertFalse( hasGroupFlag( reference ) );
             assertTrue( hasGroupFlag( setGroupFlag( reference ) ) );
-        }
-    }
-
-    @Test
-    public void shouldSetTxStateFlag()
-    {
-        ThreadLocalRandom random = ThreadLocalRandom.current();
-        for ( int i = 0; i < 1000; i++ )
-        {
-            long reference = random.nextLong( MAX_ID_LIMIT );
-            assertFalse( hasTxStateFlag( reference ) );
-            assertTrue( hasTxStateFlag( setTxStateFlag( reference ) ) );
         }
     }
 


### PR DESCRIPTION
Especially w/ regards to transaction state. Read interface has methods for initializing
node/relationship property cursors. Previously those methods didn't have the entity reference
as argument. Because of this limitation the interaction between
the NodeCursor/RelationshipCursor and PropertyCursor was made complicated by encoding
different behaviour w/ regards to transaction state into the property reference.
On top of that TxState was used as an additional helper to pass information about tx state
from NodeCursor/RelationshipCursor to PropertyCursor, resulting in more memory usage in TxState
as well as going via a map.

This is simplified by letting Read methods accept nodeReference for its nodeProperties call
and relationshipReference for its relationshipProperties call. Now TxState can be left
out of this interaction and its propertiesMap removed. This also results in simpler cursor code.