### PR TITLE
Handle large plans

### DIFF
--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/planner/logical/steps/LogicalPlanProducer.scala
@@ -28,6 +28,7 @@ import org.neo4j.cypher.internal.frontend.v3_4.ast
 import org.neo4j.cypher.internal.frontend.v3_4.ast._
 import org.neo4j.cypher.internal.ir.v3_4._
 import org.neo4j.cypher.internal.util.v3_4.attribution.{Attributes, IdGen}
+import org.neo4j.cypher.internal.util.v3_4.attribution.IdGen
 import org.neo4j.cypher.internal.util.v3_4.{ExhaustiveShortestPathForbiddenException, InternalException}
 import org.neo4j.cypher.internal.v3_4.expressions._
 import org.neo4j.cypher.internal.v3_4.logical.plans.{DeleteExpression => DeleteExpressionPlan, Limit => LimitPlan, LoadCSV => LoadCSVPlan, Skip => SkipPlan, _}
@@ -39,7 +40,7 @@ import org.neo4j.cypher.internal.v3_4.logical.plans.{DeleteExpression => DeleteE
  */
 case class LogicalPlanProducer(cardinalityModel: CardinalityModel, solveds: Solveds, cardinalities: Cardinalities, idGen : IdGen) extends ListSupport {
 
-  implicit val implicitIdGen = idGen
+  implicit val implicitIdGen: IdGen = idGen
 
   def planLock(plan: LogicalPlan, nodesToLock: Set[String], context: LogicalPlanningContext): LogicalPlan =
     annotate(LockNodes(plan, nodesToLock), solveds.get(plan.id), context)

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/procs/ProcedureCallOrSchemaCommandExecutionPlanBuilder.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/executionplan/procs/ProcedureCallOrSchemaCommandExecutionPlanBuilder.scala
@@ -28,8 +28,8 @@ import org.neo4j.cypher.internal.frontend.v3_4.phases.CompilationPhaseTracer.Com
 import org.neo4j.cypher.internal.frontend.v3_4.phases.CompilationPhaseTracer.CompilationPhase.PIPE_BUILDING
 import org.neo4j.cypher.internal.frontend.v3_4.phases.{Condition, Phase}
 import org.neo4j.cypher.internal.planner.v3_4.spi.IndexDescriptor
-import org.neo4j.cypher.internal.runtime.{QueryContext, SCHEMA_WRITE}
 import org.neo4j.cypher.internal.runtime.interpreted.commands.convert.{CommunityExpressionConverter, ExpressionConverters}
+import org.neo4j.cypher.internal.runtime.{QueryContext, SCHEMA_WRITE}
 import org.neo4j.cypher.internal.util.v3_4.{LabelId, PropertyKeyId}
 import org.neo4j.cypher.internal.v3_4.expressions.{LabelName, PropertyKeyName, RelTypeName}
 import org.neo4j.cypher.internal.v3_4.logical.plans._
@@ -125,7 +125,7 @@ case object ProcedureCallOrSchemaCommandExecutionPlanBuilder extends Phase[Commu
           }))
 
         case unknownPlan => Failure(new UnsupportedOperationException(
-          s"Plan is not a procedure Call or schema command: $unknownPlan"))
+          s"Plan is not a procedure Call or schema command: ${unknownPlan.getClass.getSimpleName}"))
       }
     }
 

--- a/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/QueryGraph.scala
+++ b/community/cypher/ir-3.4/src/main/scala/org/neo4j/cypher/internal/ir/v3_4/QueryGraph.scala
@@ -283,6 +283,7 @@ case class QueryGraph(// !!! If you change anything here, make sure to update th
   def joinHints: Set[UsingJoinHint] =
     hints.collect { case hint: UsingJoinHint => hint }
 
+
   private def connectedComponentFor(startNode: String, visited: mutable.Set[String]): QueryGraph = {
     val queue = mutable.Queue(startNode)
     var qg = QueryGraph.empty
@@ -442,7 +443,7 @@ case class QueryGraph(// !!! If you change anything here, make sure to update th
 
   override def canEqual(that: Any): Boolean = that.isInstanceOf[QueryGraph]
 
-  override def hashCode(): Int = {
+  override lazy val hashCode: Int = {
     val optionals = if(optionalMatches.nonEmpty && containsIndependentOptionalMatches)
       optionalMatches.toSet
     else

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/LogicalPlanConverter.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/LogicalPlanConverter.scala
@@ -68,7 +68,7 @@ object LogicalPlanConverter {
     case p: plans.Sort => sortAsCodeGenPlan(p)
 
     case _ =>
-      throw new CantCompileQueryException(s"This logicalPlan is not yet supported: $logicalPlan")
+      throw new CantCompileQueryException(s"This logicalPlan is not yet supported: ${logicalPlan.getClass.getSimpleName}")
   }
 
   private def argumentAsCodeGenPlan(argument: plans.Argument) = new CodeGenPlan with LeafCodeGenPlan {


### PR DESCRIPTION
In 3.4 we have introduced a few new places where we can overflow the stack and a few new inefficiencies which hurts us for big plans.

- `hashCode` for logical plan was overflowing the stack
- we did a full `toString` for the full logical plan when  the "schema" runtime and the compiled runtime decided it couldn't handle the plan. Nice for debugging but it means basically all queries need to generate big string descriptions for each query twice.
- We were keeping a hashMap with logical plans as key that was never used. Computing `equals` on logical plans is quite expensive so we should not do that if we don't really have to.
- We do a lot of hashing of QueryGraph, by memoizing the value we save a lot of time.