### PR TITLE
Tx-state aware RelationshipScanCursor and relationship writes

### DIFF
--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Read.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Read.java
@@ -75,10 +75,10 @@ public interface Read
 
     /**
      * Checks if a node exists in the database
-     * @param id The id of the node to check
+     * @param reference The reference of the node to check
      * @return <tt>true</tt> if the node exists, otherwise <tt>false</tt>
      */
-    boolean nodeExists( long id );
+    boolean nodeExists( long reference );
 
     /**
      * @param reference

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Write.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Write.java
@@ -55,7 +55,7 @@ public interface Write
      * Delete a relationship
      * @param relationship the internal id of the relationship to delete
      */
-    void relationshipDelete( long relationship );
+    boolean relationshipDelete( long relationship ) throws AutoIndexingKernelException;
 
     /**
      * Add a label to a node

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Write.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Write.java
@@ -49,7 +49,7 @@ public interface Write
      * @param targetNode the target internal node id
      * @return the internal id of the created relationship
      */
-    long relationshipCreate( long sourceNode, int relationshipLabel, long targetNode );
+    long relationshipCreate( long sourceNode, int relationshipLabel, long targetNode ) throws KernelException;
 
     /**
      * Delete a relationship

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeTransactionStateTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeTransactionStateTestBase.java
@@ -37,7 +37,7 @@ import static org.neo4j.values.storable.Values.NO_VALUE;
 import static org.neo4j.values.storable.Values.stringValue;
 
 @SuppressWarnings( "Duplicates" )
-public abstract class TransactionStateTestBase<G extends KernelAPIWriteTestSupport> extends KernelAPIWriteTestBase<G>
+public abstract class NodeTransactionStateTestBase<G extends KernelAPIWriteTestSupport> extends KernelAPIWriteTestBase<G>
 {
     @Test
     public void shouldSeeNodeInTransaction() throws Exception

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTransactionStateTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTransactionStateTestBase.java
@@ -37,15 +37,16 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
         {
             n1 = tx.dataWrite().nodeCreate();
             n2 = tx.dataWrite().nodeCreate();
+
+            // setup extra relationship to challenge the implementation
             long decoyNode = tx.dataWrite().nodeCreate();
-            label = tx.tokenWrite().relationshipTypeGetOrCreateForName( "R" ); // to have >1 relationship in the db
+            label = tx.tokenWrite().relationshipTypeGetOrCreateForName( "R" );
             tx.dataWrite().relationshipCreate( n2, label, decoyNode );
             tx.success();
         }
 
         try ( Transaction tx = session.beginTransaction() )
         {
-            label = tx.tokenWrite().relationshipTypeGetOrCreateForName( "R" );
             long r = tx.dataWrite().relationshipCreate( n1, label, n2 );
             try ( RelationshipScanCursor relationship = cursors.allocateRelationshipScanCursor() )
             {

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTransactionStateTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTransactionStateTestBase.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.kernel.api;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@SuppressWarnings( "Duplicates" )
+public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWriteTestSupport> extends KernelAPIWriteTestBase<G>
+{
+    @Test
+    public void shouldSeeSingleRelationshipInTransaction() throws Exception
+    {
+        int label;
+        long n1, n2;
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            n1 = tx.dataWrite().nodeCreate();
+            n2 = tx.dataWrite().nodeCreate();
+            long decoyNode = tx.dataWrite().nodeCreate();
+            label = tx.tokenWrite().relationshipTypeGetOrCreateForName( "R" ); // to have >1 relationship in the db
+            tx.dataWrite().relationshipCreate( n2, label, decoyNode );
+            tx.success();
+        }
+
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            label = tx.tokenWrite().relationshipTypeGetOrCreateForName( "R" );
+            long r = tx.dataWrite().relationshipCreate( n1, label, n2 );
+            try ( RelationshipScanCursor relationship = cursors.allocateRelationshipScanCursor() )
+            {
+                tx.dataRead().singleRelationship( r, relationship );
+                assertTrue( "should find relationship", relationship.next() );
+
+                assertEquals( label, relationship.label() );
+                assertEquals( n1, relationship.sourceNodeReference() );
+                assertEquals( n2, relationship.targetNodeReference() );
+                assertEquals( r, relationship.relationshipReference() );
+
+                assertFalse( "should only find one relationship", relationship.next() );
+            }
+            tx.success();
+        }
+    }
+}

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipWriteTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipWriteTestBase.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.kernel.api;
+
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.List;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.NotFoundException;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.internal.kernel.api.exceptions.KernelException;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.neo4j.graphdb.Label.label;
+import static org.neo4j.values.storable.Values.NO_VALUE;
+import static org.neo4j.values.storable.Values.intValue;
+import static org.neo4j.values.storable.Values.stringValue;
+
+@SuppressWarnings( "Duplicates" )
+public abstract class RelationshipWriteTestBase<G extends KernelAPIWriteTestSupport> extends KernelAPIWriteTestBase<G>
+{
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void shouldCreateRelationship() throws Exception
+    {
+        long n1, n2;
+        try ( org.neo4j.graphdb.Transaction tx = graphDb.beginTx() )
+        {
+            n1 = graphDb.createNode().getId();
+            n2 = graphDb.createNode().getId();
+            tx.success();
+        }
+
+        long r;
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            int label = session.token().relationshipTypeGetOrCreateForName( "R" );
+            r = tx.dataWrite().relationshipCreate( n1, label, n2 );
+            tx.success();
+        }
+
+        try ( org.neo4j.graphdb.Transaction ignore = graphDb.beginTx() )
+        {
+            List<Relationship> relationships = Iterables.asList( graphDb.getNodeById( n1 ).getRelationships() );
+            assertEquals( 1, relationships.size() );
+            assertEquals( relationships.get( 0 ).getId(), r );
+        }
+    }
+
+    @Test
+    public void shouldCreateRelationshipBetweenInTransactionNodes() throws Exception
+    {
+        long n1, n2, r;
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            n1 = tx.dataWrite().nodeCreate();
+            n2 = tx.dataWrite().nodeCreate();
+            int label = session.token().relationshipTypeGetOrCreateForName( "R" );
+            r = tx.dataWrite().relationshipCreate( n1, label, n2 );
+            tx.success();
+        }
+
+        try ( org.neo4j.graphdb.Transaction ignore = graphDb.beginTx() )
+        {
+            List<Relationship> relationships = Iterables.asList( graphDb.getNodeById( n1 ).getRelationships() );
+            assertEquals( 1, relationships.size() );
+            assertEquals( relationships.get( 0 ).getId(), r );
+        }
+    }
+
+    @Test
+    public void shouldRollbackRelationshipOnFailure() throws Exception
+    {
+        long n1, n2;
+        try ( org.neo4j.graphdb.Transaction tx = graphDb.beginTx() )
+        {
+            n1 = graphDb.createNode().getId();
+            n2 = graphDb.createNode().getId();
+            tx.success();
+        }
+
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            int label = session.token().relationshipTypeGetOrCreateForName( "R" );
+            tx.dataWrite().relationshipCreate( n1, label, n2 );
+            tx.failure();
+        }
+
+        try ( org.neo4j.graphdb.Transaction ignore = graphDb.beginTx() )
+        {
+            assertEquals( 0, graphDb.getNodeById( n1 ).getDegree() );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
@@ -93,7 +93,7 @@ import static org.neo4j.helpers.collection.Iterables.map;
  * into one component. Now that that work is done, this class should be refactored to increase transparency in how it
  * works.
  */
