### PR TITLE
Rename setting dbms.logs.timezone to dbms.db.timezone

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/logging/BoltMessageLogging.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/logging/BoltMessageLogging.java
@@ -65,7 +65,7 @@ public class BoltMessageLogging
             {
                 File boltLogFile = config.get( GraphDatabaseSettings.bolt_log_filename );
                 Executor executor = scheduler.executor( JobScheduler.Groups.boltLogRotation );
-                ZoneId logTimeZoneId = config.get( GraphDatabaseSettings.log_timezone ).getZoneId();
+                ZoneId logTimeZoneId = config.get( GraphDatabaseSettings.db_timezone ).getZoneId();
                 return new BoltMessageLog( fs, logTimeZoneId, boltLogFile, executor );
             }
             catch ( Throwable t )

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/CheckConsistencyCommand.java
@@ -182,7 +182,7 @@ public class CheckConsistencyCommand implements AdminCommand
         {
             File storeDir = backupPath.map( Path::toFile ).orElse( config.get( database_path ) );
             checkDbState( storeDir, config );
-            ZoneId logTimeZone = config.get( GraphDatabaseSettings.log_timezone ).getZoneId();
+            ZoneId logTimeZone = config.get( GraphDatabaseSettings.db_timezone ).getZoneId();
             // Only output progress indicator if a console receives the output
             ProgressMonitorFactory progressMonitorFactory = ProgressMonitorFactory.NONE;
             if ( System.console() != null )

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckTool.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckTool.java
@@ -114,7 +114,7 @@ public class ConsistencyCheckTool
 
         checkDbState( storeDir, tuningConfiguration );
 
-        ZoneId logTimeZone = tuningConfiguration.get( GraphDatabaseSettings.log_timezone ).getZoneId();
+        ZoneId logTimeZone = tuningConfiguration.get( GraphDatabaseSettings.db_timezone ).getZoneId();
         LogProvider logProvider = FormattedLogProvider.withZoneId( logTimeZone ).toOutputStream( systemOut );
         try
         {

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckToolTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/ConsistencyCheckToolTest.java
@@ -113,7 +113,7 @@ public class ConsistencyCheckToolTest
             File storeDir = testDirectory.directory();
             File configFile = testDirectory.file( Config.DEFAULT_CONFIG_FILE_NAME );
             Properties properties = new Properties();
-            properties.setProperty( GraphDatabaseSettings.log_timezone.name(), LogTimeZone.SYSTEM.name() );
+            properties.setProperty( GraphDatabaseSettings.db_timezone.name(), LogTimeZone.SYSTEM.name() );
             properties.store( new FileWriter( configFile ), null );
             String[] args = {storeDir.getPath(), "-config", configFile.getPath()};
 

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -366,7 +366,13 @@ public class GraphDatabaseSettings implements LoadableConfig
     public static final Setting<Level> store_internal_log_level = setting( "dbms.logs.debug.level",
             options( Level.class ), "INFO" );
 
+    @Description( "Database timezone." )
+    public static final Setting<LogTimeZone> db_timezone =
+            setting( "dbms.db.timezone", options( LogTimeZone.class ), LogTimeZone.UTC.name() );
+
     @Description( "Database logs timezone." )
+    @Deprecated
+    @ReplacedBy( "dbms.db.timezone" )
     public static final Setting<LogTimeZone> log_timezone =
             setting( "dbms.logs.timezone", options( LogTimeZone.class ), LogTimeZone.UTC.name() );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/GraphDatabaseConfigurationMigrator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/GraphDatabaseConfigurationMigrator.java
@@ -109,5 +109,14 @@ public class GraphDatabaseConfigurationMigrator extends BaseConfigurationMigrato
                 rawConfiguration.put( GraphDatabaseSettings.allow_upgrade.name(), value );
             }
         } );
