### PR TITLE
Allow null realm in ShiroAuthToken

### DIFF
--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthToken.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthToken.java
@@ -24,10 +24,11 @@ import org.apache.shiro.authc.AuthenticationToken;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.neo4j.kernel.api.security.AuthToken;
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
+
+import static java.util.stream.Collectors.joining;
 
 public class ShiroAuthToken implements AuthenticationToken
 {
@@ -97,17 +98,14 @@ public class ShiroAuthToken implements AuthenticationToken
             keys.set( 0, AuthToken.SCHEME_KEY );
         }
 
-        Iterable<String> keyValuePairs =
-                keys.stream()
-                    .map( this::keyValueString )
-                    .collect( Collectors.toList() );
-
-        return "{ " + String.join( PAIR_DELIMITER, keyValuePairs ) + " }";
+        return keys.stream()
+                .map( this::keyValueString )
+                .collect( joining( PAIR_DELIMITER, "{ ", " }" ) );
     }
 
     private String keyValueString( String key )
     {
-        String valueString = key.equals( AuthToken.CREDENTIALS ) ? "******" : authToken.get( key ).toString();
+        String valueString = key.equals( AuthToken.CREDENTIALS ) ? "******" : String.valueOf( authToken.get( key ) );
         return key + KEY_VALUE_DELIMITER + VALUE_DELIMITER + valueString + VALUE_DELIMITER;
     }
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthToken.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/ShiroAuthToken.java
@@ -73,10 +73,12 @@ public class ShiroAuthToken implements AuthenticationToken
     /** returns true if token map does not specify a realm, or if it specifies the requested realm */
     public boolean supportsRealm( String realm )
     {
-        return !authToken.containsKey( AuthToken.REALM_KEY ) ||
-               authToken.get( AuthToken.REALM_KEY ).toString().length() == 0 ||
-               authToken.get( AuthToken.REALM_KEY ).equals( "*" ) ||
-               authToken.get( AuthToken.REALM_KEY ).equals( realm );
+        Object providedRealm = authToken.get( AuthToken.REALM_KEY );
+
+        return providedRealm == null ||
+               providedRealm.equals( "*" ) ||
+               providedRealm.equals( realm ) ||
+               providedRealm.toString().isEmpty();
     }
 
     @Override

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroAuthTokenTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroAuthTokenTest.java
@@ -27,6 +27,7 @@ import org.neo4j.kernel.api.security.AuthToken;
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.neo4j.helpers.collection.MapUtil.map;
 
@@ -121,6 +122,16 @@ public class ShiroAuthTokenTest
                         "parameters", params ) ) );
         testTokenSupportsRealm( token, true, realm );
         testTokenSupportsRealm( token, false, "unknown", "native" );
+    }
+
+    @Test
+    public void shouldHaveStringRepresentationWithNullRealm() throws Exception
+    {
+        ShiroAuthToken token = new ShiroAuthToken( AuthToken.newBasicAuthToken( USERNAME, PASSWORD, null ) );
+        testBasicAuthToken( token, USERNAME, PASSWORD, AuthToken.BASIC_SCHEME );
+
+        String stringRepresentation = token.toString();
+        assertThat( stringRepresentation, containsString( "realm='null'" ) );
     }
 
     private void testTokenSupportsRealm( ShiroAuthToken token, boolean supports, String... realms )

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroAuthTokenTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ShiroAuthTokenTest.java
@@ -32,8 +32,8 @@ import static org.neo4j.helpers.collection.MapUtil.map;
 
 public class ShiroAuthTokenTest
 {
-    private final String USERNAME = "myuser";
-    private final String PASSWORD = "mypw123";
+    private static final String USERNAME = "myuser";
+    private static final String PASSWORD = "mypw123";
 
     @Test
     public void shouldSupportBasicAuthToken() throws Exception
@@ -43,6 +43,28 @@ public class ShiroAuthTokenTest
         assertThat( "Token map should have only expected values", token.getAuthTokenMap(),
                 equalTo( map( AuthToken.PRINCIPAL, USERNAME, AuthToken.CREDENTIALS, PASSWORD, AuthToken.SCHEME_KEY,
                         AuthToken.BASIC_SCHEME ) ) );
+        testTokenSupportsRealm( token, true, "unknown", "native", "ldap" );
+    }
+
+    @Test
+    public void shouldSupportBasicAuthTokenWithEmptyRealm() throws Exception
+    {
+        ShiroAuthToken token = new ShiroAuthToken( AuthToken.newBasicAuthToken( USERNAME, PASSWORD, "" ) );
+        testBasicAuthToken( token, USERNAME, PASSWORD, AuthToken.BASIC_SCHEME );
+        assertThat( "Token map should have only expected values", token.getAuthTokenMap(),
+                equalTo( map( AuthToken.PRINCIPAL, USERNAME, AuthToken.CREDENTIALS, PASSWORD, AuthToken.SCHEME_KEY,
+                        AuthToken.BASIC_SCHEME, AuthToken.REALM_KEY, "" ) ) );
+        testTokenSupportsRealm( token, true, "unknown", "native", "ldap" );
+    }
+
+    @Test
+    public void shouldSupportBasicAuthTokenWithNullRealm() throws Exception
+    {
+        ShiroAuthToken token = new ShiroAuthToken( AuthToken.newBasicAuthToken( USERNAME, PASSWORD, null ) );
+        testBasicAuthToken( token, USERNAME, PASSWORD, AuthToken.BASIC_SCHEME );
+        assertThat( "Token map should have only expected values", token.getAuthTokenMap(),
+                equalTo( map( AuthToken.PRINCIPAL, USERNAME, AuthToken.CREDENTIALS, PASSWORD, AuthToken.SCHEME_KEY,
+                        AuthToken.BASIC_SCHEME, AuthToken.REALM_KEY, null ) ) );
         testTokenSupportsRealm( token, true, "unknown", "native", "ldap" );
     }
 


### PR DESCRIPTION
This PR makes `ShiroAuthToken` handle `null` realm values. It is possible for the provided auth token map to contain `null` as explicit value.