-public final class TxState implements TransactionState, RelationshipVisitor.Home
+public class TxState implements TransactionState, RelationshipVisitor.Home
 {
     private static final LabelState.Defaults LABEL_STATE = new TransactionLabelState();
     private static final NodeStateImpl.Defaults NODE_STATE = new TransactionNodeState();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
@@ -95,23 +95,23 @@ public class AllStoreHolder extends Read
     }
 
     @Override
-    public boolean nodeExists( long id )
+    public boolean nodeExists( long reference )
     {
         ktx.assertOpen();
 
         if ( hasTxStateWithChanges() )
         {
             TransactionState txState = txState();
-            if ( txState.nodeIsDeletedInThisTx( id ) )
+            if ( txState.nodeIsDeletedInThisTx( reference ) )
             {
                 return false;
             }
-            else if ( txState.nodeIsAddedInThisTx( id ) )
+            else if ( txState.nodeIsAddedInThisTx( reference ) )
             {
                 return true;
             }
         }
-        return storeReadLayer.nodeExists( id );
+        return storeReadLayer.nodeExists( reference );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/HasChanges.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/HasChanges.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.newapi;
+
+enum HasChanges
+{
+    MAYBE,
+    YES,
+    NO
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/KernelToken.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/KernelToken.java
@@ -50,7 +50,7 @@ public class KernelToken implements Token
     @Override
     public int relationshipTypeGetOrCreateForName( String relationshipTypeName ) throws IllegalTokenNameException
     {
-        return store.propertyKeyGetOrCreateForName( checkValidTokenName( relationshipTypeName ) );
+        return store.relationshipTypeGetOrCreateForName( checkValidTokenName( relationshipTypeName ) );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeCursor.java
@@ -48,13 +48,6 @@ class NodeCursor extends NodeRecord implements org.neo4j.internal.kernel.api.Nod
     private HasChanges hasChanges = HasChanges.MAYBE;
     private Set<Long> addedNodes;
 
-    private enum HasChanges
-    {
-        MAYBE,
-        YES,
-        NO
-    }
-
     NodeCursor()
     {
         super( NO_ID );
@@ -203,6 +196,7 @@ class NodeCursor extends NodeRecord implements org.neo4j.internal.kernel.api.Nod
             {
                 read.node( this, next++, pageCursor );
             }
+
             if ( next > highMark )
             {
                 if ( isSingle() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
@@ -133,17 +133,16 @@ abstract class RelationshipCursor extends RelationshipRecord implements Relation
         }
     }
 
+    // Load transaction state using RelationshipVisitor
     protected void loadFromTxState( long reference )
     {
         read.txState().relationshipVisit( reference, this );
     }
 
+    // used to visit transaction state
     @Override
-    public void visit( long relationshipId, int typeId, long startNodeId, long endNodeId ) throws RuntimeException
+    public void visit( long relationshipId, int typeId, long startNodeId, long endNodeId )
     {
-        setId( relationshipId );
-        setType( typeId );
-        setFirstNode( startNodeId );
-        setSecondNode( endNodeId );
+        initialize( true, NO_ID, startNodeId, endNodeId, typeId, NO_ID, NO_ID, NO_ID, NO_ID, false, false );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
@@ -143,6 +143,7 @@ abstract class RelationshipCursor extends RelationshipRecord implements Relation
     @Override
     public void visit( long relationshipId, int typeId, long startNodeId, long endNodeId )
     {
+        setId( relationshipId );
         initialize( true, NO_ID, startNodeId, endNodeId, typeId, NO_ID, NO_ID, NO_ID, NO_ID, false, false );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
@@ -19,16 +19,30 @@
  */
 package org.neo4j.kernel.impl.newapi;
 
+import java.util.Set;
+
 import org.neo4j.internal.kernel.api.RelationshipDataAccessor;
+import org.neo4j.kernel.impl.api.RelationshipVisitor;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 
-abstract class RelationshipCursor extends RelationshipRecord implements RelationshipDataAccessor
+import static java.util.Collections.emptySet;
+
+abstract class RelationshipCursor extends RelationshipRecord implements RelationshipDataAccessor, RelationshipVisitor<RuntimeException>
 {
     Read read;
+    private HasChanges hasChanges = HasChanges.MAYBE;
+    Set<Long> addedRelationships;
 
     RelationshipCursor()
     {
         super( NO_ID );
+    }
+
+    protected void init( Read read )
+    {
+        this.read = read;
+        this.hasChanges = HasChanges.MAYBE;
+        this.addedRelationships = emptySet();
     }
 
     @Override
@@ -83,5 +97,53 @@ abstract class RelationshipCursor extends RelationshipRecord implements Relation
     public long propertiesReference()
     {
         return getNextProp();
+    }
+
+    protected abstract boolean shouldGetAddedTxStateSnapshot();
+
+    /**
+     * RelationshipCursor should only see changes that are there from the beginning
+     * otherwise it will not be stable.
+     */
+    protected boolean hasChanges()
+    {
+        switch ( hasChanges )
+        {
+        case MAYBE:
+            boolean changes = read.hasTxStateWithChanges();
+            if ( changes )
+            {
+                if ( shouldGetAddedTxStateSnapshot() )
+                {
+                    addedRelationships = read.txState().addedAndRemovedRelationships().getAddedSnapshot();
+                }
+                hasChanges = HasChanges.YES;
+            }
+            else
+            {
+                hasChanges = HasChanges.NO;
+            }
+            return changes;
+        case YES:
+            return true;
+        case NO:
+            return false;
+        default:
+            throw new IllegalStateException( "Style guide, why are you making me do this" );
+        }
+    }
+
+    protected void loadFromTxState( long reference )
+    {
+        read.txState().relationshipVisit( reference, this );
+    }
+
+    @Override
+    public void visit( long relationshipId, int typeId, long startNodeId, long endNodeId ) throws RuntimeException
+    {
+        setId( relationshipId );
+        setType( typeId );
+        setFirstNode( startNodeId );
+        setSecondNode( endNodeId );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipScanCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipScanCursor.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.newapi;
 
 import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.kernel.api.txstate.TransactionState;
 
 class RelationshipScanCursor extends RelationshipCursor implements org.neo4j.internal.kernel.api.RelationshipScanCursor
 {
@@ -41,7 +42,7 @@ class RelationshipScanCursor extends RelationshipCursor implements org.neo4j.int
         next = 0;
         this.label = label;
         highMark = read.relationshipHighMark();
-        this.read = read;
+        init( read );
     }
 
     void single( long reference, Read read )
@@ -57,44 +58,70 @@ class RelationshipScanCursor extends RelationshipCursor implements org.neo4j.int
         next = reference;
         label = -1;
         highMark = NO_ID;
-        this.read = read;
+        init( read );
     }
 
     @Override
     public boolean next()
     {
+        if ( next == NO_ID )
+        {
+            reset();
+            return false;
+        }
+
+        // Check tx state
+        boolean hasChanges = hasChanges();
+        TransactionState txs = hasChanges ? read.txState() : null;
+
         do
         {
-            if ( next == NO_ID )
+            if ( hasChanges && containsRelationship( txs ) )
             {
-                reset();
-                return false;
+                loadFromTxState( next++ );
+                setInUse( true );
             }
-            do
+            else if ( hasChanges && txs.relationshipIsDeletedInThisTx( next ) )
+            {
+                next++;
+                setInUse( false );
+            }
+            else
             {
                 read.relationship( this, next++, pageCursor );
-                if ( next > highMark )
+            }
+
+            if ( next > highMark )
+            {
+                if ( isSingle() )
                 {
-                    if ( highMark == NO_ID )
+                    next = NO_ID;
+                    return isWantedLabelAndInUse();
+                }
+                else
+                {
+                    highMark = read.relationshipHighMark();
+                    if ( next > highMark )
                     {
                         next = NO_ID;
-                        return (label == -1 || label() == label) && inUse();
-                    }
-                    else
-                    {
-                        highMark = read.relationshipHighMark();
-                        if ( next > highMark )
-                        {
-                            next = NO_ID;
-                            return (label == -1 || label() == label) && inUse();
-                        }
+                        return isWantedLabelAndInUse();
                     }
                 }
             }
-            while ( !inUse() );
         }
-        while ( label != -1 && label() != label );
+        while ( !isWantedLabelAndInUse() );
+
         return true;
+    }
+
+    private boolean isWantedLabelAndInUse()
+    {
+        return (label == -1 || label() == label) && inUse();
+    }
+
+    private boolean containsRelationship( TransactionState txs )
+    {
+        return isSingle() ? txs.relationshipIsAddedInThisTx( next ) : addedRelationships.contains( next );
     }
 
     @Override
@@ -138,5 +165,15 @@ class RelationshipScanCursor extends RelationshipCursor implements org.neo4j.int
             return "RelationshipScanCursor[id=" + getId() + ", open state with: highMark=" + highMark + ", next=" + next + ", label=" + label +
                     ", underlying record=" + super.toString() + " ]";
         }
+    }
+
+    private boolean isSingle()
+    {
+        return highMark == NO_ID;
+    }
+
+    protected boolean shouldGetAddedTxStateSnapshot()
+    {
+        return !isSingle();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipTraversalCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipTraversalCursor.java
@@ -439,6 +439,12 @@ class RelationshipTraversalCursor extends RelationshipCursor
     }
 
     @Override
+    protected boolean shouldGetAddedTxStateSnapshot()
+    {
+        return true;
+    }
+
+    @Override
     public boolean isClosed()
     {
         return pageCursor == null && !hasBufferedData();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/OperationsLockTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/OperationsLockTest.java
@@ -22,6 +22,8 @@ package org.neo4j.kernel.impl.newapi;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.Iterator;
@@ -50,21 +52,20 @@ import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.ResourceTypes;
 import org.neo4j.kernel.impl.locking.SimpleStatementLocks;
 import org.neo4j.storageengine.api.StorageEngine;
-import org.neo4j.storageengine.api.StorageProperty;
 import org.neo4j.storageengine.api.StorageStatement;
 import org.neo4j.storageengine.api.StoreReadLayer;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
 
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.helpers.collection.Iterators.asList;
@@ -77,8 +78,10 @@ public class OperationsLockTest
     private Operations operations;
     private final Locks.Client locks = mock( Locks.Client.class );
     private final Write write = mock( Write.class );
+    private InOrder order;
     private NodeCursor nodeCursor;
     private PropertyCursor propertyCursor;
+    private RelationshipScanCursor relationshipCursor;
     private TransactionState txState;
     private AllStoreHolder allStoreHolder;
     private final LabelSchemaDescriptor descriptor = SchemaDescriptorFactory.forLabel( 123, 456 );
@@ -87,7 +90,7 @@ public class OperationsLockTest
     @Before
     public void setUp() throws InvalidTransactionTypeKernelException
     {
-        txState = new TxState();
+        txState = Mockito.spy( new TxState() );
         when( transaction.getReasonIfTerminated() ).thenReturn( Optional.empty() );
         when( transaction.locks() ).thenReturn( new SimpleStatementLocks( locks ) );
         when( transaction.dataWrite() ).thenReturn( write );
@@ -97,28 +100,118 @@ public class OperationsLockTest
         Cursors cursors = mock( Cursors.class );
         nodeCursor = mock( NodeCursor.class );
         propertyCursor = mock( PropertyCursor.class );
+        relationshipCursor = mock( RelationshipScanCursor.class );
         when( cursors.allocateNodeCursor() ).thenReturn( nodeCursor );
         when( cursors.allocatePropertyCursor() ).thenReturn( propertyCursor );
+        when( cursors.allocateRelationshipScanCursor() ).thenReturn( relationshipCursor );
         AutoIndexing autoindexing = mock( AutoIndexing.class );
         when( autoindexing.nodes() ).thenReturn( mock( AutoIndexOperations.class ) );
-        StorageStatement storageStatement = mock( StorageStatement.class );
+        when( autoindexing.relationships() ).thenReturn( mock( AutoIndexOperations.class ) );
+        StorageStatement store = mock( StorageStatement.class );
         StorageEngine engine = mock( StorageEngine.class );
         storeReadLayer = mock( StoreReadLayer.class );
         when( storeReadLayer.nodeExists( anyLong() ) ).thenReturn( true );
         when( storeReadLayer.constraintsGetForLabel( anyInt() )).thenReturn( Collections.emptyIterator() );
         when( engine.storeReadLayer() ).thenReturn( storeReadLayer );
-        allStoreHolder = new AllStoreHolder( engine, storageStatement,  transaction, cursors, mock(
+        allStoreHolder = new AllStoreHolder( engine, store,  transaction, cursors, mock(
                 ExplicitIndexStore.class ) );
         operations = new Operations( allStoreHolder, mock( IndexTxStateUpdater.class ),
-                storageStatement, transaction, new KernelToken( storeReadLayer ), cursors, autoindexing,
+                store, transaction, new KernelToken( storeReadLayer ), cursors, autoindexing,
                 mock( NodeSchemaMatcher.class ) );
         operations.initialize();
+
+        this.order = inOrder( locks, txState, storeReadLayer );
     }
 
     @After
     public void tearDown()
     {
         operations.release();
+    }
+
+    @Test
+    public void shouldAcquireEntityWriteLockCreatingRelationship() throws Exception
+    {
+        // when
+        long rId = operations.relationshipCreate( 1, 2, 3 );
+
+        // then
+        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 1 );
+        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 3 );
+        order.verify( txState ).relationshipDoCreate( rId, 2, 1, 3 );
+    }
+
+    @Test
+    public void shouldAcquireNodeLocksWhenCreatingRelationshipInOrderOfAscendingId() throws Exception
+    {
+        // GIVEN
+        long lowId = 3;
+        long highId = 5;
+        int relationshipLabel = 0;
+
+        {
+            // WHEN
+            operations.relationshipCreate( lowId, relationshipLabel, highId );
+
+            // THEN
+            InOrder lockingOrder = inOrder( locks );
+            lockingOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, lowId );
+            lockingOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, highId );
+            lockingOrder.verifyNoMoreInteractions();
+            reset( locks );
+        }
+
+        {
+            // WHEN
+            operations.relationshipCreate( highId, relationshipLabel, lowId );
+
+            // THEN
+            InOrder lockingOrder = inOrder( locks );
+            lockingOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, lowId );
+            lockingOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, highId );
+            lockingOrder.verifyNoMoreInteractions();
+        }
+    }
+
+    @Test
+    public void shouldAcquireNodeLocksWhenDeletingRelationshipInOrderOfAscendingId() throws Exception
+    {
+        // GIVEN
+        final long relationshipId = 10;
+        final long lowId = 3;
+        final long highId = 5;
+        int relationshipLabel = 0;
+
+        {
+            // and GIVEN
+            setStoreRelationship( relationshipId, lowId, highId, relationshipLabel );
+
+            // WHEN
+            operations.relationshipDelete( relationshipId );
+
+            // THEN
+            InOrder lockingOrder = inOrder( locks );
+            lockingOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, lowId );
+            lockingOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, highId );
+            lockingOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.RELATIONSHIP, relationshipId );
+            lockingOrder.verifyNoMoreInteractions();
+            reset( locks );
+        }
+
+        {
+            // and GIVEN
+            setStoreRelationship( relationshipId, highId, lowId, relationshipLabel );
+
+            // WHEN
+            operations.relationshipDelete( relationshipId );
+
+            // THEN
+            InOrder lockingOrder = inOrder( locks );
+            lockingOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, lowId );
+            lockingOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, highId );
+            lockingOrder.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.RELATIONSHIP, relationshipId );
+            lockingOrder.verifyNoMoreInteractions();
+        }
     }
 
     @Test
