### PR TITLE
Fixes a rare race in EncodingIdMapper regarding duplicate ids

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
@@ -275,12 +275,12 @@ public class EncodingIdMapper implements IdMapper
             sortBuckets = new ParallelSort( radix, dataCache, highestSetIndex, trackerCache,
                     processorsForParallelWork, progress, comparator ).run();
 
-            int numberOfCollisions = detectAndMarkCollisions( progress );
-            if ( numberOfCollisions > 0 )
+            int pessimisticNumberOfCollisions = detectAndMarkCollisions( progress );
+            if ( pessimisticNumberOfCollisions > 0 )
             {
                 try ( InputIterator<Object> idIterator = ids.iterator() )
                 {
-                    buildCollisionInfo( idIterator, numberOfCollisions, collector, progress );
+                    buildCollisionInfo( idIterator, pessimisticNumberOfCollisions, collector, progress );
                 }
             }
         }
@@ -448,6 +448,10 @@ public class EncodingIdMapper implements IdMapper
      * - accidental: there are two different input values coerced into the same encoded value
      *   in the same id space
      *     ==> original input values needs to be kept
+     *
+     * @return rough number of collisions. The number can be slightly more than it actually is due to benign
+     * races between detector workers. This is not a problem though, this value serves as a pessimistic value
+     * for allocating arrays to hold collision data to later sort and use to discover duplicates.
      */
     private int detectAndMarkCollisions( ProgressListener progress )
     {
@@ -507,16 +511,17 @@ public class EncodingIdMapper implements IdMapper
         return true;
     }
 
-    private void buildCollisionInfo( InputIterator<Object> ids, int numberOfCollisions,
+    private void buildCollisionInfo( InputIterator<Object> ids, int pessimisticNumberOfCollisions,
             Collector collector, ProgressListener progress )
             throws InterruptedException
     {
-        progress.started( "RESOLVE (" + numberOfCollisions + " collisions)" );
+        progress.started( "RESOLVE (~" + pessimisticNumberOfCollisions + " collisions)" );
         Radix radix = radixFactory.newInstance();
         List<String> sourceDescriptions = new ArrayList<>();
         String lastSourceDescription = null;
-        collisionSourceDataCache = cacheFactory.newLongArray( numberOfCollisions, ID_NOT_FOUND );
-        collisionTrackerCache = trackerFactory.create( cacheFactory, numberOfCollisions );
+        collisionSourceDataCache = cacheFactory.newLongArray( pessimisticNumberOfCollisions, ID_NOT_FOUND );
+        collisionTrackerCache = trackerFactory.create( cacheFactory, pessimisticNumberOfCollisions );
+        int numberOfCollisions = 0;
         for ( long i = 0; ids.hasNext(); )
         {
             long j = 0;
@@ -527,6 +532,7 @@ public class EncodingIdMapper implements IdMapper
                 if ( isCollision( eId ) )
                 {
                     // Store this collision input id for matching later in get()
+                    numberOfCollisions++;
                     long eIdFromInputId = encode( id );
                     long eIdWithoutCollisionBit = clearCollision( eId );
                     assert eIdFromInputId == eIdWithoutCollisionBit : format( "Encoding mismatch during building of " +


### PR DESCRIPTION
This was a problem when detecting duplicates which would later trigger a failure
when sorting the duplicate values. There were multiple detector workers which got
its own slice of the data, the trackerCache more specifically.
Detectors marks data items as collisions and the data structure is shared
between the detectors and intentionally unsynchronized. This allows a benign race
of slightly over-counting the number of collisions when doing the detection.
The rest of the duplication logic, including sorting of the duplicate values, would
use that count as a de-facto count to determine ranges and high id in the
duplicate data array. This would sometimes cause the sort algorithm to notice
unexpected ids in the high end of the spectrum which looked uninitialized
and so fail. Now instead the initial collision count is used as a pessimistic
count to instantiate the data structures capable of holding the duplicates,
but the actual collision count is used for the rest of the algorithm.
The actual count can be had by piggy-backing on the gathering of duplicate
values, so no overhead.

ImportToolTest and EncodingIdMapperTest would see this problem now and then