### PR TITLE
Ability to drop a broken uniqueness constraint

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/TransactionToRecordStateVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storageengine/impl/recordstorage/TransactionToRecordStateVisitor.java
@@ -192,7 +192,10 @@ public class TransactionToRecordStateVisitor extends TxStateVisitor.Adapter
     public void visitRemovedIndex( IndexDescriptor index )
     {
         IndexRule rule = schemaStorage.indexGetForSchema( index );
-        recordState.dropSchemaRule( rule );
+        if ( rule != null )
+        {
+            recordState.dropSchemaRule( rule );
+        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/state/TransactionRecordState.java
@@ -250,7 +250,10 @@ public class TransactionRecordState implements RecordState
         }
         for ( RecordProxy<SchemaRecord, SchemaRule> change : recordChangeSet.getSchemaRuleChanges().changes() )
         {
-            integrityValidator.validateSchemaRule( change.getAdditionalData() );
+            if ( change.forReadingLinkage().inUse() )
+            {
+                integrityValidator.validateSchemaRule( change.getAdditionalData() );
+            }
             commands.add( new Command.SchemaRuleCommand(
                     change.getBefore(), change.forChangingData(), change.getAdditionalData() ) );
         }
@@ -585,6 +588,7 @@ public class TransactionRecordState implements RecordState
         {
             record.setInUse( false );
         }
+        records.setInUse( false );
     }
 
     public void changeSchemaRule( SchemaRule rule, SchemaRule updatedRule )

--- a/community/kernel/src/test/java/org/neo4j/graphdb/schema/DropBrokenUniquenessConstraintIT.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/schema/DropBrokenUniquenessConstraintIT.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.graphdb.schema;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngine;
+import org.neo4j.kernel.impl.store.SchemaStore;
+import org.neo4j.kernel.impl.store.record.DynamicRecord;
+import org.neo4j.kernel.impl.store.record.IndexRule;
+import org.neo4j.storageengine.api.schema.SchemaRule;
+import org.neo4j.test.rule.DatabaseRule;
+import org.neo4j.test.rule.EmbeddedDatabaseRule;
+
+import static org.junit.Assert.assertFalse;
+
+import static org.neo4j.helpers.collection.Iterators.filter;
+import static org.neo4j.helpers.collection.Iterators.single;
+
+public class DropBrokenUniquenessConstraintIT
+{
+    private final Label label = Label.label( "Label" );
+    private final String key = "key";
+
+    @Rule
+    public final DatabaseRule db = new EmbeddedDatabaseRule();
+
+    @Test
+    public void shouldDropUniquenessConstraintWithBrokenBackingIndex() throws Exception
+    {
+        // given
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.schema().constraintFor( label ).assertPropertyIsUnique( key ).create();
+            tx.success();
+        }
+
+        // when intentionally breaking the schema by setting the backing index rule to unused
+        RecordStorageEngine storageEngine = db.getDependencyResolver().resolveDependency( RecordStorageEngine.class );
+        SchemaStore schemaStore = storageEngine.testAccessNeoStores().getSchemaStore();
+        SchemaRule indexRule = single( filter( rule -> rule instanceof IndexRule, schemaStore.loadAllSchemaRules() ) );
+        setSchemaRecordNotInUse( schemaStore, indexRule.getId() );
+        // At this point the SchemaCache doesn't know about this change so we have to reload it
+        storageEngine.loadSchemaCache();
+        try ( Transaction tx = db.beginTx() )
+        {
+            single( db.schema().getConstraints( label ).iterator() ).drop();
+            tx.success();
+        }
+
+        // then
+        try ( Transaction tx = db.beginTx() )
+        {
+            assertFalse( db.schema().getConstraints().iterator().hasNext() );
+        }
+    }
+
+    private void setSchemaRecordNotInUse( SchemaStore schemaStore, long id )
+    {
+        DynamicRecord record = schemaStore.newRecord();
+        record.setId( id );
+        record.setInUse( false );
+        schemaStore.updateRecord( record );
+    }
+}


### PR DESCRIPTION
Dropping a uniqueness constraint will also drop its backing index rule.
In the event of a broken constraint, where the backing index rule is
missing or somehow broken this drop transaction would fail for that
reason. This commit changes so that such broken uniqueness constraints
can be dropped.