### PR TITLE
Report tool now check free disk space before starting

### DIFF
--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/DiagnosticsReportCommand.java
@@ -49,7 +49,7 @@ import org.neo4j.dbms.diagnostics.jmx.JmxDump;
 import org.neo4j.diagnostics.DiagnosticsReportSource;
 import org.neo4j.diagnostics.DiagnosticsReportSources;
 import org.neo4j.diagnostics.DiagnosticsReporter;
-import org.neo4j.diagnostics.DiagnosticsReporterProgressInteractions;
+import org.neo4j.diagnostics.DiagnosticsReporterProgress;
 import org.neo4j.diagnostics.InteractiveProgress;
 import org.neo4j.diagnostics.NonInteractiveProgress;
 import org.neo4j.helpers.Args;
@@ -80,7 +80,6 @@ public class DiagnosticsReportCommand implements AdminCommand
     private final PrintStream out;
     private final FileSystemAbstraction fs;
     private final PrintStream err;
-    private boolean force;
 
     DiagnosticsReportCommand( Path homeDir, Path configDir, OutsideWorld outsideWorld )
     {
@@ -102,7 +101,7 @@ public class DiagnosticsReportCommand implements AdminCommand
         Args args = Args.withFlags( "list", "to", "verbose", "force" ).parse( stringArgs );
         verbose = args.has( "verbose" );
         jmxDumper = new JMXDumper( homeDir, fs, out, err, verbose );
-        force = args.has( "force" );
+        boolean force = args.has( "force" );
 
         DiagnosticsReporter reporter = createAndRegisterSources();
 
@@ -112,7 +111,7 @@ public class DiagnosticsReportCommand implements AdminCommand
             return;
         }
 
-        DiagnosticsReporterProgressInteractions progress = buildProgress();
+        DiagnosticsReporterProgress progress = buildProgress();
 
         // Start dumping
         Path destinationDir = new File( destinationArgument.parse( args ) ).toPath();
@@ -121,7 +120,7 @@ public class DiagnosticsReportCommand implements AdminCommand
             SimpleDateFormat dumpFormat = new SimpleDateFormat( "yyyy-MM-dd_HHmmss" );
             Path reportFile = destinationDir.resolve( dumpFormat.format( new Date() ) + ".zip" );
             out.println( "Writing report to " + reportFile.toAbsolutePath().toString() );
-            reporter.dump( classifiers.get(), reportFile, progress );
+            reporter.dump( classifiers.get(), reportFile, progress, force );
         }
         catch ( IOException e )
         {
@@ -129,16 +128,16 @@ public class DiagnosticsReportCommand implements AdminCommand
         }
     }
 
-    private DiagnosticsReporterProgressInteractions buildProgress()
+    private DiagnosticsReporterProgress buildProgress()
     {
-        DiagnosticsReporterProgressInteractions progress;
+        DiagnosticsReporterProgress progress;
         if ( System.console() != null )
         {
-            progress = new InteractiveProgress( out, verbose, force );
+            progress = new InteractiveProgress( out, verbose );
         }
         else
         {
-            progress = new NonInteractiveProgress( out, verbose, force );
+            progress = new NonInteractiveProgress( out, verbose );
         }
         return progress;
     }

--- a/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/JmxDump.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/JmxDump.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
 import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
 import java.lang.management.MonitorInfo;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
@@ -44,7 +45,7 @@ import javax.management.remote.JMXServiceURL;
 
 import org.neo4j.diagnostics.DiagnosticsReportSource;
 import org.neo4j.diagnostics.DiagnosticsReportSources;
