### PR TITLE
Better reaction to half-initialized GBPTree index file

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
@@ -44,6 +44,7 @@ import org.neo4j.io.pagecache.PagedFile;
 
 import static java.lang.String.format;
 
+import static org.neo4j.helpers.Exceptions.withMessage;
 import static org.neo4j.index.internal.gbptree.Generation.generation;
 import static org.neo4j.index.internal.gbptree.Generation.stableGeneration;
 import static org.neo4j.index.internal.gbptree.Generation.unstableGeneration;
@@ -420,6 +421,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
         setRoot( rootId, Generation.unstableGeneration( generation ) );
         this.layout = layout;
 
+        boolean success = false;
         try
         {
             this.pagedFile = openOrCreate( pageCache, indexFile, tentativePageSize, layout );
@@ -447,19 +449,19 @@ public class GBPTree<KEY,VALUE> implements Closeable
             forceState();
             cleaning = createCleanupJob( needsCleaning );
             recoveryCleanupWorkCollector.add( cleaning );
+            success = true;
         }
         catch ( Throwable t )
         {
             appendTreeInformation( t );
-            try
+            throw t;
+        }
+        finally
+        {
+            if ( !success )
             {
                 close();
             }
-            catch ( Throwable e )
-            {
-                t.addSuppressed( e );
-            }
-            throw t;
         }
     }
 
@@ -511,23 +513,24 @@ public class GBPTree<KEY,VALUE> implements Closeable
         PagedFile pagedFile = pageCache.map( indexFile, pageCache.pageSize() );
         // This index already exists, verify meta data aligns with expectations
 
+        boolean success = false;
         try
         {
             int pageSize = readMeta( layout, pagedFile );
             pagedFile = mapWithCorrectPageSize( pageCache, indexFile, pagedFile, pageSize );
+            success = true;
             return pagedFile;
         }
-        catch ( Throwable t )
+        catch ( IllegalStateException e )
         {
-            try
+            throw new IOException( "Index is not fully initialized since it's missing the meta page", e );
+        }
+        finally
+        {
+            if ( !success )
             {
                 pagedFile.close();
             }
-            catch ( IOException e )
-            {
-                t.addSuppressed( e );
-            }
-            throw t;
         }
     }
 
