### PR TITLE
Better error messages for failing backup

### DIFF
--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupImpl.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupImpl.java
@@ -73,11 +73,15 @@ class BackupImpl implements TheBackupInterface
                     logFileInformation, storeId, copyStartContext.lastAppliedTransaction() + 1,
                     storeCopyServer.monitor() );
             long optionalTransactionId = copyStartContext.lastAppliedTransaction();
-            return responsePacker.packTransactionStreamResponse( anonymous( optionalTransactionId ), null/*no response object*/ );
-        }
-        finally
-        {
+
+            Response<Void> response = responsePacker.packTransactionStreamResponse( anonymous( optionalTransactionId ), null );
             logger.log( "%s: Full backup finished.", backupIdentifier );
+            return response;
+        }
+        catch ( Throwable e )
+        {
+            logger.log( backupIdentifier + ": Full backup ended with exception.", e );
+            throw e;
         }
     }
 
@@ -88,11 +92,14 @@ class BackupImpl implements TheBackupInterface
         try
         {
             logger.log( "%s: Incremental backup started...", backupIdentifier );
-            return incrementalResponsePacker.packTransactionStreamResponse( context, null );
-        }
-        finally
-        {
+            Response<Void> response = incrementalResponsePacker.packTransactionStreamResponse( context, null );
             logger.log( "%s: Incremental backup finished.", backupIdentifier );
+            return response;
+        }
+        catch ( Throwable e )
+        {
+            logger.log( backupIdentifier + ": Incremental backup ended with exception.", e );
+            throw e;
         }
     }
 


### PR DESCRIPTION
Backup will log if an exception occurred during execution.

Previously there was a finally block that logged that the backup finished
even though it was aborted due to an exception. That message is only logged
if the backup actually ends, with a different error message if anything
is aborted.