### PR TITLE
Fix bug in NodeOuterHashJoin slot allocation and row creation

### DIFF
--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeHashJoin.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeHashJoin.scala
@@ -36,7 +36,10 @@ import org.neo4j.cypher.internal.util.v3_4.attribution.IdGen
   *   for ( leftRow <- group )
   *     produce (leftRow merge rightRow)
   */
-case class NodeHashJoin(nodes: Set[String], left: LogicalPlan, right: LogicalPlan)(implicit idGen: IdGen) extends LogicalPlan(idGen) with EagerLogicalPlan {
+case class NodeHashJoin(nodes: Set[String],
+                        left: LogicalPlan,
+                        right: LogicalPlan)
+                       (implicit idGen: IdGen) extends LogicalPlan(idGen) with EagerLogicalPlan with NodeJoin {
 
   val lhs = Some(left)
   val rhs = Some(right)

--- a/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeJoin.scala
+++ b/community/cypher/cypher-logical-plans-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/logical/plans/NodeJoin.scala
@@ -19,22 +19,10 @@
  */
 package org.neo4j.cypher.internal.v3_4.logical.plans
 
-import org.neo4j.cypher.internal.util.v3_4.attribution.IdGen
-
 /**
-  * Variant of NodeHashJoin. Also builds a hash table using 'left' and produces merged left and right rows using this
-  * table. In addition, also produces left and right rows with missing key values, and right rows that do not match
-  * in the hash table. In these additional rows, variables from the opposing stream are set to NO_VALUE.
-  *
-  * This is equivalent to an outer join in relational algebra.
+  * Operator which joins lhs and rhs by a set of nodes.
   */
-case class OuterHashJoin(nodes: Set[String],
-                         left: LogicalPlan,
-                         right: LogicalPlan)
-                        (implicit idGen: IdGen) extends LogicalPlan(idGen) with EagerLogicalPlan with NodeJoin {
+trait NodeJoin {
 
-  val lhs = Some(left)
-  val rhs = Some(right)
-
-  val availableSymbols: Set[String] = left.availableSymbols ++ right.availableSymbols
+  def nodes: Set[String]
 }

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
@@ -534,16 +534,15 @@ object SlotAllocation {
         }
         result
 
-      case NodeHashJoin(nodes, _, _) =>
+      case join:NodeJoin => // NodeHashJoin and OuterHashJoin
         // A new pipeline is not strictly needed here unless we have batching/vectorization
         recordArgument(lp)
         val result = lhs.copy()
         rhs.foreachSlotOrdered {
-          case (k, slot) if !nodes(k) =>
+          case (k, slot) if !join.nodes(k) =>
             result.add(k, slot)
-            // If the column is one of the join columns there is no need to add it again
 
-          case _ =>
+          case _ => // If the column is one of the join columns there is no need to add it again
         }
         result
 


### PR DESCRIPTION
Rows need to be created using the `ExecutionContextFactory`, otherwise they do not get the correct slots when mixed in from the slotted runtime.