@@ -552,7 +555,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
 
     private void loadState( PagedFile pagedFile, Header.Reader headerReader ) throws IOException
     {
-        Pair<TreeState,TreeState> states = readStatePages( pagedFile );
+        Pair<TreeState,TreeState> states = loadStatePages( pagedFile );
         TreeState state = TreeStatePair.selectNewestValidState( states );
         try ( PageCursor cursor = pagedFile.io( state.pageId(), PagedFile.PF_SHARED_READ_LOCK ) )
         {
@@ -586,12 +589,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
     {
         try ( PagedFile pagedFile = openExistingIndexFile( pageCache, indexFile, layout ) )
         {
-            Pair<TreeState,TreeState> states = readStatePages( pagedFile );
-            if ( states.getLeft().isEmpty() && states.getRight().isEmpty() )
-            {
-                throw new IllegalStateException( "Both state pages are empty" );
-            }
-
+            Pair<TreeState,TreeState> states = loadStatePages( pagedFile );
             TreeState state = TreeStatePair.selectNewestValidState( states );
             try ( PageCursor cursor = pagedFile.io( state.pageId(), PagedFile.PF_SHARED_READ_LOCK ) )
             {
@@ -599,12 +597,13 @@ public class GBPTree<KEY,VALUE> implements Closeable
                 doReadHeader( headerReader, cursor );
             }
         }
-        catch ( IllegalStateException e )
+        catch ( Throwable t )
         {
-            // Thrown from PageCursorUtil.goTo, meaning that this index hasn't even been properly initialized
-            // and so should be treated as non-existent
-            throw new IOException( format( "GBPTree[file:%s, layout:%s] seems to not be fully initialized since it's missing meta pages",
-                    indexFile, layout ), e );
+            // Decorate outgoing exceptions with basic tree information. This is similar to how the constructor
+            // appends its information, but the constructor has read more information at that point so this one
+            // is a bit more sparse on information.
+            withMessage( t, t.getMessage() + " | " + format( "GBPTree[file:%s, layout:%s]", indexFile, layout ) );
+            throw t;
         }
     }
 
@@ -686,6 +685,31 @@ public class GBPTree<KEY,VALUE> implements Closeable
     private static TreeState other( Pair<TreeState,TreeState> states, TreeState state )
     {
         return states.getLeft() == state ? states.getRight() : states.getLeft();
+    }
+
+    /**
+     * Basically {@link #readStatePages(PagedFile)} with some more checks, suitable for when first opening an index file,
+     * not while running it and check pointing.
+     *
+     * @param pagedFile {@link PagedFile} to read the state pages from.
+     * @return both read state pages.
+     * @throws IOException if state pages are missing (file is smaller than that) or if they are both empty.
+     */
+    private static Pair<TreeState,TreeState> loadStatePages( PagedFile pagedFile ) throws IOException
+    {
+        try
+        {
+            Pair<TreeState,TreeState> states = readStatePages( pagedFile );
+            if ( states.getLeft().isEmpty() && states.getRight().isEmpty() )
+            {
+                throw new IOException( "Index is not fully initialized since its state pages are empty" );
+            }
+            return states;
+        }
+        catch ( IllegalStateException e )
+        {
+            throw new IOException( "Index is not fully initialized since it's missing state pages", e );
+        }
     }
 
     private static Pair<TreeState,TreeState> readStatePages( PagedFile pagedFile ) throws IOException
@@ -959,7 +983,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
 
     private void internalIndexClose() throws IOException
     {
-        if ( !changesSinceLastCheckpoint && !cleaning.needed() )
+        if ( cleaning != null && !changesSinceLastCheckpoint && !cleaning.needed() )
         {
             clean = true;
             forceState();

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeState.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/TreeState.java
@@ -103,7 +103,7 @@ class TreeState
     /**
      * Is tree clean or dirty. Clean means it was closed without any non-checkpointed changes.
      */
-    private boolean clean;
+    private final boolean clean;
 
     TreeState( long pageId, long stableGeneration, long unstableGeneration, long rootId, long rootGeneration,
             long lastId, long freeListWritePageId, long freeListReadPageId, int freeListWritePos, int freeListReadPos,
@@ -233,7 +233,7 @@ class TreeState
         return this;
     }
 
-    private boolean isEmpty()
+    boolean isEmpty()
     {
         return stableGeneration == 0L && unstableGeneration == 0L && rootId == 0L && lastId == 0L &&
                 freeListWritePageId == 0L && freeListReadPageId == 0L && freeListWritePos == 0 && freeListReadPos == 0;

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreePartialCreateFuzzIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreePartialCreateFuzzIT.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index.internal.gbptree;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.neo4j.io.fs.DefaultFileSystemAbstraction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.io.pagecache.impl.SingleFilePageSwapperFactory;
+import org.neo4j.io.pagecache.impl.muninn.MuninnPageCache;
+import org.neo4j.io.pagecache.tracing.PageCacheTracer;
+import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier;
+import org.neo4j.test.rule.PageCacheAndDependenciesRule;
+import org.neo4j.test.rule.fs.DefaultFileSystemRule;
+
+import static org.junit.Assert.assertNotEquals;
+
+import static java.lang.ProcessBuilder.Redirect.INHERIT;
+import static java.util.Arrays.asList;
+import static org.neo4j.graphdb.config.Configuration.EMPTY;
+import static org.neo4j.index.internal.gbptree.GBPTree.NO_HEADER_READER;
+import static org.neo4j.io.ByteUnit.kibiBytes;
+
+/**
+ * Tests functionality around process crashing, or similar, when having started, but not completed creation of an index file,
+ * i.e. opening an index file for the first time.
+ *
+ * This test is an asset in finding potentially new issues regarding partially created index files over time.
+ * It will not guarantee, in one run, that every case has been covered. There are other specific test cases for that.
+ * When this test finds a new issue that should be encoded into a proper unit test in {@link GBPTreeTest} or similar.
+ */
+public class GBPTreePartialCreateFuzzIT
+{
+    @Rule
+    public final PageCacheAndDependenciesRule storage = new PageCacheAndDependenciesRule( DefaultFileSystemRule::new, getClass() );
+
+    @Test
+    public void shouldDetectAndThrowIOExceptionOnPartiallyCreatedFile() throws Exception
+    {
+        // given a crashed-on-open index
+        File file = storage.directory().file( "index" );
+        Process process = new ProcessBuilder( asList( "java", "-cp", System.getProperty( "java.class.path" ), getClass().getName(),
+                file.getAbsolutePath() ) ).redirectError( INHERIT ).redirectOutput( INHERIT ).start();
+        Thread.sleep( ThreadLocalRandom.current().nextInt( 1_000 ) );
+        int exitCode = process.destroyForcibly().waitFor();
+
+        // then reading it should either work or throw IOException
+        try ( PageCache pageCache = storage.pageCache() )
+        {
+            SimpleLongLayout layout = new SimpleLongLayout();
+
+            // check readHeader
+            try
+            {
+                GBPTree.readHeader( pageCache, file, layout, NO_HEADER_READER );
+            }
+            catch ( IOException e )
+            {
+                // It's OK if the process was destroyed
+                assertNotEquals( 0, exitCode );
+            }
+
+            // check constructor
+            try
+            {
+                new GBPTreeBuilder<>( pageCache, file, layout ).build().close();
+            }
+            catch ( IOException e )
+            {
+                // It's OK if the process was destroyed
+                assertNotEquals( 0, exitCode );
+            }
+        }
+    }
+
+    public static void main( String[] args ) throws IOException
+    {
+        // Just start and immediately close. The process spawning this subprocess will kill it in the middle of all this
+        File file = new File( args[0] );
+        try ( FileSystemAbstraction fs = new DefaultFileSystemAbstraction() )
+        {
+            SingleFilePageSwapperFactory swapper = new SingleFilePageSwapperFactory();
+            swapper.open( fs, EMPTY );
+            try ( PageCache pageCache = new MuninnPageCache( swapper, 10, (int) kibiBytes( 8 ),
+                      PageCacheTracer.NULL, PageCursorTracerSupplier.NULL ) )
+            {
+                fs.deleteFile( file );
+                new GBPTreeBuilder<>( pageCache, file, new SimpleLongLayout() ).build().close();
+            }
+        }
+    }
+}


### PR DESCRIPTION
If creation of a GBPTree index file is interrupted mid-way, e.g. by process
crashing or something similar then the index file will exist, but its
meta pages empty or half-initialized. Previously only a missing index file
was interpreted correctly by throwing IOException, such that the layer
immediately above GBPTree would recognized that and rebuild that index or similar,
whereas the other cases of half-initialized meta pages would throw other
types of internal exceptions and not be properly handled by above layer.

This commit improves on this situation to interpret one or more missing or
all-zero meta pages the same way, i.e. by throwing proper IOException.