### PR TITLE
Guarantee release cleanerLock in GBPTree

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/internal/SchemaIndexExtensionLoader.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/internal/SchemaIndexExtensionLoader.java
@@ -79,9 +79,16 @@ public class SchemaIndexExtensionLoader
         @Override
         public void add( CleanupJob job )
         {
-            if ( job.needed() )
+            try
             {
-                throw new IllegalStateException( "Consistency checker should not do recovery" );
+                if ( job.needed() )
+                {
+                    throw new IllegalStateException( "Consistency checker should not do recovery" );
+                }
+            }
+            finally
+            {
+                job.close();
             }
         }
     }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/CleanupJob.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/CleanupJob.java
@@ -43,7 +43,7 @@ public interface CleanupJob extends Runnable
     Exception getCause();
 
     /**
-     * Mark this job and cleanup all it's resources.
+     * Mark this job as closed and cleanup all it's resources.
      */
     void close();
 

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/CleanupJob.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/CleanupJob.java
@@ -43,6 +43,11 @@ public interface CleanupJob extends Runnable
     Exception getCause();
 
     /**
+     * Mark this job and cleanup all it's resources.
+     */
+    void close();
+
+    /**
      * A {@link CleanupJob} that doesn't need cleaning, i.e. it's already clean.
      */
     CleanupJob CLEAN = new CleanupJob()
@@ -68,6 +73,11 @@ public interface CleanupJob extends Runnable
         public Exception getCause()
         {
             return null;
+        }
+
+        @Override
+        public void close()
+        {   // no-op
         }
     };
 }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTreeCleanupJob.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTreeCleanupJob.java
@@ -57,6 +57,12 @@ class GBPTreeCleanupJob implements CleanupJob
     }
 
     @Override
+    public void close()
+    {
+        gbpTreeLock.cleanerUnlock();
+    }
+
+    @Override
     public void run()
     {
         try
@@ -67,10 +73,6 @@ class GBPTreeCleanupJob implements CleanupJob
         catch ( Exception e )
         {
             failure = e;
-        }
-        finally
-        {
-            gbpTreeLock.cleanerUnlock();
         }
     }
 }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GroupingRecoveryCleanupWorkCollector.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GroupingRecoveryCleanupWorkCollector.java
@@ -80,7 +80,14 @@ public class GroupingRecoveryCleanupWorkCollector implements RecoveryCleanupWork
             CleanupJob job;
             while ( (job = jobs.poll()) != null )
             {
-                job.run();
+                try
+                {
+                    job.run();
+                }
+                finally
+                {
+                    job.close();
+                }
             }
         };
     }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/RecoveryCleanupWorkCollector.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/RecoveryCleanupWorkCollector.java