@@ -132,8 +225,8 @@ public class OperationsLockTest
         operations.nodeAddLabel( 123L, 456 );
 
         // then
-        verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 123L );
-        assertThat( txState.getNodeState( 123L ).labelDiffSets().getAdded(), contains( 456 ) );
+        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 123L );
+        order.verify( txState ).nodeDoAddLabel( 456, 123L );
     }
 
     @Test
@@ -164,8 +257,8 @@ public class OperationsLockTest
         operations.nodeAddLabel( 123, labelId );
 
         // then
-        verify( locks, atLeastOnce() ).acquireShared( LockTracer.NONE, ResourceTypes.LABEL, labelId );
-        assertThat( txState.getNodeState( 123L ).labelDiffSets().getAdded(), contains( 456 ) );
+        order.verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.LABEL, labelId );
+        order.verify( txState ).nodeDoAddLabel( labelId, 123 );
     }
 
     @Test
@@ -184,10 +277,8 @@ public class OperationsLockTest
         operations.nodeSetProperty( 123, propertyKeyId, value );
 
         // then
-        verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 123 );
-        Iterator<StorageProperty> properties = txState.getNodeState( 123L ).addedProperties();
-        assertThat( properties.next().propertyKeyId(), equalTo( propertyKeyId ) );
-        assertThat( properties.hasNext(), equalTo( false ) );
+        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 123 );
+        order.verify( txState ).nodeDoAddProperty( 123, propertyKeyId, value );
     }
 
     @Test
