### PR TITLE
Plan OuterHashJoins by using the smaller side to build the hash table

### DIFF
--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/solveOptionalMatches.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/solveOptionalMatches.scala
@@ -45,7 +45,15 @@ case object outerHashJoin extends OptionalSolver {
     if (joinNodes.nonEmpty &&
       joinNodes.forall(lhs.availableSymbols) &&
       joinNodes.forall(optionalQg.patternNodes)) {
-      Some(context.logicalPlanProducer.planOuterHashJoin(joinNodes, lhs, rhs, context))
+
+      // Use the smaller of the two sides to build the hash table
+      val lhsCard = lhs.solved.estimatedCardinality
+      val rhsCard = rhs.solved.estimatedCardinality
+
+      if(lhsCard < rhsCard)
+        Some(context.logicalPlanProducer.planOuterHashJoin(joinNodes, lhs, rhs, context))
+      else
+        Some(context.logicalPlanProducer.planOuterHashJoin(joinNodes, rhs, lhs, context))
     } else {
       None
     }


### PR DESCRIPTION
For NodeHashJoins, this seems to be done already (see joinSolverStep )
but not for outerHashJoins so far.