### PR TITLE
Remove deprecation annotation for legacy ssl settings

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/LegacySslPolicyConfig.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/LegacySslPolicyConfig.java
@@ -31,27 +31,24 @@ import static org.neo4j.kernel.configuration.Settings.derivedSetting;
 import static org.neo4j.kernel.configuration.Settings.pathSetting;
 
 /**
- * Deprecated in favour of {@link SslPolicyConfig}.
+ * To be removed in favour of {@link SslPolicyConfig}. The settings below are still
+ * incorporated in a backwards compatible manner, under the "legacy" policy name.
  */
-@Deprecated
 @Description( "Legacy SSL policy settings" )
 public class LegacySslPolicyConfig implements LoadableConfig
 {
     public static final String LEGACY_POLICY_NAME = "legacy";
 
-    @Deprecated
     @Description( "Directory for storing certificates to be used by Neo4j for TLS connections" )
     public static Setting<File> certificates_directory =
             pathSetting( "dbms.directories.certificates", "certificates" );
 
-    @Deprecated
     @Internal
     @Description( "Path to the X.509 public certificate to be used by Neo4j for TLS connections" )
     public static Setting<File> tls_certificate_file =
             derivedSetting( "unsupported.dbms.security.tls_certificate_file", certificates_directory,
                     certificates -> new File( certificates, "neo4j.cert" ), PATH );
 
-    @Deprecated
     @Internal
     @Description( "Path to the X.509 private key to be used by Neo4j for TLS connections" )
     public static final Setting<File> tls_key_file =


### PR DESCRIPTION
The annotation is used by the configuration validator to issue
warnings, leading to unnecessary warnings, since the setting
is still valid though not preferred. This was an unintended
side-effect and most easily resolved by not using the deprecation
annotation here.