### PR TITLE
Make `dbms.tx_log.rotation.*` settings dynamic

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -47,7 +47,6 @@ import org.neo4j.kernel.impl.cache.MonitorGc;
 import org.neo4j.logging.Level;
 import org.neo4j.logging.LogTimeZone;
 
-import static org.neo4j.kernel.configuration.Settings.ANY;
 import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
 import static org.neo4j.kernel.configuration.Settings.BYTES;
 import static org.neo4j.kernel.configuration.Settings.DEFAULT;
@@ -507,13 +506,19 @@ public class GraphDatabaseSettings implements LoadableConfig
             "Can be used for specifying the threshold to prune logical logs after. For example \"10 days\" will " +
             "prune logical logs that only contains transactions older than 10 days from the current time, " +
             "or \"100k txs\" will keep the 100k latest transactions and prune any older transactions." )
-    public static final Setting<String> keep_logical_logs = buildSetting( "dbms.tx_log.rotation.retention_policy",
-            STRING, "7 days" ).constraint( illegalValueMessage( "must be `true`/`false` or " +
-                    "of format '<number><optional unit> <type>' for example `100M size` for " +
-                    "limiting logical log space on disk to 100Mb," +
-                    " or `200k txs` for limiting the number of transactions to keep to 200 000", matches(ANY) ) ).build();
+    @Dynamic
+    public static final Setting<String> keep_logical_logs =
+            buildSetting( "dbms.tx_log.rotation.retention_policy", STRING, "7 days" ).constraint( illegalValueMessage(
+                    "must be `true`, `false` or of format `<number><optional unit> <type>`. " +
+                            "Valid units are `k`, `M` and `G`. " +
+                            "Valid types are `files`, `size`, `txs`, `entries`, `hours` and `days`. " +
+                            "For example, `100M size` will limiting logical log space on disk to 100Mb," +
+                            " or `200k txs` will limiting the number of transactions to keep to 200 000", matches(
+                            "^(true|keep_all|false|keep_none|(\\d+[KkMmGg]?( (files|size|txs|entries|hours|days))))$" ) ) )
+                    .build();
 
     @Description( "Specifies at which file size the logical log will auto-rotate. Minimum accepted value is 1M. " )
+    @Dynamic
     public static final Setting<Long> logical_log_rotation_threshold =
             buildSetting( "dbms.tx_log.rotation.size", BYTES, "250M" ).constraint( min( ByteUnit.mebiBytes( 1 ) ) ).build();
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFile.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFile.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.transaction.log.files;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.OpenMode;
@@ -41,7 +42,7 @@ import org.neo4j.kernel.lifecycle.LifecycleAdapter;
  */
 class TransactionLogFile extends LifecycleAdapter implements LogFile
 {
-    private final long rotateAtSize;
+    private final AtomicLong rotateAtSize;
     private final TransactionLogFiles logFiles;
     private final TransactionLogFilesContext context;
     private final LogVersionBridge readerLogVersionBridge;
@@ -103,7 +104,7 @@ class TransactionLogFile extends LifecycleAdapter implements LogFile
          * Whereas channel.size() should be fine, we're safer calling position() due to possibility
          * of this file being memory mapped or whatever.
          */
-        return channel.position() >= rotateAtSize;
+        return channel.position() >= rotateAtSize.get();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFilesContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFilesContext.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.transaction.log.files;
 
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
@@ -28,7 +29,7 @@ import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
 
 class TransactionLogFilesContext
 {
-    private final long rotationThreshold;
+    private final AtomicLong rotationThreshold;
     private final LogEntryReader logEntryReader;
     private final LongSupplier lastCommittedTransactionIdSupplier;
     private final LongSupplier committingTransactionIdSupplier;
@@ -36,7 +37,7 @@ class TransactionLogFilesContext
     private final LogFileCreationMonitor logFileCreationMonitor;
     private final FileSystemAbstraction fileSystem;
 
-    TransactionLogFilesContext( long rotationThreshold, LogEntryReader logEntryReader,
+    TransactionLogFilesContext( AtomicLong rotationThreshold, LogEntryReader logEntryReader,
             LongSupplier lastCommittedTransactionIdSupplier, LongSupplier committingTransactionIdSupplier,
             LogFileCreationMonitor logFileCreationMonitor, Supplier<LogVersionRepository> logVersionRepositorySupplier,
             FileSystemAbstraction fileSystem )
@@ -50,7 +51,7 @@ class TransactionLogFilesContext
         this.fileSystem = fileSystem;
     }
 
-    long getRotationThreshold()
+    AtomicLong getRotationThreshold()
     {
         return rotationThreshold;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruneStrategyFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruneStrategyFactory.java
@@ -19,9 +19,8 @@
  */
 package org.neo4j.kernel.impl.transaction.log.pruning;
 
-import java.util.stream.LongStream;
-
 import java.time.Clock;
+import java.util.stream.LongStream;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
@@ -49,7 +48,7 @@ public class LogPruneStrategyFactory
         }
     };
 
-    private LogPruneStrategyFactory()
+    public LogPruneStrategyFactory()
     {
     }
 
@@ -67,7 +66,7 @@ public class LogPruneStrategyFactory
      *   <li>1k hours - For keeping last 1000 hours worth of log data</li>
      * </ul>
      */
-    public static LogPruneStrategy fromConfigValue( FileSystemAbstraction fileSystem, LogFiles logFiles,
+    public LogPruneStrategy strategyFromConfigValue( FileSystemAbstraction fileSystem, LogFiles logFiles,
             Clock clock, String configValue )
     {
         ThresholdConfigValue value = parse( configValue );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/ThresholdConfigParser.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/pruning/ThresholdConfigParser.java
@@ -87,8 +87,8 @@ public class ThresholdConfigParser
                 return ThresholdConfigValue.KEEP_LAST_FILE;
             default:
                 throw new IllegalArgumentException( "Invalid log pruning configuration value '" + configValue +
-                        "'. The form is 'all' or '<number><unit> <type>' for example '100k txs' " +
-                        "for the latest 100 000 transactions" );
+                        "'. The form is 'true', 'false' or '<number><unit> <type>'. For example, '100k txs' " +
+                        "will keep the 100 000 latest transactions." );
             }
         }
         else