@@ -29,6 +29,8 @@ import org.neo4j.kernel.lifecycle.LifecycleAdapter;
  * this, implementing class must be ready to receive new jobs through {@link #add(CleanupJob)}.
  * <p>
  * Jobs may be processed during {@link #add(CleanupJob) add} or {@link Lifecycle#start() start}.
+ * <p>
+ * Take full responsibility for closing added {@link CleanupJob CleanupJobs} as soon as possible after run.
  */
 public interface RecoveryCleanupWorkCollector extends Lifecycle
 {
@@ -48,7 +50,7 @@ public interface RecoveryCleanupWorkCollector extends Lifecycle
     /**
      * Ignore all clean jobs.
      */
-    RecoveryCleanupWorkCollector NULL = new NullRecoveryCleanupWorkCollector();
+    RecoveryCleanupWorkCollector IGNORE = new IgnoringRecoveryCleanupWorkCollector();
 
     /**
      * {@link RecoveryCleanupWorkCollector} which runs added {@link CleanupJob} as part of the {@link #add(CleanupJob)}
@@ -59,18 +61,26 @@ public interface RecoveryCleanupWorkCollector extends Lifecycle
         @Override
         public void add( CleanupJob job )
         {
-            job.run();
+            try
+            {
+                job.run();
+            }
+            finally
+            {
+                job.close();
+            }
         }
     }
 
     /**
      * {@link RecoveryCleanupWorkCollector} ignoring all {@link CleanupJob} added to it.
      */
-    class NullRecoveryCleanupWorkCollector extends LifecycleAdapter implements RecoveryCleanupWorkCollector
+    class IgnoringRecoveryCleanupWorkCollector extends LifecycleAdapter implements RecoveryCleanupWorkCollector
     {
         @Override
         public void add( CleanupJob job )
-        {   // no-op
+        {
+            job.close();
         }
     }
 }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
@@ -625,6 +625,21 @@ public class GBPTreeTest
         verifyHeader( pageCache, expectedHeader );
     }
 
+    @Test( timeout = 10_000 )
+    public void writeHeaderInDirtyTreeMustNotDeadlock() throws Exception
+    {
+        PageCache pageCache = createPageCache( 256 );
+        makeDirty( pageCache );
+
+        Consumer<PageCursor> headerWriter = pc -> pc.putBytes( "failed".getBytes() );
+        try ( GBPTree<MutableLong,MutableLong> index = index( pageCache ).with( RecoveryCleanupWorkCollector.IGNORE ).build() )
+        {
+            index.checkpoint( IOLimiter.unlimited(), headerWriter );
+        }
+
+        verifyHeader( pageCache, "failed".getBytes() );
+    }
+
     private void verifyHeader( PageCache pageCache, byte[] expectedHeader ) throws IOException
     {
         // WHEN
@@ -1605,8 +1620,15 @@ public class GBPTreeTest
             CleanupJob job;
             while ( (job = jobs.poll()) != null )
             {
-                job.run();
-                startedJobs.add( job );
+                try
+                {
+                    job.run();
+                    startedJobs.add( job );
+                }
+                finally
+                {
+                    job.close();
+                }
             }
         }
 
@@ -1689,7 +1711,12 @@ public class GBPTreeTest
 
     private void makeDirty() throws IOException
     {
-        try ( GBPTree<MutableLong,MutableLong> index = index().build() )
+        makeDirty( createPageCache( DEFAULT_PAGE_SIZE ) );
+    }
+
+    private void makeDirty( PageCache pageCache ) throws IOException
+    {
+        try ( GBPTree<MutableLong,MutableLong> index = index( pageCache ).build() )
         {
             // Make dirty
             index.writer().close();

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GroupingRecoveryCleanupWorkCollectorTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GroupingRecoveryCleanupWorkCollectorTest.java
@@ -185,6 +185,11 @@ public class GroupingRecoveryCleanupWorkCollectorTest
         }
 
         @Override
+        public void close()
+        {   // no-op
+        }
+
+        @Override
         public void run()
         {
             allRuns.add( this );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexPopulator.java
@@ -211,7 +211,7 @@ public abstract class NativeSchemaNumberIndexPopulator<KEY extends SchemaNumberK
     {
         if ( tree == null )
         {
-            instantiateTree( RecoveryCleanupWorkCollector.NULL, NO_HEADER_WRITER );
+            instantiateTree( RecoveryCleanupWorkCollector.IGNORE, NO_HEADER_WRITER );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigratorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/storemigration/participant/NativeLabelScanStoreMigratorTest.java
@@ -200,7 +200,7 @@ public class NativeLabelScanStoreMigratorTest
     private NativeLabelScanStore getNativeLabelScanStore( File dir, boolean readOnly )
     {
         return new NativeLabelScanStore( pageCache, dir, FullStoreChangeStream.EMPTY, readOnly, new Monitors(),
-                RecoveryCleanupWorkCollector.NULL );
+                RecoveryCleanupWorkCollector.IGNORE );
     }
 
     private void initializeNativeLabelScanStoreWithContent( File dir ) throws IOException


### PR DESCRIPTION
In CleanupJob, processing the job and releasing the cleaner lock
is separated into run and close such that a RecoveryCleanupWorkCollector
can close a CleanupJob and thus release the cleaner lock without
actually running the cleanup job. This makes it possible to open a dirty
GBPTree and write a new header without starting cleanup jobs and
not risking a deadlock between checkpoint (needed for writing header)
and cleanup job.