### PR TITLE
Much reduced memory usage of collision values in importer

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ImportLogic.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ImportLogic.java
@@ -248,7 +248,7 @@ public class ImportLogic implements Closeable
             MemoryUsageStatsProvider memoryUsageStats = new MemoryUsageStatsProvider( neoStore, idMapper );
             LongFunction<Object> inputIdLookup = new NodeInputIdPropertyLookup( neoStore.getTemporaryPropertyStore() );
             executeStage( new IdMapperPreparationStage( config, idMapper, inputIdLookup, badCollector, memoryUsageStats ) );
-            PrimitiveLongIterator duplicateNodeIds = badCollector.leftOverDuplicateNodesIds();
+            PrimitiveLongIterator duplicateNodeIds = idMapper.leftOverDuplicateNodesIds();
             if ( duplicateNodeIds.hasNext() )
             {
                 executeStage( new DeleteDuplicateNodesStage( config, duplicateNodeIds, neoStore, storeUpdateMonitor ) );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/ByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/ByteArray.java
@@ -78,6 +78,16 @@ public interface ByteArray extends NumberArray<ByteArray>
 
     /**
      * Gets a part of an item, at the given {@code index}. An item in this array can consist of
+     * multiple values. This call will get a 5-byte long at the given {@code offset}.
+     *
+     * @param index array index to get.
+     * @param offset offset into this index to get the value from.
+     * @return the 5-byte long at the given offset at the given array index.
+     */
+    long get5ByteLong( long index, int offset );
+
+    /**
+     * Gets a part of an item, at the given {@code index}. An item in this array can consist of
      * multiple values. This call will get a 6-byte long at the given {@code offset}.
      *
      * @param index array index to get.
@@ -133,6 +143,16 @@ public interface ByteArray extends NumberArray<ByteArray>
      * @param value the int value to set at the given offset at the given array index.
      */
     void setInt( long index, int offset, int value );
+
+    /**
+     * Sets a part of an item, at the given {@code index}. An item in this array can consist of
+     * multiple values. This call will set a 5-byte long at the given {@code offset}.
+     *
+     * @param index array index to get.
+     * @param offset offset into this index to set the value for.
+     * @param value the 5-byte long value to set at the given offset at the given array index.
+     */
+    void set5ByteLong( long index, int offset, long value );
 
     /**
      * Sets a part of an item, at the given {@code index}. An item in this array can consist of

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicByteArray.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 
 import static org.neo4j.unsafe.impl.batchimport.cache.HeapByteArray.get3ByteIntFromByteBuffer;
 import static org.neo4j.unsafe.impl.batchimport.cache.HeapByteArray.get6BLongFromByteBuffer;
+import static org.neo4j.unsafe.impl.batchimport.cache.HeapByteArray.get5BLongFromByteBuffer;
 
 public class DynamicByteArray extends DynamicNumberArray<ByteArray> implements ByteArray
 {
@@ -95,6 +96,14 @@ public class DynamicByteArray extends DynamicNumberArray<ByteArray> implements B
     }
 
     @Override
+    public long get5ByteLong( long index, int offset )
+    {
+        ByteArray chunk = chunkOrNullAt( index );
+        return chunk != null ? chunk.get5ByteLong( index, offset ) :
+            get5BLongFromByteBuffer( defaultValueConvenienceBuffer, offset );
+    }
+
+    @Override
     public long get6ByteLong( long index, int offset )
     {
         ByteArray chunk = chunkOrNullAt( index );
@@ -131,6 +140,12 @@ public class DynamicByteArray extends DynamicNumberArray<ByteArray> implements B
     public void setInt( long index, int offset, int value )
     {
         at( index ).setInt( index, offset, value );
+    }
+
+    @Override
+    public void set5ByteLong( long index, int offset, long value )
+    {
+        at( index ).set5ByteLong( index, offset, value );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapByteArray.java
@@ -124,6 +124,12 @@ public class HeapByteArray extends HeapNumberArray<ByteArray> implements ByteArr
     }
 
     @Override
+    public long get5ByteLong( long index, int offset )
+    {
+        return get5BLongFromByteBuffer( buffer, index( index, offset ) );
+    }
+
+    @Override
     public long get6ByteLong( long index, int offset )
     {
         return get6BLongFromByteBuffer( buffer, index( index, offset ) );
@@ -132,15 +138,25 @@ public class HeapByteArray extends HeapNumberArray<ByteArray> implements ByteArr
     protected static int get3ByteIntFromByteBuffer( ByteBuffer buffer, int address )
     {
         int lowWord = buffer.getShort( address ) & 0xFFFF;
-        int highByte = buffer.get( address + Short.BYTES );
-        return lowWord | (highByte << Short.SIZE);
+        int highByte = buffer.get( address + Short.BYTES ) & 0xFF;
+        int result = lowWord | (highByte << Short.SIZE);
+        return result == 0xFFFFFF ? -1 : result;
+    }
+
+    protected static long get5BLongFromByteBuffer( ByteBuffer buffer, int startOffset )
+    {
+        long low4b = buffer.getInt( startOffset ) & 0xFFFFFFFFL;
+        long high1b = buffer.get( startOffset + Integer.BYTES ) & 0xFF;
+        long result = low4b | (high1b << 32);
+        return result == 0xFFFFFFFFFFL ? -1 : result;
     }
 
     protected static long get6BLongFromByteBuffer( ByteBuffer buffer, int startOffset )
     {
         long low4b = buffer.getInt( startOffset ) & 0xFFFFFFFFL;
-        long high2b = buffer.getShort( startOffset + Integer.BYTES );
-        return low4b | (high2b << 32);
+        long high2b = buffer.getShort( startOffset + Integer.BYTES ) & 0xFFFF;
+        long result = low4b | (high2b << 32);
+        return result == 0xFFFFFFFFFFFFL ? -1 : result;
     }
 
     @Override
@@ -171,6 +187,14 @@ public class HeapByteArray extends HeapNumberArray<ByteArray> implements ByteArr
     public void setInt( long index, int offset, int value )
     {
         buffer.putInt( index( index, offset ), value );
+    }
+
+    @Override
+    public void set5ByteLong( long index, int offset, long value )
+    {
+        int absIndex = index( index, offset );
+        buffer.putInt( absIndex, (int) value );
+        buffer.put( absIndex + Integer.BYTES, (byte) (value >>> 32) );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapByteArray.java
@@ -167,12 +167,23 @@ public class OffHeapByteArray extends OffHeapNumberArray<ByteArray> implements B
     }
 
     @Override
+    public long get5ByteLong( long index, int offset )
+    {
+        long address = address( index, offset );
+        long low4b = getInt( address ) & 0xFFFFFFFFL;
+        long high1b = UnsafeUtil.getByte( address + Integer.BYTES ) & 0xFF;
+        long result = low4b | (high1b << 32);
+        return result == 0xFFFFFFFFFFL ? -1 : result;
+    }
+
+    @Override
     public long get6ByteLong( long index, int offset )
     {
         long address = address( index, offset );
         long low4b = getInt( address ) & 0xFFFFFFFFL;
-        long high2b = getShort( address + Integer.BYTES );
-        return low4b | (high2b << 32);
+        long high2b = getShort( address + Integer.BYTES ) & 0xFFFF;
+        long result = low4b | (high2b << 32);
+        return result == 0xFFFFFFFFFFFFL ? -1 : result;
     }
 
     @Override
@@ -250,6 +261,14 @@ public class OffHeapByteArray extends OffHeapNumberArray<ByteArray> implements B
     }
 
     @Override
+    public void set5ByteLong( long index, int offset, long value )
+    {
+        long address = address( index, offset );
+        putInt( address, (int) value );
+        UnsafeUtil.putByte( address + Integer.BYTES, (byte) (value >>> 32) );
+    }
+
+    @Override
     public void set6ByteLong( long index, int offset, long value )
     {
         long address = address( index, offset );
@@ -281,8 +300,9 @@ public class OffHeapByteArray extends OffHeapNumberArray<ByteArray> implements B
     {
         long address = address( index, offset );
         int lowWord = UnsafeUtil.getShort( address ) & 0xFFFF;
-        byte highByte = UnsafeUtil.getByte( address + Short.BYTES );
-        return lowWord | (highByte << Short.SIZE);
+        int highByte = UnsafeUtil.getByte( address + Short.BYTES ) & 0xFF;
+        int result = lowWord | (highByte << Short.SIZE);
+        return result == 0xFFFFFF ? -1 : result;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMapper.java
@@ -22,7 +22,6 @@ package org.neo4j.unsafe.impl.batchimport.cache.idmapping;
 import java.util.function.LongFunction;
 
 import org.neo4j.helpers.progress.ProgressListener;
-import org.neo4j.unsafe.impl.batchimport.InputIterable;
 import org.neo4j.unsafe.impl.batchimport.cache.MemoryStatsVisitor;
 import org.neo4j.unsafe.impl.batchimport.input.Collector;
 import org.neo4j.unsafe.impl.batchimport.input.Group;
@@ -48,7 +47,7 @@ public interface IdMapper extends MemoryStatsVisitor.Visitable
     void put( Object inputId, long actualId, Group group );
 
     /**
-     * @return whether or not a call to {@link #prepare(InputIterable, Collector, ProgressListener)} needs to commence after all calls to
+     * @return whether or not a call to {@link #prepare(LongFunction, Collector, ProgressListener)} needs to commence after all calls to
      * {@link #put(Object, long, Group)} and before any call to {@link #get(Object, Group)}. I.e. whether or not all ids
      * needs to be put before making any call to {@link #get(Object, Group)}.
      */
@@ -67,6 +66,8 @@ public interface IdMapper extends MemoryStatsVisitor.Visitable
     void prepare( LongFunction<Object> inputIdLookup, Collector collector, ProgressListener progress );
 
     /**
+     * Returns an actual node id representing {@code inputId}.
+     * For this call to work {@link #prepare(LongFunction, Collector, ProgressListener)} must have
      * been called after all calls to {@link #put(Object, long, Group)} have been made,
      * iff {@link #needsPreparation()} returns {@code true}. Otherwise ids can be retrieved right after
      * {@link #put(Object, long, Group) being put}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMapper.java
@@ -21,6 +21,7 @@ package org.neo4j.unsafe.impl.batchimport.cache.idmapping;
 
 import java.util.function.LongFunction;
 
+import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.helpers.progress.ProgressListener;
 import org.neo4j.unsafe.impl.batchimport.cache.MemoryStatsVisitor;
 import org.neo4j.unsafe.impl.batchimport.input.Collector;
@@ -90,4 +91,6 @@ public interface IdMapper extends MemoryStatsVisitor.Visitable
      * @return memory usage for the given number of nodes.
      */
     long calculateMemoryUsage( long numberOfNodes );
+
+    PrimitiveLongIterator leftOverDuplicateNodesIds();
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMappers.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMappers.java
@@ -25,8 +25,10 @@ import org.neo4j.helpers.progress.ProgressListener;
 import org.neo4j.unsafe.impl.batchimport.cache.MemoryStatsVisitor;
 import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.EncodingIdMapper;
+import org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.LongCollisionValues;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.LongEncoder;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.Radix;
+import org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.StringCollisionValues;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.StringEncoder;
 import org.neo4j.unsafe.impl.batchimport.input.Collector;
 import org.neo4j.unsafe.impl.batchimport.input.Group;
@@ -110,7 +112,8 @@ public class IdMappers
      */
     public static IdMapper strings( NumberArrayFactory cacheFactory, Groups groups )
     {
-        return new EncodingIdMapper( cacheFactory, new StringEncoder(), Radix.STRING, NO_MONITOR, dynamic(), groups );
+        return new EncodingIdMapper( cacheFactory, new StringEncoder(), Radix.STRING, NO_MONITOR, dynamic(), groups,
+                numberOfCollisions -> new StringCollisionValues( cacheFactory, numberOfCollisions ) );
     }
 
     /**
@@ -122,6 +125,7 @@ public class IdMappers
      */
     public static IdMapper longs( NumberArrayFactory cacheFactory, Groups groups )
     {
-        return new EncodingIdMapper( cacheFactory, new LongEncoder(), Radix.LONG, NO_MONITOR, dynamic(), groups );
+        return new EncodingIdMapper( cacheFactory, new LongEncoder(), Radix.LONG, NO_MONITOR, dynamic(), groups,
+                numberOfCollisions -> new LongCollisionValues( cacheFactory, numberOfCollisions ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMappers.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/IdMappers.java
@@ -21,6 +21,8 @@ package org.neo4j.unsafe.impl.batchimport.cache.idmapping;
 
 import java.util.function.LongFunction;
 
+import org.neo4j.collection.primitive.PrimitiveLongCollections;
+import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.helpers.progress.ProgressListener;
 import org.neo4j.unsafe.impl.batchimport.cache.MemoryStatsVisitor;
 import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
@@ -86,6 +88,12 @@ public class IdMappers
         public long calculateMemoryUsage( long numberOfNodes )
         {
             return 0;
+        }
+
+        @Override
+        public PrimitiveLongIterator leftOverDuplicateNodesIds()
+        {
+            return PrimitiveLongCollections.emptyIterator();
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/BigIdTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/BigIdTracker.java
@@ -22,18 +22,21 @@ package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
 import java.util.Arrays;
 
 import org.neo4j.unsafe.impl.batchimport.cache.ByteArray;
+import org.neo4j.unsafe.impl.batchimport.cache.LongBitsManipulator;
 
 /**
  * {@link Tracker} capable of keeping 6B range values, using {@link ByteArray}.
  */
 public class BigIdTracker extends AbstractTracker<ByteArray>
 {
-    static final int ID_SIZE = 5;
+    static final int SIZE = 5;
+    static final int ID_BITS = (Byte.SIZE * SIZE) - 1;
     static final byte[] DEFAULT_VALUE;
-    public static final long MAX_ID = 2L << (ID_SIZE * Byte.SIZE) - 1;
+    public static final long MAX_ID = 1L << ID_BITS - 1;
+    private static final LongBitsManipulator BITS = new LongBitsManipulator( ID_BITS, 1 );
     static
     {
-        DEFAULT_VALUE = new byte[ID_SIZE];
+        DEFAULT_VALUE = new byte[SIZE];
         Arrays.fill( DEFAULT_VALUE, (byte) -1 );
     }
 
@@ -45,12 +48,29 @@ public class BigIdTracker extends AbstractTracker<ByteArray>
     @Override
     public long get( long index )
     {
-        return array.get5ByteLong( index, 0 );
+        return BITS.get( array.get5ByteLong( index, 0 ), 0 );
     }
 
     @Override
     public void set( long index, long value )
     {
-        array.set5ByteLong( index, 0, value );
+        long field = array.get5ByteLong( index, 0 );
+        field = BITS.set( field, 0, value );
+        array.set5ByteLong( index, 0, field );
+    }
+
+    @Override
+    public void markAsDuplicate( long index )
+    {
+        long field = array.get5ByteLong( index, 0 );
+        field = BITS.set( field, 1, 0 );
+        array.set5ByteLong( index, 0, field );
+    }
+
+    @Override
+    public boolean isMarkedAsDuplicate( long index )
+    {
+        long field = array.get5ByteLong( index, 0 );
+        return BITS.get( field, 1 ) == 0;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/BigIdTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/BigIdTracker.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
 
+import java.util.Arrays;
+
 import org.neo4j.unsafe.impl.batchimport.cache.ByteArray;
 
 /**
@@ -26,8 +28,14 @@ import org.neo4j.unsafe.impl.batchimport.cache.ByteArray;
  */
 public class BigIdTracker extends AbstractTracker<ByteArray>
 {
-    static final int ID_SIZE = 6;
-    static final byte[] DEFAULT_VALUE = new byte[] {-1, -1, -1, -1, -1, -1};
+    static final int ID_SIZE = 5;
+    static final byte[] DEFAULT_VALUE;
+    public static final long MAX_ID = 2L << (ID_SIZE * Byte.SIZE) - 1;
+    static
+    {
+        DEFAULT_VALUE = new byte[ID_SIZE];
+        Arrays.fill( DEFAULT_VALUE, (byte) -1 );
+    }
 
     public BigIdTracker( ByteArray array )
     {
@@ -37,12 +45,12 @@ public class BigIdTracker extends AbstractTracker<ByteArray>
     @Override
     public long get( long index )
     {
-        return array.get6ByteLong( index, 0 );
+        return array.get5ByteLong( index, 0 );
     }
 
     @Override
     public void set( long index, long value )
     {
-        array.set6ByteLong( index, 0, value );
+        array.set5ByteLong( index, 0, value );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/CollisionValues.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/CollisionValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/CollisionValues.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/CollisionValues.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
+
+import org.neo4j.unsafe.impl.batchimport.cache.MemoryStatsVisitor;
+
+/**
+ * Stores collision values efficiently for retrieval later. The idea is that there's a single thread {@link #add(Object) adding}
+ * ids, each gets assigned an offset, and later use those offsets to get back the added ids.
+ */
+public interface CollisionValues extends MemoryStatsVisitor.Visitable, AutoCloseable
+{
+    long add( Object id );
+
+    Object get( long offset );
+
+    @Override
+    void close();
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
@@ -742,7 +742,6 @@ public class EncodingIdMapper implements IdMapper
         return clearCollision( dataCache.get( trackerCache.get( index ) ) );
     }
 
-//<<<<<<< HEAD
     private long findCollisionIndex( long value )
     {
         // can't be done on unsorted data

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
@@ -19,16 +19,18 @@
  */
 package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.function.IntFunction;
 import java.util.function.LongFunction;
 
 import org.neo4j.function.Factory;
 import org.neo4j.helpers.progress.ProgressListener;
 import org.neo4j.unsafe.impl.batchimport.HighestId;
 import org.neo4j.unsafe.impl.batchimport.Utils.CompareType;
+import org.neo4j.unsafe.impl.batchimport.cache.ByteArray;
+import org.neo4j.unsafe.impl.batchimport.cache.IntArray;
 import org.neo4j.unsafe.impl.batchimport.cache.LongArray;
 import org.neo4j.unsafe.impl.batchimport.cache.LongBitsManipulator;
 import org.neo4j.unsafe.impl.batchimport.cache.MemoryStatsVisitor;
@@ -92,7 +94,7 @@ public class EncodingIdMapper implements IdMapper
         /**
          * @param count Number of eIds that have been marked as collisions.
          */
-        void numberOfCollisions( int count );
+        void numberOfCollisions( long count );
     }
 
     public static final Monitor NO_MONITOR = count ->
@@ -104,8 +106,9 @@ public class EncodingIdMapper implements IdMapper
     // This bit is the least significant in the most significant byte of the encoded values,
     // where the 7 most significant bits in that byte denotes length of original string.
     // See StringEncoder.
-    private static LongBitsManipulator COLLISION_BIT = new LongBitsManipulator( 56, 1 );
-    private static int DEFAULT_CACHE_CHUNK_SIZE = 1_000_000; // 8MB a piece
+    private static final LongBitsManipulator COLLISION_BIT = new LongBitsManipulator( 56, 1 );
+    private static final int DEFAULT_CACHE_CHUNK_SIZE = 1_000_000; // 8MB a piece
+    private static final int COLLISION_ENTRY_SIZE = 5/*nodeId*/ + 6/*offset*/;
     // Using 0 as gap value, i.e. value for a node not having an id, i.e. not present in dataCache is safe
     // because the current set of Encoder implementations will always set some amount of bits higher up in
     // the long value representing the length of the id.
@@ -132,11 +135,9 @@ public class EncodingIdMapper implements IdMapper
     private final int processorsForParallelWork;
     private final Comparator comparator;
 
-    private final List<Object> collisionValues = new ArrayList<>();
-    private final LongArray collisionNodeIdCache;
+    private ByteArray collisionNodeIdCache;
     // These 3 caches below are needed only during duplicate input id detection, but referenced here so
     // that the memory visitor can see them when they are active.
-    private LongArray collisionSourceDataCache;
     private Tracker collisionTrackerCache;
 
     private boolean readyForUse;
@@ -145,23 +146,26 @@ public class EncodingIdMapper implements IdMapper
     private final Monitor monitor;
     private final Groups groups;
 
-    private int numberOfCollisions;
+    private long numberOfCollisions;
+    private final LongFunction<CollisionValues> collisionValuesFactory;
+    private CollisionValues collisionValues;
 
     public EncodingIdMapper( NumberArrayFactory cacheFactory, Encoder encoder, Factory<Radix> radixFactory,
-            Monitor monitor, TrackerFactory trackerFactory, Groups groups )
+            Monitor monitor, TrackerFactory trackerFactory, Groups groups, LongFunction<CollisionValues> collisionValuesFactory )
     {
-        this( cacheFactory, encoder, radixFactory, monitor, trackerFactory, groups, DEFAULT_CACHE_CHUNK_SIZE,
+        this( cacheFactory, encoder, radixFactory, monitor, trackerFactory, groups, collisionValuesFactory, DEFAULT_CACHE_CHUNK_SIZE,
                 Runtime.getRuntime().availableProcessors() - 1, DEFAULT );
     }
 
     EncodingIdMapper( NumberArrayFactory cacheFactory, Encoder encoder, Factory<Radix> radixFactory,
-            Monitor monitor, TrackerFactory trackerFactory, Groups groups, int chunkSize, int processorsForParallelWork,
-            Comparator comparator )
+            Monitor monitor, TrackerFactory trackerFactory, Groups groups, LongFunction<CollisionValues> collisionValuesFactory,
+            int chunkSize, int processorsForParallelWork, Comparator comparator )
     {
         this.radixFactory = radixFactory;
         this.monitor = monitor;
         this.cacheFactory = cacheFactory;
         this.trackerFactory = trackerFactory;
+        this.collisionValuesFactory = collisionValuesFactory;
         this.comparator = comparator;
         this.processorsForParallelWork = max( processorsForParallelWork, 1 );
         this.dataCache = cacheFactory.newDynamicLongArray( chunkSize, GAP_VALUE );
@@ -169,7 +173,6 @@ public class EncodingIdMapper implements IdMapper
         this.groups = groups;
         this.encoder = encoder;
         this.radix = radixFactory.newInstance();
-        this.collisionNodeIdCache = cacheFactory.newDynamicLongArray( chunkSize, ID_NOT_FOUND );
     }
 
     /**
@@ -230,7 +233,7 @@ public class EncodingIdMapper implements IdMapper
             sortBuckets = new ParallelSort( radix, dataCache, highestSetIndex, trackerCache,
                     processorsForParallelWork, progress, comparator ).run();
 
-            int pessimisticNumberOfCollisions = detectAndMarkCollisions( progress );
+            long pessimisticNumberOfCollisions = detectAndMarkCollisions( progress );
             if ( pessimisticNumberOfCollisions > 0 )
             {
                 buildCollisionInfo( inputIdLookup, pessimisticNumberOfCollisions, collector, progress );
@@ -413,7 +416,7 @@ public class EncodingIdMapper implements IdMapper
      * races between detector workers. This is not a problem though, this value serves as a pessimistic value
      * for allocating arrays to hold collision data to later sort and use to discover duplicates.
      */
-    private int detectAndMarkCollisions( ProgressListener progress )
+    private long detectAndMarkCollisions( ProgressListener progress )
     {
         progress.started( "DETECT" );
         long totalCount = highestSetIndex + 1;
@@ -471,21 +474,22 @@ public class EncodingIdMapper implements IdMapper
         return true;
     }
 
-    private void buildCollisionInfo( LongFunction<Object> inputIdLookup, int pessimisticNumberOfCollisions,
+    private void buildCollisionInfo( LongFunction<Object> inputIdLookup, long pessimisticNumberOfCollisions,
             Collector collector, ProgressListener progress )
             throws InterruptedException
     {
         progress.started( "RESOLVE (~" + pessimisticNumberOfCollisions + " collisions)" );
         Radix radix = radixFactory.newInstance();
-        collisionSourceDataCache = cacheFactory.newLongArray( pessimisticNumberOfCollisions, ID_NOT_FOUND );
+        collisionNodeIdCache = cacheFactory.newByteArray( pessimisticNumberOfCollisions, new byte[COLLISION_ENTRY_SIZE] );
         collisionTrackerCache = trackerFactory.create( cacheFactory, pessimisticNumberOfCollisions );
+        collisionValues = collisionValuesFactory.apply( pessimisticNumberOfCollisions );
         for ( long nodeId = 0; nodeId <= highestSetIndex; nodeId++ )
         {
             long eId = dataCache.get( nodeId );
             if ( isCollision( eId ) )
             {
                 // Store this collision input id for matching later in get()
-                numberOfCollisions++;
+                long collisionIndex = numberOfCollisions++;
                 Object id = inputIdLookup.apply( nodeId );
                 long eIdFromInputId = encode( id );
                 long eIdWithoutCollisionBit = clearCollision( eId );
@@ -493,9 +497,11 @@ public class EncodingIdMapper implements IdMapper
                         "collision info. input id %s (a %s) marked as collision where this id was encoded into " +
                         "%d when put, but was now encoded into %d",
                         id, id.getClass().getSimpleName(), eIdWithoutCollisionBit, eIdFromInputId );
-                int collisionIndex = collisionValues.size();
-                collisionValues.add( id );
-                collisionNodeIdCache.set( collisionIndex, nodeId );
+                long offset = collisionValues.add( id );
+                collisionNodeIdCache.set5ByteLong( collisionIndex, 0, nodeId );
+                collisionNodeIdCache.set6ByteLong( collisionIndex, 5, offset );
+
+                // The base of our sorting this time is going to be node id, so register that in the radix
                 radix.registerRadixOf( eIdWithoutCollisionBit );
             }
             progress.add( 1 );
@@ -503,16 +509,14 @@ public class EncodingIdMapper implements IdMapper
         progress.done();
 
         // Detect input id duplicates within the same group, with source information, line number and the works
-        detectDuplicateInputIds( radix, numberOfCollisions, collector, progress );
+        detectDuplicateInputIds( radix, collector, progress );
 
         // We won't be needing these anymore
-        collisionSourceDataCache.close();
-        collisionSourceDataCache = null;
         collisionTrackerCache.close();
         collisionTrackerCache = null;
     }
 
-    private void detectDuplicateInputIds( Radix radix, int numberOfCollisions, Collector collector, ProgressListener progress )
+    private void detectDuplicateInputIds( Radix radix, Collector collector, ProgressListener progress )
             throws InterruptedException
     {
         // We do this collision sort using ParallelSort which has the data cache and the tracker cache,
@@ -561,7 +565,7 @@ public class EncodingIdMapper implements IdMapper
             }
         };
 
-        new ParallelSort( radix, collisionNodeIdCache, numberOfCollisions - 1,
+        new ParallelSort( radix, as5ByteLongArray( collisionNodeIdCache ), numberOfCollisions - 1,
                 collisionTrackerCache, processorsForParallelWork, progress, duplicateComparator ).run();
 
         // Here we have a populated C
@@ -573,7 +577,8 @@ public class EncodingIdMapper implements IdMapper
         for ( int i = 0; i < numberOfCollisions; i++ )
         {
             long collisionIndex = collisionTrackerCache.get( i );
-            long nodeId = collisionNodeIdCache.get( collisionIndex );
+            long nodeId = collisionNodeIdCache.get5ByteLong( collisionIndex, 0 );
+            long offset = collisionNodeIdCache.get6ByteLong( collisionIndex, 5 );
             long eid = dataCache.get( nodeId );
             int groupId = groupOf( nodeId );
             // collisions of same eId AND groupId are always together
@@ -587,11 +592,12 @@ public class EncodingIdMapper implements IdMapper
             // We cast the collision index to an int here. This means that we can't support > int-range
             // number of collisions. But that's probably alright since the data structures and
             // actual collisions values for all these collisions wouldn't fit in a heap anyway.
-            Object inputId = collisionValues.get( safeCastLongToInt( collisionIndex ) );
+            Object inputId = collisionValues.get( offset );
             int detectorIndex = detector.add( inputId );
             if ( detectorIndex != -1 )
             {   // Duplicate
                 collector.collectDuplicateNode( inputId, nodeId, groups.get( groupId ).name() );
+                trackerCache.markAsDuplicate( nodeId );
             }
 
             previousEid = eid;
@@ -599,6 +605,54 @@ public class EncodingIdMapper implements IdMapper
             progress.add( 1 );
         }
         progress.done();
+    }
+
+    private LongArray as5ByteLongArray( ByteArray byteArray )
+    {
+        return new LongArray()
+        {
+            @Override
+            public void acceptMemoryStatsVisitor( MemoryStatsVisitor visitor )
+            {
+                byteArray.acceptMemoryStatsVisitor( visitor );
+            }
+
+            @Override
+            public long length()
+            {
+                return byteArray.length();
+            }
+
+            @Override
+            public void close()
+            {
+                byteArray.close();
+            }
+
+            @Override
+            public void clear()
+            {
+                byteArray.clear();
+            }
+
+            @Override
+            public LongArray at( long index )
+            {
+                return null;
+            }
+
+            @Override
+            public void set( long index, long value )
+            {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public long get( long index )
+            {
+                return byteArray.get5ByteLong( index, 0 );
+            }
+        };
     }
 
     private static class SameInputIdDetector
@@ -678,6 +732,7 @@ public class EncodingIdMapper implements IdMapper
         return clearCollision( dataCache.get( trackerCache.get( index ) ) );
     }
 
+//<<<<<<< HEAD
     private long findCollisionIndex( long value )
     {
         // can't be done on unsorted data
@@ -686,7 +741,7 @@ public class EncodingIdMapper implements IdMapper
         while ( low <= high )
         {
             long mid = (low + high) / 2;
-            long midValue = collisionNodeIdCache.get( mid );
+            long midValue = collisionNodeIdCache.get5ByteLong( mid, 0 );
             switch ( unsignedDifference( midValue, value ) )
             {
             case EQ: return mid;
@@ -733,8 +788,9 @@ public class EncodingIdMapper implements IdMapper
                 if ( isCollision( eId ) )
                 {   // We found a data value for our group, but there are collisions within this group.
                     // We need to consult the collision cache and original input id
-                    int collisionIndex = safeCastLongToInt( findCollisionIndex( nodeId ) );
-                    Object value = collisionValues.get( collisionIndex );
+                    long collisionIndex = findCollisionIndex( nodeId );
+                    long offset = collisionNodeIdCache.get6ByteLong( collisionIndex, 5 );
+                    Object value = collisionValues.get( offset );
                     if ( inputId.equals( value ) )
                     {
                         // :)
@@ -764,8 +820,8 @@ public class EncodingIdMapper implements IdMapper
         nullSafeAcceptMemoryStatsVisitor( visitor, dataCache );
         nullSafeAcceptMemoryStatsVisitor( visitor, trackerCache );
         nullSafeAcceptMemoryStatsVisitor( visitor, collisionTrackerCache );
-        nullSafeAcceptMemoryStatsVisitor( visitor, collisionSourceDataCache );
         nullSafeAcceptMemoryStatsVisitor( visitor, collisionNodeIdCache );
+        nullSafeAcceptMemoryStatsVisitor( visitor, collisionValues );
     }
 
     private void nullSafeAcceptMemoryStatsVisitor( MemoryStatsVisitor visitor, MemoryStatsVisitor.Visitable mem )
@@ -790,12 +846,11 @@ public class EncodingIdMapper implements IdMapper
         {
             trackerCache.close();
         }
-        if ( collisionSourceDataCache != null )
-        {
-            collisionTrackerCache.close();
-            collisionSourceDataCache.close();
-        }
         collisionNodeIdCache.close();
+        if ( collisionValues != null )
+        {
+            collisionValues.close();
+        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/LongCollisionValues.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/LongCollisionValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/LongCollisionValues.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/LongCollisionValues.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
+
+import org.neo4j.unsafe.impl.batchimport.cache.LongArray;
+import org.neo4j.unsafe.impl.batchimport.cache.MemoryStatsVisitor;
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
+
+/**
+ * Stores longs in a {@link LongArray} provided by {@link NumberArrayFactory}.
+ */
+public class LongCollisionValues implements CollisionValues
+{
+    private final LongArray cache;
+    private long nextOffset;
+
+    public LongCollisionValues( NumberArrayFactory factory, long length )
+    {
+        cache = factory.newLongArray( length, 0 );
+    }
+
+    @Override
+    public long add( Object id )
+    {
+        long collisionIndex = nextOffset++;
+        cache.set( collisionIndex, ((Number)id).longValue() );
+        return collisionIndex;
+    }
+
+    @Override
+    public Object get( long offset )
+    {
+        return (long) cache.get( offset );
+    }
+
+    @Override
+    public void acceptMemoryStatsVisitor( MemoryStatsVisitor visitor )
+    {
+        cache.acceptMemoryStatsVisitor( visitor );
+    }
+
+    @Override
+    public void close()
+    {
+        cache.close();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/StringCollisionValues.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/StringCollisionValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/StringCollisionValues.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/StringCollisionValues.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
+
+import org.neo4j.string.UTF8;
+import org.neo4j.unsafe.impl.batchimport.cache.ByteArray;
+import org.neo4j.unsafe.impl.batchimport.cache.MemoryStatsVisitor;
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
+
+import static java.lang.Long.max;
+
+/**
+ * Stores {@link String strings} in a {@link ByteArray} provided by {@link NumberArrayFactory}. Each string can have different
+ * length, where maximum string length is 2^16 - 1.
+ */
+public class StringCollisionValues implements CollisionValues
+{
+    private final ByteArray cache;
+    private long offset;
+    private ByteArray current;
+
+    public StringCollisionValues( NumberArrayFactory factory, long length )
+    {
+        cache = factory.newDynamicByteArray( max( length, 10_000 ), new byte[1] );
+        current = cache.at( 0 );
+    }
+
+    @Override
+    public long add( Object id )
+    {
+        String string = (String) id;
+        byte[] bytes = UTF8.encode( string );
+        int length = bytes.length;
+        if ( length > 0xFFFF )
+        {
+            throw new IllegalArgumentException( string );
+        }
+
+        long endOffset = offset + 2 + bytes.length;
+        ByteArray end = cache.at( endOffset );
+        if ( end != current )
+        {
+            offset = endOffset;
+            current = end;
+        }
+
+        long startOffset = offset;
+        current.setByte( offset++, 0, (byte) (length & 0xFF) );
+        current.setByte( offset++, 0, (byte) ((length >>> 8) & 0xFF) );
+        for ( byte charByte : bytes )
+        {
+            current.setByte( offset++, 0, charByte );
+        }
+
+        return startOffset;
+    }
+
+    @Override
+    public Object get( long offset )
+    {
+        ByteArray array = cache.at( offset );
+        int lengthLsb = array.getByte( offset++, 0 ) & 0xFF;
+        int lengthMsb = array.getByte( offset++, 0 ) & 0xFF;
+        int length = (lengthMsb << 8) | lengthLsb;
+        byte[] bytes = new byte[length];
+        for ( int i = 0; i < length; i++ )
+        {
+            bytes[i] = array.getByte( offset++, 0 );
+        }
+        return UTF8.decode( bytes );
+    }
+
+    @Override
+    public void acceptMemoryStatsVisitor( MemoryStatsVisitor visitor )
+    {
+        cache.acceptMemoryStatsVisitor( visitor );
+    }
+
+    @Override
+    public void close()
+    {
+        cache.close();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Tracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Tracker.java
@@ -64,6 +64,10 @@ public interface Tracker extends MemoryStatsVisitor.Visitable, AutoCloseable
      */
     void set( long index, long value );
 
+    void markAsDuplicate( long index );
+
+    boolean isMarkedAsDuplicate( long index );
+
     @Override
     void close();
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/TrackerFactories.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/TrackerFactories.java
@@ -24,8 +24,6 @@ package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
  */
 public class TrackerFactories
 {
-    public static final long HIGHEST_ID_FOR_SMALL_TRACKER = Integer.MAX_VALUE;
-
     private TrackerFactories()
     {
     }
@@ -35,7 +33,7 @@ public class TrackerFactories
      */
     public static TrackerFactory dynamic()
     {
-        return ( arrayFactory, size ) -> size > HIGHEST_ID_FOR_SMALL_TRACKER
+        return ( arrayFactory, size ) -> size > IntTracker.MAX_ID
                 ? new BigIdTracker( arrayFactory.newByteArray( size, BigIdTracker.DEFAULT_VALUE ) )
                 : new IntTracker( arrayFactory.newIntArray( size, IntTracker.DEFAULT_VALUE ) );
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Collector.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/input/Collector.java
@@ -19,9 +19,6 @@
  */
 package org.neo4j.unsafe.impl.batchimport.input;
 
-import org.neo4j.collection.primitive.PrimitiveLongCollections;
-import org.neo4j.collection.primitive.PrimitiveLongIterator;
-
 /**
  * Collects items and is {@link #close() closed} after any and all items have been collected.
  * The {@link Collector} is responsible for closing whatever closeable resource received from the importer.
@@ -41,13 +38,6 @@ public interface Collector extends AutoCloseable
     boolean isCollectingBadRelationships();
 
     /**
-     * @return iterator of node ids that were found to be duplicates of already imported nodes.
-     * Returned node ids was imported, but never used to connect any relationship to, and should
-     * be deleted. Must be returned sorted in ascending id order.
-     */
-    PrimitiveLongIterator leftOverDuplicateNodesIds();
-
-    /**
      * Flushes whatever changes to the underlying resource supplied from the importer.
      */
     @Override
@@ -55,12 +45,6 @@ public interface Collector extends AutoCloseable
 
     Collector EMPTY = new Collector()
     {
-        @Override
-        public PrimitiveLongIterator leftOverDuplicateNodesIds()
-        {
-            return PrimitiveLongCollections.emptyIterator();
-        }
-
         @Override
         public void collectExtraColumns( String source, long row, String value )
         {

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/ByteArrayTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/ByteArrayTest.java
@@ -47,7 +47,7 @@ import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.auto;
 @RunWith( Parameterized.class )
 public class ByteArrayTest extends NumberArrayPageCacheTestSupport
 {
-    private static final byte[] DEFAULT = new byte[25];
+    private static final byte[] DEFAULT = new byte[50];
     private static final int LENGTH = 1_000;
     private static Fixture fixture;
 
@@ -130,12 +130,9 @@ public class ByteArrayTest extends NumberArrayPageCacheTestSupport
         array.setShort( index, 1, (short) 1234 );
         array.setInt( index, 5, 12345 );
         array.setLong( index, 9, Long.MAX_VALUE - 100 );
-        array.set3ByteInt( index, 17, 76767 );
-    }
-
-    private void setArray( int index, byte[] bytes )
-    {
-        array.set( index, bytes );
+        array.set3ByteInt( index, 17, 0b10101010_10101010_10101010 );
+        array.set5ByteLong( index, 20, 0b10101010_10101010_10101010_10101010_10101010L );
+        array.set6ByteLong( index, 25, 0b10101010_10101010_10101010_10101010_10101010_10101010L );
     }
 
     private void verifySimpleValues( int index )
@@ -144,7 +141,14 @@ public class ByteArrayTest extends NumberArrayPageCacheTestSupport
         assertEquals( (short) 1234, array.getShort( index, 1 ) );
         assertEquals( 12345, array.getInt( index, 5 ) );
         assertEquals( Long.MAX_VALUE - 100, array.getLong( index, 9 ) );
-        assertEquals( 76767, array.get3ByteInt( index, 17 ) );
+        assertEquals( 0b10101010_10101010_10101010, array.get3ByteInt( index, 17 ) );
+        assertEquals( 0b10101010_10101010_10101010_10101010_10101010L, array.get5ByteLong( index, 20 ) );
+        assertEquals( 0b10101010_10101010_10101010_10101010_10101010_10101010L, array.get6ByteLong( index, 25 ) );
+    }
+
+    private void setArray( int index, byte[] bytes )
+    {
+        array.set( index, bytes );
     }
 
     private void verifyArray( int index, byte[] actualBytes, byte[] scratchBuffer )
@@ -154,7 +158,31 @@ public class ByteArrayTest extends NumberArrayPageCacheTestSupport
     }
 
     @Test
-    public void shouldDetectMinusOne() throws Exception
+    public void shouldDetectMinusOneFor3ByteInts() throws Exception
+    {
+        // WHEN
+        array.set3ByteInt( 10, 2, -1 );
+        array.set3ByteInt( 10, 5, -1 );
+
+        // THEN
+        assertEquals( -1L, array.get3ByteInt( 10, 2 ) );
+        assertEquals( -1L, array.get3ByteInt( 10, 5 ) );
+    }
+
+    @Test
+    public void shouldDetectMinusOneFor5ByteLongs() throws Exception
+    {
+        // WHEN
+        array.set5ByteLong( 10, 2, -1 );
+        array.set5ByteLong( 10, 7, -1 );
+
+        // THEN
+        assertEquals( -1L, array.get5ByteLong( 10, 2 ) );
+        assertEquals( -1L, array.get5ByteLong( 10, 7 ) );
+    }
+
+    @Test
+    public void shouldDetectMinusOneFor6ByteLongs() throws Exception
     {
         // WHEN
         array.set6ByteLong( 10, 2, -1 );

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCacheTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/NodeRelationshipCacheTest.java
@@ -503,6 +503,24 @@ public class NodeRelationshipCacheTest
         assertEquals( highCount + 1, nextHighCount );
     }
 
+    @Test
+    public void shouldFailFastOnTooHighNodeCount() throws Exception
+    {
+        // given
+        cache = new NodeRelationshipCache( NumberArrayFactory.HEAP, 1 );
+
+        try
+        {
+            // when
+            cache.setNodeCount( 2L << (5 * Byte.SIZE) );
+            fail( "Should have failed" );
+        }
+        catch ( IllegalArgumentException e )
+        {
+            // then good
+        }
+    }
+
     private void testNode( NodeRelationshipCache link, long node, Direction direction )
     {
         int typeId = 0; // doesn't matter here because it's all sparse

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/BigIdTrackerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/BigIdTrackerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/BigIdTrackerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/BigIdTrackerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.test.rule.RandomRule;
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.BigIdTracker.MAX_ID;
+
+public class BigIdTrackerTest
+{
+    @Rule
+    public final RandomRule random = new RandomRule();
+
+    @Test
+    public void shouldKeepIdsAndMarkDuplicates() throws Exception
+    {
+        // given
+        int length = 10_000;
+        try ( BigIdTracker tracker = new BigIdTracker( NumberArrayFactory.HEAP.newByteArray( length, BigIdTracker.DEFAULT_VALUE ) ) )
+        {
+            // when
+            long[] values = new long[length];
+            boolean[] marks = new boolean[length];
+            for ( int i = 0; i < length; i++ )
+            {
+                tracker.set( i, values[i] = random.nextLong( MAX_ID ) );
+                if ( random.nextBoolean() )
+                {
+                    tracker.markAsDuplicate( i );
+                    marks[i] = true;
+                }
+            }
+
+            // then
+            for ( int i = 0; i < length; i++ )
+            {
+                assertEquals( values[i], tracker.get( i ) );
+                assertEquals( marks[i], tracker.isMarkedAsDuplicate( i ) );
+            }
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapperTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapperTest.java
@@ -28,12 +28,14 @@ import org.junit.runners.Parameterized.Parameters;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.IntFunction;
 import java.util.function.LongFunction;
 
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
@@ -51,6 +53,8 @@ import org.neo4j.unsafe.impl.batchimport.input.Group;
 import org.neo4j.unsafe.impl.batchimport.input.Groups;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -63,6 +67,7 @@ import static org.mockito.Mockito.when;
 
 import static java.lang.Math.toIntExact;
 
+import static org.neo4j.collection.primitive.PrimitiveLongCollections.count;
 import static org.neo4j.helpers.progress.ProgressListener.NONE;
 import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper.ID_NOT_FOUND;
 import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.EncodingIdMapper.NO_MONITOR;
@@ -99,16 +104,17 @@ public class EncodingIdMapperTest
         // GIVEN
         IdMapper idMapper = mapper( new StringEncoder(), Radix.STRING, NO_MONITOR );
         LongFunction<Object> inputIdLookup = String::valueOf;
+        int count = 300_000;
 
         // WHEN
-        for ( long nodeId = 0; nodeId < 300_000; nodeId++ )
+        for ( long nodeId = 0; nodeId < count; nodeId++ )
         {
             idMapper.put( inputIdLookup.apply( nodeId ), nodeId, GLOBAL );
         }
         idMapper.prepare( inputIdLookup, mock( Collector.class ), NONE );
 
         // THEN
-        for ( long nodeId = 0; nodeId < 300_000; nodeId++ )
+        for ( long nodeId = 0; nodeId < count; nodeId++ )
         {
             // the UUIDs here will be generated in the same sequence as above because we reset the random
             Object id = inputIdLookup.apply( nodeId );
@@ -208,6 +214,11 @@ public class EncodingIdMapperTest
         // THEN
         verify( collector, times( 1 ) ).collectDuplicateNode( "10", 2, GLOBAL.name() );
         verifyNoMoreInteractions( collector );
+    }
+
+    private static LongFunction<Object> wrap( List<Object> ids )
+    {
+        return nodeId -> ids.get( toIntExact( nodeId ) );
     }
 
     @Test
@@ -313,6 +324,7 @@ public class EncodingIdMapperTest
         assertEquals( 0L, mapper.get( "10", firstGroup ) );
         assertEquals( 1L, mapper.get( "9", firstGroup ) );
         assertEquals( 2L, mapper.get( "10", secondGroup ) );
+        assertFalse( mapper.leftOverDuplicateNodesIds().hasNext() );
     }
 
     @Test
@@ -381,7 +393,8 @@ public class EncodingIdMapperTest
         {
             groups.getOrCreate( "Group " + i );
         }
-        IdMapper mapper = mapper( encoder, Radix.LONG, NO_MONITOR );
+        IdMapper mapper = mapper( encoder, Radix.LONG, NO_MONITOR, ParallelSort.DEFAULT,
+                numberOfCollisions -> new LongCollisionValues( NumberArrayFactory.HEAP, numberOfCollisions ) );
         final AtomicReference<Group> group = new AtomicReference<>();
         LongFunction<Object> ids = nodeId ->
         {
@@ -413,6 +426,7 @@ public class EncodingIdMapperTest
             mapper.put( ids.apply( nodeId ), nodeId, group.get() );
         }
         Collector collector = mock( Collector.class );
+
         mapper.prepare( ids, collector, NONE );
 
         // THEN
@@ -421,6 +435,8 @@ public class EncodingIdMapperTest
         {
             assertEquals( nodeId, mapper.get( ids.apply( nodeId ), group.get() ) );
         }
+        verifyNoMoreInteractions( collector );
+        assertFalse( mapper.leftOverDuplicateNodesIds().hasNext() );
     }
 
     @Test
@@ -482,6 +498,7 @@ public class EncodingIdMapperTest
 
         // THEN
         verify( collector, times( high ) ).collectDuplicateNode( any( Object.class ), anyLong(), anyString() );
+        assertEquals( high, count( mapper.leftOverDuplicateNodesIds() ) );
     }
 
     @Test
@@ -579,8 +596,22 @@ public class EncodingIdMapperTest
 
     private IdMapper mapper( Encoder encoder, Factory<Radix> radix, Monitor monitor, Comparator comparator )
     {
+        return mapper( encoder, radix, monitor, comparator, autoDetect( encoder ) );
+    }
+
+    private IdMapper mapper( Encoder encoder, Factory<Radix> radix, Monitor monitor, Comparator comparator,
+            LongFunction<CollisionValues> collisionValuesFactory )
+    {
         return new EncodingIdMapper( NumberArrayFactory.HEAP, encoder, radix, monitor, RANDOM_TRACKER_FACTORY, groups,
-                1_000, processors, comparator );
+                collisionValuesFactory, 1_000, processors, comparator );
+    }
+
+    private LongFunction<CollisionValues> autoDetect( Encoder encoder )
+    {
+        return numberOfCollisions -> encoder instanceof LongEncoder
+                ? new LongCollisionValues( NumberArrayFactory.HEAP, numberOfCollisions )
+                : new StringCollisionValues( NumberArrayFactory.HEAP, numberOfCollisions );
+
     }
 
     private static final TrackerFactory RANDOM_TRACKER_FACTORY =

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapperTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapperTest.java
@@ -38,7 +38,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntFunction;
 import java.util.function.LongFunction;
 
-import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.function.Factory;
 import org.neo4j.helpers.progress.ProgressListener;
 import org.neo4j.test.Race;
@@ -795,12 +794,6 @@ public class EncodingIdMapperTest
 
         @Override
         public long badEntries()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public PrimitiveLongIterator leftOverDuplicateNodesIds()
         {
             throw new UnsupportedOperationException();
         }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/IntTrackerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/IntTrackerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/IntTrackerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/IntTrackerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.test.rule.RandomRule;
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.unsafe.impl.batchimport.cache.idmapping.string.IntTracker.MAX_ID;
+
+public class IntTrackerTest
+{
+    @Rule
+    public final RandomRule random = new RandomRule();
+
+    @Test
+    public void shouldKeepIdsAndMarkDuplicates() throws Exception
+    {
+        // given
+        int length = 10_000;
+        try ( IntTracker tracker = new IntTracker( NumberArrayFactory.HEAP.newIntArray( length, IntTracker.DEFAULT_VALUE ) ) )
+        {
+            // when
+            long[] values = new long[length];
+            boolean[] marks = new boolean[length];
+            for ( int i = 0; i < length; i++ )
+            {
+                tracker.set( i, values[i] = random.nextLong( MAX_ID ) );
+                if ( random.nextBoolean() )
+                {
+                    tracker.markAsDuplicate( i );
+                    marks[i] = true;
+                }
+            }
+
+            // then
+            for ( int i = 0; i < length; i++ )
+            {
+                assertEquals( values[i], tracker.get( i ) );
+                assertEquals( marks[i], tracker.isMarkedAsDuplicate( i ) );
+            }
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/LongCollisionValuesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/LongCollisionValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/LongCollisionValuesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/LongCollisionValuesTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.neo4j.test.rule.RandomRule;
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO_WITHOUT_PAGECACHE;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.CHUNKED_FIXED_SIZE;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.HEAP;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.OFF_HEAP;
+
+@RunWith( Parameterized.class )
+public class LongCollisionValuesTest
+{
+    @Rule
+    public final RandomRule random = new RandomRule();
+
+    @Parameters
+    public static Collection<NumberArrayFactory> data()
+    {
+        return Arrays.asList( HEAP, OFF_HEAP, AUTO_WITHOUT_PAGECACHE, CHUNKED_FIXED_SIZE );
+    }
+
+    @Parameter( 0 )
+    public NumberArrayFactory factory;
+
+    @Test
+    public void shouldStoreAndLoadLongs() throws Exception
+    {
+        // given
+        try ( LongCollisionValues values = new LongCollisionValues( factory, 100 ); )
+        {
+            // when
+            long[] offsets = new long[100];
+            long[] longs = new long[offsets.length];
+            for ( int i = 0; i < offsets.length; i++ )
+            {
+                long value = random.nextLong( Long.MAX_VALUE );
+                offsets[i] = values.add( value );
+                longs[i] = value;
+            }
+
+            // then
+            for ( int i = 0; i < offsets.length; i++ )
+            {
+                assertEquals( longs[i], (long) values.get( offsets[i] ) );
+            }
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/StringCollisionValuesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/StringCollisionValuesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/StringCollisionValuesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/StringCollisionValuesTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.neo4j.test.rule.RandomRule;
+import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.AUTO_WITHOUT_PAGECACHE;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.CHUNKED_FIXED_SIZE;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.HEAP;
+import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.OFF_HEAP;
+
+@RunWith( Parameterized.class )
+public class StringCollisionValuesTest
+{
+    @Rule
+    public final RandomRule random = new RandomRule();
+
+    @Parameters
+    public static Collection<NumberArrayFactory> data()
+    {
+        return Arrays.asList( HEAP, OFF_HEAP, AUTO_WITHOUT_PAGECACHE, CHUNKED_FIXED_SIZE );
+    }
+
+    @Parameter( 0 )
+    public NumberArrayFactory factory;
+
+    @Test
+    public void shouldStoreAndLoadStrings() throws Exception
+    {
+        // given
+        try ( StringCollisionValues values = new StringCollisionValues( factory, 100_000 ); )
+        {
+            // when
+            long[] offsets = new long[100];
+            String[] strings = new String[offsets.length];
+            for ( int i = 0; i < offsets.length; i++ )
+            {
+                String string = random.string();
+                offsets[i] = values.add( string );
+                strings[i] = string;
+            }
+
+            // then
+            for ( int i = 0; i < offsets.length; i++ )
+            {
+                assertEquals( strings[i], values.get( offsets[i] ) );
+            }
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/StringCollisionValuesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/StringCollisionValuesTest.java
@@ -29,6 +29,7 @@ import org.junit.runners.Parameterized.Parameters;
 import java.util.Arrays;
 import java.util.Collection;
 
+import org.neo4j.test.Randoms;
 import org.neo4j.test.rule.RandomRule;
 import org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory;
 
@@ -43,7 +44,14 @@ import static org.neo4j.unsafe.impl.batchimport.cache.NumberArrayFactory.OFF_HEA
 public class StringCollisionValuesTest
 {
     @Rule
-    public final RandomRule random = new RandomRule();
+    public final RandomRule random = new RandomRule().withConfiguration( new Randoms.Default()
+    {
+        @Override
+        public int stringMaxLength()
+        {
+            return 1 << Short.SIZE;
+        }
+    } );
 
     @Parameters
     public static Collection<NumberArrayFactory> data()
@@ -58,7 +66,7 @@ public class StringCollisionValuesTest
     public void shouldStoreAndLoadStrings() throws Exception
     {
         // given
-        try ( StringCollisionValues values = new StringCollisionValues( factory, 100_000 ); )
+        try ( StringCollisionValues values = new StringCollisionValues( factory, 10_000 ); )
         {
             // when
             long[] offsets = new long[100];

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/BadCollectorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/input/BadCollectorTest.java
@@ -27,15 +27,11 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 
-import org.neo4j.collection.primitive.PrimitiveLongCollections;
-import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.io.NullOutputStream;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import static org.neo4j.unsafe.impl.batchimport.input.BadCollector.COLLECT_ALL;
@@ -147,49 +143,6 @@ public class BadCollectorTest
                 // then expect to end up here
                 assertEquals( 1 /* only duplicate rel collected */, badCollector.badEntries() );
             }
-        }
-    }
-
-    @Test
-    public void shouldBeAbleToRetrieveDuplicateNodeIds() throws IOException
-    {
-        // given
-        int tolerance = 15;
-
-        try ( BadCollector badCollector = new BadCollector( badOutputFile(), tolerance, BadCollector.COLLECT_ALL ); )
-        {
-            // when
-            for ( int i = 0; i < 15; i++ )
-            {
-                badCollector.collectDuplicateNode( i, i, "group" );
-            }
-
-            // then
-            assertEquals( 15, PrimitiveLongCollections.count( badCollector.leftOverDuplicateNodesIds() ) );
-
-            PrimitiveLongSet longs = PrimitiveLongCollections.asSet( badCollector.leftOverDuplicateNodesIds() );
-            for ( int i = 0; i < 15; i++ )
-            {
-                assertTrue( longs.contains( i ) );
-            }
-        }
-    }
-
-    @Test
-    public void shouldProvideNodeIdsSorted() throws Exception
-    {
-        // GIVEN
-        try ( BadCollector badCollector = new BadCollector( badOutputFile(), 10, BadCollector.DUPLICATE_NODES ); )
-        {
-            badCollector.collectDuplicateNode( "a", 10, "group" );
-            badCollector.collectDuplicateNode( "b", 8, "group" );
-            badCollector.collectDuplicateNode( "c", 12, "group" );
-
-            // WHEN
-            long[] nodeIds = PrimitiveLongCollections.asArray( badCollector.leftOverDuplicateNodesIds() );
-
-            // THEN
-            assertArrayEquals( new long[] {8, 10, 12}, nodeIds );
         }
     }
 


### PR DESCRIPTION
- Reduced big tracker cache from 6 --> 5 bytes, i.e. an overall ~8% lowered memory usage for large imports
- Moved keeping of collision values off-heap and reduced down to 1/6th of the memory it used to occupy in heap
- Removed array for keeping duplicate node ids entirely

These changes are targeted to improve scenarios where there are lots of duplicate node IDs in the input files. Previously the management of those duplicates required a lot of heap memory. Now this has changed to require only a fraction of that, and also moved off-heap.

There is now only remnants of the page cache meta data left in the heap that needs to be considered when chosing heap size for an import, nothing else by design requires a heap larger than a couple of gigabytes, tops, for an import regardless of data size and its condition.
  