### PR TITLE
Fix online backup problems.

### DIFF
--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupSupportingClassesFactoryProvider.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupSupportingClassesFactoryProvider.java
@@ -26,7 +26,7 @@ import org.neo4j.helpers.Service;
 
 import static java.util.Comparator.comparingInt;
 
-class BackupSupportingClassesFactoryProvider extends Service
+public class BackupSupportingClassesFactoryProvider extends Service
 {
     /**
      * Create a new instance of a service implementation identified with the
@@ -34,12 +34,12 @@ class BackupSupportingClassesFactoryProvider extends Service
      *
      * @param key the main key for identifying this service implementation
      */
-    protected BackupSupportingClassesFactoryProvider( String key )
+    public BackupSupportingClassesFactoryProvider( String key )
     {
         super( key );
     }
 
-    protected BackupSupportingClassesFactoryProvider()
+    public BackupSupportingClassesFactoryProvider()
     {
         super( "default-backup-support-provider" );
     }

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupProtocolServiceIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/BackupProtocolServiceIT.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import org.neo4j.backup.IncrementalBackupNotPossibleException;
 import org.neo4j.backup.OnlineBackupExtensionFactory;
@@ -415,7 +416,11 @@ public class BackupProtocolServiceIT
         db.shutdown();
 
         // then
-        File[] files = Files.list( backupDir ).map( Path::toFile ).toArray( File[]::new );
+        File[] files;
+        try ( Stream<Path> listing = Files.list( backupDir ) )
+        {
+            files = listing.map( Path::toFile ).toArray( File[]::new );
+        }
 
         assertTrue( files.length > 0 );
 


### PR DESCRIPTION
* Fixes a service loading problem on Java9: To be able to service load class implementations across implicit module boundaries, the classes involved must be public.
* Fixes a directory file descriptor leak in `BackupProtocolServiceIT`, that caused a test to fail on Windows.