### PR TITLE
Use cursor directly instead of intermediate iterator

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIndexAccessor.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.labelscan;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collection;
+
+import org.neo4j.cursor.RawCursor;
+import org.neo4j.index.internal.gbptree.Hit;
+
+/**
+ * Base class for iterator and index-progressor of label scans.
+ */
+abstract class LabelScanValueIndexAccessor
+{
+    /**
+     * {@link RawCursor} to lazily read new {@link LabelScanValue} from.
+     */
+    protected final RawCursor<Hit<LabelScanKey,LabelScanValue>,IOException> cursor;
+    /**
+     * Remove provided cursor from this collection when iterator is exhausted.
+     */
+    private final Collection<RawCursor<Hit<LabelScanKey,LabelScanValue>,IOException>> toRemoveFromWhenClosed;
+    /**
+     * Current base nodeId, i.e. the {@link LabelScanKey#idRange} of the current {@link LabelScanKey}.
+     */
+    long baseNodeId;
+    /**
+     * Bit set of the current {@link LabelScanValue}.
+     */
+    protected long bits;
+    /**
+     * LabelId of previously retrieved {@link LabelScanKey}, for debugging and asserting purposes.
+     */
+    private int prevLabel = -1;
+    /**
+     * IdRange of previously retrieved {@link LabelScanKey}, for debugging and asserting purposes.
+     */
+    private long prevRange = -1;
+    /**
+     * Indicate provided cursor has been closed.
+     */
+    private boolean closed;
+
+    LabelScanValueIndexAccessor(
+            Collection<RawCursor<Hit<LabelScanKey,LabelScanValue>,IOException>> toRemoveFromWhenClosed,
+            RawCursor<Hit<LabelScanKey,LabelScanValue>,IOException> cursor )
+    {
+        this.toRemoveFromWhenClosed = toRemoveFromWhenClosed;
+        this.cursor = cursor;
+    }
+
+    boolean keysInOrder( LabelScanKey key )
+    {
+        assert key.labelId >= prevLabel : "Expected to get ordered results, got " + key +
+                " where previous label was " + prevLabel;
+        assert key.idRange > prevRange : "Expected to get ordered results, got " + key +
+                " where previous range was " + prevRange;
+        prevLabel = key.labelId;
+        prevRange = key.idRange;
+        // Made as a method returning boolean so that it can participate in an assert call.
+        return true;
+    }
+
+    public void close()
+    {
+        if ( !closed )
+        {
+            try
+            {
+                cursor.close();
+            }
+            catch ( IOException e )
+            {
+                throw new UncheckedIOException( e );
+            }
+            finally
+            {
+                toRemoveFromWhenClosed.remove( cursor );
+                closed = true;
+            }
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIndexProgressor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIndexProgressor.java
@@ -47,16 +47,18 @@ class LabelScanValueIndexProgressor extends LabelScanValueIndexAccessor implemen
     }
 
     /**
-     * @return next node id in the current {@link LabelScanValue} or, if current value exhausted,
-     * goes to next {@link LabelScanValue} from {@link RawCursor}. Returns {@code true} if next node id
-     * was found, otherwise {@code false}.
+     *  Progress through the index until the next accepted entry.
+     *
+     *  Progress the cursor to the current {@link LabelScanValue}, if this is not accepted by the client or if current
+     *  value is exhausted it continues to the next {@link LabelScanValue}  from {@link RawCursor}.
+     * @return <code>true</code> if an accepted entry was found, <code>false</code> otherwise
      */
     @Override
     public boolean next()
     {
-        while ( true )
+        for ( ; ; )
         {
-            if ( bits != 0 )
+            while ( bits != 0 )
             {
                 int delta = Long.numberOfTrailingZeros( bits );
                 bits &= bits - 1;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanReader.java
@@ -32,7 +32,6 @@ import org.neo4j.cursor.RawCursor;
 import org.neo4j.graphdb.index.Index;
 import org.neo4j.index.internal.gbptree.GBPTree;
 import org.neo4j.index.internal.gbptree.Hit;
-import org.neo4j.kernel.impl.index.schema.NumberHitIndexProgressor;
 import org.neo4j.storageengine.api.schema.IndexProgressor;
 import org.neo4j.storageengine.api.schema.LabelScanReader;
 
@@ -110,7 +109,8 @@ class NativeLabelScanReader implements LabelScanReader
         return new CompositeLabelScanValueIterator( iterators, true );
     }
 
-    public LabelScanValueIndexProgressor nodesWithLabelIndex( IndexProgressor.NodeLabelClient client,
+    @Override
+    public LabelScanValueIndexProgressor nodesWithLabel( IndexProgressor.NodeLabelClient client,
             int labelId )
     {
         RawCursor<Hit<LabelScanKey,LabelScanValue>,IOException> cursor;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanReader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanReader.java
@@ -110,8 +110,7 @@ class NativeLabelScanReader implements LabelScanReader
     }
 
     @Override
-    public LabelScanValueIndexProgressor nodesWithLabel( IndexProgressor.NodeLabelClient client,
-            int labelId )
+    public void nodesWithLabel( IndexProgressor.NodeLabelClient client, int labelId )
     {
         RawCursor<Hit<LabelScanKey,LabelScanValue>,IOException> cursor;
         try
@@ -124,7 +123,7 @@ class NativeLabelScanReader implements LabelScanReader
             throw new UncheckedIOException( e );
         }
 
-        return new LabelScanValueIndexProgressor( cursor, openCursors, client );
+        client.initialize( new LabelScanValueIndexProgressor( cursor, openCursors, client ), false );
     }
 
     private List<PrimitiveLongResourceIterator> iteratorsForLabels( int[] labelIds )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Read.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Read.java
@@ -141,7 +141,7 @@ abstract class Read implements TxStateHolder,
 
         NodeLabelIndexCursor indexCursor = (NodeLabelIndexCursor) cursor;
         indexCursor.setRead( this );
-        indexCursor.initialize( labelScanReader().nodesWithLabel( indexCursor, label ) );
+        labelScanReader().nodesWithLabel( indexCursor, label );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Read.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Read.java
@@ -141,7 +141,7 @@ abstract class Read implements TxStateHolder,
 
         NodeLabelIndexCursor indexCursor = (NodeLabelIndexCursor) cursor;
         indexCursor.setRead( this );
-        indexCursor.initialize( labelScanReader().nodesWithLabelIndex( indexCursor, label ) );
+        indexCursor.initialize( labelScanReader().nodesWithLabel( indexCursor, label ) );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Read.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Read.java
@@ -139,8 +139,9 @@ abstract class Read implements TxStateHolder,
     {
         ktx.assertOpen();
 
-        ((NodeLabelIndexCursor) cursor).setRead( this );
-        labelScan( (NodeLabelIndexCursor) cursor, labelScanReader().nodesWithLabel( label ) );
+        NodeLabelIndexCursor indexCursor = (NodeLabelIndexCursor) cursor;
+        indexCursor.setRead( this );
+        indexCursor.initialize( labelScanReader().nodesWithLabelIndex( indexCursor, label ) );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/LabelScanReader.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/LabelScanReader.java
@@ -34,6 +34,15 @@ public interface LabelScanReader extends Resource
     PrimitiveLongResourceIterator nodesWithLabel( int labelId );
 
     /**
+     * Returns the index progressor over the label id
+     *
+     * @param client the client to communicate with
+     * @param labelId label token id
+     * @return index progressor with the given {@code labelId}
+     */
+    IndexProgressor nodesWithLabelIndex( IndexProgressor.NodeLabelClient client, int labelId );
+
+    /**
      * @param labelIds label token ids.
      * @return node ids with any of the given label ids.
      */

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/LabelScanReader.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/LabelScanReader.java
@@ -40,7 +40,7 @@ public interface LabelScanReader extends Resource
      * @param labelId label token id
      * @return index progressor with the given {@code labelId}
      */
-    IndexProgressor nodesWithLabelIndex( IndexProgressor.NodeLabelClient client, int labelId );
+    IndexProgressor nodesWithLabel( IndexProgressor.NodeLabelClient client, int labelId );
 
     /**
      * @param labelIds label token ids.

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/LabelScanReader.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/LabelScanReader.java
@@ -34,13 +34,12 @@ public interface LabelScanReader extends Resource
     PrimitiveLongResourceIterator nodesWithLabel( int labelId );
 
     /**
-     * Returns the index progressor over the label id
+     * Sets the client up for a label scan on <code>labelId</code>
      *
      * @param client the client to communicate with
      * @param labelId label token id
-     * @return index progressor with the given {@code labelId}
      */
-    IndexProgressor nodesWithLabel( IndexProgressor.NodeLabelClient client, int labelId );
+    void nodesWithLabel( IndexProgressor.NodeLabelClient client, int labelId );
 
     /**
      * @param labelIds label token ids.

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIndexProgressorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIndexProgressorTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.index.labelscan;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashSet;
+
+import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.cursor.RawCursor;
+import org.neo4j.index.internal.gbptree.Hit;
+import org.neo4j.storageengine.api.schema.IndexProgressor;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class LabelScanValueIndexProgressorTest
+{
+    @Test
+    public void shouldCloseExhaustedCursors() throws Exception
+    {
+        // GIVEN
+        RawCursor<Hit<LabelScanKey,LabelScanValue>,IOException> cursor = mock( RawCursor.class );
+        when( cursor.next() ).thenReturn( false );
+        Collection<RawCursor<Hit<LabelScanKey,LabelScanValue>,IOException>> toRemoveFrom = new HashSet<>();
+        LabelScanValueIndexProgressor iterator = new LabelScanValueIndexProgressor( cursor, toRemoveFrom, mock(
+                IndexProgressor.NodeLabelClient.class ) );
+        verify( cursor, times( 0 ) ).close();
+
+        // WHEN
+        exhaust( iterator );
+        verify( cursor, times( 1 ) ).close();
+
+        // retrying to get more items from the first one should not close it again
+        iterator.next();
+        verify( cursor, times( 1 ) ).close();
+
+        // and set should be empty
+        assertTrue( toRemoveFrom.isEmpty() );
+    }
+
+    private void exhaust( LabelScanValueIndexProgressor pro )
+    {
+        while ( pro.next() )
+        {
+            //do nothing
+        }
+    }
+}


### PR DESCRIPTION
By having direct access to the cursor we can get a significant speedup
instead of delegating via an iterator when doing label scans.