@@ -206,9 +297,7 @@ public class OperationsLockTest
 
         // then
         verify( locks, never() ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 123 );
-        Iterator<StorageProperty> properties = txState.getNodeState( 123L ).addedProperties();
-        assertThat( properties.next().propertyKeyId(), equalTo( propertyKeyId ) );
-        assertThat( properties.hasNext(), equalTo( false ) );
+        verify( txState ).nodeDoAddProperty( 123, propertyKeyId, value );
     }
 
     @Test
@@ -224,8 +313,8 @@ public class OperationsLockTest
         operations.nodeDelete(  123 );
 
         //THEN
-        verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 123 );
-        assertThat( txState.nodeIsDeletedInThisTx( 123 ), equalTo( true ) );
+        order.verify( locks ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 123 );
+        order.verify( txState ).nodeDoDelete( 123 );
     }
 
     @Test
@@ -240,7 +329,7 @@ public class OperationsLockTest
 
         //THEN
         verify( locks, never() ).acquireExclusive( LockTracer.NONE, ResourceTypes.NODE, 123 );
-        assertThat( txState.nodeIsDeletedInThisTx( 123 ), equalTo( true ) );
+        verify( txState ).nodeDoDelete( 123 );
     }
 
     @Test
@@ -250,7 +339,8 @@ public class OperationsLockTest
         allStoreHolder.constraintsGetForSchema( descriptor );
 
         // THEN
