### PR TITLE
Cleanup accidental Path exposure as a Resource.

### DIFF
--- a/community/graph-algo/src/test/java/common/Neo4jAlgoTestCase.java
+++ b/community/graph-algo/src/test/java/common/Neo4jAlgoTestCase.java
@@ -172,7 +172,6 @@ public abstract class Neo4jAlgoTestCase
                 {
                     unexpectedDefs.add( getPathDef( path ) );
                 }
-                path.close();
             }
         }
         assertTrue( "These unexpected paths were found: " + unexpectedDefs +

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/DijkstraTest.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/DijkstraTest.java
@@ -65,15 +65,12 @@ public class DijkstraTest extends Neo4jAlgoTestCase
 
         // WHEN
         PathFinder<WeightedPath> finder = factory.dijkstra( PathExpanders.allTypesAndDirections() );
-        try ( WeightedPath path = finder.findSinglePath( start, start ) )
-        {
-
-            // THEN
-            assertNotNull( path );
-            assertEquals( start, path.startNode() );
-            assertEquals( start, path.endNode() );
-            assertEquals( 0, path.length() );
-        }
+        WeightedPath path = finder.findSinglePath( start, start );
+        // THEN
+        assertNotNull( path );
+        assertEquals( start, path.startNode() );
+        assertEquals( start, path.endNode() );
+        assertEquals( 0, path.length() );
     }
 
     @Test

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestAStar.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestAStar.java
@@ -63,14 +63,12 @@ public class TestAStar extends Neo4jAlgoTestCase
         Node start = graph.makeNode( "start", "x", 0d, "y", 0d );
 
         // WHEN
-        try ( WeightedPath path = finder.findSinglePath( start, start ) )
-        {
-            // THEN
-            assertNotNull( path );
-            assertEquals( start, path.startNode() );
-            assertEquals( start, path.endNode() );
-            assertEquals( 0, path.length() );
-        }
+        WeightedPath path = finder.findSinglePath( start, start );
+        // THEN
+        assertNotNull( path );
+        assertEquals( start, path.startNode() );
+        assertEquals( start, path.endNode() );
+        assertEquals( 0, path.length() );
     }
 
     @Test
@@ -90,8 +88,6 @@ public class TestAStar extends Neo4jAlgoTestCase
             assertEquals( start, path.endNode() );
             assertEquals( 0, path.length() );
         }
-
-        paths.forEach( Path::close );
     }
 
     @Test
@@ -128,12 +124,9 @@ public class TestAStar extends Neo4jAlgoTestCase
         graph.makeEdge( "e", "end", "length", 2 );
 
         // WHEN
-        try ( WeightedPath path = finder.findSinglePath( start, end ) )
-        {
-
-            // THEN
-            assertPathDef( path, "start", "d", "e", "end" );
-        }
+        WeightedPath path = finder.findSinglePath( start, end );
+        // THEN
+        assertPathDef( path, "start", "d", "e", "end" );
     }
 
     /**
@@ -165,7 +158,6 @@ public class TestAStar extends Neo4jAlgoTestCase
             assertPath( path, nodeA, nodeB, nodeC );
             counter++;
         }
-        allPaths.forEach( Path::close );
         assertEquals( 1, counter );
     }
 
@@ -228,12 +220,10 @@ public class TestAStar extends Neo4jAlgoTestCase
         PathFinder<WeightedPath> traversalFinder = new TraversalAStar( expander,
                 new InitialBranchState.State( initialStateValue, initialStateValue ),
                 doubleCostEvaluator( "length" ), ESTIMATE_EVALUATOR );
-        try ( WeightedPath path = traversalFinder.findSinglePath( nodeA, nodeC ) )
-        {
-            assertEquals( (Double) 5.0D, (Double) path.weight() );
-            assertPathDef( path, "A", "B", "C" );
-            assertEquals( MapUtil.<Node,Double>genericMap( nodeA, 0D, nodeB, 2D ), seenBranchStates );
-        }
+        WeightedPath path = traversalFinder.findSinglePath( nodeA, nodeC );
+        assertEquals( (Double) 5.0D, (Double) path.weight() );
+        assertPathDef( path, "A", "B", "C" );
+        assertEquals( MapUtil.<Node,Double>genericMap( nodeA, 0D, nodeB, 2D ), seenBranchStates );
     }
 
     @Test
@@ -257,11 +247,9 @@ public class TestAStar extends Neo4jAlgoTestCase
         graph.makeEdge( "3", "4", "weight", 0.013d );
 
         // WHEN
-        try ( WeightedPath best1_4 = finder.findSinglePath( node1, node4 ) )
-        {
-            // THEN
-            assertPath( best1_4, node1, node2, node3, node4 );
-        }
+        WeightedPath best1_4 = finder.findSinglePath( node1, node4 );
+        // THEN
+        assertPath( best1_4, node1, node2, node3, node4 );
     }
 
     static EstimateEvaluator<Double> ESTIMATE_EVALUATOR = ( node, goal ) ->

--- a/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestExactDepthPathFinder.java
+++ b/community/graph-algo/src/test/java/org/neo4j/graphalgo/path/TestExactDepthPathFinder.java
@@ -65,11 +65,9 @@ public class TestExactDepthPathFinder extends Neo4jAlgoTestCase
     {
         createGraph();
         PathFinder<Path> finder = newFinder();
-        try ( Path path = finder.findSinglePath( graph.getNode( "SOURCE" ), graph.getNode( "TARGET" ) ) )
-        {
-            assertNotNull( path );
-            assertPathDef( path, "SOURCE", "z", "9", "0", "TARGET" );
-        }
+        Path path = finder.findSinglePath( graph.getNode( "SOURCE" ), graph.getNode( "TARGET" ) );
+        assertNotNull( path );
+        assertPathDef( path, "SOURCE", "z", "9", "0", "TARGET" );
     }
 
     @Test

--- a/community/graphdb-api/src/main/java/org/neo4j/graphdb/Path.java
+++ b/community/graphdb-api/src/main/java/org/neo4j/graphdb/Path.java
@@ -30,7 +30,7 @@ import java.util.Iterator;
  * position of the traverser is represented by each such path. The current
  * node in such a traversal is reached via {@link Path#endNode()}.
  */
