### PR TITLE
No unnecessary copies when rewriting.

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/LogicalPlanConverter.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/LogicalPlanConverter.scala
@@ -28,7 +28,7 @@ import org.neo4j.cypher.internal.frontend.{v3_3 => frontendV3_3}
 import org.neo4j.cypher.internal.ir.v3_3.{IdName => IdNameV3_3}
 import org.neo4j.cypher.internal.ir.v3_4.{PlannerQuery, IdName => IdNameV3_4}
 import org.neo4j.cypher.internal.ir.{v3_3 => irV3_3, v3_4 => irV3_4}
-import org.neo4j.cypher.internal.util.v3_4.Rewritable.{DuplicatableProduct, RewritableAny}
+import org.neo4j.cypher.internal.util.v3_4.Rewritable.RewritableAny
 import org.neo4j.cypher.internal.util.v3_4.{symbols => symbolsV3_4, _}
 import org.neo4j.cypher.internal.util.{v3_4 => utilV3_4}
 import org.neo4j.cypher.internal.v3_3.logical.plans.{LogicalPlan => LogicalPlanV3_3}

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/LogicalPlanConverter.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/LogicalPlanConverter.scala
@@ -152,13 +152,6 @@ object LogicalPlanConverter {
           convertVersion("frontend.v3_3", "v3_4.logical.plans", item, children)
         case (item: compilerV3_3.SeekRange[_], children: Seq[AnyRef]) =>
           convertVersion("compiler.v3_3", "v3_4.logical.plans", item, children)
-
-        case (_: List[_], children: Seq[AnyRef]) => children.toList
-        case (_: Seq[_], children: Seq[AnyRef]) => children.toIndexedSeq
-        case (_: Set[_], children: Seq[AnyRef]) => children.toSet
-        case (_: Map[_, _], children: Seq[AnyRef]) => Map(children.map(_.asInstanceOf[(_, _)]): _*)
-        case (None, _) => None
-        case (p: Product, children: Seq[AnyRef]) => new DuplicatableProduct(p).copyConstructor.invoke(p, children: _*)
       }.apply(before)
       before._1 match {
         case plan: LogicalPlanV3_3 =>

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/PathExpression.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/PathExpression.scala
@@ -29,7 +29,7 @@ sealed trait PathStep extends Product with Foldable with Rewritable {
     if (children.iterator eqElements this.children)
       this
     else {
-      val constructor = this.copyConstructor
+      val constructor = Rewritable.copyConstructor(this)
       val params = constructor.getParameterTypes
       val args = children.toVector
       val ctorArgs = args

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/ReturnItemSafeTopDownRewriter.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/ast/rewriters/ReturnItemSafeTopDownRewriter.scala
@@ -18,7 +18,7 @@ package org.neo4j.cypher.internal.frontend.v3_4.ast.rewriters
 
 import org.neo4j.cypher.internal.util.v3_4.Foldable.TreeAny
 import org.neo4j.cypher.internal.util.v3_4.Rewritable._
-import org.neo4j.cypher.internal.util.v3_4.{InternalException, Rewriter}
+import org.neo4j.cypher.internal.util.v3_4.{InternalException, Rewritable, Rewriter}
 import org.neo4j.cypher.internal.frontend.v3_4.ast.AliasedReturnItem
 import org.neo4j.cypher.internal.v3_4.expressions.Expression
 
@@ -53,7 +53,7 @@ case class ReturnItemSafeTopDownRewriter(inner: Rewriter) extends Rewriter {
             val newReturnItem = returnItem.copy(expression = newExpression)(returnItem.position)
             stack.push((jobs, doneJobs += newReturnItem))
           case (job :: jobs, doneJobs) =>
-            val doneJob = job.dup(newChildren)
+            val doneJob = Rewritable.dupAny(job, newChildren)
             stack.push((jobs, doneJobs += doneJob))
         }
 

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/ASTNode.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/ASTNode.scala
@@ -28,7 +28,7 @@ trait ASTNode extends Product with Foldable with Rewritable {
     if (children.iterator eqElements this.children)
       this
     else {
-      val constructor = this.copyConstructor
+      val constructor = Rewritable.copyConstructor(this)
       val params = constructor.getParameterTypes
       val args = children.toVector
       val hasExtraParam = params.length == args.length + 1

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/Foldable.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/Foldable.scala
@@ -33,14 +33,6 @@ object Foldable {
       case _ => Iterator.empty.asInstanceOf[Iterator[AnyRef]]
     }
 
-    def childrenWithListsAsSeq: Iterator[AnyRef] = that match {
-      case s: Seq[_] => s.iterator.asInstanceOf[Iterator[AnyRef]]
-      case p: Product => p.productIterator.asInstanceOf[Iterator[AnyRef]]
-      case s: Set[_] => s.iterator.asInstanceOf[Iterator[AnyRef]]
-      case m: Map[_, _] => m.iterator.asInstanceOf[Iterator[AnyRef]]
-      case _ => Iterator.empty.asInstanceOf[Iterator[AnyRef]]
-    }
-
     def reverseChildren: Iterator[AnyRef] = that match {
       case p: Product => reverseProductIterator(p)
       case s: Seq[_] => s.reverseIterator.asInstanceOf[Iterator[AnyRef]]

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/Rewritable.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/Rewritable.scala
@@ -52,24 +52,25 @@ object Rewritable {
 
     def dup(children: Seq[AnyRef]): AnyRef =
       try {
-        that match {
-          case a: Rewritable =>
-            a.dup(children)
-          case p: Product =>
-            if (children.iterator eqElements p.children)
-              p
-            else
-              p.copyConstructor.invoke(p, children: _*)
-          case _: IndexedSeq[_] =>
-            children.toIndexedSeq
-          case _: Seq[_] =>
-            children
-          case _: Set[_] =>
-            children.toSet
-          case _: Map[_, _] =>
-            children.map(value => value.asInstanceOf[(String, AnyRef)]).toMap
-          case t =>
-            t
+        if (children.iterator eqElements that.children) {
+          that
+        } else {
+          that match {
+            case a: Rewritable =>
+              a.dup(children)
+            case p: Product =>
+                p.copyConstructor.invoke(p, children: _*)
+            case _: IndexedSeq[_] =>
+              children.toIndexedSeq
+            case _: Seq[_] =>
+              children
+            case _: Set[_] =>
+              children.toSet
+            case _: Map[_, _] =>
+              children.map(value => value.asInstanceOf[(String, AnyRef)]).toMap
+            case t =>
+              t
+          }
         }
       } catch {
         case e: IllegalArgumentException =>

--- a/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/RewritableTest.scala
+++ b/community/cypher/util-3.4/src/test/scala/org/neo4j/cypher/internal/util/v3_4/RewritableTest.scala
@@ -18,6 +18,8 @@ package org.neo4j.cypher.internal.util.v3_4
 
 import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 
+import scala.collection.mutable.ListBuffer
+
 object RewritableTest {
   trait Exp extends Product with Rewritable
   case class Val(int: Int) extends Exp {
@@ -191,5 +193,27 @@ class RewritableTest extends CypherFunSuite {
     }))
 
     assert(result === Add(Val(99), Options(Seq((Val(99), Val(99)), (Val(99), Val(99))))))
+  }
+
+  test("should not create unnecessary copies of objects that have Seq's as Children (when using ListBuffer)") {
+    import org.neo4j.cypher.internal.util.v3_4.Rewritable._
+    import org.neo4j.cypher.internal.util.v3_4.Foldable._
+
+    case class Thing(texts: Seq[String]) extends Rewritable {
+      def dup(children: Seq[AnyRef]): this.type =
+        if (children.iterator eqElements this.children)
+          this
+        else {
+          Thing(children.head.asInstanceOf[Seq[String]]).asInstanceOf[this.type]
+        }
+    }
+    case object NotUsed
+
+    val thing = Thing(ListBuffer("a", "b", "c"))
+    val rewritten = thing.rewrite(bottomUp(Rewriter.lift {
+      case NotUsed => NotUsed
+    }))
+
+    rewritten should be theSameInstanceAs(thing)
   }
 }

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeProperty.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/ast/RuntimeProperty.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime.ast
 import org.neo4j.cypher.internal.frontend.v3_4.SemanticCheck
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.{SemanticCheckResult, SemanticCheckableExpression}
 import org.neo4j.cypher.internal.util.v3_4.AssertionUtils.ifAssertionsEnabled
-import org.neo4j.cypher.internal.util.v3_4.{InputPosition, InternalException}
+import org.neo4j.cypher.internal.util.v3_4.{InputPosition, InternalException, Rewritable}
 import org.neo4j.cypher.internal.v3_4.expressions.{Expression, LogicalProperty, PropertyKeyName}
 
 abstract class RuntimeProperty(val prop: LogicalProperty) extends LogicalProperty with SemanticCheckableExpression{
@@ -35,7 +35,7 @@ abstract class RuntimeProperty(val prop: LogicalProperty) extends LogicalPropert
   override def propertyKey: PropertyKeyName = prop.propertyKey
 
   override def dup(children: Seq[AnyRef]): this.type = {
-    val constructor = this.copyConstructor
+    val constructor = Rewritable.copyConstructor(this)
     val args = children.toVector
 
     ifAssertionsEnabled {


### PR DESCRIPTION
We created a lot of unnecessary copies of case classes that have Seq's as children , if the
used implementation was a ListBuffer. We don't do that any more.