-import org.neo4j.diagnostics.DiagnosticsReporterProgressCallback;
+import org.neo4j.diagnostics.DiagnosticsReporterProgressInteractions;
 import org.neo4j.diagnostics.ProgressAwareInputStream;
 
 /**
@@ -111,8 +112,7 @@ public class JmxDump
         ThreadMXBean threadMxBean;
         try
         {
-            threadMxBean =
-                    ManagementFactory.newPlatformMXBeanProxy( mBeanServer, "java.lang:type=Threading", ThreadMXBean.class );
+            threadMxBean = ManagementFactory.getPlatformMXBean( mBeanServer, ThreadMXBean.class );
         }
         catch ( IOException e )
         {
@@ -181,25 +181,43 @@ public class JmxDump
             }
 
             @Override
-            public void addToArchive( Path archiveDestination, DiagnosticsReporterProgressCallback monitor )
+            public void addToArchive( Path archiveDestination, DiagnosticsReporterProgressInteractions progress )
                     throws IOException
             {
                 // Heap dump has to target an actual file, we cannot stream directly to the archive
-                monitor.info( "dumping..." );
+                progress.info( "dumping..." );
                 Path tempFile = Files.createTempFile("neo4j-heapdump", ".hprof");
                 Files.deleteIfExists( tempFile );
                 heapDump( tempFile.toAbsolutePath().toString() );
 
                 // Track progress of archiving process
-                monitor.info( "archiving..." );
+                progress.info( "archiving..." );
                 long size = Files.size( tempFile );
                 InputStream in = Files.newInputStream( tempFile );
-                try ( ProgressAwareInputStream inStream = new ProgressAwareInputStream( in, size, monitor::percentChanged ) )
+                try ( ProgressAwareInputStream inStream = new ProgressAwareInputStream( in, size, progress::percentChanged ) )
                 {
                     Files.copy( inStream, archiveDestination );
                 }
 
                 Files.delete( tempFile );
+            }
+
+            @Override
+            public long estimatedSize( DiagnosticsReporterProgressInteractions progress )
+            {
+                try
+                {
+                    MemoryMXBean bean = ManagementFactory.getPlatformMXBean( mBeanServer, MemoryMXBean.class );
+                    long totalMemory = bean.getHeapMemoryUsage().getCommitted() + bean.getNonHeapMemoryUsage().getCommitted();
+
+                    // We first write raw to disk then write to archive, 5x compression is a reasonable worst case estimation
+                    return (long) (totalMemory * 1.2);
+                }
+                catch ( IOException e )
+                {
+                    progress.error( "Unable to determine size of neo4j instance memory", e );
+                }
+                return 0;
             }
         };
     }
@@ -209,10 +227,8 @@ public class JmxDump
      */
     private void heapDump( String destination ) throws IOException
     {
-        HotSpotDiagnosticMXBean hotSpotDiagnosticMXBean = ManagementFactory
-                .newPlatformMXBeanProxy( mBeanServer, "com.sun.management:type=HotSpotDiagnostic",
-                        HotSpotDiagnosticMXBean.class );
-
+        HotSpotDiagnosticMXBean hotSpotDiagnosticMXBean =
+                ManagementFactory.getPlatformMXBean( mBeanServer, HotSpotDiagnosticMXBean.class );
         hotSpotDiagnosticMXBean.dumpHeap( destination, false );
     }
 
@@ -227,13 +243,19 @@ public class JmxDump
             }
 
             @Override
-            public void addToArchive( Path archiveDestination, DiagnosticsReporterProgressCallback monitor )
+            public void addToArchive( Path archiveDestination, DiagnosticsReporterProgressInteractions progress )
                     throws IOException
             {
                 try ( PrintStream printStream = new PrintStream( Files.newOutputStream( archiveDestination ) ) )
                 {
                     systemProperties.list( printStream );
                 }
+            }
+
+            @Override
+            public long estimatedSize( DiagnosticsReporterProgressInteractions progress )
+            {
+                return 0;
             }
         };
     }

--- a/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/JmxDump.java
+++ b/community/dbms/src/main/java/org/neo4j/dbms/diagnostics/jmx/JmxDump.java
@@ -45,7 +45,7 @@ import javax.management.remote.JMXServiceURL;
 
 import org.neo4j.diagnostics.DiagnosticsReportSource;
 import org.neo4j.diagnostics.DiagnosticsReportSources;
