### PR TITLE
Fix regression for label scans

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -119,6 +119,7 @@ import static org.neo4j.kernel.impl.api.explicitindex.InternalAutoIndexing.NODE_
 import static org.neo4j.kernel.impl.api.explicitindex.InternalAutoIndexing.RELATIONSHIP_AUTO_INDEX;
 import static org.neo4j.kernel.impl.api.operations.KeyReadOperations.NO_SUCH_LABEL;
 import static org.neo4j.kernel.impl.api.operations.KeyReadOperations.NO_SUCH_PROPERTY_KEY;
+import static org.neo4j.kernel.impl.store.record.AbstractBaseRecord.NO_ID;
 
 /**
  * Implementation of the GraphDatabaseService/GraphDatabaseService interfaces - the "Core API". Given an {@link SPI}
@@ -898,8 +899,6 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI, EmbeddedProxySPI
 
     private final class NodeCursorResourceIterator implements ResourceIterator<Node>
     {
-        private static final long UNINITIALIZED = -2L;
-        private static final long NO_ID = -1L;
         private final NodeLabelIndexCursor cursor;
         private final Statement statement;
         private long next;
@@ -909,16 +908,12 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI, EmbeddedProxySPI
         {
             this.cursor = cursor;
             this.statement = statement;
-            next = -2L;
+            fetchNext();
         }
 
         @Override
         public boolean hasNext()
         {
-            if ( next == UNINITIALIZED )
-            {
-                fetchNext();
-            }
             return next != NO_ID;
         }
 
@@ -943,7 +938,6 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI, EmbeddedProxySPI
             }
             else
             {
-                next = NO_ID;
                 close();
             }
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -903,17 +903,22 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI, EmbeddedProxySPI
         private final Statement statement;
         private long next;
         private boolean closed;
+        private static final long NOT_INITIALIZED = -2L;
 
         NodeCursorResourceIterator( NodeLabelIndexCursor cursor, Statement statement )
         {
             this.cursor = cursor;
             this.statement = statement;
-            fetchNext();
+            this.next = NOT_INITIALIZED;
         }
 
         @Override
         public boolean hasNext()
         {
+            if ( next == NOT_INITIALIZED )
+            {
+                fetchNext();
+            }
             return next != NO_ID;
         }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIndexProgressor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/LabelScanValueIndexProgressor.java
@@ -33,7 +33,7 @@ import org.neo4j.storageengine.api.schema.IndexProgressor;
  * iterate over each set bit, returning actual node ids, i.e. {@code nodeIdRange+bitOffset}.
  *
  */
