### PR TITLE
Remove unused QueryState.queryId and PipeMonitor

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/BuildInterpretedExecutionPlan.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/BuildInterpretedExecutionPlan.scala
@@ -91,7 +91,7 @@ object BuildInterpretedExecutionPlan extends Phase[CompilerContext, CompilationS
       if (profiling)
         builder.setPipeDecorator(new Profiler(queryContext.transactionalContext.databaseInfo))
 
-      builder.build(queryId, planType, params, notificationLogger)
+      builder.build(planType, params, notificationLogger)
     }
 
   /**

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/DefaultExecutionResultBuilderFactory.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/DefaultExecutionResultBuilderFactory.scala
@@ -65,9 +65,9 @@ case class DefaultExecutionResultBuilderFactory(pipeInfo: PipeInfo,
       exceptionDecorator = newDecorator
     }
 
-    def build(queryId: AnyRef, planType: ExecutionMode, params: Map[String, Any], notificationLogger: InternalNotificationLogger): InternalExecutionResult = {
+    def build(planType: ExecutionMode, params: Map[String, Any], notificationLogger: InternalNotificationLogger): InternalExecutionResult = {
       taskCloser.addTask(queryContext.transactionalContext.close)
-      val state = new QueryState(queryContext, externalResource, params, pipeDecorator, queryId = queryId,
+      val state = new QueryState(queryContext, externalResource, params, pipeDecorator,
                                  triadicState = mutable.Map.empty, repeatableReads = mutable.Map.empty,
                                  typeConverter = typeConverter)
       try {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/ExecutionResultBuilder.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/ExecutionResultBuilder.scala
@@ -30,7 +30,7 @@ trait ExecutionResultBuilder {
   def setLoadCsvPeriodicCommitObserver(batchRowCount: Long)
   def setPipeDecorator(newDecorator: PipeDecorator)
   def setExceptionDecorator(newDecorator: CypherException => CypherException)
-  def build(queryId: AnyRef, planType: ExecutionMode, params: Map[String, Any], notificationLogger: InternalNotificationLogger): InternalExecutionResult
+  def build(planType: ExecutionMode, params: Map[String, Any], notificationLogger: InternalNotificationLogger): InternalExecutionResult
 }
 
 trait ExecutionResultBuilderFactory {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/AllNodesScanPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/AllNodesScanPipe.scala
@@ -22,13 +22,10 @@ package org.neo4j.cypher.internal.compiler.v3_2.pipes
 import org.neo4j.cypher.internal.compiler.v3_2.ExecutionContext
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
-case class AllNodesScanPipe(ident: String)(val id: Id = new Id)
-                           (implicit pipeMonitor: PipeMonitor) extends Pipe {
+case class AllNodesScanPipe(ident: String)(val id: Id = new Id) extends Pipe {
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
     val baseContext = state.createOrGetInitialContext()
     state.query.nodeOps.all.map(n => baseContext.newWith1(ident, n))
   }
-
-  override def monitor = pipeMonitor
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ApplyPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ApplyPipe.scala
@@ -22,8 +22,7 @@ package org.neo4j.cypher.internal.compiler.v3_2.pipes
 import org.neo4j.cypher.internal.compiler.v3_2.ExecutionContext
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
-case class ApplyPipe(source: Pipe, inner: Pipe)(val id: Id = new Id)
-                    (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) {
+case class ApplyPipe(source: Pipe, inner: Pipe)(val id: Id = new Id) extends PipeWithSource(source) {
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] =
     input.flatMap {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ArgumentPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ArgumentPipe.scala
@@ -22,9 +22,7 @@ package org.neo4j.cypher.internal.compiler.v3_2.pipes
 import org.neo4j.cypher.internal.compiler.v3_2.ExecutionContext
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
-case class ArgumentPipe()
-                       (val id: Id = new Id)
-                       (implicit val monitor: PipeMonitor) extends Pipe {
+case class ArgumentPipe()(val id: Id = new Id) extends Pipe {
   def internalCreateResults(state: QueryState): Iterator[ExecutionContext] =
     Iterator(state.initialContext.get)
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/AssertSameNodePipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/AssertSameNodePipe.scala
@@ -26,8 +26,8 @@ import org.neo4j.cypher.internal.frontend.v3_2.MergeConstraintConflictException
 import org.neo4j.graphdb.Node
 
 case class AssertSameNodePipe(source: Pipe, inner: Pipe, node: String)
-                             (val id: Id = new Id)(implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(source, pipeMonitor) {
+                             (val id: Id = new Id)
+  extends PipeWithSource(source) {
 
   protected def internalCreateResults(lhsResult: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     val rhsResults = inner.createResults(state)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/CartesianProductPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/CartesianProductPipe.scala
@@ -23,13 +23,10 @@ import org.neo4j.cypher.internal.compiler.v3_2.ExecutionContext
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
 case class CartesianProductPipe(lhs: Pipe, rhs: Pipe)
-                               (val id: Id = new Id)
-                               (implicit pipeMonitor: PipeMonitor) extends Pipe {
+                               (val id: Id = new Id) extends Pipe {
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
     for (outer <- lhs.createResults(state);
          inner <- rhs.createResults(state))
       yield outer ++ inner
   }
-
-  def monitor: PipeMonitor = pipeMonitor
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ConditionalApplyPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ConditionalApplyPipe.scala
@@ -23,8 +23,8 @@ import org.neo4j.cypher.internal.compiler.v3_2.ExecutionContext
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
 case class ConditionalApplyPipe(source: Pipe, inner: Pipe, items: Seq[String], negated: Boolean)
-                               (val id: Id = new Id)(implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(source, pipeMonitor) {
+                               (val id: Id = new Id)
+  extends PipeWithSource(source) {
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] =
     input.flatMap {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ConstraintOperationPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ConstraintOperationPipe.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 import org.neo4j.cypher.internal.compiler.v3_2.IndexDescriptor
 
 class ConstraintOperationPipe(op: PropertyConstraintOperation, keyToken: KeyToken, propertyKey: KeyToken)
-                             (val id: Id = new Id)(implicit val monitor: PipeMonitor) extends Pipe {
+                             (val id: Id = new Id) extends Pipe {
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
     val keyTokenId = keyToken.getOrCreateId(state.query)
     val propertyKeyId = propertyKey.getOrCreateId(state.query)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/CreateNodePipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/CreateNodePipe.scala
@@ -30,8 +30,8 @@ import org.neo4j.graphdb.{Node, Relationship}
 
 import scala.collection.Map
 
-abstract class BaseCreateNodePipe(src: Pipe, key: String, labels: Seq[LazyLabel], properties: Option[Expression], pipeMonitor: PipeMonitor)
-  extends PipeWithSource(src, pipeMonitor) with GraphElementPropertyFunctions with ListSupport {
+abstract class BaseCreateNodePipe(src: Pipe, key: String, labels: Seq[LazyLabel], properties: Option[Expression])
+  extends PipeWithSource(src) with GraphElementPropertyFunctions with ListSupport {
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] =
     input.map(createNode(_, state))
@@ -78,8 +78,7 @@ abstract class BaseCreateNodePipe(src: Pipe, key: String, labels: Seq[LazyLabel]
 }
 
 case class CreateNodePipe(src: Pipe, key: String, labels: Seq[LazyLabel], properties: Option[Expression])
-                         (val id: Id = new Id)
-                         (implicit pipeMonitor: PipeMonitor) extends BaseCreateNodePipe(src, key, labels, properties, pipeMonitor) {
+                         (val id: Id = new Id) extends BaseCreateNodePipe(src, key, labels, properties) {
 
   override protected def handleNull(key: String) {
     // do nothing
@@ -87,8 +86,7 @@ case class CreateNodePipe(src: Pipe, key: String, labels: Seq[LazyLabel], proper
 }
 
 case class MergeCreateNodePipe(src: Pipe, key: String, labels: Seq[LazyLabel], properties: Option[Expression])
-                              (val id: Id = new Id)
-                         (implicit pipeMonitor: PipeMonitor) extends BaseCreateNodePipe(src, key, labels, properties, pipeMonitor) {
+                              (val id: Id = new Id) extends BaseCreateNodePipe(src, key, labels, properties) {
   override protected def handleNull(key: String) {
     //merge cannot use null properties, since in that case the match part will not find the result of the create
     throw new InvalidSemanticsException(s"Cannot merge node using null property value for $key")

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/CreateRelationshipPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/CreateRelationshipPipe.scala
@@ -31,8 +31,8 @@ import org.neo4j.graphdb.{Node, Relationship}
 import scala.collection.Map
 
 abstract class BaseRelationshipPipe(src: Pipe, key: String, startNode: String, typ: LazyType, endNode: String,
-                                    properties: Option[Expression], pipeMonitor: PipeMonitor)
-  extends PipeWithSource(src, pipeMonitor) with GraphElementPropertyFunctions with ListSupport {
+                                    properties: Option[Expression])
+  extends PipeWithSource(src) with GraphElementPropertyFunctions with ListSupport {
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] =
     input.map(createRelationship(_, state))
@@ -85,8 +85,7 @@ case class CreateRelationshipPipe(src: Pipe,
                                   key: String, startNode: String, typ: LazyType, endNode: String,
                                   properties: Option[Expression])
                                  (val id: Id = new Id)
-                                 (implicit pipeMonitor: PipeMonitor)
-  extends BaseRelationshipPipe(src, key, startNode, typ, endNode, properties, pipeMonitor) {
+  extends BaseRelationshipPipe(src, key, startNode, typ, endNode, properties) {
   override protected def handleNull(key: String) {
     //do nothing
   }
@@ -95,8 +94,7 @@ case class CreateRelationshipPipe(src: Pipe,
 case class MergeCreateRelationshipPipe(src: Pipe, key: String, startNode: String, typ: LazyType, endNode: String,
                                        properties: Option[Expression])
                                       (val id: Id = new Id)
-                                      (implicit pipeMonitor: PipeMonitor)
-  extends BaseRelationshipPipe(src, key, startNode, typ, endNode, properties, pipeMonitor) {
+  extends BaseRelationshipPipe(src, key, startNode, typ, endNode, properties) {
 
   override protected def handleNull(key: String) {
     //merge cannot use null properties, since in that case the match part will not find the result of the create

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/DeletePipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/DeletePipe.scala
@@ -31,8 +31,7 @@ import scala.collection.JavaConverters._
 
 case class DeletePipe(src: Pipe, expression: Expression, forced: Boolean)
                      (val id: Id = new Id)
-                     (implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(src, pipeMonitor) with GraphElementPropertyFunctions with ListSupport {
+  extends PipeWithSource(src) with GraphElementPropertyFunctions with ListSupport {
 
   override protected def internalCreateResults(input: Iterator[ExecutionContext],
                                                state: QueryState): Iterator[ExecutionContext] = {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/DirectedRelationshipByIdSeekPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/DirectedRelationshipByIdSeekPipe.scala
@@ -25,7 +25,6 @@ import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
 case class DirectedRelationshipByIdSeekPipe(ident: String, relIdExpr: SeekArgs, toNode: String, fromNode: String)
                                            (val id: Id = new Id)
-                                           (implicit pipeMonitor: PipeMonitor)
   extends Pipe
   with ListSupport {
 
@@ -36,6 +35,4 @@ case class DirectedRelationshipByIdSeekPipe(ident: String, relIdExpr: SeekArgs, 
     val relIds = relIdExpr.expressions(ctx, state).flatMap(Option(_))
     new DirectedRelationshipIdSeekIterator(ident, fromNode, toNode, ctx, state.query.relationshipOps, relIds.iterator)
   }
-
-  def monitor = pipeMonitor
  }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/DistinctPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/DistinctPipe.scala
@@ -28,8 +28,7 @@ import org.neo4j.cypher.internal.frontend.v3_2.helpers.Eagerly
 import scala.collection.mutable
 
 case class DistinctPipe(source: Pipe, expressions: Map[String, Expression])
-                       (val id: Id = new Id)
-                       (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) {
+                       (val id: Id = new Id) extends PipeWithSource(source) {
 
   val keyNames: Seq[String] = expressions.keys.toIndexedSeq
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/EagerAggregationPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/EagerAggregationPipe.scala
@@ -31,8 +31,7 @@ import scala.collection.mutable.{Map => MutableMap}
 // to emit aggregated results.
 // Cypher is lazy until it can't - this pipe will eagerly load the full match
 case class EagerAggregationPipe(source: Pipe, keyExpressions: Set[String], aggregations: Map[String, AggregationExpression])
-                               (val id: Id = new Id)
-                               (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) {
+                               (val id: Id = new Id) extends PipeWithSource(source) {
 
   aggregations.values.foreach(_.registerOwningPipe(this))
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/EagerPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/EagerPipe.scala
@@ -22,8 +22,7 @@ package org.neo4j.cypher.internal.compiler.v3_2.pipes
 import org.neo4j.cypher.internal.compiler.v3_2._
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
-case class EagerPipe(src: Pipe)(val id: Id = new Id)(implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(src, pipeMonitor) {
+case class EagerPipe(src: Pipe)(val id: Id = new Id) extends PipeWithSource(src) {
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] =
     input.toIndexedSeq.toIterator

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/EmptyResultPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/EmptyResultPipe.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v3_2.pipes
 import org.neo4j.cypher.internal.compiler.v3_2._
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
-case class EmptyResultPipe(source: Pipe)(val id: Id = new Id)(implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) {
+case class EmptyResultPipe(source: Pipe)(val id: Id = new Id) extends PipeWithSource(source) {
 
   protected def internalCreateResults(input:Iterator[ExecutionContext], state: QueryState) = {
     while(input.hasNext) {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ErrorPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ErrorPipe.scala
@@ -23,8 +23,8 @@ import org.neo4j.cypher.internal.compiler.v3_2.ExecutionContext
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
 case class ErrorPipe(source: Pipe, exception: Exception)
-                    (val id: Id = new Id)(implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(source, pipeMonitor) {
+                    (val id: Id = new Id)
+  extends PipeWithSource(source) {
   override protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] =
     throw exception
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ExpandAllPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ExpandAllPipe.scala
@@ -31,8 +31,7 @@ case class ExpandAllPipe(source: Pipe,
                          dir: SemanticDirection,
                          types: LazyTypes)
                         (val id: Id = new Id)
-                        (implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(source, pipeMonitor) {
+  extends PipeWithSource(source) {
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     input.flatMap {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ExpandIntoPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ExpandIntoPipe.scala
@@ -40,8 +40,7 @@ case class ExpandIntoPipe(source: Pipe,
                           dir: SemanticDirection,
                           lazyTypes: LazyTypes)
                           (val id: Id = new Id)
-                          (implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(source, pipeMonitor) with CachingExpandInto {
+  extends PipeWithSource(source) with CachingExpandInto {
   self =>
   private final val CACHE_SIZE = 100000
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/FilterPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/FilterPipe.scala
@@ -24,8 +24,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.commands.predicates.Predicate
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
 case class FilterPipe(source: Pipe, predicate: Predicate)
-                     (val id: Id = new Id)
-                     (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) {
+                     (val id: Id = new Id) extends PipeWithSource(source) {
 
   predicate.registerOwningPipe(this)
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ForeachPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ForeachPipe.scala
@@ -26,8 +26,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
 case class ForeachPipe(source: Pipe, inner: Pipe, variable: String, expression: Expression)
                       (val id: Id = new Id)
-                      (implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(source, pipeMonitor) with ListSupport {
+  extends PipeWithSource(source) with ListSupport {
 
   override protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] =
     input.map {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/FullPruningVarLengthExpandPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/FullPruningVarLengthExpandPipe.scala
@@ -33,8 +33,7 @@ case class FullPruningVarLengthExpandPipe(source: Pipe,
                                           min: Int,
                                           max: Int,
                                           filteringStep: VarLengthPredicate = VarLengthPredicate.NONE)
-                                         (val id: Id = new Id)
-                                         (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) with Pipe {
+                                         (val id: Id = new Id) extends PipeWithSource(source) with Pipe {
   self =>
 
   assert(min <= max)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/IndexOperationPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/IndexOperationPipe.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.commands._
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 import org.neo4j.cypher.internal.frontend.v3_2.SyntaxException
 
-case class IndexOperationPipe(indexOp: IndexOperation)(val id: Id = new Id)(implicit val monitor: PipeMonitor) extends Pipe {
+case class IndexOperationPipe(indexOp: IndexOperation)(val id: Id = new Id) extends Pipe {
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
     val queryContext = state.query
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/LetSelectOrSemiApplyPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/LetSelectOrSemiApplyPipe.scala
@@ -25,8 +25,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
 case class LetSelectOrSemiApplyPipe(source: Pipe, inner: Pipe, letVarName: String, predicate: Predicate, negated: Boolean)
                                    (val id: Id = new Id)
-                                   (implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(source, pipeMonitor) {
+  extends PipeWithSource(source) {
 
   predicate.registerOwningPipe(this)
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/LetSemiApplyPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/LetSemiApplyPipe.scala
@@ -23,8 +23,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.ExecutionContext
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
 case class LetSemiApplyPipe(source: Pipe, inner: Pipe, letVarName: String, negated: Boolean)
-                           (val id: Id = new Id)
-                           (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) {
+                           (val id: Id = new Id) extends PipeWithSource(source) {
   def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     input.map {
       (outerContext) =>

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/LimitPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/LimitPipe.scala
@@ -25,8 +25,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
 case class LimitPipe(source: Pipe, exp: Expression)
                     (val id: Id = new Id)
-                    (implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(source, pipeMonitor) with NumericHelper {
+  extends PipeWithSource(source) with NumericHelper {
 
   exp.registerOwningPipe(this)
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/LoadCSVPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/LoadCSVPipe.scala
@@ -36,8 +36,7 @@ case class LoadCSVPipe(source: Pipe,
                        fieldTerminator: Option[String],
                        legacyCsvQuoteEscaping: Boolean)
                       (val id: Id = new Id)
-                      (implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(source, pipeMonitor) {
+  extends PipeWithSource(source) {
 
   urlExpression.registerOwningPipe(this)
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/LockNodesPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/LockNodesPipe.scala
@@ -24,8 +24,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 import org.neo4j.graphdb.Node
 
 case class LockNodesPipe(src: Pipe, variablesToLock: Set[String])(val id: Id = new Id)
-                        (implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(src, pipeMonitor)  {
+  extends PipeWithSource(src)  {
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] =
     input.map { ctx =>

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeByIdSeekPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeByIdSeekPipe.scala
@@ -58,7 +58,6 @@ case class ManySeekArgs(coll: Expression) extends SeekArgs {
 
 case class NodeByIdSeekPipe(ident: String, nodeIdsExpr: SeekArgs)
                            (val id: Id = new Id)
-                           (implicit pipeMonitor: PipeMonitor)
   extends Pipe
   with ListSupport  {
 
@@ -69,6 +68,4 @@ case class NodeByIdSeekPipe(ident: String, nodeIdsExpr: SeekArgs)
     val nodeIds = nodeIdsExpr.expressions(ctx, state)
     new NodeIdSeekIterator(ident, ctx, state.query.nodeOps, nodeIds.iterator)
   }
-
-  override def monitor = pipeMonitor
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeByLabelScanPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeByLabelScanPipe.scala
@@ -24,7 +24,6 @@ import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
 case class NodeByLabelScanPipe(ident: String, label: LazyLabel)
                               (val id: Id = new Id)
-                              (implicit pipeMonitor: PipeMonitor)
   extends Pipe
   {
 
@@ -39,6 +38,4 @@ case class NodeByLabelScanPipe(ident: String, label: LazyLabel)
         Iterator.empty
     }
   }
-
-  override def monitor = pipeMonitor
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeCountFromCountStorePipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeCountFromCountStorePipe.scala
@@ -24,8 +24,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 import org.neo4j.cypher.internal.frontend.v3_2.NameId
 
 case class NodeCountFromCountStorePipe(ident: String, label: Option[LazyLabel])
-                                      (val id: Id = new Id)
-                                      (implicit pipeMonitor: PipeMonitor) extends Pipe {
+                                      (val id: Id = new Id) extends Pipe {
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
     val baseContext = state.createOrGetInitialContext()
@@ -38,6 +37,4 @@ case class NodeCountFromCountStorePipe(ident: String, label: Option[LazyLabel])
     }
     Seq(baseContext.newWith1(ident, count)).iterator
   }
-
-  override def monitor = pipeMonitor
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeHashJoinPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeHashJoinPipe.scala
@@ -28,8 +28,7 @@ import scala.collection.mutable
 
 case class NodeHashJoinPipe(nodeVariables: Set[String], left: Pipe, right: Pipe)
                            (val id: Id = new Id)
-                           (implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(left, pipeMonitor) {
+  extends PipeWithSource(left) {
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     if (input.isEmpty)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeIndexContainsScanPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeIndexContainsScanPipe.scala
@@ -29,7 +29,7 @@ import org.neo4j.graphdb.Node
 abstract class AbstractNodeIndexStringScanPipe(ident: String,
                                                label: LabelToken,
                                                propertyKey: PropertyKeyToken,
-                                               valueExpr: Expression)(implicit pipeMonitor: PipeMonitor)
+                                               valueExpr: Expression)
   extends Pipe {
 
   private val descriptor = IndexDescriptor(label.nameId.id, propertyKey.nameId.id)
@@ -53,8 +53,6 @@ abstract class AbstractNodeIndexStringScanPipe(ident: String,
   }
 
   protected def queryContextCall(state: QueryState, indexDescriptor: IndexDescriptor, value: String): Iterator[Node]
-
-  override def monitor = pipeMonitor
 }
 
 case class NodeIndexContainsScanPipe(ident: String,
@@ -62,7 +60,6 @@ case class NodeIndexContainsScanPipe(ident: String,
                                      propertyKey: PropertyKeyToken,
                                      valueExpr: Expression)
                                     (val id: Id = new Id)
-                                    (implicit pipeMonitor: PipeMonitor)
   extends AbstractNodeIndexStringScanPipe(ident, label, propertyKey, valueExpr) {
 
   override protected def queryContextCall(state: QueryState, indexDescriptor: IndexDescriptor, value: String) =
@@ -74,7 +71,6 @@ case class NodeIndexEndsWithScanPipe(ident: String,
                                      propertyKey: PropertyKeyToken,
                                      valueExpr: Expression)
                                     (val id: Id = new Id)
-                                    (implicit pipeMonitor: PipeMonitor)
   extends AbstractNodeIndexStringScanPipe(ident, label, propertyKey, valueExpr) {
 
   override protected def queryContextCall(state: QueryState, indexDescriptor: IndexDescriptor, value: String) =

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeIndexScanPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeIndexScanPipe.scala
@@ -27,7 +27,6 @@ case class NodeIndexScanPipe(ident: String,
                              label: LabelToken,
                              propertyKey: PropertyKeyToken)
                             (val id: Id = new Id)
-                            (implicit pipeMonitor: PipeMonitor)
   extends Pipe {
 
   private val descriptor = IndexDescriptor(label.nameId.id, propertyKey.nameId.id)
@@ -37,6 +36,4 @@ case class NodeIndexScanPipe(ident: String,
     val resultNodes = state.query.indexScan(descriptor)
     resultNodes.map(node => baseContext.newWith1(ident, node))
   }
-
-  override def monitor = pipeMonitor
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeIndexSeekPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeIndexSeekPipe.scala
@@ -31,7 +31,6 @@ case class NodeIndexSeekPipe(ident: String,
                              valueExpr: QueryExpression[Expression],
                              indexMode: IndexSeekMode = IndexSeek)
                             (val id: Id = new Id)
-                            (implicit pipeMonitor: PipeMonitor)
   extends Pipe {
 
   private val propertyIds: Array[Int] = propertyKeys.map(_.nameId.id).toArray
@@ -48,6 +47,4 @@ case class NodeIndexSeekPipe(ident: String,
     val resultNodes = indexQuery(valueExpr, baseContext, state, index, label.name, propertyKeys.map(_.name))
     resultNodes.map(node => baseContext.newWith1(ident, node))
   }
-
-  override def monitor = pipeMonitor
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeOuterHashJoinPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeOuterHashJoinPipe.scala
@@ -27,8 +27,8 @@ import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 
 case class NodeOuterHashJoinPipe(nodeVariables: Set[String], source: Pipe, inner: Pipe, nullableVariables: Set[String])
-                                (val id: Id = new Id)(implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(source, pipeMonitor) {
+                                (val id: Id = new Id)
+  extends PipeWithSource(source) {
   val nullColumns: Map[String, Any] = nullableVariables.map(_ -> null).toMap
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/OptionalExpandAllPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/OptionalExpandAllPipe.scala
@@ -28,8 +28,7 @@ import org.neo4j.graphdb.Node
 case class OptionalExpandAllPipe(source: Pipe, fromName: String, relName: String, toName: String, dir: SemanticDirection,
                                  types: LazyTypes, predicate: Predicate)
                                 (val id: Id = new Id)
-                                (implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(source, pipeMonitor) {
+  extends PipeWithSource(source) {
 
   predicate.registerOwningPipe(this)
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/OptionalExpandIntoPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/OptionalExpandIntoPipe.scala
@@ -30,8 +30,7 @@ import scala.collection.mutable.ListBuffer
 case class OptionalExpandIntoPipe(source: Pipe, fromName: String, relName: String, toName: String,
                                   dir: SemanticDirection, types: LazyTypes, predicate: Predicate)
                                  (val id: Id = new Id)
-                                 (implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(source, pipeMonitor) with CachingExpandInto {
+  extends PipeWithSource(source) with CachingExpandInto {
   private final val CACHE_SIZE = 100000
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/OptionalPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/OptionalPipe.scala
@@ -24,8 +24,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
 case class OptionalPipe(nullableVariables: Set[String], source: Pipe)
                        (val id: Id = new Id)
-                       (implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(source, pipeMonitor) {
+  extends PipeWithSource(source) {
 
   private def notFoundExecutionContext(initialContext: Option[ExecutionContext]): ExecutionContext = {
     val context = initialContext.getOrElse(ExecutionContext.empty)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ProcedureCallPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ProcedureCallPipe.scala
@@ -45,8 +45,7 @@ case class ProcedureCallPipe(source: Pipe,
                              resultSymbols: Seq[(String, CypherType)],
                              resultIndices: Seq[(Int, String)])
                             (val id: Id = new Id)
-                            (implicit monitor: PipeMonitor)
-  extends PipeWithSource(source, monitor) with ListSupport {
+  extends PipeWithSource(source) with ListSupport {
 
   argExprs.foreach(_.registerOwningPipe(this))
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ProduceResultsPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ProduceResultsPipe.scala
@@ -23,8 +23,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.ExecutionContext
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
 case class ProduceResultsPipe(source: Pipe, columns: Seq[String])
-                             (val id: Id = new Id)
-                             (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) {
+                             (val id: Id = new Id) extends PipeWithSource(source) {
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState) = {
     // do not register this pipe as parent as it does not do anything except filtering of already fetched
     // key-value pairs and thus should not have any stats

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ProjectEndpointsPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ProjectEndpointsPipe.scala
@@ -30,8 +30,7 @@ case class ProjectEndpointsPipe(source: Pipe, relName: String,
                                 end: String, endInScope: Boolean,
                                 relTypes: Option[LazyTypes], directed: Boolean, simpleLength: Boolean)
                                (val id: Id = new Id)
-                               (implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(source, pipeMonitor)
+  extends PipeWithSource(source)
   with ListSupport  {
   type Projector = (ExecutionContext) => Iterator[ExecutionContext]
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ProjectionPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ProjectionPipe.scala
@@ -28,8 +28,7 @@ Projection evaluates expressions and stores their values into new slots in the e
 It's an additive operation - nothing is lost in the execution context, the pipe simply adds new key-value pairs.
  */
 case class ProjectionPipe(source: Pipe, expressions: Map[String, Expression])
