### PR TITLE
Use plain ReentrantLock in IndexSamplingController

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingController.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/sampling/IndexSamplingController.java
@@ -44,7 +44,7 @@ public class IndexSamplingController
     private final JobScheduler scheduler;
     private final RecoveryCondition indexRecoveryCondition;
     private final boolean backgroundSampling;
-    private final Lock samplingLock = new ReentrantLock( true );
+    private final Lock samplingLock = new ReentrantLock();
 
     private JobHandle backgroundSamplingHandle;
 


### PR DESCRIPTION
Previously controller was using fail lock, and there is no reason to do
that so switch to plain ReentrantLock