-class LabelScanValueIndexProgressor extends LabelScanValueIndexAccessor implements IndexProgressor, Resource
+public class LabelScanValueIndexProgressor extends LabelScanValueIndexAccessor implements IndexProgressor, Resource
 {
 
     private final NodeLabelClient client;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/ExplicitIndexProgressor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/ExplicitIndexProgressor.java
@@ -22,7 +22,7 @@ package org.neo4j.kernel.impl.newapi;
 import org.neo4j.kernel.api.ExplicitIndexHits;
 import org.neo4j.storageengine.api.schema.IndexProgressor;
 
-class ExplicitIndexProgressor implements IndexProgressor
+public class ExplicitIndexProgressor implements IndexProgressor
 {
     private final ExplicitClient client;
     private final ExplicitIndexHits hits;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/IndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/IndexCursor.java
@@ -21,11 +21,11 @@ package org.neo4j.kernel.impl.newapi;
 
 import org.neo4j.storageengine.api.schema.IndexProgressor;
 
-abstract class IndexCursor
+abstract class IndexCursor<T extends IndexProgressor>
 {
-    private IndexProgressor progressor;
+    protected T progressor;
 
-    final void initialize( IndexProgressor progressor )
+    final void initialize( T progressor )
     {
         if ( this.progressor != null )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/IndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/IndexCursor.java
@@ -23,7 +23,7 @@ import org.neo4j.storageengine.api.schema.IndexProgressor;
 
 abstract class IndexCursor<T extends IndexProgressor>
 {
-    protected T progressor;
+    private T progressor;
 
     final void initialize( T progressor )
     {
@@ -39,7 +39,7 @@ abstract class IndexCursor<T extends IndexProgressor>
         return false;
     }
 
-    boolean innerNext()
+    final boolean innerNext()
     {
         return progressor != null && progressor.next();
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeExplicitIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeExplicitIndexCursor.java
@@ -20,12 +20,11 @@
 package org.neo4j.kernel.impl.newapi;
 
 import org.neo4j.internal.kernel.api.NodeCursor;
-import org.neo4j.storageengine.api.schema.IndexProgressor;
 import org.neo4j.storageengine.api.schema.IndexProgressor.ExplicitClient;
 
 import static org.neo4j.kernel.impl.store.record.AbstractBaseRecord.NO_ID;
 
-class NodeExplicitIndexCursor extends IndexCursor
+class NodeExplicitIndexCursor extends IndexCursor<ExplicitIndexProgressor>
         implements org.neo4j.internal.kernel.api.NodeExplicitIndexCursor, ExplicitClient
 {
     private Read read;
@@ -39,7 +38,7 @@ class NodeExplicitIndexCursor extends IndexCursor
     }
 
     @Override
-    public void initialize( IndexProgressor progressor, int expectedSize )
+    public void initialize( ExplicitIndexProgressor progressor, int expectedSize )
     {
         super.initialize( progressor );
         this.expectedSize = expectedSize;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeLabelIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeLabelIndexCursor.java
@@ -109,8 +109,7 @@ class NodeLabelIndexCursor extends IndexCursor<LabelScanValueIndexProgressor>
         }
         else
         {
-            LabelScanValueIndexProgressor p = progressor;
-            return p != null && p.next();
+            return innerNext();
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeLabelIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeLabelIndexCursor.java
@@ -19,24 +19,28 @@
  */
 package org.neo4j.kernel.impl.newapi;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.internal.kernel.api.LabelSet;
 import org.neo4j.internal.kernel.api.NodeCursor;
+import org.neo4j.kernel.impl.index.labelscan.LabelScanValueIndexProgressor;
 import org.neo4j.storageengine.api.schema.IndexProgressor;
 import org.neo4j.storageengine.api.schema.IndexProgressor.NodeLabelClient;
 import org.neo4j.storageengine.api.txstate.ReadableDiffSets;
 
 import static org.neo4j.kernel.impl.store.record.AbstractBaseRecord.NO_ID;
 
-class NodeLabelIndexCursor extends IndexCursor
+class NodeLabelIndexCursor extends IndexCursor<LabelScanValueIndexProgressor>
         implements org.neo4j.internal.kernel.api.NodeLabelIndexCursor, NodeLabelClient
 {
     private Read read;
     private long node;
     private LabelSet labels;
     private PrimitiveLongIterator added;
-    private ReadableDiffSets<Long> changes;
+    private Set<Long> removed;
 
     NodeLabelIndexCursor()
     {
@@ -44,25 +48,22 @@ class NodeLabelIndexCursor extends IndexCursor
     }
 
     @Override
-    public void scan( IndexProgressor progressor, boolean providesLabels, int label )
+    public void scan( LabelScanValueIndexProgressor progressor, boolean providesLabels, int label )
     {
         super.initialize( progressor );
         if ( read.hasTxStateWithChanges() )
         {
-            changes = read.txState().nodesWithLabelChanged( label );
+            ReadableDiffSets<Long> changes =
+                    read.txState().nodesWithLabelChanged( label );
             added = changes.augment( PrimitiveLongCollections.emptyIterator() );
+            removed = new HashSet<>( read.txState().addedAndRemovedNodes().getRemoved() );
+            removed.addAll( changes.getRemoved() );
         }
     }
 
     @Override
     public void unionScan( IndexProgressor progressor, boolean providesLabels, int... labels )
     {
-        super.initialize( progressor );
-        if ( read.hasTxStateWithChanges() )
-        {
-            changes = read.txState().nodesWithAnyOfLabelsChanged( labels );
-            added = changes.augment( PrimitiveLongCollections.emptyIterator() );
-        }
         //TODO: Currently we don't have a good way of handling this in the tx state
         //The problem is this case:
         //Given a node with label :A
@@ -75,7 +76,6 @@ class NodeLabelIndexCursor extends IndexCursor
     @Override
     public void intersectionScan( IndexProgressor progressor, boolean providesLabels, int... labels )
     {
-        super.initialize( progressor );
         //TODO: Currently we don't have a good way of handling this in the tx state
         //The problem is for the nodes where some - but not all of the labels - are
         //added in the transaction. For these we need to go to disk and check if they
@@ -109,7 +109,8 @@ class NodeLabelIndexCursor extends IndexCursor
         }
         else
         {
-            return innerNext();
+            LabelScanValueIndexProgressor p = progressor;
+            return p != null && p.next();
         }
     }
 
@@ -143,6 +144,7 @@ class NodeLabelIndexCursor extends IndexCursor
         node = NO_ID;
         labels = null;
         read = null;
+        removed = null;
     }
 
     @Override
@@ -167,7 +169,6 @@ class NodeLabelIndexCursor extends IndexCursor
 
     private boolean isRemoved( long reference )
     {
-        return (changes != null && changes.isRemoved( reference ) ) ||
-               (read.hasTxStateWithChanges() && read.txState().addedAndRemovedNodes().isRemoved( reference ));
+        return removed != null && removed.contains( reference );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeValueIndexCursor.java
@@ -35,7 +35,7 @@ import static org.neo4j.collection.primitive.PrimitiveLongCollections.emptyItera
 import static org.neo4j.kernel.impl.api.StateHandlingStatementOperations.assertOnlyExactPredicates;
 import static org.neo4j.kernel.impl.store.record.AbstractBaseRecord.NO_ID;
 
-class NodeValueIndexCursor extends IndexCursor
+class NodeValueIndexCursor extends IndexCursor<IndexProgressor>
         implements org.neo4j.internal.kernel.api.NodeValueIndexCursor, NodeValueClient
 {
     private Read read;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipExplicitIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipExplicitIndexCursor.java
@@ -21,12 +21,11 @@ package org.neo4j.kernel.impl.newapi;
 
 import org.neo4j.internal.kernel.api.NodeCursor;
 import org.neo4j.internal.kernel.api.RelationshipScanCursor;
-import org.neo4j.storageengine.api.schema.IndexProgressor;
 import org.neo4j.storageengine.api.schema.IndexProgressor.ExplicitClient;
 
 import static org.neo4j.kernel.impl.store.record.AbstractBaseRecord.NO_ID;
 
-class RelationshipExplicitIndexCursor extends IndexCursor
+class RelationshipExplicitIndexCursor extends IndexCursor<ExplicitIndexProgressor>
         implements org.neo4j.internal.kernel.api.RelationshipExplicitIndexCursor, ExplicitClient
 {
     private Read read;
@@ -35,7 +34,7 @@ class RelationshipExplicitIndexCursor extends IndexCursor
     private float score;
 
     @Override
-    public void initialize( IndexProgressor progressor, int expectedSize )
+    public void initialize( ExplicitIndexProgressor progressor, int expectedSize )
     {
         super.initialize( progressor );
         this.expectedSize = expectedSize;

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/IndexProgressor.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/IndexProgressor.java
@@ -22,6 +22,8 @@ package org.neo4j.storageengine.api.schema;
 import org.neo4j.internal.kernel.api.IndexQuery;
 import org.neo4j.internal.kernel.api.LabelSet;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
+import org.neo4j.kernel.impl.index.labelscan.LabelScanValueIndexProgressor;
+import org.neo4j.kernel.impl.newapi.ExplicitIndexProgressor;
 import org.neo4j.values.storable.Value;
 
 /**
@@ -100,7 +102,7 @@ public interface IndexProgressor extends AutoCloseable
          * @param providesLabels true if the progression can provide label information
          * @param label the label to scan for
          */
-        void scan( IndexProgressor progressor, boolean providesLabels, int label );
+        void scan( LabelScanValueIndexProgressor progressor, boolean providesLabels, int label );
 
         void unionScan( IndexProgressor progressor, boolean providesLabels, int... labels );
 
@@ -126,7 +128,7 @@ public interface IndexProgressor extends AutoCloseable
          * @param progressor the progressor
          * @param expectedSize expected number of entries this progressor will feed the client.
          */
-        void initialize( IndexProgressor progressor, int expectedSize );
+        void initialize( ExplicitIndexProgressor progressor, int expectedSize );
 
         /**
          * Accept the entity id and a score. Return true if the entry is accepted, false otherwise

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/IndexCursorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/IndexCursorTest.java
@@ -46,7 +46,7 @@ public class IndexCursorTest
         assertFalse( "new still open", otherProgressor.isClosed );
     }
 
-    private static class StubIndexCursor extends IndexCursor
+    private static class StubIndexCursor extends IndexCursor<StubProgressor>
     {
     }
 


### PR DESCRIPTION
After switching to the new API there was a regression for scanning nodes by label in the Core API. This PR addresses that PR by:
- Less indirection in the cursor, or rather the cursor knows about the type of the progressor and thus avoiding a megamorphic call site
- More efficient cursor-to-iterator in `GraphDatabaseFacade`