-        verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.LABEL, descriptor.getLabelId() );
+        order.verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.LABEL, descriptor.getLabelId() );
+        order.verify( storeReadLayer ).constraintsGetForSchema( descriptor );
     }
 
     @Test
@@ -260,7 +350,8 @@ public class OperationsLockTest
         allStoreHolder.constraintsGetForLabel( 42 );
 
         // THEN
-        verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.LABEL, 42 );
+        order.verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.LABEL, 42 );
+        order.verify( storeReadLayer ).constraintsGetForLabel( 42 );
     }
 
     @Test
@@ -270,11 +361,12 @@ public class OperationsLockTest
         allStoreHolder.constraintExists( ConstraintDescriptorFactory.uniqueForSchema( descriptor ) );
 
         // THEN
-        verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.LABEL, 123 );
+        order.verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.LABEL, 123 );
+        order.verify( storeReadLayer ).constraintExists( any() );
     }
 
     @Test
-    public void shouldAcquireSchemaReadLockBeforeGettingAllConstraints() throws Exception
+    public void shouldAcquireSchemaReadLockLazilyBeforeGettingAllConstraints() throws Exception
     {
         // given
         int labelId = 1;
@@ -290,7 +382,17 @@ public class OperationsLockTest
 
         // then
         assertThat( asList( result ), empty() );
-        verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.LABEL, labelId );
-        verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.RELATIONSHIP_TYPE, relTypeId );
+        order.verify( storeReadLayer ).constraintsGetAll();
+        order.verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.LABEL, labelId );
+        order.verify( locks ).acquireShared( LockTracer.NONE, ResourceTypes.RELATIONSHIP_TYPE, relTypeId );
+    }
+
+    private void setStoreRelationship( long relationshipId, long sourceNode, long targetNode, int relationshipLabel )
+    {
+        when( relationshipCursor.next() ).thenReturn( true );
+        when( relationshipCursor.relationshipReference() ).thenReturn( relationshipId );
+        when( relationshipCursor.sourceNodeReference() ).thenReturn( sourceNode );
+        when( relationshipCursor.targetNodeReference() ).thenReturn( targetNode );
+        when( relationshipCursor.label() ).thenReturn( relationshipLabel );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/RelationshipWriteTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/RelationshipWriteTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.newapi;
+
+import org.neo4j.internal.kernel.api.RelationshipWriteTestBase;
+
+public class RelationshipWriteTest extends RelationshipWriteTestBase<WriteTestSupport>
+{
+    @Override
+    public WriteTestSupport newTestSupport()
+    {
+        return new WriteTestSupport();
+    }
+}

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeTransactionStateTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/NodeTransactionStateTest.java
@@ -19,9 +19,9 @@
  */
 package org.neo4j.kernel.impl.newapi;
 
-import org.neo4j.internal.kernel.api.TransactionStateTestBase;
+import org.neo4j.internal.kernel.api.NodeTransactionStateTestBase;
 
-public class TransactionStateTest extends TransactionStateTestBase<WriteTestSupport>
+public class NodeTransactionStateTest extends NodeTransactionStateTestBase<WriteTestSupport>
 {
     @Override
     public WriteTestSupport newTestSupport()

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/RelationshipTransactionStateTest.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/impl/newapi/RelationshipTransactionStateTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.newapi;
+
+import org.neo4j.internal.kernel.api.RelationshipTransactionStateTestBase;
+
+public class RelationshipTransactionStateTest extends RelationshipTransactionStateTestBase<WriteTestSupport>
+{
+    @Override
+    public WriteTestSupport newTestSupport()
+    {
+        return new WriteTestSupport();
+    }
+}


### PR DESCRIPTION
Add the following functionality to the Kernel API implementation

 * Create relationship
 * Delete relationship
 * Tx-state aware single relationship lookups

Probably relationship scans are also tx-state aware, but haven't added tests yet. Could are here or in separate PR - indicate how we should do it in review.