### PR TITLE
Read Replicas updates can be started and stopped via a procedure.

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
@@ -121,10 +121,14 @@ import static org.neo4j.causalclustering.discovery.ResolutionResolverFactory.cho
  */
 public class EnterpriseReadReplicaEditionModule extends EditionModule
 {
+
+    private final CatchupPollingProcess catchupPollingProcess;
+    private final LogService logService;
+
     EnterpriseReadReplicaEditionModule( final PlatformModule platformModule,
                                         final DiscoveryServiceFactory discoveryServiceFactory, MemberId myself )
     {
-        LogService logging = platformModule.logging;
+        logService = platformModule.logging;
 
         ioLimiter = new ConfigurableIOLimiter( platformModule.config );
 
@@ -141,14 +145,14 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
 
         this.accessCapability = new ReadOnly();
 
-        watcherService = createFileSystemWatcherService( fileSystem, storeDir, logging, platformModule.jobScheduler, fileWatcherFileNameFilter() );
+        watcherService = createFileSystemWatcherService( fileSystem, storeDir, logService, platformModule.jobScheduler, fileWatcherFileNameFilter() );
         dependencies.satisfyDependencies( watcherService );
 
         GraphDatabaseFacade graphDatabaseFacade = platformModule.graphDatabaseFacade;
 
         lockManager = dependencies.satisfyDependency( new ReadReplicaLockManager() );
 
-        statementLocksFactory = new StatementLocksFactorySelector( lockManager, config, logging ).select();
+        statementLocksFactory = new StatementLocksFactorySelector( lockManager, config, logService ).select();
 
         idTypeConfigurationProvider = new EnterpriseIdTypeConfigurationProvider( config );
         idGeneratorFactory = dependencies.satisfyDependency( new DefaultIdGeneratorFactory( fileSystem, idTypeConfigurationProvider ) );
@@ -257,15 +261,15 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
         UpstreamDatabaseStrategySelector upstreamDatabaseStrategySelector =
                 new UpstreamDatabaseStrategySelector( defaultStrategy, loader, myself, logProvider );
 
-        CatchupPollingProcess catchupProcess =
+        catchupPollingProcess =
                 new CatchupPollingProcess( logProvider, localDatabase, servicesToStopOnStoreCopy, catchUpClient, upstreamDatabaseStrategySelector,
                         timerService, config.get( CausalClusteringSettings.pull_interval ).toMillis(), batchingTxApplier, platformModule.monitors,
                         storeCopyProcess, databaseHealthSupplier, topologyService );
-        dependencies.satisfyDependencies( catchupProcess );
+        dependencies.satisfyDependencies( catchupPollingProcess );
 
         txPulling.add( batchingTxApplier );
-        txPulling.add( catchupProcess );
-        txPulling.add( new WaitForUpToDateStore( catchupProcess, logProvider ) );
+        txPulling.add( catchupPollingProcess );
+        txPulling.add( new WaitForUpToDateStore( catchupPollingProcess, logProvider ) );
 
         ExponentialBackoffStrategy retryStrategy = new ExponentialBackoffStrategy( 1, 30, TimeUnit.SECONDS );
         life.add( new ReadReplicaStartupProcess( remoteStore, localDatabase, txPulling, upstreamDatabaseStrategySelector, retryStrategy, logProvider,
@@ -308,6 +312,8 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
     {
         procedures.registerProcedure( EnterpriseBuiltInDbmsProcedures.class, true );
         procedures.register( new ReadReplicaRoleProcedure() );
+        procedures.register( new FreezeReadReplicaProcedure( catchupPollingProcess, logService.getInternalLog( FreezeReadReplicaProcedure.class ) ) );
+        procedures.register( new UnfreezeReadReplicaProcedure( catchupPollingProcess, logService.getInternalLog( UnfreezeReadReplicaProcedure.class ) ) );
     }
 
     private void registerRecovery( final DatabaseInfo databaseInfo, LifeSupport life, final DependencyResolver dependencyResolver )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/FreezeReadReplicaProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/FreezeReadReplicaProcedure.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.readreplica;
+
+import org.neo4j.causalclustering.catchup.tx.CatchupPollingProcess;
+import org.neo4j.collection.RawIterator;
+import org.neo4j.kernel.api.exceptions.ProcedureException;
+import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.api.proc.CallableProcedure;
+import org.neo4j.kernel.api.proc.Context;
+import org.neo4j.kernel.api.proc.Neo4jTypes;
+import org.neo4j.kernel.api.proc.QualifiedName;
+import org.neo4j.logging.Log;
+import org.neo4j.procedure.Procedure;
+
+import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
+
+public class FreezeReadReplicaProcedure extends CallableProcedure.BasicProcedure
+{
+    private static final String PROCEDURE_NAME = "freezeReadReplica";
+    private static final String[] PROCEDURE_NAMESPACE = {"dbms", "cluster"};
+    private static final String OUTPUT_NAME = "status";
+
+    private CatchupPollingProcess catchupPollingProcess;
+    private Log log;
+
+    FreezeReadReplicaProcedure( CatchupPollingProcess catchupPollingProcess, Log log )
+    {
+        super( procedureSignature( new QualifiedName( PROCEDURE_NAMESPACE, PROCEDURE_NAME ) )
+                .out( OUTPUT_NAME, Neo4jTypes.NTString )
+                .description( "Freeze the current read replica. It will no longer pull data from other cluster members until it is unfrozen." )
+                .build() );
+
+        this.catchupPollingProcess = catchupPollingProcess;
+        this.log = log;
+    }
+
+    @Override
+    public RawIterator<Object[],ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException
+    {
+        try
+        {
+            catchupPollingProcess.stop();
+        }
+        catch ( Throwable throwable )
+        {
+            log.error( "Failed to freeze read replica.", throwable );
+            throw new ProcedureException( Status.Procedure.ProcedureCallFailed, throwable, "Failed to freeze read replica. Check neo4j.log for details." );
+        }
+        return RawIterator.<Object[],ProcedureException>of( new Object[]{"frozen"} );
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/UnfreezeReadReplicaProcedure.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/UnfreezeReadReplicaProcedure.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.readreplica;
+
+import org.neo4j.causalclustering.catchup.tx.CatchupPollingProcess;
+import org.neo4j.collection.RawIterator;
+import org.neo4j.kernel.api.exceptions.ProcedureException;
+import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.api.proc.CallableProcedure;
+import org.neo4j.kernel.api.proc.Context;
+import org.neo4j.kernel.api.proc.Neo4jTypes;
+import org.neo4j.kernel.api.proc.QualifiedName;
+import org.neo4j.logging.Log;
+
+import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
+
+public class UnfreezeReadReplicaProcedure extends CallableProcedure.BasicProcedure
+{
+    private static final String PROCEDURE_NAME = "unfreezeReadReplica";
+    private static final String[] PROCEDURE_NAMESPACE = {"dbms", "cluster"};
+    private static final String OUTPUT_NAME = "status";
+
+    private CatchupPollingProcess catchupPollingProcess;
+    private Log log;
+
+    UnfreezeReadReplicaProcedure( CatchupPollingProcess catchupPollingProcess, Log log )
+    {
+        super( procedureSignature( new QualifiedName( PROCEDURE_NAMESPACE, PROCEDURE_NAME ) )
+                .out( OUTPUT_NAME, Neo4jTypes.NTString )
+                .description( "Unfreeze the current read replica. It will synchronize with other cluster members." )
+                .build() );
+
+        this.catchupPollingProcess = catchupPollingProcess;
+        this.log = log;
+    }
+
+    @Override
+    public RawIterator<Object[],ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException
+    {
+        try
+        {
+            catchupPollingProcess.start();
+        }
+        catch ( Throwable throwable )
+        {
+            log.error( "Failed to unfreeze read replica.", throwable );
+            throw new ProcedureException( Status.Procedure.ProcedureCallFailed, throwable, "Failed to unfreeze read replica. Check neo4j.log for details." );
+        }
+        return RawIterator.<Object[],ProcedureException>of( new Object[]{"unfrozen"} );
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/FreezeReadReplicaProcedureTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/FreezeReadReplicaProcedureTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.readreplica;
+
+import org.junit.Test;
+
+import org.neo4j.causalclustering.catchup.tx.CatchupPollingProcess;
+import org.neo4j.collection.RawIterator;
+import org.neo4j.kernel.api.exceptions.ProcedureException;
+import org.neo4j.logging.AssertableLogProvider;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.NullLogProvider;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+public class FreezeReadReplicaProcedureTest
+{
+    @Test
+    public void shouldRespondFrozenWhenSuccessfullyCalled() throws Exception
+    {
+        // given
+        CatchupPollingProcess catchupPollingProcess = mock( CatchupPollingProcess.class );
+        FreezeReadReplicaProcedure proc = new FreezeReadReplicaProcedure( catchupPollingProcess, NullLogProvider.getInstance().getLog( getClass() ) );
+
+        // when
+        RawIterator<Object[],ProcedureException> rawIterator = proc.apply( null, null );
+
+        // then
+        assertEquals( "frozen", rawIterator.next()[0] );
+    }
+
+    @Test
+    public void shouldRespondFailedAndLogWhenFailedToCall() throws Throwable
+    {
+        // given
+        AssertableLogProvider logProvider = new AssertableLogProvider( true );
+        Log log = logProvider.getLog( getClass() );
+
+        CatchupPollingProcess catchupPollingProcess = mock( CatchupPollingProcess.class );
+        doThrow( new Exception() ).when( catchupPollingProcess ).stop();
+
+        FreezeReadReplicaProcedure proc = new FreezeReadReplicaProcedure( catchupPollingProcess, log );
+
+        // when
+        try
+        {
+            RawIterator<Object[],ProcedureException> rawIterator = proc.apply( null, null );
+        }
+        catch ( ProcedureException expected )
+        {
+            // then
+            assertThat( expected.getMessage(), containsString( "Failed to freeze read replica. Check neo4j.log for details" ) );
+        }
+
+        logProvider.assertContainsLogCallContaining( "Failed to freeze read replica." );
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/UnfreezeReadReplicaProcedureTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/UnfreezeReadReplicaProcedureTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.readreplica;
+
+import org.junit.Test;
+
+import org.neo4j.causalclustering.catchup.tx.CatchupPollingProcess;
+import org.neo4j.collection.RawIterator;
+import org.neo4j.kernel.api.exceptions.ProcedureException;
+import org.neo4j.logging.AssertableLogProvider;
+import org.neo4j.logging.Log;
+import org.neo4j.logging.NullLogProvider;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+public class UnfreezeReadReplicaProcedureTest
+{
+    @Test
+    public void shouldRespondUnfreezeWhenSuccessfullyCalled() throws Exception
+    {
+        // given
+        CatchupPollingProcess catchupPollingProcess = mock( CatchupPollingProcess.class );
+        UnfreezeReadReplicaProcedure proc = new UnfreezeReadReplicaProcedure( catchupPollingProcess, NullLogProvider.getInstance().getLog( getClass() ) );
+
+        // when
+        RawIterator<Object[],ProcedureException> rawIterator = proc.apply( null, null );
+
+        // then
+        assertEquals( "unfrozen", rawIterator.next()[0] );
+    }
+
+    @Test
+    public void shouldRespondFailedAndLogWhenFailedToCall() throws Throwable
+    {
+        // given
+        AssertableLogProvider logProvider = new AssertableLogProvider( true );
+        Log log = logProvider.getLog( getClass() );
+
+        CatchupPollingProcess catchupPollingProcess = mock( CatchupPollingProcess.class );
+        doThrow( new Exception() ).when( catchupPollingProcess ).start();
+
+        UnfreezeReadReplicaProcedure proc = new UnfreezeReadReplicaProcedure( catchupPollingProcess, log );
+
+        // when
+        try
+        {
+            RawIterator<Object[],ProcedureException> rawIterator = proc.apply( null, null );
+        }
+        catch ( ProcedureException expected )
+        {
+            // then
+            assertThat( expected.getMessage(), containsString( "Failed to unfreeze read replica. Check neo4j.log for details." ) );
+        }
+
+        // then
+        logProvider.assertContainsLogCallContaining( "Failed to unfreeze read replica." );
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaStopStartIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ReadReplicaStopStartIT.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.scenarios;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.causalclustering.discovery.Cluster;
+import org.neo4j.causalclustering.readreplica.ReadReplicaGraphDatabase;
+import org.neo4j.function.ThrowingSupplier;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.causalclustering.ClusterRule;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.helpers.collection.Iterables.count;
+import static org.neo4j.test.assertion.Assert.assertEventually;
+
+public class ReadReplicaStopStartIT
+{
+    @Rule
+    public final ClusterRule clusterRule = new ClusterRule().withNumberOfCoreMembers( 2 ).withNumberOfReadReplicas( 1 );
+
+    @Test
+    public void shouldBeAbleToFreezeAndUnfreezeReadReplicaWhileClusterContinues() throws Exception
+    {
+        // given
+        Cluster cluster = clusterRule.startCluster();
+
+        cluster.coreTx( ( db, tx ) ->
+        {
+            Node node = db.createNode();
+            node.setProperty( "name", "Jodie Whittaker" );
+            tx.success();
+        } );
+
+        // when
+        ReadReplicaGraphDatabase readReplica = cluster.findAnyReadReplica().database();
+
+        // then
+        Object firstStatus = readReplica.execute( "CALL dbms.cluster.freezeReadReplica()" ).next().get( "status" );
+        assertEquals( String.class, firstStatus.getClass() );
+        assertEquals( "frozen",firstStatus );
+
+        // when
+        cluster.coreTx( ( db, tx ) ->
+        {
+            Node node = db.createNode();
+            node.setProperty( "name", "Peter Capaldi" );
+            tx.success();
+        } );
+
+        // then
+        Object secondStatus = readReplica.execute( "CALL dbms.cluster.unfreezeReadReplica()" ).next().get( "status" );
+        assertEquals( String.class, secondStatus.getClass() );
+        assertEquals( "unfrozen", secondStatus );
+
+        try ( Transaction tx = readReplica.beginTx() )
+        {
+            ThrowingSupplier<Long,Exception> nodeCount = () -> count( readReplica.getAllNodes() );
+            assertEventually( "Read replica should have restarted and caught up", nodeCount, is( 2L ), 1, MINUTES );
+            tx.success();
+        }
+    }
+}


### PR DESCRIPTION
Use case: user wants to do large analytical job on some read replica
and doesn't want updates while the job us running.

CALL dbms.cluster.freezeReadReplica()
pauses catchup

CALL dbms.cluster.unfreezeReadReplica()
resumes catchup

This only works on read replicas.