### PR TITLE
Less indirections in iterators

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LookupFilter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/LookupFilter.java
@@ -24,6 +24,7 @@ import java.util.function.LongPredicate;
 
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.collection.primitive.PrimitiveLongResourceIterator;
 import org.neo4j.cursor.Cursor;
 import org.neo4j.internal.kernel.api.IndexQuery;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
@@ -101,8 +102,8 @@ public class LookupFilter
      *
      * used in "normal" operation
      */
-    public static PrimitiveLongIterator exactIndexMatches( EntityOperations operations, KernelStatement state,
-            PrimitiveLongIterator indexedNodeIds, IndexQuery... predicates )
+    public static PrimitiveLongResourceIterator exactIndexMatches( EntityOperations operations, KernelStatement state,
+            PrimitiveLongResourceIterator indexedNodeIds, IndexQuery... predicates )
     {
         if ( !indexedNodeIds.hasNext() )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
@@ -33,6 +33,7 @@ import org.neo4j.collection.primitive.PrimitiveIntObjectVisitor;
 import org.neo4j.collection.primitive.PrimitiveIntSet;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.collection.primitive.PrimitiveLongObjectMap;
+import org.neo4j.collection.primitive.PrimitiveLongResourceIterator;
 import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.cursor.Cursor;
 import org.neo4j.helpers.collection.Iterables;
@@ -1245,7 +1246,7 @@ public final class TxState implements TransactionState, RelationshipVisitor.Home
     }
 
     @Override