+        add( new SpecificPropertyMigration( "dbms.logs.timezone",
+                "dbms.logs.timezone has been replaced with dbms.db.timezone." )
+        {
+            @Override
+            public void setValueWithOldSetting( String value, Map<String,String> rawConfiguration )
+            {
+                rawConfiguration.put( GraphDatabaseSettings.db_timezone.name(), value );
+            }
+        } );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/PlatformModule.java
@@ -266,7 +266,7 @@ public class PlatformModule
             builder.withLevel( debugContext, Level.DEBUG );
         }
         builder.withDefaultLevel( config.get( GraphDatabaseSettings.store_internal_log_level ) )
-               .withTimeZone( config.get( GraphDatabaseSettings.log_timezone ).getZoneId() );
+               .withTimeZone( config.get( GraphDatabaseSettings.db_timezone ).getZoneId() );
 
         File logFile = config.get( store_internal_log_path );
         if ( !logFile.getParentFile().exists() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfigurableStandalonePageCacheFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfigurableStandalonePageCacheFactory.java
@@ -67,7 +67,7 @@ public final class ConfigurableStandalonePageCacheFactory
             PageCursorTracerSupplier pageCursorTracerSupplier, Config config )
     {
         config.augmentDefaults( GraphDatabaseSettings.pagecache_memory, "8M" );
-        ZoneId logTimeZone = config.get( GraphDatabaseSettings.log_timezone ).getZoneId();
+        ZoneId logTimeZone = config.get( GraphDatabaseSettings.db_timezone ).getZoneId();
         FormattedLogProvider logProvider = FormattedLogProvider.withZoneId( logTimeZone ).toOutputStream( System.err );
         ConfiguringPageCacheFactory pageCacheFactory = new ConfiguringPageCacheFactory(
                 fileSystem, config, pageCacheTracer, pageCursorTracerSupplier,

--- a/community/kernel/src/test/java/org/neo4j/kernel/configuration/SystemTimeZoneLoggingIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/configuration/SystemTimeZoneLoggingIT.java
@@ -63,7 +63,7 @@ public class SystemTimeZoneLoggingIT
         TimeZone.setDefault( TimeZone.getTimeZone( ZoneOffset.ofHours( hoursShift ) ) );
         File storeDir = testDirectory.directory( String.valueOf( hoursShift ) );
         GraphDatabaseService database = new TestGraphDatabaseFactory().newEmbeddedDatabaseBuilder( storeDir )
-                .setConfig( GraphDatabaseSettings.log_timezone, LogTimeZone.SYSTEM.name() ).newGraphDatabase();
+                .setConfig( GraphDatabaseSettings.db_timezone, LogTimeZone.SYSTEM.name() ).newGraphDatabase();
         database.shutdown();
         Path databasePath = storeDir.toPath();
         Path debugLog = Paths.get( "logs", "debug.log" );

--- a/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
+++ b/community/server/src/main/java/org/neo4j/server/AbstractNeoServer.java
@@ -87,7 +87,7 @@ import org.neo4j.udc.UsageData;
 
 import static java.lang.Math.round;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.neo4j.graphdb.factory.GraphDatabaseSettings.log_timezone;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.db_timezone;
 import static org.neo4j.helpers.collection.Iterables.map;
 import static org.neo4j.scheduler.JobScheduler.Groups.serverTransactionTimeout;
 import static org.neo4j.server.configuration.ServerSettings.http_log_path;
@@ -363,7 +363,7 @@ public abstract class AbstractNeoServer implements NeoServer
 
         AsyncRequestLog requestLog = new AsyncRequestLog(
                 dependencyResolver.resolveDependency( FileSystemAbstraction.class ),
-                config.get( log_timezone ).getZoneId(),
+                config.get( db_timezone ).getZoneId(),
                 config.get( http_log_path ).toString(),
                 config.get( http_logging_rotation_size ),
                 config.get( http_logging_rotation_keep_number ) );

--- a/community/server/src/main/java/org/neo4j/server/ServerBootstrapper.java
+++ b/community/server/src/main/java/org/neo4j/server/ServerBootstrapper.java
@@ -173,7 +173,7 @@ public abstract class ServerBootstrapper implements Bootstrapper
     private static LogProvider setupLogging( Config config )
     {
         LogProvider userLogProvider = FormattedLogProvider.withoutRenderingContext()
-                            .withZoneId( config.get( GraphDatabaseSettings.log_timezone ).getZoneId() )
+                            .withZoneId( config.get( GraphDatabaseSettings.db_timezone ).getZoneId() )
                             .withDefaultLogLevel( config.get( GraphDatabaseSettings.store_internal_log_level ) )
                             .toOutputStream( System.out );
         JULBridge.resetJUL();

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupTool.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupTool.java
@@ -295,7 +295,7 @@ public class BackupTool
 
         try
         {
-            ZoneId logTimeZone = config.get( GraphDatabaseSettings.log_timezone ).getZoneId();
+            ZoneId logTimeZone = config.get( GraphDatabaseSettings.db_timezone ).getZoneId();
             FormattedLogProvider userLogProvider = FormattedLogProvider.withZoneId( logTimeZone ).toOutputStream( System.out );
             return service.resolve( from, args, new SimpleLogService( userLogProvider, NullLogProvider.getInstance() ) );
         }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/ProceduresTimeFormatHelper.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/ProceduresTimeFormatHelper.java
@@ -31,12 +31,10 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class ProceduresTimeFormatHelper
 {
-    public static final ZoneId UTC_ZONE_ID = ZoneId.of( "UTC" );
-
-    static String formatTime( final long startTime )
+    static String formatTime( final long startTime, ZoneId zoneId )
     {
         return OffsetDateTime
-                .ofInstant( Instant.ofEpochMilli( startTime ), UTC_ZONE_ID )
+                .ofInstant( Instant.ofEpochMilli( startTime ), zoneId )
                 .format( ISO_OFFSET_DATE_TIME );
     }
 

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/QueryStatusResult.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/QueryStatusResult.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.enterprise.builtinprocs;
 
+import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,8 +34,8 @@ import org.neo4j.kernel.api.query.ExecutingQuery;
 import org.neo4j.kernel.api.query.QuerySnapshot;
 import org.neo4j.kernel.impl.core.EmbeddedProxySPI;
 import org.neo4j.kernel.impl.query.clientconnection.ClientConnectionInfo;
-import org.neo4j.values.storable.CoordinateReferenceSystem;
 import org.neo4j.kernel.impl.util.BaseToObjectValueWriter;
+import org.neo4j.values.storable.CoordinateReferenceSystem;
 import org.neo4j.values.virtual.MapValue;
 
 import static java.util.Collections.singletonList;
@@ -87,18 +88,18 @@ public class QueryStatusResult
     /** @since Neo4j 3.2 */
     public final long pageFaults;
 
-    QueryStatusResult( ExecutingQuery query, EmbeddedProxySPI manager ) throws InvalidArgumentsException
+    QueryStatusResult( ExecutingQuery query, EmbeddedProxySPI manager, ZoneId zoneId ) throws InvalidArgumentsException
     {
-        this( query.snapshot(), manager );
+        this( query.snapshot(), manager, zoneId );
     }
 
-    private QueryStatusResult( QuerySnapshot query, EmbeddedProxySPI manager ) throws InvalidArgumentsException
+    private QueryStatusResult( QuerySnapshot query, EmbeddedProxySPI manager, ZoneId zoneId ) throws InvalidArgumentsException
     {
         this.queryId = ofInternalId( query.internalQueryId() ).toString();
         this.username = query.username();
         this.query = query.queryText();
         this.parameters = asRawMap( query.queryParameters(), new ParameterWriter( manager ) );
-        this.startTime = formatTime( query.startTimestampMillis() );
+        this.startTime = formatTime( query.startTimestampMillis(), zoneId );
         this.elapsedTimeMillis = query.elapsedTimeMillis();
         this.elapsedTime = formatInterval( elapsedTimeMillis );
         ClientConnectionInfo clientConnection = query.clientConnection();

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/TransactionStatusResult.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/TransactionStatusResult.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.enterprise.builtinprocs;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -66,11 +67,11 @@ public class TransactionStatusResult
 
     public TransactionStatusResult( KernelTransactionHandle transaction,
             TransactionDependenciesResolver transactionDependenciesResolver,
-            Map<KernelTransactionHandle,List<QuerySnapshot>> handleSnapshotsMap ) throws InvalidArgumentsException
+            Map<KernelTransactionHandle,List<QuerySnapshot>> handleSnapshotsMap, ZoneId zoneId ) throws InvalidArgumentsException
     {
         this.transactionId = transaction.getUserTransactionName();
         this.username = transaction.securityContext().subject().username();
-        this.startTime = ProceduresTimeFormatHelper.formatTime( transaction.startTime() );
+        this.startTime = ProceduresTimeFormatHelper.formatTime( transaction.startTime(), zoneId );
         Optional<Status> terminationReason = transaction.terminationReason();
         this.activeLockCount = transaction.activeLocks().count();
         List<QuerySnapshot> querySnapshots = handleSnapshotsMap.get( transaction );

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/TransactionStatusResultTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/TransactionStatusResultTest.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.enterprise.builtinprocs;
 import org.junit.Test;
 
 import java.net.InetSocketAddress;
+import java.time.ZoneId;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -68,9 +69,9 @@ public class TransactionStatusResultTest
     {
         snapshotsMap.put( transactionHandle, singletonList( createQuerySnapshot( 7L ) ) );
         TransactionStatusResult statusResult =
-                new TransactionStatusResult( transactionHandle, blockerResolver, snapshotsMap );
+                new TransactionStatusResult( transactionHandle, blockerResolver, snapshotsMap, ZoneId.of( "UTC" ) );
 
-        checkTransactionStatus( statusResult, "testQuery", "query-7" );
+        checkTransactionStatus( statusResult, "testQuery", "query-7", "1970-01-01T00:00:01.984Z" );
     }
 
     @Test
@@ -78,7 +79,7 @@ public class TransactionStatusResultTest
     {
         snapshotsMap.put( transactionHandle, emptyList() );
         TransactionStatusResult statusResult =
-                new TransactionStatusResult( transactionHandle, blockerResolver, snapshotsMap );
+                new TransactionStatusResult( transactionHandle, blockerResolver, snapshotsMap, ZoneId.of( "UTC" ) );
 
         checkTransactionStatusWithoutQueries( statusResult );
     }
@@ -88,9 +89,19 @@ public class TransactionStatusResultTest
     {
         snapshotsMap.put( transactionHandle, asList( createQuerySnapshot( 7L ), createQuerySnapshot( 8L ) ) );
         TransactionStatusResult statusResult =
-                new TransactionStatusResult( transactionHandle, blockerResolver, snapshotsMap );
+                new TransactionStatusResult( transactionHandle, blockerResolver, snapshotsMap, ZoneId.of( "UTC" ) );
 
-        checkTransactionStatus( statusResult, "testQuery", "query-7" );
+        checkTransactionStatus( statusResult, "testQuery", "query-7", "1970-01-01T00:00:01.984Z" );
+    }
+
+    @Test
+    public void statusOfTransactionWithDifferentTimeZone() throws InvalidArgumentsException
+    {
+        snapshotsMap.put( transactionHandle, singletonList( createQuerySnapshot( 7L ) ) );
+        TransactionStatusResult statusResult =
+                new TransactionStatusResult( transactionHandle, blockerResolver, snapshotsMap, ZoneId.of( "UTC+1" ) );
+
+        checkTransactionStatus( statusResult, "testQuery", "query-7", "1970-01-01T01:00:01.984+01:00" );
     }
 
     private void checkTransactionStatusWithoutQueries( TransactionStatusResult statusResult )
@@ -117,12 +128,12 @@ public class TransactionStatusResultTest
     }
 
     private void checkTransactionStatus( TransactionStatusResult statusResult, String currentQuery,
-            String currentQueryId )
+            String currentQueryId, String startTime )
     {
         assertEquals( "transaction-8", statusResult.transactionId );
         assertEquals( "testUser", statusResult.username );
         assertEquals( Collections.emptyMap(), statusResult.metaData );
-        assertEquals( "1970-01-01T00:00:01.984Z", statusResult.startTime );
+        assertEquals( startTime, statusResult.startTime );
         assertEquals( "https", statusResult.protocol );
         assertEquals( "localhost:1000", statusResult.clientAddress );
         assertEquals( "https://localhost:1001/path", statusResult.requestUri );

--- a/enterprise/management/src/main/java/org/neo4j/management/impl/DiagnosticsBean.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/impl/DiagnosticsBean.java
@@ -91,7 +91,7 @@ public class DiagnosticsBean extends ManagementBeanProvider
         public String dumpAll(  )
         {
             StringWriter stringWriter = new StringWriter();
-            ZoneId zoneId = config.get( GraphDatabaseSettings.log_timezone ).getZoneId();
+            ZoneId zoneId = config.get( GraphDatabaseSettings.db_timezone ).getZoneId();
             FormattedLog.Builder logBuilder = FormattedLog.withZoneId( zoneId );
             diagnostics.dumpAll( logBuilder.toWriter( stringWriter ) );
             return stringWriter.toString();
@@ -101,7 +101,7 @@ public class DiagnosticsBean extends ManagementBeanProvider
         public String extract( String providerId )
         {
             StringWriter stringWriter = new StringWriter();
-            ZoneId zoneId = config.get( GraphDatabaseSettings.log_timezone ).getZoneId();
+            ZoneId zoneId = config.get( GraphDatabaseSettings.db_timezone ).getZoneId();
             FormattedLog.Builder logBuilder = FormattedLog.withZoneId( zoneId );
             diagnostics.extract( providerId, logBuilder.toWriter( stringWriter ) );
             return stringWriter.toString();

--- a/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/DynamicLoggingQueryExecutionMonitor.java
+++ b/enterprise/query-logging/src/main/java/org/neo4j/kernel/impl/query/DynamicLoggingQueryExecutionMonitor.java
@@ -73,7 +73,7 @@ class DynamicLoggingQueryExecutionMonitor implements QueryExecutionMonitor
     synchronized void init() throws IOException
     {
         // This set of settings are currently not dynamic:
-        currentLogTimeZone = config.get( GraphDatabaseSettings.log_timezone ).getZoneId();
+        currentLogTimeZone = config.get( GraphDatabaseSettings.db_timezone ).getZoneId();
         logBuilder = FormattedLog.withZoneId( currentLogTimeZone );
         currentQueryLogFile = config.get( GraphDatabaseSettings.log_queries_filename );
 

--- a/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
+++ b/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
@@ -461,7 +461,7 @@ public class QueryLoggerIT
     {
         GraphDatabaseFacade database =
                 (GraphDatabaseFacade) databaseBuilder.setConfig( log_queries, Settings.TRUE )
-                        .setConfig( GraphDatabaseSettings.log_timezone, LogTimeZone.SYSTEM.name() )
+                        .setConfig( GraphDatabaseSettings.db_timezone, LogTimeZone.SYSTEM.name() )
                         .setConfig( logs_directory, logsDirectory.getPath() )
                         .newGraphDatabase();
         database.execute( QUERY ).close();

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/log/SecurityLog.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/log/SecurityLog.java
@@ -26,8 +26,8 @@ import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.FormattedLog;
@@ -46,7 +46,7 @@ public class SecurityLog extends LifecycleAdapter implements Log
 
     public SecurityLog( Config config, FileSystemAbstraction fileSystem, Executor executor ) throws IOException
     {
-        ZoneId logTimeZoneId = config.get( GraphDatabaseSettings.log_timezone ).getZoneId();
+        ZoneId logTimeZoneId = config.get( GraphDatabaseSettings.db_timezone ).getZoneId();
         File logFile = config.get( SecuritySettings.security_log_filename );
 
         FormattedLog.Builder builder = FormattedLog.withZoneId( logTimeZoneId );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BuiltInProceduresInteractionTestBase.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 
 import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -43,7 +44,6 @@ import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.enterprise.builtinprocs.QueryId;
-import org.neo4j.kernel.impl.api.LockingStatementOperations;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.kernel.impl.newapi.Operations;
@@ -76,7 +76,6 @@ import static org.neo4j.graphdb.security.AuthorizationViolationException.PERMISS
 import static org.neo4j.helpers.collection.Iterables.single;
 import static org.neo4j.helpers.collection.MapUtil.map;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
-import static org.neo4j.kernel.enterprise.builtinprocs.ProceduresTimeFormatHelper.UTC_ZONE_ID;
 import static org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles.PUBLISHER;
 import static org.neo4j.test.assertion.Assert.assertEventually;
 import static org.neo4j.test.matchers.CommonMatchers.matchesOneToOneInAnyOrder;
@@ -275,7 +274,7 @@ public abstract class BuiltInProceduresInteractionTestBase<S> extends ProcedureI
         String listQueriesQuery = "CALL dbms.listQueries()";
 
         DoubleLatch latch = new DoubleLatch( 2 );
-        OffsetDateTime startTime = now( UTC_ZONE_ID );
+        OffsetDateTime startTime = now( ZoneOffset.UTC );
 
         ThreadedTransaction<S> tx = new ThreadedTransaction<>( neo, latch );
         tx.execute( threading, writeSubject, setMetaDataQuery, matchQuery );
@@ -1436,6 +1435,6 @@ public abstract class BuiltInProceduresInteractionTestBase<S> extends ProcedureI
 
     private static OffsetDateTime getStartTime()
     {
-        return ofInstant( Instant.ofEpochMilli( now().toEpochSecond() ), UTC_ZONE_ID );
+        return ofInstant( Instant.ofEpochMilli( now().toEpochSecond() ), ZoneOffset.UTC );
     }
 }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/log/SecurityLogTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/log/SecurityLogTest.java
@@ -91,7 +91,7 @@ public class SecurityLogTest
     private void checkLogTimeZone( int hoursShift, String timeZoneSuffix ) throws Exception
     {
         TimeZone.setDefault( TimeZone.getTimeZone( ZoneOffset.ofHours( hoursShift ) ) );
-        Config timeZoneConfig = Config.defaults( GraphDatabaseSettings.log_timezone, LogTimeZone.SYSTEM.name() );
+        Config timeZoneConfig = Config.defaults( GraphDatabaseSettings.db_timezone, LogTimeZone.SYSTEM.name() );
         SecurityLog securityLog = new SecurityLog( timeZoneConfig, fileSystemRule.get(), Runnable::run );
         securityLog.info( "line 1" );
 

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/ArbiterBootstrapper.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/enterprise/ArbiterBootstrapper.java
@@ -131,7 +131,7 @@ public class ArbiterBootstrapper implements Bootstrapper, AutoCloseable
         File logFile = config.get( store_internal_log_path );
         try
         {
-            ZoneId zoneId = config.get( GraphDatabaseSettings.log_timezone ).getZoneId();
+            ZoneId zoneId = config.get( GraphDatabaseSettings.db_timezone ).getZoneId();
             FormattedLogProvider logProvider = FormattedLogProvider.withZoneId( zoneId ).toOutputStream( System.out );
             return StoreLogService.withUserLogProvider( logProvider )
                     .withInternalLog( logFile )


### PR DESCRIPTION
The setting `dbms.logs.timezone` is renamed to `dbms.db.timezone` and the setting now affects results returned by the `dbms.listQueries` and `dbms.listTransactions` procedures as well.

The setting  `dbms.logs.timezone` will continue to work in 3.4 and be synonymous with `dbms.db.timezone`, before being removed in 4.0