### PR TITLE
Added a `neo4j-admin memrec` command, which can print recommendations for the Neo4j heap and pagecache memory settings.

### DIFF
--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommand.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.dbms;
+
+import java.util.Locale;
+import java.util.function.ToDoubleFunction;
+
+import org.neo4j.commandline.admin.AdminCommand;
+import org.neo4j.commandline.admin.IncorrectUsage;
+import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.commandline.arguments.Arguments;
+import org.neo4j.commandline.arguments.OptionalNamedArg;
+import org.neo4j.kernel.impl.util.OsBeanUtil;
+
+import static java.lang.String.format;
+import static org.neo4j.configuration.ExternalSettings.initialHeapSize;
+import static org.neo4j.configuration.ExternalSettings.maxHeapSize;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
+import static org.neo4j.io.ByteUnit.ONE_GIBI_BYTE;
+import static org.neo4j.io.ByteUnit.ONE_KIBI_BYTE;
+import static org.neo4j.io.ByteUnit.ONE_MEBI_BYTE;
+import static org.neo4j.io.ByteUnit.gibiBytes;
+import static org.neo4j.io.ByteUnit.mebiBytes;
+import static org.neo4j.io.ByteUnit.tebiBytes;
+import static org.neo4j.kernel.configuration.Settings.BYTES;
+import static org.neo4j.kernel.configuration.Settings.buildSetting;
+
+public class MemoryRecommendationsCommand implements AdminCommand
+{
+    // Fields: {System Memory in GiBs; OS memory reserve in GiBs; JVM Heap memory in GiBs}.
+    // And the page cache gets what's left, though always at least 100 MiB.
+    // Heap never goes beyond 31 GiBs, which is the upper limit for compressed oops.
+    // More details on heap sizing wrt. compressed oops:
+    // https://www.elastic.co/guide/en/elasticsearch/guide/current/heap-sizing.html
+    private static final Bracket[] datapoints = {
+            new Bracket( 0.01, 0.005, 0.005 ),
+            new Bracket( 1.0, 0.5, 0.5 ),
+            new Bracket( 2.0, 1, 0.5 ),
+            new Bracket( 4.0, 1.5, 2 ),
+            new Bracket( 6.0, 2, 3 ),
+            new Bracket( 8.0, 2.5, 3.5 ),
+            new Bracket( 10.0, 3, 4 ),
+            new Bracket( 12.0, 3.5, 4.5 ),
+            new Bracket( 16.0, 4, 5 ),
+            new Bracket( 24.0, 6, 8 ),
+            new Bracket( 32.0, 8, 12 ),
+            new Bracket( 64.0, 12, 24 ),
+            new Bracket( 128.0, 16, 31 ),
+            new Bracket( 256.0, 20, 31 ),
+            new Bracket( 512.0, 24, 31 ),
+            new Bracket( 1024.0, 30, 31 ),
+    };
+    private static final String ARG_MEMORY = "memory";
+    private final OutsideWorld outsideWorld;
+
+    static long recommendOsMemory( long totalMemoryBytes )
+    {
+        Brackets brackets = findMemoryBrackets( totalMemoryBytes );
+        return brackets.recommend( Bracket::osMemory );
+    }
+
+    static long recommendHeapMemory( long totalMemoryBytes )
+    {
+        Brackets brackets = findMemoryBrackets( totalMemoryBytes );
+        return brackets.recommend( Bracket::heapMemory );
+    }
+
+    static long recommendPageCacheMemory( long totalMemoryBytes )
+    {
+        long osMemory = recommendOsMemory( totalMemoryBytes );
+        long heapMemory = recommendHeapMemory( totalMemoryBytes );
+        long recommendation = totalMemoryBytes - osMemory - heapMemory;
+        recommendation = Math.max( mebiBytes( 100 ), recommendation );
+        recommendation = Math.min( tebiBytes( 16 ), recommendation );
+        return recommendation;
+    }
+
+    private static Brackets findMemoryBrackets( long totalMemoryBytes )
+    {
+        double totalMemoryGB = ((double) totalMemoryBytes) / ((double) gibiBytes( 1 ));
+        Bracket lower = null;
+        Bracket upper = null;
+        for ( int i = 1; i < datapoints.length; i++ )
+        {
+            if ( totalMemoryGB < datapoints[i].totalMemory )
+            {
+                lower = datapoints[i - 1];
+                upper = datapoints[i];
+                break;
+            }
+        }
+        if ( lower == null )
+        {
+            lower = datapoints[datapoints.length - 1];
+            upper = datapoints[datapoints.length - 1];
+        }
+        return new Brackets( totalMemoryGB, lower, upper );
+    }
+
+    public static Arguments buildArgs()
+    {
+        long totalPhysicalMemory = OsBeanUtil.getTotalPhysicalMemory();
+        return new Arguments()
+                .withArgument( new OptionalNamedArg( ARG_MEMORY, "8g", bytesToString( totalPhysicalMemory ),
+                        "Recommend memory settings with respect to the given amount of memory, " +
+                        "instead of the total memory of the system running the command." ) );
+    }
+
+    static String bytesToString( long bytes )
+    {
+        if ( bytes > ONE_GIBI_BYTE )
+        {
+            return format( Locale.ROOT, "%.1fg", bytes / (double) ONE_GIBI_BYTE );
+        }
+        else if ( bytes > ONE_MEBI_BYTE )
+        {
+            return format( Locale.ROOT, "%.1fm", bytes / (double) ONE_MEBI_BYTE );
+        }
+        else if ( bytes > ONE_KIBI_BYTE )
+        {
+            return format( Locale.ROOT, "%.0fk", bytes / (double) ONE_KIBI_BYTE );
+        }
+        else
+        {
+            return String.valueOf( bytes );
+        }
+    }
+
+    MemoryRecommendationsCommand( OutsideWorld outsideWorld )
+    {
+        this.outsideWorld = outsideWorld;
+    }
+
+    @Override
+    public void execute( String[] args ) throws IncorrectUsage
+    {
+        Arguments arguments = buildArgs().parse( args );
+
+        String mem = arguments.get( ARG_MEMORY );
+        long memory = buildSetting( ARG_MEMORY, BYTES ).build().apply( arguments::get );
+        String os = bytesToString( recommendOsMemory( memory ) );
+        String heap = bytesToString( recommendHeapMemory( memory ) );
+        String pagecache = bytesToString( recommendPageCacheMemory( memory ) );
+
+        print( "# Memory settings recommendation from neo4j-admin memrec:" );
+        print( "#" );
+        print( "# Assuming the system is dedicated to running Neo4j and has " + mem + " of memory," );
+        print( "# we recommend a heap size of around " + heap + ", and a page cache of around " + pagecache + "," );
+        print( "# and that about " + os + " is left for the operating system, and the native memory" );
+        print( "# needed by Lucene and Netty." );
+        print( "#" );
+        print( "# Tip: If the indexing storage use is high, e.g. there are many indexes or most" );
+        print( "# data indexed, then it might advantageous to leave more memory for the" );
+        print( "# operating system." );
+        print( "#" );
+        print( "# Tip: The more concurrent transactions your workload has and the more updates" );
+        print( "# they do, the more heap memory you will need. However, don't allocate more" );
+        print( "# than 31g of heap, since this will disable pointer compression, also known as" );
+        print( "# \"compressed oops\", in the JVM and make less effective use of the heap." );
+        print( "#" );
+        print( "# Tip: Setting the initial and the max heap size to the same value means the" );
+        print( "# JVM will never need to change the heap size. Changing the heap size otherwise" );
+        print( "# involves a full GC, which is desirable to avoid." );
+        print( "#" );
+        print( "# Based on the above, the following memory settings are recommended:" );
+        print( initialHeapSize.name() + "=" + heap );
+        print( maxHeapSize.name() + "=" + heap );
+        print( pagecache_memory.name() + "=" + pagecache );
+    }
+
+    private void print( String text )
+    {
+        outsideWorld.stdOutLine( text );
+    }
+
+    private static final class Bracket
+    {
+        private final double totalMemory;
+        private final double osMemory;
+        private final double heapMemory;
+
+        private Bracket( double totalMemory, double osMemory, double heapMemory )
+        {
+            this.totalMemory = totalMemory;
+            this.osMemory = osMemory;
+            this.heapMemory = heapMemory;
+        }
+
+        double osMemory()
+        {
+            return osMemory;
+        }
+
+        double heapMemory()
+        {
+            return heapMemory;
+        }
+    }
+
+    private static final class Brackets
+    {
+        private final double totalMemoryGB;
+        private final Bracket lower;
+        private final Bracket upper;
+
+        private Brackets( double totalMemoryGB, Bracket lower, Bracket upper )
+        {
+            this.totalMemoryGB = totalMemoryGB;
+            this.lower = lower;
+            this.upper = upper;
+        }
+
+        private double differenceFactor()
+        {
+            if ( lower == upper )
+            {
+                return 0;
+            }
+            return (totalMemoryGB - lower.totalMemory) / (upper.totalMemory - lower.totalMemory);
+        }
+
+        public long recommend( ToDoubleFunction<Bracket> parameter )
+        {
+            double factor = differenceFactor();
+            double lowerParam = parameter.applyAsDouble( lower );
+            double upperParam = parameter.applyAsDouble( upper );
+            double diff = upperParam - lowerParam;
+            double recommend = lowerParam + (diff * factor);
+            return mebiBytes( (long) (recommend * 1024.0) );
+        }
+    }
+}

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommand.java
@@ -123,19 +123,37 @@ public class MemoryRecommendationsCommand implements AdminCommand
                         "instead of the total memory of the system running the command." ) );
     }
 
