### PR TITLE
Fix slot allocation of cartesian product to honor slot order

### DIFF
--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildSlottedExecutionPlan.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/BuildSlottedExecutionPlan.scala
@@ -42,7 +42,7 @@ import org.neo4j.values.virtual.MapValue
 object BuildSlottedExecutionPlan extends Phase[EnterpriseRuntimeContext, LogicalPlanState, CompilationState] {
   override def phase: CompilationPhaseTracer.CompilationPhase = PIPE_BUILDING
 
-  override def description = "create interpreted execution plan"
+  override def description = "create slotted execution plan"
 
   override def postConditions = Set(CompilationContains[ExecutionPlan])
 

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/PipelineInformation.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/PipelineInformation.scala
@@ -182,7 +182,7 @@ class PipelineInformation(private var slots: Map[String, Slot],
   }
 
   def foreachSlotOrdered[U](f: ((String, Slot)) => U): Unit =
-    slots.toSeq.sortBy(_._2)(SlotOrdering).foreach(f)
+    slots.toIndexedSeq.sortBy(_._2)(SlotOrdering).foreach(f)
 
   def canEqual(other: Any): Boolean = other.isInstanceOf[PipelineInformation]
 
@@ -206,6 +206,11 @@ class PipelineInformation(private var slots: Map[String, Slot],
     if (slots.contains(key))
       throw new InternalException("Tried overwriting already taken variable name")
 
+  /**
+    * Orders LongSlots before RefSlots, and lower offsets before higher. As we keep separate arrays for
+    * references and longs it doesn't matter which of these we do first. It is crucial that we process
+    * slots in their offset order withing the slot group though, when merging PipelineInformations.
+    */
   object SlotOrdering extends Ordering[Slot] {
     def compare(x: Slot, y: Slot): Int = (x, y) match {
       case (_: LongSlot, _: RefSlot) =>

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/SlotAllocation.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_3/runtime/SlotAllocation.scala
@@ -272,7 +272,7 @@ object SlotAllocation {
 
       case _:CartesianProduct =>
         val cartesianProductPipeline = lhsPipeline.seedClone()
-        rhsPipeline.foreachSlot {
+        rhsPipeline.foreachSlotOrdered {
           case (k, slot) =>
             cartesianProductPipeline.add(k, slot)
         }


### PR DESCRIPTION
Slot allocation for `CartesianProduct` was not maintaining the slot order from the rhs, which could lead to scrambled variable values upstream. This is already fixed in `3.4`, so simply forward-merging the test is enough.

Fixes #10611.