-import org.neo4j.diagnostics.DiagnosticsReporterProgressInteractions;
+import org.neo4j.diagnostics.DiagnosticsReporterProgress;
 import org.neo4j.diagnostics.ProgressAwareInputStream;
 
 /**
@@ -181,7 +181,7 @@ public class JmxDump
             }
 
             @Override
-            public void addToArchive( Path archiveDestination, DiagnosticsReporterProgressInteractions progress )
+            public void addToArchive( Path archiveDestination, DiagnosticsReporterProgress progress )
                     throws IOException
             {
                 // Heap dump has to target an actual file, we cannot stream directly to the archive
@@ -203,21 +203,13 @@ public class JmxDump
             }
 
             @Override
-            public long estimatedSize( DiagnosticsReporterProgressInteractions progress )
+            public long estimatedSize( DiagnosticsReporterProgress progress ) throws IOException
             {
-                try
-                {
-                    MemoryMXBean bean = ManagementFactory.getPlatformMXBean( mBeanServer, MemoryMXBean.class );
-                    long totalMemory = bean.getHeapMemoryUsage().getCommitted() + bean.getNonHeapMemoryUsage().getCommitted();
+                MemoryMXBean bean = ManagementFactory.getPlatformMXBean( mBeanServer, MemoryMXBean.class );
+                long totalMemory = bean.getHeapMemoryUsage().getCommitted() + bean.getNonHeapMemoryUsage().getCommitted();
 
-                    // We first write raw to disk then write to archive, 5x compression is a reasonable worst case estimation
-                    return (long) (totalMemory * 1.2);
-                }
-                catch ( IOException e )
-                {
-                    progress.error( "Unable to determine size of neo4j instance memory", e );
-                }
-                return 0;
+                // We first write raw to disk then write to archive, 5x compression is a reasonable worst case estimation
+                return (long) (totalMemory * 1.2);
             }
         };
     }
@@ -243,7 +235,7 @@ public class JmxDump
             }
 
             @Override
-            public void addToArchive( Path archiveDestination, DiagnosticsReporterProgressInteractions progress )
+            public void addToArchive( Path archiveDestination, DiagnosticsReporterProgress progress )
                     throws IOException
             {
                 try ( PrintStream printStream = new PrintStream( Files.newOutputStream( archiveDestination ) ) )
@@ -253,7 +245,7 @@ public class JmxDump
             }
 
             @Override
-            public long estimatedSize( DiagnosticsReporterProgressInteractions progress )
+            public long estimatedSize( DiagnosticsReporterProgress progress )
             {
                 return 0;
             }

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReportSource.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReportSource.java
@@ -40,9 +40,18 @@ public interface DiagnosticsReportSource
      * This method should output the diagnostics source to the provided destination.
      *
      * @param archiveDestination the target destination that should be written to.
-     * @param monitor a monitor that can track progress.
+     * @param progress a monitor that can track progress.
      * @throws IOException if any file operations fail, exceptions should be handled by the caller for better error
      * reporting to the user.
      */
-    void addToArchive( Path archiveDestination, DiagnosticsReporterProgressCallback monitor ) throws IOException;
+    void addToArchive( Path archiveDestination, DiagnosticsReporterProgressInteractions progress ) throws IOException;
+
+    /**
+     * Returns an estimated upper bound of the input file size. Since the content will be placed in an archive the final
+     * size can actually both increase and decrease.
+     *
+     * @param progress a monitor that can track progress.
+     * @return the estimated file size in bytes.
+     */
+    long estimatedSize( DiagnosticsReporterProgressInteractions progress );
 }

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReportSource.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReportSource.java
@@ -44,7 +44,7 @@ public interface DiagnosticsReportSource
      * @throws IOException if any file operations fail, exceptions should be handled by the caller for better error
      * reporting to the user.
      */
-    void addToArchive( Path archiveDestination, DiagnosticsReporterProgressInteractions progress ) throws IOException;
+    void addToArchive( Path archiveDestination, DiagnosticsReporterProgress progress ) throws IOException;
 
     /**
      * Returns an estimated upper bound of the input file size. Since the content will be placed in an archive the final
@@ -52,6 +52,7 @@ public interface DiagnosticsReportSource
      *
      * @param progress a monitor that can track progress.
      * @return the estimated file size in bytes.
+     * @throws IOException if size cannot be determined.
      */
-    long estimatedSize( DiagnosticsReporterProgressInteractions progress );
+    long estimatedSize( DiagnosticsReporterProgress progress ) throws IOException;
 }

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReportSources.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReportSources.java
@@ -119,7 +119,7 @@ public class DiagnosticsReportSources
         }
 
         @Override
-        public void addToArchive( Path archiveDestination, DiagnosticsReporterProgressInteractions progress )
+        public void addToArchive( Path archiveDestination, DiagnosticsReporterProgress progress )
                 throws IOException
         {
             long size = fs.getFileSize( source );
@@ -133,7 +133,7 @@ public class DiagnosticsReportSources
         }
 
         @Override
