### PR TITLE
Allow changing types of properties

### DIFF
--- a/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SetAcceptanceTest.scala
+++ b/community/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/SetAcceptanceTest.scala
@@ -23,6 +23,26 @@ import org.neo4j.cypher._
 
 class SetAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with NewPlannerTestSupport {
 
+  test("should be able to force a type change of a node property") {
+    // given
+    createNode("prop" -> 1337)
+
+    // when
+    updateWithBothPlanners("MATCH (n) SET n.prop = tofloat(n.prop)")
+
+    executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH (n) RETURN n.prop").next()("n.prop") shouldBe a[java.lang.Double]
+  }
+
+  test("should be able to force a type change of a relationship property") {
+    // given
+    relate(createNode(), createNode(), "prop" -> 1337)
+
+    // when
+    updateWithBothPlanners("MATCH ()-[r]->() SET r.prop = tofloat(r.prop)")
+
+    executeWithAllPlannersAndRuntimesAndCompatibilityMode("MATCH ()-[r]->() RETURN r.prop").next()("r.prop") shouldBe a[java.lang.Double]
+  }
+
   test("should be able to set property to collection") {
     // given
     val node = createNode()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -969,10 +969,7 @@ public class StateHandlingStatementOperations implements
             // This because there are established ways of rebuilding auto-indexes which involves this function.
             autoIndexProperty( nodeId, property, ops, existingProperty, autoIndexing.nodes() );
 
-            //It is not enough to check equality here since by our equality semantics `int == tofloat(int)` is `true`
-            //so by only checking for equality users cannot change type of property without also "changing" the value.
-            //Hence the extra type check here.
-            if ( property.getClass() != existingProperty.getClass() || !property.equals( existingProperty ) )
+            if ( propertyHasChanged( property, existingProperty ) )
             {
                 state.txState().nodeDoReplaceProperty( node.id(), existingProperty, property );
 
@@ -1023,10 +1020,7 @@ public class StateHandlingStatementOperations implements
             // This because there are established ways of rebuilding auto-indexes which involves this function.
             autoIndexProperty( relationshipId, property, ops, existingProperty, autoIndexing.relationships() );
 
-            //It is not enough to check equality here since by our equality semantics `int == tofloat(int)` is `true`
-            //so by only checking for equality users cannot change type of property without also "changing" the value.
-            //Hence the extra type check here.
-            if ( property.getClass() != existingProperty.getClass() || !property.equals( existingProperty ) )
+            if ( propertyHasChanged( property, existingProperty ) )
             {
                 state.txState().relationshipDoReplaceProperty( relationship.id(), existingProperty, property );
             }
@@ -1728,6 +1722,14 @@ public class StateHandlingStatementOperations implements
             }
         }
         return storeLayer.nodeExists( id );
+    }
+
+    private boolean propertyHasChanged( Property lhs, Property rhs )
+    {
+        //It is not enough to check equality here since by our equality semantics `int == tofloat(int)` is `true`
+        //so by only checking for equality users cannot change type of property without also "changing" the value.
+        //Hence the extra type check here.
+        return lhs.getClass() != rhs.getClass() || !lhs.equals( rhs );
     }
 
     private static DefinedProperty definedPropertyOrNull( Property existingProperty )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -969,7 +969,10 @@ public class StateHandlingStatementOperations implements
             // This because there are established ways of rebuilding auto-indexes which involves this function.
             autoIndexProperty( nodeId, property, ops, existingProperty, autoIndexing.nodes() );
 
-            if ( !property.equals( existingProperty ) )
+            //It is not enough to check equality here since by our equality semantics `int == tofloat(int)` is `true`
+            //so by only checking for equality users cannot change type of property without also "changing" the value.
+            //Hence the extra type check here.
+            if ( property.getClass() != existingProperty.getClass() || !property.equals( existingProperty ) )
             {
                 state.txState().nodeDoReplaceProperty( node.id(), existingProperty, property );
 
@@ -1020,7 +1023,10 @@ public class StateHandlingStatementOperations implements
             // This because there are established ways of rebuilding auto-indexes which involves this function.
             autoIndexProperty( relationshipId, property, ops, existingProperty, autoIndexing.relationships() );
 
-            if ( !property.equals( existingProperty ) )
+            //It is not enough to check equality here since by our equality semantics `int == tofloat(int)` is `true`
+            //so by only checking for equality users cannot change type of property without also "changing" the value.
+            //Hence the extra type check here.
+            if ( property.getClass() != existingProperty.getClass() || !property.equals( existingProperty ) )
             {
                 state.txState().relationshipDoReplaceProperty( relationship.id(), existingProperty, property );
             }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/NodeProxyTest.java
@@ -323,6 +323,32 @@ public class NodeProxyTest extends PropertyContainerProxyTest
         }
     }
 
+    @Test
+    public void shouldBeAbleToForceTypeChangeOfProperty()
+    {
+        // Given
+        Node node;
+        try ( Transaction tx = db.beginTx() )
+        {
+            node = db.createNode();
+            node.setProperty( "prop", 1337 );
+            tx.success();
+        }
+
+        // When
+        try ( Transaction tx = db.beginTx() )
+        {
+            node.setProperty( "prop", 1337.0 );
+            tx.success();
+        }
+
+        // Then
+        try ( Transaction ignore = db.beginTx() )
+        {
+            assertThat( node.getProperty( "prop" ), instanceOf( Double.class ) );
+        }
+    }
+
     private void createNodeWith( String key )
     {
         try ( Transaction tx = db.beginTx() )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/RelationshipProxyTest.java
@@ -33,9 +33,11 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.impl.core.RelationshipProxy.RelationshipActions;
 
+import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.mock;
@@ -194,6 +196,32 @@ public class RelationshipProxyTest extends PropertyContainerProxyTest
             Relationship relationship = db.getRelationshipById( 0 );
             assertFalse( relationship.hasProperty( testPropertyKey ) );
             tx.success();
+        }
+    }
+
+    @Test
+    public void shouldBeAbleToForceTypeChangeOfProperty()
+    {
+        // Given
+        Relationship relationship;
+        try ( Transaction tx = db.beginTx() )
+        {
+            relationship = db.createNode().createRelationshipTo( db.createNode(), withName( "R" ) );
+            relationship.setProperty( "prop", 1337 );
+            tx.success();
+        }
+
+        // When
+        try ( Transaction tx = db.beginTx() )
+        {
+            relationship.setProperty( "prop", 1337.0 );
+            tx.success();
+        }
+
+        // Then
+        try ( Transaction ignore = db.beginTx() )
+        {
+            assertThat( relationship.getProperty( "prop" ), instanceOf( Double.class ) );
         }
     }
 


### PR DESCRIPTION
Before applying a property update to the transaction state we do a check
to see if the value has actually been changed. However since by our
equality semantics a change of type not necessarily implies a change of
value, e.g. `intValue == tofloat(intvalue)` evaluates to `true`
(at least for integers small enough to fit the mantissa of the
float), we run into problems when users want to force a type change via
for example,

```
MATCH (n) SET n.prop = tofloat(n.prop)
```

in Cypher or via

```
n.setProperty( "prop", (Double) n.getProperty("prop") );
```

in Core API.
  