-    static String bytesToString( long bytes )
+    static String bytesToString( double bytes )
     {
-        if ( bytes > ONE_GIBI_BYTE )
+        double gibi1 = ONE_GIBI_BYTE;
+        double mebi1 = ONE_MEBI_BYTE;
+        double mebi100 = 100 * mebi1;
+        long kibi100 = 100 * ONE_KIBI_BYTE;
+        if ( bytes >= gibi1 )
         {
-            return format( Locale.ROOT, "%.1fg", bytes / (double) ONE_GIBI_BYTE );
+            double gibibytes = bytes / gibi1;
+            double modMebi = bytes % gibi1;
+            if ( modMebi >= mebi100 )
+            {
+                return format( Locale.ROOT, "%dm", Math.round( bytes / mebi100 ) * 100 );
+            }
+            else
+            {
+                return format( Locale.ROOT, "%.0fg", gibibytes );
+            }
         }
-        else if ( bytes > ONE_MEBI_BYTE )
+        else if ( bytes >= mebi1 )
         {
-            return format( Locale.ROOT, "%.1fm", bytes / (double) ONE_MEBI_BYTE );
-        }
-        else if ( bytes > ONE_KIBI_BYTE )
-        {
-            return format( Locale.ROOT, "%.0fk", bytes / (double) ONE_KIBI_BYTE );
+            double mebibytes = bytes / mebi1;
+            double modKibi = bytes % mebi1;
+            if ( modKibi >= kibi100 )
+            {
+                return format( Locale.ROOT, "%dk", Math.round( bytes / kibi100 ) * 100 );
+            }
+            else
+            {
+                return format( Locale.ROOT, "%.0fm", mebibytes );
+            }
         }
         else
         {

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommand.java
@@ -46,9 +46,7 @@ public class MemoryRecommendationsCommand implements AdminCommand
 {
     // Fields: {System Memory in GiBs; OS memory reserve in GiBs; JVM Heap memory in GiBs}.
     // And the page cache gets what's left, though always at least 100 MiB.
-    // Heap never goes beyond 31 GiBs, which is the upper limit for compressed oops.
-    // More details on heap sizing wrt. compressed oops:
-    // https://www.elastic.co/guide/en/elasticsearch/guide/current/heap-sizing.html
+    // Heap never goes beyond 31 GiBs.
     private static final Bracket[] datapoints = {
             new Bracket( 0.01, 0.005, 0.005 ),
             new Bracket( 1.0, 0.5, 0.5 ),

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommand.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommand.java
@@ -116,9 +116,9 @@ public class MemoryRecommendationsCommand implements AdminCommand
 
     public static Arguments buildArgs()
     {
-        long totalPhysicalMemory = OsBeanUtil.getTotalPhysicalMemory();
+        String memory = bytesToString( OsBeanUtil.getTotalPhysicalMemory() );
         return new Arguments()
-                .withArgument( new OptionalNamedArg( ARG_MEMORY, "8g", bytesToString( totalPhysicalMemory ),
+                .withArgument( new OptionalNamedArg( ARG_MEMORY, memory, memory,
                         "Recommend memory settings with respect to the given amount of memory, " +
                         "instead of the total memory of the system running the command." ) );
     }

--- a/community/dbms/src/main/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommandProvider.java
+++ b/community/dbms/src/main/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommandProvider.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.dbms;
+
+import java.nio.file.Path;
+import javax.annotation.Nonnull;
+
+import org.neo4j.commandline.admin.AdminCommand;
+import org.neo4j.commandline.admin.AdminCommandSection;
+import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.commandline.arguments.Arguments;
+
+import static java.lang.String.format;
+
+public class MemoryRecommendationsCommandProvider extends AdminCommand.Provider
+{
+    public MemoryRecommendationsCommandProvider()
+    {
+        super( "memrec" );
+    }
+
+    @Nonnull
+    @Override
+    public Arguments allArguments()
+    {
+        return MemoryRecommendationsCommand.buildArgs();
+    }
+
+    @Nonnull
+    @Override
+    public String summary()
+    {
+        return "Print Neo4j heap and pagecache memory settings recommendations.";
+    }
+
+    @Nonnull
+    @Override
+    public AdminCommandSection commandSection()
+    {
+        return AdminCommandSection.general();
+    }
+
+    @Nonnull
+    @Override
+    public String description()
+    {
+        return format(
+                "Print heuristic memory setting recommendations for the Neo4j JVM heap and pagecache. The " +
+                "heuristic is based on the total memory of the system the command is running on, or on the amount of " +
+                "memory specified with the --memory argument. The heuristic assumes that the system is dedicated to " +
+                "running Neo4j. If this is not the case, then use the --memory argument to specify how much memory " +
+                "can be expected to be dedicated to Neo4j.%n" +
+                "%n" +
+                "The output is formatted such that it can be copy-posted into the neo4j.conf file." );
+    }
+
+    @Nonnull
+    @Override
+    public AdminCommand create( Path homeDir, Path configDir, OutsideWorld outsideWorld )
+    {
+        return new MemoryRecommendationsCommand( outsideWorld );
+    }
+}

--- a/community/dbms/src/main/resources/META-INF/services/org.neo4j.commandline.admin.AdminCommand$Provider
+++ b/community/dbms/src/main/resources/META-INF/services/org.neo4j.commandline.admin.AdminCommand$Provider
@@ -2,3 +2,4 @@ org.neo4j.commandline.dbms.ImportCommandProvider
 org.neo4j.commandline.dbms.DumpCommandProvider
 org.neo4j.commandline.dbms.LoadCommandProvider
 org.neo4j.commandline.dbms.StoreInfoCommandProvider
+org.neo4j.commandline.dbms.MemoryRecommendationsCommandProvider

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/MemoryRecommendationsCommandTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.commandline.dbms;
+
+import org.hamcrest.Matcher;
+import org.junit.Test;
+
+import java.io.StringReader;
+import java.util.Map;
+
+import org.neo4j.commandline.admin.OutsideWorld;
+import org.neo4j.commandline.admin.RealOutsideWorld;
+import org.neo4j.helpers.collection.MapUtil;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThat;
+import static org.neo4j.commandline.dbms.MemoryRecommendationsCommand.bytesToString;
+import static org.neo4j.commandline.dbms.MemoryRecommendationsCommand.recommendHeapMemory;
+import static org.neo4j.commandline.dbms.MemoryRecommendationsCommand.recommendOsMemory;
+import static org.neo4j.commandline.dbms.MemoryRecommendationsCommand.recommendPageCacheMemory;
+import static org.neo4j.configuration.ExternalSettings.initialHeapSize;
+import static org.neo4j.configuration.ExternalSettings.maxHeapSize;
+import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
+import static org.neo4j.io.ByteUnit.exbiBytes;
+import static org.neo4j.io.ByteUnit.gibiBytes;
+import static org.neo4j.io.ByteUnit.mebiBytes;
+import static org.neo4j.io.ByteUnit.tebiBytes;
+
+public class MemoryRecommendationsCommandTest
+{
+    @Test
+    public void mustRecommendOSMemory()
+    {
+        assertThat( recommendOsMemory( mebiBytes( 100 ) ), between( mebiBytes( 45 ), mebiBytes( 55 ) ) );
+        assertThat( recommendOsMemory( gibiBytes( 1 ) ), between( mebiBytes( 450 ), mebiBytes( 550 ) ) );
+        assertThat( recommendOsMemory( gibiBytes( 3 ) ), between( mebiBytes( 1256 ), mebiBytes( 1356 ) ) );
+        assertThat( recommendOsMemory( gibiBytes( 192 ) ), between( gibiBytes( 17 ), gibiBytes( 19 ) ) );
+        assertThat( recommendOsMemory( gibiBytes( 1920 ) ), greaterThan( gibiBytes( 29 ) ) );
+    }
+
+    @Test
+    public void mustRecommendHeapMemory()
+    {
+        assertThat( recommendHeapMemory( mebiBytes( 100 ) ), between( mebiBytes( 45 ), mebiBytes( 55 ) ) );
+        assertThat( recommendHeapMemory( gibiBytes( 1 ) ), between( mebiBytes( 450 ), mebiBytes( 550 ) ) );
+        assertThat( recommendHeapMemory( gibiBytes( 3 ) ), between( mebiBytes( 1256 ), mebiBytes( 1356 ) ) );
+        assertThat( recommendHeapMemory( gibiBytes( 6 ) ), between( mebiBytes( 3000 ), mebiBytes( 3200 ) ) );
+        assertThat( recommendHeapMemory( gibiBytes( 192 ) ), between( gibiBytes( 30 ), gibiBytes( 32 ) ) );
+        assertThat( recommendHeapMemory( gibiBytes( 1920 ) ), between( gibiBytes( 30 ), gibiBytes( 32 ) ) );
+    }
+
+    @Test
+    public void mustRecommendPageCacheMemory()
+    {
+        assertThat( recommendPageCacheMemory( mebiBytes( 100 ) ), between( mebiBytes( 95 ), mebiBytes( 105 ) ) );
+        assertThat( recommendPageCacheMemory( gibiBytes( 1 ) ), between( mebiBytes( 95 ), mebiBytes( 105 ) ) );
+        assertThat( recommendPageCacheMemory( gibiBytes( 3 ) ), between( mebiBytes( 470 ), mebiBytes( 530 ) ) );
+        assertThat( recommendPageCacheMemory( gibiBytes( 6 ) ), between( mebiBytes( 980 ), mebiBytes( 1048 ) ) );
+        assertThat( recommendPageCacheMemory( gibiBytes( 192 ) ), between( gibiBytes( 140 ), gibiBytes( 150 ) ) );
+        assertThat( recommendPageCacheMemory( gibiBytes( 1920 ) ), between( gibiBytes( 1850 ), gibiBytes( 1900 ) ) );
+
+        // Also never recommend more than 16 TiB of page cache memory, regardless of how much is available.
+        assertThat( recommendPageCacheMemory( exbiBytes( 1 ) ), lessThan( tebiBytes( 17 ) ) );
+    }
+
+    private Matcher<Long> between( long lowerBound, long upperBound )
+    {
+        return allOf( greaterThan( lowerBound ), lessThan( upperBound ) );
+    }
+
+    @Test
+    public void mustPrintRecommendationsAsConfigReadableOutput() throws Exception
+    {
+        StringBuilder output = new StringBuilder();
+        OutsideWorld outsideWorld = new RealOutsideWorld()
+        {
+            @Override
+            public void stdOutLine( String text )
+            {
+                output.append( text ).append( System.lineSeparator() );
+            }
+        };
+        MemoryRecommendationsCommand command = new MemoryRecommendationsCommand( outsideWorld );
+        String heap = bytesToString( recommendHeapMemory( gibiBytes( 8 ) ) );
+        String pagecache = bytesToString( recommendPageCacheMemory( gibiBytes( 8 ) ) );
+
+        command.execute( new String[]{"--memory=8g"} );
+
+        Map<String,String> stringMap = MapUtil.load( new StringReader( output.toString() ) );
+        assertThat( stringMap.get( initialHeapSize.name() ), is( heap ) );
+        assertThat( stringMap.get( maxHeapSize.name() ), is( heap ) );
+        assertThat( stringMap.get( pagecache_memory.name() ), is( pagecache ) );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfiguringPageCacheFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfiguringPageCacheFactory.java
@@ -92,13 +92,6 @@ public class ConfiguringPageCacheFactory
     {
         Long pageCacheMemorySetting = config.get( pagecache_memory );
         long pageCacheMemory = interpretMemorySetting( pageCacheMemorySetting );
-        long maxHeap = Runtime.getRuntime().maxMemory();
-        if ( pageCacheMemory / maxHeap > 100 )
-        {
-            log.warn( "The memory configuration looks unbalanced. It is generally recommended to have at least " +
-                      "10 KiB of heap memory, for every 1 MiB of page cache memory. The current configuration is " +
-                      "allocating %s bytes for the page cache, and %s bytes for the heap.", pageCacheMemory, maxHeap );
-        }
         long pageCount = pageCacheMemory / cachePageSize;
         return (int) Math.min( Integer.MAX_VALUE - 2000, pageCount );
     }
@@ -112,7 +105,8 @@ public class ConfiguringPageCacheFactory
         long heuristic = defaultHeuristicPageCacheMemory();
         log.warn( "The " + pagecache_memory.name() + " setting has not been configured. It is recommended that this " +
                   "setting is always explicitly configured, to ensure the system has a balanced configuration. " +
-                  "Until then, a computed heuristic value of " + heuristic + " bytes will be used instead. " );
+                  "Until then, a computed heuristic value of " + heuristic + " bytes will be used instead. " +
+                  "Run `neo4j-admin memrec` for memory configuration suggestions." );
         return heuristic;
     }
 

--- a/integrationtests/src/test/java/org/neo4j/commandline/admin/Neo4jAdminUsageTest.java
+++ b/integrationtests/src/test/java/org/neo4j/commandline/admin/Neo4jAdminUsageTest.java
@@ -58,6 +58,8 @@ public class Neo4jAdminUsageTest
                         "        Check the consistency of a database.\n" +
                         "    import\n" +
                         "        Import from a collection of CSV files or a pre-3.0 database.\n" +
+                        "    memrec\n" +
+                        "        Print Neo4j heap and pagecache memory settings recommendations.\n" +
                         "    store-info\n" +
                         "        Prints information about a Neo4j database store.\n" +
                         "\n" +


### PR DESCRIPTION
This is an initial stab at having automated recommendations for the Neo4j memory settings.

It looks like this:

```
$ bin/neo4j-admin help
usage: neo4j-admin <command>

Manage your Neo4j instance.

environment variables:
    NEO4J_CONF    Path to directory which contains neo4j.conf.
    NEO4J_DEBUG   Set to anything to enable debug output.
    NEO4J_HOME    Neo4j home directory.
    HEAP_SIZE     Set size of JVM heap during command execution.
                  Takes a number and a unit, for example 512m.

available commands:

General
    check-consistency
        Check the consistency of a database.
    help
        This help text, or help for the command specified in <command>.
    import
        Import from a collection of CSV files or a pre-3.0 database.
    memrec
        Print Neo4j heap and pagecache memory settings recommendations.
    store-info
        Prints information about a Neo4j database store.

Authentication
    set-default-admin
        Sets the default admin user when no roles are present.
    set-initial-password
        Sets the initial password of the initial admin user ('neo4j').

Offline backup
    dump
        Dump a database into a single-file archive.
    load
        Load a database from an archive created with the dump command.

Use neo4j-admin help <command> for more details.
```

And

```
$ bin/neo4j-admin help memrec
usage: neo4j-admin memrec [--memory=<16g>]

environment variables:
    NEO4J_CONF    Path to directory which contains neo4j.conf.
    NEO4J_DEBUG   Set to anything to enable debug output.
    NEO4J_HOME    Neo4j home directory.
    HEAP_SIZE     Set size of JVM heap during command execution.
                  Takes a number and a unit, for example 512m.

Print heuristic memory setting recommendations for the Neo4j JVM heap and
pagecache. The heuristic is based on the total memory of the system the command
is running on, or on the amount of memory specified with the --memory argument.
The heuristic assumes that the system is dedicated to running Neo4j. If this is
not the case, then use the --memory argument to specify how much memory can be
expected to be dedicated to Neo4j.

The output is formatted such that it can be copy-posted into the neo4j.conf
file.

options:
  --memory=<16g>   Recommend memory settings with respect to the given amount of
                  memory, instead of the total memory of the system running the
                  command. [default:16g]
```

And

```
$ bin/neo4j-admin memrec --memory 12g
# Memory settings recommendation from neo4j-admin memrec:
#
# Assuming the system is dedicated to running Neo4j and has 12g of memory,
# we recommend a heap size of around 4600m, and a page cache of around 4g,
# and that about 3600m is left for the operating system, and the native memory
# needed by Lucene and Netty.
#
# Tip: If the indexing storage use is high, e.g. there are many indexes or most
# data indexed, then it might advantageous to leave more memory for the
# operating system.
#
# Tip: The more concurrent transactions your workload has and the more updates
# they do, the more heap memory you will need. However, don't allocate more
# than 31g of heap, since this will disable pointer compression, also known as
# "compressed oops", in the JVM and make less effective use of the heap.
#
# Tip: Setting the initial and the max heap size to the same value means the
# JVM will never need to change the heap size. Changing the heap size otherwise
# involves a full GC, which is desirable to avoid.
#
# Based on the above, the following memory settings are recommended:
dbms.memory.heap.initial_size=4600m
dbms.memory.heap.max_size=4600m
dbms.memory.pagecache.size=4g
```