-        public long estimatedSize( DiagnosticsReporterProgressInteractions progress )
+        public long estimatedSize( DiagnosticsReporterProgress progress )
         {
             return fs.getFileSize( source );
         }
@@ -157,7 +157,7 @@ public class DiagnosticsReportSources
         }
 
         @Override
-        public void addToArchive( Path archiveDestination, DiagnosticsReporterProgressInteractions progress )
+        public void addToArchive( Path archiveDestination, DiagnosticsReporterProgress progress )
                 throws IOException
         {
             String message = messageSupplier.get();
@@ -166,7 +166,7 @@ public class DiagnosticsReportSources
         }
 
         @Override
-        public long estimatedSize( DiagnosticsReporterProgressInteractions progress )
+        public long estimatedSize( DiagnosticsReporterProgress progress )
         {
             return 0; // Size of strings should be negligible
         }

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReportSources.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReportSources.java
@@ -119,17 +119,23 @@ public class DiagnosticsReportSources
         }
 
         @Override
-        public void addToArchive( Path archiveDestination, DiagnosticsReporterProgressCallback monitor )
+        public void addToArchive( Path archiveDestination, DiagnosticsReporterProgressInteractions progress )
                 throws IOException
         {
             long size = fs.getFileSize( source );
             InputStream in = fs.openAsInputStream( source );
 
             // Track progress of the file reading, source might be a very large file
-            try ( ProgressAwareInputStream inStream = new ProgressAwareInputStream( in, size, monitor::percentChanged ) )
+            try ( ProgressAwareInputStream inStream = new ProgressAwareInputStream( in, size, progress::percentChanged ) )
             {
                 Files.copy( inStream, archiveDestination );
             }
+        }
+
+        @Override
+        public long estimatedSize( DiagnosticsReporterProgressInteractions progress )
+        {
+            return fs.getFileSize( source );
         }
     }
 
@@ -151,12 +157,18 @@ public class DiagnosticsReportSources
         }
 
         @Override