-public interface Path extends Iterable<PropertyContainer>, Resource
+public interface Path extends Iterable<PropertyContainer>
 {
     /**
      * Returns the start node of this path. It's also the first node returned
@@ -130,10 +130,4 @@ public interface Path extends Iterable<PropertyContainer>, Resource
      * @see Iterable#iterator()
      */
     Iterator<PropertyContainer> iterator();
-
-    @Override
-    default void close()
-    {
-        // empty
-    }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestPath.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/traversal/TestPath.java
@@ -73,9 +73,9 @@ public class TestPath extends TraversalTestBase
     public void testPathIterator()
     {
         Traverser traverse = getGraphDb().traversalDescription().evaluator( atDepth( 4 ) ).traverse( node( "A" ) );
-        try ( ResourceIterator<Path> resourceIterator = traverse.iterator();
-              Path path = resourceIterator.next() )
+        try ( ResourceIterator<Path> resourceIterator = traverse.iterator() )
         {
+            Path path = resourceIterator.next();
             assertPathIsCorrect( path );
         }
     }
@@ -84,38 +84,30 @@ public class TestPath extends TraversalTestBase
     public void reverseNodes() throws Exception
     {
         Traverser traverse = getGraphDb().traversalDescription().evaluator( atDepth( 0 ) ).traverse( a );
-        try ( Path path = getFirstPath( traverse ) )
-        {
-            assertContains( path.reverseNodes(), a );
-        }
+        Path path = getFirstPath( traverse );
+        assertContains( path.reverseNodes(), a );
 
         Traverser traverse2 = getGraphDb().traversalDescription().evaluator( atDepth( 4 ) ).traverse( a );
-        try ( Path path = getFirstPath( traverse2 ) )
-        {
-            assertContainsInOrder( path.reverseNodes(), e, d, c, b, a );
-        }
+        Path path2 = getFirstPath( traverse2 );
+        assertContainsInOrder( path2.reverseNodes(), e, d, c, b, a );
     }
 
     @Test
     public void reverseRelationships() throws Exception
     {
         Traverser traverser = getGraphDb().traversalDescription().evaluator( atDepth( 0 ) ).traverse( a );
-        try ( Path path = getFirstPath( traverser ) )
-        {
-            assertFalse( path.reverseRelationships().iterator().hasNext() );
-        }
+        Path path = getFirstPath( traverser );
+        assertFalse( path.reverseRelationships().iterator().hasNext() );
 
         Traverser traverser2 = getGraphDb().traversalDescription().evaluator( atDepth( 4 ) ).traverse( a );
-        try ( Path path2 = getFirstPath( traverser2 ) )
+        Path path2 = getFirstPath( traverser2 );
+        Node[] expectedNodes = new Node[]{e, d, c, b, a};
+        int index = 0;
+        for ( Relationship rel : path2.reverseRelationships() )
         {
-            Node[] expectedNodes = new Node[]{e, d, c, b, a};
-            int index = 0;
-            for ( Relationship rel : path2.reverseRelationships() )
-            {
-                assertEquals( "For index " + index, expectedNodes[index++], rel.getEndNode() );
-            }
-            assertEquals( 4, index );
+            assertEquals( "For index " + index, expectedNodes[index++], rel.getEndNode() );
         }
+        assertEquals( 4, index );
     }
 
     @Test
@@ -124,48 +116,34 @@ public class TestPath extends TraversalTestBase
         TraversalDescription side = getGraphDb().traversalDescription().uniqueness( Uniqueness.NODE_PATH );
         BidirectionalTraversalDescription bidirectional =
                 getGraphDb().bidirectionalTraversalDescription().mirroredSides( side );
-        try ( Path bidirectionalPath = getFirstPath( bidirectional.traverse( a, e ) ) )
-        {
-            assertPathIsCorrect( bidirectionalPath );
+        Path bidirectionalPath = getFirstPath( bidirectional.traverse( a, e ) );
+        assertPathIsCorrect( bidirectionalPath );
 
-            try ( Path path = getFirstPath( bidirectional.traverse( a, e ) ) )
-            {
-                Node node = path.startNode();
-                assertEquals( a, node );
-            }
-        }
+        Path path = getFirstPath( bidirectional.traverse( a, e ) );
+        Node node = path.startNode();
+        assertEquals( a, node );
 
         // White box testing below: relationships(), nodes(), reverseRelationships(), reverseNodes()
         // does cache the start node if not already cached, so just make sure they to it properly.
-        try ( Path bidirectionalPath = getFirstPath( bidirectional.traverse( a, e ) ) )
-        {
-            bidirectionalPath.relationships();
-            assertEquals( a, bidirectionalPath.startNode() );
-        }
+        bidirectionalPath = getFirstPath( bidirectional.traverse( a, e ) );
+        bidirectionalPath.relationships();
+        assertEquals( a, bidirectionalPath.startNode() );
 
-        try ( Path bidirectionalPath = getFirstPath(bidirectional.traverse(a,e ) ) )
-        {
-            bidirectionalPath.nodes();
-            assertEquals( a, bidirectionalPath.startNode() );
-        }
+        bidirectionalPath = getFirstPath(bidirectional.traverse(a,e ) );
+        bidirectionalPath.nodes();
+        assertEquals( a, bidirectionalPath.startNode() );
 
-        try ( Path bidirectionalPath = getFirstPath( bidirectional.traverse( a, e ) ) )
-        {
-            bidirectionalPath.reverseRelationships();
-            assertEquals( a, bidirectionalPath.startNode() );
-        }
+        bidirectionalPath = getFirstPath( bidirectional.traverse( a, e ) );
+        bidirectionalPath.reverseRelationships();
+        assertEquals( a, bidirectionalPath.startNode() );
 
-        try ( Path bidirectionalPath = getFirstPath( bidirectional.traverse( a, e ) ) )
-        {
-            bidirectionalPath.reverseNodes();
-            assertEquals( a, bidirectionalPath.startNode() );
-        }
+        bidirectionalPath = getFirstPath( bidirectional.traverse( a, e ) );
+        bidirectionalPath.reverseNodes();
+        assertEquals( a, bidirectionalPath.startNode() );
 
-        try ( Path bidirectionalPath = getFirstPath( bidirectional.traverse( a, e ) ) )
-        {
-            bidirectionalPath.iterator();
-            assertEquals( a, bidirectionalPath.startNode() );
-        }
+        bidirectionalPath = getFirstPath( bidirectional.traverse( a, e ) );
+        bidirectionalPath.iterator();
+        assertEquals( a, bidirectionalPath.startNode() );
     }
 
     private Path getFirstPath( Traverser traverse )

--- a/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseActions.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/DatabaseActions.java
@@ -107,7 +107,6 @@ import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.helpers.collection.Iterables.filter;
 import static org.neo4j.helpers.collection.Iterables.map;
 import static org.neo4j.helpers.collection.Iterators.asList;
-import static org.neo4j.helpers.collection.ResourceClosingIterator.newResourceIterator;
 import static org.neo4j.server.rest.repr.RepresentationType.CONSTRAINT_DEFINITION;
 
 public class DatabaseActions
@@ -1101,12 +1100,6 @@ public class DatabaseActions
             protected Representation underlyingObjectToObject( Path position )
             {
                 return returnType.toRepresentation( position );
-            }
-
-            @Override
-            public Iterator<Representation> iterator()
-            {
-                return newResourceIterator( () -> paths.forEach( Path::close ), super.iterator() );
             }
         };
         return new ListRepresentation( returnType.repType, result );


### PR DESCRIPTION
Even taking into account that this change already have been already
leaked to public, cleaning this up as soon as possible to minimize
future impact.
The current effect should be minimal since path instances were not
treated as resources anywhere, except tests.
Any user code, if that exists, should be fixed by directly implementing
Resource interface if required.