-    public PrimitiveLongIterator augmentNodesGetAll( PrimitiveLongIterator committed )
+    public PrimitiveLongResourceIterator augmentNodesGetAll( PrimitiveLongIterator committed )
     {
         return addedAndRemovedNodes().augment( committed );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DiffApplyingPrimitiveLongIterator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DiffApplyingPrimitiveLongIterator.java
@@ -24,13 +24,15 @@ import java.util.Set;
 
 import org.neo4j.collection.primitive.PrimitiveLongCollections.PrimitiveLongBaseIterator;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.collection.primitive.PrimitiveLongResourceCollections;
+import org.neo4j.collection.primitive.PrimitiveLongResourceIterator;
 import org.neo4j.graphdb.Resource;
 
 /**
  * Applies a diffset to the given source PrimitiveLongIterator.
  * If the given source is a Resource, then so is this DiffApplyingPrimitiveLongIterator.
  */
-public class DiffApplyingPrimitiveLongIterator extends PrimitiveLongBaseIterator implements Resource
+public class DiffApplyingPrimitiveLongIterator extends PrimitiveLongBaseIterator implements PrimitiveLongResourceIterator
 {
     protected enum Phase
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/DiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/DiffSets.java
@@ -25,6 +25,7 @@ import java.util.function.Predicate;
 
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.collection.primitive.PrimitiveLongResourceIterator;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.impl.util.DiffApplyingPrimitiveIntIterator;
 import org.neo4j.kernel.impl.util.DiffApplyingPrimitiveLongIterator;
@@ -38,7 +39,7 @@ import org.neo4j.storageengine.api.txstate.ReadableDiffSets;
  *
  * @param <T> type of elements
  */
-public class DiffSets<T> extends SuperDiffSets<T,PrimitiveLongIterator> implements ReadableDiffSets<T>
+public class DiffSets<T> extends SuperDiffSets<T,PrimitiveLongResourceIterator, PrimitiveLongIterator> implements ReadableDiffSets<T>
 {
     public DiffSets()
     {
@@ -51,7 +52,7 @@ public class DiffSets<T> extends SuperDiffSets<T,PrimitiveLongIterator> implemen
     }
 
     @Override
-    public PrimitiveLongIterator augment( final PrimitiveLongIterator source )
+    public PrimitiveLongResourceIterator augment( final PrimitiveLongIterator source )
     {
         return new DiffApplyingPrimitiveLongIterator( source, added( false ), removed( false ) );
     }
@@ -63,7 +64,7 @@ public class DiffSets<T> extends SuperDiffSets<T,PrimitiveLongIterator> implemen
     }
 
     @Override
-    public PrimitiveLongIterator augmentWithRemovals( final PrimitiveLongIterator source )
+    public PrimitiveLongResourceIterator augmentWithRemovals( final PrimitiveLongIterator source )
     {
         return new DiffApplyingPrimitiveLongIterator( source, Collections.emptySet(), removed( false ) );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/RelationshipDiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/RelationshipDiffSets.java
@@ -40,7 +40,7 @@ import org.neo4j.storageengine.api.txstate.ReadableRelationshipDiffSets;
  *
  * @param <T> type of elements
  */
-public class RelationshipDiffSets<T> extends SuperDiffSets<T,RelationshipIterator>
+public class RelationshipDiffSets<T> extends SuperDiffSets<T,RelationshipIterator, RelationshipIterator>
         implements ReadableRelationshipDiffSets<T>
 {
     private Home txStateRelationshipHome;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/SuperDiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/SuperDiffSets.java
@@ -40,8 +40,8 @@ import static java.util.Collections.newSetFromMap;
  * Super class of readable diffsets where use of {@link PrimitiveLongIterator} can be parameterized
  * to a specific subclass instead.
  */
-abstract class SuperDiffSets<T,LONGITERATOR extends PrimitiveLongIterator>
-        implements SuperReadableDiffSets<T,LONGITERATOR>
+abstract class SuperDiffSets<T,LONGITERATOR_OUT extends PrimitiveLongIterator, LONGITERATOR_IN extends PrimitiveLongIterator>
+        implements SuperReadableDiffSets<T,LONGITERATOR_OUT, LONGITERATOR_IN>
 {
     private Set<T> addedElements;
     private Set<T> removedElements;

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/ReadableDiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/ReadableDiffSets.java
@@ -25,12 +25,15 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
+import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.collection.primitive.PrimitiveLongResourceCollections;
+import org.neo4j.collection.primitive.PrimitiveLongResourceIterator;
 
 /**
  * {@link SuperReadableDiffSets} with added method for filtering added items.
  */
-public interface ReadableDiffSets<T> extends SuperReadableDiffSets<T,PrimitiveLongIterator>
+public interface ReadableDiffSets<T> extends SuperReadableDiffSets<T,PrimitiveLongResourceIterator, PrimitiveLongIterator>
 {
     @Override
     ReadableDiffSets<T> filterAdded( Predicate<T> addedFilter );
@@ -104,9 +107,9 @@ public interface ReadableDiffSets<T> extends SuperReadableDiffSets<T,PrimitiveLo
         }
 
         @Override
-        public PrimitiveLongIterator augment( PrimitiveLongIterator source )
+        public PrimitiveLongResourceIterator augment( PrimitiveLongIterator source )
         {
-            return source;
+            return primitiveLongResourceIterator( source );
         }
 
         @Override
@@ -116,9 +119,9 @@ public interface ReadableDiffSets<T> extends SuperReadableDiffSets<T,PrimitiveLo
         }
 
         @Override
-        public PrimitiveLongIterator augmentWithRemovals( PrimitiveLongIterator source )
+        public PrimitiveLongResourceIterator augmentWithRemovals( PrimitiveLongIterator source )
         {
-            return source;
+            return primitiveLongResourceIterator( source );
         }
 
         @Override
@@ -130,6 +133,18 @@ public interface ReadableDiffSets<T> extends SuperReadableDiffSets<T,PrimitiveLo
         @Override
         public void accept( DiffSetsVisitor<T> visitor )
         {
+        }
+
+        private PrimitiveLongResourceIterator primitiveLongResourceIterator( PrimitiveLongIterator source )
+        {
+            if ( source instanceof PrimitiveLongResourceIterator )
+            {
+                return (PrimitiveLongResourceIterator) source;
+            }
+            else
+            {
+                return PrimitiveLongCollections.resourceIterator( source, null );
+            }
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/ReadableRelationshipDiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/ReadableRelationshipDiffSets.java
@@ -30,7 +30,7 @@ import org.neo4j.kernel.impl.api.store.RelationshipIterator;
 /**
  * {@link SuperReadableDiffSets} with added method for filtering added relationships.
  */
-public interface ReadableRelationshipDiffSets<T> extends SuperReadableDiffSets<T,RelationshipIterator>
+public interface ReadableRelationshipDiffSets<T> extends SuperReadableDiffSets<T,RelationshipIterator, RelationshipIterator>
 {
     @Override
     ReadableRelationshipDiffSets<T> filterAdded( Predicate<T> addedFilter );

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/ReadableTransactionState.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/ReadableTransactionState.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 
 import org.neo4j.collection.primitive.PrimitiveIntSet;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.collection.primitive.PrimitiveLongResourceIterator;
 import org.neo4j.cursor.Cursor;
 import org.neo4j.internal.kernel.api.exceptions.schema.ConstraintValidationException;
 import org.neo4j.internal.kernel.api.schema.SchemaDescriptor;
@@ -95,7 +96,7 @@ public interface ReadableTransactionState
 
     int augmentNodeDegree( long node, int committedDegree, Direction direction, int relType );
 
-    PrimitiveLongIterator augmentNodesGetAll( PrimitiveLongIterator committed );
+    PrimitiveLongResourceIterator augmentNodesGetAll( PrimitiveLongIterator committed );
 
     RelationshipIterator augmentRelationshipsGetAll( RelationshipIterator committed );
 

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/SuperReadableDiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/SuperReadableDiffSets.java
@@ -32,7 +32,7 @@ import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
  * Super class of diff sets where use of {@link PrimitiveLongIterator} can be parameterized
  * to a specific subclass instead.
  */
-public interface SuperReadableDiffSets<T,LONGITERATOR extends PrimitiveLongIterator>
+public interface SuperReadableDiffSets<T,LONGITERATOR_OUT extends PrimitiveLongIterator, LONGITERATOR_IN extends PrimitiveLongIterator>
 {
     boolean isAdded( T elem );
 
@@ -50,13 +50,13 @@ public interface SuperReadableDiffSets<T,LONGITERATOR extends PrimitiveLongItera
 
     int delta();
 
-    LONGITERATOR augment( LONGITERATOR source );
+    LONGITERATOR_OUT augment( LONGITERATOR_IN source );
 
     PrimitiveIntIterator augment( PrimitiveIntIterator source );
 
-    LONGITERATOR augmentWithRemovals( LONGITERATOR source );
+    LONGITERATOR_OUT augmentWithRemovals( LONGITERATOR_IN source );
 
-    SuperReadableDiffSets<T,LONGITERATOR> filterAdded( Predicate<T> addedFilter );
+    SuperReadableDiffSets<T,LONGITERATOR_OUT, LONGITERATOR_IN> filterAdded( Predicate<T> addedFilter );
 
     void accept( DiffSetsVisitor<T> visitor ) throws ConstraintValidationException, CreateConstraintFailureException;
 }

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/collector/DocValuesCollector.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/collector/DocValuesCollector.java
@@ -49,6 +49,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.neo4j.collection.primitive.PrimitiveLongResourceIterator;
 import org.neo4j.graphdb.index.IndexHits;
 import org.neo4j.helpers.collection.ArrayIterator;
 import org.neo4j.helpers.collection.PrefetchingIterator;
@@ -322,7 +323,7 @@ public class DocValuesCollector extends SimpleCollector
      * is crossed; one thread might think it is reading from one segment while another thread has
      * already advanced this Iterator to the next segment, having raced the first thread.
      */
-    public static class LongValuesIterator extends ValuesIterator
+    public static class LongValuesIterator extends ValuesIterator implements PrimitiveLongResourceIterator
     {
         private final Iterator<DocValuesCollector.MatchingDocs> matchingDocs;
         private final String field;
@@ -432,6 +433,12 @@ public class DocValuesCollector extends SimpleCollector
             {
                 throw new RuntimeException( e );
             }
+        }
+
+        @Override
+        public void close()
+        {
+            //nothing to close
         }
     }
 

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongCollections.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/PrimitiveLongCollections.java
@@ -278,6 +278,18 @@ public class PrimitiveLongCollections
         };
     }
 
+    public static PrimitiveLongResourceIterator filter( PrimitiveLongResourceIterator source, final LongPredicate filter )
+    {
+        return new PrimitiveLongResourceFilteringIterator( source )
+        {
+            @Override
+            public boolean test( long item )
+            {
+                return filter.test( item );
+            }
+        };
+    }
+
     public static PrimitiveLongIterator deduplicate( PrimitiveLongIterator source )
     {
         return new PrimitiveLongFilteringIterator( source )
@@ -326,7 +338,7 @@ public class PrimitiveLongCollections
     public abstract static class PrimitiveLongFilteringIterator extends PrimitiveLongBaseIterator
             implements LongPredicate
     {
-        private final PrimitiveLongIterator source;
+        protected final PrimitiveLongIterator source;
 
         public PrimitiveLongFilteringIterator( PrimitiveLongIterator source )
         {
@@ -349,6 +361,24 @@ public class PrimitiveLongCollections
 
         @Override
         public abstract boolean test( long testItem );
+    }
+
+    public abstract static class PrimitiveLongResourceFilteringIterator extends PrimitiveLongFilteringIterator
+            implements PrimitiveLongResourceIterator
+    {
+        public PrimitiveLongResourceFilteringIterator( PrimitiveLongIterator source )
+        {
+            super( source );
+        }
+
+        @Override
+        public void close()
+        {
+            if ( source instanceof Resource )
+            {
+                ((Resource) source).close();
+            }
+        }
     }
 
     // Limitinglic


### PR DESCRIPTION
There were recently added a bunch of extra layers when `PrimitiveLongIterator` were
exchanged for `PrimitiveLongResourceIterator`. Basically we ended up with three layers
of primitive iterators which caused a regression. This PR reduces the number of layers.
  