-        public void addToArchive( Path archiveDestination, DiagnosticsReporterProgressCallback monitor )
+        public void addToArchive( Path archiveDestination, DiagnosticsReporterProgressInteractions progress )
                 throws IOException
         {
             String message = messageSupplier.get();
             Files.write( archiveDestination, message.getBytes( StandardCharsets.UTF_8 ), StandardOpenOption.CREATE,
                     StandardOpenOption.APPEND );
+        }
+
+        @Override
+        public long estimatedSize( DiagnosticsReporterProgressInteractions progress )
+        {
+            return 0; // Size of strings should be negligible
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporterProgress.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporterProgress.java
@@ -23,7 +23,7 @@ package org.neo4j.diagnostics;
  * Interface for handling feedback to the user. Implementations of this should be responsible of presenting the progress
  * to the user. Some specialised implementations can choose to omit any of the information provided here.
  */
-public interface DiagnosticsReporterProgressInteractions
+public interface DiagnosticsReporterProgress
 {
     /**
      * Calling this will notify the user that the percentage has changed.
@@ -47,14 +47,6 @@ public interface DiagnosticsReporterProgressInteractions
      * @param throwable optional exception, used to include a stacktrace if applicable.
      */
     void error( String msg, Throwable throwable );
-
-    /**
-     * A check whether to ignore the free available disk space when generating the archive.
-     *
-     * @param message with information about the disk space.
-     * @return true if the execution should continue even if risking to fill up the disk.
-     */
-    boolean shouldIgnorePotentialFullDisk( String message );
 
     /**
      * @apiNote Called by dispatching class. Should not be called from diagnostics sources.

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporterProgressInteractions.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/DiagnosticsReporterProgressInteractions.java
@@ -23,7 +23,7 @@ package org.neo4j.diagnostics;
  * Interface for handling feedback to the user. Implementations of this should be responsible of presenting the progress
  * to the user. Some specialised implementations can choose to omit any of the information provided here.
  */
-public interface DiagnosticsReporterProgressCallback
+public interface DiagnosticsReporterProgressInteractions
 {
     /**
      * Calling this will notify the user that the percentage has changed.
@@ -47,6 +47,14 @@ public interface DiagnosticsReporterProgressCallback
      * @param throwable optional exception, used to include a stacktrace if applicable.
      */
     void error( String msg, Throwable throwable );
+
+    /**
+     * A check whether to ignore the free available disk space when generating the archive.
+     *
+     * @param message with information about the disk space.
+     * @return true if the execution should continue even if risking to fill up the disk.
+     */
+    boolean shouldIgnorePotentialFullDisk( String message );
 
     /**
      * @apiNote Called by dispatching class. Should not be called from diagnostics sources.

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/InteractiveProgress.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/InteractiveProgress.java
@@ -26,22 +26,20 @@ import java.util.Collections;
  * Tracks progress in an interactive way, relies on the fact that the {@code PrintStream} echoes to a terminal that can
  * interpret the carrier return to reset the current line.
  */
-public class InteractiveProgress implements DiagnosticsReporterProgressInteractions
+public class InteractiveProgress implements DiagnosticsReporterProgress
 {
     private String prefix;
     private String suffix;
     private String totalSteps = "?";
     private final PrintStream out;
     private final boolean verbose;
-    private final boolean force;
     private String info = "";
     private int longestInfo;
 
-    public InteractiveProgress( PrintStream out, boolean verbose, boolean force )
+    public InteractiveProgress( PrintStream out, boolean verbose )
     {
         this.out = out;
         this.verbose = verbose;
-        this.force = force;
     }
 
     @Override
@@ -101,33 +99,6 @@ public class InteractiveProgress implements DiagnosticsReporterProgressInteracti
         if ( verbose )
         {
             throwable.printStackTrace( out );
-        }
-    }
-
-    @Override
-    public boolean shouldIgnorePotentialFullDisk( String message )
-    {
-        if ( force )
-        {
-            return true;
-        }
-        out.println( message );
-        while ( true )
-        {
-            out.print( "Ignore available disk space warning? [yN]: " );
-            String answer = System.console().readLine();
-            if ( answer.length() == 0 || answer.toLowerCase().equals( "n" ) )
-            {
-                return false;
-            }
-            else if ( answer.toLowerCase().equals( "y" ) )
-            {
-                return true;
-            }
-            else
-            {
-                out.println( "Unrecognised option: " + answer );
-            }
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/InteractiveProgress.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/InteractiveProgress.java
@@ -26,20 +26,22 @@ import java.util.Collections;
  * Tracks progress in an interactive way, relies on the fact that the {@code PrintStream} echoes to a terminal that can
  * interpret the carrier return to reset the current line.
  */
-public class InteractiveProgress implements DiagnosticsReporterProgressCallback
+public class InteractiveProgress implements DiagnosticsReporterProgressInteractions
 {
     private String prefix;
     private String suffix;
     private String totalSteps = "?";
     private final PrintStream out;
     private final boolean verbose;
+    private final boolean force;
     private String info = "";
     private int longestInfo;
 
-    public InteractiveProgress( PrintStream out, boolean verbose )
+    public InteractiveProgress( PrintStream out, boolean verbose, boolean force )
     {
         this.out = out;
         this.verbose = verbose;
+        this.force = force;
     }
 
     @Override
@@ -99,6 +101,33 @@ public class InteractiveProgress implements DiagnosticsReporterProgressCallback
         if ( verbose )
         {
             throwable.printStackTrace( out );
+        }
+    }
+
+    @Override
+    public boolean shouldIgnorePotentialFullDisk( String message )
+    {
+        if ( force )
+        {
+            return true;
+        }
+        out.println( message );
+        while ( true )
+        {
+            out.print( "Ignore available disk space warning? [yN]: " );
+            String answer = System.console().readLine();
+            if ( answer.length() == 0 || answer.toLowerCase().equals( "n" ) )
+            {
+                return false;
+            }
+            else if ( answer.toLowerCase().equals( "y" ) )
+            {
+                return true;
+            }
+            else
+            {
+                out.println( "Unrecognised option: " + answer );
+            }
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/NonInteractiveProgress.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/NonInteractiveProgress.java
@@ -21,17 +21,19 @@ package org.neo4j.diagnostics;
 
 import java.io.PrintStream;
 
-public class NonInteractiveProgress implements DiagnosticsReporterProgressCallback
+public class NonInteractiveProgress implements DiagnosticsReporterProgressInteractions
 {
     private String totalSteps = "?";
     private final PrintStream out;
     private final boolean verbose;
+    private final boolean force;
     private int lastPercentage;
 
-    public NonInteractiveProgress( PrintStream out, boolean verbose )
+    public NonInteractiveProgress( PrintStream out, boolean verbose, boolean force )
     {
         this.out = out;
         this.verbose = verbose;
+        this.force = force;
     }
 
     @Override
@@ -78,6 +80,18 @@ public class NonInteractiveProgress implements DiagnosticsReporterProgressCallba
         {
             throwable.printStackTrace( out );
         }
+    }
+
+    @Override
+    public boolean shouldIgnorePotentialFullDisk( String message )
+    {
+        if ( force )
+        {
+            return true;
+        }
+        out.println( message );
+        out.println( "To ignore available disk space warning, add '--force' to the command" );
+        return false;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/diagnostics/NonInteractiveProgress.java
+++ b/community/kernel/src/main/java/org/neo4j/diagnostics/NonInteractiveProgress.java
@@ -21,19 +21,17 @@ package org.neo4j.diagnostics;
 
 import java.io.PrintStream;
 
-public class NonInteractiveProgress implements DiagnosticsReporterProgressInteractions
+public class NonInteractiveProgress implements DiagnosticsReporterProgress
 {
     private String totalSteps = "?";
     private final PrintStream out;
     private final boolean verbose;
-    private final boolean force;
     private int lastPercentage;
 
-    public NonInteractiveProgress( PrintStream out, boolean verbose, boolean force )
+    public NonInteractiveProgress( PrintStream out, boolean verbose )
     {
         this.out = out;
         this.verbose = verbose;
-        this.force = force;
     }
 
     @Override
@@ -80,18 +78,6 @@ public class NonInteractiveProgress implements DiagnosticsReporterProgressIntera
         {
             throwable.printStackTrace( out );
         }
-    }
-
-    @Override
-    public boolean shouldIgnorePotentialFullDisk( String message )
-    {
-        if ( force )
-        {
-            return true;
-        }
-        out.println( message );
-        out.println( "To ignore available disk space warning, add '--force' to the command" );
-        return false;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/OnDemandDetailsExecutionMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/OnDemandDetailsExecutionMonitor.java
@@ -43,7 +43,6 @@ import org.neo4j.unsafe.impl.batchimport.stats.StepStats;
 
 import static java.lang.Long.max;
 import static java.lang.System.currentTimeMillis;
-
 import static org.neo4j.helpers.Format.bytes;
 import static org.neo4j.helpers.Format.date;
 import static org.neo4j.helpers.Format.duration;
@@ -95,7 +94,7 @@ public class OnDemandDetailsExecutionMonitor implements ExecutionMonitor
     @Override
     public void initialize( DependencyResolver dependencyResolver )
     {
-        out.println( "Interactive command list (end with ENTER):" );
+        out.println( "InteractiveReporterInteractions command list (end with ENTER):" );
         actions.forEach( ( key, action ) -> out.println( "  " + key + ": " + action.first() ) );
         out.println();
         gcMonitor.start();

--- a/community/kernel/src/test/java/org/neo4j/diagnostics/DiagnosticsReporterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/diagnostics/DiagnosticsReporterTest.java
@@ -45,7 +45,6 @@ import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.neo4j.diagnostics.DiagnosticsReportSources.newDiagnosticsFile;
 
 public class DiagnosticsReporterTest
@@ -102,10 +101,56 @@ public class DiagnosticsReporterTest
         }
 
         @Override
-        public void addToArchive( Path archiveDestination, DiagnosticsReporterProgressCallback monitor )
+        public void addToArchive( Path archiveDestination, DiagnosticsReporterProgressInteractions progress )
         {
-            monitor.percentChanged( 30 );
+            progress.percentChanged( 30 );
             throw new RuntimeException( "You had it coming..." );
+        }
+
+        @Override
+        public long estimatedSize( DiagnosticsReporterProgressInteractions progress )
+        {
+            return 0;
+        }
+    }
+
+    private static class AcceptingProgress implements DiagnosticsReporterProgressInteractions
+    {
+
+        @Override
+        public void percentChanged( int percent )
+        {
+        }
+
+        @Override
+        public void info( String info )
+        {
+        }
+
+        @Override
+        public void error( String msg, Throwable throwable )
+        {
+        }
+
+        @Override
+        public boolean shouldIgnorePotentialFullDisk( String message )
+        {
+            return true;
+        }
+
+        @Override
+        public void setTotalSteps( long steps )
+        {
+        }
+
+        @Override
+        public void started( long currentStepIndex, String target )
+        {
+        }
+
+        @Override
+        public void finished()
+        {
         }
     }
 
@@ -121,7 +166,7 @@ public class DiagnosticsReporterTest
 
         Path destination = testDirectory.file( "logs.zip" ).toPath();
 
-        reporter.dump( Collections.singleton( "logs" ), destination, mock( DiagnosticsReporterProgressCallback.class ) );
+        reporter.dump( Collections.singleton( "logs" ), destination, new AcceptingProgress() );
 
         // Verify content
         URI uri = URI.create("jar:file:" + destination.toAbsolutePath().toUri().getPath() );
@@ -154,7 +199,7 @@ public class DiagnosticsReporterTest
         try ( ByteArrayOutputStream baos = new ByteArrayOutputStream() )
         {
             PrintStream out = new PrintStream( baos );
-            NonInteractiveProgress progress = new NonInteractiveProgress( out, false );
+            NonInteractiveProgress progress = new NonInteractiveProgress( out, false, true );
 
             reporter.dump( classifiers, destination, progress );
 

--- a/community/kernel/src/test/java/org/neo4j/diagnostics/DiagnosticsReporterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/diagnostics/DiagnosticsReporterTest.java
@@ -45,6 +45,7 @@ import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.neo4j.diagnostics.DiagnosticsReportSources.newDiagnosticsFile;
 
 public class DiagnosticsReporterTest
@@ -101,56 +102,16 @@ public class DiagnosticsReporterTest
         }
 
         @Override
-        public void addToArchive( Path archiveDestination, DiagnosticsReporterProgressInteractions progress )
+        public void addToArchive( Path archiveDestination, DiagnosticsReporterProgress progress )
         {
             progress.percentChanged( 30 );
             throw new RuntimeException( "You had it coming..." );
         }
 
         @Override
-        public long estimatedSize( DiagnosticsReporterProgressInteractions progress )
+        public long estimatedSize( DiagnosticsReporterProgress progress )
         {
             return 0;
-        }
-    }
-
-    private static class AcceptingProgress implements DiagnosticsReporterProgressInteractions
-    {
-
-        @Override
-        public void percentChanged( int percent )
-        {
-        }
-
-        @Override
-        public void info( String info )
-        {
-        }
-
-        @Override
-        public void error( String msg, Throwable throwable )
-        {
-        }
-
-        @Override
-        public boolean shouldIgnorePotentialFullDisk( String message )
-        {
-            return true;
-        }
-
-        @Override
-        public void setTotalSteps( long steps )
-        {
-        }
-
-        @Override
-        public void started( long currentStepIndex, String target )
-        {
-        }
-
-        @Override
-        public void finished()
-        {
         }
     }
 
@@ -166,7 +127,7 @@ public class DiagnosticsReporterTest
 
         Path destination = testDirectory.file( "logs.zip" ).toPath();
 
-        reporter.dump( Collections.singleton( "logs" ), destination, new AcceptingProgress() );
+        reporter.dump( Collections.singleton( "logs" ), destination, mock( DiagnosticsReporterProgress.class), true );
 
         // Verify content
         URI uri = URI.create("jar:file:" + destination.toAbsolutePath().toUri().getPath() );
@@ -199,9 +160,9 @@ public class DiagnosticsReporterTest
         try ( ByteArrayOutputStream baos = new ByteArrayOutputStream() )
         {
             PrintStream out = new PrintStream( baos );
-            NonInteractiveProgress progress = new NonInteractiveProgress( out, false, true );
+            NonInteractiveProgress progress = new NonInteractiveProgress( out, false );
 
-            reporter.dump( classifiers, destination, progress );
+            reporter.dump( classifiers, destination, progress, true );
 
             assertThat( baos.toString(), is(String.format(
                     "1/2 fail.txt%n" +


### PR DESCRIPTION
Reports can be quite large if both transaction files and heap dump is included.

This PR makes sure that the available disk space is large enough before starting to generate a report to avoid running out of disk space. The estimation of the final size is a pure guess and pessimistically chosen.

It also introduces a `--force` argument to the tool that can be used to ignore the warning about the free disk space.