### PR TITLE
Simplify Cypher version page cache stats test

### DIFF
--- a/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionResultTest.java
+++ b/enterprise/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionResultTest.java
@@ -36,6 +36,7 @@ import org.neo4j.test.rule.EnterpriseDatabaseRule;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.IsNull.notNullValue;
@@ -327,26 +328,10 @@ public class ExecutionResultTest
             assertThat( "Mismatching db-hits for version " + version, stats.getDbHits(), equalTo( 2L ) );
             assertThat( "Mismatching rows for version " + version, stats.getRows(), equalTo( 1L ) );
 
-            long expectedPageCacheHits = 2;
-            long expectedPageCacheMisses = 0;
-            double expectedPageCacheRatio = 1.0;
-
-            //These stats are not available in older versions
-            int verAsInt = Integer.parseInt( version.replace( ".", "" ) );
-            if ( verAsInt < 33 )
-            {
-                expectedPageCacheHits = 0;
-                expectedPageCacheMisses = 0;
-                expectedPageCacheRatio = 0.0;
-            }
-            else if ( verAsInt == 33 )
-            {
-                expectedPageCacheHits = 1;
-            }
-
-            assertThat( "Mismatching page cache hits for version " + version, stats.getPageCacheHits(), equalTo( expectedPageCacheHits ) );
-            assertThat( "Mismatching page cache misses for version " + version, stats.getPageCacheMisses(), equalTo( expectedPageCacheMisses ) );
-            assertThat( "Mismatching page cache hit ratio for version " + version, stats.getPageCacheHitRatio(), equalTo( expectedPageCacheRatio ) );
+            //These stats are not available in older versions, but should at least return 0, and >0 for newer
+            assertThat( "Mismatching page cache hits for version " + version, stats.getPageCacheHits(), greaterThanOrEqualTo( 0L ) );
+            assertThat( "Mismatching page cache misses for version " + version, stats.getPageCacheMisses(), greaterThanOrEqualTo( 0L ) );
+            assertThat( "Mismatching page cache hit ratio for version " + version, stats.getPageCacheHitRatio(), greaterThanOrEqualTo( 0.0 ) );
         }
     }
 


### PR DESCRIPTION
When forward merging #10725 I enhanced the one test to handle multiple versions in a way that tests more than the test really should care about. This is a simplification back to the same scope of testing we had in 3.3.