### PR TITLE
Adds means of more efficiently calling NumberArray#swap

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicNumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/DynamicNumberArray.java
@@ -111,4 +111,10 @@ abstract class DynamicNumberArray<N extends NumberArray<N>> implements NumberArr
             chunk.close();
         }
     }
+
+    @Override
+    public N duplicate()
+    {
+        throw new UnsupportedOperationException( "Not supported for dynamic arrays" );
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapByteArray.java
@@ -32,6 +32,16 @@ public class HeapByteArray extends HeapNumberArray<ByteArray> implements ByteArr
     private final byte[] defaultValue;
     private final boolean defaultValueIsUniform;
 
+    private HeapByteArray( HeapByteArray copySource )
+    {
+        super( copySource.itemSize, copySource.base );
+        this.length = copySource.length;
+        this.array = copySource.array;
+        this.buffer = copySource.buffer;
+        this.defaultValue = copySource.defaultValue;
+        this.defaultValueIsUniform = copySource.defaultValueIsUniform;
+    }
+
     public HeapByteArray( int length, byte[] defaultValue, long base )
     {
         super( defaultValue.length, base );
@@ -54,6 +64,11 @@ public class HeapByteArray extends HeapNumberArray<ByteArray> implements ByteArr
     {
         byte[] a = defaultValue.clone();
         byte[] b = defaultValue.clone();
+        internalSwap( fromIndex, toIndex, a, b );
+    }
+
+    private void internalSwap( long fromIndex, long toIndex, byte[] a, byte[] b )
+    {
         get( fromIndex, a );
         get( toIndex, b );
         set( fromIndex, b );
@@ -195,5 +210,26 @@ public class HeapByteArray extends HeapNumberArray<ByteArray> implements ByteArr
     private int index( long index, int offset )
     {
         return toIntExact( (rebase( index ) * itemSize) + offset );
+    }
+
+    @Override
+    public ByteArray duplicate()
+    {
+        return new HeapByteArray( this )
+        {
+            private final byte[] a = new byte[defaultValue.length];
+            private final byte[] b = new byte[defaultValue.length];
+
+            @Override
+            public void swap( long fromIndex, long toIndex )
+            {
+                internalSwap( fromIndex, toIndex, a, b );
+            }
+
+            @Override
+            public void close()
+            {   // Explicitly don't close the underlying data structures
+            }
+        };
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapNumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/HeapNumberArray.java
@@ -46,4 +46,13 @@ abstract class HeapNumberArray<N extends NumberArray<N>> extends BaseNumberArray
     {
         return safeCastLongToInt( rebase( index ) );
     }
+
+    @SuppressWarnings( "unchecked" )
+    @Override
+    public N duplicate()
+    {
+        // We can return this since close() doesn't close anything. If that changes then please do what off-heap variants do,
+        // namely override close method as a no-op
+        return (N) this;
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArray.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.unsafe.impl.batchimport.cache;
 
+import java.nio.ByteBuffer;
+
 /**
  * Abstraction over primitive arrays.
  *
@@ -64,4 +66,14 @@ public interface NumberArray<N extends NumberArray<N>> extends MemoryStatsVisito
      * @return array sure to hold the given index.
      */
     N at( long index );
+
+    /**
+     * @return an equivalence of {@link ByteBuffer#duplicate()} where the duplicate can take advantage of being used
+     * only from the thread making the duplicate, e.g. some operations like {@link #swap(long, long)} could use
+     * intermediary memory allocated once instead of for every call. The returned instance should also be {@link #close() closed}
+     * when not used anymore.
+     *
+     * NOTE this is unsupported for dynamic arrays.
+     */
+    N duplicate();
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapIntArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapIntArray.java
@@ -29,6 +29,12 @@ public class OffHeapIntArray extends OffHeapRegularNumberArray<IntArray> impleme
 {
     private final int defaultValue;
 
+    private OffHeapIntArray( OffHeapIntArray copySource )
+    {
+        super( copySource );
+        this.defaultValue = copySource.defaultValue;
+    }
+
     public OffHeapIntArray( long length, int defaultValue, long base )
     {
         super( length, 2, base );
@@ -62,5 +68,17 @@ public class OffHeapIntArray extends OffHeapRegularNumberArray<IntArray> impleme
                 UnsafeUtil.putInt( adr, defaultValue );
             }
         }
+    }
+
+    @Override
+    public IntArray duplicate()
+    {
+        return new OffHeapIntArray( this )
+        {
+            @Override
+            public void close()
+            {   // Explicitly don't close the underlying data structures
+            }
+        };
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapLongArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapLongArray.java
@@ -29,6 +29,12 @@ public class OffHeapLongArray extends OffHeapRegularNumberArray<LongArray> imple
 {
     private final long defaultValue;
 
+    private OffHeapLongArray( OffHeapLongArray copySource )
+    {
+        super( copySource );
+        this.defaultValue = copySource.defaultValue;
+    }
+
     public OffHeapLongArray( long length, long defaultValue, long base )
     {
         super( length, 3, base );
@@ -62,5 +68,17 @@ public class OffHeapLongArray extends OffHeapRegularNumberArray<LongArray> imple
                 UnsafeUtil.putLong( adr, defaultValue );
             }
         }
+    }
+
+    @Override
+    public LongArray duplicate()
+    {
+        return new OffHeapLongArray( this )
+        {
+            @Override
+            public void close()
+            {   // Explicitly don't close the underlying data structures
+            }
+        };
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapNumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapNumberArray.java
@@ -23,10 +23,18 @@ import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
 public abstract class OffHeapNumberArray<N extends NumberArray<N>> extends BaseNumberArray<N>
 {
-    private final long allocatedAddress;
+    protected final long allocatedAddress;
     protected final long address;
     protected final long length;
     private boolean closed;
+
+    protected OffHeapNumberArray( OffHeapNumberArray<N> copySource )
+    {
+        super( copySource.itemSize, copySource.base );
+        this.allocatedAddress = copySource.allocatedAddress;
+        this.address = copySource.address;
+        this.length = copySource.length;
+    }
 
     protected OffHeapNumberArray( long length, int itemSize, long base )
     {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapRegularNumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapRegularNumberArray.java
@@ -26,6 +26,12 @@ abstract class OffHeapRegularNumberArray<N extends NumberArray<N>> extends OffHe
 {
     protected final int shift;
 
+    protected OffHeapRegularNumberArray( OffHeapRegularNumberArray<N> copySource )
+    {
+        super( copySource );
+        this.shift = copySource.shift;
+    }
+
     protected OffHeapRegularNumberArray( long length, int shift, long base )
     {
         super( length, 1 << shift, base );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheByteArray.java
@@ -33,11 +33,17 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
 {
     private final byte[] defaultValue;
 
+    private PageCacheByteArray( PageCacheByteArray copySource )
+    {
+        super( copySource );
+        this.defaultValue = copySource.defaultValue;
+    }
+
     PageCacheByteArray( PagedFile pagedFile, long length, byte[] defaultValue, long base ) throws IOException
     {
         // Default value is handled locally in this class, in contrast to its siblings, which lets the superclass
         // handle it.
-        super( pagedFile, defaultValue.length, length, base );
+        super( pagedFile, defaultValue.length, length, 0, base );
         this.defaultValue = defaultValue;
         setDefaultValue( -1 );
     }
@@ -56,6 +62,11 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
     {
         byte[] a = defaultValue.clone();
         byte[] b = defaultValue.clone();
+        internalSwap( fromIndex, toIndex, a, b );
+    }
+
+    private void internalSwap( long fromIndex, long toIndex, byte[] a, byte[] b )
+    {
         get( fromIndex, a );
         get( toIndex, b );
         set( fromIndex, b );
@@ -352,5 +363,17 @@ public class PageCacheByteArray extends PageCacheNumberArray<ByteArray> implemen
         {
             throw new UncheckedIOException( e );
         }
+    }
+
+    @Override
+    public ByteArray duplicate()
+    {
+        return new PageCacheByteArray( this )
+        {
+            @Override
+            public void close()
+            {   // Explicitly don't close the underlying data structures
+            }
+        };
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheIntArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheIntArray.java
@@ -31,6 +31,11 @@ import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_WRITE_LOCK;
 
 public class PageCacheIntArray extends PageCacheNumberArray<IntArray> implements IntArray
 {
+    private PageCacheIntArray( PageCacheIntArray copySource )
+    {
+        super( copySource );
+    }
+
     PageCacheIntArray( PagedFile pagedFile, long length, long defaultValue, long base ) throws IOException
     {
         super( pagedFile, Integer.BYTES, length, defaultValue | defaultValue << Integer.SIZE, base );
@@ -74,5 +79,17 @@ public class PageCacheIntArray extends PageCacheNumberArray<IntArray> implements
         {
             throw new UncheckedIOException( e );
         }
+    }
+
+    @Override
+    public IntArray duplicate()
+    {
+        return new PageCacheIntArray( this )
+        {
+            @Override
+            public void close()
+            {   // Explicitly don't close the underlying data structures
+            }
+        };
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheLongArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/PageCacheLongArray.java
@@ -31,6 +31,11 @@ import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_WRITE_LOCK;
 
 public class PageCacheLongArray extends PageCacheNumberArray<LongArray> implements LongArray
 {
+    private PageCacheLongArray( PageCacheLongArray copySource )
+    {
+        super( copySource );
+    }
+
     PageCacheLongArray( PagedFile pagedFile, long length, long defaultValue, long base ) throws IOException
     {
         super( pagedFile, Long.BYTES, length, defaultValue, base );
@@ -74,5 +79,17 @@ public class PageCacheLongArray extends PageCacheNumberArray<LongArray> implemen
         {
             throw new UncheckedIOException( e );
         }
+    }
+
+    @Override
+    public LongArray duplicate()
+    {
+        return new PageCacheLongArray( this )
+        {
+            @Override
+            public void close()
+            {   // Explicitly don't close the underlying data structures
+            }
+        };
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/BigIdTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/BigIdTracker.java
@@ -45,4 +45,10 @@ public class BigIdTracker extends AbstractTracker<ByteArray>
     {
         array.set6ByteLong( index, 0, value );
     }
+
+    @Override
+    public Tracker duplicate()
+    {
+        return new BigIdTracker( array.duplicate() );
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/IntTracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/IntTracker.java
@@ -51,4 +51,10 @@ public class IntTracker extends AbstractTracker<IntArray>
     {
         array.set( index, safeCastLongToInt( value ) );
     }
+
+    @Override
+    public Tracker duplicate()
+    {
+        return new IntTracker( array.duplicate() );
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Tracker.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Tracker.java
@@ -21,6 +21,7 @@ package org.neo4j.unsafe.impl.batchimport.cache.idmapping.string;
 
 import org.neo4j.helpers.progress.ProgressListener;
 import org.neo4j.unsafe.impl.batchimport.InputIterable;
+import org.neo4j.unsafe.impl.batchimport.cache.ByteArray;
 import org.neo4j.unsafe.impl.batchimport.cache.MemoryStatsVisitor;
 import org.neo4j.unsafe.impl.batchimport.cache.idmapping.IdMapper;
 import org.neo4j.unsafe.impl.batchimport.input.Collector;
@@ -65,4 +66,9 @@ public interface Tracker extends MemoryStatsVisitor.Visitable, AutoCloseable
 
     @Override
     void close();
+
+    /**
+     * @see ByteArray#duplicate()
+     */
+    Tracker duplicate();
 }


### PR DESCRIPTION
By introducing NumberArray#duplicate(), which can create intermediary data structure
for swapping (and potentially for other things too) once instead of for every
call to the swap method.

Those who have heavy parallel load and do lots of swap calls should consider grabbing
a duplicate of their number array and swapping on that instead of directly on the
shared number array.