### PR TITLE
Do not rebind node cursor on property set to the same node twice.

### DIFF
--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledCursorUtils.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/CompiledCursorUtils.java
@@ -59,11 +59,7 @@ public final class CompiledCursorUtils
         {
             return Values.NO_VALUE;
         }
-        read.singleNode( node, nodeCursor );
-        if ( !nodeCursor.next() )
-        {
-            throw new EntityNotFoundException( EntityType.NODE, node );
-        }
+        singleNode( read, nodeCursor, node );
         nodeCursor.properties( propertyCursor );
         while ( propertyCursor.next() )
         {
@@ -93,13 +89,18 @@ public final class CompiledCursorUtils
         {
             return false;
         }
+        singleNode( read, nodeCursor, node );
+
+        return nodeCursor.labels().contains( label );
+    }
+
+    private static void singleNode( Read read, NodeCursor nodeCursor, long node ) throws EntityNotFoundException
+    {
         read.singleNode( node, nodeCursor );
         if ( !nodeCursor.next() )
         {
             throw new EntityNotFoundException( EntityType.NODE, node );
         }
-
-        return nodeCursor.labels().contains( label );
     }
 }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -367,11 +367,7 @@ public class NodeProxy implements Node
         {
             return defaultValue;
         }
-        transaction.dataRead().singleNode( nodeId, nodes );
-        if ( !nodes.next() )
-        {
-            throw new NotFoundException( new EntityNotFoundException( EntityType.NODE, nodeId ) );
-        }
+        singleNode( transaction, nodes );
         nodes.properties( properties );
         while ( properties.next() )
         {
@@ -393,12 +389,8 @@ public class NodeProxy implements Node
         {
             NodeCursor nodes = transaction.nodeCursor();
             PropertyCursor properties = transaction.propertyCursor();
-            transaction.dataRead().singleNode( nodeId, nodes );
+            singleNode( transaction, nodes );
             TokenRead token = transaction.tokenRead();
-            if ( !nodes.next() )
-            {
-                throw new NotFoundException( new EntityNotFoundException( EntityType.NODE, nodeId ) );
-            }
             nodes.properties( properties );
             while ( properties.next() )
             {
@@ -443,11 +435,7 @@ public class NodeProxy implements Node
 
         NodeCursor nodes = transaction.nodeCursor();
         PropertyCursor propertyCursor = transaction.propertyCursor();
-        transaction.dataRead().singleNode( nodeId, nodes );
-        if ( !nodes.next() )
-        {
-            throw new NotFoundException( new EntityNotFoundException( EntityType.NODE, nodeId ) );
-        }
+        singleNode( transaction, nodes );
         nodes.properties( propertyCursor );
         int propertiesToFind = itemsToReturn;
         while ( propertiesToFind > 0 && propertyCursor.next() )
@@ -479,11 +467,7 @@ public class NodeProxy implements Node
             NodeCursor nodes = transaction.nodeCursor();
             PropertyCursor propertyCursor = transaction.propertyCursor();
             TokenRead token = transaction.tokenRead();
-            transaction.dataRead().singleNode( nodeId, nodes );
-            if ( !nodes.next() )
-            {
-                throw new NotFoundException( new EntityNotFoundException( EntityType.NODE, nodeId ) );
-            }
+            singleNode( transaction, nodes );
             nodes.properties( propertyCursor );
             while ( propertyCursor.next() )
             {
@@ -514,11 +498,7 @@ public class NodeProxy implements Node
 
         NodeCursor nodes = transaction.nodeCursor();
         PropertyCursor properties = transaction.propertyCursor();
-        transaction.dataRead().singleNode( nodeId, nodes );
-        if ( !nodes.next() )
-        {
-            throw new NotFoundException( new EntityNotFoundException( EntityType.NODE, nodeId ) );
-        }
+        singleNode( transaction, nodes );
         nodes.properties( properties );
         while ( properties.next() )
         {
@@ -552,11 +532,7 @@ public class NodeProxy implements Node
 
         NodeCursor nodes = transaction.nodeCursor();
         PropertyCursor properties = transaction.propertyCursor();
-        transaction.dataRead().singleNode( nodeId, nodes );
-        if ( !nodes.next() )
-        {
-            throw new NotFoundException( new EntityNotFoundException( EntityType.NODE, nodeId ) );
-        }
+        singleNode( transaction, nodes );
         nodes.properties( properties );
         while ( properties.next() )
         {
@@ -582,21 +558,7 @@ public class NodeProxy implements Node
     public int compareTo( Object node )
     {
         Node n = (Node) node;
-        long ourId = this.getId();
-        long theirId = n.getId();
-
-        if ( ourId < theirId )
-        {
-            return -1;
-        }
-        else if ( ourId > theirId )
-        {
-            return 1;
-        }
-        else
-        {
-            return 0;
-        }
+        return Long.compare( this.getId(), n.getId() );
     }
 
     @Override
@@ -722,7 +684,6 @@ public class NodeProxy implements Node
             int labelId = transaction.tokenRead().labelGetForName( label.name() );
             transaction.dataRead().singleNode( nodeId, nodes );
             return nodes.next() && nodes.labels().contains( labelId );
-
         }
         catch ( LabelNotFoundKernelException e )
         {
@@ -737,11 +698,7 @@ public class NodeProxy implements Node
         try ( Statement ignore = actions.statement();
               NodeCursor nodes = transaction.cursors().allocateNodeCursor() )
         {
-            transaction.dataRead().singleNode( nodeId, nodes );
-            if ( !nodes.next() )
-            {
-                throw new NotFoundException( "Node not found" );
-            }
+            singleNode( transaction, nodes );
             LabelSet labelSet = nodes.labels();
             TokenRead tokenRead = transaction.tokenRead();
             ArrayList<Label> list = new ArrayList<>( labelSet.numberOfLabels() );
@@ -866,6 +823,15 @@ public class NodeProxy implements Node
         catch ( RelationshipTypeIdNotFoundKernelException e )
         {
             throw new IllegalStateException( "Kernel API returned non-existent relationship type: " + relTypeId );
+        }
+    }
+
+    private void singleNode( KernelTransaction transaction, NodeCursor nodes )
+    {
+        transaction.dataRead().singleNode( nodeId, nodes );
+        if ( !nodes.next() )
+        {
+            throw new NotFoundException( new EntityNotFoundException( EntityType.NODE, nodeId ) );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/RelationshipProxy.java
@@ -467,21 +467,7 @@ public class RelationshipProxy implements Relationship, RelationshipVisitor<Runt
     public int compareTo( Object rel )
     {
         Relationship r = (Relationship) rel;
-        long ourId = this.getId();
-        long theirId = r.getId();
-
-        if ( ourId < theirId )
-        {
-            return -1;
-        }
-        else if ( ourId > theirId )
-        {
-            return 1;
-        }
-        else
-        {
-            return 0;
-        }
+        return Long.compare( this.getId(), r.getId() );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeCursor.java
@@ -33,6 +33,7 @@ import org.neo4j.kernel.impl.store.NodeLabelsField;
 import org.neo4j.kernel.impl.store.RecordCursor;
 import org.neo4j.kernel.impl.store.record.DynamicRecord;
 import org.neo4j.kernel.impl.store.record.NodeRecord;
+
 import static org.neo4j.kernel.impl.newapi.References.setDirectFlag;
 import static org.neo4j.kernel.impl.newapi.References.setGroupFlag;
 
@@ -105,10 +106,10 @@ class NodeCursor extends NodeRecord implements org.neo4j.internal.kernel.api.Nod
         if ( hasChanges() )
         {
             TransactionState txState = read.txState();
-            if ( txState.nodeIsAddedInThisTx( nodeReference() ) )
+            if ( txState.nodeIsAddedInThisTx( getId() ) )
             {
                 //Node just added, no reason to go down to store and check
-                return Labels.from( txState.nodeStateLabelDiffSets( nodeReference() ).getAdded() );
+                return Labels.from( txState.nodeStateLabelDiffSets( getId() ).getAdded() );
             }
             else
             {
@@ -121,7 +122,7 @@ class NodeCursor extends NodeRecord implements org.neo4j.internal.kernel.api.Nod
                 }
 
                 //Augment what was found in store with what we have in tx state
-                return Labels.from( txState.augmentLabels( labels, txState.getNodeState( nodeReference() ) ) );
+                return Labels.from( txState.augmentLabels( labels, txState.getNodeState( getId() ) ) );
             }
         }
         else
@@ -140,19 +141,19 @@ class NodeCursor extends NodeRecord implements org.neo4j.internal.kernel.api.Nod
     @Override
     public void relationships( RelationshipGroupCursor cursor )
     {
-        read.relationshipGroups( nodeReference(), relationshipGroupReference(), cursor );
+        read.relationshipGroups( getId(), relationshipGroupReference(), cursor );
     }
 
     @Override
     public void allRelationships( RelationshipTraversalCursor cursor )
     {
-        read.relationships( nodeReference(), allRelationshipsReference(), cursor );
+        read.relationships( getId(), allRelationshipsReference(), cursor );
     }
 
     @Override
     public void properties( PropertyCursor cursor )
     {
-        read.nodeProperties( nodeReference(), propertiesReference(), cursor );
+        read.nodeProperties( getId(), propertiesReference(), cursor );
     }
 
     @Override


### PR DESCRIPTION
Do not rebind node cursor to the same node on property read.
Introduce helper methods to bind cursors to single node.
Use getId directly instead of nodeReference.
Use 'Long.compare' instead of home made analog.