### PR TITLE
Non-recursive equals in LogicalPlan

### DIFF
--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/idp/ExpandSolverStepTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/idp/ExpandSolverStepTest.scala
@@ -33,13 +33,22 @@ import org.neo4j.cypher.internal.ir.v3_3._
 import org.neo4j.cypher.internal.v3_3.logical.plans.{Expand, ExpandAll, ExpandInto, LogicalPlan}
 
 class ExpandSolverStepTest extends CypherFunSuite with LogicalPlanConstructionTestSupport with AstConstructionTestSupport {
-
+  self =>
   private val solved = CardinalityEstimation.lift(PlannerQuery.empty, Cardinality(0))
 
-  private val plan1 = mock[LogicalPlan]
-  private val plan2 = mock[LogicalPlan]
-  when(plan1.solved).thenReturn(solved)
-  when(plan2.solved).thenReturn(solved)
+  case class TestPlan(availableSymbols: Set[IdName] = Set.empty) extends LogicalPlan {
+
+    override def lhs: Option[LogicalPlan] = None
+
+    override def rhs: Option[LogicalPlan] = None
+
+    override def solved: PlannerQuery with CardinalityEstimation = self.solved
+
+    override def strictness: StrictnessMode = ???
+  }
+
+  private val plan1 = TestPlan()
+
 
   private val pattern1 = PatternRelationship('r1, ('a, 'b), SemanticDirection.OUTGOING, Seq.empty, SimplePatternLength)
   private val pattern2 = PatternRelationship('r2, ('b, 'c), SemanticDirection.OUTGOING, Seq.empty, SimplePatternLength)
@@ -59,25 +68,26 @@ class ExpandSolverStepTest extends CypherFunSuite with LogicalPlanConstructionTe
   test("expands if an unsolved pattern relationship overlaps once with a single solved plan") {
     implicit val registry = IdRegistry[PatternRelationship]
 
-    when(plan1.availableSymbols).thenReturn(Set[IdName]('a, 'r1, 'b))
-    table.put(register(pattern1), plan1)
+    val plan = TestPlan(Set[IdName]('a, 'r1, 'b))
+    table.put(register(pattern1), plan)
 
     expandSolverStep(qg)(registry, register(pattern1, pattern2), table).toSet should equal(Set(
-      Expand(plan1, 'b, SemanticDirection.OUTGOING, Seq.empty, 'c, 'r2, ExpandAll)(solved)
+      Expand(plan, 'b, SemanticDirection.OUTGOING, Seq.empty, 'c, 'r2, ExpandAll)(solved)
     ))
   }
 
   test("expands if an unsolved pattern relationships overlaps twice with a single solved plan") {
     implicit val registry = IdRegistry[PatternRelationship]
 
-    when(plan1.availableSymbols).thenReturn(Set[IdName]('a, 'r1, 'b))
-    table.put(register(pattern1), plan1)
+    val plan = TestPlan(Set[IdName]('a, 'r1, 'b))
+
+    table.put(register(pattern1), plan)
 
     val patternX = PatternRelationship('r2, ('a, 'b), SemanticDirection.OUTGOING, Seq.empty, SimplePatternLength)
 
     expandSolverStep(qg)(registry, register(pattern1, patternX), table).toSet should equal(Set(
-      Expand(plan1, 'a, SemanticDirection.OUTGOING, Seq.empty, 'b, 'r2, ExpandInto)(solved),
-      Expand(plan1, 'b, SemanticDirection.INCOMING, Seq.empty, 'a, 'r2, ExpandInto)(solved)
+      Expand(plan, 'a, SemanticDirection.OUTGOING, Seq.empty, 'b, 'r2, ExpandInto)(solved),
+      Expand(plan, 'b, SemanticDirection.INCOMING, Seq.empty, 'a, 'r2, ExpandInto)(solved)
     ))
   }
 
@@ -94,15 +104,15 @@ class ExpandSolverStepTest extends CypherFunSuite with LogicalPlanConstructionTe
 
   test("expands if an unsolved pattern relationship overlaps with multiple solved plans") {
     implicit val registry = IdRegistry[PatternRelationship]
+    val plan = TestPlan(Set[IdName]('a, 'r1, 'b, 'c, 'r2, 'd))
 
-    when(plan1.availableSymbols).thenReturn(Set[IdName]('a, 'r1, 'b, 'c, 'r2, 'd))
-    table.put(register(pattern1, pattern2), plan1)
+    table.put(register(pattern1, pattern2), plan)
 
     val pattern3 = PatternRelationship('r3, ('b, 'c), SemanticDirection.OUTGOING, Seq.empty, SimplePatternLength)
 
     expandSolverStep(qg)(registry, register(pattern1, pattern2, pattern3), table).toSet should equal(Set(
-      Expand(plan1, 'b, SemanticDirection.OUTGOING, Seq.empty, 'c, 'r3, ExpandInto)(solved),
-      Expand(plan1, 'c, SemanticDirection.INCOMING, Seq.empty, 'b, 'r3, ExpandInto)(solved)
+      Expand(plan, 'b, SemanticDirection.OUTGOING, Seq.empty, 'c, 'r3, ExpandInto)(solved),
+      Expand(plan, 'c, SemanticDirection.INCOMING, Seq.empty, 'b, 'r3, ExpandInto)(solved)
     ))
   }
 

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/idp/JoinSolverStepTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/idp/JoinSolverStepTest.scala
@@ -36,10 +36,17 @@ class JoinSolverStepTest extends CypherFunSuite with LogicalPlanConstructionTest
   private implicit val context = LogicalPlanningContext(mock[PlanContext], LogicalPlanProducer(mock[CardinalityModel]),
     mock[Metrics], mock[SemanticTable], mock[QueryGraphSolver], notificationLogger = mock[InternalNotificationLogger])
 
-  val plan1 = mock[LogicalPlan]
-  val plan2 = mock[LogicalPlan]
-  when(plan1.solved).thenReturn(PlannerQuery.empty)
-  when(plan2.solved).thenReturn(PlannerQuery.empty)
+  case class TestPlan(availableSymbols: Set[IdName] = Set.empty, solved: PlannerQuery with CardinalityEstimation = PlannerQuery.empty) extends LogicalPlan {
+
+    override def lhs: Option[LogicalPlan] = None
+
+    override def rhs: Option[LogicalPlan] = None
+
+    override def strictness: StrictnessMode = ???
+  }
+
+  val plan1 = TestPlan()
+  val plan2 = TestPlan()
 
   val pattern1 = PatternRelationship('r1, ('a, 'b), SemanticDirection.OUTGOING, Seq.empty, SimplePatternLength)
   val pattern2 = PatternRelationship('r2, ('b, 'c), SemanticDirection.OUTGOING, Seq.empty, SimplePatternLength)
@@ -57,10 +64,8 @@ class JoinSolverStepTest extends CypherFunSuite with LogicalPlanConstructionTest
     implicit val registry = IdRegistry[PatternRelationship]
     val qg = QueryGraph.empty.addPatternNodes('a, 'b, 'c)
 
-    when(plan1.availableSymbols).thenReturn(Set[IdName]('a, 'r1, 'b))
-    when(plan1.solved).thenReturn(RegularPlannerQuery(QueryGraph.empty.addPatternNodes('a, 'b)))
-    when(plan2.availableSymbols).thenReturn(Set[IdName]('b, 'r2, 'c))
-    when(plan2.solved).thenReturn(RegularPlannerQuery(QueryGraph.empty.addPatternNodes('b, 'c)))
+    val plan1 = TestPlan(Set[IdName]('a, 'r1, 'b), RegularPlannerQuery(QueryGraph.empty.addPatternNodes('a, 'b)))
+    val plan2 = TestPlan(Set[IdName]('b, 'r2, 'c), RegularPlannerQuery(QueryGraph.empty.addPatternNodes('b, 'c)))
 
     table.put(register(pattern1), plan1)
     table.put(register(pattern2), plan2)
@@ -75,10 +80,8 @@ class JoinSolverStepTest extends CypherFunSuite with LogicalPlanConstructionTest
     implicit val registry = IdRegistry[PatternRelationship]
     val qg = QueryGraph.empty.addPatternNodes('a, 'b)
 
-    when(plan1.availableSymbols).thenReturn(Set[IdName]('a, 'r1, 'b))
-    when(plan1.solved).thenReturn(RegularPlannerQuery(QueryGraph.empty.addPatternNodes('a, 'b)))
-    when(plan2.availableSymbols).thenReturn(Set[IdName]('b))
-    when(plan2.solved).thenReturn(RegularPlannerQuery(QueryGraph.empty.addPatternNodes('b)))
+    val plan1 = TestPlan(Set[IdName]('a, 'r1, 'b), RegularPlannerQuery(QueryGraph.empty.addPatternNodes('a, 'b)))
+    val plan2 = TestPlan(Set[IdName]('b), RegularPlannerQuery(QueryGraph.empty.addPatternNodes('b)))
 
     table.put(register(pattern1), plan1)
     table.put(register(pattern2), plan2)
@@ -93,10 +96,8 @@ class JoinSolverStepTest extends CypherFunSuite with LogicalPlanConstructionTest
     implicit val registry = IdRegistry[PatternRelationship]
     val qg = QueryGraph.empty.addPatternNodes('a, 'b, 'c, 'd)
 
-    when(plan1.availableSymbols).thenReturn(Set[IdName]('a, 'r1, 'b))
-    when(plan1.solved).thenReturn(RegularPlannerQuery(QueryGraph.empty.addPatternNodes('a, 'b)))
-    when(plan2.availableSymbols).thenReturn(Set[IdName]('c, 'r2, 'd))
-    when(plan2.solved).thenReturn(RegularPlannerQuery(QueryGraph.empty.addPatternNodes('c, 'd)))
+    val plan1 = TestPlan(Set[IdName]('a, 'r1, 'b), RegularPlannerQuery(QueryGraph.empty.addPatternNodes('a, 'b)))
+    val plan2 = TestPlan(Set[IdName]('c, 'r2, 'd), RegularPlannerQuery(QueryGraph.empty.addPatternNodes('c, 'd)))
 
     table.put(register(pattern1), plan1)
     table.put(register(pattern2), plan2)
@@ -109,10 +110,8 @@ class JoinSolverStepTest extends CypherFunSuite with LogicalPlanConstructionTest
     implicit val registry = IdRegistry[PatternRelationship]
     val qg = QueryGraph.empty.addPatternNodes('a, 'b, 'c, 'd)
 
-    when(plan1.availableSymbols).thenReturn(Set[IdName]('a, 'r1, 'b, 'x))
-    when(plan1.solved).thenReturn(RegularPlannerQuery(QueryGraph.empty.addPatternNodes('a, 'b)))
-    when(plan2.availableSymbols).thenReturn(Set[IdName]('c, 'r2, 'd, 'x))
-    when(plan2.solved).thenReturn(RegularPlannerQuery(QueryGraph.empty.addPatternNodes('c, 'd)))
+    val plan1 = TestPlan(Set[IdName]('a, 'r1, 'b,'x), RegularPlannerQuery(QueryGraph.empty.addPatternNodes('a, 'b)))
+    val plan2 = TestPlan(Set[IdName]('c, 'r2, 'd, 'x), RegularPlannerQuery(QueryGraph.empty.addPatternNodes('c, 'd)))
 
     table.put(register(pattern1), plan1)
     table.put(register(pattern2), plan2)
@@ -124,10 +123,8 @@ class JoinSolverStepTest extends CypherFunSuite with LogicalPlanConstructionTest
     implicit val registry = IdRegistry[PatternRelationship]
     val qg = QueryGraph.empty.addPatternNodes('a, 'b, 'c, 'd).addArgumentIds(Seq('x))
 
-    when(plan1.availableSymbols).thenReturn(Set[IdName]('a, 'r1, 'b, 'x))
-    when(plan1.solved).thenReturn(RegularPlannerQuery(QueryGraph.empty.addPatternNodes('a, 'b, 'x).addArgumentIds(Seq('x))))
-    when(plan2.availableSymbols).thenReturn(Set[IdName]('c, 'r2, 'd, 'x))
-    when(plan2.solved).thenReturn(RegularPlannerQuery(QueryGraph.empty.addPatternNodes('c, 'd, 'x).addArgumentIds(Seq('x))))
+    val plan1 = TestPlan(Set[IdName]('a, 'r1, 'b, 'x), RegularPlannerQuery(QueryGraph.empty.addPatternNodes('a, 'b, 'x).addArgumentIds(Seq('x))))
+    val plan2 = TestPlan(Set[IdName]('c, 'r2, 'd, 'x), RegularPlannerQuery(QueryGraph.empty.addPatternNodes('c, 'd, 'x).addArgumentIds(Seq('x))))
 
     table.put(register(pattern1), plan1)
     table.put(register(pattern2), plan2)

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/plans/LogicalPlanEqualityTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/plans/LogicalPlanEqualityTest.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher.internal.compiler.v3_3.planner.logical.plans
+
+import org.neo4j.cypher.internal.compiler.v3_3.planner.LogicalPlanningTestSupport
+import org.neo4j.cypher.internal.frontend.v3_3.test_helpers.CypherFunSuite
+import org.neo4j.cypher.internal.ir.v3_3.{CardinalityEstimation, IdName, PlannerQuery, StrictnessMode}
+import org.neo4j.cypher.internal.v3_3.logical.plans.{Apply, Argument, LogicalPlan, SingleRow}
+
+class LogicalPlanEqualityTest extends CypherFunSuite with LogicalPlanningTestSupport  {
+  test("leafs") {
+    Leaf(Map("string" -> 42)) should equal(Leaf(Map("string" -> 42)))
+    Leaf(Map("string" -> 42)) should not equal Leaf(Map("string" -> 1337))
+  }
+
+  test("non-branching trees") {
+    Unary(Unary(Leaf("foo"), "bar"), "baz") should equal(Unary(Unary(Leaf("foo"), "bar"), "baz"))
+    Unary(Unary(Leaf("foo"), "bar"), "baz") should equal(Unary(Unary(Leaf("foo"), "bar"), "baz"))
+    Unary(Unary(Leaf("foo"), "bar"), "baz") should not equal Unary(Leaf("foo"), "bar")
+  }
+
+  test("branching trees") {
+    //Identical
+    Binary(
+      Binary(
+        Unary(Leaf("left"), "left"),
+        Unary(Unary(Leaf("left"), "left"), "left"), "branch1"),
+      Unary(Leaf("right"), "right"), "branch2") should equal(Binary(
+      Binary(
+        Unary(Leaf("left"), "left"),
+        Unary(Unary(Leaf("left"), "left"), "left"), "branch1"),
+      Unary(Leaf("right"), "right"), "branch2"))
+
+    //Flip a branch
+    Binary(
+      Binary(
+        Unary(Leaf("left"), "left"),
+        Unary(Unary(Leaf("left"), "left"), "left"), "branch1"),
+      Unary(Leaf("right"), "right"), "branch2") should not equal Binary(
+      Binary(
+        Unary(Unary(Leaf("left"), "left"), "left"),
+        Unary(Leaf("left"), "left"), "branch1"),
+      Unary(Leaf("right"), "right"), "branch2")
+
+    //Change a leaf
+    Binary(
+      Binary(
+        Unary(Leaf("left"), "left"),
+        Unary(Unary(Leaf("left"), "left"), "left"), "branch1"),
+      Unary(Leaf("right"), "right"), "branch2") should not equal Binary(
+      Binary(
+        Unary(Leaf("left"), "left"),
+        Unary(Unary(Leaf("DIFFERENT!!"), "left"), "left"), "branch1"),
+      Unary(Leaf("right"), "right"), "branch2")
+  }
+
+  case class Binary(left: LogicalPlan, right: LogicalPlan, value: Any) extends LogicalPlan {
+
+    override def solved: PlannerQuery with CardinalityEstimation = ???
+
+    override def availableSymbols: Set[IdName] = ???
+
+    override def strictness: StrictnessMode = ???
+
+    override def lhs: Option[LogicalPlan] = Some(left)
+
+    override def rhs: Option[LogicalPlan] = Some(right)
+  }
+
+  case class Unary(child: LogicalPlan, value: Any) extends LogicalPlan {
+
+
+    override def solved: PlannerQuery with CardinalityEstimation = ???
+
+    override def availableSymbols: Set[IdName] = ???
+
+    override def strictness: StrictnessMode = ???
+
+    override def rhs: Option[LogicalPlan] = None
+
+    override def lhs: Option[LogicalPlan] = Some(child)
+  }
+
+  case class Leaf(value: Any) extends LogicalPlan {
+
+    override def lhs: Option[LogicalPlan] = None
+
+    override def rhs: Option[LogicalPlan] = None
+
+    override def solved: PlannerQuery with CardinalityEstimation = ???
+
+    override def availableSymbols: Set[IdName] = ???
+
+    override def strictness: StrictnessMode = ???
+  }
+}


### PR DESCRIPTION
LogicalPlan rewriting uses `fixedPoint` a lot which uses equality
to figure out if we reached a fix point. Logical plans are case classes
and use the default equal implementation meaning that we will recursively
compare objects over the logical plan tree. For large logical plan we
run out of call stack resulting in a stack overflow.

changelog: Fixes problem where Cypher would sometimes run out of stack space for really large queries.