### PR TITLE
Fix the periodic checkpoint policy scheduling frequency.

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CountCommittedTransactionThreshold.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CountCommittedTransactionThreshold.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.transaction.log.checkpoint;
 
-import java.util.concurrent.TimeUnit;
-
 class CountCommittedTransactionThreshold extends AbstractCheckPointThreshold
 {
     private final int notificationThreshold;
@@ -54,10 +52,8 @@ class CountCommittedTransactionThreshold extends AbstractCheckPointThreshold
     @Override
     public long checkFrequencyMillis()
     {
-        // This threshold is usually combined with the TimeCheckPointThreshold, which we expect to have a much higher
-        // frequency (as in, checks more often, e.g. every 15 minutes) than this.
-        // We effectively put an upper bound on how long we can go without checking if a check-point is needed.
-        // However, at least one check per day does sound like the bare minimum that we should do anyway.
-        return TimeUnit.DAYS.toMillis( 1 );
+        // Transaction counts can change at any time, so we need to check fairly regularly to see if a checkpoint
+        // should be triggered.
+        return DEFAULT_CHECKING_FREQUENCY_MILLIS;
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointThresholdTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/checkpoint/CheckPointThresholdTest.java
@@ -26,6 +26,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointThreshold.DEFAULT_CHECKING_FREQUENCY_MILLIS;
 
 public class CheckPointThresholdTest extends CheckPointThresholdTestSupport
 {
@@ -203,8 +204,9 @@ public class CheckPointThresholdTest extends CheckPointThresholdTestSupport
     @Test
     public void timeBasedThresholdMustSuggestSchedulingFrequency() throws Exception
     {
-        long defaultInterval = intervalTime.toMillis();
-        assertThat( createThreshold().checkFrequencyMillis(), is( defaultInterval ) );
+        // By default, the transaction count based threshold wants a higher check frequency than the time based
+        // default threshold.
+        assertThat( createThreshold().checkFrequencyMillis(), is( DEFAULT_CHECKING_FREQUENCY_MILLIS ) );
 
         withIntervalTime( "100ms" );
         assertThat( createThreshold().checkFrequencyMillis(), is( 100L ) );


### PR DESCRIPTION
This fixes a mistake that snuck in with the volumetric check pointing
policy.

In order to have a somewhat accurate check pointing frequency based on
the transaction counts, we need to check those counts pretty regularly.
However, the scheduling frequency for the time based check point
threshold was changed to match that of the checkpoint interval, while
the frequency for the transaction count was changed to be once every
day. The check frequency is now the lesser of the two instead of being
hard coded to 10 seconds, which means that the transaction check
frequency would end up being dictated by the time based threshold.
Effectively rendering the transaction count based threshold useless.

To fix this, the transaction count threshold has changed its checking
frequency to 10 seconds, so _it_ now dictates the checking frequency,
and thus we will notice with much greater timeliness if we should do
a check point based on the transaction counts.