### PR TITLE
Better error message on lock acquisition failure

### DIFF
--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -184,7 +184,7 @@ public interface Status
                 "transaction was active. Transaction may succeed if retried." ),
         LockClientStopped( TransientError,
                 "The transaction has been terminated, so no more locks can be acquired. This can occur because the " +
-                "transaction ran longer than the configured transaction timeout, or because a human operator manually " + 
+                "transaction ran longer than the configured transaction timeout, or because a human operator manually " +
                 "terminated the transaction, or because the database is shutting down."),
         LockAcquisitionTimeout( TransientError,
                 "Unable to acquire lock within configured timeout." ),

--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -183,7 +183,9 @@ public interface Status
                 "Transaction has seen state which has been invalidated by applied updates while " +
                 "transaction was active. Transaction may succeed if retried." ),
         LockClientStopped( TransientError,
-                "Transaction terminated, no more locks can be acquired." ),
+                "The transaction has been terminated, so no more locks can be acquired. This can occur because the " +
+                "transaction ran longer than the configured transaction timeout, or because a human operator manually " + 
+                "terminated the transaction, or because the database is shutting down."),
         LockAcquisitionTimeout( TransientError,
                 "Unable to acquire lock within configured timeout." ),
         Terminated( TransientError,


### PR DESCRIPTION
We may want to explore swapping to use TransactionTerminated in 3.4, unless there is some reason I'm not seeing why a user would want to differentiate between this error and TransactionTerminated. For 3.2 and 3.3 it seems better to simply improve the error message to limit API changes.