### PR TITLE
Do not check whole `org.neo4j.server.rest.web` for API changes

### DIFF
--- a/community/server/pom.xml
+++ b/community/server/pom.xml
@@ -79,15 +79,6 @@
 
   <build>
     <plugins>
-      <!-- This module contains public API, run javadoc and revapi -->
-      <plugin>
-        <artifactId>maven-javadoc-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.revapi</groupId>
-        <artifactId>revapi-maven-plugin</artifactId>
-      </plugin>
-
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,8 @@
                     <regex>true</regex>
                     <include>
                       <item>org\.neo4j\.helpers\.collection\.BoundedIterable</item>
+                      <item>org\.neo4j\.server\.rest\.web\.NodeNotFoundException</item>
+                      <item>org\.neo4j\.server\.rest\.web\.RelationshipNotFoundException</item>
                     </include>
                   </classes>
                   <packages>
@@ -266,7 +268,6 @@
                       <item>org\.neo4j\.server\.helpers(\\..+)?</item>
                       <item>org\.neo4j\.server\.plugins(\\..+)?</item>
                       <item>org\.neo4j\.server\.rest\.repr(\\..+)?</item>
-                      <item>org\.neo4j\.server\.rest\.web(\\..+)?</item>
                       <item>org\.neo4j\.unsafe\.batchinsert(\\..+)?</item>
                       <item>org\.neo4j\.logging(\\..+)?</item>
                       <item>org\.neo4j\.procedure(\\..+)?</item>

--- a/pom.xml
+++ b/pom.xml
@@ -250,8 +250,6 @@
                     <regex>true</regex>
                     <include>
                       <item>org\.neo4j\.helpers\.collection\.BoundedIterable</item>
-                      <item>org\.neo4j\.server\.rest\.web\.NodeNotFoundException</item>
-                      <item>org\.neo4j\.server\.rest\.web\.RelationshipNotFoundException</item>
                     </include>
                   </classes>
                   <packages>
@@ -268,6 +266,7 @@
                       <item>org\.neo4j\.server\.helpers(\\..+)?</item>
                       <item>org\.neo4j\.server\.plugins(\\..+)?</item>
                       <item>org\.neo4j\.server\.rest\.repr(\\..+)?</item>
+                      <item>org\.neo4j\.server\.rest\.web(\\..+)?</item>
                       <item>org\.neo4j\.unsafe\.batchinsert(\\..+)?</item>
                       <item>org\.neo4j\.logging(\\..+)?</item>
                       <item>org\.neo4j\.procedure(\\..+)?</item>


### PR DESCRIPTION
Do not check whole org.neo4j.server.rest.web since together with
public classes it also contains internal and jetty dependent classes
and we do not check those.