-                         (val id: Id = new Id)
-                         (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) {
+                         (val id: Id = new Id) extends PipeWithSource(source) {
 
   expressions.values.foreach(_.registerOwningPipe(this))
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/PruningVarLengthExpandPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/PruningVarLengthExpandPipe.scala
@@ -33,8 +33,7 @@ case class PruningVarLengthExpandPipe(source: Pipe,
                                       min: Int,
                                       max: Int,
                                       filteringStep: VarLengthPredicate = VarLengthPredicate.NONE)
-                                     (val id: Id = new Id)
-                                     (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) with Pipe {
+                                     (val id: Id = new Id) extends PipeWithSource(source) with Pipe {
   self =>
 
   assert(min <= max)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/QueryState.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/QueryState.scala
@@ -37,7 +37,6 @@ class QueryState(val query: QueryContext,
                  val decorator: PipeDecorator = NullPipeDecorator,
                  val timeReader: TimeReader = new TimeReader,
                  var initialContext: Option[ExecutionContext] = None,
-                 val queryId: AnyRef = UUID.randomUUID().toString,
                  val triadicState: mutable.Map[String, PrimitiveLongSet] = mutable.Map.empty,
                  val repeatableReads: mutable.Map[Pipe, Seq[ExecutionContext]] = mutable.Map.empty,
                  val typeConverter: RuntimeTypeConverter = IdentityTypeConverter,
@@ -62,13 +61,13 @@ class QueryState(val query: QueryContext,
   def getStatistics: InternalQueryStatistics = query.getOptStatistics.getOrElse(QueryState.defaultStatistics)
 
   def withDecorator(decorator: PipeDecorator) =
-    new QueryState(query, resources, params, decorator, timeReader, initialContext, queryId, triadicState, repeatableReads, typeConverter, cachedIn)
+    new QueryState(query, resources, params, decorator, timeReader, initialContext, triadicState, repeatableReads, typeConverter, cachedIn)
 
   def withInitialContext(initialContext: ExecutionContext) =
-    new QueryState(query, resources, params, decorator, timeReader, Some(initialContext), queryId, triadicState, repeatableReads, typeConverter, cachedIn)
+    new QueryState(query, resources, params, decorator, timeReader, Some(initialContext), triadicState, repeatableReads, typeConverter, cachedIn)
 
   def withQueryContext(query: QueryContext) =
-    new QueryState(query, resources, params, decorator, timeReader, initialContext, queryId, triadicState, repeatableReads, typeConverter, cachedIn)
+    new QueryState(query, resources, params, decorator, timeReader, initialContext, triadicState, repeatableReads, typeConverter, cachedIn)
 }
 
 object QueryState {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/RelationshipCountFromCountStorePipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/RelationshipCountFromCountStorePipe.scala
@@ -25,8 +25,7 @@ import org.neo4j.cypher.internal.frontend.v3_2.NameId
 
 case class RelationshipCountFromCountStorePipe(ident: String, startLabel: Option[LazyLabel],
                                                typeNames: LazyTypes, endLabel: Option[LazyLabel])
-                                              (val id: Id = new Id)
-                                              (implicit pipeMonitor: PipeMonitor) extends Pipe {
+                                              (val id: Id = new Id) extends Pipe {
 
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = {
     val maybeStartLabelId = getLabelId(startLabel, state)
@@ -57,6 +56,4 @@ case class RelationshipCountFromCountStorePipe(ident: String, startLabel: Option
         count + state.query.relationshipCountByCountStore(startLabelId, typeId, endLabelId)
       }
     }
-
-  override def monitor = pipeMonitor
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/RemoveLabelsPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/RemoveLabelsPipe.scala
@@ -27,8 +27,7 @@ import org.neo4j.graphdb.Node
 
 case class RemoveLabelsPipe(src: Pipe, variable: String, labels: Seq[LazyLabel])
                            (val id: Id = new Id)
-                           (implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(src, pipeMonitor) with GraphElementPropertyFunctions with ListSupport {
+  extends PipeWithSource(src) with GraphElementPropertyFunctions with ListSupport {
 
   override protected def internalCreateResults(input: Iterator[ExecutionContext],
                                                state: QueryState): Iterator[ExecutionContext] = {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/RollUpApplyPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/RollUpApplyPipe.scala
@@ -24,8 +24,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
 case class RollUpApplyPipe(lhs: Pipe, rhs: Pipe, collectionName: String, identifierToCollect: String, nullableIdentifiers: Set[String])
                           (val id: Id = new Id)
-                          (implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(lhs, pipeMonitor) {
+  extends PipeWithSource(lhs) {
 
   override protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState) = {
     input.map {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/SelectOrSemiApplyPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/SelectOrSemiApplyPipe.scala
@@ -25,8 +25,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
 case class SelectOrSemiApplyPipe(source: Pipe, inner: Pipe, predicate: Predicate, negated: Boolean)
                                 (val id: Id = new Id)
-                                (implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(source, pipeMonitor) {
+  extends PipeWithSource(source) {
 
   predicate.registerOwningPipe(this)
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/SemiApplyPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/SemiApplyPipe.scala
@@ -24,8 +24,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
 case class SemiApplyPipe(source: Pipe, inner: Pipe, negated: Boolean)
                         (val id: Id = new Id)
-                        (implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(source, pipeMonitor) {
+  extends PipeWithSource(source) {
   def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     input.filter {
       (outerContext) =>

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/SetPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/SetPipe.scala
@@ -24,8 +24,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
 case class SetPipe(src: Pipe, setOperation: SetOperation)
                   (val id: Id = new Id)
-                  (implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(src, pipeMonitor) {
+  extends PipeWithSource(src) {
   override protected def internalCreateResults(input: Iterator[ExecutionContext],
                                                state: QueryState): Iterator[ExecutionContext] = {
     input.map { row =>

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ShortestPathPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ShortestPathPipe.scala
@@ -34,8 +34,7 @@ import scala.collection.JavaConverters._
 case class ShortestPathPipe(source: Pipe, shortestPathCommand: ShortestPath, predicates: Seq[Predicate] = Seq.empty,
                             withFallBack: Boolean = false, disallowSameNode: Boolean = true)
                            (val id: Id = new Id)
-                           (implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(source, pipeMonitor) with ListSupport {
+  extends PipeWithSource(source) with ListSupport {
   private def pathName = shortestPathCommand.pathName
   private val shortestPathExpression = ShortestPathExpression(shortestPathCommand, predicates, withFallBack, disallowSameNode)
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/SkipPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/SkipPipe.scala
@@ -25,8 +25,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
 case class SkipPipe(source: Pipe, exp: Expression)
                    (val id: Id = new Id)
-                   (implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(source, pipeMonitor) with NumericHelper {
+  extends PipeWithSource(source) with NumericHelper {
 
   exp.registerOwningPipe(this)
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/SortPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/SortPipe.scala
@@ -24,8 +24,7 @@ import org.neo4j.cypher.internal.compiler.v3_2.{Comparer, ExecutionContext}
 
 case class SortPipe(source: Pipe, orderBy: Seq[SortDescription])
                    (val id: Id = new Id)
-                   (implicit monitor: PipeMonitor)
-  extends PipeWithSource(source, monitor) {
+  extends PipeWithSource(source) {
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     val array = input.toArray
     java.util.Arrays.sort(array, new InnerOrdering(orderBy)(state))

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/StartPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/StartPipe.scala
@@ -27,8 +27,7 @@ import org.neo4j.graphdb.{Node, PropertyContainer, Relationship}
 
 sealed abstract class StartPipe[T <: PropertyContainer](source: Pipe,
                                                         name: String,
-                                                        createSource: EntityProducer[T],
-                                                        pipeMonitor:PipeMonitor) extends PipeWithSource(source, pipeMonitor) {
+                                                        createSource: EntityProducer[T]) extends PipeWithSource(source) {
   def variableType: CypherType
 
   protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState) = {
@@ -46,15 +45,13 @@ case class NodeStartPipe(source: Pipe,
                          createSource: EntityProducer[Node],
                          itemEffects: Effects = Effects(ReadsAllNodes))
                         (val id: Id = new Id)
-                        (implicit pipeMonitor: PipeMonitor)
-  extends StartPipe[Node](source, name, createSource, pipeMonitor) {
+  extends StartPipe[Node](source, name, createSource) {
   def variableType = CTNode
 }
 
 case class RelationshipStartPipe(source: Pipe, name: String, createSource: EntityProducer[Relationship])
                                 (val id: Id = new Id)
-                                (implicit pipeMonitor: PipeMonitor)
-  extends StartPipe[Relationship](source, name, createSource, pipeMonitor) {
+  extends StartPipe[Relationship](source, name, createSource) {
   def variableType = CTRelationship
 }
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/TopPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/TopPipe.scala
@@ -31,8 +31,8 @@ import scala.math._
  * TopPipe is used when a query does a ORDER BY ... LIMIT query. Instead of ordering the whole result set and then
  * returning the matching top results, we only keep the top results in heap, which allows us to release memory earlier
  */
-abstract class TopPipe(source: Pipe, sortDescription: List[SortDescription])(implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(source, pipeMonitor) with Comparer {
+abstract class TopPipe(source: Pipe, sortDescription: List[SortDescription])
+  extends PipeWithSource(source) with Comparer {
 
   val sortItems: Array[SortDescription] = sortDescription.toArray
   private val sortItemsCount: Int = sortItems.length
@@ -64,8 +64,7 @@ abstract class TopPipe(source: Pipe, sortDescription: List[SortDescription])(imp
 }
 
 case class TopNPipe(source: Pipe, sortDescription: List[SortDescription], countExpression: Expression)
-                   (val id: Id = new Id)
-                   (implicit pipeMonitor: PipeMonitor) extends TopPipe(source, sortDescription)(pipeMonitor) {
+                   (val id: Id = new Id) extends TopPipe(source, sortDescription) {
 
   countExpression.registerOwningPipe(this)
 
@@ -125,8 +124,7 @@ case class TopNPipe(source: Pipe, sortDescription: List[SortDescription], countE
  */
 case class Top1Pipe(source: Pipe, sortDescription: List[SortDescription])
                    (val id: Id = new Id)
-                   (implicit pipeMonitor: PipeMonitor)
-  extends TopPipe(source, sortDescription)(pipeMonitor) {
+  extends TopPipe(source, sortDescription) {
 
   protected override def internalCreateResults(input: Iterator[ExecutionContext],
                                       state: QueryState): Iterator[ExecutionContext] = {
@@ -159,8 +157,7 @@ case class Top1Pipe(source: Pipe, sortDescription: List[SortDescription])
  */
 case class Top1WithTiesPipe(source: Pipe, sortDescription: List[SortDescription])
                            (val id: Id = new Id)
-                           (implicit pipeMonitor: PipeMonitor)
-  extends TopPipe(source, sortDescription)(pipeMonitor) {
+  extends TopPipe(source, sortDescription) {
 
   protected override def internalCreateResults(input: Iterator[ExecutionContext],
                                                state: QueryState): Iterator[ExecutionContext] = {

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/TriadicSelectionPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/TriadicSelectionPipe.scala
@@ -30,8 +30,7 @@ import scala.collection.{AbstractIterator, Iterator}
 
 case class TriadicSelectionPipe(positivePredicate: Boolean, left: Pipe, source: String, seen: String, target: String, right: Pipe)
                                (val id: Id = new Id)
-                               (implicit pipeMonitor: PipeMonitor)
-extends PipeWithSource(left, pipeMonitor) {
+extends PipeWithSource(left) {
 
   override protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState) = {
     var triadicState: PrimitiveLongSet = null

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/UndirectedRelationshipByIdSeekPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/UndirectedRelationshipByIdSeekPipe.scala
@@ -25,7 +25,6 @@ import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
 case class UndirectedRelationshipByIdSeekPipe(ident: String, relIdExpr: SeekArgs, toNode: String, fromNode: String)
                                              (val id: Id = new Id)
-                                             (implicit pipeMonitor: PipeMonitor)
   extends Pipe
   with ListSupport {
 
@@ -36,6 +35,4 @@ case class UndirectedRelationshipByIdSeekPipe(ident: String, relIdExpr: SeekArgs
     val relIds = relIdExpr.expressions(ctx, state).flatMap(Option(_))
     new UndirectedRelationshipIdSeekIterator(ident, fromNode, toNode, ctx, state.query.relationshipOps, relIds.iterator)
   }
-
-  override def monitor = pipeMonitor
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/UnionPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/UnionPipe.scala
@@ -23,8 +23,7 @@ import org.neo4j.cypher.internal.compiler.v3_2._
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.Id
 
 case class UnionPipe(l: Pipe, r: Pipe)
-                    (val id: Id = new Id)
-                    (implicit val monitor: PipeMonitor) extends Pipe {
+                    (val id: Id = new Id) extends Pipe {
   protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] =
     l.createResults(state) ++ r.createResults(state)
 }

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/UnwindPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/UnwindPipe.scala
@@ -28,8 +28,7 @@ import scala.annotation.tailrec
 
 case class UnwindPipe(source: Pipe, collection: Expression, variable: String)
                      (val id: Id = new Id)
-                     (implicit monitor: PipeMonitor)
-  extends PipeWithSource(source, monitor) with ListSupport {
+  extends PipeWithSource(source) with ListSupport {
 
   collection.registerOwningPipe(this)
 

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ValueHashJoinPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ValueHashJoinPipe.scala
@@ -28,8 +28,7 @@ import scala.collection.mutable
 
 case class ValueHashJoinPipe(lhsExpression: Expression, rhsExpression: Expression, left: Pipe, right: Pipe)
                             (val id: Id = new Id)
-                            (implicit pipeMonitor: PipeMonitor)
-  extends PipeWithSource(left, pipeMonitor) {
+  extends PipeWithSource(left) {
 
   override protected def internalCreateResults(input: Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {
     implicit val x = state

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/VarLengthExpandPipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/VarLengthExpandPipe.scala
@@ -51,8 +51,7 @@ case class VarLengthExpandPipe(source: Pipe,
                                max: Option[Int],
                                nodeInScope: Boolean,
                                filteringStep: VarLengthPredicate= VarLengthPredicate.NONE)
-                              (val id: Id = new Id)
-                              (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) {
+                              (val id: Id = new Id) extends PipeWithSource(source) {
   private def varLengthExpand(node: Node, state: QueryState, maxDepth: Option[Int],
                               row: ExecutionContext): Iterator[(Node, Seq[Relationship])] = {
     val stack = new mutable.Stack[(Node, Seq[Relationship])]

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilder.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilder.scala
@@ -521,7 +521,6 @@ case class ActualPipeBuilder(monitors: Monitors, recurse: LogicalPlan => Pipe, r
 
   private val resolver = new KeyTokenResolver
   private val entityProducerFactory = new EntityProducerFactory
-  implicit private val monitor = monitors.newMonitor[PipeMonitor]()
   implicit val table: SemanticTable = context.semanticTable
 
   private object buildPipeExpressions extends Rewriter {

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/CheckForEagerLoadCsvTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/CheckForEagerLoadCsvTest.scala
@@ -20,14 +20,12 @@
 package org.neo4j.cypher.internal.compiler.v3_2.executionplan
 
 import org.neo4j.cypher.internal.compiler.v3_2.commands.expressions.Literal
-import org.neo4j.cypher.internal.compiler.v3_2.pipes.{AllNodesScanPipe, EagerPipe, LoadCSVPipe, PipeMonitor}
+import org.neo4j.cypher.internal.compiler.v3_2.pipes.{AllNodesScanPipe, EagerPipe, LoadCSVPipe}
 import org.neo4j.cypher.internal.frontend.v3_2.notification.EagerLoadCsvNotification
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.ir.v3_2.HasHeaders
 
 class CheckForEagerLoadCsvTest extends CypherFunSuite {
-  implicit val monitor = mock[PipeMonitor]
-
   test("should notify for EagerPipe on top of LoadCsvPipe") {
     val pipe = EagerPipe(LoadCSVPipe(AllNodesScanPipe("a")(), HasHeaders, Literal("foo"), "bar", None, false)())()
 

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/CheckForLoadCsvAndMatchOnLargeLabelTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/CheckForLoadCsvAndMatchOnLargeLabelTest.scala
@@ -37,7 +37,6 @@ class CheckForLoadCsvAndMatchOnLargeLabelTest extends CypherFunSuite {
   private val labelOverThreshold = "A"
   private val labelUnderThrehsold = "B"
   private val indexFor= Map(labelOverThreshold -> 1, labelUnderThrehsold -> 2)
-  private implicit val monitor = mock[PipeMonitor]
   private val planContext = mock[PlanContext]
   when(planContext.getOptLabelId(anyString)).thenAnswer(new Answer[Option[Int]] {
     override def answer(invocationOnMock: InvocationOnMock): Option[Int] = {

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/ExecutionWorkflowBuilderTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/executionplan/ExecutionWorkflowBuilderTest.scala
@@ -51,7 +51,7 @@ class ExecutionWorkflowBuilderTest extends CypherFunSuite {
     builder.setQueryContext(context)
 
     // THEN
-    val result = builder.build("42", NormalMode, Map.empty, devNullLogger)
+    val result = builder.build(NormalMode, Map.empty, devNullLogger)
     result shouldBe a [PipeExecutionResult]
     result.asInstanceOf[PipeExecutionResult].result shouldBe a[EagerResultIterator]
   }
@@ -69,7 +69,7 @@ class ExecutionWorkflowBuilderTest extends CypherFunSuite {
     builder.setQueryContext(context)
 
     // THEN
-    val result = builder.build("42", NormalMode, Map.empty, devNullLogger)
+    val result = builder.build(NormalMode, Map.empty, devNullLogger)
     result shouldBe a [PipeExecutionResult]
     result.asInstanceOf[PipeExecutionResult].result should not be an[EagerResultIterator]
   }
@@ -88,7 +88,7 @@ class ExecutionWorkflowBuilderTest extends CypherFunSuite {
     builder.setQueryContext(context)
 
     // THEN
-    val result = builder.build("42", ExplainMode, Map.empty, devNullLogger)
+    val result = builder.build(ExplainMode, Map.empty, devNullLogger)
     result shouldBe a [ExplainExecutionResult]
   }
 }

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/AllNodesScanPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/AllNodesScanPipeTest.scala
@@ -26,7 +26,6 @@ import org.neo4j.cypher.internal.compiler.v3_2.spi.{Operations, QueryContext}
 
 class AllNodesScanPipeTest extends CypherFunSuite {
 
-  private implicit val monitor = mock[PipeMonitor]
   import Mockito.when
 
   test("should scan all nodes") {

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ApplyPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ApplyPipeTest.scala
@@ -30,7 +30,7 @@ class ApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     val lhs = new FakePipe(lhsData.iterator, "a" -> CTNumber)
     val rhs = pipeWithResults { (state) => Iterator(state.initialContext.get) }
 
-    val result = ApplyPipe(lhs, rhs)()(newMonitor).createResults(QueryStateHelper.empty).toList
+    val result = ApplyPipe(lhs, rhs)().createResults(QueryStateHelper.empty).toList
 
     result should equal(lhsData)
   }
@@ -41,7 +41,7 @@ class ApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     val rhsData = "c" -> 36
     val rhs = pipeWithResults { (state) => Iterator(ExecutionContext.empty += rhsData) }
 
-    val result = ApplyPipe(lhs, rhs)()(newMonitor).createResults(QueryStateHelper.empty).toList
+    val result = ApplyPipe(lhs, rhs)().createResults(QueryStateHelper.empty).toList
 
     result should equal(lhsData.map(_ + rhsData))
   }
@@ -51,7 +51,7 @@ class ApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     val lhs = new FakePipe(lhsData.iterator, "a" -> CTNumber, "b" -> CTNumber)
     val rhs = pipeWithResults { (state) => Iterator(state.initialContext.get += "b" -> null) }
 
-    val result = ApplyPipe(lhs, rhs)()(newMonitor).createResults(QueryStateHelper.empty).toList
+    val result = ApplyPipe(lhs, rhs)().createResults(QueryStateHelper.empty).toList
 
     result should equal(lhsData)
   }

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/DirectedDirectedRelationshipByIdSeekPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/DirectedDirectedRelationshipByIdSeekPipeTest.scala
@@ -28,8 +28,6 @@ import org.neo4j.graphdb.{Node, Relationship}
 
 class DirectedDirectedRelationshipByIdSeekPipeTest extends CypherFunSuite {
 
-  implicit val monitor = mock[PipeMonitor]
-
   import Mockito.when
 
   test("should seek relationship by id") {

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/DistinctPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/DistinctPipeTest.scala
@@ -25,8 +25,6 @@ import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 
 class DistinctPipeTest extends CypherFunSuite {
 
-  private implicit val monitor = mock[PipeMonitor]
-
   test("distinct input passes through") {
     //GIVEN
     val pipe = createDistinctPipe(List(Map("x" -> 1), Map("x" -> 2)))

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/EagerAggregationPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/EagerAggregationPipeTest.scala
@@ -27,8 +27,6 @@ import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 
 class EagerAggregationPipeTest extends CypherFunSuite {
 
-  private implicit val monitor = mock[PipeMonitor]
-
   private def createReturnItemsFor(names: String*): Set[String] = names.toSet
 
   test("should aggregate count(*) on single grouping column") {

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/EagerPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/EagerPipeTest.scala
@@ -23,7 +23,6 @@ import org.neo4j.cypher.internal.compiler.v3_2._
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 
 class EagerPipeTest extends CypherFunSuite {
-  private implicit val monitor = mock[PipeMonitor]
 
   test("shouldMakeLazyEager") {
     // Given a lazy iterator that is not empty

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ErrorPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ErrorPipeTest.scala
@@ -23,8 +23,6 @@ import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 
 class ErrorPipeTest extends CypherFunSuite {
 
-  private implicit val pipeMonitor = mock[PipeMonitor]
-
   test("should throw an exception when used") {
     val exception = new RuntimeException("Boom!")
     val pipe = ErrorPipe(mock[Pipe], exception)()

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ExpandAllPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ExpandAllPipeTest.scala
@@ -32,7 +32,6 @@ import org.neo4j.graphdb.{Node, Relationship}
 
 class ExpandAllPipeTest extends CypherFunSuite {
 
-  implicit val monitor = mock[PipeMonitor]
   val startNode = newMockedNode(1)
   val endNode1 = newMockedNode(2)
   val endNode2 = newMockedNode(3)

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/FakePipe.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/FakePipe.scala
@@ -32,7 +32,5 @@ class FakePipe(val data: Iterator[Map[String, Any]], newVariables: (String, Cyph
 
   def internalCreateResults(state: QueryState) = data.map(m => ExecutionContext(collection.mutable.Map(m.toSeq: _*)))
 
-  val monitor: PipeMonitor = mock[PipeMonitor]
-
   var id = new Id
 }

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/LetSelectOrSemiApplyPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/LetSelectOrSemiApplyPipeTest.scala
@@ -36,7 +36,7 @@ class LetSelectOrSemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     })
 
     val result =
-      LetSelectOrSemiApplyPipe(lhs, rhs, "let", Not(True()), negated = false)()(newMonitor).
+      LetSelectOrSemiApplyPipe(lhs, rhs, "let", Not(True()), negated = false)().
         createResults(QueryStateHelper.empty).toList
 
     result should equal(List(
@@ -55,7 +55,7 @@ class LetSelectOrSemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     })
 
     val result =
-      LetSelectOrSemiApplyPipe(lhs, rhs, "let", Not(True()), negated = true)()(newMonitor).
+      LetSelectOrSemiApplyPipe(lhs, rhs, "let", Not(True()), negated = true)().
         createResults(QueryStateHelper.empty).toList
 
     result should equal(List(
@@ -70,7 +70,7 @@ class LetSelectOrSemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     val rhs = new FakePipe(Iterator.empty)
 
     val result =
-      LetSelectOrSemiApplyPipe(lhs, rhs, "let", Not(True()), negated = false)()(newMonitor).
+      LetSelectOrSemiApplyPipe(lhs, rhs, "let", Not(True()), negated = false)().
         createResults(QueryStateHelper.empty).toList
 
     result should equal(List(
@@ -85,7 +85,7 @@ class LetSelectOrSemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     val rhs = new FakePipe(Iterator(Map("a" -> 1)))
 
     val result =
-      LetSelectOrSemiApplyPipe(lhs, rhs, "let", Not(True()), negated = false)()(newMonitor).
+      LetSelectOrSemiApplyPipe(lhs, rhs, "let", Not(True()), negated = false)().
         createResults(QueryStateHelper.empty).toList
 
     result should equal(List(
@@ -99,7 +99,7 @@ class LetSelectOrSemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     val lhs = new FakePipe(Iterator.empty)
 
     // Should not throw
-    LetSelectOrSemiApplyPipe(lhs, rhs, "let", True(), negated = false)()(newMonitor).
+    LetSelectOrSemiApplyPipe(lhs, rhs, "let", True(), negated = false)().
       createResults(QueryStateHelper.empty).toList
   }
 
@@ -109,7 +109,7 @@ class LetSelectOrSemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     val rhs = new FakePipe(Iterator.empty)
 
     val result =
-      LetSelectOrSemiApplyPipe(lhs, rhs, "let", Equals(Variable("a"), Literal(2)), negated = false)()(newMonitor).
+      LetSelectOrSemiApplyPipe(lhs, rhs, "let", Equals(Variable("a"), Literal(2)), negated = false)().
         createResults(QueryStateHelper.empty).toList
 
     result should equal(List(
@@ -128,7 +128,7 @@ class LetSelectOrSemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     })
 
     val result =
-      LetSelectOrSemiApplyPipe(lhs, rhs, "let", Equals(Variable("a"), Literal(2)), negated = false)()(newMonitor).
+      LetSelectOrSemiApplyPipe(lhs, rhs, "let", Equals(Variable("a"), Literal(2)), negated = false)().
         createResults(QueryStateHelper.empty).toList
 
     result should equal(List(
@@ -148,7 +148,7 @@ class LetSelectOrSemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     })
 
     val result =
-      LetSelectOrSemiApplyPipe(lhs, rhs, "let", Equals(Variable("a"), Literal(2)), negated = false)()(newMonitor).
+      LetSelectOrSemiApplyPipe(lhs, rhs, "let", Equals(Variable("a"), Literal(2)), negated = false)().
         createResults(QueryStateHelper.empty).toList
     result should equal(List(
       Map("a" -> 3, "let" -> false),

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/LetSemiApplyPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/LetSemiApplyPipeTest.scala
@@ -34,7 +34,7 @@ class LetSemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     })
 
     val result =
-      LetSemiApplyPipe(lhs, rhs, "let", negated = false)()(newMonitor).
+      LetSemiApplyPipe(lhs, rhs, "let", negated = false)().
         createResults(QueryStateHelper.empty).toList
 
     result should equal(List(
@@ -53,7 +53,7 @@ class LetSemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     })
 
     val result =
-      LetSemiApplyPipe(lhs, rhs, "let", negated = true)()(newMonitor).
+      LetSemiApplyPipe(lhs, rhs, "let", negated = true)().
       createResults(QueryStateHelper.empty).toList
 
     result should equal(List(
@@ -68,7 +68,7 @@ class LetSemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     val rhs = new FakePipe(Iterator.empty)
 
     val result =
-      LetSemiApplyPipe(lhs, rhs, "let", negated = false)()(newMonitor).
+      LetSemiApplyPipe(lhs, rhs, "let", negated = false)().
         createResults(QueryStateHelper.empty).toList
 
     result should equal(List(
@@ -83,7 +83,7 @@ class LetSemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     val rhs = new FakePipe(Iterator.empty)
 
     val result =
-      LetSemiApplyPipe(lhs, rhs, "let", negated = true)()(newMonitor).
+      LetSemiApplyPipe(lhs, rhs, "let", negated = true)().
         createResults(QueryStateHelper.empty).toList
 
     result should equal(List(
@@ -98,7 +98,7 @@ class LetSemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     val rhs = new FakePipe(Iterator(Map("a" -> 1)))
 
     val result =
-      LetSemiApplyPipe(lhs, rhs, "let", negated = false)()(newMonitor).
+      LetSemiApplyPipe(lhs, rhs, "let", negated = false)().
         createResults(QueryStateHelper.empty).toList
 
     result should equal(List(
@@ -113,7 +113,7 @@ class LetSemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     val rhs = new FakePipe(Iterator(Map("a" -> 1)))
 
     val result =
-      LetSemiApplyPipe(lhs, rhs, "let", negated = true)()(newMonitor).
+      LetSemiApplyPipe(lhs, rhs, "let", negated = true)().
       createResults(QueryStateHelper.empty).toList
 
     result should equal(List(
@@ -128,6 +128,6 @@ class LetSemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     val lhs = new FakePipe(Iterator.empty)
 
     // Should not throw
-    LetSemiApplyPipe(lhs, rhs, "let", negated = false)()(newMonitor).createResults(QueryStateHelper.empty).toList
+    LetSemiApplyPipe(lhs, rhs, "let", negated = false)().createResults(QueryStateHelper.empty).toList
   }
 }

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/LimitPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/LimitPipeTest.scala
@@ -34,7 +34,7 @@ class LimitPipeTest extends CypherFunSuite {
     when(inputIterator.isEmpty).thenReturn(false)
 
     val src: Pipe = new DummyPipe(inputIterator)
-    val limitPipe = LimitPipe(src, Literal(0))()(mock[PipeMonitor])
+    val limitPipe = LimitPipe(src, Literal(0))()
 
     // When
     limitPipe.createResults(QueryStateHelper.empty)
@@ -45,7 +45,6 @@ class LimitPipeTest extends CypherFunSuite {
 }
 
 class DummyPipe(inputIterator: Iterator[ExecutionContext]) extends Pipe {
-  override def monitor: PipeMonitor = ???
 
   override protected def internalCreateResults(state: QueryState): Iterator[ExecutionContext] = ???
 

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeByIdSeekPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeByIdSeekPipeTest.scala
@@ -27,7 +27,6 @@ import org.neo4j.graphdb.Node
 
 class NodeByIdSeekPipeTest extends CypherFunSuite {
 
-  implicit val monitor = mock[PipeMonitor]
   import Mockito.when
 
   test("should seek node by id") {

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeByLabelScanPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeByLabelScanPipeTest.scala
@@ -27,7 +27,6 @@ import org.neo4j.graphdb.Node
 
 class NodeByLabelScanPipeTest extends CypherFunSuite {
 
-  implicit val monitor = mock[PipeMonitor]
   import org.mockito.Mockito.when
 
   test("should scan labeled nodes") {

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeCountFromCountStorePipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeCountFromCountStorePipeTest.scala
@@ -27,8 +27,6 @@ import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 
 class NodeCountFromCountStorePipeTest extends CypherFunSuite with AstConstructionTestSupport {
 
-  implicit val monitor = mock[PipeMonitor]
-
   test("should return a count for nodes with a label") {
     implicit val table = new SemanticTable()
     table.resolvedLabelIds.put("A", LabelId(12))

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeHashJoinPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeHashJoinPipeTest.scala
@@ -29,7 +29,6 @@ import org.neo4j.graphdb.Node
 
 class NodeHashJoinPipeTest extends CypherFunSuite {
 
-  implicit val monitor = mock[PipeMonitor]
   import org.mockito.Mockito._
 
   test("should support simple hash join over nodes") {

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeIndexScanPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeIndexScanPipeTest.scala
@@ -30,8 +30,6 @@ import org.neo4j.graphdb.Node
 
 class NodeIndexScanPipeTest extends CypherFunSuite with AstConstructionTestSupport {
 
-  private implicit val monitor = mock[PipeMonitor]
-
   private val label = LabelToken(LabelName("LabelName")_, LabelId(11))
   private val propertyKey = PropertyKeyToken(PropertyKeyName("PropertyName")_, PropertyKeyId(10))
   private val descriptor = IndexDescriptor(label.nameId.id, propertyKey.nameId.id)

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeIndexSeekPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeIndexSeekPipeTest.scala
@@ -33,7 +33,6 @@ import org.neo4j.graphdb.Node
 
 class NodeIndexSeekPipeTest extends CypherFunSuite with AstConstructionTestSupport {
 
-  implicit val monitor = mock[PipeMonitor]
   implicit val windowsSafe = WindowsStringSafe
 
   val label = LabelToken(LabelName("LabelName") _, LabelId(11))

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeOuterHashJoinPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/NodeOuterHashJoinPipeTest.scala
@@ -29,7 +29,6 @@ import org.neo4j.graphdb.Node
 
 class NodeOuterHashJoinPipeTest extends CypherFunSuite {
 
-  implicit val monitor = mock[PipeMonitor]
   val node1 = newMockedNode(1)
   val node2 = newMockedNode(2)
   val node3 = newMockedNode(3)

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/OptionalExpandAllPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/OptionalExpandAllPipeTest.scala
@@ -32,7 +32,6 @@ import org.neo4j.graphdb.{Node, Relationship}
 
 class OptionalExpandAllPipeTest extends CypherFunSuite {
 
-  implicit val monitor = mock[PipeMonitor]
   val startNode = newMockedNode(1)
   val endNode1 = newMockedNode(2)
   val endNode2 = newMockedNode(3)

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/OptionalExpandIntoPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/OptionalExpandIntoPipeTest.scala
@@ -32,7 +32,6 @@ import org.neo4j.graphdb.{Node, Relationship}
 
 class OptionalExpandIntoPipeTest extends CypherFunSuite {
 
-  implicit val monitor = mock[PipeMonitor]
   val startNode = newMockedNode(1)
   val endNode1 = newMockedNode(2)
   val endNode2 = newMockedNode(3)

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/OptionalPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/OptionalPipeTest.scala
@@ -24,8 +24,6 @@ import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 
 class OptionalPipeTest extends CypherFunSuite {
 
-  private implicit val monitor = mock[PipeMonitor]
-
   test("should return results if it finds them") {
     val source = new FakePipe( Iterator(Map("a" -> 1)), "a" -> CTNumber)
     val state = QueryStateHelper.empty

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/PipeTestSupport.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/PipeTestSupport.scala
@@ -34,12 +34,10 @@ import org.scalatest.mock.MockitoSugar
 
 trait PipeTestSupport extends CypherTestSupport with MockitoSugar {
 
-  implicit val newMonitor = mock[PipeMonitor]
   val query = mock[QueryContext]
 
   def pipeWithResults(f: QueryState => Iterator[ExecutionContext]): Pipe = new Pipe {
     protected def internalCreateResults(state: QueryState) = f(state)
-    def monitor: PipeMonitor = newMonitor
 
     // Used by profiling to identify where to report dbhits and rows
     override def id: Id = new Id

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ProcedureCallPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ProcedureCallPipeTest.scala
@@ -47,7 +47,7 @@ class ProcedureCallPipeTest
       rowProcessing = FlatMapAndAppendToRow,
       resultSymbols = Seq("r" -> CTString),
       resultIndices = Seq(0 -> "r")
-    )()(newMonitor)
+    )()
 
     val qtx = new FakeQueryContext(procedureName, resultsTransformer, ProcedureReadOnlyAccess(emptyStringArray))
 
@@ -70,7 +70,7 @@ class ProcedureCallPipeTest
       rowProcessing = FlatMapAndAppendToRow,
       resultSymbols = Seq("r" -> CTString),
       resultIndices = Seq(0 -> "r")
-    )()(newMonitor)
+    )()
 
     val qtx = new FakeQueryContext(procedureName, resultsTransformer, ProcedureReadWriteAccess(emptyStringArray))
     pipe.createResults(QueryStateHelper.emptyWith(qtx)).toList should equal(List(
@@ -92,7 +92,7 @@ class ProcedureCallPipeTest
       rowProcessing = PassThroughRow,
       resultSymbols = Seq.empty,
       resultIndices = Seq.empty
-    )()(newMonitor)
+    )()
 
     val qtx = new FakeQueryContext(procedureName, _ => Iterator.empty, ProcedureReadWriteAccess(emptyStringArray))
     pipe.createResults(QueryStateHelper.emptyWith(qtx)).toList should equal(List(

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ProduceResultsPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ProduceResultsPipeTest.scala
@@ -25,8 +25,6 @@ import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 
 class ProduceResultsPipeTest extends CypherFunSuite {
 
-  implicit val monitor = mock[PipeMonitor]
-
   test("should project needed columns") {
     val sourcePipe = mock[Pipe]
     val queryState = mock[QueryState]

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ProjectEndpointsPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ProjectEndpointsPipeTest.scala
@@ -30,7 +30,6 @@ import org.neo4j.graphdb.{Node, Relationship}
 
 class ProjectEndpointsPipeTest extends CypherFunSuite {
 
-  implicit val monitor = mock[PipeMonitor]
   val node1 = newMockedNode(1)
   val node2 = newMockedNode(2)
   val node3 = newMockedNode(3)

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/RelationshipCountFromCountStorePipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/RelationshipCountFromCountStorePipeTest.scala
@@ -28,8 +28,6 @@ import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 
 class RelationshipCountFromCountStorePipeTest extends CypherFunSuite with AstConstructionTestSupport {
 
-  implicit val monitor = mock[PipeMonitor]
-
   test("should return a count for relationships without a type or any labels") {
     val pipe = RelationshipCountFromCountStorePipe("count(r)", None, LazyTypes.empty, None)()
 

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/SelectOrSemiApplyPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/SelectOrSemiApplyPipeTest.scala
@@ -36,7 +36,7 @@ class SelectOrSemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     })
 
     val result =
-      SelectOrSemiApplyPipe(lhs, rhs, Not(True()), negated = false)()(newMonitor).
+      SelectOrSemiApplyPipe(lhs, rhs, Not(True()), negated = false)().
         createResults(QueryStateHelper.empty).toList
 
     result should equal(List(Map("a" -> 1)))
@@ -52,7 +52,7 @@ class SelectOrSemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     })
 
     val result =
-      SelectOrSemiApplyPipe(lhs, rhs, Not(True()), negated = true)()(newMonitor).
+      SelectOrSemiApplyPipe(lhs, rhs, Not(True()), negated = true)().
         createResults(QueryStateHelper.empty).toList
 
     result should equal(List(Map("a" -> 2)))
@@ -64,7 +64,7 @@ class SelectOrSemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     val rhs = new FakePipe(Iterator.empty)
 
     val result =
-      SelectOrSemiApplyPipe(lhs, rhs, Not(True()), negated = false)()(newMonitor).
+      SelectOrSemiApplyPipe(lhs, rhs, Not(True()), negated = false)().
         createResults(QueryStateHelper.empty).toList
 
     result should equal(List.empty)
@@ -76,7 +76,7 @@ class SelectOrSemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     val rhs = new FakePipe(Iterator(Map("a" -> 1)))
 
     val result =
-      SelectOrSemiApplyPipe(lhs, rhs, Not(True()), negated = false)()(newMonitor).
+      SelectOrSemiApplyPipe(lhs, rhs, Not(True()), negated = false)().
         createResults(QueryStateHelper.empty).toList
 
     result should equal(lhsData)
@@ -87,7 +87,7 @@ class SelectOrSemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     val lhs = new FakePipe(Iterator.empty)
 
     // Should not throw
-    SelectOrSemiApplyPipe(lhs, rhs, True(), negated = false)()(newMonitor).
+    SelectOrSemiApplyPipe(lhs, rhs, True(), negated = false)().
       createResults(QueryStateHelper.empty).toList
   }
 
@@ -97,7 +97,7 @@ class SelectOrSemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     val rhs = new FakePipe(Iterator.empty)
 
     val result =
-      SelectOrSemiApplyPipe(lhs, rhs, Equals(Variable("a"), Literal(2)), negated = false)()(newMonitor).createResults(QueryStateHelper.empty).toList
+      SelectOrSemiApplyPipe(lhs, rhs, Equals(Variable("a"), Literal(2)), negated = false)().createResults(QueryStateHelper.empty).toList
 
     result should equal(List(Map("a" -> 2)))
   }
@@ -111,7 +111,7 @@ class SelectOrSemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
         if (initialContext("a") == 1) Iterator(initialContext) else Iterator.empty
       })
 
-    val result = SelectOrSemiApplyPipe(lhs, rhs, Equals(Variable("a"), Literal(2)), negated = false)()(newMonitor).createResults(QueryStateHelper.empty).toList
+    val result = SelectOrSemiApplyPipe(lhs, rhs, Equals(Variable("a"), Literal(2)), negated = false)().createResults(QueryStateHelper.empty).toList
 
     result should equal(List(Map("a" -> 1), Map("a" -> 2)))
   }
@@ -125,7 +125,7 @@ class SelectOrSemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
         if (initialContext("a") == 1) Iterator(initialContext) else Iterator.empty
       })
 
-    val result = SelectOrSemiApplyPipe(lhs, rhs, Equals(Variable("a"), Literal(2)), negated = false)()(newMonitor).createResults(QueryStateHelper.empty).toList
+    val result = SelectOrSemiApplyPipe(lhs, rhs, Equals(Variable("a"), Literal(2)), negated = false)().createResults(QueryStateHelper.empty).toList
     result should equal(List.empty)
   }
 }

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/SemiApplyPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/SemiApplyPipeTest.scala
@@ -33,7 +33,7 @@ class SemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
         if (initialContext("a") == 1) Iterator(initialContext) else Iterator.empty
       })
 
-    val result = SemiApplyPipe(lhs, rhs, negated = false)()(newMonitor).createResults(QueryStateHelper.empty).toList
+    val result = SemiApplyPipe(lhs, rhs, negated = false)().createResults(QueryStateHelper.empty).toList
 
     result should equal(List(Map("a" -> 1)))
   }
@@ -47,7 +47,7 @@ class SemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
         if (initialContext("a") == 1) Iterator(initialContext) else Iterator.empty
       })
 
-    val result = SemiApplyPipe(lhs, rhs, negated = true)()(newMonitor).createResults(QueryStateHelper.empty).toList
+    val result = SemiApplyPipe(lhs, rhs, negated = true)().createResults(QueryStateHelper.empty).toList
 
     result should equal(List(Map("a" -> 2)))
   }
@@ -57,7 +57,7 @@ class SemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     val lhs = new FakePipe(lhsData.iterator, "a" -> CTNumber)
     val rhs = new FakePipe(Iterator.empty)
 
-    val result = SemiApplyPipe(lhs, rhs, negated = false)()(newMonitor).createResults(QueryStateHelper.empty).toList
+    val result = SemiApplyPipe(lhs, rhs, negated = false)().createResults(QueryStateHelper.empty).toList
 
     result should be(empty)
   }
@@ -67,7 +67,7 @@ class SemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     val lhs = new FakePipe(lhsData.iterator, "a" -> CTNumber)
     val rhs = new FakePipe(Iterator.empty)
 
-    val result = SemiApplyPipe(lhs, rhs, negated = true)()(newMonitor).createResults(QueryStateHelper.empty).toList
+    val result = SemiApplyPipe(lhs, rhs, negated = true)().createResults(QueryStateHelper.empty).toList
 
     result should equal(lhsData)
   }
@@ -77,7 +77,7 @@ class SemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     val lhs = new FakePipe(lhsData.iterator, "a" -> CTNumber)
     val rhs = new FakePipe(Iterator(Map("a" -> 1)))
 
-    val result = SemiApplyPipe(lhs, rhs, negated = false)()(newMonitor).createResults(QueryStateHelper.empty).toList
+    val result = SemiApplyPipe(lhs, rhs, negated = false)().createResults(QueryStateHelper.empty).toList
 
     result should equal(lhsData)
   }
@@ -87,7 +87,7 @@ class SemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     val lhs = new FakePipe(lhsData.iterator, "a" -> CTNumber)
     val rhs = new FakePipe(Iterator(Map("a" -> 1)))
 
-    val result = SemiApplyPipe(lhs, rhs, negated = true)()(newMonitor).createResults(QueryStateHelper.empty).toList
+    val result = SemiApplyPipe(lhs, rhs, negated = true)().createResults(QueryStateHelper.empty).toList
 
     result should be(empty)
   }
@@ -98,6 +98,6 @@ class SemiApplyPipeTest extends CypherFunSuite with PipeTestSupport {
     val lhs = new FakePipe(Iterator.empty)
 
     // Should not throw
-    SemiApplyPipe(lhs, rhs, negated = false)()(newMonitor).createResults(QueryStateHelper.empty).toList
+    SemiApplyPipe(lhs, rhs, negated = false)().createResults(QueryStateHelper.empty).toList
   }
 }

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/SkipPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/SkipPipeTest.scala
@@ -33,7 +33,7 @@ class SkipPipeTest extends CypherFunSuite {
     when(inputIterator.isEmpty).thenReturn(false)
 
     val src: Pipe = new DummyPipe(inputIterator)
-    val limitPipe = SkipPipe(src, Literal(0))()(mock[PipeMonitor])
+    val limitPipe = SkipPipe(src, Literal(0))()
 
     // When
     val result = limitPipe.createResults(QueryStateHelper.empty)

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/SortPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/SortPipeTest.scala
@@ -28,8 +28,6 @@ import scala.collection.mutable.{Map => MutableMap}
 
 class SortPipeTest extends CypherFunSuite with MockitoSugar {
 
-  private implicit val monitor = mock[PipeMonitor]
-
   test("empty input gives empty output") {
     val source = new FakePipe(List(), "x" -> CTAny)
     val sortPipe = new SortPipe(source, List(Ascending("x")))()

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/Top1WithTiesPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/Top1WithTiesPipeTest.scala
@@ -25,8 +25,6 @@ import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 
 class Top1WithTiesPipeTest extends CypherFunSuite {
 
-  private implicit val monitor = mock[PipeMonitor]
-
   test("empty input gives empty output") {
     val source = new FakePipe(List(), "x" -> CTAny)
     val sortPipe = Top1WithTiesPipe(source, List(Ascending("x")))()

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/TopPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/TopPipeTest.scala
@@ -27,8 +27,6 @@ import scala.util.Random
 
 class TopPipeTest extends CypherFunSuite {
 
-  private implicit val monitor = mock[PipeMonitor]
-
   test("returning top 10 from 5 possible should return all") {
     val input = createFakePipeWith(5)
     val pipe = new TopNPipe(input, List(Ascending("a")), Literal(10))()

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/TriadicSelectionPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/TriadicSelectionPipeTest.scala
@@ -29,7 +29,6 @@ import org.neo4j.kernel.impl.core.NodeProxy
 import scala.collection.Map
 
 class TriadicSelectionPipeTest extends CypherFunSuite {
-  private implicit val monitor = mock[PipeMonitor]
 
   test("triadic from input with no cycles") {
     val input = createFakePipeWith(Array("a", "b"), 0 -> List(1, 2))

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/UndirectedDirectedRelationshipByIdSeekPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/UndirectedDirectedRelationshipByIdSeekPipeTest.scala
@@ -28,8 +28,6 @@ import org.neo4j.graphdb.{Node, Relationship}
 
 class UndirectedDirectedRelationshipByIdSeekPipeTest extends CypherFunSuite {
 
-  implicit val monitor = mock[PipeMonitor]
-
   import Mockito.when
 
   test("should seek relationship by id") {

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/UnwindPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/UnwindPipeTest.scala
@@ -25,8 +25,6 @@ import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 
 class UnwindPipeTest extends CypherFunSuite {
 
-  private implicit val monitor = mock[PipeMonitor]
-
   private def unwindWithInput(data: Traversable[Map[String, Any]]) = {
     val source = new FakePipe(data, "x" -> CTList(CTInteger))
     val unwindPipe = new UnwindPipe(source, Variable("x"), "y")()

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ValueHashJoinPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ValueHashJoinPipeTest.scala
@@ -29,8 +29,6 @@ import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 
 class ValueHashJoinPipeTest extends CypherFunSuite {
 
-  implicit val monitor = mock[PipeMonitor]
-
   import org.mockito.Mockito._
 
   test("should support simple hash join between two identifiers") {

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/VarLengthExpandPipeTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/VarLengthExpandPipeTest.scala
@@ -33,8 +33,6 @@ import org.neo4j.graphdb.{Node, Relationship}
 
 class VarLengthExpandPipeTest extends CypherFunSuite {
 
-  implicit val monitor = mock[PipeMonitor]
-
   test("should support var length expand between two nodes") {
     // given
     val startNode = newMockedNode(1)

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planDescription/RenderSummaryTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planDescription/RenderSummaryTest.scala
@@ -19,13 +19,13 @@
  */
 package org.neo4j.cypher.internal.compiler.v3_2.planDescription
 
-import org.neo4j.cypher.internal.compiler.v3_2.pipes.{PipeMonitor, SingleRowPipe}
+import org.neo4j.cypher.internal.compiler.v3_2.pipes.SingleRowPipe
 import org.neo4j.cypher.internal.compiler.v3_2.planDescription.InternalPlanDescription.Arguments._
 import org.neo4j.cypher.internal.frontend.v3_2.test_helpers.CypherFunSuite
 
 class RenderSummaryTest extends CypherFunSuite {
 
-  val pipe = SingleRowPipe()()(mock[PipeMonitor])
+  val pipe = SingleRowPipe()()
 
   test("single node is represented nicely") {
     val arguments = Seq(

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilderIT.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/execution/PipeExecutionPlanBuilderIT.scala
@@ -42,7 +42,6 @@ import org.neo4j.cypher.internal.ir.v3_2._
 class PipeExecutionPlanBuilderIT extends CypherFunSuite with LogicalPlanningTestSupport {
 
   implicit val planContext: PlanContext = newMockedPlanContext
-  implicit val pipeMonitor = mock[PipeMonitor]
   implicit val LogicalPlanningContext = newMockedLogicalPlanningContext(planContext)
   implicit val pipeBuildContext = newMockedPipeExecutionPlanBuilderContext
   val patternRel = PatternRelationship("r", ("a", "b"), SemanticDirection.OUTGOING, Seq.empty, SimplePatternLength)

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/profiler/ProfilerTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/profiler/ProfilerTest.scala
@@ -31,8 +31,6 @@ import org.neo4j.kernel.impl.factory.DatabaseInfo
 
 class ProfilerTest extends CypherFunSuite {
 
-  private implicit val monitor = mock[PipeMonitor]
-
   test("should report simplest case") {
     //GIVEN
     val start = SingleRowPipe()()
@@ -312,11 +310,11 @@ class ProfilerTest extends CypherFunSuite {
 }
 
 case class ProfilerTestPipe(source: Pipe, name: String, rows: Int, dbAccess: Int,
-                            statisticProvider: ConfiguredKernelStatisticProvider = null, hits: Long = 0, misses: Long
-                            = 0)  //
+                            statisticProvider: ConfiguredKernelStatisticProvider = null,
+                            hits: Long = 0, misses: Long = 0) extends PipeWithSource(source) {
                            // MATCH a, ()-[r]->()
                            // WHERE id(r) = length(a-->())
-                  (implicit pipeMonitor: PipeMonitor) extends PipeWithSource(source, pipeMonitor) {
+
   var id = new Id
 
   protected def internalCreateResults(input:Iterator[ExecutionContext], state: QueryState): Iterator[ExecutionContext] = {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/AllShortestPathsPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/AllShortestPathsPipeTest.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v3_2
 import org.neo4j.cypher.GraphDatabaseFunSuite
 import org.neo4j.cypher.internal.compiler.v3_2.QueryStateHelper.queryStateFrom
 import org.neo4j.cypher.internal.compiler.v3_2.commands.{ShortestPath, SingleNode}
-import org.neo4j.cypher.internal.compiler.v3_2.pipes.{FakePipe, PipeMonitor, ShortestPathPipe}
+import org.neo4j.cypher.internal.compiler.v3_2.pipes.{FakePipe, ShortestPathPipe}
 import org.neo4j.cypher.internal.frontend.v3_2.SemanticDirection
 import org.neo4j.cypher.internal.frontend.v3_2.symbols._
 import org.neo4j.graphdb.{Node, Path}
@@ -30,8 +30,6 @@ import org.neo4j.graphdb.{Node, Path}
 import scala.collection.mutable
 
 class AllShortestPathsPipeTest extends GraphDatabaseFunSuite {
-
-  private implicit val monitor = mock[PipeMonitor]
 
   def runThroughPipeAndGetPath(a: Node, b: Node) = {
     val source = new FakePipe(List(mutable.Map("a" -> a, "b" -> b)), "a" -> CTNode, "b" -> CTNode)

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/PipeLazynessTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/PipeLazynessTest.scala
@@ -38,7 +38,6 @@ in fact are lazy. Every Pipe should be represented here
  */
 
 class PipeLazynessTest extends GraphDatabaseFunSuite with QueryStateTestSupport {
-  private implicit val monitor = mock[PipeMonitor]
 
   test("test") {
     distinctPipe.!!()
@@ -72,7 +71,7 @@ class PipeLazynessTest extends GraphDatabaseFunSuite with QueryStateTestSupport 
 
   private def filterPipe = {
     val (iter, src) = emptyFakes
-    val pipe = new FilterPipe(src, True())()(mock[PipeMonitor])
+    val pipe = new FilterPipe(src, True())()
     (pipe, iter)
   }
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/SingleShortestPathPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/SingleShortestPathPipeTest.scala
@@ -21,13 +21,12 @@ package org.neo4j.cypher.internal.compiler.v3_2
 
 import org.neo4j.cypher.GraphDatabaseFunSuite
 import org.neo4j.cypher.internal.compiler.v3_2.commands._
-import org.neo4j.cypher.internal.compiler.v3_2.pipes.{FakePipe, PipeMonitor, ShortestPathPipe}
+import org.neo4j.cypher.internal.compiler.v3_2.pipes.{FakePipe, ShortestPathPipe}
 import org.neo4j.cypher.internal.frontend.v3_2.SemanticDirection
 import org.neo4j.cypher.internal.frontend.v3_2.symbols._
 import org.neo4j.graphdb.{Direction, Node, Path}
 
 class SingleShortestPathPipeTest extends GraphDatabaseFunSuite {
-  private implicit val monitor = mock[PipeMonitor]
   private val path = ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq(), SemanticDirection.BOTH,
     allowZeroLength = false, Some(15), single = true, relIterator = None)
 

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ActualCostCalculationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/ActualCostCalculationTest.scala
@@ -54,12 +54,6 @@ import scala.collection.mutable.ListBuffer
  */
 class ActualCostCalculationTest extends CypherFunSuite {
 
-  implicit val monitor = new PipeMonitor {
-    def stopStep(queryId: AnyRef, pipe: Pipe) {}
-    def stopSetup(queryId: AnyRef, pipe: Pipe) {}
-    def startSetup(queryId: AnyRef, pipe: Pipe) {}
-    def startStep(queryId: AnyRef, pipe: Pipe) {}
-  }
   private val N = 1000000
   private val STEPS = 100
   private val LABEL = Label.label("L")

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/FullPruningVarLengthExpandPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/FullPruningVarLengthExpandPipeTest.scala
@@ -35,7 +35,6 @@ import scala.util.Random
 
 class FullPruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
   val types = LazyTypes(Seq.empty[String])
-  implicit val pipeMonitor = mock[PipeMonitor]
 
   test("node without any relationships produces empty result") {
     val n1 = createNode()

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/PruningVarLengthExpandPipeTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/pipes/PruningVarLengthExpandPipeTest.scala
@@ -35,7 +35,6 @@ import scala.util.Random
 
 class PruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
   val types = LazyTypes(Seq.empty[String])
-  implicit val pipeMonitor = mock[PipeMonitor]
 
   test("node without any relationships produces empty result") {
     val n1 = createNode()


### PR DESCRIPTION
This reduces a contention-problem for users with very large numbers of secure connections, where the server would run low on entropy, needed to generate SecureRandom UUIDs. The default `queryId` generated a UUID, which added unnecessarily to that problem every time the query consisted of a single procedure call.