--- a/community/kernel/src/test/java/org/neo4j/graphdb/factory/GraphDatabaseSettingsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/factory/GraphDatabaseSettingsTest.java
@@ -429,7 +429,7 @@ public class GraphDatabaseSettingsTest
 
         for ( String valid : validSet )
         {
-            Config.defaults( keep_logical_logs, valid );
+            assertEquals( valid, Config.defaults( keep_logical_logs, valid ).get( keep_logical_logs ) );
         }
 
         for ( String invalid : invalidSet )

--- a/community/kernel/src/test/java/org/neo4j/graphdb/factory/GraphDatabaseSettingsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/graphdb/factory/GraphDatabaseSettingsTest.java
@@ -45,6 +45,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.keep_logical_logs;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
 import static org.neo4j.kernel.configuration.HttpConnector.Encryption.TLS;
 
@@ -74,7 +75,7 @@ public class GraphDatabaseSettingsTest
         {
             if ( field.getType() == Setting.class )
             {
-                Setting setting = (Setting) field.get( null );
+                Setting<?> setting = (Setting<?>) field.get( null );
 
                 assertFalse(
                         String.format( "'%s' in %s has already been defined in %s", setting.name(), field.getName(),
@@ -415,5 +416,32 @@ public class GraphDatabaseSettingsTest
         assertEquals( 1, config.enabledHttpConnectors().size() );
         assertEquals( new ListenSocketAddress( "127.0.0.1", 9000 ),
                 config.get( config.enabledHttpConnectors().get( 0 ).listen_address ) );
+    }
+
+    @Test
+    public void validateRetentionPolicy()
+    {
+        String[] validSet =
+                new String[]{"true", "keep_all", "false", "keep_none", "10 files", "10k files", "10K size", "10m txs",
+                        "10M entries", "10g hours", "10G days"};
+
+        String[] invalidSet = new String[]{"invalid", "all", "10", "10k", "10k a"};
+
+        for ( String valid : validSet )
+        {
+            Config.defaults( keep_logical_logs, valid );
+        }
+
+        for ( String invalid : invalidSet )
+        {
+            try
+            {
+                Config.defaults( keep_logical_logs, invalid );
+                fail( "Value \"" + invalid + "\" should be considered invalid" );
+            }
+            catch ( InvalidSettingException ignored )
+            {
+            }
+        }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/files/LogFilesBuilderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/files/LogFilesBuilderTest.java
@@ -73,7 +73,7 @@ public class LogFilesBuilderTest
         assertEquals( fileSystem, context.getFileSystem() );
         assertNotNull( context.getLogEntryReader() );
         assertSame( LogFileCreationMonitor.NO_MONITOR, context.getLogFileCreationMonitor() );
-        assertEquals( Long.MAX_VALUE, context.getRotationThreshold() );
+        assertEquals( Long.MAX_VALUE, context.getRotationThreshold().get() );
         assertEquals( 0, context.getLastCommittedTransactionId() );
         assertEquals( 0, context.getLogVersionRepository().getCurrentLogVersion() );
     }
@@ -95,7 +95,7 @@ public class LogFilesBuilderTest
         assertEquals( fileSystem, context.getFileSystem() );
         assertNotNull( context.getLogEntryReader() );
         assertSame( LogFileCreationMonitor.NO_MONITOR, context.getLogFileCreationMonitor() );
-        assertEquals( ByteUnit.mebiBytes( 250 ), context.getRotationThreshold() );
+        assertEquals( ByteUnit.mebiBytes( 250 ), context.getRotationThreshold().get() );
         assertEquals( 1, context.getLastCommittedTransactionId() );
         assertEquals( 2, context.getLogVersionRepository().getCurrentLogVersion() );
     }
@@ -115,7 +115,7 @@ public class LogFilesBuilderTest
         assertEquals( fileSystem, context.getFileSystem() );
         assertNotNull( context.getLogEntryReader() );
         assertSame( LogFileCreationMonitor.NO_MONITOR, context.getLogFileCreationMonitor() );
-        assertEquals( ByteUnit.mebiBytes( 250 ), context.getRotationThreshold() );
+        assertEquals( ByteUnit.mebiBytes( 250 ), context.getRotationThreshold().get() );
         assertEquals( 1, context.getLastCommittedTransactionId() );
         assertEquals( 2, context.getLogVersionRepository().getCurrentLogVersion() );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruningIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruningIT.java
@@ -44,16 +44,17 @@ import static org.neo4j.graphdb.factory.GraphDatabaseSettings.keep_logical_logs;
 public class LogPruningIT
 {
     @Rule
-    public DatabaseRule db = new EmbeddedDatabaseRule().withSetting( keep_logical_logs, "true" );
+    public final DatabaseRule db = new EmbeddedDatabaseRule().withSetting( keep_logical_logs, "true" );
 
     private final SimpleTriggerInfo triggerInfo = new SimpleTriggerInfo( "forced trigger" );
 
     @Test
     public void pruningStrategyShouldBeDynamic() throws IOException
     {
-        CheckPointer checkPointer = db.getDependencyResolver().resolveDependency( CheckPointer.class );
-        Config config = db.getDependencyResolver().resolveDependency( Config.class );
-        FileSystemAbstraction fs = db.getDependencyResolver().resolveDependency( FileSystemAbstraction.class );
+        CheckPointer checkPointer = getInstanceFromDb( CheckPointer.class );
+        Config config = getInstanceFromDb( Config.class );
+        FileSystemAbstraction fs = getInstanceFromDb( FileSystemAbstraction.class );
+
         LogFiles logFiles = LogFilesBuilder.builder( db.getStoreDir(), fs )
                 .withLogVersionRepository( new SimpleLogVersionRepository() )
                 .withLastCommittedTransactionIdSupplier( () -> 1 )
@@ -104,6 +105,11 @@ public class LogPruningIT
             db.createNode();
             tx.success();
         }
+    }
+
+    private <T> T getInstanceFromDb( Class<T> clazz )
+    {
+        return db.getDependencyResolver().resolveDependency( clazz );
     }
 
     private int countTransactionLogs( LogFiles logFiles )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruningIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruningIT.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.transaction.log.pruning;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.transaction.SimpleLogVersionRepository;
+import org.neo4j.kernel.impl.transaction.SimpleTransactionIdStore;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.CheckPointer;
+import org.neo4j.kernel.impl.transaction.log.checkpoint.SimpleTriggerInfo;
+import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
+import org.neo4j.kernel.impl.transaction.log.files.LogFilesBuilder;
+import org.neo4j.kernel.impl.transaction.log.rotation.LogRotation;
+import org.neo4j.test.rule.DatabaseRule;
+import org.neo4j.test.rule.EmbeddedDatabaseRule;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.keep_logical_logs;
+
+public class LogPruningIT
+{
+    @Rule
+    public DatabaseRule db = new EmbeddedDatabaseRule().withSetting( keep_logical_logs, "true" );
+
+    private final SimpleTriggerInfo triggerInfo = new SimpleTriggerInfo( "forced trigger" );
+
+    @Test
+    public void pruningStrategyShouldBeDynamic() throws IOException
+    {
+        CheckPointer checkPointer = db.getDependencyResolver().resolveDependency( CheckPointer.class );
+        Config config = db.getDependencyResolver().resolveDependency( Config.class );
+        FileSystemAbstraction fs = db.getDependencyResolver().resolveDependency( FileSystemAbstraction.class );
+        LogFiles logFiles = LogFilesBuilder.builder( db.getStoreDir(), fs )
+                .withLogVersionRepository( new SimpleLogVersionRepository() )
+                .withLastCommittedTransactionIdSupplier( () -> 1 )
+                .withTransactionIdStore( new SimpleTransactionIdStore() ).build();
+
+        // Force transaction log rotation
+        writeTransactionsAndRotateTwice();
+
+        // Checkpoint to make sure strategy is evaluated
+        checkPointer.forceCheckPoint( triggerInfo );
+
+        // Make sure file is still there since we have disable pruning
+        assertThat( countTransactionLogs( logFiles ), is( 3 ) );
+
+        // Change pruning to true
+        config.updateDynamicSetting( keep_logical_logs.name(), "false", "test" );
+
+        // Checkpoint to make sure strategy is evaluated
+        checkPointer.forceCheckPoint( triggerInfo );
+
+        // Make sure file is removed
+        assertThat( countTransactionLogs( logFiles ), is( 2 ) );
+    }
+
+    private void writeTransactionsAndRotateTwice() throws IOException
+    {
+        LogRotation logRotation = db.getDependencyResolver().resolveDependency( LogRotation.class );
+        // Apparently we always keep an extra log file what even though the threshold is reached... produce two then
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.createNode();
+            tx.success();
+        }
+        logRotation.rotateLogFile();
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.createNode();
+            tx.success();
+        }
+        logRotation.rotateLogFile();
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.createNode();
+            tx.success();
+        }
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.createNode();
+            tx.success();
+        }
+    }
+
+    private int countTransactionLogs( LogFiles logFiles )
+    {
+        return logFiles.logFiles().length;
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruningTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/log/pruning/LogPruningTest.java
@@ -24,9 +24,11 @@ import org.junit.Test;
 import org.mockito.InOrder;
 
 import java.io.File;
+import java.time.Clock;
 import java.util.stream.LongStream;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
@@ -34,6 +36,8 @@ import org.neo4j.logging.NullLogProvider;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -42,9 +46,12 @@ import static org.mockito.Mockito.when;
 
 public class LogPruningTest
 {
+    private final Config config = Config.defaults();
     private FileSystemAbstraction fs;
     private LogFiles logFiles;
     private LogProvider logProvider;
+    private Clock clock;
+    private LogPruneStrategyFactory factory;
 
     @Before
     public void setUp()
@@ -54,13 +61,16 @@ public class LogPruningTest
         doAnswer( inv -> new File( String.valueOf( inv.getArguments()[0] ) ) )
                 .when( logFiles ).getLogFileForVersion( anyLong() );
         logProvider = NullLogProvider.getInstance();
+        clock = mock( Clock.class );
+        factory = mock( LogPruneStrategyFactory.class );
     }
 
     @Test
     public void mustDeleteLogFilesThatCanBePruned() throws Exception
     {
-        LogPruneStrategy strategy = upTo -> LongStream.range( 3, upTo );
-        LogPruning pruning = new LogPruningImpl( fs, strategy, logFiles, logProvider );
+        when( factory.strategyFromConfigValue( eq( fs ), eq( logFiles ), eq( clock ), anyString() ) )
+                .thenReturn( upTo -> LongStream.range( 3, upTo ) );
+        LogPruning pruning = new LogPruningImpl( fs, logFiles,logProvider,factory, clock, config );
         pruning.pruneLogs( 5 );
         InOrder order = inOrder( fs );
         order.verify( fs ).deleteFile( new File( "3" ) );
@@ -72,17 +82,19 @@ public class LogPruningTest
     @Test
     public void mustHaveLogFilesToPruneIfStrategyFindsFiles() throws Exception
     {
-        LogPruneStrategy strategy = upTo -> LongStream.range( 3, upTo );
+        when( factory.strategyFromConfigValue( eq( fs ), eq( logFiles ), eq( clock ), anyString() ) )
+                .thenReturn(  upTo -> LongStream.range( 3, upTo ) );
         when( logFiles.getHighestLogVersion() ).thenReturn( 4L );
-        LogPruning pruning = new LogPruningImpl( fs, strategy, logFiles, logProvider );
+        LogPruning pruning = new LogPruningImpl( fs, logFiles, logProvider, factory, clock, config );
         assertTrue( pruning.mightHaveLogsToPrune() );
     }
 
     @Test
     public void mustNotHaveLogsFilesToPruneIfStrategyFindsNoFiles() throws Exception
     {
-        LogPruneStrategy strategy = x -> LongStream.empty();
-        LogPruning pruning = new LogPruningImpl( fs, strategy, logFiles, logProvider );
+        when( factory.strategyFromConfigValue( eq( fs ), eq( logFiles ), eq( clock ), anyString() ) )
+                .thenReturn(  x -> LongStream.empty() );
+        LogPruning pruning = new LogPruningImpl( fs, logFiles, logProvider, factory, clock, config );
         assertFalse( pruning.mightHaveLogsToPrune() );
     }
 }


### PR DESCRIPTION
`dbms.tx_log.rotation.retention_policy` and `dbms.tx_log.rotation.size` is now makred as dynamic and can be changed at runtime.

If the retention policy is changed while a logical log pruning is happening, it will take effect the next time the pruning is evaluated, typically after a checkpoint has occurred.