### PR TITLE
Introduce temporal types to Cypher

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPackV1.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/messaging/Neo4jPackV1.java
@@ -294,6 +294,48 @@ public class Neo4jPackV1 implements Neo4jPack
         }
 
         @Override
+        public void writeDuration( long months, long days, long seconds, int nanos ) throws IOException
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
+        public void writeDate( long epochDay ) throws IOException
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
+        public void writeLocalTime( long nanoOfDay ) throws IOException
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
+        public void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws IOException
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
+        public void writeLocalDateTime( long epochSecond, int nano ) throws IOException
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
+        public void writeDateTime( long epochSecondUTC, int nano, int offsetSeconds ) throws IOException
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
+        public void writeDateTime( long epochSecondUTC, int nano, String zoneId ) throws IOException
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
         public void writeNull() throws IOException
         {
             packNull();

--- a/community/common/src/main/java/org/neo4j/time/FakeClock.java
+++ b/community/common/src/main/java/org/neo4j/time/FakeClock.java
@@ -50,7 +50,7 @@ public class FakeClock extends SystemNanoClock
     @Override
     public Clock withZone( ZoneId zone )
     {
-        throw new UnsupportedOperationException();
+        return new WithZone( zone );
     }
 
     @Override
@@ -75,5 +75,39 @@ public class FakeClock extends SystemNanoClock
     {
         nanoTime += unit.toNanos( delta );
         return this;
+    }
+
+    private class WithZone extends Clock
+    {
+        private final ZoneId zone;
+
+        WithZone( ZoneId zone )
+        {
+            this.zone = zone;
+        }
+
+        @Override
+        public ZoneId getZone()
+        {
+            return zone;
+        }
+
+        @Override
+        public Clock withZone( ZoneId zone )
+        {
+            return new WithZone( zone );
+        }
+
+        @Override
+        public long millis()
+        {
+            return FakeClock.this.millis();
+        }
+
+        @Override
+        public Instant instant()
+        {
+            return FakeClock.this.instant();
+        }
     }
 }

--- a/community/common/src/main/java/org/neo4j/time/SystemNanoClock.java
+++ b/community/common/src/main/java/org/neo4j/time/SystemNanoClock.java
@@ -46,13 +46,19 @@ public class SystemNanoClock extends Clock
     @Override
     public Clock withZone( ZoneId zone )
     {
-        throw new UnsupportedOperationException( "Zone update is not supported." );
+        return Clock.system( zone ); // the users of this method do not need a NanoClock
     }
 
     @Override
     public Instant instant()
     {
-        return Instant.now();
+        return Instant.ofEpochMilli( millis() );
+    }
+
+    @Override
+    public long millis()
+    {
+        return System.currentTimeMillis();
     }
 
     public long nanos()

--- a/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/ParameterConverter.java
+++ b/community/cypher/cypher/src/main/java/org/neo4j/cypher/internal/codegen/ParameterConverter.java
@@ -20,6 +20,8 @@
 package org.neo4j.cypher.internal.codegen;
 
 import java.lang.reflect.Array;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,8 +38,14 @@ import org.neo4j.helpers.collection.ReverseArrayIterator;
 import org.neo4j.kernel.impl.core.EmbeddedProxySPI;
 import org.neo4j.values.AnyValueWriter;
 import org.neo4j.values.storable.CoordinateReferenceSystem;
+import org.neo4j.values.storable.DateTimeValue;
+import org.neo4j.values.storable.DateValue;
+import org.neo4j.values.storable.DurationValue;
+import org.neo4j.values.storable.LocalDateTimeValue;
+import org.neo4j.values.storable.LocalTimeValue;
 import org.neo4j.values.storable.TextArray;
 import org.neo4j.values.storable.TextValue;
+import org.neo4j.values.storable.TimeValue;
 import org.neo4j.values.storable.Values;
 import org.neo4j.values.virtual.RelationshipValue;
 import org.neo4j.values.virtual.MapValue;
@@ -346,6 +354,48 @@ class ParameterConverter implements AnyValueWriter<RuntimeException>
     public void writePoint( CoordinateReferenceSystem crs, double[] coordinate ) throws RuntimeException
     {
         writeValue( Values.pointValue( crs, coordinate ) );
+    }
+
+    @Override
+    public void writeDuration( long months, long days, long seconds, int nanos ) throws RuntimeException
+    {
+        writeValue( DurationValue.duration( months, days, seconds, nanos ) );
+    }
+
+    @Override
+    public void writeDate( long epochDay ) throws RuntimeException
+    {
+        writeValue( DateValue.epochDate( epochDay ) );
+    }
+
+    @Override
+    public void writeLocalTime( long nanoOfDay ) throws RuntimeException
+    {
+        writeValue( LocalTimeValue.localTime( nanoOfDay ) );
+    }
+
+    @Override
+    public void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws RuntimeException
+    {
+        writeValue( TimeValue.time( nanosOfDayUTC, ZoneOffset.ofTotalSeconds( offsetSeconds ) ) );
+    }
+
+    @Override
+    public void writeLocalDateTime( long epochSecond, int nano ) throws RuntimeException
+    {
+        writeValue( LocalDateTimeValue.localDateTime( epochSecond, nano ) );
+    }
+
+    @Override
+    public void writeDateTime( long epochSecondUTC, int nano, int offsetSeconds ) throws RuntimeException
+    {
+        writeValue( DateTimeValue.datetime( epochSecondUTC, nano, ZoneOffset.ofTotalSeconds( offsetSeconds ) ) );
+    }
+
+    @Override
+    public void writeDateTime( long epochSecondUTC, int nano, String zoneId ) throws RuntimeException
+    {
+        writeValue( DateTimeValue.datetime( epochSecondUTC, nano, ZoneId.of( zoneId ) ) );
     }
 
     private interface Writer

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/ExceptionTranslatingQueryContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/ExceptionTranslatingQueryContext.scala
@@ -154,7 +154,7 @@ class ExceptionTranslatingQueryContext(val inner: QueryContext) extends QueryCon
   override def callDbmsProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]): Iterator[Array[AnyRef]] =
     translateIterator(inner.callDbmsProcedure(name, args, allowed))
 
-  override def callFunction(name: QualifiedName, args: Seq[Any], allowed: Array[String]) =
+  override def callFunction(name: QualifiedName, args: Seq[AnyValue], allowed: Array[String]) =
     translateException(inner.callFunction(name, args, allowed))
 
 

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundPlanContext.scala
@@ -195,6 +195,12 @@ class TransactionBoundPlanContext(tc: TransactionalContextWrapper, logger: Inter
     case Neo4jTypes.NTGeometry => symbols.CTGeometry
     case Neo4jTypes.NTMap => symbols.CTMap
     case Neo4jTypes.NTAny => symbols.CTAny
+    case Neo4jTypes.NTDateTime => symbols.CTAny
+    case Neo4jTypes.NTLocalDateTime => symbols.CTAny
+    case Neo4jTypes.NTDate => symbols.CTAny
+    case Neo4jTypes.NTTime => symbols.CTAny
+    case Neo4jTypes.NTLocalTime => symbols.CTAny
+    case Neo4jTypes.NTDuration => symbols.CTAny
   }
 
   override def notificationLogger(): InternalNotificationLogger = logger

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_1/TransactionBoundPlanContext.scala
@@ -38,7 +38,7 @@ import org.neo4j.kernel.api.proc.{Neo4jTypes, QualifiedName => KernelQualifiedNa
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory
 import org.neo4j.kernel.api.schema.constaints.ConstraintDescriptor
 import org.neo4j.kernel.api.schema.index.{IndexDescriptor => KernelIndexDescriptor}
-import org.neo4j.kernel.impl.proc.Neo4jValue
+import org.neo4j.kernel.impl.proc.DefaultParameterValue
 import org.neo4j.procedure.Mode
 
 import scala.collection.JavaConverters._
@@ -179,7 +179,7 @@ class TransactionBoundPlanContext(tc: TransactionalContextWrapper, logger: Inter
       "Unable to execute procedure, because it requires an unrecognized execution mode: " + mode.name(), null )
   }
 
-  private def asCypherValue(neo4jValue: Neo4jValue) = CypherValue(neo4jValue.value, asCypherType(neo4jValue.neo4jType()))
+  private def asCypherValue(neo4jValue: DefaultParameterValue) = CypherValue(neo4jValue.value, asCypherType(neo4jValue.neo4jType()))
 
   private def asCypherType(neoType: AnyType): CypherType = neoType match {
     case Neo4jTypes.NTString => symbols.CTString

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundPlanContext.scala
@@ -189,6 +189,12 @@ class TransactionBoundPlanContext(readOperationsSupplier: () => ReadOperations, 
     case Neo4jTypes.NTGeometry => symbols.CTGeometry
     case Neo4jTypes.NTMap => symbols.CTMap
     case Neo4jTypes.NTAny => symbols.CTAny
+    case Neo4jTypes.NTDateTime => symbols.CTAny
+    case Neo4jTypes.NTLocalDateTime => symbols.CTAny
+    case Neo4jTypes.NTDate => symbols.CTAny
+    case Neo4jTypes.NTTime => symbols.CTAny
+    case Neo4jTypes.NTLocalTime => symbols.CTAny
+    case Neo4jTypes.NTDuration => symbols.CTAny
   }
 
   override def notificationLogger(): InternalNotificationLogger = logger

--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundPlanContext.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_3/TransactionBoundPlanContext.scala
@@ -35,7 +35,7 @@ import org.neo4j.kernel.api.proc.Neo4jTypes.AnyType
 import org.neo4j.kernel.api.proc.{Neo4jTypes, QualifiedName => KernelQualifiedName}
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory
 import org.neo4j.kernel.api.schema.index.{IndexDescriptor => KernelIndexDescriptor}
-import org.neo4j.kernel.impl.proc.Neo4jValue
+import org.neo4j.kernel.impl.proc.DefaultParameterValue
 import org.neo4j.procedure.Mode
 
 import scala.collection.JavaConverters._
@@ -172,7 +172,7 @@ class TransactionBoundPlanContext(readOperationsSupplier: () => ReadOperations, 
       "Unable to execute procedure, because it requires an unrecognized execution mode: " + mode.name(), null)
   }
 
-  private def asCypherValue(neo4jValue: Neo4jValue) = CypherValue(neo4jValue.value,
+  private def asCypherValue(neo4jValue: DefaultParameterValue) = CypherValue(neo4jValue.value,
     asCypherType(neo4jValue.neo4jType()))
 
   private def asCypherType(neoType: AnyType): CypherType = neoType match {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/LogicalPlanConverterTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compatibility/v3_3/LogicalPlanConverterTest.scala
@@ -412,6 +412,24 @@ class LogicalPlanConverterTest extends FunSuite with Matchers {
       }
   }
 
+  test("should convert function call with 'null' default value") {
+    val allowed = Array.empty[String] // this is passed through as the same instance - so shared
+    val name3_3 = plansV3_3.QualifiedName(Seq.empty, "foo")
+    val call3_3 = compilerV3_3.ast.ResolvedFunctionInvocation(name3_3,
+      Some(plansV3_3.UserFunctionSignature(name3_3, Vector(plansV3_3.FieldSignature("input", symbolsV3_3.CTAny,
+        default = Some(plansV3_3.CypherValue(null, symbolsV3_3.CTAny)))),
+        symbolsV3_3.CTAny, None, allowed, None, isAggregate = false)), Vector())(InputPositionV3_3(1, 2, 3))
+
+    val name3_4 = plansV3_4.QualifiedName(Seq.empty, "foo")
+    val call3_4 = plansV3_4.ResolvedFunctionInvocation(name3_4,
+      Some(plansV3_4.UserFunctionSignature(name3_4, Vector(plansV3_4.FieldSignature("input", symbolsV3_4.CTAny,
+        default = Some(plansV3_4.CypherValue(null, symbolsV3_4.CTAny)))),
+        symbolsV3_4.CTAny, None, allowed, None, isAggregate = false)), Vector())(InputPosition(1, 2, 3))
+
+    val rewritten = LogicalPlanConverter.convertExpression[plansV3_4.ResolvedFunctionInvocation](call3_3, new Solveds, new Cardinalities)
+    rewritten should be(call3_4)
+  }
+
   private def argumentProvider[T <: AnyRef](clazz: Class[T]): T = {
     val variable = astV3_3.Variable("n")(pos3_3)
     val value = clazz.getSimpleName match {

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/CastSupport.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/CastSupport.scala
@@ -19,6 +19,9 @@
  */
 package org.neo4j.cypher.internal.runtime.interpreted
 
+import java.time.temporal.{Temporal, TemporalAmount}
+import java.time.{ZoneId, ZoneOffset}
+
 import org.neo4j.cypher.internal.util.v3_4.CypherTypeException
 import org.neo4j.graphdb.spatial.Point
 import org.neo4j.values.storable.{ArrayValue, _}
@@ -215,6 +218,27 @@ object CastSupport {
 
     override def writePoint(crs: CoordinateReferenceSystem, coordinate: Array[Double]): Unit =
       write(Values.pointValue(crs, coordinate: _*))
+
+    override def writeDuration(months: Long, days: Long, seconds: Long, nanos: Int): Unit =
+      write(DurationValue.duration(months, days, seconds, nanos))
+
+    override def writeDate(epochDay: Long): Unit =
+      write(DateValue.epochDate(epochDay).asObject())
+
+    override def writeLocalTime(nanoOfDay: Long): Unit =
+      write(LocalTimeValue.localTime(nanoOfDay).asObject())
+
+    override def writeTime(nanosOfDayUTC: Long, offsetSeconds: Int): Unit =
+      write(TimeValue.time(nanosOfDayUTC, ZoneOffset.ofTotalSeconds(offsetSeconds)).asObject())
+
+    override def writeLocalDateTime(epochSecond: Long, nano: Int): Unit =
+      write(LocalDateTimeValue.localDateTime(epochSecond,nano).asObject())
+
+    override def writeDateTime(epochSecondUTC: Long, nano: Int, offsetSeconds: Int): Unit =
+      write(DateTimeValue.datetime(epochSecondUTC, nano, ZoneOffset.ofTotalSeconds(offsetSeconds)).asObject())
+
+    override def writeDateTime(epochSecondUTC: Long, nano: Int, zoneId: String): Unit =
+      write(DateTimeValue.datetime(epochSecondUTC, nano, ZoneId.of(zoneId)).asObject())
   }
 
 }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/CastSupport.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/CastSupport.scala
@@ -140,6 +140,18 @@ object CastSupport {
       transform(new ArrayConverterWriter(classOf[PointValue], a => Values.pointArray(a.asInstanceOf[Array[PointValue]]))))
     case _: Point => Converter(
       transform(new ArrayConverterWriter(classOf[Point], a => Values.pointArray(a.asInstanceOf[Array[Point]]))))
+    case _: DurationValue => Converter(
+      transform(new ArrayConverterWriter(classOf[DurationValue], a => Values.durationArray(a.asInstanceOf[Array[TemporalAmount]]))))
+    case _: DateValue => Converter(
+      transform(new ArrayConverterWriter(classOf[DateValue], a => Values.temporalArray(a.asInstanceOf[Array[Temporal]]))))
+    case _: LocalTimeValue => Converter(
+      transform(new ArrayConverterWriter(classOf[LocalTimeValue], a => Values.temporalArray(a.asInstanceOf[Array[Temporal]]))))
+    case _: TimeValue => Converter(
+      transform(new ArrayConverterWriter(classOf[TimeValue], a => Values.temporalArray(a.asInstanceOf[Array[Temporal]]))))
+    case _: LocalDateTimeValue => Converter(
+      transform(new ArrayConverterWriter(classOf[LocalDateTimeValue], a => Values.temporalArray(a.asInstanceOf[Array[Temporal]]))))
+    case _: DateTimeValue => Converter(
+      transform(new ArrayConverterWriter(classOf[DateTimeValue], a => Values.temporalArray(a.asInstanceOf[Array[Temporal]]))))
     case _ => throw new CypherTypeException("Property values can only be of primitive types or arrays thereof")
   }
 

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/DelegatingQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/DelegatingQueryContext.scala
@@ -221,7 +221,7 @@ abstract class DelegatingQueryContext(val inner: QueryContext) extends QueryCont
   override def callDbmsProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]) =
     inner.callDbmsProcedure(name, args, allowed)
 
-  override def callFunction(name: QualifiedName, args: Seq[Any], allowed: Array[String]) =
+  override def callFunction(name: QualifiedName, args: Seq[AnyValue], allowed: Array[String]) =
     singleDbHit(inner.callFunction(name, args, allowed))
 
   override def aggregateFunction(name: QualifiedName,

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundPlanContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundPlanContext.scala
@@ -185,6 +185,12 @@ class TransactionBoundPlanContext(tc: TransactionalContextWrapper, logger: Inter
     case Neo4jTypes.NTNumber => CTNumber
     case Neo4jTypes.NTBoolean => CTBoolean
     case l: Neo4jTypes.ListType => CTList(asCypherType(l.innerType()))
+    case Neo4jTypes.NTDateTime => CTDateTime
+    case Neo4jTypes.NTLocalDateTime => CTLocalDateTime
+    case Neo4jTypes.NTDate => CTDate
+    case Neo4jTypes.NTTime => CTTime
+    case Neo4jTypes.NTLocalTime => CTLocalTime
+    case Neo4jTypes.NTDuration => CTDuration
     case Neo4jTypes.NTPoint => CTPoint
     case Neo4jTypes.NTNode => CTNode
     case Neo4jTypes.NTRelationship => CTRelationship

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundPlanContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundPlanContext.scala
@@ -33,7 +33,7 @@ import org.neo4j.kernel.api.proc.Neo4jTypes.AnyType
 import org.neo4j.kernel.api.proc.{Neo4jTypes, QualifiedName => KernelQualifiedName}
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory
 import org.neo4j.kernel.api.schema.index.{IndexDescriptor => KernelIndexDescriptor}
-import org.neo4j.kernel.impl.proc.Neo4jValue
+import org.neo4j.kernel.impl.proc.DefaultParameterValue
 import org.neo4j.procedure.Mode
 
 import scala.collection.JavaConverters._
@@ -175,7 +175,7 @@ class TransactionBoundPlanContext(tc: TransactionalContextWrapper, logger: Inter
       "Unable to execute procedure, because it requires an unrecognized execution mode: " + mode.name(), null)
   }
 
-  private def asCypherValue(neo4jValue: Neo4jValue) = CypherValue(neo4jValue.value,
+  private def asCypherValue(neo4jValue: DefaultParameterValue) = CypherValue(neo4jValue.value,
                                                                   asCypherType(neo4jValue.neo4jType()))
 
   private def asCypherType(neoType: AnyType): CypherType = neoType match {

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/FunctionInvocation.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/FunctionInvocation.scala
@@ -19,24 +19,20 @@
  */
 package org.neo4j.cypher.internal.runtime.interpreted.commands.expressions
 
-import org.neo4j.cypher.internal.runtime.interpreted.ExecutionContext
-import org.neo4j.cypher.internal.runtime.interpreted.ValueConversion
-import org.neo4j.cypher.internal.runtime.interpreted.GraphElementPropertyFunctions
+import org.neo4j.cypher.internal.runtime.interpreted.{ExecutionContext, GraphElementPropertyFunctions}
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.QueryState
 import org.neo4j.cypher.internal.v3_4.logical.plans.UserFunctionSignature
 import org.neo4j.values._
 
 case class FunctionInvocation(signature: UserFunctionSignature, arguments: IndexedSeq[Expression])
   extends Expression with GraphElementPropertyFunctions {
-  private val valueConverter = ValueConversion.getValueConverter(signature.outputType)
 
   override def apply(ctx: ExecutionContext, state: QueryState): AnyValue = {
     val query = state.query
     val argValues = arguments.map(arg => {
-      query.asObject(arg(ctx, state))
+      arg(ctx, state)
     })
-    val result = query.callFunction(signature.name, argValues, signature.allowed)
-    valueConverter(result)
+    query.callFunction(signature.name, argValues, signature.allowed)
   }
 
   override def rewrite(f: (Expression) => Expression) =

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/QueryContextAdaptation.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/QueryContextAdaptation.scala
@@ -153,7 +153,7 @@ trait QueryContextAdaptation {
 
   override def callDbmsProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]): Iterator[Array[AnyRef]] = ???
 
-  override def callFunction(name: QualifiedName, args: Seq[Any], allowed: Array[String]): AnyRef = ???
+  override def callFunction(name: QualifiedName, args: Seq[AnyValue], allowed: Array[String]): AnyValue = ???
 
   override def aggregateFunction(name: QualifiedName,
                                  allowed: Array[String]): UserDefinedAggregator = ???

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContextTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContextTest.scala
@@ -37,7 +37,7 @@ import org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier
 import org.neo4j.kernel.api.KernelTransaction
 import org.neo4j.kernel.api.security.AnonymousContext
-import org.neo4j.kernel.impl.api.{KernelStatement, KernelTransactionImplementation, StatementOperationParts}
+import org.neo4j.kernel.impl.api.{ClockContext, KernelStatement, KernelTransactionImplementation, StatementOperationParts}
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge
 import org.neo4j.kernel.impl.coreapi.{InternalTransaction, PropertyContainerLocker}
 import org.neo4j.kernel.impl.factory.CanWrite
@@ -69,7 +69,7 @@ class TransactionBoundQueryContextTest extends CypherFunSuite {
     val storeStatement = mock[StorageStatement]
     val operations = mock[StatementOperationParts](RETURNS_DEEP_STUBS)
     statement = new KernelStatement(kernelTransaction, null, storeStatement, new Procedures(), new CanWrite(),
-      LockTracer.NONE, operations)
+      LockTracer.NONE, operations, new ClockContext())
     statement.initialize(null, PageCursorTracerSupplier.NULL.get())
     statement.acquire()
   }

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryContext.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryContext.scala
@@ -190,7 +190,7 @@ trait QueryContext extends TokenContext {
 
   def callDbmsProcedure(name: QualifiedName, args: Seq[Any], allowed: Array[String]): Iterator[Array[AnyRef]]
 
-  def callFunction(name: QualifiedName, args: Seq[Any], allowed: Array[String]): AnyRef
+  def callFunction(name: QualifiedName, args: Seq[AnyValue], allowed: Array[String]): AnyValue
 
   def aggregateFunction(name: QualifiedName, allowed: Array[String]): UserDefinedAggregator
 

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/FakeClock.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/FakeClock.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.cypher
+
+import java.time.Instant
+
+import org.neo4j.time.Clocks
+
+trait FakeClock {
+  val clock: org.neo4j.time.FakeClock = Clocks.fakeClock(Instant.now())
+}

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/Rewritable.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/Rewritable.scala
@@ -38,6 +38,7 @@ object RewriterWithArgs {
       // We need to dup anything not matched by f given the children
       case (p: Product, children) => Rewritable.dupProduct(p, children).asInstanceOf[AnyRef]
       case (a: AnyRef, children) => Rewritable.dupAny(a, children)
+      case (null, _) => null
     }))
 }
 

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/TemporalTypes.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/TemporalTypes.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypher.internal.util.v3_4.symbols
+
+object TemporalTypes {
+  val datetime = new DateTimeType {
+    val parentType = CTAny
+    override val toString = "DateTime"
+    override val toNeoTypeString = "DATETIME?"
+  }
+  val localdatetime = new LocalDateTimeType {
+    val parentType = CTAny
+    override val toString = "LocalDateTime"
+    override val toNeoTypeString = "LOCALDATETIME?"
+  }
+  val date = new DateType {
+    val parentType = CTAny
+    override val toString = "Date"
+    override val toNeoTypeString = "DATE?"
+  }
+  val time = new TimeType {
+    val parentType = CTAny
+    override val toString = "Time"
+    override val toNeoTypeString = "TIME?"
+  }
+  val localtime = new LocalTimeType {
+    val parentType = CTAny
+    override val toString = "LocalTime"
+    override val toNeoTypeString = "LOCALTIME?"
+  }
+  val duration = new DurationType {
+    val parentType = CTAny
+    override val toString = "Duration"
+    override val toNeoTypeString = "DURATION?"
+  }
+}
+
+sealed abstract class DateTimeType extends CypherType
+sealed abstract class LocalDateTimeType extends CypherType
+sealed abstract class DateType extends CypherType
+sealed abstract class TimeType extends CypherType
+sealed abstract class LocalTimeType extends CypherType
+sealed abstract class DurationType extends CypherType

--- a/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/package.scala
+++ b/community/cypher/util-3.4/src/main/scala/org/neo4j/cypher/internal/util/v3_4/symbols/package.scala
@@ -29,6 +29,12 @@ package object symbols {
   val CTNode: NodeType = NodeType.instance
   val CTRelationship: RelationshipType = RelationshipType.instance
   val CTPoint: PointType = PointType.instance
+  val CTDateTime: DateTimeType = TemporalTypes.datetime
+  val CTLocalDateTime: LocalDateTimeType = TemporalTypes.localdatetime
+  val CTDate: DateType = TemporalTypes.date
+  val CTTime: TimeType = TemporalTypes.time
+  val CTLocalTime: LocalTimeType = TemporalTypes.localtime
+  val CTDuration: DurationType = TemporalTypes.duration
   val CTGeometry: GeometryType = GeometryType.instance
   val CTPath: PathType = PathType.instance
   val CTGraphRef: GraphRefType = GraphRefType.instance

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/ProcedureCallOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/ProcedureCallOperations.java
@@ -24,6 +24,8 @@ import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.CallableUserAggregationFunction;
 import org.neo4j.kernel.api.proc.QualifiedName;
 import org.neo4j.internal.kernel.api.security.AccessMode;
+import org.neo4j.values.AnyValue;
+import org.neo4j.values.ValueMapper;
 
 /**
  * Specifies procedure call operations for the three types of procedure calls that can be made.
@@ -99,7 +101,7 @@ public interface ProcedureCallOperations
      * @param arguments the function arguments.
      * @throws ProcedureException if there was an exception thrown during function execution.
      */
-    Object functionCall( QualifiedName name, Object[] arguments ) throws ProcedureException;
+    AnyValue functionCall( QualifiedName name, AnyValue[] arguments ) throws ProcedureException;
 
     /** Invoke a read-only function by name, and set the transaction's access mode to
      * {@link AccessMode.Static#READ READ} for the duration of the function execution.
@@ -107,7 +109,7 @@ public interface ProcedureCallOperations
      * @param arguments the function arguments.
      * @throws ProcedureException if there was an exception thrown during function execution.
      */
-    Object functionCallOverride( QualifiedName name, Object[] arguments ) throws ProcedureException;
+    AnyValue functionCallOverride( QualifiedName name, AnyValue[] arguments ) throws ProcedureException;
 
     /**
      * Create a read-only aggregation function by name
@@ -123,4 +125,10 @@ public interface ProcedureCallOperations
      * @throws ProcedureException if there was an exception thrown during function execution.
      */
     CallableUserAggregationFunction.Aggregator aggregationFunctionOverride( QualifiedName name ) throws ProcedureException;
+
+    /**
+     * Retrieve a value mapper for mapping values to regular Java objects.
+     * @return a value mapper that maps to Java objects.
+     */
+    ValueMapper<Object> valueMapper();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/dbms/DbmsOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/dbms/DbmsOperations.java
@@ -24,6 +24,7 @@ import org.neo4j.kernel.api.InwardKernel;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.proc.QualifiedName;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.values.AnyValue;
 
 /**
  * Defines all types of system-oriented operations - i.e. those which do not read from or
@@ -44,9 +45,9 @@ public interface DbmsOperations
     ) throws ProcedureException;
 
     /** Invoke a DBMS function by name */
-    Object functionCallDbms(
+    AnyValue functionCallDbms(
             QualifiedName name,
-            Object[] input,
+            AnyValue[] input,
             SecurityContext securityContext
     ) throws ProcedureException;
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/ArrayEncoder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/ArrayEncoder.java
@@ -151,6 +151,48 @@ public final class ArrayEncoder
         }
 
         @Override
+        public void writeDuration( long months, long days, long seconds, int nanos ) throws RuntimeException
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
+        public void writeDate( long epochDay ) throws RuntimeException
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
+        public void writeLocalTime( long nanoOfDay ) throws RuntimeException
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
+        public void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws RuntimeException
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
+        public void writeLocalDateTime( long epochSecond, int nano ) throws RuntimeException
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
+        public void writeDateTime( long epochSecondUTC, int nano, int offsetSeconds ) throws RuntimeException
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
+        public void writeDateTime( long epochSecondUTC, int nano, String zoneId ) throws RuntimeException
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
         public void beginArray( int size, ArrayType arrayType )
         {
             if ( size > 0 )

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/CallableUserFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/CallableUserFunction.java
@@ -20,11 +20,12 @@
 package org.neo4j.kernel.api.proc;
 
 import org.neo4j.kernel.api.exceptions.ProcedureException;
+import org.neo4j.values.AnyValue;
 
 public interface CallableUserFunction
 {
     UserFunctionSignature signature();
-    Object apply( Context ctx, Object[] input ) throws ProcedureException;
+    AnyValue apply( Context ctx, AnyValue[] input ) throws ProcedureException;
 
     abstract class BasicUserFunction implements CallableUserFunction
     {
@@ -42,6 +43,6 @@ public interface CallableUserFunction
         }
 
         @Override
-        public abstract Object apply( Context ctx, Object[] input ) throws ProcedureException;
+        public abstract AnyValue apply( Context ctx, AnyValue[] input ) throws ProcedureException;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/Context.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/Context.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.api.proc;
 
+import java.time.Clock;
+
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
@@ -36,6 +38,9 @@ public interface Context
     Key<KernelTransaction> KERNEL_TRANSACTION = Key.key( "KernelTransaction", KernelTransaction.class );
     Key<SecurityContext> SECURITY_CONTEXT = Key.key( "SecurityContext", SecurityContext.class );
     Key<Thread> THREAD = Key.key( "Thread", Thread.class );
+    Key<Clock> SYSTEM_CLOCK = Key.key( "SystemClock", Clock.class );
+    Key<Clock> STATEMENT_CLOCK = Key.key( "StatementClock", Clock.class );
+    Key<Clock> TRANSACTION_CLOCK = Key.key( "TransactionClock", Clock.class );
 
     <T> T get( Key<T> key ) throws ProcedureException;
     <T> T getOrElse( Key<T> key, T orElse );

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/FailedLoadFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/FailedLoadFunction.java
@@ -19,9 +19,9 @@
  */
 package org.neo4j.kernel.api.proc;
 
-import org.neo4j.collection.RawIterator;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.values.AnyValue;
 
 public class FailedLoadFunction extends CallableUserFunction.BasicUserFunction
 {
@@ -31,7 +31,7 @@ public class FailedLoadFunction extends CallableUserFunction.BasicUserFunction
     }
 
     @Override
-    public RawIterator<Object[],ProcedureException> apply( Context ctx, Object[] input ) throws ProcedureException
+    public AnyValue apply( Context ctx, AnyValue[] input ) throws ProcedureException
     {
         throw new ProcedureException( Status.Procedure.ProcedureRegistrationFailed,
                 signature().description().orElse( "Failed to load " + signature().name().toString() ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/FieldSignature.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/FieldSignature.java
@@ -22,7 +22,7 @@ package org.neo4j.kernel.api.proc;
 import java.util.Objects;
 import java.util.Optional;
 
-import org.neo4j.kernel.impl.proc.Neo4jValue;
+import org.neo4j.kernel.impl.proc.DefaultParameterValue;
 
 import static java.util.Objects.requireNonNull;
 
@@ -34,7 +34,7 @@ public class FieldSignature
         return new FieldSignature( name, type, null, false );
     }
 
-    public static FieldSignature inputField( String name, Neo4jTypes.AnyType type, Neo4jValue defaultValue )
+    public static FieldSignature inputField( String name, Neo4jTypes.AnyType type, DefaultParameterValue defaultValue )
     {
         return new FieldSignature( name, type, requireNonNull( defaultValue, "defaultValue" ), false );
     }
@@ -51,10 +51,10 @@ public class FieldSignature
 
     private final String name;
     private final Neo4jTypes.AnyType type;
-    private final Neo4jValue defaultValue;
+    private final DefaultParameterValue defaultValue;
     private final boolean deprecated;
 
-    private FieldSignature( String name, Neo4jTypes.AnyType type, Neo4jValue defaultValue, boolean deprecated )
+    private FieldSignature( String name, Neo4jTypes.AnyType type, DefaultParameterValue defaultValue, boolean deprecated )
     {
         this.name = requireNonNull( name, "name" );
         this.type = requireNonNull( type, "type" );
@@ -81,7 +81,7 @@ public class FieldSignature
         return type;
     }
 
-    public Optional<Neo4jValue> defaultValue()
+    public Optional<DefaultParameterValue> defaultValue()
     {
         return Optional.ofNullable( defaultValue );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/proc/Neo4jTypes.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/proc/Neo4jTypes.java
@@ -40,6 +40,12 @@ public class Neo4jTypes
     public static final PathType NTPath = new PathType();
     public static final GeometryType NTGeometry = new GeometryType();
     public static final PointType NTPoint = new PointType();
+    public static final DateTimeType NTDateTime = new DateTimeType();
+    public static final LocalDateTimeType NTLocalDateTime = new LocalDateTimeType();
+    public static final DateType NTDate = new DateType();
+    public static final TimeType NTTime = new TimeType();
+    public static final LocalTimeType NTLocalTime = new LocalTimeType();
+    public static final DurationType NTDuration = new DurationType();
 
     private Neo4jTypes()
     {
@@ -204,6 +210,54 @@ public class Neo4jTypes
         public PointType()
         {
             super( "POINT?" );
+        }
+    }
+
+    public static class DateTimeType extends AnyType
+    {
+        public DateTimeType()
+        {
+            super( "DATETIME?" );
+        }
+    }
+
+    public static class LocalDateTimeType extends AnyType
+    {
+        public LocalDateTimeType()
+        {
+            super( "LOCALDATETIME?" );
+        }
+    }
+
+    public static class DateType extends AnyType
+    {
+        public DateType()
+        {
+            super( "DATE?" );
+        }
+    }
+
+    public static class TimeType extends AnyType
+    {
+        public TimeType()
+        {
+            super( "TIME?" );
+        }
+    }
+
+    public static class LocalTimeType extends AnyType
+    {
+        public LocalTimeType()
+        {
+            super( "LOCALTIME?" );
+        }
+    }
+
+    public static class DurationType extends AnyType
+    {
+        public DurationType()
+        {
+            super( "DURATION?" );
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ClockContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ClockContext.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api;
+
+import java.time.Clock;
+import java.time.ZoneId;
+import java.util.Objects;
+
+public final class ClockContext
+{
+    private final Clock system;
+    private Clock statement;
+    private Clock transaction;
+
+    public ClockContext()
+    {
+        this( Clock.systemDefaultZone() );
+    }
+
+    public ClockContext( Clock clock )
+    {
+        this.system = Objects.requireNonNull( clock, "system clock" );
+    }
+
+    public void initializeTransaction()
+    {
+        this.transaction = Clock.fixed( system.instant(), timezone() );
+        this.statement = null;
+    }
+
+    public void initializeStatement()
+    {
+        if ( this.statement == null ) // this is the first statement in the transaction, use the transaction time
+        {
+            this.statement = this.transaction;
+        }
+        else // this is not the first statement in the transaction, initialize with a new time
+        {
+            this.statement = Clock.fixed( system.instant(), timezone() );
+        }
+    }
+
+    public ZoneId timezone()
+    {
+        return system.getZone();
+    }
+
+    public Clock systemClock()
+    {
+        return system;
+    }
+
+    public Clock statementClock()
+    {
+        assert statement != null : "statement clock not initialized";
+        return statement;
+    }
+
+    public Clock transactionClock()
+    {
+        assert transaction != null : "transaction clock not initialized";
+        return transaction;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -199,7 +199,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         this.cursorTracerSupplier = cursorTracerSupplier;
         this.storageStatement = storeLayer.newStatement();
         this.currentStatement = new KernelStatement( this, this, storageStatement,
-                procedures, accessCapability, lockTracer, statementOperations );
+                procedures, accessCapability, lockTracer, statementOperations, new ClockContext( clock ) );
         this.accessCapability = accessCapability;
         this.statistics = new Statistics( this, cpuClockRef, heapAllocationRef );
         this.userMetaData = new HashMap<>();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.kernel.impl.api;
 
+import java.time.Clock;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
@@ -1516,6 +1517,10 @@ public class OperationsFacade
             BasicContext ctx = new BasicContext();
             ctx.put( Context.KERNEL_TRANSACTION, tx );
             ctx.put( Context.THREAD, Thread.currentThread() );
+            ClockContext clocks = statement.clocks();
+            ctx.put( Context.SYSTEM_CLOCK, clocks.systemClock() );
+            ctx.put( Context.STATEMENT_CLOCK, clocks.statementClock() );
+            ctx.put( Context.TRANSACTION_CLOCK, clocks.transactionClock() );
             return procedures.callFunction( ctx, name, input );
         }
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -112,6 +112,8 @@ import org.neo4j.storageengine.api.Token;
 import org.neo4j.storageengine.api.lock.ResourceType;
 import org.neo4j.storageengine.api.schema.PopulationProgress;
 import org.neo4j.storageengine.api.schema.SchemaRule;
+import org.neo4j.values.AnyValue;
+import org.neo4j.values.ValueMapper;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
 import org.neo4j.values.virtual.MapValue;
@@ -1463,7 +1465,7 @@ public class OperationsFacade
     }
 
     @Override
-    public Object functionCall( QualifiedName name, Object[] arguments ) throws ProcedureException
+    public AnyValue functionCall( QualifiedName name, AnyValue[] arguments ) throws ProcedureException
     {
         if ( !tx.securityContext().mode().allowsReads() )
         {
@@ -1475,7 +1477,7 @@ public class OperationsFacade
     }
 
     @Override
-    public Object functionCallOverride( QualifiedName name, Object[] arguments ) throws ProcedureException
+    public AnyValue functionCallOverride( QualifiedName name, AnyValue[] arguments ) throws ProcedureException
     {
         return callFunction( name, arguments,
                 new OverriddenAccessMode( tx.securityContext().mode(), AccessMode.Static.READ ) );
@@ -1499,7 +1501,13 @@ public class OperationsFacade
                 new OverriddenAccessMode( tx.securityContext().mode(), AccessMode.Static.READ ) );
     }
 
-    private Object callFunction( QualifiedName name, Object[] input, final AccessMode mode ) throws ProcedureException
+    @Override
+    public ValueMapper<Object> valueMapper()
+    {
+        return procedures.valueMapper();
+    }
+
+    private AnyValue callFunction( QualifiedName name, AnyValue[] input, final AccessMode mode ) throws ProcedureException
     {
         statement.assertOpen();
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/dbms/NonTransactionalDbmsOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/dbms/NonTransactionalDbmsOperations.java
@@ -27,6 +27,7 @@ import org.neo4j.kernel.api.proc.Context;
 import org.neo4j.kernel.api.proc.QualifiedName;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.proc.Procedures;
+import org.neo4j.values.AnyValue;
 
 public class NonTransactionalDbmsOperations implements DbmsOperations
 {
@@ -51,9 +52,9 @@ public class NonTransactionalDbmsOperations implements DbmsOperations
     }
 
     @Override
-    public Object functionCallDbms(
+    public AnyValue functionCallDbms(
             QualifiedName name,
-            Object[] input,
+            AnyValue[] input,
             SecurityContext securityContext
     ) throws ProcedureException
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/EmbeddedProxySPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/EmbeddedProxySPI.java
@@ -45,4 +45,6 @@ public interface EmbeddedProxySPI
     GraphPropertiesProxy newGraphPropertiesProxy();
 
     RelationshipType getRelationshipTypeById( int type );
+
+    int getRelationshipTypeIdByName( String typeName );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/PathProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/PathProxy.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.core;
+
+import java.util.Arrays;
+import java.util.Iterator;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.traversal.Paths;
+
+import static org.neo4j.helpers.collection.Iterators.iteratorsEqual;
+
+public class PathProxy implements Path
+{
+    private final EmbeddedProxySPI proxySPI;
+    private final long[] nodes;
+    private final long[] relationships;
+    private final int[] directedTypes;
+
+    /**
+     * @param proxySPI
+     *         the API into the kernel.
+     * @param nodes
+     *         the ids of the nodes in the path, in order.
+     * @param relationships
+     *         the ids of the relationships in the path, in order.
+     * @param directedTypes
+     *         an encoding of the types and directions of the relationships.
+     *         An entry at position {@code i} of this array should be {@code typeId} if the relationship at {@code i}
+     *         has its start node at {@code i} and its end node at {@code i + 1}, and should be {@code ~typeId} if the
+     *         relationship at {@code i} has its start node at {@code i + 1} and its end node at {@code i}.
+     */
+    public PathProxy( EmbeddedProxySPI proxySPI, long[] nodes, long[] relationships, int[] directedTypes )
+    {
+        assert nodes.length == relationships.length + 1;
+        assert relationships.length == directedTypes.length;
+        this.proxySPI = proxySPI;
+        this.nodes = nodes;
+        this.relationships = relationships;
+        this.directedTypes = directedTypes;
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder string = new StringBuilder();
+        string.append( '(' ).append( nodes[0] ).append( ')' );
+        boolean inTx = true;
+        for ( int i = 0; i < relationships.length; i++ )
+        {
+            int type = directedTypes[i];
+            string.append( type < 0 ? "<-[" : "-[" );
+            string.append( relationships[i] );
+            if ( inTx )
+            {
+                try
+                {
+                    String name = proxySPI.getRelationshipTypeById( type < 0 ? ~type : type ).name();
+                    string.append( ':' ).append( name );
+                }
+                catch ( Exception e )
+                {
+                    inTx = false;
+                }
+            }
+            string.append( type < 0 ? "]-(" : "]->(" ).append( nodes[i + 1] ).append( ')' );
+        }
+        return string.toString();
+    }
+
+    @Override
+    public int hashCode()
+    {
+        if ( relationships.length == 0 )
+        {
+            return Long.hashCode( nodes[0] );
+        }
+        else
+        {
+            return Arrays.hashCode( relationships );
+        }
+    }
+
+    @Override
+    public boolean equals( Object obj )
+    {
+        if ( this == obj )
+        {
+            return true;
+        }
+        if ( obj instanceof PathProxy )
+        {
+            PathProxy that = (PathProxy) obj;
+            return Arrays.equals( this.nodes, that.nodes ) && Arrays.equals( this.relationships, that.relationships );
+        }
+        else if ( obj instanceof Path )
+        {
+            Path other = (Path) obj;
+            if ( nodes[0] != other.startNode().getId() )
+            {
+                return false;
+            }
+            return iteratorsEqual( this.relationships().iterator(), other.relationships().iterator() );
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    @Override
+    public Node startNode()
+    {
+        return new NodeProxy( proxySPI, nodes[0] );
+    }
+
+    @Override
+    public Node endNode()
+    {
+        return new NodeProxy( proxySPI, nodes[nodes.length - 1] );
+    }
+
+    @Override
+    public Relationship lastRelationship()
+    {
+        return relationships.length == 0
+                ? null
+                : relationship( relationships.length - 1 );
+    }
+
+    private RelationshipProxy relationship( int offset )
+    {
+        int type = directedTypes[offset];
+        if ( type >= 0 )
+        {
+            return new RelationshipProxy( proxySPI, relationships[offset], nodes[offset], type, nodes[offset + 1] );
+        }
+        else
+        {
+            return new RelationshipProxy( proxySPI, relationships[offset], nodes[offset + 1], ~type, nodes[offset] );
+        }
+    }
+
+    @Override
+    public Iterable<Relationship> relationships()
+    {
+        return () -> new Iterator<Relationship>()
+        {
+            int i;
+
+            @Override
+            public boolean hasNext()
+            {
+                return i < relationships.length;
+            }
+
+            @Override
+            public Relationship next()
+            {
+                return relationship( i++ );
+            }
+        };
+    }
+
+    @Override
+    public Iterable<Relationship> reverseRelationships()
+    {
+        return () -> new Iterator<Relationship>()
+        {
+            int i = relationships.length;
+
+            @Override
+            public boolean hasNext()
+            {
+                return i > 0;
+            }
+
+            @Override
+            public Relationship next()
+            {
+                return relationship( --i );
+            }
+        };
+    }
+
+    @Override
+    public Iterable<Node> nodes()
+    {
+        return () -> new Iterator<Node>()
+        {
+            int i;
+
+            @Override
+            public boolean hasNext()
+            {
+                return i < nodes.length;
+            }
+
+            @Override
+            public Node next()
+            {
+                return new NodeProxy( proxySPI, nodes[i++] );
+            }
+        };
+    }
+
+    @Override
+    public Iterable<Node> reverseNodes()
+    {
+        return () -> new Iterator<Node>()
+        {
+            int i = nodes.length;
+
+            @Override
+            public boolean hasNext()
+            {
+                return i > 0;
+            }
+
+            @Override
+            public Node next()
+            {
+                return new NodeProxy( proxySPI, nodes[--i] );
+            }
+        };
+    }
+
+    @Override
+    public int length()
+    {
+        return relationships.length;
+    }
+
+    @Override
+    public Iterator<PropertyContainer> iterator()
+    {
+        return new Iterator<PropertyContainer>()
+        {
+            int i;
+            boolean relationship;
+
+            @Override
+            public boolean hasNext()
+            {
+                return i < relationships.length || !relationship;
+            }
+
+            @Override
+            public PropertyContainer next()
+            {
+                if ( relationship )
+                {
+                    relationship = false;
+                    return relationship( i++ );
+                }
+                else
+                {
+                    relationship = true;
+                    return new NodeProxy( proxySPI, nodes[i] );
+                }
+            }
+        };
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -62,7 +62,7 @@ import org.neo4j.kernel.impl.proc.ProcedureGDSFactory;
 import org.neo4j.kernel.impl.proc.ProcedureTransactionProvider;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.proc.TerminationGuardProvider;
-import org.neo4j.kernel.impl.proc.TypeMappers.SimpleConverter;
+import org.neo4j.kernel.impl.proc.TypeMappers.DefaultValueConverter;
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
 import org.neo4j.kernel.impl.store.StoreId;
 import org.neo4j.kernel.impl.transaction.log.files.LogFileCreationMonitor;
@@ -249,11 +249,11 @@ public class DataSourceModule
         platform.life.add( procedures );
         platform.dependencies.satisfyDependency( procedures );
 
-        procedures.registerType( Node.class, new SimpleConverter( NTNode, Node.class ) );
-        procedures.registerType( Relationship.class, new SimpleConverter( NTRelationship, Relationship.class ) );
-        procedures.registerType( Path.class, new SimpleConverter( NTPath, Path.class ) );
-        procedures.registerType( Geometry.class, new SimpleConverter( NTGeometry, Geometry.class ) );
-        procedures.registerType( Point.class, new SimpleConverter( NTPoint, Point.class ) );
+        procedures.registerType( Node.class, NTNode );
+        procedures.registerType( Relationship.class, NTRelationship );
+        procedures.registerType( Path.class, NTPath );
+        procedures.registerType( Geometry.class, NTGeometry );
+        procedures.registerType( Point.class, NTPoint );
 
         // Register injected public API components
         Log proceduresLog = platform.logging.getUserLog( Procedures.class );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/DataSourceModule.java
@@ -52,6 +52,9 @@ import org.neo4j.kernel.impl.api.explicitindex.InternalAutoIndexing;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.cache.MonitorGc;
 import org.neo4j.kernel.impl.core.DatabasePanicEventGenerator;
+import org.neo4j.kernel.impl.core.EmbeddedProxySPI;
+import org.neo4j.kernel.impl.core.NodeProxy;
+import org.neo4j.kernel.impl.core.RelationshipProxy;
 import org.neo4j.kernel.impl.core.RelationshipTypeTokenHolder;
 import org.neo4j.kernel.impl.core.StartupStatisticsProvider;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
@@ -241,8 +244,9 @@ public class DataSourceModule
     {
         File pluginDir = platform.config.get( GraphDatabaseSettings.plugin_dir );
         Log internalLog = platform.logging.getInternalLog( Procedures.class );
+        EmbeddedProxySPI proxySPI = platform.dependencies.resolveDependency( EmbeddedProxySPI.class );
 
-        Procedures procedures = new Procedures(
+        Procedures procedures = new Procedures( proxySPI,
                 new SpecialBuiltInProcedures( Version.getNeo4jVersion(),
                         platform.databaseInfo.edition.toString() ),
                 pluginDir, internalLog, new ProcedureConfig( platform.config ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/EditionModule.java
@@ -24,12 +24,12 @@ import java.util.function.Predicate;
 
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.helpers.Service;
+import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.watcher.RestartableFileSystemWatcher;
 import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.api.bolt.BoltConnectionTracker;
-import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.security.SecurityModule;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.api.CommitProcessFactory;
@@ -66,6 +66,8 @@ import org.neo4j.udc.UsageData;
 import org.neo4j.udc.UsageDataKeys;
 import org.neo4j.unsafe.impl.internal.dragons.FeatureToggles;
 
+import static org.neo4j.kernel.impl.proc.temporal.TemporalFunction.registerTemporalFunctions;
+
 /**
  * Edition module for {@link org.neo4j.kernel.impl.factory.GraphDatabaseFacadeFactory}. Implementations of this class
  * need to create all the services that would be specific for a particular edition of the database.
@@ -82,6 +84,7 @@ public abstract class EditionModule
         procedures.registerProcedure( org.neo4j.kernel.builtinprocs.TokenProcedures.class );
         procedures.registerProcedure( org.neo4j.kernel.builtinprocs.BuiltInDbmsProcedures.class );
         procedures.registerBuiltInFunctions( org.neo4j.kernel.builtinprocs.BuiltInFunctions.class );
+        registerTemporalFunctions( procedures );
 
         registerEditionSpecificProcedures( procedures );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacade.java
@@ -876,6 +876,12 @@ public class GraphDatabaseFacade implements GraphDatabaseAPI, EmbeddedProxySPI
     }
 
     @Override
+    public int getRelationshipTypeIdByName( String typeName )
+    {
+        return relationshipTypeTokenHolder.getIdByName( typeName );
+    }
+
+    @Override
     public GraphPropertiesProxy newGraphPropertiesProxy()
     {
         return new GraphPropertiesProxy( this );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/DefaultParameterValue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/DefaultParameterValue.java
@@ -24,12 +24,12 @@ import java.util.Map;
 
 import org.neo4j.kernel.api.proc.Neo4jTypes;
 
-public class Neo4jValue
+public class DefaultParameterValue
 {
     private final Object value;
     private final Neo4jTypes.AnyType type;
 
-    public Neo4jValue( Object value, Neo4jTypes.AnyType type )
+    public DefaultParameterValue( Object value, Neo4jTypes.AnyType type )
     {
         this.value = value;
         this.type = type;
@@ -45,40 +45,45 @@ public class Neo4jValue
         return type;
     }
 
-    public static Neo4jValue ntString( String value )
+    public static DefaultParameterValue ntString( String value )
     {
-        return new Neo4jValue( value, Neo4jTypes.NTString );
+        return new DefaultParameterValue( value, Neo4jTypes.NTString );
     }
 
-    public static Neo4jValue ntInteger( long value )
+    static DefaultParameterValue ntInteger( long value )
     {
-        return new Neo4jValue( value, Neo4jTypes.NTInteger );
+        return new DefaultParameterValue( value, Neo4jTypes.NTInteger );
     }
 
-    public static Neo4jValue ntFloat( double value )
+    static DefaultParameterValue ntFloat( double value )
     {
-        return new Neo4jValue( value, Neo4jTypes.NTFloat );
+        return new DefaultParameterValue( value, Neo4jTypes.NTFloat );
     }
 
-    public static Neo4jValue ntBoolean( boolean value )
+    static DefaultParameterValue ntBoolean( boolean value )
     {
-        return new Neo4jValue( value, Neo4jTypes.NTBoolean );
+        return new DefaultParameterValue( value, Neo4jTypes.NTBoolean );
     }
 
-    public static Neo4jValue ntMap( Map<String,Object> value )
+    static DefaultParameterValue ntMap( Map<String,Object> value )
     {
-        return new Neo4jValue( value, Neo4jTypes.NTMap );
+        return new DefaultParameterValue( value, Neo4jTypes.NTMap );
     }
 
-    public static Neo4jValue ntList( List<?> value, Neo4jTypes.AnyType inner )
+    static DefaultParameterValue ntList( List<?> value, Neo4jTypes.AnyType inner )
     {
-        return new Neo4jValue( value, Neo4jTypes.NTList( inner ) );
+        return new DefaultParameterValue( value, Neo4jTypes.NTList( inner ) );
+    }
+
+    static DefaultParameterValue nullValue( Neo4jTypes.AnyType type )
+    {
+        return new DefaultParameterValue( null, type );
     }
 
     @Override
     public String toString()
     {
-        return "Neo4jValue{" +
+        return "DefaultParameterValue{" +
                "value=" + value +
                ", type=" + type +
                '}';
@@ -96,14 +101,13 @@ public class Neo4jValue
             return false;
         }
 
-        Neo4jValue that = (Neo4jValue) o;
+        DefaultParameterValue that = (DefaultParameterValue) o;
 
         if ( value != null ? !value.equals( that.value ) : that.value != null )
         {
             return false;
         }
         return type.equals( that.type );
-
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/DefaultParameterValue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/DefaultParameterValue.java
@@ -75,7 +75,7 @@ public class DefaultParameterValue
         return new DefaultParameterValue( value, Neo4jTypes.NTList( inner ) );
     }
 
-    static DefaultParameterValue nullValue( Neo4jTypes.AnyType type )
+    public static DefaultParameterValue nullValue( Neo4jTypes.AnyType type )
     {
         return new DefaultParameterValue( null, type );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ListConverter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ListConverter.java
@@ -24,11 +24,11 @@ import java.util.function.Function;
 
 import org.neo4j.kernel.api.proc.Neo4jTypes;
 
-import static org.neo4j.kernel.impl.proc.Neo4jValue.ntList;
+import static org.neo4j.kernel.impl.proc.DefaultParameterValue.ntList;
 import static org.neo4j.kernel.impl.proc.ParseUtil.parseList;
 
 
-public class ListConverter implements Function<String,Neo4jValue>
+public class ListConverter implements Function<String,DefaultParameterValue>
 {
     private final Type type;
     private final Neo4jTypes.AnyType neoType;
@@ -40,7 +40,7 @@ public class ListConverter implements Function<String,Neo4jValue>
     }
 
     @Override
-    public Neo4jValue apply( String s )
+    public DefaultParameterValue apply( String s )
     {
         String value = s.trim();
         if ( value.equalsIgnoreCase( "null" ) )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/MapConverter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/MapConverter.java
@@ -21,7 +21,7 @@ package org.neo4j.kernel.impl.proc;
 
 import java.util.function.Function;
 
-import static org.neo4j.kernel.impl.proc.Neo4jValue.ntMap;
+import static org.neo4j.kernel.impl.proc.DefaultParameterValue.ntMap;
 import static org.neo4j.kernel.impl.proc.ParseUtil.parseMap;
 
 /**
@@ -29,10 +29,10 @@ import static org.neo4j.kernel.impl.proc.ParseUtil.parseMap;
  * for parsing huge json-document in a place where performance matters - you probably need
  * to rethink your decision.
  */
-public class MapConverter implements Function<String,Neo4jValue>
+public class MapConverter implements Function<String,DefaultParameterValue>
 {
     @Override
-    public Neo4jValue apply( String s )
+    public DefaultParameterValue apply( String s )
     {
         String value = s.trim();
         if ( value.equalsIgnoreCase( "null" ) )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/MethodSignatureCompiler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/MethodSignatureCompiler.java
@@ -30,7 +30,7 @@ import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.proc.FieldSignature;
 import org.neo4j.kernel.api.proc.Neo4jTypes;
-import org.neo4j.kernel.impl.proc.TypeMappers.NeoValueConverter;
+import org.neo4j.kernel.impl.proc.TypeMappers.DefaultValueConverter;
 import org.neo4j.procedure.Name;
 
 import static org.neo4j.kernel.api.proc.FieldSignature.inputField;
@@ -54,8 +54,7 @@ public class MethodSignatureCompiler
         List<Neo4jTypes.AnyType> neoTypes = new ArrayList<>( types.length );
         for ( Type type : types )
         {
-            NeoValueConverter valueConverter = typeMappers.converterFor( type );
-            neoTypes.add( valueConverter.type() );
+            neoTypes.add( typeMappers.toNeo4jType( type ) );
         }
 
         return neoTypes;
@@ -92,8 +91,8 @@ public class MethodSignatureCompiler
 
             try
             {
-                NeoValueConverter valueConverter = typeMappers.converterFor( type );
-                Optional<Neo4jValue> defaultValue = valueConverter.defaultValue( parameter );
+                DefaultValueConverter valueConverter = typeMappers.converterFor( type );
+                Optional<DefaultParameterValue> defaultValue = valueConverter.defaultValue( parameter );
                 //it is not allowed to have holes in default values
                 if ( seenDefault && !defaultValue.isPresent() )
                 {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/OutputMappers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/OutputMappers.java
@@ -98,18 +98,18 @@ public class OutputMappers
     private static class FieldMapper
     {
         private final MethodHandle getter;
-        private final TypeMappers.NeoValueConverter mapper;
+        private final TypeMappers.TypeChecker checker;
 
-        FieldMapper( MethodHandle getter, TypeMappers.NeoValueConverter mapper )
+        FieldMapper( MethodHandle getter, TypeMappers.TypeChecker checker )
         {
             this.getter = getter;
-            this.mapper = mapper;
+            this.checker = checker;
         }
 
         Object apply( Object record ) throws ProcedureException
         {
             Object invoke = getValue( record );
-            return mapper.toNeoValue( invoke );
+            return checker.typeCheck( invoke );
         }
 
         private Object getValue( Object record ) throws ProcedureException
@@ -196,12 +196,12 @@ public class OutputMappers
 
             try
             {
-                TypeMappers.NeoValueConverter mapper = typeMappers.converterFor( field.getGenericType() );
+                TypeMappers.TypeChecker checker = typeMappers.checkerFor( field.getGenericType() );
                 MethodHandle getter = lookup.unreflectGetter( field );
-                FieldMapper fieldMapper = new FieldMapper( getter, mapper );
+                FieldMapper fieldMapper = new FieldMapper( getter, checker );
 
                 fieldMappers[i] = fieldMapper;
-                signature[i] = FieldSignature.outputField( field.getName(), mapper.type(), field.isAnnotationPresent( Deprecated.class ) );
+                signature[i] = FieldSignature.outputField( field.getName(), checker.type(), field.isAnnotationPresent( Deprecated.class ) );
             }
             catch ( ProcedureException e )
             {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureRegistry.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureRegistry.java
@@ -39,6 +39,7 @@ import org.neo4j.kernel.api.proc.FieldSignature;
 import org.neo4j.kernel.api.proc.ProcedureSignature;
 import org.neo4j.kernel.api.proc.QualifiedName;
 import org.neo4j.kernel.api.proc.UserFunctionSignature;
+import org.neo4j.values.AnyValue;
 
 public class ProcedureRegistry
 {
@@ -201,7 +202,7 @@ public class ProcedureRegistry
         return proc.apply( ctx, input );
     }
 
-    public Object callFunction( Context ctx, QualifiedName name, Object[] input )
+    public AnyValue callFunction( Context ctx, QualifiedName name, AnyValue[] input )
             throws ProcedureException
     {
         CallableUserFunction func = functions.get( name );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/Procedures.java
@@ -31,6 +31,7 @@ import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.CallableUserAggregationFunction;
 import org.neo4j.kernel.api.proc.CallableUserFunction;
 import org.neo4j.kernel.api.proc.Context;
+import org.neo4j.kernel.api.proc.Neo4jTypes;
 import org.neo4j.kernel.api.proc.ProcedureSignature;
 import org.neo4j.kernel.api.proc.QualifiedName;
 import org.neo4j.kernel.api.proc.UserFunctionSignature;
@@ -213,13 +214,16 @@ public class Procedures extends LifecycleAdapter
     }
 
     /**
-     * Registers a type and how to convert it to a Neo4jType
-     * @param javaClass the class of the native type
-     * @param toNeo the conversion to Neo4jTypes
+     * Registers a type and its mapping to Neo4jTypes
+     *
+     * @param javaClass
+     *         the class of the native type
+     * @param type
+     *         the mapping to Neo4jTypes
      */
-    public void registerType( Class<?> javaClass, TypeMappers.NeoValueConverter toNeo )
+    public void registerType( Class<?> javaClass, Neo4jTypes.AnyType type )
     {
-        typeMappers.registerType( javaClass, toNeo );
+        typeMappers.registerType( javaClass, new TypeMappers.DefaultValueConverter( type, javaClass ) );
     }
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/TypeMappers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/TypeMappers.java
@@ -21,6 +21,12 @@ package org.neo4j.kernel.impl.proc;
 
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAmount;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,12 +50,18 @@ import static java.lang.Double.parseDouble;
 import static java.lang.Long.parseLong;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTAny;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTBoolean;
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTDate;
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTDateTime;
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTDuration;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTFloat;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTInteger;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTList;
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTLocalDateTime;
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTLocalTime;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTMap;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTNumber;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTString;
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTTime;
 import static org.neo4j.kernel.impl.proc.DefaultParameterValue.ntBoolean;
 import static org.neo4j.kernel.impl.proc.DefaultParameterValue.ntFloat;
 import static org.neo4j.kernel.impl.proc.DefaultParameterValue.ntInteger;
@@ -126,6 +138,12 @@ public class TypeMappers extends DefaultValueMapper
         registerType( Map.class, TO_MAP );
         registerType( List.class, TO_LIST );
         registerType( Object.class, TO_ANY );
+        registerType( ZonedDateTime.class, new DefaultValueConverter( NTDateTime, ZonedDateTime.class ) );
+        registerType( LocalDateTime.class, new DefaultValueConverter( NTLocalDateTime, LocalDateTime.class ) );
+        registerType( LocalDate.class, new DefaultValueConverter( NTDate, LocalDate.class ) );
+        registerType( OffsetTime.class, new DefaultValueConverter( NTTime, OffsetTime.class ) );
+        registerType( LocalTime.class, new DefaultValueConverter( NTLocalTime, LocalTime.class ) );
+        registerType( TemporalAmount.class, new DefaultValueConverter( NTDuration, TemporalAmount.class ) );
     }
 
     public AnyType toNeo4jType( Type type ) throws ProcedureException

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/TypeMappers.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/TypeMappers.java
@@ -33,7 +33,11 @@ import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.proc.Neo4jTypes;
 import org.neo4j.kernel.api.proc.Neo4jTypes.AnyType;
+import org.neo4j.kernel.impl.util.DefaultValueMapper;
+import org.neo4j.kernel.impl.core.EmbeddedProxySPI;
+import org.neo4j.kernel.impl.util.ValueUtils;
 import org.neo4j.procedure.Name;
+import org.neo4j.values.AnyValue;
 
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.Double.parseDouble;
@@ -51,7 +55,7 @@ import static org.neo4j.kernel.impl.proc.DefaultParameterValue.ntFloat;
 import static org.neo4j.kernel.impl.proc.DefaultParameterValue.ntInteger;
 import static org.neo4j.kernel.impl.proc.DefaultParameterValue.nullValue;
 
-public class TypeMappers
+public class TypeMappers extends DefaultValueMapper
 {
     public abstract static class TypeChecker
     {
@@ -79,12 +83,26 @@ public class TypeMappers
                     "Expected `%s` to be a `%s`, found `%s`.", javaValue, javaClass.getSimpleName(),
                     javaValue.getClass() );
         }
+
+        public AnyValue toValue( Object obj )
+        {
+            return ValueUtils.of( obj );
+        }
     }
 
     private final Map<Type,DefaultValueConverter> javaToNeo = new HashMap<>();
 
+    /**
+     * Used by testing.
+     */
     public TypeMappers()
     {
+        this( null );
+    }
+
+    public TypeMappers( EmbeddedProxySPI proxySPI )
+    {
+        super( proxySPI );
         registerScalarsAndCollections();
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/DateFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/DateFunction.java
@@ -26,60 +26,55 @@ import java.util.function.Supplier;
 
 import org.neo4j.procedure.Description;
 import org.neo4j.values.AnyValue;
-import org.neo4j.values.storable.DateTimeValue;
+import org.neo4j.values.storable.DateValue;
 import org.neo4j.values.storable.TemporalValue;
 import org.neo4j.values.storable.TextValue;
 import org.neo4j.values.virtual.MapValue;
 
-import static org.neo4j.kernel.api.proc.Neo4jTypes.NTDateTime;
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTDate;
 
-@Description( "Create a DateTime instant." )
-class DateTimeFunction extends TemporalFunction<DateTimeValue>
+@Description( "Create a Date instant." )
+class DateFunction extends TemporalFunction<DateValue>
 {
-    DateTimeFunction()
+    DateFunction()
     {
-        super( NTDateTime );
+        super( NTDate );
     }
 
     @Override
-    protected DateTimeValue now( Clock clock, String timezone )
+    protected DateValue now( Clock clock, String timezone )
     {
-        return timezone == null ? DateTimeValue.now( clock ) : DateTimeValue.now( clock, timezone );
+        return timezone == null ? DateValue.now( clock ) : DateValue.now( clock, timezone );
     }
 
     @Override
-    protected DateTimeValue parse( TextValue value, Supplier<ZoneId> defaultZone )
+    protected DateValue parse( TextValue value, Supplier<ZoneId> defaultZone )
     {
-        return DateTimeValue.parse( value, defaultZone );
+        return DateValue.parse( value );
     }
 
     @Override
-    protected DateTimeValue build( MapValue map, Supplier<ZoneId> defaultZone )
+    protected DateValue build( MapValue map, Supplier<ZoneId> defaultZone )
     {
-        return DateTimeValue.build( map, defaultZone );
+        return DateValue.build( map, defaultZone );
     }
 
     @Override
-    protected DateTimeValue positionalCreate( AnyValue[] input )
+    protected DateValue positionalCreate( AnyValue[] input )
     {
-        if ( input.length != 8 )
+        if ( input.length != 3 )
         {
-            throw new IllegalArgumentException( "expected 8 arguments" );
+            throw new IllegalArgumentException( "expected 3 arguments" );
         }
-        return DateTimeValue.datetime(
+        return DateValue.date(
                 anInt( "year", input[0] ),
                 anInt( "month", input[1] ),
-                anInt( "day", input[2] ),
-                anInt( "hour", input[3] ),
-                anInt( "minute", input[4] ),
-                anInt( "second", input[5] ),
-                anInt( "nanos", input[6] ),
-                aString( "timezone", input[7] ) );
+                anInt( "day", input[2] ) );
     }
 
     @Override
-    protected DateTimeValue truncate( TemporalUnit unit, TemporalValue input, MapValue fields, Supplier<ZoneId> defaultZone )
+    protected DateValue truncate( TemporalUnit unit, TemporalValue input, MapValue fields, Supplier<ZoneId> defaultZone )
     {
-        return DateTimeValue.truncate( unit, input, fields, defaultZone );
+        return DateValue.truncate( unit, input, fields, defaultZone );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/DateTimeFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/DateTimeFunction.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.proc.temporal;
+
+import java.time.Clock;
+import java.time.ZoneId;
+import java.time.temporal.TemporalUnit;
+import java.util.function.Supplier;
+
+import org.neo4j.procedure.Description;
+import org.neo4j.values.AnyValue;
+import org.neo4j.values.storable.DateTimeValue;
+import org.neo4j.values.storable.TextValue;
+import org.neo4j.values.virtual.MapValue;
+
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTDateTime;
+
+@Description( "Construct a DateTime instant." )
+class DateTimeFunction extends TemporalFunction<DateTimeValue>
+{
+    DateTimeFunction()
+    {
+        super( "datetime", NTDateTime );
+    }
+
+    @Override
+    @Description( "Get the current DateTime instant." )
+    protected DateTimeValue now( Clock clock, String timezone )
+    {
+        return timezone == null ? DateTimeValue.now( clock ) : DateTimeValue.now( clock, timezone );
+    }
+
+    @Override
+    protected DateTimeValue parse( TextValue value, Supplier<ZoneId> defaultZone )
+    {
+        return DateTimeValue.parse( value, defaultZone );
+    }
+
+    @Override
+    protected DateTimeValue build( MapValue map, Supplier<ZoneId> defaultZone )
+    {
+        return DateTimeValue.build( map );
+    }
+
+    @Override
+    protected DateTimeValue positionalCreate( AnyValue[] input )
+    {
+        if ( input.length != 8 )
+        {
+            throw new IllegalArgumentException( "expected 8 arguments" );
+        }
+        return DateTimeValue.datetime(
+                anInt( "year", input[0] ),
+                anInt( "month", input[1] ),
+                anInt( "day", input[2] ),
+                anInt( "hour", input[3] ),
+                anInt( "minute", input[4] ),
+                anInt( "second", input[5] ),
+                anInt( "nanos", input[6] ),
+                aString( "timezone", input[7] ) );
+    }
+
+    @Override
+    @Description( "Truncate to a DateTime instant." )
+    protected DateTimeValue truncate( TemporalUnit unit, AnyValue input, MapValue fields, Supplier<ZoneId> defaultZone )
+    {
+        return DateTimeValue.truncate( unit, input, fields, defaultZone );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/DurationFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/DurationFunction.java
@@ -87,7 +87,7 @@ class DurationFunction implements CallableUserFunction
             if ( input[0] instanceof MapValue )
             {
                 MapValue map = (MapValue) input[0];
-                return DurationValue.build(map);
+                return DurationValue.build( map );
             }
         }
         throw new ProcedureException( Status.Procedure.ProcedureCallFailed, "Invalid call signature" );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/DurationFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/DurationFunction.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.proc.temporal;
+
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.IsoFields;
+import java.time.temporal.TemporalUnit;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.neo4j.kernel.api.exceptions.ProcedureException;
+import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.api.proc.CallableUserFunction;
+import org.neo4j.kernel.api.proc.Context;
+import org.neo4j.kernel.api.proc.FieldSignature;
+import org.neo4j.kernel.api.proc.Neo4jTypes;
+import org.neo4j.kernel.api.proc.QualifiedName;
+import org.neo4j.kernel.api.proc.UserFunctionSignature;
+import org.neo4j.kernel.impl.proc.Procedures;
+import org.neo4j.procedure.Description;
+import org.neo4j.values.AnyValue;
+import org.neo4j.values.storable.DurationValue;
+import org.neo4j.values.storable.TemporalValue;
+import org.neo4j.values.storable.TextValue;
+import org.neo4j.values.virtual.MapValue;
+
+import static org.neo4j.kernel.api.proc.FieldSignature.inputField;
+
+@Description( "Construct a Duration value." )
+class DurationFunction implements CallableUserFunction
+{
+    private static final UserFunctionSignature DURATION =
+            new UserFunctionSignature(
+                    new QualifiedName( new String[0], "duration" ),
+                    Collections.singletonList( inputField( "input", Neo4jTypes.NTAny ) ),
+                    Neo4jTypes.NTDuration, Optional.empty(), new String[0],
+                    Optional.of( DurationFunction.class.getAnnotation( Description.class ).value() ) );
+
+    static void register( Procedures procedures ) throws ProcedureException
+    {
+        procedures.register( new DurationFunction() );
+        procedures.register( new Between( "between" ) );
+        procedures.register( new Between( "years" ) );
+        procedures.register( new Between( "quarters" ) );
+        procedures.register( new Between( "months" ) );
+        procedures.register( new Between( "weeks" ) );
+        procedures.register( new Between( "days" ) );
+        procedures.register( new Between( "hours" ) );
+        procedures.register( new Between( "minutes" ) );
+        procedures.register( new Between( "seconds" ) );
+    }
+
+    @Override
+    public UserFunctionSignature signature()
+    {
+        return DURATION;
+    }
+
+    @Override
+    public DurationValue apply( Context ctx, AnyValue[] input ) throws ProcedureException
+    {
+        if ( input != null && input.length == 1 )
+        {
+            if ( input[0] instanceof TextValue )
+            {
+                return DurationValue.parse( (TextValue) input[0] );
+            }
+            if ( input[0] instanceof MapValue )
+            {
+                MapValue map = (MapValue) input[0];
+                return DurationValue.build(map);
+            }
+        }
+        throw new ProcedureException( Status.Procedure.ProcedureCallFailed, "Invalid call signature" );
+    }
+
+    private static class Between implements CallableUserFunction
+    {
+        private static final String DESCRIPTION =
+                "Compute the duration between the 'form' instant (inclusive) and the 'to' instant (exclusive) in %s.";
+        private static final List<FieldSignature> SIGNATURE = Arrays.asList(
+                inputField( "from", Neo4jTypes.NTAny ),
+                inputField( "to", Neo4jTypes.NTAny ) );
+        private final UserFunctionSignature signature;
+        private final TemporalUnit unit;
+
+        private Between( String unit )
+        {
+            this.signature = new UserFunctionSignature(
+                    new QualifiedName( new String[] {"duration"}, unit ),
+                    SIGNATURE, Neo4jTypes.NTDuration, Optional.empty(), new String[0],
+                    Optional.of( String.format(
+                            DESCRIPTION, "between".equals( unit ) ? "logical units" : unit ) ) );
+            switch ( unit )
+            {
+            case "between":
+                this.unit = null;
+                break;
+            case "years":
+                this.unit = ChronoUnit.YEARS;
+                break;
+            case "quarters":
+                this.unit = IsoFields.QUARTER_YEARS;
+                break;
+            case "months":
+                this.unit = ChronoUnit.MONTHS;
+                break;
+            case "weeks":
+                this.unit = ChronoUnit.WEEKS;
+                break;
+            case "days":
+                this.unit = ChronoUnit.DAYS;
+                break;
+            case "hours":
+                this.unit = ChronoUnit.HOURS;
+                break;
+            case "minutes":
+                this.unit = ChronoUnit.MINUTES;
+                break;
+            case "seconds":
+                this.unit = ChronoUnit.SECONDS;
+                break;
+            default:
+                throw new IllegalStateException( "Unsupported unit: " + unit );
+            }
+        }
+
+        @Override
+        public UserFunctionSignature signature()
+        {
+            return signature;
+        }
+
+        @Override
+        public AnyValue apply( Context ctx, AnyValue[] input ) throws ProcedureException
+        {
+            if ( input != null && input.length == 2 )
+            {
+                if ( input[0] instanceof TemporalValue && input[1] instanceof TemporalValue )
+                {
+                    TemporalValue from = (TemporalValue) input[0];
+                    TemporalValue to = (TemporalValue) input[1];
+                    return DurationValue.between( unit, from, to );
+                }
+            }
+            throw new ProcedureException( Status.Procedure.ProcedureCallFailed, "Invalid call signature" );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/LocalDateTimeFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/LocalDateTimeFunction.java
@@ -26,60 +26,59 @@ import java.util.function.Supplier;
 
 import org.neo4j.procedure.Description;
 import org.neo4j.values.AnyValue;
-import org.neo4j.values.storable.DateTimeValue;
+import org.neo4j.values.storable.LocalDateTimeValue;
 import org.neo4j.values.storable.TemporalValue;
 import org.neo4j.values.storable.TextValue;
 import org.neo4j.values.virtual.MapValue;
 
-import static org.neo4j.kernel.api.proc.Neo4jTypes.NTDateTime;
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTLocalDateTime;
 
-@Description( "Create a DateTime instant." )
-class DateTimeFunction extends TemporalFunction<DateTimeValue>
+@Description( "Create a LocalDateTime instant." )
+class LocalDateTimeFunction extends TemporalFunction<LocalDateTimeValue>
 {
-    DateTimeFunction()
+    LocalDateTimeFunction()
     {
-        super( NTDateTime );
+        super( NTLocalDateTime );
     }
 
     @Override
-    protected DateTimeValue now( Clock clock, String timezone )
+    protected LocalDateTimeValue now( Clock clock, String timezone )
     {
-        return timezone == null ? DateTimeValue.now( clock ) : DateTimeValue.now( clock, timezone );
+        return timezone == null ? LocalDateTimeValue.now( clock ) : LocalDateTimeValue.now( clock, timezone );
     }
 
     @Override
-    protected DateTimeValue parse( TextValue value, Supplier<ZoneId> defaultZone )
+    protected LocalDateTimeValue parse( TextValue value, Supplier<ZoneId> defaultZone )
     {
-        return DateTimeValue.parse( value, defaultZone );
+        return LocalDateTimeValue.parse( value );
     }
 
     @Override
-    protected DateTimeValue build( MapValue map, Supplier<ZoneId> defaultZone )
+    protected LocalDateTimeValue build( MapValue map, Supplier<ZoneId> defaultZone )
     {
-        return DateTimeValue.build( map, defaultZone );
+        return LocalDateTimeValue.build( map, defaultZone );
     }
 
     @Override
-    protected DateTimeValue positionalCreate( AnyValue[] input )
+    protected LocalDateTimeValue positionalCreate( AnyValue[] input )
     {
-        if ( input.length != 8 )
+        if ( input.length != 7 )
         {
-            throw new IllegalArgumentException( "expected 8 arguments" );
+            throw new IllegalArgumentException( "expected 7 arguments" );
         }
-        return DateTimeValue.datetime(
+        return LocalDateTimeValue.localDateTime(
                 anInt( "year", input[0] ),
                 anInt( "month", input[1] ),
                 anInt( "day", input[2] ),
                 anInt( "hour", input[3] ),
                 anInt( "minute", input[4] ),
                 anInt( "second", input[5] ),
-                anInt( "nanos", input[6] ),
-                aString( "timezone", input[7] ) );
+                anInt( "nanos", input[6] ) );
     }
 
     @Override
-    protected DateTimeValue truncate( TemporalUnit unit, TemporalValue input, MapValue fields, Supplier<ZoneId> defaultZone )
+    protected LocalDateTimeValue truncate( TemporalUnit unit, TemporalValue input, MapValue fields, Supplier<ZoneId> defaultZone )
     {
-        return DateTimeValue.truncate( unit, input, fields, defaultZone );
+        return LocalDateTimeValue.truncate( unit, input, fields, defaultZone );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/LocalTimeFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/LocalTimeFunction.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.proc.temporal;
+
+import java.time.Clock;
+import java.time.ZoneId;
+import java.time.temporal.TemporalUnit;
+import java.util.function.Supplier;
+
+import org.neo4j.procedure.Description;
+import org.neo4j.values.AnyValue;
+import org.neo4j.values.storable.TemporalValue;
+import org.neo4j.values.storable.TextValue;
+import org.neo4j.values.storable.LocalTimeValue;
+import org.neo4j.values.virtual.MapValue;
+
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTLocalTime;
+
+@Description( "Create a LocalTime instant." )
+class LocalTimeFunction extends TemporalFunction<LocalTimeValue>
+{
+    LocalTimeFunction()
+    {
+        super( NTLocalTime );
+    }
+
+    @Override
+    protected LocalTimeValue now( Clock clock, String timezone )
+    {
+        return timezone == null ? LocalTimeValue.now( clock ) : LocalTimeValue.now( clock, timezone );
+    }
+
+    @Override
+    protected LocalTimeValue parse( TextValue value, Supplier<ZoneId> defaultZone )
+    {
+        return LocalTimeValue.parse( value );
+    }
+
+    @Override
+    protected LocalTimeValue build( MapValue map, Supplier<ZoneId> defaultZone )
+    {
+        return LocalTimeValue.build( map, defaultZone );
+    }
+
+    @Override
+    protected LocalTimeValue positionalCreate( AnyValue[] input )
+    {
+        if ( input.length != 4 )
+        {
+            throw new IllegalArgumentException( "expected 4 arguments" );
+        }
+        return LocalTimeValue.localTime(
+                anInt( "hour", input[0] ),
+                anInt( "minute", input[1] ),
+                anInt( "second", input[2] ),
+                anInt( "nanos", input[3] ) );
+    }
+
+    @Override
+    protected LocalTimeValue truncate( TemporalUnit unit, TemporalValue input, MapValue fields, Supplier<ZoneId> defaultZone )
+    {
+        return LocalTimeValue.truncate( unit, input, fields, defaultZone );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/TemporalFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/TemporalFunction.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.proc.temporal;
+
+import java.lang.reflect.Method;
+import java.time.Clock;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.IsoFields;
+import java.time.temporal.TemporalUnit;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.neo4j.kernel.api.exceptions.ProcedureException;
+import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.api.proc.CallableUserFunction;
+import org.neo4j.kernel.api.proc.Context;
+import org.neo4j.kernel.api.proc.FieldSignature;
+import org.neo4j.kernel.api.proc.Key;
+import org.neo4j.kernel.api.proc.Neo4jTypes;
+import org.neo4j.kernel.api.proc.QualifiedName;
+import org.neo4j.kernel.api.proc.UserFunctionSignature;
+import org.neo4j.kernel.impl.proc.Procedures;
+import org.neo4j.procedure.Description;
+import org.neo4j.values.AnyValue;
+import org.neo4j.values.storable.IntegralValue;
+import org.neo4j.values.storable.TextValue;
+import org.neo4j.values.virtual.MapValue;
+
+import static java.util.Collections.singletonList;
+import static org.neo4j.helpers.collection.Iterables.single;
+import static org.neo4j.kernel.api.proc.FieldSignature.inputField;
+import static org.neo4j.kernel.impl.proc.DefaultParameterValue.nullValue;
+import static org.neo4j.values.storable.Values.NO_VALUE;
+import static org.neo4j.values.virtual.VirtualValues.EMPTY_MAP;
+
+public abstract class TemporalFunction<T extends AnyValue> implements CallableUserFunction
+{
+    public static void registerTemporalFunctions( Procedures procedures ) throws ProcedureException
+    {
+        register( new DateTimeFunction(), procedures );
+        DurationFunction.register( procedures );
+    }
+
+    private static final Key<Clock> DEFAULT_CLOCK = Context.STATEMENT_CLOCK;
+
+    protected abstract T now( Clock clock, String timezone );
+
+    protected abstract T parse( TextValue value, Supplier<ZoneId> defaultZone );
+
+    protected abstract T build( MapValue map, Supplier<ZoneId> defaultZone );
+
+    protected abstract T positionalCreate( AnyValue[] input );
+
+    protected abstract T truncate( TemporalUnit unit, AnyValue input, MapValue fields, Supplier<ZoneId> defaultZone );
+
+    private static final List<FieldSignature> INPUT_SIGNATURE = singletonList( inputField(
+            "input", Neo4jTypes.NTAny, nullValue( Neo4jTypes.NTAny ) ) );
+    private static final String[] ALLOWED = {};
+    private final UserFunctionSignature signature;
+
+    TemporalFunction( String name, Neo4jTypes.AnyType result )
+    {
+        Description description = getClass().getAnnotation( Description.class );
+        this.signature = new UserFunctionSignature(
+                new QualifiedName( new String[0], name ),
+                INPUT_SIGNATURE, result, Optional.empty(), ALLOWED,
+                description == null ? Optional.empty() : Optional.of( description.value() ) );
+    }
+
+    private static void register( TemporalFunction<?> base, Procedures procedures ) throws ProcedureException
+    {
+        procedures.register( base );
+        procedures.register( new Now<>( base, "transaction" ) );
+        procedures.register( new Now<>( base, "statement" ) );
+        procedures.register( new Now<>( base, "realtime" ) );
+        procedures.register( new Truncate<>( base ) );
+    }
+
+    static int anInt( String name, AnyValue value )
+    {
+        if ( value instanceof IntegralValue )
+        {
+            long v = ((IntegralValue) value).longValue();
+            if ( v <= Integer.MAX_VALUE && v >= Integer.MIN_VALUE )
+            {
+                return (int) v;
+            }
+        }
+        throw new IllegalArgumentException( name + " should be an int, not: " + value );
+    }
+
+    static String aString( String name, AnyValue value )
+    {
+        if ( value instanceof TextValue )
+        {
+            return ((TextValue) value).stringValue();
+        }
+        throw new IllegalArgumentException( name + " should be a string, not: " + value );
+    }
+
+    @Override
+    public final UserFunctionSignature signature()
+    {
+        return signature;
+    }
+
+    @Override
+    public final T apply( Context ctx, AnyValue[] input ) throws ProcedureException
+    {
+        if ( input == null || input.length == 0 || input[0] == NO_VALUE || input[0] == null )
+        {
+            return now( ctx.get( DEFAULT_CLOCK ), null );
+        }
+        else if ( input.length > 1 )
+        {
+            return positionalCreate( input );
+        }
+        else if ( input[0] instanceof TextValue )
+        {
+            return parse( (TextValue) input[0], defaultZone( ctx ) );
+        }
+        else if ( input[0] instanceof MapValue )
+        {
+            MapValue map = (MapValue) input[0];
+            String timezone = onlyTimezone( map );
+            if ( timezone != null )
+            {
+                return now( ctx.get( DEFAULT_CLOCK ), timezone );
+            }
+            return build( map, defaultZone( ctx ) );
+        }
+        else
+        {
+            throw new ProcedureException( Status.Procedure.ProcedureCallFailed, "Invalid call signature" );
+        }
+    }
+
+    private static Supplier<ZoneId> defaultZone( Context ctx ) throws ProcedureException
+    {
+        Clock clock = ctx.get( DEFAULT_CLOCK );
+        return clock::getZone;
+    }
+
+    private static String onlyTimezone( MapValue map )
+    {
+        if ( map.size() == 1 )
+        {
+            String key = single( map.keySet() );
+            if ( "timezone".equalsIgnoreCase( key ) )
+            {
+                AnyValue timezone = map.get( key );
+                if ( timezone instanceof TextValue )
+                {
+                    return ((TextValue) timezone).stringValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    private abstract static class SubFunction<T extends AnyValue> implements CallableUserFunction
+    {
+        private final UserFunctionSignature signature;
+        final TemporalFunction<T> function;
+
+        SubFunction( TemporalFunction<T> base, String name, List<FieldSignature> input )
+        {
+            this.function = base;
+            this.signature = new UserFunctionSignature(
+                    new QualifiedName( new String[] {base.signature.name().name()}, name ),
+                    input, base.signature.outputType(), Optional.empty(), ALLOWED, description( base, getClass() ) );
+        }
+
+        private static Optional<String> description( TemporalFunction<?> base, Class<? extends SubFunction> sub )
+        {
+            StringBuilder name = new StringBuilder( sub.getSimpleName() );
+            name.setCharAt( 0, Character.toLowerCase( name.charAt( 0 ) ) );
+            String methodName = name.toString();
+            for ( Method method : base.getClass().getDeclaredMethods() )
+            {
+                if ( methodName.equals( method.getName() ) )
+                {
+                    Description description = method.getAnnotation( Description.class );
+                    if ( description != null )
+                    {
+                        return Optional.of( description.value() );
+                    }
+                }
+            }
+            return Optional.empty();
+        }
+
+        @Override
+        public final UserFunctionSignature signature()
+        {
+            return signature;
+        }
+
+        @Override
+        public abstract T apply( Context ctx, AnyValue[] input ) throws ProcedureException;
+    }
+
+    private static class Now<T extends AnyValue> extends SubFunction<T>
+    {
+        private static final List<FieldSignature> SIGNATURE = singletonList( inputField(
+                "timezone", Neo4jTypes.NTString, nullValue( Neo4jTypes.NTString ) ) );
+        private final Key<Clock> key;
+
+        Now( TemporalFunction<T> function, String clock )
+        {
+            super( function, clock, SIGNATURE );
+            switch ( clock )
+            {
+            case "transaction":
+                this.key = Context.TRANSACTION_CLOCK;
+                break;
+            case "statement":
+                this.key = Context.STATEMENT_CLOCK;
+                break;
+            case "realtime":
+                this.key = Context.SYSTEM_CLOCK;
+                break;
+            default:
+                throw new IllegalArgumentException( "Unrecognized clock: " + clock );
+            }
+        }
+
+        @Override
+        public T apply( Context ctx, AnyValue[] input ) throws ProcedureException
+        {
+            if ( input == null || input.length == 0 ||
+                    ((input[0] == NO_VALUE || input[0] == null) && input.length == 1) )
+            {
+                return function.now( ctx.get( key ), null );
+            }
+            else if ( input.length == 1 && input[0] instanceof TextValue )
+            {
+                TextValue timezone = (TextValue) input[0];
+                return function.now( ctx.get( key ), timezone.stringValue() );
+            }
+            else
+            {
+                throw new ProcedureException( Status.Procedure.ProcedureCallFailed, "Invalid call signature" );
+            }
+        }
+    }
+
+    private static class Truncate<T extends AnyValue> extends SubFunction<T>
+    {
+        private static final List<FieldSignature> SIGNATURE = Arrays.asList(
+                inputField( "unit", Neo4jTypes.NTString ),
+                inputField( "input", Neo4jTypes.NTAny ),
+                inputField( "fields", Neo4jTypes.NTMap, nullValue( Neo4jTypes.NTMap ) ) );
+
+        Truncate( TemporalFunction<T> function )
+        {
+            super( function, "truncate", SIGNATURE );
+        }
+
+        @Override
+        public T apply( Context ctx, AnyValue[] args ) throws ProcedureException
+        {
+            if ( args != null && args.length >= 2 && args.length <= 3 )
+            {
+                AnyValue unit = args[0];
+                AnyValue input = args[1];
+                AnyValue fields = args.length == 3 ? args[2] : EMPTY_MAP;
+                if ( unit instanceof TextValue && fields instanceof MapValue )
+                {
+                    return function.truncate(
+                            unit( ((TextValue) unit).stringValue() ),
+                            input,
+                            (MapValue) fields,
+                            defaultZone( ctx ) );
+                }
+            }
+            throw new ProcedureException( Status.Procedure.ProcedureCallFailed, "Invalid call signature" );
+        }
+
+        private static TemporalUnit unit( String unit )
+        {
+            switch ( unit )
+            {
+            case "millennium":
+                return ChronoUnit.MILLENNIA;
+            case "century":
+                return ChronoUnit.CENTURIES;
+            case "decade":
+                return ChronoUnit.DECADES;
+            case "year":
+                return ChronoUnit.YEARS;
+            case "quarter":
+                return IsoFields.QUARTER_YEARS;
+            case "month":
+                return ChronoUnit.MONTHS;
+            case "week":
+                return ChronoUnit.WEEKS;
+            case "day":
+                return ChronoUnit.DAYS;
+            case "hour":
+                return ChronoUnit.HOURS;
+            case "minute":
+                return ChronoUnit.MINUTES;
+            case "second":
+                return ChronoUnit.SECONDS;
+            case "millisecond":
+                return ChronoUnit.MILLIS;
+            case "microsecond":
+                return ChronoUnit.MICROS;
+            default:
+                throw new IllegalArgumentException( "Unsupported unit: " + unit );
+            }
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/TimeFunction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/temporal/TimeFunction.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.proc.temporal;
+
+import java.time.Clock;
+import java.time.ZoneId;
+import java.time.temporal.TemporalUnit;
+import java.util.function.Supplier;
+
+import org.neo4j.procedure.Description;
+import org.neo4j.values.AnyValue;
+import org.neo4j.values.storable.TimeValue;
+import org.neo4j.values.storable.TemporalValue;
+import org.neo4j.values.storable.TextValue;
+import org.neo4j.values.virtual.MapValue;
+
+import static org.neo4j.kernel.api.proc.Neo4jTypes.NTTime;
+
+@Description( "Create a Time instant." )
+class TimeFunction extends TemporalFunction<TimeValue>
+{
+    TimeFunction()
+    {
+        super( NTTime );
+    }
+
+    @Override
+    protected TimeValue now( Clock clock, String timezone )
+    {
+        return timezone == null ? TimeValue.now( clock ) : TimeValue.now( clock, timezone );
+    }
+
+    @Override
+    protected TimeValue parse( TextValue value, Supplier<ZoneId> defaultZone )
+    {
+        return TimeValue.parse( value, defaultZone );
+    }
+
+    @Override
+    protected TimeValue build( MapValue map, Supplier<ZoneId> defaultZone )
+    {
+        return TimeValue.build( map, defaultZone );
+    }
+
+    @Override
+    protected TimeValue positionalCreate( AnyValue[] input )
+    {
+        if ( input.length != 5 )
+        {
+            throw new IllegalArgumentException( "expected 5 arguments" );
+        }
+        return TimeValue.time(
+                anInt( "hour", input[0] ),
+                anInt( "minute", input[1] ),
+                anInt( "second", input[2] ),
+                anInt( "nanos", input[3] ),
+                aString( "offset", input[4] ) );
+    }
+
+    @Override
+    protected TimeValue truncate( TemporalUnit unit, TemporalValue input, MapValue fields, Supplier<ZoneId> defaultZone )
+    {
+        return TimeValue.truncate( unit, input, fields, defaultZone );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/PropertyStore.java
@@ -521,6 +521,48 @@ public class PropertyStore extends CommonAbstractStore<PropertyRecord,NoStoreHea
                 throw new UnsupportedFormatCapabilityException( Capability.POINT_PROPERTIES );
             }
         }
+
+        @Override
+        public void writeDuration( long months, long days, long seconds, int nanos ) throws IllegalArgumentException
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
+        public void writeDate( long epochDay ) throws IllegalArgumentException
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
+        public void writeLocalTime( long nanoOfDay ) throws IllegalArgumentException
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
+        public void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws IllegalArgumentException
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
+        public void writeLocalDateTime( long epochSecond, int nano ) throws IllegalArgumentException
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
+        public void writeDateTime( long epochSecondUTC, int nano, int offsetSeconds ) throws IllegalArgumentException
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
+
+        @Override
+        public void writeDateTime( long epochSecondUTC, int nano, String zoneId ) throws IllegalArgumentException
+        {
+            throw new UnsupportedOperationException( "not implemented" );
+        }
     }
 
     public static void setSingleBlockValue( PropertyBlock block, int keyId, PropertyType type, long longValue )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/BaseToObjectValueWriter.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/BaseToObjectValueWriter.java
@@ -20,6 +20,8 @@
 package org.neo4j.kernel.impl.util;
 
 import java.lang.reflect.Array;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -38,10 +40,16 @@ import org.neo4j.graphdb.spatial.Point;
 import org.neo4j.graphdb.traversal.Paths;
 import org.neo4j.helpers.collection.ReverseArrayIterator;
 import org.neo4j.values.AnyValueWriter;
+import org.neo4j.values.storable.CoordinateReferenceSystem;
+import org.neo4j.values.storable.DateTimeValue;
+import org.neo4j.values.storable.DateValue;
+import org.neo4j.values.storable.DurationValue;
+import org.neo4j.values.storable.LocalDateTimeValue;
+import org.neo4j.values.storable.LocalTimeValue;
 import org.neo4j.values.storable.TextArray;
 import org.neo4j.values.storable.TextValue;
-import org.neo4j.values.storable.CoordinateReferenceSystem;
 import org.neo4j.values.virtual.RelationshipValue;
+import org.neo4j.values.storable.TimeValue;
 import org.neo4j.values.virtual.MapValue;
 import org.neo4j.values.virtual.NodeValue;
 
@@ -398,6 +406,48 @@ public abstract class BaseToObjectValueWriter<E extends Exception> implements An
     public void writeByteArray( byte[] value ) throws RuntimeException
     {
         writeValue( value );
+    }
+
+    @Override
+    public void writeDuration( long months, long days, long seconds, int nanos )
+    {
+        writeValue( DurationValue.duration( months, days, seconds, nanos ) );
+    }
+
+    @Override
+    public void writeDate( long epochDay ) throws RuntimeException
+    {
+        writeValue( DateValue.epochDate( epochDay ) );
+    }
+
+    @Override
+    public void writeLocalTime( long nanoOfDay ) throws RuntimeException
+    {
+        writeValue( LocalTimeValue.localTime( nanoOfDay ) );
+    }
+
+    @Override
+    public void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws RuntimeException
+    {
+        writeValue( TimeValue.time( nanosOfDayUTC, ZoneOffset.ofTotalSeconds( offsetSeconds ) ) );
+    }
+
+    @Override
+    public void writeLocalDateTime( long epochSecond, int nano ) throws RuntimeException
+    {
+        writeValue( LocalDateTimeValue.localDateTime( epochSecond, nano ) );
+    }
+
+    @Override
+    public void writeDateTime( long epochSecondUTC, int nano, int offsetSeconds ) throws RuntimeException
+    {
+        writeValue( DateTimeValue.datetime( epochSecondUTC, nano, ZoneOffset.ofTotalSeconds( offsetSeconds ) ) );
+    }
+
+    @Override
+    public void writeDateTime( long epochSecondUTC, int nano, String zoneId ) throws RuntimeException
+    {
+        writeValue( DateTimeValue.datetime( epochSecondUTC, nano, ZoneId.of( zoneId ) ) );
     }
 
     private interface Writer

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DefaultValueMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/DefaultValueMapper.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.util;
+
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.kernel.impl.core.EmbeddedProxySPI;
+import org.neo4j.kernel.impl.core.NodeProxy;
+import org.neo4j.kernel.impl.core.PathProxy;
+import org.neo4j.kernel.impl.core.RelationshipProxy;
+import org.neo4j.values.ValueMapper;
+import org.neo4j.values.virtual.NodeValue;
+import org.neo4j.values.virtual.PathValue;
+import org.neo4j.values.virtual.RelationshipValue;
+import org.neo4j.values.virtual.VirtualNodeValue;
+import org.neo4j.values.virtual.VirtualRelationshipValue;
+
+public class DefaultValueMapper extends ValueMapper.JavaMapper
+{
+    private final EmbeddedProxySPI proxySPI;
+
+    public DefaultValueMapper( EmbeddedProxySPI proxySPI )
+    {
+        this.proxySPI = proxySPI;
+    }
+
+    @Override
+    public Node mapNode( VirtualNodeValue value )
+    {
+        if ( value instanceof NodeProxyWrappingNodeValue )
+        { // this is the back door through which "virtual nodes" slip
+            return ((NodeProxyWrappingNodeValue) value).nodeProxy();
+        }
+        return new NodeProxy( proxySPI, value.id() );
+    }
+
+    @Override
+    public Relationship mapRelationship( VirtualRelationshipValue value )
+    {
+        if ( value instanceof RelationshipProxyWrappingValue )
+        { // this is the back door through which "virtual relationships" slip
+            return ((RelationshipProxyWrappingValue) value).relationshipProxy();
+        }
+        return new RelationshipProxy( proxySPI, value.id() );
+    }
+
+    @Override
+    public Path mapPath( PathValue value )
+    {
+        NodeValue[] nodeValues = value.nodes();
+        RelationshipValue[] relationshipValues = value.relationships();
+        long[] nodes = new long[nodeValues.length];
+        long[] relationships = new long[relationshipValues.length];
+        int[] directedTypes = new int[relationshipValues.length];
+        for ( int i = 0; i < nodes.length; i++ )
+        {
+            nodes[i] = nodeValues[i].id();
+        }
+        for ( int i = 0; i < relationships.length; i++ )
+        {
+            RelationshipValue relationship = relationshipValues[i];
+            relationships[i] = relationship.id();
+            int typeId = proxySPI.getRelationshipTypeIdByName( relationship.type().stringValue() );
+            directedTypes[i] = nodes[i] == relationship.startNode().id() ? typeId : ~typeId;
+        }
+        return new PathProxy( proxySPI, nodes, relationships, directedTypes );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/proc/FieldSignatureTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/proc/FieldSignatureTest.java
@@ -26,7 +26,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
 import static org.neo4j.kernel.api.proc.FieldSignature.inputField;
 import static org.neo4j.kernel.api.proc.FieldSignature.outputField;
-import static org.neo4j.kernel.impl.proc.Neo4jValue.ntString;
+import static org.neo4j.kernel.impl.proc.DefaultParameterValue.ntString;
 
 public class FieldSignatureTest
 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/BuiltInProceduresTest.java
@@ -471,9 +471,9 @@ public class BuiltInProceduresTest
         procs.registerComponent( GraphDatabaseAPI.class, ctx -> ctx.get( GRAPHDATABASEAPI ), false );
         procs.registerComponent( SecurityContext.class, ctx -> ctx.get( SECURITY_CONTEXT ), true );
 
-        procs.registerType( Node.class, new TypeMappers.SimpleConverter( NTNode, Node.class ) );
-        procs.registerType( Relationship.class, new TypeMappers.SimpleConverter( NTRelationship, Relationship.class ) );
-        procs.registerType( Path.class, new TypeMappers.SimpleConverter( NTPath, Path.class ) );
+        procs.registerType( Node.class, NTNode );
+        procs.registerType( Relationship.class, NTRelationship );
+        procs.registerType( Path.class, NTPath );
 
         new SpecialBuiltInProcedures( "1.3.37", Edition.enterprise.toString() ).accept( procs );
         procs.registerProcedure( BuiltInProcedures.class );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelStatementTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelStatementTest.java
@@ -53,7 +53,7 @@ public class KernelStatementTest
         when( transaction.securityContext() ).thenReturn( AUTH_DISABLED );
 
         KernelStatement statement = new KernelStatement( transaction, null, mock( StorageStatement.class ), null, new CanWrite(),
-                LockTracer.NONE, mock( StatementOperationParts.class ) );
+                LockTracer.NONE, mock( StatementOperationParts.class ), new ClockContext() );
         statement.acquire();
 
         statement.readOperations().nodeExists( 0 );
@@ -66,7 +66,7 @@ public class KernelStatementTest
         StorageStatement storeStatement = mock( StorageStatement.class );
         KernelStatement statement = new KernelStatement( mock( KernelTransactionImplementation.class ),
                 null, storeStatement, new Procedures(), new CanWrite(), LockTracer.NONE,
-                mock( StatementOperationParts.class ) );
+                mock( StatementOperationParts.class ), new ClockContext() );
         statement.acquire();
 
         // when
@@ -92,7 +92,8 @@ public class KernelStatementTest
         AccessCapability accessCapability = mock( AccessCapability.class );
         Procedures procedures = mock( Procedures.class );
         KernelStatement statement = new KernelStatement( transaction, txStateHolder,
-                storeStatement, procedures, accessCapability, LockTracer.NONE, mock( StatementOperationParts.class ) );
+                storeStatement, procedures, accessCapability, LockTracer.NONE, mock( StatementOperationParts.class ),
+                new ClockContext() );
 
         statement.assertOpen();
     }
@@ -112,7 +113,8 @@ public class KernelStatementTest
         when( transaction.executingQueries() ).thenReturn( ExecutingQueryList.EMPTY );
 
         KernelStatement statement = new KernelStatement( transaction, txStateHolder,
-                storeStatement, procedures, accessCapability, LockTracer.NONE, mock( StatementOperationParts.class ) );
+                storeStatement, procedures, accessCapability, LockTracer.NONE, mock( StatementOperationParts.class ),
+                new ClockContext() );
         statement.acquire();
 
         ExecutingQuery query = getQueryWithWaitingTime();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
@@ -89,7 +89,8 @@ public class LockingStatementOperationsTest
     private final KernelTransactionImplementation transaction = mock( KernelTransactionImplementation.class );
     private final TxState txState = new TxState();
     private final KernelStatement state = new KernelStatement( transaction, new SimpleTxStateHolder( txState ),
-            mock( StorageStatement.class ), new Procedures(), new CanWrite(), LockTracer.NONE, null );
+            mock( StorageStatement.class ), new Procedures(), new CanWrite(), LockTracer.NONE, null,
+            new ClockContext() );
     private final SchemaStateOperations schemaStateOps;
 
     private final LabelSchemaDescriptor descriptor = SchemaDescriptorFactory.forLabel( 123, 456 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementLifecycleTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/StatementLifecycleTest.java
@@ -79,6 +79,6 @@ public class StatementLifecycleTest
             StorageStatement storageStatement )
     {
         return new KernelStatement( transaction, null, storageStatement, new Procedures(), new CanWrite(),
-                LockTracer.NONE, mock( StatementOperationParts.class ) );
+                LockTracer.NONE, mock( StatementOperationParts.class ), new ClockContext() );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorageLayerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/store/StorageLayerTest.java
@@ -31,6 +31,7 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.api.Statement;
+import org.neo4j.kernel.impl.api.ClockContext;
 import org.neo4j.kernel.impl.api.KernelStatement;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.factory.CanWrite;
@@ -67,7 +68,7 @@ public abstract class StorageLayerTest
         DependencyResolver resolver = db.getDependencyResolver();
         this.disk = resolver.resolveDependency( StorageEngine.class ).storeReadLayer();
         this.state = new KernelStatement( null, null, disk.newStatement(), new Procedures(), new CanWrite(),
-                LockTracer.NONE, null );
+                LockTracer.NONE, null, new ClockContext() );
     }
 
     protected GraphDatabaseService createGraphDatabase()

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/core/PathProxyTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/core/PathProxyTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.core;
+
+import java.util.Iterator;
+
+import org.junit.Test;
+
+import org.neo4j.graphdb.Entity;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Path;
+import org.neo4j.graphdb.PropertyContainer;
+import org.neo4j.graphdb.Relationship;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class PathProxyTest
+{
+    @Test
+    public void shouldIterateThroughNodes()
+    {
+        // given
+        Path path = new PathProxy( null, new long[] {1, 2, 3}, new long[] {100, 200}, new int[] {0, ~0} );
+
+        Iterator<Node> iterator = path.nodes().iterator();
+        Node node;
+
+        // then
+        assertTrue( iterator.hasNext() );
+        assertThat( node = iterator.next(), instanceOf( Node.class ) );
+        assertEquals( 1, node.getId() );
+        assertTrue( iterator.hasNext() );
+        assertThat( node = iterator.next(), instanceOf( Node.class ) );
+        assertEquals( 2, node.getId() );
+        assertTrue( iterator.hasNext() );
+        assertThat( node = iterator.next(), instanceOf( Node.class ) );
+        assertEquals( 3, node.getId() );
+        assertFalse( iterator.hasNext() );
+    }
+
+    @Test
+    public void shouldIterateThroughNodesInReverse()
+    {
+        // given
+        Path path = new PathProxy( null, new long[] {1, 2, 3}, new long[] {100, 200}, new int[] {0, ~0} );
+
+        Iterator<Node> iterator = path.reverseNodes().iterator();
+        Node node;
+
+        // then
+        assertTrue( iterator.hasNext() );
+        assertThat( node = iterator.next(), instanceOf( Node.class ) );
+        assertEquals( 3, node.getId() );
+        assertTrue( iterator.hasNext() );
+        assertThat( node = iterator.next(), instanceOf( Node.class ) );
+        assertEquals( 2, node.getId() );
+        assertTrue( iterator.hasNext() );
+        assertThat( node = iterator.next(), instanceOf( Node.class ) );
+        assertEquals( 1, node.getId() );
+        assertFalse( iterator.hasNext() );
+    }
+
+    @Test
+    public void shouldIterateThroughRelationships()
+    {
+        // given
+        Path path = new PathProxy( null, new long[] {1, 2, 3}, new long[] {100, 200}, new int[] {0, ~0} );
+
+        Iterator<Relationship> iterator = path.relationships().iterator();
+        Relationship relationship;
+
+        // then
+        assertTrue( iterator.hasNext() );
+        assertThat( relationship = iterator.next(), instanceOf( Relationship.class ) );
+        assertEquals( 100, relationship.getId() );
+        assertEquals( 1, relationship.getStartNodeId() );
+        assertEquals( 2, relationship.getEndNodeId() );
+        assertTrue( iterator.hasNext() );
+        assertThat( relationship = iterator.next(), instanceOf( Relationship.class ) );
+        assertEquals( 200, relationship.getId() );
+        assertEquals( 3, relationship.getStartNodeId() );
+        assertEquals( 2, relationship.getEndNodeId() );
+        assertFalse( iterator.hasNext() );
+    }
+
+    @Test
+    public void shouldIterateThroughRelationshipsInReverse()
+    {
+        // given
+        Path path = new PathProxy( null, new long[] {1, 2, 3}, new long[] {100, 200}, new int[] {0, ~0} );
+
+        Iterator<Relationship> iterator = path.reverseRelationships().iterator();
+        Relationship relationship;
+
+        // then
+        assertTrue( iterator.hasNext() );
+        assertThat( relationship = iterator.next(), instanceOf( Relationship.class ) );
+        assertEquals( 200, relationship.getId() );
+        assertEquals( 3, relationship.getStartNodeId() );
+        assertEquals( 2, relationship.getEndNodeId() );
+        assertTrue( iterator.hasNext() );
+        assertThat( relationship = iterator.next(), instanceOf( Relationship.class ) );
+        assertEquals( 100, relationship.getId() );
+        assertEquals( 1, relationship.getStartNodeId() );
+        assertEquals( 2, relationship.getEndNodeId() );
+        assertFalse( iterator.hasNext() );
+    }
+
+    @Test
+    public void shouldIterateAlternatingNodesAndRelationships()
+    {
+        // given
+        Path path = new PathProxy( null, new long[] {1, 2, 3}, new long[] {100, 200}, new int[] {0, ~0} );
+
+        Iterator<PropertyContainer> iterator = path.iterator();
+        PropertyContainer entity;
+
+        // then
+        assertTrue( iterator.hasNext() );
+        assertThat( entity = iterator.next(), instanceOf( Node.class ) );
+        assertEquals( 1, ((Entity) entity).getId() );
+        assertTrue( iterator.hasNext() );
+        assertThat( entity = iterator.next(), instanceOf( Relationship.class ) );
+        assertEquals( 100, ((Entity) entity).getId() );
+        assertTrue( iterator.hasNext() );
+        assertThat( entity = iterator.next(), instanceOf( Node.class ) );
+        assertEquals( 2, ((Entity) entity).getId() );
+        assertTrue( iterator.hasNext() );
+        assertThat( entity = iterator.next(), instanceOf( Relationship.class ) );
+        assertEquals( 200, ((Entity) entity).getId() );
+        assertTrue( iterator.hasNext() );
+        assertThat( entity = iterator.next(), instanceOf( Node.class ) );
+        assertEquals( 3, ((Entity) entity).getId() );
+        assertFalse( iterator.hasNext() );
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ListConverterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ListConverterTest.java
@@ -43,7 +43,7 @@ import static org.neo4j.kernel.api.proc.Neo4jTypes.NTInteger;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTList;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTMap;
 import static org.neo4j.kernel.api.proc.Neo4jTypes.NTString;
-import static org.neo4j.kernel.impl.proc.Neo4jValue.ntList;
+import static org.neo4j.kernel.impl.proc.DefaultParameterValue.ntList;
 
 public class ListConverterTest
 {
@@ -59,7 +59,7 @@ public class ListConverterTest
         String listString = "null";
 
         // When
-        Neo4jValue converted = converter.apply( listString );
+        DefaultParameterValue converted = converter.apply( listString );
 
         // Then
         assertThat( converted, equalTo( ntList( null, NTString ) ) );
@@ -73,7 +73,7 @@ public class ListConverterTest
         String listString = "[]";
 
         // When
-        Neo4jValue converted = converter.apply( listString );
+        DefaultParameterValue converted = converter.apply( listString );
 
         // Then
         assertThat( converted, equalTo( ntList( emptyList(), NTString ) ) );
@@ -87,7 +87,7 @@ public class ListConverterTest
         String listString = " [  ]   ";
 
         // When
-        Neo4jValue converted = converter.apply( listString );
+        DefaultParameterValue converted = converter.apply( listString );
 
         // Then
         assertThat( converted, equalTo( ntList( emptyList(), NTString ) ) );
@@ -101,7 +101,7 @@ public class ListConverterTest
         String listString = "['foo', 'bar']";
 
         // When
-        Neo4jValue converted = converter.apply( listString );
+        DefaultParameterValue converted = converter.apply( listString );
 
         // Then
         assertThat( converted, equalTo( ntList( asList( "foo", "bar" ), NTString ) ) );
@@ -115,7 +115,7 @@ public class ListConverterTest
         String listString = "[\"foo\", \"bar\"]";
 
         // When
-        Neo4jValue converted = converter.apply( listString );
+        DefaultParameterValue converted = converter.apply( listString );
 
         // Then
         assertThat( converted, equalTo( ntList( asList( "foo", "bar" ), NTString ) ) );
@@ -129,7 +129,7 @@ public class ListConverterTest
         String listString = "[1337, 42]";
 
         // When
-        Neo4jValue converted = converter.apply( listString );
+        DefaultParameterValue converted = converter.apply( listString );
 
         // Then
         assertThat( converted, equalTo( ntList( asList( 1337L, 42L ), NTInteger ) ) );
@@ -143,7 +143,7 @@ public class ListConverterTest
         String listSting = "[2.718281828, 3.14]";
 
         // When
-        Neo4jValue converted = converter.apply( listSting );
+        DefaultParameterValue converted = converter.apply( listSting );
 
         // Then
         assertThat( converted, equalTo( ntList( asList( 2.718281828, 3.14 ), NTFloat ) ) );
@@ -157,7 +157,7 @@ public class ListConverterTest
         String listString = "[null]";
 
         // When
-        Neo4jValue converted = converter.apply( listString );
+        DefaultParameterValue converted = converter.apply( listString );
 
         // Then
         assertThat( converted, equalTo( ntList( singletonList( null ), NTFloat ) ) );
@@ -171,7 +171,7 @@ public class ListConverterTest
         String mapString = "[false, true]";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         assertThat( converted, equalTo( ntList( asList( false, true ), NTBoolean ) ) );
@@ -188,7 +188,7 @@ public class ListConverterTest
         String mapString = "[42, [42, 1337]]";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         List<Object> list = (List<Object>) converted.value();
@@ -219,7 +219,7 @@ public class ListConverterTest
         String listString = "[1337, 'forty-two']";
 
         // When
-        Neo4jValue value = converter.apply( listString );
+        DefaultParameterValue value = converter.apply( listString );
 
         // Then
         assertThat( value, equalTo( ntList( asList( 1337L, "forty-two" ), NTAny ) ) );
@@ -234,7 +234,7 @@ public class ListConverterTest
         String mapString = "[{k1: 42}, {k1: 1337}]";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         List<Object> list = (List<Object>) converted.value();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/MapConverterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/MapConverterTest.java
@@ -30,7 +30,7 @@ import static java.util.Collections.emptyMap;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.neo4j.helpers.collection.MapUtil.map;
-import static org.neo4j.kernel.impl.proc.Neo4jValue.ntMap;
+import static org.neo4j.kernel.impl.proc.DefaultParameterValue.ntMap;
 
 public class MapConverterTest
 {
@@ -46,7 +46,7 @@ public class MapConverterTest
         String mapString = "null";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         assertThat( converted, equalTo( ntMap( null ) ) );
@@ -59,7 +59,7 @@ public class MapConverterTest
         String mapString = "{}";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         assertThat( converted, equalTo( ntMap( emptyMap() ) ) );
@@ -72,7 +72,7 @@ public class MapConverterTest
         String mapString = " {  }  ";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         assertThat( converted, equalTo( ntMap( emptyMap() ) ) );
@@ -85,7 +85,7 @@ public class MapConverterTest
         String mapString = "{key: 'value'}";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         assertThat( converted, equalTo( ntMap( map( "key", "value" ) ) ) );
@@ -98,7 +98,7 @@ public class MapConverterTest
         String mapString = "{key: 'va\'lue'}";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         assertThat( converted, equalTo( ntMap( map( "key", "va\'lue" ) ) ) );
@@ -111,7 +111,7 @@ public class MapConverterTest
         String mapString = "{key: \"va\'lue\"}";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         assertThat( converted, equalTo( ntMap( map( "key", "va\'lue" ) ) ) );
@@ -124,7 +124,7 @@ public class MapConverterTest
         String mapString = "{key: \"va\"lue\"}";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         assertThat( converted, equalTo( ntMap( map( "key", "va\"lue" ) ) ) );
@@ -137,7 +137,7 @@ public class MapConverterTest
         String mapString = "{key: 'va\"lue'}";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         assertThat( converted, equalTo( ntMap( map( "key", "va\"lue" ) ) ) );
@@ -150,7 +150,7 @@ public class MapConverterTest
         String mapString = "{key: \"value\"}";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         assertThat( converted, equalTo( ntMap( map( "key", "value" ) ) ) );
@@ -163,7 +163,7 @@ public class MapConverterTest
         String mapString = "{'key;: 'value'}";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         assertThat( converted, equalTo( ntMap( map( "key", "value" ) ) ) );
@@ -176,7 +176,7 @@ public class MapConverterTest
         String mapString = "{\"key\": \"value\"}";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         assertThat( converted, equalTo( ntMap( map( "key", "value" ) ) ) );
@@ -189,7 +189,7 @@ public class MapConverterTest
         String mapString = "{\"k\'ey\": \"value\"}";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         assertThat( converted, equalTo( ntMap( map( "k\'ey", "value" ) ) ) );
@@ -202,7 +202,7 @@ public class MapConverterTest
         String mapString = "{\"k\"ey\": \"value\"}";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         assertThat( converted, equalTo( ntMap( map( "k\"ey", "value" ) ) ) );
@@ -215,7 +215,7 @@ public class MapConverterTest
         String mapString = "{key: 1337}";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         assertThat( converted, equalTo( ntMap( map( "key", 1337L ) ) ) );
@@ -228,7 +228,7 @@ public class MapConverterTest
         String mapString = "{key: 2.718281828}";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         assertThat( converted, equalTo( ntMap( map( "key", 2.718281828 ) ) ) );
@@ -241,7 +241,7 @@ public class MapConverterTest
         String mapString = "{key: null}";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         assertThat( converted, equalTo( ntMap( map( "key", null ) ) ) );
@@ -254,7 +254,7 @@ public class MapConverterTest
         String mapString = "{key: false}";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         assertThat( converted, equalTo( ntMap( map( "key", false ) ) ) );
@@ -267,7 +267,7 @@ public class MapConverterTest
         String mapString = "{key: true}";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         assertThat( converted, equalTo( ntMap( map( "key", true ) ) ) );
@@ -280,7 +280,7 @@ public class MapConverterTest
         String mapString = "{k1: 2.718281828, k2: 'e'}";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         assertThat( converted, equalTo( ntMap( map( "k1", 2.718281828, "k2", "e" ) ) ) );
@@ -308,7 +308,7 @@ public class MapConverterTest
         String mapString = "{k1: 1337, k2: { k1 : 1337, k2: {k1: 1337}}}";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         Map<String,Object> map1 = (Map<String,Object>) converted.value();
@@ -341,7 +341,7 @@ public class MapConverterTest
         String mapString = "{k1: [1337, 42]}";
 
         // When
-        Neo4jValue converted = converter.apply( mapString );
+        DefaultParameterValue converted = converter.apply( mapString );
 
         // Then
         Map<String,Object> map1 = (Map<String,Object>) converted.value();

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureJarLoaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ProcedureJarLoaderTest.java
@@ -45,6 +45,8 @@ import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Name;
 import org.neo4j.procedure.Procedure;
 import org.neo4j.procedure.UserFunction;
+import org.neo4j.values.AnyValue;
+import org.neo4j.values.storable.Values;
 
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.contains;
@@ -253,7 +255,7 @@ public class ProcedureJarLoaderTest
                 functionSignature( "org", "neo4j", "kernel", "impl", "proc", "unsafeFullAccessFunction" )
                         .out( NTInteger ).build() ) );
 
-        assertThat( functions.get( 0 ).apply( new BasicContext(), new Object[0] ), equalTo( 7331L ) );
+        assertThat( functions.get( 0 ).apply( new BasicContext(), new AnyValue[0] ), equalTo( Values.of( 7331L ) ) );
     }
 
     public URL createJarFor( Class<?> ... targets ) throws IOException

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserAggregationFunctionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserAggregationFunctionTest.java
@@ -285,9 +285,11 @@ public class ReflectiveUserAggregationFunctionTest
         exception.expect( ProcedureException.class );
         exception.expectMessage( String.format("Don't know how to map `char[]` to the Neo4j Type System.%n" +
                                  "Please refer to to the documentation for full details.%n" +
-                                 "For your reference, known types are: [boolean, double, java.lang.Boolean, java.lang" +
-                                 ".Double, java.lang.Long, java.lang.Number, java.lang.Object, java.lang.String, java" +
-                                 ".util.List, java.util.Map, long]" ));
+                                 "For your reference, known types are: [boolean, double, java.lang.Boolean, " +
+                                 "java.lang.Double, java.lang.Long, java.lang.Number, java.lang.Object, " +
+                                 "java.lang.String, java.time.LocalDate, java.time.LocalDateTime, " +
+                                 "java.time.LocalTime, java.time.OffsetTime, java.time.ZonedDateTime, " +
+                                 "java.time.temporal.TemporalAmount, java.util.List, java.util.Map, long]" ));
 
         // When
         compile( FunctionWithInvalidOutput.class ).get( 0 );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserFunctionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ReflectiveUserFunctionTest.java
@@ -38,10 +38,13 @@ import org.neo4j.kernel.api.proc.BasicContext;
 import org.neo4j.kernel.api.proc.CallableUserFunction;
 import org.neo4j.kernel.api.proc.Neo4jTypes;
 import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.impl.util.ValueUtils;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.NullLog;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.UserFunction;
+import org.neo4j.values.AnyValue;
+import org.neo4j.values.virtual.MapValue;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertEquals;
@@ -80,7 +83,7 @@ public class ReflectiveUserFunctionTest
         CallableUserFunction function = procedureCompiler.compileFunction( LoggingFunction.class ).get( 0 );
 
         // When
-        function.apply( new BasicContext(), new Object[0] );
+        function.apply( new BasicContext(), new AnyValue[0] );
 
         // Then
         verify( log ).debug( "1" );
@@ -110,10 +113,10 @@ public class ReflectiveUserFunctionTest
         CallableUserFunction func = compile( SingleReadOnlyFunction.class ).get( 0 );
 
         // When
-        Object out = func.apply( new BasicContext(), new Object[0] );
+        Object out = func.apply( new BasicContext(), new AnyValue[0] );
 
         // Then
-        assertThat(out, equalTo(Arrays.asList("Bonnie", "Clyde")) );
+        assertThat(out, equalTo( ValueUtils.of( Arrays.asList("Bonnie", "Clyde") ) ) );
     }
 
     @Test
@@ -135,13 +138,13 @@ public class ReflectiveUserFunctionTest
         CallableUserFunction coolPeople = compiled.get( 1 );
 
         // When
-        Object coolOut = coolPeople.apply( new BasicContext(), new Object[0] );
-        Object bananaOut = bananaPeople.apply( new BasicContext(), new Object[0] );
+        Object coolOut = coolPeople.apply( new BasicContext(), new AnyValue[0] );
+        Object bananaOut = bananaPeople.apply( new BasicContext(), new AnyValue[0] );
 
         // Then
-        assertThat( coolOut , equalTo(Arrays.asList("Bonnie", "Clyde")));
+        assertThat( coolOut , equalTo(ValueUtils.of( Arrays.asList("Bonnie", "Clyde") ) ) );
 
-        assertThat( ((Map) bananaOut).get("foo"), equalTo(Arrays.asList( "bar", "baz" )) );
+        assertThat( ((MapValue) bananaOut).get("foo"), equalTo( ValueUtils.of( Arrays.asList( "bar", "baz" ) ) ) );
     }
 
     @Test
@@ -188,9 +191,11 @@ public class ReflectiveUserFunctionTest
         exception.expect( ProcedureException.class );
         exception.expectMessage( String.format("Don't know how to map `char[]` to the Neo4j Type System.%n" +
                                  "Please refer to to the documentation for full details.%n" +
-                                 "For your reference, known types are: [boolean, double, java.lang.Boolean, java.lang" +
-                                 ".Double, java.lang.Long, java.lang.Number, java.lang.Object, java.lang.String, java" +
-                                 ".util.List, java.util.Map, long]" ));
+                                 "For your reference, known types are: [boolean, double, java.lang.Boolean, " +
+                                 "java.lang.Double, java.lang.Long, java.lang.Number, java.lang.Object, " +
+                                 "java.lang.String, java.time.LocalDate, java.time.LocalDateTime, " +
+                                 "java.time.LocalTime, java.time.OffsetTime, java.time.ZonedDateTime, " +
+                                 "java.time.temporal.TemporalAmount, java.util.List, java.util.Map, long]" ));
 
         // When
         compile( FunctionWithInvalidOutput.class ).get( 0 );
@@ -244,7 +249,7 @@ public class ReflectiveUserFunctionTest
                                  "Caused by: java.lang.IndexOutOfBoundsException" );
 
         // When
-        proc.apply( new BasicContext(), new Object[0] );
+        proc.apply( new BasicContext(), new AnyValue[0] );
     }
 
     @Test
@@ -258,8 +263,8 @@ public class ReflectiveUserFunctionTest
         CallableUserFunction method = compile( SingleReadOnlyFunction.class ).get( 0 );
 
         // Expect
-        Object out = method.apply( new BasicContext(), new Object[0] );
-        assertThat(out, equalTo(Arrays.asList("Bonnie", "Clyde")) );
+        Object out = method.apply( new BasicContext(), new AnyValue[0] );
+        assertThat(out, equalTo( ValueUtils.of( Arrays.asList("Bonnie", "Clyde") ) ) );
     }
 
     @Test
@@ -305,7 +310,7 @@ public class ReflectiveUserFunctionTest
         for ( CallableUserFunction func : funcs )
         {
             String name = func.signature().name().name();
-            func.apply( new BasicContext(), new Object[0] );
+            func.apply( new BasicContext(), new AnyValue[0] );
             switch ( name )
             {
             case "newFunc":

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ResourceInjectionTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/ResourceInjectionTest.java
@@ -42,6 +42,8 @@ import org.neo4j.procedure.UserAggregationFunction;
 import org.neo4j.procedure.UserAggregationResult;
 import org.neo4j.procedure.UserAggregationUpdate;
 import org.neo4j.procedure.UserFunction;
+import org.neo4j.values.AnyValue;
+import org.neo4j.values.storable.Values;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -160,10 +162,10 @@ public class ResourceInjectionTest
                 compiler.compileFunction( FunctionWithInjectedAPI.class).get( 0 );
 
         // When
-        Object out = proc.apply( new BasicContext(), new Object[0] );
+        Object out = proc.apply( new BasicContext(), new AnyValue[0] );
 
         // Then
-        assertThat( out, equalTo( "[Bonnie, Clyde]" ) );
+        assertThat( out, equalTo( Values.of("[Bonnie, Clyde]") ) );
     }
 
     @Test
@@ -190,7 +192,7 @@ public class ResourceInjectionTest
         assertThat( procList.size(), equalTo( 1 ) );
         try
         {
-            procList.get( 0 ).apply( new BasicContext(), new Object[0] );
+            procList.get( 0 ).apply( new BasicContext(), new AnyValue[0] );
             fail();
         }
         catch ( ProcedureException e )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/TypeMappersTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/TypeMappersTest.java
@@ -19,19 +19,19 @@
  */
 package org.neo4j.kernel.impl.proc;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
 import org.neo4j.kernel.api.proc.Neo4jTypes;
-import org.neo4j.kernel.impl.proc.TypeMappers.NeoValueConverter;
+import org.neo4j.kernel.impl.proc.TypeMappers.TypeChecker;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
@@ -141,20 +141,20 @@ public class TypeMappersTest
     public void shouldDetectCorrectType() throws Throwable
     {
         // When
-        NeoValueConverter mapper = new TypeMappers().converterFor( javaClass );
+        Neo4jTypes.AnyType type = new TypeMappers().toNeo4jType( javaClass );
 
         // Then
-        assertEquals( neoType, mapper.type() );
+        assertEquals( neoType, type );
     }
 
     @Test
     public void shouldMapCorrectly() throws Throwable
     {
         // Given
-        NeoValueConverter mapper = new TypeMappers().converterFor( javaClass );
+        TypeChecker mapper = new TypeMappers().checkerFor( javaClass );
 
         // When
-        Object converted = mapper.toNeoValue( javaValue );
+        Object converted = mapper.typeCheck( javaValue );
 
         // Then
         Assert.assertEquals( expectedNeoValue, converted );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/UserFunctionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/proc/UserFunctionsTest.java
@@ -19,12 +19,12 @@
  */
 package org.neo4j.kernel.impl.proc;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-
-import java.util.List;
-import java.util.Optional;
 
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
@@ -35,6 +35,8 @@ import org.neo4j.kernel.api.proc.Context;
 import org.neo4j.kernel.api.proc.Key;
 import org.neo4j.kernel.api.proc.Neo4jTypes;
 import org.neo4j.kernel.api.proc.UserFunctionSignature;
+import org.neo4j.values.AnyValue;
+import org.neo4j.values.storable.Values;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
@@ -42,6 +44,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertThat;
 import static org.neo4j.kernel.api.proc.Key.key;
 import static org.neo4j.kernel.api.proc.UserFunctionSignature.functionSignature;
+import static org.neo4j.values.storable.Values.numberValue;
 
 public class UserFunctionsTest
 {
@@ -104,10 +107,10 @@ public class UserFunctionsTest
         procs.register( function );
 
         // When
-        Object result = procs.callFunction( new BasicContext(), signature.name(), new Object[]{1337} );
+        Object result = procs.callFunction( new BasicContext(), signature.name(), new AnyValue[] {numberValue( 1337 )} );
 
         // Then
-        assertThat( result , equalTo( new Object[]{1337} ) );
+        assertThat( result , equalTo( Values.of(1337) ) );
     }
 
     @Test
@@ -120,7 +123,7 @@ public class UserFunctionsTest
                                  "function name correctly and that the function is properly deployed." );
 
         // When
-        procs.callFunction( new BasicContext(), signature.name(), new Object[]{1337} );
+        procs.callFunction( new BasicContext(), signature.name(), new AnyValue[] {numberValue( 1337 )} );
     }
 
     @Test
@@ -153,9 +156,9 @@ public class UserFunctionsTest
         procs.register( new CallableUserFunction.BasicUserFunction( signature )
         {
             @Override
-            public Object apply( Context ctx, Object[] input ) throws ProcedureException
+            public AnyValue apply( Context ctx, AnyValue[] input ) throws ProcedureException
             {
-                return ctx.get( someKey );
+                return Values.stringValue( ctx.get( someKey ) );
             }
         } );
 
@@ -163,10 +166,10 @@ public class UserFunctionsTest
         ctx.put( someKey, "hello, world" );
 
         // When
-        Object result = procs.callFunction( ctx, signature.name(), new Object[0] );
+        Object result = procs.callFunction( ctx, signature.name(), new AnyValue[0] );
 
         // Then
-        assertThat( result, equalTo("hello, world" ) );
+        assertThat( result, equalTo(Values.of("hello, world") ) );
     }
 
     private CallableUserFunction function( UserFunctionSignature signature )
@@ -174,9 +177,9 @@ public class UserFunctionsTest
         return new CallableUserFunction.BasicUserFunction( signature )
         {
             @Override
-            public Object apply( Context ctx, Object[] input )
+            public AnyValue apply( Context ctx, AnyValue[] input )
             {
-                return input;
+                return input[0];
             }
         };
     }

--- a/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactory.java
@@ -50,6 +50,7 @@ import org.neo4j.kernel.internal.locker.StoreLocker;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.logging.NullLogProvider;
+import org.neo4j.time.SystemNanoClock;
 
 import static org.neo4j.kernel.configuration.Connector.ConnectorType.BOLT;
 import static org.neo4j.kernel.configuration.Settings.TRUE;
@@ -163,6 +164,12 @@ public class TestGraphDatabaseFactory extends GraphDatabaseFactory
     public TestGraphDatabaseFactory setInternalLogProvider( LogProvider logProvider )
     {
         getCurrentState().setInternalLogProvider( logProvider );
+        return this;
+    }
+
+    public TestGraphDatabaseFactory setClock( SystemNanoClock clock )
+    {
+        getCurrentState().setClock( clock );
         return this;
     }
 
@@ -316,6 +323,13 @@ public class TestGraphDatabaseFactory extends GraphDatabaseFactory
                     internalLogProvider = NullLogProvider.getInstance();
                 }
                 return new SimpleLogService( userLogProvider, internalLogProvider );
+            }
+
+            @Override
+            protected SystemNanoClock createClock()
+            {
+                SystemNanoClock clock = state.clock();
+                return clock != null ? clock : super.createClock();
             }
         }
 

--- a/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactoryState.java
+++ b/community/kernel/src/test/java/org/neo4j/test/TestGraphDatabaseFactoryState.java
@@ -22,11 +22,13 @@ package org.neo4j.test;
 import org.neo4j.graphdb.factory.GraphDatabaseFactoryState;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.logging.LogProvider;
+import org.neo4j.time.SystemNanoClock;
 
 public class TestGraphDatabaseFactoryState extends GraphDatabaseFactoryState
 {
     private FileSystemAbstraction fileSystem;
     private LogProvider internalLogProvider;
+    private SystemNanoClock clock;
 
     public TestGraphDatabaseFactoryState()
     {
@@ -39,6 +41,7 @@ public class TestGraphDatabaseFactoryState extends GraphDatabaseFactoryState
         super( previous );
         fileSystem = previous.fileSystem;
         internalLogProvider = previous.internalLogProvider;
+        clock = previous.clock;
     }
 
     public FileSystemAbstraction getFileSystem()
@@ -59,5 +62,15 @@ public class TestGraphDatabaseFactoryState extends GraphDatabaseFactoryState
     public void setInternalLogProvider( LogProvider logProvider )
     {
         this.internalLogProvider = logProvider;
+    }
+
+    public SystemNanoClock clock()
+    {
+        return clock;
+    }
+
+    public void setClock( SystemNanoClock clock )
+    {
+        this.clock = clock;
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/AnyValue.java
+++ b/community/values/src/main/java/org/neo4j/values/AnyValue.java
@@ -24,13 +24,13 @@ public abstract class AnyValue
     private int hash;
 
     @Override
-    public boolean equals( Object other )
+    public final boolean equals( Object other )
     {
-        return eq( other );
+        return this == other || other != null && eq( other );
     }
 
     @Override
-    public int hashCode()
+    public final int hashCode()
     {
         //We will always recompute hashcode for values
         //where `hashCode == 0`, e.g. empty strings and empty lists

--- a/community/values/src/main/java/org/neo4j/values/AnyValue.java
+++ b/community/values/src/main/java/org/neo4j/values/AnyValue.java
@@ -23,8 +23,10 @@ public abstract class AnyValue
 {
     private int hash;
 
+    // this should be final, but Mockito barfs if it is,
+    // so we need to just manually ensure it isn't overridden
     @Override
-    public final boolean equals( Object other )
+    public boolean equals( Object other )
     {
         return this == other || other != null && eq( other );
     }

--- a/community/values/src/main/java/org/neo4j/values/AnyValue.java
+++ b/community/values/src/main/java/org/neo4j/values/AnyValue.java
@@ -54,4 +54,6 @@ public abstract class AnyValue
     }
 
     public abstract Boolean ternaryEquals( AnyValue other );
+
+    public abstract <T> T map( ValueMapper<T> mapper );
 }

--- a/community/values/src/main/java/org/neo4j/values/StructureBuilder.java
+++ b/community/values/src/main/java/org/neo4j/values/StructureBuilder.java
@@ -17,32 +17,29 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.values.storable;
+package org.neo4j.values;
 
-import org.neo4j.values.AnyValue;
+import java.util.Map;
 
-public abstract class StructureBuilder<Input, Result>
+import org.neo4j.values.virtual.MapValue;
+
+public interface StructureBuilder<Input, Result>
 {
-    public abstract StructureBuilder<Input,Result> add( String field, Input value );
+    StructureBuilder<Input,Result> add( String field, Input value );
 
-    public abstract Result build();
+    Result build();
 
-    StructureBuilder()
+    static <T> T build( StructureBuilder<AnyValue,T> builder, MapValue map )
     {
-        // Particular subclasses defined in this package
+        return build( builder, map.entrySet() );
     }
 
-    static long unpackInteger( String name, AnyValue value )
+    static <T> T build( StructureBuilder<AnyValue,T> builder, Iterable<Map.Entry<String,AnyValue>> entries )
     {
-        if ( value == null )
+        for ( Map.Entry<String,AnyValue> entry : entries )
         {
-            return 0;
+            builder.add( entry.getKey(), entry.getValue() );
         }
-        if ( value instanceof IntegralValue )
-        {
-            return ((IntegralValue) value).longValue();
-        }
-        throw new IllegalArgumentException(
-                name + " must be an integer value, but was a " + value.getClass().getSimpleName() );
+        return builder.build();
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/ValueMapper.java
+++ b/community/values/src/main/java/org/neo4j/values/ValueMapper.java
@@ -19,6 +19,12 @@
  */
 package org.neo4j.values;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetTime;
+import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAmount;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -31,8 +37,11 @@ import org.neo4j.values.storable.ByteArray;
 import org.neo4j.values.storable.ByteValue;
 import org.neo4j.values.storable.CharArray;
 import org.neo4j.values.storable.CharValue;
+import org.neo4j.values.storable.DateTimeValue;
+import org.neo4j.values.storable.DateValue;
 import org.neo4j.values.storable.DoubleArray;
 import org.neo4j.values.storable.DoubleValue;
+import org.neo4j.values.storable.DurationValue;
 import org.neo4j.values.storable.FloatArray;
 import org.neo4j.values.storable.FloatValue;
 import org.neo4j.values.storable.FloatingPointArray;
@@ -41,6 +50,8 @@ import org.neo4j.values.storable.IntArray;
 import org.neo4j.values.storable.IntValue;
 import org.neo4j.values.storable.IntegralArray;
 import org.neo4j.values.storable.IntegralValue;
+import org.neo4j.values.storable.LocalDateTimeValue;
+import org.neo4j.values.storable.LocalTimeValue;
 import org.neo4j.values.storable.LongArray;
 import org.neo4j.values.storable.LongValue;
 import org.neo4j.values.storable.NumberArray;
@@ -53,6 +64,7 @@ import org.neo4j.values.storable.StringArray;
 import org.neo4j.values.storable.StringValue;
 import org.neo4j.values.storable.TextArray;
 import org.neo4j.values.storable.TextValue;
+import org.neo4j.values.storable.TimeValue;
 import org.neo4j.values.virtual.MapValue;
 import org.neo4j.values.virtual.PathValue;
 import org.neo4j.values.virtual.VirtualNodeValue;
@@ -197,6 +209,18 @@ public interface ValueMapper<Base>
         return mapFloatingPointArray( value );
     }
 
+    Base mapDateTime( DateTimeValue value );
+
+    Base mapLocalDateTime( LocalDateTimeValue value );
+
+    Base mapDate( DateValue value );
+
+    Base mapTime( TimeValue value );
+
+    Base mapLocalTime( LocalTimeValue value );
+
+    Base mapDuration( DurationValue value );
+
     Base mapPoint( PointValue value );
 
     default Base mapPointArray( PointArray value )
@@ -302,6 +326,42 @@ public interface ValueMapper<Base>
 
         @Override
         public double[] mapDoubleArray( DoubleArray value )
+        {
+            return value.asObjectCopy();
+        }
+
+        @Override
+        public ZonedDateTime mapDateTime( DateTimeValue value )
+        {
+            return value.asObjectCopy();
+        }
+
+        @Override
+        public LocalDateTime mapLocalDateTime( LocalDateTimeValue value )
+        {
+            return value.asObjectCopy();
+        }
+
+        @Override
+        public LocalDate mapDate( DateValue value )
+        {
+            return value.asObjectCopy();
+        }
+
+        @Override
+        public OffsetTime mapTime( TimeValue value )
+        {
+            return value.asObjectCopy();
+        }
+
+        @Override
+        public LocalTime mapLocalTime( LocalTimeValue value )
+        {
+            return value.asObjectCopy();
+        }
+
+        @Override
+        public TemporalAmount mapDuration( DurationValue value )
         {
             return value.asObjectCopy();
         }

--- a/community/values/src/main/java/org/neo4j/values/ValueMapper.java
+++ b/community/values/src/main/java/org/neo4j/values/ValueMapper.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.neo4j.graphdb.spatial.Point;
+import org.neo4j.values.storable.BooleanArray;
+import org.neo4j.values.storable.BooleanValue;
+import org.neo4j.values.storable.ByteArray;
+import org.neo4j.values.storable.ByteValue;
+import org.neo4j.values.storable.CharArray;
+import org.neo4j.values.storable.CharValue;
+import org.neo4j.values.storable.DoubleArray;
+import org.neo4j.values.storable.DoubleValue;
+import org.neo4j.values.storable.FloatArray;
+import org.neo4j.values.storable.FloatValue;
+import org.neo4j.values.storable.FloatingPointArray;
+import org.neo4j.values.storable.FloatingPointValue;
+import org.neo4j.values.storable.IntArray;
+import org.neo4j.values.storable.IntValue;
+import org.neo4j.values.storable.IntegralArray;
+import org.neo4j.values.storable.IntegralValue;
+import org.neo4j.values.storable.LongArray;
+import org.neo4j.values.storable.LongValue;
+import org.neo4j.values.storable.NumberArray;
+import org.neo4j.values.storable.NumberValue;
+import org.neo4j.values.storable.PointArray;
+import org.neo4j.values.storable.PointValue;
+import org.neo4j.values.storable.ShortArray;
+import org.neo4j.values.storable.ShortValue;
+import org.neo4j.values.storable.StringArray;
+import org.neo4j.values.storable.StringValue;
+import org.neo4j.values.storable.TextArray;
+import org.neo4j.values.storable.TextValue;
+import org.neo4j.values.virtual.MapValue;
+import org.neo4j.values.virtual.PathValue;
+import org.neo4j.values.virtual.VirtualNodeValue;
+import org.neo4j.values.virtual.VirtualRelationshipValue;
+
+public interface ValueMapper<Base>
+{
+    // Virtual
+
+    Base mapPath( PathValue value );
+
+    Base mapNode( VirtualNodeValue value );
+
+    Base mapRelationship( VirtualRelationshipValue value );
+
+    Base mapMap( MapValue value );
+
+    // Storable
+
+    Base mapNoValue();
+
+    Base mapSequence( SequenceValue value );
+
+    Base mapText( TextValue value );
+
+    default Base mapString( StringValue value )
+    {
+        return mapText( value );
+    }
+
+    default Base mapTextArray( TextArray value )
+    {
+        return mapSequence( value );
+    }
+
+    default Base mapStringArray( StringArray value )
+    {
+        return mapTextArray( value );
+    }
+
+    default Base mapChar( CharValue value )
+    {
+        return mapText( value );
+    }
+
+    default Base mapCharArray( CharArray value )
+    {
+        return mapTextArray( value );
+    }
+
+    Base mapBoolean( BooleanValue value );
+
+    default Base mapBooleanArray( BooleanArray value )
+    {
+        return mapSequence( value );
+    }
+
+    Base mapNumber( NumberValue value );
+
+    default Base mapNumberArray( NumberArray value )
+    {
+        return mapSequence( value );
+    }
+
+    default Base mapIntegral( IntegralValue value )
+    {
+        return mapNumber( value );
+    }
+
+    default Base mapIntegralArray( IntegralArray value )
+    {
+        return mapNumberArray( value );
+    }
+
+    default Base mapByte( ByteValue value )
+    {
+        return mapIntegral( value );
+    }
+
+    default Base mapByteArray( ByteArray value )
+    {
+        return mapIntegralArray( value );
+    }
+
+    default Base mapShort( ShortValue value )
+    {
+        return mapIntegral( value );
+    }
+
+    default Base mapShortArray( ShortArray value )
+    {
+        return mapIntegralArray( value );
+    }
+
+    default Base mapInt( IntValue value )
+    {
+        return mapIntegral( value );
+    }
+
+    default Base mapIntArray( IntArray value )
+    {
+        return mapIntegralArray( value );
+    }
+
+    default Base mapLong( LongValue value )
+    {
+        return mapIntegral( value );
+    }
+
+    default Base mapLongArray( LongArray value )
+    {
+        return mapIntegralArray( value );
+    }
+
+    default Base mapFloatingPoint( FloatingPointValue value )
+    {
+        return mapNumber( value );
+    }
+
+    default Base mapFloatingPointArray( FloatingPointArray value )
+    {
+        return mapNumberArray( value );
+    }
+
+    default Base mapDouble( DoubleValue value )
+    {
+        return mapFloatingPoint( value );
+    }
+
+    default Base mapDoubleArray( DoubleArray value )
+    {
+        return mapFloatingPointArray( value );
+    }
+
+    default Base mapFloat( FloatValue value )
+    {
+        return mapFloatingPoint( value );
+    }
+
+    default Base mapFloatArray( FloatArray value )
+    {
+        return mapFloatingPointArray( value );
+    }
+
+    Base mapPoint( PointValue value );
+
+    default Base mapPointArray( PointArray value )
+    {
+        return mapSequence( value );
+    }
+
+    abstract class JavaMapper implements ValueMapper<Object>
+    {
+        @Override
+        public Object mapNoValue()
+        {
+            return null;
+        }
+
+        @Override
+        public Object mapMap( MapValue value )
+        {
+            Map<Object,Object> map = new HashMap<>();
+            value.foreach( ( k, v ) -> map.put( k, v.map( this ) ) );
+            return map;
+        }
+
+        @Override
+        public List<?> mapSequence( SequenceValue value )
+        {
+            List<Object> list = new ArrayList<>( value.length() );
+            value.forEach( v -> list.add( v.map( this ) ) );
+            return list;
+        }
+
+        @Override
+        public Character mapChar( CharValue value )
+        {
+            return value.value();
+        }
+
+        @Override
+        public String mapText( TextValue value )
+        {
+            return value.stringValue();
+        }
+
+        @Override
+        public String[] mapStringArray( StringArray value )
+        {
+            return value.asObjectCopy();
+        }
+
+        @Override
+        public char[] mapCharArray( CharArray value )
+        {
+            return value.asObjectCopy();
+        }
+
+        @Override
+        public Boolean mapBoolean( BooleanValue value )
+        {
+            return value.booleanValue();
+        }
+
+        @Override
+        public boolean[] mapBooleanArray( BooleanArray value )
+        {
+            return value.asObjectCopy();
+        }
+
+        @Override
+        public Number mapNumber( NumberValue value )
+        {
+            return value.asObject();
+        }
+
+        @Override
+        public byte[] mapByteArray( ByteArray value )
+        {
+            return value.asObjectCopy();
+        }
+
+        @Override
+        public short[] mapShortArray( ShortArray value )
+        {
+            return value.asObjectCopy();
+        }
+
+        @Override
+        public int[] mapIntArray( IntArray value )
+        {
+            return value.asObjectCopy();
+        }
+
+        @Override
+        public long[] mapLongArray( LongArray value )
+        {
+            return value.asObjectCopy();
+        }
+
+        @Override
+        public float[] mapFloatArray( FloatArray value )
+        {
+            return value.asObjectCopy();
+        }
+
+        @Override
+        public double[] mapDoubleArray( DoubleArray value )
+        {
+            return value.asObjectCopy();
+        }
+
+        @Override
+        public Point mapPoint( PointValue value )
+        {
+            return value.asObjectCopy();
+        }
+    }
+}

--- a/community/values/src/main/java/org/neo4j/values/storable/ArrayValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ArrayValue.java
@@ -24,6 +24,7 @@ import java.util.NoSuchElementException;
 
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.SequenceValue;
+import org.neo4j.values.ValueMapper;
 
 /**
  * Array of one of the storable primitives

--- a/community/values/src/main/java/org/neo4j/values/storable/BooleanArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/BooleanArray.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import org.neo4j.graphdb.spatial.Geometry;
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.SequenceValue;
+import org.neo4j.values.ValueMapper;
 
 import static java.lang.String.format;
 
@@ -115,20 +116,26 @@ public abstract class BooleanArray extends ArrayValue
     }
 
     @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapBooleanArray( this );
+    }
+
+    @Override
     public <E extends Exception> void writeTo( ValueWriter<E> writer ) throws E
     {
         PrimitiveArrayWriting.writeTo( writer, value() );
     }
 
     @Override
-    public Object asObjectCopy()
+    public boolean[] asObjectCopy()
     {
         return value().clone();
     }
 
     @Override
     @Deprecated
-    public Object asObject()
+    public boolean[] asObject()
     {
         return value();
     }

--- a/community/values/src/main/java/org/neo4j/values/storable/BooleanValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/BooleanValue.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.values.storable;
 
+import org.neo4j.values.ValueMapper;
+
 import static java.lang.String.format;
 
 /**
@@ -36,6 +38,12 @@ public abstract class BooleanValue extends ScalarValue
     public boolean eq( Object other )
     {
         return other != null && other instanceof Value && equals( (Value) other );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapBoolean( this );
     }
 
     public ValueGroup valueGroup()

--- a/community/values/src/main/java/org/neo4j/values/storable/ByteArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ByteArray.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.SequenceValue;
+import org.neo4j.values.ValueMapper;
 
 import static java.lang.String.format;
 
@@ -46,6 +47,12 @@ public abstract class ByteArray extends IntegralArray
     public int computeHash()
     {
         return NumberValues.hash( value() );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapByteArray( this );
     }
 
     @Override
@@ -112,14 +119,14 @@ public abstract class ByteArray extends IntegralArray
     }
 
     @Override
-    public Object asObjectCopy()
+    public byte[] asObjectCopy()
     {
         return value().clone();
     }
 
     @Override
     @Deprecated
-    public Object asObject()
+    public byte[] asObject()
     {
         return value();
     }

--- a/community/values/src/main/java/org/neo4j/values/storable/ByteValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ByteValue.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.values.storable;
 
+import org.neo4j.values.ValueMapper;
+
 import static java.lang.String.format;
 
 /**
@@ -85,5 +87,11 @@ public final class ByteValue extends IntegralValue
     public String toString()
     {
         return format( "Byte(%d)", value );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapByte( this );
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/CharArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/CharArray.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import org.neo4j.graphdb.spatial.Geometry;
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.SequenceValue;
+import org.neo4j.values.ValueMapper;
 
 import static java.lang.String.format;
 
@@ -102,14 +103,14 @@ public abstract class CharArray extends TextArray
     }
 
     @Override
-    public Object asObjectCopy()
+    public char[] asObjectCopy()
     {
         return value().clone();
     }
 
     @Override
     @Deprecated
-    public Object asObject()
+    public char[] asObject()
     {
         return value();
     }
@@ -124,6 +125,12 @@ public abstract class CharArray extends TextArray
     public AnyValue value( int position )
     {
         return Values.charValue( value()[position] );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapCharArray( this );
     }
 
     static final class Direct extends CharArray

--- a/community/values/src/main/java/org/neo4j/values/storable/CharValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/CharValue.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.values.storable;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.neo4j.values.ValueMapper;
 import org.neo4j.values.virtual.ListValue;
 
@@ -192,6 +195,12 @@ public final class CharValue extends TextValue
     public <T> T map( ValueMapper<T> mapper )
     {
         return mapper.mapChar( this );
+    }
+
+    @Override
+    Matcher matcher( Pattern pattern )
+    {
+        return pattern.matcher( "" + value ); // TODO: we should be able to do this without allocation
     }
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/CharValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/CharValue.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.values.storable;
 
+import org.neo4j.values.ValueMapper;
 import org.neo4j.values.virtual.ListValue;
 
 import static java.lang.String.format;
@@ -185,6 +186,12 @@ public final class CharValue extends TextValue
     public int compareTo( TextValue other )
     {
         return TextValues.compareCharToString( value, other.stringValue() );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapChar( this );
     }
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/Comparison.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/Comparison.java
@@ -19,30 +19,31 @@
  */
 package org.neo4j.values.storable;
 
-/**
- * The ValueGroup is the logical group or type of a Value. For example byte, short, int and long are all attempting
- * to represent mathematical integers, meaning that for comparison purposes they should be treated the same.
- *
- * The order here is defined in <a href="https://github.com/opencypher/openCypher/blob/master/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc">
- *   The Cypher CIP defining orderability
- * </a>
- */
-public enum ValueGroup
+public enum Comparison
 {
-    UNKNOWN,
-    GEOMETRY_ARRAY,
-    TEXT_ARRAY,
-    BOOLEAN_ARRAY,
-    NUMBER_ARRAY,
-    GEOMETRY,
-    ZONED_DATE_TIME,
-    LOCAL_DATE_TIME,
-    DATE,
-    ZONED_TIME,
-    LOCAL_TIME,
-    DURATION,
-    TEXT,
-    BOOLEAN,
-    NUMBER,
-    NO_VALUE,
+    LHS_SMALLER_THAN_RHS( 1 ),
+    LHS_EQUAL_TO_RHS( 0 ),
+    LHS_GREATER_THAN_RHS( -1 );
+    private final int cmp;
+
+    Comparison( int cmp )
+    {
+        this.cmp = cmp;
+    }
+
+    public static Comparison comparison( long cmp )
+    {
+        if ( cmp == 0 )
+        {
+            return LHS_EQUAL_TO_RHS;
+        }
+        if ( cmp < 0 )
+        {
+            return LHS_SMALLER_THAN_RHS;
+        }
+        else
+        {
+            return LHS_GREATER_THAN_RHS;
+        }
+    }
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/DateTimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DateTimeValue.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.storable;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.TemporalQueries;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.neo4j.values.ValueMapper;
+
+import static java.time.Instant.ofEpochSecond;
+import static java.time.ZonedDateTime.ofInstant;
+import static java.util.Objects.requireNonNull;
+import static org.neo4j.values.storable.DateValue.DATE_PATTERN;
+import static org.neo4j.values.storable.DateValue.parseDate;
+import static org.neo4j.values.storable.LocalDateTimeValue.optTime;
+import static org.neo4j.values.storable.TimeValue.TIME_PATTERN;
+import static org.neo4j.values.storable.TimeValue.parseOffset;
+
+public final class DateTimeValue extends TemporalValue<ZonedDateTime,DateTimeValue>
+{
+    public static DateTimeValue datetime( DateValue date, LocalTimeValue time, ZoneId zone )
+    {
+        return new DateTimeValue( ZonedDateTime.of( date.temporal(), time.temporal(), zone ) );
+    }
+
+    public static DateTimeValue datetime( DateValue date, TimeValue time )
+    {
+        OffsetTime t = time.temporal();
+        return new DateTimeValue( ZonedDateTime.of( date.temporal(), t.toLocalTime(), t.getOffset() ) );
+    }
+
+    public static DateTimeValue datetime(
+            int year, int month, int day, int hour, int minute, int second, int nanoOfSecond, ZoneId zone )
+    {
+        return new DateTimeValue( ZonedDateTime.of( year, month, day, hour, minute, second, nanoOfSecond, zone ) );
+    }
+
+    public static DateTimeValue datetime( ZonedDateTime datetime )
+    {
+        return new DateTimeValue( requireNonNull( datetime, "ZonedDateTime" ) );
+    }
+
+    public static DateTimeValue datetime( OffsetDateTime datetime )
+    {
+        return new DateTimeValue( requireNonNull( datetime, "OffsetDateTime" ).toZonedDateTime() );
+    }
+
+    public static DateTimeValue datetime( long epochSecondUTC, long nano, ZoneId zone )
+    {
+        return new DateTimeValue( ofInstant( ofEpochSecond( epochSecondUTC, nano ), zone ) );
+    }
+
+    public static DateTimeValue parse( CharSequence text, Supplier<ZoneId> defaultZone )
+    {
+        return parse( DateTimeValue.class, PATTERN, DateTimeValue::parse, text, defaultZone );
+    }
+
+    public static DateTimeValue parse( TextValue text, Supplier<ZoneId> defaultZone )
+    {
+        return parse( DateTimeValue.class, PATTERN, DateTimeValue::parse, text, defaultZone );
+    }
+
+    private final ZonedDateTime value;
+
+    private DateTimeValue( ZonedDateTime value )
+    {
+        this.value = value;
+    }
+
+    @Override
+    ZonedDateTime temporal()
+    {
+        return value;
+    }
+
+    @Override
+    public boolean equals( Value other )
+    {
+        if ( other instanceof DateTimeValue )
+        {
+            DateTimeValue that = (DateTimeValue) other;
+            return value.toInstant().equals( that.value.toInstant() );
+        }
+        return false;
+    }
+
+    @Override
+    public <E extends Exception> void writeTo( ValueWriter<E> writer ) throws E
+    {
+        throw new UnsupportedOperationException( "not implemented" );
+    }
+
+    @Override
+    public String prettyPrint()
+    {
+        return value.format( DateTimeFormatter.ISO_DATE_TIME );
+    }
+
+    @Override
+    public ValueGroup valueGroup()
+    {
+        return ValueGroup.ZONED_DATE_TIME;
+    }
+
+    @Override
+    protected int computeHash()
+    {
+        throw new UnsupportedOperationException( "not implemented" );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapDateTime( this );
+    }
+
+    @Override
+    public DateTimeValue add( DurationValue duration )
+    {
+        return replacement( value.plus( duration ) );
+    }
+
+    @Override
+    public DateTimeValue sub( DurationValue duration )
+    {
+        return replacement( value.minus( duration ) );
+    }
+
+    @Override
+    DateTimeValue replacement( ZonedDateTime datetime )
+    {
+        return value == datetime ? this : new DateTimeValue( datetime );
+    }
+
+    private static final String ZONE_NAME = "(?<zoneName>[a-zA-Z0-9_ /+-]+)";
+    private static final Pattern PATTERN = Pattern.compile(
+            DATE_PATTERN + "(?<time>T" + TIME_PATTERN + "(?:\\[" + ZONE_NAME + "\\])?" + ")?",
+            Pattern.CASE_INSENSITIVE );
+    private static final DateTimeFormatter ZONE_NAME_PARSER = new DateTimeFormatterBuilder()
+            .parseCaseInsensitive()
+            .appendZoneRegionId()
+            .toFormatter();
+
+    private static DateTimeValue parse( Matcher matcher, Supplier<ZoneId> defaultZone )
+    {
+        LocalDateTime local = LocalDateTime.of( parseDate( matcher ), optTime( matcher ) );
+        String zoneName = matcher.group( "zoneName" );
+        ZoneOffset offset = parseOffset( matcher );
+        ZoneId zone;
+        if ( zoneName != null )
+        {
+            zone = parseZoneName( zoneName );
+            if ( offset != null )
+            {
+                ZoneOffset expected = zone.getRules().getOffset( local );
+                if ( !expected.equals( offset ) )
+                {
+                    throw new IllegalArgumentException( "Timezone and offset do not match: " + matcher.group() );
+                }
+            }
+        }
+        else if ( offset != null )
+        {
+            zone = offset;
+        }
+        else
+        {
+            zone = defaultZone.get();
+        }
+        return new DateTimeValue( ZonedDateTime.of( local, zone ) );
+    }
+
+    private static ZoneId parseZoneName( String zoneName )
+    {
+        return ZONE_NAME_PARSER.parse( zoneName.replace( ' ', '_' ) ).query( TemporalQueries.zoneId() );
+    }
+}

--- a/community/values/src/main/java/org/neo4j/values/storable/DateTimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DateTimeValue.java
@@ -50,6 +50,7 @@ import static org.neo4j.values.storable.IntegralValue.safeCastIntegral;
 import static org.neo4j.values.storable.LocalDateTimeValue.optTime;
 import static org.neo4j.values.storable.TimeValue.TIME_PATTERN;
 import static org.neo4j.values.storable.TimeValue.parseOffset;
+import static org.neo4j.values.storable.TimeValue.validNano;
 
 public final class DateTimeValue extends TemporalValue<ZonedDateTime,DateTimeValue>
 {
@@ -216,15 +217,8 @@ public final class DateTimeValue extends TemporalValue<ZonedDateTime,DateTimeVal
                         (int) safeCastIntegral( "hour", hour, 0 ),
                         (int) safeCastIntegral( "minute", minute, 0 ),
                         (int) safeCastIntegral( "second", second, 0 ),
-                        nano( millisecond, microsecond, nanosecond ),
+                        validNano( millisecond, microsecond, nanosecond ),
                         timezone() );
-            }
-
-            private int nano( AnyValue millisecond, AnyValue microsecond, AnyValue nanosecond )
-            {
-                return (int) safeCastIntegral( "millisecond", millisecond, 0 ) * 1000_000 +
-                        (int) safeCastIntegral( "microsecond", microsecond, 0 ) * 1000 +
-                        (int) safeCastIntegral( "nanosecond", nanosecond, 0 );
             }
 
             @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/DateTimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DateTimeValue.java
@@ -64,6 +64,12 @@ public final class DateTimeValue extends TemporalValue<ZonedDateTime,DateTimeVal
     }
 
     public static DateTimeValue datetime(
+            int year, int month, int day, int hour, int minute, int second, int nanoOfSecond, String zone )
+    {
+        return datetime( year, month, day, hour, minute, second, nanoOfSecond, parseZoneName( zone ) );
+    }
+
+    public static DateTimeValue datetime(
             int year, int month, int day, int hour, int minute, int second, int nanoOfSecond, ZoneId zone )
     {
         return new DateTimeValue( ZonedDateTime.of( year, month, day, hour, minute, second, nanoOfSecond, zone ) );

--- a/community/values/src/main/java/org/neo4j/values/storable/DateTimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DateTimeValue.java
@@ -115,7 +115,17 @@ public final class DateTimeValue extends TemporalValue<ZonedDateTime,DateTimeVal
     @Override
     public <E extends Exception> void writeTo( ValueWriter<E> writer ) throws E
     {
-        throw new UnsupportedOperationException( "not implemented" );
+        Instant instant = value.toInstant();
+        ZoneId zone = value.getZone();
+        if ( zone instanceof ZoneOffset )
+        {
+            ZoneOffset offset = (ZoneOffset) zone;
+            writer.writeDateTime( instant.getEpochSecond(), instant.getNano(), offset.getTotalSeconds() );
+        }
+        else
+        {
+            writer.writeDateTime( instant.getEpochSecond(), instant.getNano(), zone.getId() );
+        }
     }
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/DateValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DateValue.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.storable;
+
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
+import java.time.temporal.IsoFields;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.neo4j.values.ValueMapper;
+
+import static java.lang.Integer.parseInt;
+import static java.util.Objects.requireNonNull;
+import static org.neo4j.unsafe.impl.internal.dragons.FeatureToggles.flag;
+
+public final class DateValue extends TemporalValue<LocalDate,DateValue>
+{
+    public static DateValue date( LocalDate value )
+    {
+        return new DateValue( requireNonNull( value, "LocalDate" ) );
+    }
+
+    public static DateValue date( int year, int month, int day )
+    {
+        return new DateValue( LocalDate.of( year, month, day ) );
+    }
+
+    public static DateValue weekDate( int year, int week, int dayOfWeek )
+    {
+        return new DateValue( localWeekDate( year, week, dayOfWeek ) );
+    }
+
+    public static DateValue quarterDate( int year, int quarter, int dayOfQuarter )
+    {
+        return new DateValue( localQuarterDate( year, quarter, dayOfQuarter ) );
+    }
+
+    public static DateValue ordinalDate( int year, int dayOfYear )
+    {
+        return new DateValue( LocalDate.ofYearDay( year, dayOfYear ) );
+    }
+
+    public static DateValue epochDate( long epochDay )
+    {
+        return new DateValue( LocalDate.ofEpochDay( epochDay ) );
+    }
+
+    public static DateValue parse( CharSequence text )
+    {
+        return parse( DateValue.class, PATTERN, DateValue::parse, text );
+    }
+
+    public static DateValue parse( TextValue text )
+    {
+        return parse( DateValue.class, PATTERN, DateValue::parse, text );
+    }
+
+    private final LocalDate value;
+
+    private DateValue( LocalDate value )
+    {
+        this.value = value;
+    }
+
+    @Override
+    LocalDate temporal()
+    {
+        return value;
+    }
+
+    @Override
+    public boolean equals( Value other )
+    {
+        return other instanceof DateValue && value.equals( ((DateValue) other).value );
+    }
+
+    @Override
+    public <E extends Exception> void writeTo( ValueWriter<E> writer ) throws E
+    {
+        throw new UnsupportedOperationException( "not implemented" );
+    }
+
+    @Override
+    public String prettyPrint()
+    {
+        return value.format( DateTimeFormatter.ISO_DATE );
+    }
+
+    @Override
+    public ValueGroup valueGroup()
+    {
+        return ValueGroup.DATE;
+    }
+
+    @Override
+    protected int computeHash()
+    {
+        return Long.hashCode( value.toEpochDay() );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapDate( this );
+    }
+
+    @Override
+    public DateValue add( DurationValue duration )
+    {
+        return replacement( value.plusMonths( duration.totalMonths() ).plusDays( duration.totalDays() ) );
+    }
+
+    @Override
+    public DateValue sub( DurationValue duration )
+    {
+        return replacement( value.minusMonths( duration.totalMonths() ).minusDays( duration.totalDays() ) );
+    }
+
+    @Override
+    DateValue replacement( LocalDate date )
+    {
+        return date == value ? this : new DateValue( date );
+    }
+
+    static final boolean QUARTER_DATES = flag( DateValue.class, "QUARTER_DATES", true );
+    /**
+     * The regular expression pattern for parsing dates. All fields come in two versions - long and short form, the
+     * long form is for formats containing dashes, the short form is for formats without dashes. The long format is
+     * the only one that handles signed years, since that is how the only case that supports years with other than 4
+     * numbers, and not having dashes then would make the format ambiguous. In order to not have two cases that can
+     * parse only the year, we let the long case handle that.
+     * <p/>
+     * Valid formats:
+     * <ul>
+     * <li>Year:<ul>
+     * <li>{@code [0-9]{4}} - unique without dashes, since it is the only one 4 numbers long<br>
+     * Parsing: {@code longYear}</li>
+     * <li>{@code [+-] [0-9]{1,9}}<br>
+     * Parsing: {@code longYear}</li>
+     * </ul></li>
+     * <li>Year & Month:<ul>
+     * <li>{@code [0-9]{4} [0-9]{2}} - unique without dashes, since it is the only one 6 numbers long<br>
+     * Parsing: {@code shortYear, shortMonth}</li>
+     * <li>{@code [0-9]{4} - [0-9]{1,2}}<br>
+     * Parsing: {@code longYear, longMonth}</li>
+     * <li>{@code [+-] [0-9]{1,9} - [0-9]{1,2}}<br>
+     * Parsing: {@code longYear, longMonth}</li>
+     * </ul></li>
+     * <li>Calendar date (Year & Month & Day):<ul>
+     * <li>{@code [0-9]{4} [0-9]{2} [0-9]{2}} - unique without dashes, since it is the only one 8 numbers long<br>
+     * Parsing: {@code shortYear, shortMonth, shortDay}</li>
+     * <li>{@code [0-9]{4} - [0-9]{1,2} - [0-9]{1,2}}<br>
+     * Parsing: {@code longYear, longMonth, longDay}</li>
+     * <li>{@code [+-] [0-9]{1,9} - [0-9]{1,2} - [0-9]{1,2}}<br>
+     * Parsing: {@code longYear, longMonth, longDay}</li>
+     * </ul></li>
+     * <li>Year & Week:<ul>
+     * <li>{@code [0-9]{4} W [0-9]{2}}<br>
+     * Parsing: {@code shortYear, shortWeek}</li>
+     * <li>{@code [0-9]{4} - W [0-9]{2}}<br>
+     * Parsing: {@code longYear, longWeek}</li>
+     * <li>{@code [+-] [0-9]{1,9} - W [0-9]{2}}<br>
+     * Parsing: {@code longYear, longWeek}</li>
+     * </ul></li>
+     * <li>Week date (year & week & day of week):<ul>
+     * <li>{@code [0-9]{4} W [0-9]{2} [0-9]} - unique without dashes, contains W followed by 2 numbers<br>
+     * Parsing: {@code shortYear, shortWeek, shortDOW}</li>
+     * <li>{@code [0-9]{4} - W [0-9]{1,2} - [0-9]}<br>
+     * Parsing: {@code longYear, longWeek, longDOW}</li>
+     * <li>{@code [+-] [0-9]{1,9} - W [0-9]{2} - [0-9]}<br>
+     * Parsing: {@code longYear, longWeek, longDOW}</li>
+     * </ul></li>
+     * <li>Ordinal date (year & day of year):<ul>
+     * <li>{@code [0-9]{4} [0-9]{3}} - unique without dashes, since it is the only one 7 number long<br>
+     * Parsing: {@code shortYear, shortDOY}</li>
+     * <li>{@code [0-9]{4} - [0-9]{3}} - needs to be exactly 3 numbers long to distinguish from Year & Month<br>
+     * Parsing: {@code longYear, longDOY}</li>
+     * <li>{@code [+-] [0-9]{1,9} - [0-9]{3}} - needs to be exactly 3 numbers long to distinguish from Year & Month<br>
+     * Parsing: {@code longYear, longDOY}</li>
+     * </ul></li>
+     * </ul>
+     */
+    static final String DATE_PATTERN = "(?:"
+            // short formats - without dashes:
+            + "(?<shortYear>[0-9]{4})(?:"
+            + "(?<shortMonth>[0-9]{2})(?<shortDay>[0-9]{2})?|" // calendar date
+            + "W(?<shortWeek>[0-9]{2})(?<shortDOW>[0-9])?|" // week date
+            + (QUARTER_DATES ? "Q(?<shortQuarter>[0-9])(?<shortDOQ>[0-9]{2})?|" : "") // quarter date
+            + "(?<shortDOY>[0-9]{3}))" + "|" // ordinal date
+            // long formats - includes dashes:
+            + "(?<longYear>(?:[0-9]{4}|[+-][0-9]{1,9}))(?:"
+            + "-(?<longMonth>[0-9]{1,2})(?:-(?<longDay>[0-9]{1,2}))?|" // calendar date
+            + "-W(?<longWeek>[0-9]{1,2})(?:-(?<longDOW>[0-9]))?|" // week date
+            + (QUARTER_DATES ? "-Q(?<longQuarter>[0-9])(?:-(?<longDOQ>[0-9]{1,2}))?|" : "") // quarter date
+            + "-(?<longDOY>[0-9]{3}))?" + ")"; // ordinal date
+    private static final Pattern PATTERN = Pattern.compile( DATE_PATTERN );
+
+    /**
+     * Creates a {@link LocalDate} from a {@link Matcher} that matches the regular expression defined by
+     * {@link #DATE_PATTERN}. The decision tree in the implementation of this method is guided by the parsing notes
+     * for {@link #DATE_PATTERN}.
+     *
+     * @param matcher
+     *         a {@link Matcher} that matches the regular expression defined in {@link #DATE_PATTERN}.
+     * @return a {@link LocalDate} parsed from the given {@link Matcher}.
+     */
+    static LocalDate parseDate( Matcher matcher )
+    {
+        String longYear = matcher.group( "longYear" );
+        if ( longYear != null )
+        {
+            return parse( matcher, parseInt( longYear ),
+                    "longMonth", "longDay", "longWeek", "longDOW", "longQuarter", "longDOQ", "longDOY" );
+        }
+        else
+        {
+            return parse( matcher, parseInt( matcher.group( "shortYear" ) ),
+                    "shortMonth", "shortDay", "shortWeek", "shortDOW", "shortQuarter", "shortDOQ", "shortDOY" );
+        }
+    }
+
+    private static LocalDate parse(
+            Matcher matcher, int year,
+            String MONTH, String DAY, String WEEK, String DOW, String QUARTER, String DOQ, String DOY )
+    {
+        String month = matcher.group( MONTH );
+        if ( month != null )
+        {
+            return LocalDate.of( year, parseInt( month ), optInt( matcher.group( DAY ) ) );
+        }
+        String week = matcher.group( WEEK );
+        if ( week != null )
+        {
+            return localWeekDate( year, parseInt( week ), optInt( matcher.group( DOW ) ) );
+        }
+        String quarter = matcher.group( QUARTER );
+        if ( quarter != null )
+        {
+            return localQuarterDate( year, parseInt( quarter ), optInt( matcher.group( DOQ ) ) );
+        }
+        String doy = matcher.group( DOY );
+        if ( doy != null )
+        {
+            return LocalDate.ofYearDay( year, parseInt( doy ) );
+        }
+        return LocalDate.of( year, 1, 1 );
+    }
+
+    private static DateValue parse( Matcher matcher )
+    {
+        return new DateValue( parseDate( matcher ) );
+    }
+
+    private static int optInt( String value )
+    {
+        return value == null ? 1 : parseInt( value );
+    }
+
+    private static LocalDate localWeekDate( int year, int week, int dayOfWeek )
+    {
+        LocalDate weekOne = LocalDate.of( year, 1, 4 ); // the fourth is guaranteed to be in week 1 by definition
+        LocalDate withWeek = weekOne.with( IsoFields.WEEK_OF_WEEK_BASED_YEAR, week );
+        // the implementation of WEEK_OF_WEEK_BASED_YEAR uses addition to adjust the date, this means that it accepts
+        // week 53 of years that don't have 53 weeks, so we have to guard for this:
+        if ( week == 53 && withWeek.get( IsoFields.WEEK_BASED_YEAR ) != year )
+        {
+            throw new DateTimeException( String.format( "Year %d does not contain %d weeks.", year, week ) );
+        }
+        return withWeek.with( ChronoField.DAY_OF_WEEK, dayOfWeek );
+    }
+
+    private static LocalDate localQuarterDate( int year, int quarter, int dayOfQuarter )
+    {
+        // special handling for the range of Q1 and Q2, since they are shorter than Q3 and Q4
+        if ( quarter == 2 && dayOfQuarter == 92 )
+        {
+            throw new DateTimeException( "Quarter 2 only has 91 days." );
+        }
+        // instantiate the yearDate now, because we use it to know if it is a leap year
+        LocalDate yearDate = LocalDate.ofYearDay( year, dayOfQuarter ); // guess on the day
+        if ( quarter == 1 && dayOfQuarter > 90 && (!yearDate.isLeapYear() || dayOfQuarter == 92) )
+        {
+            throw new DateTimeException( String.format(
+                    "Quarter 1 of %d only has %d days.", year, yearDate.isLeapYear() ? 91 : 90 ) );
+        }
+        return yearDate
+                .with( IsoFields.QUARTER_OF_YEAR, quarter )
+                .with( IsoFields.DAY_OF_QUARTER, dayOfQuarter );
+    }
+}

--- a/community/values/src/main/java/org/neo4j/values/storable/DateValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DateValue.java
@@ -97,7 +97,7 @@ public final class DateValue extends TemporalValue<LocalDate,DateValue>
     @Override
     public <E extends Exception> void writeTo( ValueWriter<E> writer ) throws E
     {
-        throw new UnsupportedOperationException( "not implemented" );
+        writer.writeDate( value.toEpochDay() );
     }
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/DateValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DateValue.java
@@ -19,14 +19,20 @@
  */
 package org.neo4j.values.storable;
 
+import java.lang.invoke.MethodHandle;
+import java.time.Clock;
 import java.time.DateTimeException;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
 import java.time.temporal.IsoFields;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.neo4j.values.AnyValue;
 import org.neo4j.values.ValueMapper;
 
 import static java.lang.Integer.parseInt;
@@ -73,6 +79,58 @@ public final class DateValue extends TemporalValue<LocalDate,DateValue>
     public static DateValue parse( TextValue text )
     {
         return parse( DateValue.class, PATTERN, DateValue::parse, text );
+    }
+
+    public static StructureBuilder<AnyValue,DateValue> builder( Supplier<ZoneId> defaulZone )
+    {
+        return new DateBuilder<AnyValue,DateValue>()
+        {
+            @Override
+            protected ZoneId timezone( AnyValue timezone )
+            {
+                return timezone == null ? defaulZone.get() : timezoneOf( timezone );
+            }
+
+            @Override
+            protected DateValue selectDate( AnyValue temporal )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            protected DateValue constructYear( AnyValue year )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            protected DateValue constructCalendarDate( AnyValue year, AnyValue month, AnyValue day )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            protected DateValue constructWeekDate( AnyValue year, AnyValue week, AnyValue dayOfWeek )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            protected DateValue constructQuarterDate( AnyValue year, AnyValue quarter, AnyValue dayOfQuarter )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            protected DateValue constructOrdinalDate( AnyValue year, AnyValue ordinalDay )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+        };
+    }
+
+    public abstract static class Compiler<Input> extends DateBuilder<Input,MethodHandle>
+    {
     }
 
     private final LocalDate value;
@@ -306,5 +364,145 @@ public final class DateValue extends TemporalValue<LocalDate,DateValue>
         return yearDate
                 .with( IsoFields.QUARTER_OF_YEAR, quarter )
                 .with( IsoFields.DAY_OF_QUARTER, dayOfQuarter );
+    }
+
+    private abstract static class DateBuilder<Input, Result> extends Builder<Input,Result>
+    {
+        @Override
+        protected final boolean supportsDate()
+        {
+            return true;
+        }
+
+        @Override
+        protected final boolean supportsTime()
+        {
+            return false;
+        }
+
+        @Override
+        protected final Result selectDateTime( Input temporal )
+        {
+            throw new IllegalStateException( "time not supported" );
+        }
+
+        @Override
+        protected final Result selectDateAndTime( Input date, Input time )
+        {
+            throw new IllegalStateException( "time not supported" );
+        }
+
+        @Override
+        protected final Result selectDateWithConstructedTime(
+                Input date,
+                Input hour,
+                Input minute,
+                Input second,
+                Input millisecond,
+                Input microsecond,
+                Input nanosecond )
+        {
+            throw new IllegalStateException( "time not supported" );
+        }
+
+        @Override
+        protected final Result selectTime( Input temporal )
+        {
+            throw new IllegalStateException( "time not supported" );
+        }
+
+        @Override
+        protected final Result constructCalendarDateWithSelectedTime( Input year, Input month, Input day, Input time )
+        {
+            throw new IllegalStateException( "time not supported" );
+        }
+
+        @Override
+        protected final Result constructCalendarDateWithConstructedTime(
+                Input year,
+                Input month,
+                Input day,
+                Input hour,
+                Input minute,
+                Input second,
+                Input millisecond,
+                Input microsecond,
+                Input nanosecond )
+        {
+            throw new IllegalStateException( "time not supported" );
+        }
+
+        @Override
+        protected final Result constructWeekDateWithSelectedTime( Input year, Input week, Input dayOfWeek, Input time )
+        {
+            throw new IllegalStateException( "time not supported" );
+        }
+
+        @Override
+        protected final Result constructWeekDateWithConstructedTime(
+                Input year,
+                Input week,
+                Input dayOfWeek,
+                Input hour,
+                Input minute,
+                Input second,
+                Input millisecond,
+                Input microsecond,
+                Input nanosecond )
+        {
+            throw new IllegalStateException( "time not supported" );
+        }
+
+        @Override
+        protected final Result constructQuarterDateWithSelectedTime(
+                Input year,
+                Input quarter,
+                Input dayOfQuarter,
+                Input time )
+        {
+            throw new IllegalStateException( "time not supported" );
+        }
+
+        @Override
+        protected final Result constructQuarterDateWithConstructedTime(
+                Input year,
+                Input quarter,
+                Input dayOfQuarter,
+                Input hour,
+                Input minute,
+                Input second,
+                Input millisecond,
+                Input microsecond,
+                Input nanosecond )
+        {
+            throw new IllegalStateException( "time not supported" );
+        }
+
+        @Override
+        protected final Result constructOrdinalDateWithSelectedTime( Input year, Input ordinalDay, Input time )
+        {
+            throw new IllegalStateException( "time not supported" );
+        }
+
+        @Override
+        protected final Result constructOrdinalDateWithConstructedTime(
+                Input year,
+                Input ordinalDay,
+                Input hour,
+                Input minute,
+                Input second,
+                Input millisecond,
+                Input microsecond,
+                Input nanosecond )
+        {
+            throw new IllegalStateException( "time not supported" );
+        }
+
+        @Override
+        protected final Result constructTime(
+                Input hour, Input minute, Input second, Input millisecond, Input microsecond, Input nanosecond )
+        {
+            throw new IllegalStateException( "time not supported" );
+        }
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/DateValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DateValue.java
@@ -27,17 +27,20 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
 import java.time.temporal.IsoFields;
-import java.util.function.Function;
+import java.time.temporal.TemporalUnit;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.neo4j.values.AnyValue;
+import org.neo4j.values.StructureBuilder;
 import org.neo4j.values.ValueMapper;
+import org.neo4j.values.virtual.MapValue;
 
 import static java.lang.Integer.parseInt;
 import static java.util.Objects.requireNonNull;
 import static org.neo4j.unsafe.impl.internal.dragons.FeatureToggles.flag;
+import static org.neo4j.values.storable.DateTimeValue.parseZoneName;
 
 public final class DateValue extends TemporalValue<LocalDate,DateValue>
 {
@@ -81,14 +84,38 @@ public final class DateValue extends TemporalValue<LocalDate,DateValue>
         return parse( DateValue.class, PATTERN, DateValue::parse, text );
     }
 
-    public static StructureBuilder<AnyValue,DateValue> builder( Supplier<ZoneId> defaulZone )
+    public static DateValue now( Clock clock )
+    {
+        return new DateValue( LocalDate.now( clock ) );
+    }
+
+    public static DateValue now( Clock clock, String timezone )
+    {
+        return now( clock.withZone( parseZoneName( timezone ) ) );
+    }
+
+    public static DateValue build( MapValue map, Supplier<ZoneId> defaultZone )
+    {
+        return StructureBuilder.build( builder( defaultZone ), map );
+    }
+
+    public static DateValue truncate(
+            TemporalUnit unit,
+            TemporalValue input,
+            MapValue fields,
+            Supplier<ZoneId> defaultZone )
+    {
+        throw new UnsupportedOperationException( "not implemented" );
+    }
+
+    static StructureBuilder<AnyValue,DateValue> builder( Supplier<ZoneId> defaultZone )
     {
         return new DateBuilder<AnyValue,DateValue>()
         {
             @Override
             protected ZoneId timezone( AnyValue timezone )
             {
-                return timezone == null ? defaulZone.get() : timezoneOf( timezone );
+                return timezone == null ? defaultZone.get() : timezoneOf( timezone );
             }
 
             @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/DoubleArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DoubleArray.java
@@ -23,10 +23,11 @@ import java.util.Arrays;
 
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.SequenceValue;
+import org.neo4j.values.ValueMapper;
 
 import static java.lang.String.format;
 
-abstract class DoubleArray extends FloatingPointArray
+public abstract class DoubleArray extends FloatingPointArray
 {
     abstract double[] value();
 
@@ -46,6 +47,12 @@ abstract class DoubleArray extends FloatingPointArray
     public int computeHash()
     {
         return NumberValues.hash( value() );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapDoubleArray( this );
     }
 
     @Override
@@ -112,14 +119,14 @@ abstract class DoubleArray extends FloatingPointArray
     }
 
     @Override
-    public Object asObjectCopy()
+    public double[] asObjectCopy()
     {
         return value().clone();
     }
 
     @Override
     @Deprecated
-    public Object asObject()
+    public double[] asObject()
     {
         return value();
     }

--- a/community/values/src/main/java/org/neo4j/values/storable/DoubleValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DoubleValue.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.values.storable;
 
+import org.neo4j.values.ValueMapper;
+
 import static java.lang.String.format;
 
 public final class DoubleValue extends FloatingPointValue
@@ -81,5 +83,11 @@ public final class DoubleValue extends FloatingPointValue
     public String toString()
     {
         return format( "Double(%e)", value );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapDouble( this );
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/DurationBuilder.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DurationBuilder.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.storable;
+
+abstract class DurationBuilder<Input, Result> extends StructureBuilder<Input,Result>
+{
+    private Input years;
+    private Input months;
+    private Input weeks;
+    private Input days;
+    private Input hours;
+    private Input minutes;
+    private Input seconds;
+    private Input milliseconds;
+    private Input microseconds;
+    private Input nanoseconds;
+
+    @Override
+    public final StructureBuilder<Input,Result> add( String field, Input value )
+    {
+        switch ( field.toLowerCase() )
+        {
+        case "years":
+            this.years = value;
+            break;
+        case "months":
+            this.months = value;
+            break;
+        case "weeks":
+            this.weeks = value;
+            break;
+        case "days":
+            this.days = value;
+            break;
+        case "hours":
+            this.hours = value;
+            break;
+        case "minutes":
+            this.minutes = value;
+            break;
+        case "seconds":
+            this.seconds = value;
+            break;
+        case "milliseconds":
+            this.milliseconds = value;
+            break;
+        case "microseconds":
+            this.microseconds = value;
+            break;
+        case "nanoseconds":
+            this.nanoseconds = value;
+            break;
+        default:
+            throw new IllegalStateException( "Unknown field: " + field );
+        }
+        return this;
+    }
+
+    @Override
+    public final Result build()
+    {
+        return create(
+                years,
+                months,
+                weeks,
+                days,
+                hours,
+                minutes,
+                seconds,
+                milliseconds,
+                microseconds,
+                nanoseconds );
+    }
+
+    abstract Result create(
+            Input years,
+            Input months,
+            Input weeks,
+            Input days,
+            Input hours,
+            Input minutes,
+            Input seconds,
+            Input milliseconds,
+            Input microseconds,
+            Input nanoseconds );
+}

--- a/community/values/src/main/java/org/neo4j/values/storable/DurationBuilder.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DurationBuilder.java
@@ -19,7 +19,9 @@
  */
 package org.neo4j.values.storable;
 
-abstract class DurationBuilder<Input, Result> extends StructureBuilder<Input,Result>
+import org.neo4j.values.StructureBuilder;
+
+abstract class DurationBuilder<Input, Result> implements StructureBuilder<Input,Result>
 {
     private Input years;
     private Input months;

--- a/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
@@ -521,6 +521,12 @@ public final class DurationValue extends ScalarValue implements TemporalAmount
     }
 
     @Override
+    public final String toString()
+    {
+        return getClass().getSimpleName() + "<" + prettyPrint() + ">";
+    }
+
+    @Override
     public String prettyPrint()
     {
         if ( this == ZERO )

--- a/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
@@ -521,7 +521,7 @@ public final class DurationValue extends ScalarValue implements TemporalAmount
     }
 
     @Override
-    public final String toString()
+    public String toString()
     {
         return getClass().getSimpleName() + "<" + prettyPrint() + ">";
     }

--- a/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
@@ -521,7 +521,7 @@ public final class DurationValue extends ScalarValue implements TemporalAmount
     @Override
     public <E extends Exception> void writeTo( ValueWriter<E> writer ) throws E
     {
-        throw new UnsupportedOperationException( "not implemented" );
+        writer.writeDuration( months, days, seconds, nanos );
     }
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/DurationValue.java
@@ -1,0 +1,805 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.storable;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.Period;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAmount;
+import java.time.temporal.TemporalUnit;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.neo4j.values.AnyValue;
+import org.neo4j.values.ValueMapper;
+
+import static java.lang.Long.parseLong;
+import static java.time.temporal.ChronoField.EPOCH_DAY;
+import static java.time.temporal.ChronoField.NANO_OF_SECOND;
+import static java.time.temporal.ChronoField.OFFSET_SECONDS;
+import static java.time.temporal.ChronoField.SECOND_OF_DAY;
+import static java.time.temporal.ChronoUnit.DAYS;
+import static java.time.temporal.ChronoUnit.HOURS;
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static java.time.temporal.ChronoUnit.MONTHS;
+import static java.time.temporal.ChronoUnit.NANOS;
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.time.temporal.ChronoUnit.WEEKS;
+import static java.time.temporal.ChronoUnit.YEARS;
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.requireNonNull;
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+import static org.neo4j.values.storable.NumberType.NO_NUMBER;
+
+/**
+ * We use our own implementation because neither {@link java.time.Duration} nor {@link java.time.Period} fits our needs.
+ * {@link java.time.Duration} only works with seconds, assumes 24H days, and is unable to handle larger units than days.
+ * {@link java.time.Period} only works with units from days or larger, and does not deal with time.
+ */
+public final class DurationValue extends ScalarValue implements TemporalAmount
+{
+    public static DurationValue duration( Duration value )
+    {
+        requireNonNull( value, "Duration" );
+        return newDuration( 0, 0, value.getSeconds(), value.getNano() );
+    }
+
+    public static DurationValue duration( Period value )
+    {
+        requireNonNull( value, "Period" );
+        return newDuration( value.toTotalMonths(), value.getDays(), 0, 0 );
+    }
+
+    public static DurationValue duration( long months, long days, long seconds, long nanos )
+    {
+        seconds += nanos / NANOS_PER_SECOND;
+        nanos %= NANOS_PER_SECOND;
+        if ( seconds < 0 && nanos > 0 )
+        {
+            seconds += 1;
+            nanos -= NANOS_PER_SECOND;
+        }
+        else if ( seconds > 0 && nanos < 0 )
+        {
+            seconds -= 1;
+            nanos += NANOS_PER_SECOND;
+        }
+        return newDuration( months, days, seconds, (int) nanos );
+    }
+
+    public static DurationValue parse( CharSequence text )
+    {
+        return TemporalValue.parse( DurationValue.class, PATTERN, DurationValue::parse, text );
+    }
+
+    public static DurationValue parse( TextValue text )
+    {
+        return TemporalValue.parse( DurationValue.class, PATTERN, DurationValue::parse, text );
+    }
+
+    private static final DurationValue ZERO = new DurationValue( 0, 0, 0, 0 );
+    private static final List<TemporalUnit> UNITS = unmodifiableList( asList( MONTHS, DAYS, SECONDS, NANOS ) );
+    static final int NANOS_PER_SECOND = 1_000_000_000;
+    static final long SECONDS_PER_DAY = DAYS.getDuration().getSeconds();
+    /** 30.4375 days = 30 days, 10 hours, 30 minutes */
+    private static final double AVERAGE_DAYS_PER_MONTH = 365.25 / 12;
+    private final long months;
+    private final long days;
+    private final long seconds;
+    private final int nanos;
+
+    private static DurationValue newDuration( long months, long days, long seconds, int nanos )
+    {
+        return seconds == 0 && days == 0 && months == 0 && nanos == 0 // ordered by probability of non-zero
+                ? ZERO : new DurationValue( months, days, seconds, nanos );
+    }
+
+    private DurationValue( long months, long days, long seconds, long nanos )
+    {
+        seconds += nanos / NANOS_PER_SECOND;
+        nanos %= NANOS_PER_SECOND;
+        if ( seconds < 0 && nanos > 0 )
+        {
+            seconds += 1;
+            nanos -= NANOS_PER_SECOND;
+        }
+        else if ( seconds > 0 && nanos < 0 )
+        {
+            seconds -= 1;
+            nanos += NANOS_PER_SECOND;
+        }
+        this.months = months;
+        this.days = days;
+        this.seconds = seconds;
+        this.nanos = (int) nanos;
+    }
+
+    long nanosOfDay()
+    {
+        return (seconds % SECONDS_PER_DAY) * NANOS_PER_SECOND + nanos;
+    }
+
+    long totalMonths()
+    {
+        return months;
+    }
+
+    /**
+     * The number of days of this duration, as computed by the days and the whole days made up of seconds. This
+     * excludes the days contributed by the months.
+     *
+     * @return the total number of days of this duration.
+     */
+    long totalDays()
+    {
+        return days + (seconds / SECONDS_PER_DAY);
+    }
+
+    private static final String UNIT_BASED_PATTERN = "(?:(?<years>[-+]?[0-9]+)Y)?"
+            + "(?:(?<months>[-+]?[0-9]+)M)?"
+            + "(?:(?<weeks>[-+]?[0-9]+)W)?"
+            + "(?:(?<days>[-+]?[0-9]+)D)?"
+            + "(?<T>T"
+            + "(?:(?<hours>[-+]?[0-9]+)H)?"
+            + "(?:(?<minutes>[-+]?[0-9]+)M)?"
+            + "(?:(?<seconds>[-+]?[0-9]+)(?:[.,](?<subseconds>[0-9]{1,9}))?S)?)?";
+    private static final String DATE_BASED_PATTERN = "(?:"
+            + "(?<year>[0-9]{4})(?:"
+            + "-(?<longMonth>[0-9]{2})-(?<longDay>[0-9]{2})|"
+            + "(?<shortMonth>[0-9]{2})(?<shortDay>[0-9]{2}))"
+            + ")?(?<time>T"
+            + "(?:(?<shortHour>[0-9]{2})(?:(?<shortMinute>[0-9]{2})"
+            + "(?:(?<shortSecond>[0-9]{2})(?:[.,](?<shortSub>[0-9]{1,9}))?)?)?|"
+            + "(?<longHour>[0-9]{2}):(?<longMinute>[0-9]{2})"
+            + "(?::(?<longSecond>[0-9]{2})(?:[.,](?<longSub>[0-9]{1,9}))?)?))?";
+    private static final Pattern PATTERN = Pattern.compile(
+            "(?<sign>[-+]?)P(?:" + UNIT_BASED_PATTERN + "|" + DATE_BASED_PATTERN + ")",
+            CASE_INSENSITIVE );
+
+    private static DurationValue parse( Matcher matcher )
+    {
+        String year = matcher.group( "year" );
+        String time = matcher.group( "time" );
+        if ( year != null || time != null )
+        {
+            return parseDateDuration( year, matcher, time != null );
+        }
+        else
+        {
+            return parseDuration( matcher );
+        }
+    }
+
+    private static DurationValue parseDuration( Matcher matcher )
+    {
+        int sign = "-".equals( matcher.group( "sign" ) ) ? -1 : 1;
+        String y = matcher.group( "years" );
+        String m = matcher.group( "months" );
+        String w = matcher.group( "weeks" );
+        String d = matcher.group( "days" );
+        String t = matcher.group( "T" );
+        if ( (y == null && m == null && w == null && d == null && t == null) || "T".equalsIgnoreCase( t ) )
+        {
+            return null;
+        }
+        long months = optLong( y ) * 12 + optLong( m );
+        long days = optLong( w ) * 7 + optLong( d );
+        return parseDuration( sign, months, days, matcher, false, "hours", "minutes", "seconds", "subseconds" );
+    }
+
+    private static DurationValue parseDateDuration( String year, Matcher matcher, boolean time )
+    {
+        int sign = "-".equals( matcher.group( "sign" ) ) ? -1 : 1;
+        long months = 0;
+        long days = 0;
+        if ( year != null )
+        {
+            String month = matcher.group( "longMonth" );
+            String day;
+            if ( month == null )
+            {
+                month = matcher.group( "shortMonth" );
+                day = matcher.group( "shortDay" );
+            }
+            else
+            {
+                day = matcher.group( "longDay" );
+            }
+            months = parseLong( month );
+            if ( months > 12 )
+            {
+                throw new IllegalArgumentException( "months is out of range: " + month );
+            }
+            months += parseLong( year ) * 12;
+            days = parseLong( day );
+            if ( days > 31 )
+            {
+                throw new IllegalArgumentException( "days is out of range: " + day );
+            }
+        }
+        if ( time )
+        {
+            if ( matcher.group( "longHour" ) != null )
+            {
+                return parseDuration(
+                        sign, months, days, matcher, true, "longHour", "longMinute", "longSecond", "longSub" );
+            }
+            else
+            {
+                return parseDuration(
+                        sign, months, days, matcher, true, "shortHour", "shortMinute", "shortSecond", "shortSub" );
+            }
+        }
+        else
+        {
+            return duration( sign * months, sign * days, 0, 0 );
+        }
+    }
+
+    private static DurationValue parseDuration(
+            int sign, long months, long days, Matcher matcher, boolean strict,
+            String hour, String min, String sec, String sub )
+    {
+        long h = optLong( matcher.group( hour ) );
+        long m = optLong( matcher.group( min ) );
+        String s = matcher.group( sec );
+        String n = matcher.group( sub );
+        long seconds = optLong( s );
+        if ( strict )
+        {
+            if ( h > 24 )
+            {
+                throw new IllegalArgumentException( "hours out of range: " + h );
+            }
+            if ( m > 60 )
+            {
+                throw new IllegalArgumentException( "minutes out of range: " + m );
+            }
+            if ( seconds > 60 )
+            {
+                throw new IllegalArgumentException( "seconds out of range: " + seconds );
+            }
+        }
+        seconds += h * 3600 + m * 60;
+        long nanos = optLong( n );
+        if ( nanos != 0 )
+        {
+            for ( int i = n.length(); i < 9; i++ )
+            {
+                nanos *= 10;
+            }
+            if ( s.startsWith( "-" ) )
+            {
+                nanos = -nanos;
+            }
+        }
+        return duration( sign * months, sign * days, sign * seconds, sign * nanos );
+    }
+
+    private static long optLong( String value )
+    {
+        return value == null ? 0 : parseLong( value );
+    }
+
+    /**
+     * Compute the duration from one {@link Temporal} to another. If one temporal has a date and the other one does
+     * not, the one without a date is treated as being the same date as the one with date. If one temporal has a time
+     * and the other one does not, the one without a time is treated as midnight at the start of its date. If one
+     * temporal has a timezone and the other one does not, the one without a timezone is treated as having the same
+     * timezone as the one with a timezone.
+     */
+    private static DurationValue durationBetween( Difference type, Temporal from, Temporal to )
+    {
+        switch ( type )
+        {
+        case DEFAULT:
+            return durationBetween( from, to );
+        case years:
+            return yearsBetween( from, to );
+        case months:
+            return monthsBetween( from, to );
+        case weeks:
+            return weeksBetween( from, to );
+        case days:
+            return daysBetween( from, to );
+        case hours:
+            return hoursBetween( from, to );
+        case minutes:
+            return minutesBetween( from, to );
+        case seconds:
+            return difference( 0, 0, from, to );
+        default:
+            throw new UnsupportedOperationException( type.name() );
+        }
+    }
+
+    private static DurationValue yearsBetween( Temporal from, Temporal to )
+    {
+        return newDuration( from.until( to, YEARS ) * 12, 0, 0, 0 );
+    }
+
+    private static DurationValue monthsBetween( Temporal from, Temporal to )
+    {
+        return newDuration( from.until( to, MONTHS ), 0, 0, 0 );
+    }
+
+    private static DurationValue weeksBetween( Temporal from, Temporal to )
+    {
+        return newDuration( 0, from.until( to, WEEKS ) * 7, 0, 0 );
+    }
+
+    private static DurationValue daysBetween( Temporal from, Temporal to )
+    {
+        return newDuration( 0, from.until( to, DAYS ), 0, 0 );
+    }
+
+    private static DurationValue hoursBetween( Temporal from, Temporal to )
+    {
+        return newDuration( 0, 0, from.until( to, HOURS ) * 3600, 0 );
+    }
+
+    private static DurationValue minutesBetween( Temporal from, Temporal to )
+    {
+        return newDuration( 0, 0, from.until( to, MINUTES ) * 60, 0 );
+    }
+
+    static DurationValue durationBetween( Temporal from, Temporal to )
+    {
+        long months = 0;
+        long days = 0;
+        if ( from.isSupported( EPOCH_DAY ) && to.isSupported( EPOCH_DAY ) )
+        {
+            Period period = Period.between( LocalDate.from( from ), LocalDate.from( to ) );
+            months = period.getYears() * 12L + period.getMonths();
+            days = period.getDays();
+            if ( months != 0 || days != 0 )
+            {
+                // Adjust in order to get to a point where we can compute the time difference,
+                // without having to bother with the length of days (which might differ due to timezone)
+                from = from.plus( period );
+            }
+        }
+        // Compute the time difference - which is simple at this point
+        return difference( months, days, from, to );
+    }
+
+    private static DurationValue difference( long months, long days, Temporal from, Temporal to )
+    {
+        long seconds = 0;
+        long nanos = 0;
+        if ( from.isSupported( SECONDS ) )
+        {
+            if ( to.isSupported( SECONDS ) )
+            {
+                boolean negate = false;
+                if ( from.isSupported( OFFSET_SECONDS ) && !to.isSupported( OFFSET_SECONDS ) )
+                {
+                    negate = true;
+                    Temporal tmp = from;
+                    from = to;
+                    to = tmp;
+                }
+                seconds = from.until( to, SECONDS );
+                nanos = to.getLong( NANO_OF_SECOND ) - from.getLong( NANO_OF_SECOND );
+                if ( seconds > 0 && nanos < 0 )
+                {
+                    seconds--;
+                    nanos = NANOS_PER_SECOND - nanos;
+                }
+                else if ( seconds < 0 && nanos > 0 )
+                {
+                    seconds++;
+                    nanos = nanos - NANOS_PER_SECOND;
+                }
+                if ( negate )
+                {
+                    seconds = -seconds;
+                    nanos = -nanos;
+                }
+            }
+            else
+            {
+                seconds = -from.getLong( SECOND_OF_DAY );
+                nanos = -from.getLong( NANO_OF_SECOND );
+            }
+        }
+        else if ( to.isSupported( SECONDS ) )
+        {
+            seconds = to.getLong( SECOND_OF_DAY );
+            nanos = to.getLong( NANO_OF_SECOND );
+        }
+        return duration( months, days, seconds, nanos );
+    }
+
+    enum Difference
+    {
+        DEFAULT,
+        years,
+        months,
+        weeks,
+        days,
+        hours,
+        minutes,
+        seconds,;
+
+        public DurationValue between( Temporal from, Temporal to )
+        {
+            return durationBetween( this, from, to );
+        }
+
+        private Temporal temporal( String field, AnyValue value )
+        {
+            if ( value instanceof TemporalValue )
+            {
+                return ((TemporalValue) value).temporal();
+            }
+            else
+            {
+                StringBuilder message = new StringBuilder().append( "'" );
+                if ( this == DEFAULT )
+                {
+                    message.append( field );
+                }
+                else
+                {
+                    message.append( name() ).append( Character.toUpperCase( field.charAt( 0 ) ) );
+                    message.append( field, 1, field.length() );
+                }
+                throw new IllegalArgumentException( message.append( "' must be a temporal value" ).toString() );
+            }
+        }
+    }
+
+    @Override
+    public boolean equals( Value other )
+    {
+        if ( other instanceof DurationValue )
+        {
+            DurationValue that = (DurationValue) other;
+            return that.months == this.months &&
+                    that.days == this.days &&
+                    that.seconds == this.seconds &&
+                    that.nanos == this.nanos;
+        }
+        else
+        {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean equals( boolean x )
+    {
+        return false;
+    }
+
+    @Override
+    public boolean equals( long x )
+    {
+        return false;
+    }
+
+    @Override
+    public boolean equals( double x )
+    {
+        return false;
+    }
+
+    @Override
+    public boolean equals( char x )
+    {
+        return false;
+    }
+
+    @Override
+    public boolean equals( String x )
+    {
+        return false;
+    }
+
+    @Override
+    public <E extends Exception> void writeTo( ValueWriter<E> writer ) throws E
+    {
+        throw new UnsupportedOperationException( "not implemented" );
+    }
+
+    @Override
+    public TemporalAmount asObjectCopy()
+    {
+        return this;
+    }
+
+    @Override
+    public String prettyPrint()
+    {
+        if ( this == ZERO )
+        {
+            return "PT0S"; // no need to allocate a string builder if we know the result
+        }
+        StringBuilder str = new StringBuilder().append( "P" );
+        append( str, months / 12, 'Y' );
+        append( str, months % 12, 'M' );
+        append( str, days, 'D' );
+        if ( seconds != 0 || nanos != 0 )
+        {
+            str.append( 'T' );
+            long s = seconds % 3600;
+            append( str, seconds / 3600, 'H' );
+            append( str, s / 60, 'M' );
+            s %= 60;
+            if ( s != 0 )
+            {
+                str.append( s );
+                if ( nanos != 0 )
+                {
+                    nanos( str );
+                }
+                str.append( 'S' );
+            }
+            else if ( nanos != 0 )
+            {
+                str.append( '0' );
+                nanos( str );
+                str.append( 'S' );
+            }
+        }
+        if ( str.length() == 1 )
+        { // this was all zeros (but not ZERO for some reason), ensure well formed output:
+            str.append( "T0S" );
+        }
+        return str.toString();
+    }
+
+    private void nanos( StringBuilder str )
+    {
+        str.append( '.' );
+        int n = nanos < 0 ? -nanos : nanos;
+        for ( int mod = NANOS_PER_SECOND; mod > 1 && n > 0; n %= mod )
+        {
+            str.append( n / (mod /= 10) );
+        }
+    }
+
+    private static void append( StringBuilder str, long quantity, char unit )
+    {
+        if ( quantity != 0 )
+        {
+            str.append( quantity ).append( unit );
+        }
+    }
+
+    @Override
+    public ValueGroup valueGroup()
+    {
+        return ValueGroup.DURATION;
+    }
+
+    @Override
+    public NumberType numberType()
+    {
+        return NO_NUMBER;
+    }
+
+    @Override
+    protected int computeHash()
+    {
+        int result = (int) (months ^ (months >>> 32));
+        result = 31 * result + (int) (days ^ (days >>> 32));
+        result = 31 * result + (int) (seconds ^ (seconds >>> 32));
+        result = 31 * result + nanos;
+        return result;
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapDuration( this );
+    }
+
+    @Override
+    public long get( TemporalUnit unit )
+    {
+        if ( unit instanceof ChronoUnit )
+        {
+            switch ( (ChronoUnit) unit )
+            {
+            case MONTHS:
+                return months;
+            case DAYS:
+                return days;
+            case SECONDS:
+                return seconds;
+            case NANOS:
+                return nanos;
+            default:
+                break;
+            }
+        }
+        throw new UnsupportedOperationException( "Unsupported unit: " + unit );
+    }
+
+    @Override
+    public List<TemporalUnit> getUnits()
+    {
+        return UNITS;
+    }
+
+    public DurationValue plus( long amount, TemporalUnit unit )
+    {
+        if ( unit instanceof ChronoUnit )
+        {
+            switch ( (ChronoUnit) unit )
+            {
+            case NANOS:
+                return duration( months, days, seconds, nanos + amount );
+            case MICROS:
+                return duration( months, days, seconds, nanos + amount * 1000 );
+            case MILLIS:
+                return duration( months, days, seconds, nanos + amount * 1000_000 );
+            case SECONDS:
+                return duration( months, days, seconds + amount, nanos );
+            case MINUTES:
+                return duration( months, days, seconds + amount * 60, nanos );
+            case HOURS:
+                return duration( months, days, seconds + amount * 3600, nanos );
+            case HALF_DAYS:
+                return duration( months, days, seconds + amount * 12 * 3600, nanos );
+            case DAYS:
+                return duration( months, days + amount, seconds, nanos );
+            case WEEKS:
+                return duration( months, days + amount * 7, seconds, nanos );
+            case MONTHS:
+                return duration( months + amount, days, seconds, nanos );
+            case YEARS:
+                return duration( months + amount * 12, days, seconds, nanos );
+            case DECADES:
+                return duration( months + amount * 120, days, seconds, nanos );
+            case CENTURIES:
+                return duration( months + amount * 1200, days, seconds, nanos );
+            case MILLENNIA:
+                return duration( months + amount * 12000, days, seconds, nanos );
+            default:
+                break;
+            }
+        }
+        throw new UnsupportedOperationException( "Unsupported unit: " + unit );
+    }
+
+    @Override
+    public Temporal addTo( Temporal temporal )
+    {
+        if ( months != 0 && temporal.isSupported( MONTHS ) )
+        {
+            temporal = temporal.plus( months, MONTHS );
+        }
+        if ( days != 0 && temporal.isSupported( DAYS ) )
+        {
+            temporal = temporal.plus( days, DAYS );
+        }
+        if ( seconds != 0 )
+        {
+            if ( temporal.isSupported( SECONDS ) )
+            {
+                temporal = temporal.plus( seconds, SECONDS );
+            }
+            else
+            {
+                long asDays = seconds / SECONDS_PER_DAY;
+                if ( asDays != 0 )
+                {
+                    temporal = temporal.plus( asDays, DAYS );
+                }
+            }
+        }
+        if ( nanos != 0 && temporal.isSupported( NANOS ) )
+        {
+            temporal = temporal.plus( nanos, NANOS );
+        }
+        return temporal;
+    }
+
+    @Override
+    public Temporal subtractFrom( Temporal temporal )
+    {
+        if ( months != 0 && temporal.isSupported( MONTHS ) )
+        {
+            temporal = temporal.minus( months, MONTHS );
+        }
+        if ( days != 0 && temporal.isSupported( DAYS ) )
+        {
+            temporal = temporal.minus( days, DAYS );
+        }
+        if ( seconds != 0 )
+        {
+            if ( temporal.isSupported( SECONDS ) )
+            {
+                temporal = temporal.minus( seconds, SECONDS );
+            }
+            else if ( temporal.isSupported( DAYS ) )
+            {
+                long asDays = seconds / SECONDS_PER_DAY;
+                if ( asDays != 0 )
+                {
+                    temporal = temporal.minus( asDays, DAYS );
+                }
+            }
+        }
+        if ( nanos != 0 && temporal.isSupported( NANOS ) )
+        {
+            temporal = temporal.minus( nanos, NANOS );
+        }
+        return temporal;
+    }
+
+    public DurationValue add( DurationValue that )
+    {
+        return duration(
+                this.months + that.months,
+                this.days + that.days,
+                this.seconds + that.seconds,
+                this.nanos + that.nanos );
+    }
+
+    public DurationValue sub( DurationValue that )
+    {
+        return duration(
+                this.months - that.months,
+                this.days - that.days,
+                this.seconds - that.seconds,
+                this.nanos - that.nanos );
+    }
+
+    public DurationValue mul( NumberValue number )
+    {
+        if ( number instanceof IntegralValue )
+        {
+            long factor = number.longValue();
+            return duration( months * factor, days * factor, seconds * factor, nanos * factor );
+        }
+        if ( number instanceof FloatingPointValue )
+        {
+            double factor = number.doubleValue();
+            return approximate( months * factor, days * factor, seconds * factor, nanos * factor );
+        }
+        throw new IllegalArgumentException( "Factor must be either integer of floating point number." );
+    }
+
+    public DurationValue div( NumberValue number )
+    {
+        double divisor = number.doubleValue();
+        return approximate( months / divisor, days / divisor, seconds / divisor, nanos / divisor );
+    }
+
+    private static DurationValue approximate( double months, double days, double seconds, double nanos )
+    {
+        long m = (long) months;
+        days += AVERAGE_DAYS_PER_MONTH * (months - m);
+        long d = (long) days;
+        seconds += SECONDS_PER_DAY * (days - d);
+        long s = (long) seconds;
+        nanos += NANOS_PER_SECOND * (seconds - s);
+        long n = (long) nanos;
+        return duration( m, d, s, n );
+    }
+}

--- a/community/values/src/main/java/org/neo4j/values/storable/FloatArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/FloatArray.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.SequenceValue;
+import org.neo4j.values.ValueMapper;
 
 import static java.lang.String.format;
 
@@ -46,6 +47,12 @@ public abstract class FloatArray extends FloatingPointArray
     public int computeHash()
     {
         return NumberValues.hash( value() );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapFloatArray( this );
     }
 
     @Override
@@ -112,14 +119,14 @@ public abstract class FloatArray extends FloatingPointArray
     }
 
     @Override
-    public Object asObjectCopy()
+    public float[] asObjectCopy()
     {
         return value().clone();
     }
 
     @Override
     @Deprecated
-    public Object asObject()
+    public float[] asObject()
     {
         return value();
     }

--- a/community/values/src/main/java/org/neo4j/values/storable/FloatValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/FloatValue.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.values.storable;
 
+import org.neo4j.values.ValueMapper;
+
 import static java.lang.String.format;
 
 public final class FloatValue extends FloatingPointValue
@@ -81,5 +83,11 @@ public final class FloatValue extends FloatingPointValue
     public String toString()
     {
         return format( "Float(%e)", value );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapFloat( this );
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/IntArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/IntArray.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.SequenceValue;
+import org.neo4j.values.ValueMapper;
 
 import static java.lang.String.format;
 
@@ -46,6 +47,12 @@ public abstract class IntArray extends IntegralArray
     public int computeHash()
     {
         return NumberValues.hash( value() );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapIntArray( this );
     }
 
     @Override
@@ -112,14 +119,14 @@ public abstract class IntArray extends IntegralArray
     }
 
     @Override
-    public Object asObjectCopy()
+    public int[] asObjectCopy()
     {
         return value().clone();
     }
 
     @Override
     @Deprecated
-    public Object asObject()
+    public int[] asObject()
     {
         return value();
     }

--- a/community/values/src/main/java/org/neo4j/values/storable/IntValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/IntValue.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.values.storable;
 
+import org.neo4j.values.ValueMapper;
+
 import static java.lang.String.format;
 
 public final class IntValue extends IntegralValue
@@ -63,5 +65,11 @@ public final class IntValue extends IntegralValue
     public String toString()
     {
         return format( "Int(%d)", value );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapInt( this );
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/IntegralArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/IntegralArray.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.values.storable;
 
-abstract class IntegralArray extends NumberArray
+public abstract class IntegralArray extends NumberArray
 {
     abstract long longValue( int offset );
 

--- a/community/values/src/main/java/org/neo4j/values/storable/IntegralValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/IntegralValue.java
@@ -19,8 +19,24 @@
  */
 package org.neo4j.values.storable;
 
+import org.neo4j.values.AnyValue;
+
 public abstract class IntegralValue extends NumberValue
 {
+    public static long safeCastIntegral( String name, AnyValue value, long defaultValue )
+    {
+        if ( value == null )
+        {
+            return defaultValue;
+        }
+        if ( value instanceof IntegralValue )
+        {
+            return ((IntegralValue) value).longValue();
+        }
+        throw new IllegalArgumentException(
+                name + " must be an integer value, but was a " + value.getClass().getSimpleName() );
+    }
+
     @Override
     public boolean equals( long x )
     {

--- a/community/values/src/main/java/org/neo4j/values/storable/LocalDateTimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/LocalDateTimeValue.java
@@ -19,12 +19,18 @@
  */
 package org.neo4j.values.storable;
 
+import java.lang.invoke.MethodHandle;
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.neo4j.values.AnyValue;
 import org.neo4j.values.ValueMapper;
 
 import static java.time.Instant.ofEpochSecond;
@@ -72,6 +78,171 @@ public final class LocalDateTimeValue extends TemporalValue<LocalDateTime,LocalD
     public static LocalDateTimeValue parse( TextValue text )
     {
         return parse( LocalDateTimeValue.class, PATTERN, LocalDateTimeValue::parse, text );
+    }
+
+    public static StructureBuilder<AnyValue,LocalDateTimeValue> builder( Supplier<ZoneId> defaultZone )
+    {
+        return new DateTimeValue.DateTimeBuilder<AnyValue,LocalDateTimeValue>()
+        {
+            @Override
+            protected ZoneId timezone( AnyValue timezone )
+            {
+                return timezone == null ? defaultZone.get() : timezoneOf( timezone );
+            }
+
+            @Override
+            protected LocalDateTimeValue selectDateTime( AnyValue temporal )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            protected LocalDateTimeValue selectDateAndTime( AnyValue date, AnyValue time )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            protected LocalDateTimeValue selectDateWithConstructedTime(
+                    AnyValue date,
+                    AnyValue hour,
+                    AnyValue minute,
+                    AnyValue second,
+                    AnyValue millisecond,
+                    AnyValue microsecond,
+                    AnyValue nanosecond )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            protected LocalDateTimeValue selectDate( AnyValue temporal )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            protected LocalDateTimeValue constructYear( AnyValue year )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            protected LocalDateTimeValue constructCalendarDate( AnyValue year, AnyValue month, AnyValue day )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            protected LocalDateTimeValue constructCalendarDateWithSelectedTime(
+                    AnyValue year, AnyValue month, AnyValue day, AnyValue time )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            protected LocalDateTimeValue constructCalendarDateWithConstructedTime(
+                    AnyValue year,
+                    AnyValue month,
+                    AnyValue day,
+                    AnyValue hour,
+                    AnyValue minute,
+                    AnyValue second,
+                    AnyValue millisecond,
+                    AnyValue microsecond,
+                    AnyValue nanosecond )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            protected LocalDateTimeValue constructWeekDate( AnyValue year, AnyValue week, AnyValue dayOfWeek )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            protected LocalDateTimeValue constructWeekDateWithSelectedTime(
+                    AnyValue year, AnyValue week, AnyValue dayOfWeek, AnyValue time )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            protected LocalDateTimeValue constructWeekDateWithConstructedTime(
+                    AnyValue year,
+                    AnyValue week,
+                    AnyValue dayOfWeek,
+                    AnyValue hour,
+                    AnyValue minute,
+                    AnyValue second,
+                    AnyValue millisecond,
+                    AnyValue microsecond,
+                    AnyValue nanosecond )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            protected LocalDateTimeValue constructQuarterDate(
+                    AnyValue year, AnyValue quarter, AnyValue dayOfQuarter )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            protected LocalDateTimeValue constructQuarterDateWithSelectedTime(
+                    AnyValue year, AnyValue quarter, AnyValue dayOfQuarter, AnyValue time )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            protected LocalDateTimeValue constructQuarterDateWithConstructedTime(
+                    AnyValue year,
+                    AnyValue quarter,
+                    AnyValue dayOfQuarter,
+                    AnyValue hour,
+                    AnyValue minute,
+                    AnyValue second,
+                    AnyValue millisecond,
+                    AnyValue microsecond,
+                    AnyValue nanosecond )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            protected LocalDateTimeValue constructOrdinalDate( AnyValue year, AnyValue ordinalDay )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            protected LocalDateTimeValue constructOrdinalDateWithSelectedTime(
+                    AnyValue year, AnyValue ordinalDay, AnyValue time )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            protected LocalDateTimeValue constructOrdinalDateWithConstructedTime(
+                    AnyValue year,
+                    AnyValue ordinalDay,
+                    AnyValue hour,
+                    AnyValue minute,
+                    AnyValue second,
+                    AnyValue millisecond,
+                    AnyValue microsecond,
+                    AnyValue nanosecond )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+        };
+    }
+
+    public abstract static class Compiler<Input> extends DateTimeValue.DateTimeBuilder<Input,MethodHandle>
+    {
     }
 
     private final LocalDateTime value;

--- a/community/values/src/main/java/org/neo4j/values/storable/LocalDateTimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/LocalDateTimeValue.java
@@ -25,18 +25,21 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.function.Function;
+import java.time.temporal.TemporalUnit;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.neo4j.values.AnyValue;
+import org.neo4j.values.StructureBuilder;
 import org.neo4j.values.ValueMapper;
+import org.neo4j.values.virtual.MapValue;
 
 import static java.time.Instant.ofEpochSecond;
 import static java.time.LocalDateTime.ofInstant;
 import static java.time.ZoneOffset.UTC;
 import static java.util.Objects.requireNonNull;
+import static org.neo4j.values.storable.DateTimeValue.parseZoneName;
 import static org.neo4j.values.storable.DateValue.DATE_PATTERN;
 import static org.neo4j.values.storable.DateValue.parseDate;
 import static org.neo4j.values.storable.LocalTimeValue.TIME_PATTERN;
@@ -80,7 +83,31 @@ public final class LocalDateTimeValue extends TemporalValue<LocalDateTime,LocalD
         return parse( LocalDateTimeValue.class, PATTERN, LocalDateTimeValue::parse, text );
     }
 
-    public static StructureBuilder<AnyValue,LocalDateTimeValue> builder( Supplier<ZoneId> defaultZone )
+    public static LocalDateTimeValue now( Clock clock )
+    {
+        return new LocalDateTimeValue( LocalDateTime.now( clock ) );
+    }
+
+    public static LocalDateTimeValue now( Clock clock, String timezone )
+    {
+        return now( clock.withZone( parseZoneName( timezone ) ) );
+    }
+
+    public static LocalDateTimeValue build( MapValue map, Supplier<ZoneId> defaultZone )
+    {
+        return StructureBuilder.build( builder( defaultZone ), map );
+    }
+
+    public static LocalDateTimeValue truncate(
+            TemporalUnit unit,
+            TemporalValue input,
+            MapValue fields,
+            Supplier<ZoneId> defaultZone )
+    {
+        throw new UnsupportedOperationException( "not implemented" );
+    }
+
+    static StructureBuilder<AnyValue,LocalDateTimeValue> builder( Supplier<ZoneId> defaultZone )
     {
         return new DateTimeValue.DateTimeBuilder<AnyValue,LocalDateTimeValue>()
         {

--- a/community/values/src/main/java/org/neo4j/values/storable/LocalDateTimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/LocalDateTimeValue.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.storable;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.neo4j.values.ValueMapper;
+
+import static java.time.Instant.ofEpochSecond;
+import static java.time.LocalDateTime.ofInstant;
+import static java.time.ZoneOffset.UTC;
+import static java.util.Objects.requireNonNull;
+import static org.neo4j.values.storable.DateValue.DATE_PATTERN;
+import static org.neo4j.values.storable.DateValue.parseDate;
+import static org.neo4j.values.storable.LocalTimeValue.TIME_PATTERN;
+import static org.neo4j.values.storable.LocalTimeValue.parseTime;
+
+public final class LocalDateTimeValue extends TemporalValue<LocalDateTime,LocalDateTimeValue>
+{
+    public static LocalDateTimeValue localDateTime( DateValue date, LocalTimeValue time )
+    {
+        return new LocalDateTimeValue( LocalDateTime.of( date.temporal(), time.temporal() ) );
+    }
+
+    public static LocalDateTimeValue localDateTime(
+            int year, int month, int day, int hour, int minute, int second, int nanoOfSecond )
+    {
+        return new LocalDateTimeValue( LocalDateTime.of( year, month, day, hour, minute, second, nanoOfSecond ) );
+    }
+
+    public static LocalDateTimeValue localDateTime( LocalDateTime value )
+    {
+        return new LocalDateTimeValue( requireNonNull( value, "LocalDateTime" ) );
+    }
+
+    public static LocalDateTimeValue localDateTime( long epochSecond, long nano )
+    {
+        return new LocalDateTimeValue( ofInstant( ofEpochSecond( epochSecond, nano ), UTC ) );
+    }
+
+    public static LocalDateTimeValue inUTC( DateTimeValue datetime )
+    {
+        return new LocalDateTimeValue( datetime.temporal().withZoneSameInstant( UTC ).toLocalDateTime() );
+    }
+
+    public static LocalDateTimeValue parse( CharSequence text )
+    {
+        return parse( LocalDateTimeValue.class, PATTERN, LocalDateTimeValue::parse, text );
+    }
+
+    public static LocalDateTimeValue parse( TextValue text )
+    {
+        return parse( LocalDateTimeValue.class, PATTERN, LocalDateTimeValue::parse, text );
+    }
+
+    private final LocalDateTime value;
+
+    private LocalDateTimeValue( LocalDateTime value )
+    {
+        this.value = value;
+    }
+
+    @Override
+    LocalDateTime temporal()
+    {
+        return value;
+    }
+
+    @Override
+    public boolean equals( Value other )
+    {
+        return other instanceof LocalDateTimeValue && value.equals( ((LocalDateTimeValue) other).value );
+    }
+
+    @Override
+    public <E extends Exception> void writeTo( ValueWriter<E> writer ) throws E
+    {
+        throw new UnsupportedOperationException( "not implemented" );
+    }
+
+    @Override
+    public String prettyPrint()
+    {
+        return value.format( DateTimeFormatter.ISO_LOCAL_DATE_TIME );
+    }
+
+    @Override
+    public ValueGroup valueGroup()
+    {
+        return ValueGroup.LOCAL_DATE_TIME;
+    }
+
+    @Override
+    protected int computeHash()
+    {
+        return Long.hashCode( value.toEpochSecond( UTC ) );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapLocalDateTime( this );
+    }
+
+    @Override
+    public LocalDateTimeValue add( DurationValue duration )
+    {
+        return replacement( value.plus( duration ) );
+    }
+
+    @Override
+    public LocalDateTimeValue sub( DurationValue duration )
+    {
+        return replacement( value.minus( duration ) );
+    }
+
+    @Override
+    LocalDateTimeValue replacement( LocalDateTime dateTime )
+    {
+        return dateTime == value ? this : new LocalDateTimeValue( dateTime );
+    }
+
+    private static final Pattern PATTERN = Pattern.compile(
+            DATE_PATTERN + "(?<time>T" + TIME_PATTERN + ")?",
+            Pattern.CASE_INSENSITIVE );
+
+    private static LocalDateTimeValue parse( Matcher matcher )
+    {
+        return localDateTime( LocalDateTime.of( parseDate( matcher ), optTime( matcher ) ) );
+    }
+
+    static LocalTime optTime( Matcher matcher )
+    {
+        return matcher.group( "time" ) != null ? parseTime( matcher ) : LocalTime.MIN;
+    }
+}

--- a/community/values/src/main/java/org/neo4j/values/storable/LocalDateTimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/LocalDateTimeValue.java
@@ -96,7 +96,7 @@ public final class LocalDateTimeValue extends TemporalValue<LocalDateTime,LocalD
     @Override
     public <E extends Exception> void writeTo( ValueWriter<E> writer ) throws E
     {
-        throw new UnsupportedOperationException( "not implemented" );
+        writer.writeLocalDateTime( value.toEpochSecond( UTC ), value.getNano() );
     }
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/LocalTimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/LocalTimeValue.java
@@ -25,17 +25,20 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
-import java.util.function.Function;
+import java.time.temporal.TemporalUnit;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.neo4j.values.AnyValue;
+import org.neo4j.values.StructureBuilder;
 import org.neo4j.values.ValueMapper;
+import org.neo4j.values.virtual.MapValue;
 
 import static java.lang.Integer.parseInt;
 import static java.time.ZoneOffset.UTC;
 import static java.util.Objects.requireNonNull;
+import static org.neo4j.values.storable.DateTimeValue.parseZoneName;
 
 public final class LocalTimeValue extends TemporalValue<LocalTime,LocalTimeValue>
 {
@@ -69,7 +72,31 @@ public final class LocalTimeValue extends TemporalValue<LocalTime,LocalTimeValue
         return parse( LocalTimeValue.class, PATTERN, LocalTimeValue::parse, text );
     }
 
-    public static StructureBuilder<AnyValue,LocalTimeValue> builder( Supplier<ZoneId> defaultZone )
+    public static LocalTimeValue now( Clock clock )
+    {
+        return new LocalTimeValue( LocalTime.now( clock ) );
+    }
+
+    public static LocalTimeValue now( Clock clock, String timezone )
+    {
+        return now( clock.withZone( parseZoneName( timezone ) ) );
+    }
+
+    public static LocalTimeValue build( MapValue map, Supplier<ZoneId> defaultZone )
+    {
+        return StructureBuilder.build( builder( defaultZone ), map );
+    }
+
+    public static LocalTimeValue truncate(
+            TemporalUnit unit,
+            TemporalValue input,
+            MapValue fields,
+            Supplier<ZoneId> defaultZone )
+    {
+        throw new UnsupportedOperationException( "not implemented" );
+    }
+
+    static StructureBuilder<AnyValue,LocalTimeValue> builder( Supplier<ZoneId> defaultZone )
     {
         return new TimeValue.TimeBuilder<AnyValue,LocalTimeValue>()
         {

--- a/community/values/src/main/java/org/neo4j/values/storable/LocalTimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/LocalTimeValue.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.storable;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.neo4j.values.ValueMapper;
+
+import static java.lang.Integer.parseInt;
+import static java.time.ZoneOffset.UTC;
+import static java.util.Objects.requireNonNull;
+
+public final class LocalTimeValue extends TemporalValue<LocalTime,LocalTimeValue>
+{
+    public static LocalTimeValue localTime( LocalTime value )
+    {
+        return new LocalTimeValue( requireNonNull( value, "LocalTime" ) );
+    }
+
+    public static LocalTimeValue localTime( int hour, int minute, int second, int nanosOfSecond )
+    {
+        return new LocalTimeValue( LocalTime.of( hour, minute, second, nanosOfSecond ) );
+    }
+
+    public static LocalTimeValue localTime( long nanoOfDay )
+    {
+        return new LocalTimeValue( LocalTime.ofNanoOfDay( nanoOfDay ) );
+    }
+
+    public static LocalTimeValue inUTC( TimeValue time )
+    {
+        return new LocalTimeValue( time.temporal().withOffsetSameInstant( UTC ).toLocalTime() );
+    }
+
+    public static LocalTimeValue parse( CharSequence text )
+    {
+        return parse( LocalTimeValue.class, PATTERN, LocalTimeValue::parse, text );
+    }
+
+    public static LocalTimeValue parse( TextValue text )
+    {
+        return parse( LocalTimeValue.class, PATTERN, LocalTimeValue::parse, text );
+    }
+
+    private final LocalTime value;
+
+    private LocalTimeValue( LocalTime value )
+    {
+        this.value = value;
+    }
+
+    @Override
+    LocalTime temporal()
+    {
+        return value;
+    }
+
+    @Override
+    public boolean equals( Value other )
+    {
+        return other instanceof LocalTimeValue && value.equals( ((LocalTimeValue) other).value );
+    }
+
+    @Override
+    public <E extends Exception> void writeTo( ValueWriter<E> writer ) throws E
+    {
+        throw new UnsupportedOperationException( "not implemented" );
+    }
+
+    @Override
+    public String prettyPrint()
+    {
+        return value.format( DateTimeFormatter.ISO_LOCAL_TIME );
+    }
+
+    @Override
+    public ValueGroup valueGroup()
+    {
+        return ValueGroup.LOCAL_TIME;
+    }
+
+    @Override
+    protected int computeHash()
+    {
+        return value.hashCode();
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapLocalTime( this );
+    }
+
+    @Override
+    public LocalTimeValue add( DurationValue duration )
+    {
+        return replacement( value.plusNanos( duration.nanosOfDay() ) );
+    }
+
+    @Override
+    public LocalTimeValue sub( DurationValue duration )
+    {
+        return replacement( value.minusNanos( duration.nanosOfDay() ) );
+    }
+
+    @Override
+    LocalTimeValue replacement( LocalTime time )
+    {
+        return time == value ? this : new LocalTimeValue( time );
+    }
+
+    static final String TIME_PATTERN = "(?:(?:(?<longHour>[0-9]{1,2})(?::(?<longMinute>[0-9]{1,2})"
+            + "(?::(?<longSecond>[0-9]{1,2})(?:.(?<longFraction>[0-9]{1,9}))?)?)?)|"
+            + "(?:(?<shortHour>[0-9]{2})(?:(?<shortMinute>[0-9]{2})"
+            + "(?:(?<shortSecond>[0-9]{2})(?:.(?<shortFraction>[0-9]{1,9}))?)?)?))";
+    private static final Pattern PATTERN = Pattern.compile( "(?:T)?" + TIME_PATTERN );
+
+    private static LocalTimeValue parse( Matcher matcher )
+    {
+        return new LocalTimeValue( parseTime( matcher ) );
+    }
+
+    static LocalTime parseTime( Matcher matcher )
+    {
+        int hour;
+        int minute;
+        int second;
+        int fraction;
+        String longHour = matcher.group( "longHour" );
+        if ( longHour != null )
+        {
+            hour = parseInt( longHour );
+            minute = optInt( matcher.group( "longMinute" ) );
+            second = optInt( matcher.group( "longSecond" ) );
+            fraction = parseNanos( matcher.group( "longFraction" ) );
+        }
+        else
+        {
+            String shortHour = matcher.group( "shortHour" );
+            hour = parseInt( shortHour );
+            minute = optInt( matcher.group( "shortMinute" ) );
+            second = optInt( matcher.group( "shortSecond" ) );
+            fraction = parseNanos( matcher.group( "shortFraction" ) );
+        }
+        return LocalTime.of( hour, minute, second, fraction );
+    }
+
+    private static int parseNanos( String value )
+    {
+        if ( value == null )
+        {
+            return 0;
+        }
+        int nanos = parseInt( value );
+        if ( nanos != 0 )
+        {
+            for ( int i = value.length(); i < 9; i++ )
+            {
+                nanos *= 10;
+            }
+        }
+        return nanos;
+    }
+
+    static int optInt( String value )
+    {
+        return value == null ? 0 : parseInt( value );
+    }
+}

--- a/community/values/src/main/java/org/neo4j/values/storable/LocalTimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/LocalTimeValue.java
@@ -19,12 +19,18 @@
  */
 package org.neo4j.values.storable;
 
+import java.lang.invoke.MethodHandle;
+import java.time.Clock;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.neo4j.values.AnyValue;
 import org.neo4j.values.ValueMapper;
 
 import static java.lang.Integer.parseInt;
@@ -61,6 +67,40 @@ public final class LocalTimeValue extends TemporalValue<LocalTime,LocalTimeValue
     public static LocalTimeValue parse( TextValue text )
     {
         return parse( LocalTimeValue.class, PATTERN, LocalTimeValue::parse, text );
+    }
+
+    public static StructureBuilder<AnyValue,LocalTimeValue> builder( Supplier<ZoneId> defaultZone )
+    {
+        return new TimeValue.TimeBuilder<AnyValue,LocalTimeValue>()
+        {
+            @Override
+            protected ZoneId timezone( AnyValue timezone )
+            {
+                return timezone == null ? defaultZone.get() : timezoneOf( timezone );
+            }
+
+            @Override
+            protected LocalTimeValue selectTime( AnyValue temporal )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            protected LocalTimeValue constructTime(
+                    AnyValue hour,
+                    AnyValue minute,
+                    AnyValue second,
+                    AnyValue millisecond,
+                    AnyValue microsecond,
+                    AnyValue nanosecond )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+        };
+    }
+
+    public abstract static class Compiler<Input> extends TimeValue.TimeBuilder<Input,MethodHandle>
+    {
     }
 
     private final LocalTime value;

--- a/community/values/src/main/java/org/neo4j/values/storable/LocalTimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/LocalTimeValue.java
@@ -85,7 +85,7 @@ public final class LocalTimeValue extends TemporalValue<LocalTime,LocalTimeValue
     @Override
     public <E extends Exception> void writeTo( ValueWriter<E> writer ) throws E
     {
-        throw new UnsupportedOperationException( "not implemented" );
+        writer.writeLocalTime( value.getLong( ChronoField.NANO_OF_DAY ) );
     }
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/LongArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/LongArray.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.SequenceValue;
+import org.neo4j.values.ValueMapper;
 
 import static java.lang.String.format;
 
@@ -46,6 +47,12 @@ public abstract class LongArray extends IntegralArray
     public int computeHash()
     {
         return NumberValues.hash( value() );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapLongArray( this );
     }
 
     @Override
@@ -112,7 +119,7 @@ public abstract class LongArray extends IntegralArray
     }
 
     @Override
-    public Object asObjectCopy()
+    public long[] asObjectCopy()
     {
         return value().clone();
     }
@@ -125,7 +132,7 @@ public abstract class LongArray extends IntegralArray
 
     @Override
     @Deprecated
-    public Object asObject()
+    public long[] asObject()
     {
         return value();
     }

--- a/community/values/src/main/java/org/neo4j/values/storable/LongValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/LongValue.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.values.storable;
 
+import org.neo4j.values.ValueMapper;
+
 import static java.lang.String.format;
 
 public final class LongValue extends IntegralValue
@@ -81,5 +83,11 @@ public final class LongValue extends IntegralValue
     public String toString()
     {
         return format( "Long(%d)", value );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapLong( this );
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/NoValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/NoValue.java
@@ -21,6 +21,7 @@ package org.neo4j.values.storable;
 
 import org.neo4j.values.AnyValue;
 import org.neo4j.graphdb.spatial.Geometry;
+import org.neo4j.values.ValueMapper;
 
 /**
  * Not a value.
@@ -47,6 +48,12 @@ final class NoValue extends Value
     public Boolean ternaryEquals( AnyValue other )
     {
         return null;
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapNoValue();
     }
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/NumberArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/NumberArray.java
@@ -21,7 +21,7 @@ package org.neo4j.values.storable;
 
 import org.neo4j.graphdb.spatial.Geometry;
 
-abstract class NumberArray extends ArrayValue
+public abstract class NumberArray extends ArrayValue
 {
     abstract int compareTo( IntegralArray other );
 

--- a/community/values/src/main/java/org/neo4j/values/storable/PointArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/PointArray.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import org.neo4j.graphdb.spatial.Geometry;
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.SequenceValue;
+import org.neo4j.values.ValueMapper;
 
 import static java.lang.String.format;
 
@@ -146,6 +147,12 @@ public abstract class PointArray extends ArrayValue
     public int computeHash()
     {
         return Arrays.hashCode( value() );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapPointArray( this );
     }
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/PointValue.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.neo4j.graphdb.spatial.CRS;
 import org.neo4j.graphdb.spatial.Coordinate;
 import org.neo4j.graphdb.spatial.Point;
+import org.neo4j.values.ValueMapper;
 import org.neo4j.values.utils.PrettyPrinter;
 
 import static java.lang.String.format;
@@ -168,9 +169,9 @@ public class PointValue extends ScalarValue implements Comparable<PointValue>, P
     }
 
     @Override
-    public Object asObjectCopy()
+    public Point asObjectCopy()
     {
-        return new PointValue( this.crs, this.coordinate );
+        return this;
     }
 
     public CoordinateReferenceSystem getCoordinateReferenceSystem()
@@ -193,6 +194,12 @@ public class PointValue extends ScalarValue implements Comparable<PointValue>, P
         result = 31 * result + NumberValues.hash( crs.getCode() );
         result = 31 * result + NumberValues.hash( coordinate );
         return result;
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapPoint( this );
     }
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/ShortArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ShortArray.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.SequenceValue;
+import org.neo4j.values.ValueMapper;
 
 import static java.lang.String.format;
 
@@ -46,6 +47,12 @@ public abstract class ShortArray extends IntegralArray
     public int computeHash()
     {
         return NumberValues.hash( value() );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapShortArray( this );
     }
 
     @Override
@@ -112,14 +119,14 @@ public abstract class ShortArray extends IntegralArray
     }
 
     @Override
-    public Object asObjectCopy()
+    public short[] asObjectCopy()
     {
         return value().clone();
     }
 
     @Override
     @Deprecated
-    public Object asObject()
+    public short[] asObject()
     {
         return value();
     }

--- a/community/values/src/main/java/org/neo4j/values/storable/ShortValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ShortValue.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.values.storable;
 
+import org.neo4j.values.ValueMapper;
+
 import static java.lang.String.format;
 
 /**
@@ -85,5 +87,11 @@ public final class ShortValue extends IntegralValue
     public String toString()
     {
         return format( "Short(%d)", value );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapShort( this );
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/StringArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringArray.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import org.neo4j.graphdb.spatial.Geometry;
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.SequenceValue;
+import org.neo4j.values.ValueMapper;
 
 import static java.lang.String.format;
 
@@ -95,14 +96,14 @@ public abstract class StringArray extends TextArray
     }
 
     @Override
-    public Object asObjectCopy()
+    public String[] asObjectCopy()
     {
         return value().clone();
     }
 
     @Override
     @Deprecated
-    public Object asObject()
+    public String[] asObject()
     {
         return value();
     }
@@ -123,6 +124,12 @@ public abstract class StringArray extends TextArray
     public AnyValue value( int offset )
     {
         return Values.stringValue( stringValue( offset ) );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapStringArray( this );
     }
 
     static final class Direct extends StringArray

--- a/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.values.storable;
 
+import org.neo4j.values.ValueMapper;
 import org.neo4j.values.virtual.ListValue;
 
 import static java.lang.String.format;
@@ -112,6 +113,12 @@ public abstract class StringValue extends TextValue
     public String prettyPrint()
     {
         return format( "'%s'", value() );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapString( this );
     }
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringValue.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.values.storable;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.neo4j.values.ValueMapper;
 import org.neo4j.values.virtual.ListValue;
 
@@ -217,6 +220,12 @@ public abstract class StringValue extends TextValue
         public int compareTo( TextValue other )
         {
             return -other.length();
+        }
+
+        @Override
+        Matcher matcher( Pattern pattern )
+        {
+            return pattern.matcher( "" );
         }
 
         @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/StringWrappingStringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StringWrappingStringValue.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.values.storable;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 /**
  * Implementation of StringValue that wraps a `java.lang.String` and
  * delegates methods to that instance.
@@ -100,6 +103,12 @@ final class StringWrappingStringValue extends StringValue
     {
         StringBuilder stringBuilder = new StringBuilder( value() );
         return Values.stringValue( stringBuilder.reverse().toString() );
+    }
+
+    @Override
+    Matcher matcher( Pattern pattern )
+    {
+        return pattern.matcher( value );
     }
 
     private int ltrimIndex( String value )

--- a/community/values/src/main/java/org/neo4j/values/storable/StructureBuilder.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/StructureBuilder.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.storable;
+
+import org.neo4j.values.AnyValue;
+
+public abstract class StructureBuilder<Input, Result>
+{
+    public abstract StructureBuilder<Input,Result> add( String field, Input value );
+
+    public abstract Result build();
+
+    StructureBuilder()
+    {
+        // Particular subclasses defined in this package
+    }
+
+    static long unpackInteger( String name, AnyValue value )
+    {
+        if ( value == null )
+        {
+            return 0;
+        }
+        if ( value instanceof IntegralValue )
+        {
+            return ((IntegralValue) value).longValue();
+        }
+        throw new IllegalArgumentException(
+                name + " must be an integer value, but was a " + value.getClass().getSimpleName() );
+    }
+}

--- a/community/values/src/main/java/org/neo4j/values/storable/TemporalValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TemporalValue.java
@@ -415,7 +415,7 @@ public abstract class TemporalValue<T extends Temporal, V extends TemporalValue<
             {
                 if ( builder.timezone != null )
                 {
-                    throw new IllegalArgumentException( "cannot assign timezone twice" );
+                    throw new IllegalArgumentException( "Cannot assign timezone twice." );
                 }
                 builder.timezone = value;
             }
@@ -526,19 +526,19 @@ public abstract class TemporalValue<T extends Temporal, V extends TemporalValue<
         @Override
         BuilderState<Input> assign( Field field, Input value )
         {
-            throw new IllegalArgumentException( "cannot assign " + field + " when selecting datetime" );
+            throw new IllegalArgumentException( "Cannot assign " + field + " when selecting datetime." );
         }
 
         @Override
         BuilderState<Input> date( Input date )
         {
-            throw new IllegalArgumentException( "cannot select date when selecting datetime" );
+            throw new IllegalArgumentException( "Cannot select date when selecting datetime." );
         }
 
         @Override
         BuilderState<Input> time( Input time )
         {
-            throw new IllegalArgumentException( "cannot select time when selecting datetime" );
+            throw new IllegalArgumentException( "Cannot select time when selecting datetime." );
         }
 
         @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/TemporalValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TemporalValue.java
@@ -21,6 +21,8 @@ package org.neo4j.values.storable;
 
 import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoField;
+import java.time.temporal.IsoFields;
 import java.time.temporal.Temporal;
 import java.time.temporal.TemporalAdjuster;
 import java.time.temporal.TemporalAmount;
@@ -28,12 +30,17 @@ import java.time.temporal.TemporalField;
 import java.time.temporal.TemporalQuery;
 import java.time.temporal.TemporalUnit;
 import java.time.temporal.ValueRange;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.neo4j.values.AnyValue;
+
+import static org.neo4j.values.storable.DateTimeValue.parseZoneName;
 import static org.neo4j.values.storable.NumberType.NO_NUMBER;
 
 public abstract class TemporalValue<T extends Temporal, V extends TemporalValue<T,V>>
@@ -250,5 +257,762 @@ public abstract class TemporalValue<T extends Temporal, V extends TemporalValue<
     {
         String name = type.getSimpleName();
         return name.substring( 0, name.length() - /*"Value" is*/5/*characters*/ );
+    }
+
+    abstract static class Builder<Input, Result> extends StructureBuilder<Input,Result>
+    {
+        private BuilderState<Input> state;
+        private Input timezone;
+
+        @Override
+        public final Result build()
+        {
+            if ( state == null )
+            {
+                throw new IllegalArgumentException( "Builder state empty" );
+            }
+            return state.build( this );
+        }
+
+        @Override
+        public final StructureBuilder<Input,Result> add( String fieldName, Input value )
+        {
+            Field field = Field.fields.get( fieldName.toLowerCase() );
+            if ( field == null )
+            {
+                throw new IllegalArgumentException( "No such field: " + fieldName );
+            }
+            field.assign( this, value );
+            return this;
+        }
+
+        @SuppressWarnings( "BooleanMethodIsAlwaysInverted" )
+        private boolean supports( TemporalField field )
+        {
+            if ( field.isDateBased() )
+            {
+                return supportsDate();
+            }
+            if ( field.isTimeBased() )
+            {
+                return supportsTime();
+            }
+            throw new IllegalStateException( "Fields should be either date based or time based" );
+        }
+
+        protected abstract boolean supportsDate();
+
+        protected abstract boolean supportsTime();
+
+        protected abstract ZoneId timezone( Input timezone );
+
+        // Selection
+
+        protected abstract Result selectDateTime( Input temporal );
+
+        protected abstract Result selectDateAndTime( Input date, Input time );
+
+        protected abstract Result selectDateWithConstructedTime(
+                Input date,
+                Input hour, Input minute, Input second, Input millisecond, Input microsecond, Input nanosecond );
+
+        protected abstract Result selectDate( Input temporal );
+
+        protected abstract Result selectTime( Input temporal );
+
+        // Construction
+
+        protected abstract Result constructYear( Input year );
+
+        protected abstract Result constructTime(
+                Input hour, Input minute, Input second, Input millisecond, Input microsecond, Input nanosecond );
+
+        // - by calendar date
+
+        protected abstract Result constructCalendarDate( Input year, Input month, Input day );
+
+        protected abstract Result constructCalendarDateWithSelectedTime(
+                Input year, Input month, Input day, Input time );
+
+        protected abstract Result constructCalendarDateWithConstructedTime(
+                Input year, Input month, Input day,
+                Input hour, Input minute, Input second, Input millisecond, Input microsecond, Input nanosecond );
+
+        // - by week date
+
+        protected abstract Result constructWeekDate( Input year, Input week, Input dayOfWeek );
+
+        protected abstract Result constructWeekDateWithSelectedTime(
+                Input year, Input week, Input dayOfWeek, Input time );
+
+        protected abstract Result constructWeekDateWithConstructedTime(
+                Input year, Input week, Input dayOfWeek,
+                Input hour, Input minute, Input second, Input millisecond, Input microsecond, Input nanosecond );
+
+        // - by quarter date
+
+        protected abstract Result constructQuarterDate( Input year, Input quarter, Input dayOfQuarter );
+
+        protected abstract Result constructQuarterDateWithSelectedTime(
+                Input year, Input quarter, Input dayOfQuarter, Input time );
+
+        protected abstract Result constructQuarterDateWithConstructedTime(
+                Input year, Input quarter, Input dayOfQuarter,
+                Input hour, Input minute, Input second, Input millisecond, Input microsecond, Input nanosecond );
+
+        // - by ordinal date
+
+        protected abstract Result constructOrdinalDate( Input year, Input ordinalDay );
+
+        protected abstract Result constructOrdinalDateWithSelectedTime( Input year, Input ordinalDay, Input time );
+
+        protected abstract Result constructOrdinalDateWithConstructedTime(
+                Input year, Input ordinalDay,
+                Input hour, Input minute, Input second, Input millisecond, Input microsecond, Input nanosecond );
+
+        protected final ZoneId optionalTimezone()
+        {
+            return timezone == null ? null : timezone();
+        }
+
+        protected final ZoneId timezone()
+        {
+            return timezone( timezone );
+        }
+
+        protected final ZoneId timezoneOf( AnyValue timezone )
+        {
+            if ( timezone instanceof TextValue )
+            {
+                return parseZoneName( ((TextValue) timezone).stringValue() );
+            }
+            throw new UnsupportedOperationException( "Cannot convert to ZoneId: " + timezone );
+        }
+    }
+
+    private enum Field
+    {
+        year( ChronoField.YEAR ),
+        quarter( IsoFields.QUARTER_OF_YEAR ),
+        month( ChronoField.MONTH_OF_YEAR ),
+        week( IsoFields.WEEK_OF_WEEK_BASED_YEAR ),
+        ordinalDay( ChronoField.DAY_OF_YEAR ),
+        dayOfQuarter( IsoFields.DAY_OF_QUARTER ),
+        dayOfWeek( ChronoField.DAY_OF_WEEK ),
+        day( ChronoField.DAY_OF_MONTH ),
+        hour( ChronoField.HOUR_OF_DAY ),
+        minute( ChronoField.MINUTE_OF_HOUR ),
+        second( ChronoField.SECOND_OF_MINUTE ),
+        millisecond( ChronoField.MILLI_OF_SECOND ),
+        microsecond( ChronoField.MICRO_OF_SECOND ),
+        nanosecond( ChronoField.NANO_OF_SECOND ),
+        timezone//<pre>
+        { //</pre>
+
+            @Override
+            <Input> void assign( Builder<Input,?> builder, Input value )
+            {
+                if ( builder.timezone != null )
+                {
+                    throw new IllegalArgumentException( "cannot assign timezone twice" );
+                }
+                builder.timezone = value;
+            }
+        },
+        // group selectors
+        date//<pre>
+        { //</pre>
+
+            @Override
+            <Input> void assign( Builder<Input,?> builder, Input value )
+            {
+                if ( builder.state == null )
+                {
+                    builder.state = new DateTimeBuilder<>();
+                }
+                builder.state = builder.state.date( value );
+            }
+        },
+        time//<pre>
+        { //</pre>
+
+            @Override
+            <Input> void assign( Builder<Input,?> builder, Input value )
+            {
+                if ( builder.state == null )
+                {
+                    builder.state = new DateTimeBuilder<>();
+                }
+                builder.state = builder.state.time( value );
+            }
+        },
+        datetime//<pre>
+        { //</pre>
+
+            @Override
+            <Input> void assign( Builder<Input,?> builder, Input value )
+            {
+                if ( builder.state == null )
+                {
+                    builder.state = new SelectDateTime<>( value );
+                }
+                else
+                {
+                    throw new IllegalArgumentException( "Cannot select datetime when assigning other fields." );
+                }
+            }
+        };
+        private static final Map<String,Field> fields = new HashMap<>();
+
+        static
+        {
+            for ( Field field : values() )
+            {
+                fields.put( field.name().toLowerCase(), field );
+            }
+            // aliases
+            fields.put( "weekday", dayOfWeek );
+            fields.put( "quarterday", dayOfQuarter );
+        }
+
+        private final TemporalField field;
+
+        Field( TemporalField field )
+        {
+            this.field = field;
+        }
+
+        Field()
+        {
+            this.field = null;
+        }
+
+        <Input> void assign( Builder<Input,?> builder, Input value )
+        {
+            assert field != null : "method should have been overridden";
+            if ( !builder.supports( field ) )
+            {
+                throw new IllegalArgumentException( "Not supported: " + name() );
+            }
+            if ( builder.state == null )
+            {
+                builder.state = new DateTimeBuilder<>();
+            }
+            builder.state = builder.state.assign( this, value );
+        }
+    }
+
+    private abstract static class BuilderState<Input>
+    {
+        abstract BuilderState<Input> assign( Field field, Input value );
+
+        abstract BuilderState<Input> date( Input date );
+
+        abstract BuilderState<Input> time( Input time );
+
+        abstract <Result> Result build( Builder<Input,Result> builder );
+    }
+
+    private static final class SelectDateTime<Input> extends BuilderState<Input>
+    {
+        private final Input datetime;
+
+        SelectDateTime( Input temporal )
+        {
+            this.datetime = temporal;
+        }
+
+        @Override
+        BuilderState<Input> assign( Field field, Input value )
+        {
+            throw new IllegalArgumentException( "cannot assign " + field + " when selecting datetime" );
+        }
+
+        @Override
+        BuilderState<Input> date( Input date )
+        {
+            throw new IllegalArgumentException( "cannot select date when selecting datetime" );
+        }
+
+        @Override
+        BuilderState<Input> time( Input time )
+        {
+            throw new IllegalArgumentException( "cannot select time when selecting datetime" );
+        }
+
+        @Override
+        <Result> Result build( Builder<Input,Result> builder )
+        {
+            return builder.selectDateTime( datetime );
+        }
+    }
+
+    private static final class DateTimeBuilder<Input> extends BuilderState<Input>
+    {
+        private DateBuilder<Input> date;
+        private TimeBuilder<Input> time;
+
+        @Override
+        BuilderState<Input> assign( Field field, Input value )
+        {
+            if ( field.field.isDateBased() )
+            {
+                if ( date == null )
+                {
+                    date = new ConstructDate<>();
+                }
+                date = date.assign( field, value );
+            }
+            else
+            {
+                if ( time == null )
+                {
+                    time = new ConstructTime<>();
+                }
+                time.assign( field, value );
+            }
+            return this;
+        }
+
+        @Override
+        BuilderState<Input> date( Input date )
+        {
+            if ( this.date != null )
+            {
+                throw new IllegalArgumentException( "cannot select date when also assigning date" );
+            }
+            this.date = new SelectDate<>( date );
+            return this;
+        }
+
+        @Override
+        BuilderState<Input> time( Input time )
+        {
+            if ( this.time != null )
+            {
+                throw new IllegalArgumentException( "cannot select time when also assigning time" );
+            }
+            this.time = new SelectTime<>( time );
+            return this;
+        }
+
+        @Override
+        <Result> Result build( Builder<Input,Result> builder )
+        {
+            if ( time == null )
+            {
+                return date.build( builder );
+            }
+            else if ( date == null )
+            {
+                return time.build( builder );
+            }
+            else
+            {
+                return time.build( builder, date );
+            }
+        }
+    }
+
+    private abstract static class DateBuilder<Input>
+    {
+        abstract DateBuilder<Input> assign( Field field, Input value );
+
+        abstract <Result> Result build( Builder<Input,Result> builder );
+
+        abstract <Result> Result selectTime( Input time, Builder<Input,Result> builder );
+
+        abstract <Result> Result constructTime(
+                Builder<Input,Result> builder,
+                Input hour, Input minute, Input second, Input millisecond, Input microsecond, Input nanosecond );
+    }
+
+    private abstract static class TimeBuilder<Input>
+    {
+        abstract void assign( Field field, Input value );
+
+        abstract <Result> Result build( Builder<Input,Result> builder );
+
+        abstract <Result> Result build( Builder<Input,Result> builder, DateBuilder<Input> date );
+    }
+
+    private static final class SelectDate<Input> extends DateBuilder<Input>
+    {
+        private final Input temporal;
+
+        SelectDate( Input temporal )
+        {
+            this.temporal = temporal;
+        }
+
+        @Override
+        SelectDate<Input> assign( Field field, Input value )
+        {
+            throw new IllegalArgumentException( "cannot assign " + field + " when selecting date" );
+        }
+
+        @Override
+        <Result> Result build( Builder<Input,Result> builder )
+        {
+            return builder.selectDate( temporal );
+        }
+
+        @Override
+        <Result> Result selectTime( Input time, Builder<Input,Result> builder )
+        {
+            return builder.selectDateAndTime( temporal, time );
+        }
+
+        @Override
+        <Result> Result constructTime(
+                Builder<Input,Result> builder,
+                Input hour, Input minute, Input second, Input millisecond, Input microsecond, Input nanosecond )
+        {
+            return builder.selectDateWithConstructedTime(
+                    temporal,
+                    hour,
+                    minute,
+                    second,
+                    millisecond,
+                    microsecond,
+                    nanosecond );
+        }
+    }
+
+    private static final class SelectTime<Input> extends TimeBuilder<Input>
+    {
+        private final Input temporal;
+
+        SelectTime( Input temporal )
+        {
+            this.temporal = temporal;
+        }
+
+        @Override
+        void assign( Field field, Input value )
+        {
+            throw new IllegalArgumentException( "cannot assign " + field + " when selecting time" );
+        }
+
+        @Override
+        <Result> Result build( Builder<Input,Result> builder )
+        {
+            return builder.selectTime( temporal );
+        }
+
+        @Override
+        <Result> Result build( Builder<Input,Result> builder, DateBuilder<Input> date )
+        {
+            return date.selectTime( temporal, builder );
+        }
+    }
+
+    private static final class ConstructTime<Input> extends TimeBuilder<Input>
+    {
+        private Input hour;
+        private Input minute;
+        private Input second;
+        private Input millisecond;
+        private Input microsecond;
+        private Input nanosecond;
+
+        @Override
+        void assign( Field field, Input value )
+        {
+            switch ( field )
+            {
+            case hour:
+                hour = assignment( field, hour, value );
+                break;
+            case minute:
+                minute = assignment( field, minute, value );
+                break;
+            case second:
+                second = assignment( field, second, value );
+                break;
+            case millisecond:
+                millisecond = assignment( field, millisecond, value );
+                break;
+            case microsecond:
+                microsecond = assignment( field, microsecond, value );
+                break;
+            case nanosecond:
+                nanosecond = assignment( field, nanosecond, value );
+                break;
+            default:
+                throw new IllegalStateException( "Not a time field: " + field );
+            }
+        }
+
+        @Override
+        <Result> Result build( Builder<Input,Result> builder )
+        {
+
+            return builder.constructTime( hour, minute, second, millisecond, microsecond, nanosecond );
+        }
+
+        @Override
+        <Result> Result build( Builder<Input,Result> builder, DateBuilder<Input> date )
+        {
+            return date.constructTime( builder, hour, minute, second, millisecond, microsecond, nanosecond );
+        }
+    }
+
+    private static class ConstructDate<Input> extends DateBuilder<Input>
+    {
+        Input year;
+
+        @Override
+        ConstructDate<Input> assign( Field field, Input value )
+        {
+            switch ( field )
+            {
+            case year:
+                year = assignment( field, year, value );
+                return this;
+            case quarter:
+            case dayOfQuarter:
+                return new QuarterDate<>( year ).assign( field, value );
+            case month:
+            case day:
+                return new CalendarDate<>( year ).assign( field, value );
+            case week:
+            case dayOfWeek:
+                return new WeekDate<>( year ).assign( field, value );
+            case ordinalDay:
+                return new OrdinalDate<>( year ).assign( field, value );
+            default:
+                throw new IllegalStateException( "Not a date field: " + field );
+            }
+        }
+
+        @Override
+        <Result> Result build( Builder<Input,Result> builder )
+        {
+            return builder.constructYear( year );
+        }
+
+        @Override
+        <Result> Result selectTime( Input time, Builder<Input,Result> builder )
+        {
+            throw new IllegalStateException( "Cannot specify time for a year." );
+        }
+
+        @Override
+        <Result> Result constructTime(
+                Builder<Input,Result> builder,
+                Input hour, Input minute, Input second, Input millisecond, Input microsecond, Input nanosecond )
+        {
+            throw new IllegalStateException( "Cannot specify time for a year." );
+        }
+    }
+
+    private static final class CalendarDate<Input> extends ConstructDate<Input>
+    {
+        private Input month;
+        private Input day;
+
+        CalendarDate( Input year )
+        {
+            this.year = year;
+        }
+
+        @Override
+        ConstructDate<Input> assign( Field field, Input value )
+        {
+            switch ( field )
+            {
+            case year:
+                year = assignment( field, year, value );
+                return this;
+            case month:
+                month = assignment( field, month, value );
+                return this;
+            case day:
+                day = assignment( field, day, value );
+                return this;
+            default:
+                throw new IllegalArgumentException( "Cannot assign " + field + " to calendar date." );
+            }
+        }
+
+        @Override
+        <Result> Result build( Builder<Input,Result> builder )
+        {
+            return builder.constructCalendarDate( year, month, day );
+        }
+
+        @Override
+        <Result> Result selectTime( Input time, Builder<Input,Result> builder )
+        {
+            return builder.constructCalendarDateWithSelectedTime( year, month, day, time );
+        }
+
+        @Override
+        <Result> Result constructTime(
+                Builder<Input,Result> builder,
+                Input hour, Input minute, Input second, Input millisecond, Input microsecond, Input nanosecond )
+        {
+            return builder.constructCalendarDateWithConstructedTime( year, month, day,
+                    hour, minute, second, millisecond, microsecond, nanosecond );
+        }
+    }
+
+    private static final class WeekDate<Input> extends ConstructDate<Input>
+    {
+        private Input week;
+        private Input dayOfWeek;
+
+        WeekDate( Input year )
+        {
+            this.year = year;
+        }
+
+        @Override
+        ConstructDate<Input> assign( Field field, Input value )
+        {
+            switch ( field )
+            {
+            case year:
+                year = assignment( field, year, value );
+                return this;
+            case week:
+                week = assignment( field, week, value );
+                return this;
+            case dayOfWeek:
+                dayOfWeek = assignment( field, dayOfWeek, value );
+                return this;
+            default:
+                throw new IllegalArgumentException( "Cannot assign " + field + " to week date." );
+            }
+        }
+
+        @Override
+        <Result> Result build( Builder<Input,Result> builder )
+        {
+            return builder.constructWeekDate( year, week, dayOfWeek );
+        }
+
+        @Override
+        <Result> Result selectTime( Input time, Builder<Input,Result> builder )
+        {
+            return builder.constructWeekDateWithSelectedTime( year, week, dayOfWeek, time );
+        }
+
+        @Override
+        <Result> Result constructTime(
+                Builder<Input,Result> builder,
+                Input hour, Input minute, Input second, Input millisecond, Input microsecond, Input nanosecond )
+        {
+            return builder.constructWeekDateWithConstructedTime( year, week, dayOfWeek,
+                    hour, minute, second, millisecond, microsecond, nanosecond );
+        }
+    }
+
+    private static final class QuarterDate<Input> extends ConstructDate<Input>
+    {
+        private Input quarter;
+        private Input dayOfQuarter;
+
+        QuarterDate( Input year )
+        {
+            this.year = year;
+        }
+
+        @Override
+        ConstructDate<Input> assign( Field field, Input value )
+        {
+            switch ( field )
+            {
+            case year:
+                year = assignment( field, year, value );
+                return this;
+            case quarter:
+                quarter = assignment( field, quarter, value );
+                return this;
+            case dayOfQuarter:
+                dayOfQuarter = assignment( field, dayOfQuarter, value );
+                return this;
+            default:
+                throw new IllegalArgumentException( "Cannot assign " + field + " to quarter date." );
+            }
+        }
+
+        @Override
+        <Result> Result build( Builder<Input,Result> builder )
+        {
+            return builder.constructQuarterDate( year, quarter, dayOfQuarter );
+        }
+
+        @Override
+        <Result> Result selectTime( Input time, Builder<Input,Result> builder )
+        {
+            return builder.constructQuarterDateWithSelectedTime( year, quarter, dayOfQuarter, time );
+        }
+
+        @Override
+        <Result> Result constructTime(
+                Builder<Input,Result> builder,
+                Input hour, Input minute, Input second, Input millisecond, Input microsecond, Input nanosecond )
+        {
+            return builder.constructQuarterDateWithConstructedTime( year, quarter, dayOfQuarter,
+                    hour, minute, second, millisecond, microsecond, nanosecond );
+        }
+    }
+
+    private static final class OrdinalDate<Input> extends ConstructDate<Input>
+    {
+        private Input ordinalDay;
+
+        OrdinalDate( Input year )
+        {
+            this.year = year;
+        }
+
+        @Override
+        ConstructDate<Input> assign( Field field, Input value )
+        {
+            switch ( field )
+            {
+            case year:
+                year = assignment( field, year, value );
+                return this;
+            case ordinalDay:
+                ordinalDay = assignment( field, ordinalDay, value );
+                return this;
+            default:
+                throw new IllegalArgumentException( "Cannot assign " + field + " to ordinal date." );
+            }
+        }
+
+        @Override
+        <Result> Result build( Builder<Input,Result> builder )
+        {
+            return builder.constructOrdinalDate( year, ordinalDay );
+        }
+
+        @Override
+        <Result> Result selectTime( Input time, Builder<Input,Result> builder )
+        {
+            return builder.constructOrdinalDateWithSelectedTime( year, ordinalDay, time );
+        }
+
+        @Override
+        <Result> Result constructTime(
+                Builder<Input,Result> builder,
+                Input hour, Input minute, Input second, Input millisecond, Input microsecond, Input nanosecond )
+        {
+            return builder.constructOrdinalDateWithConstructedTime( year, ordinalDay,
+                    hour, minute, second, millisecond, microsecond, nanosecond );
+        }
+    }
+
+    private static <Input> Input assignment( Field field, Input oldValue, Input newValue )
+    {
+        if ( oldValue != null )
+        {
+            throw new IllegalArgumentException( "cannot re-assign " + field );
+        }
+        return newValue;
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/TemporalValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TemporalValue.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.storable;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.Temporal;
+import java.time.temporal.TemporalAdjuster;
+import java.time.temporal.TemporalAmount;
+import java.time.temporal.TemporalField;
+import java.time.temporal.TemporalQuery;
+import java.time.temporal.TemporalUnit;
+import java.time.temporal.ValueRange;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.neo4j.values.storable.NumberType.NO_NUMBER;
+
+public abstract class TemporalValue<T extends Temporal, V extends TemporalValue<T,V>>
+        extends ScalarValue implements Temporal
+{
+    TemporalValue()
+    {
+        // subclasses are confined to this package,
+        // but type-checking is valuable to be able to do outside
+        // (therefore the type itself is public)
+    }
+
+    private static final String DEFAULT_WHEN = "statement";
+
+    public abstract TemporalValue add( DurationValue duration );
+
+    public abstract TemporalValue sub( DurationValue duration );
+
+    abstract T temporal();
+
+    abstract V replacement( T temporal );
+
+    @Override
+    public final T asObjectCopy()
+    {
+        return temporal();
+    }
+
+    @Override
+    @SuppressWarnings( "unchecked" )
+    public final V with( TemporalAdjuster adjuster )
+    {
+        return replacement( (T) temporal().with( adjuster ) );
+    }
+
+    @Override
+    @SuppressWarnings( "unchecked" )
+    public final V plus( TemporalAmount amount )
+    {
+        return replacement( (T) temporal().plus( amount ) );
+    }
+
+    @Override
+    @SuppressWarnings( "unchecked" )
+    public final V minus( TemporalAmount amount )
+    {
+        return replacement( (T) temporal().minus( amount ) );
+    }
+
+    @Override
+    @SuppressWarnings( "unchecked" )
+    public final V minus( long amountToSubtract, TemporalUnit unit )
+    {
+        return replacement( (T) temporal().minus( amountToSubtract, unit ) );
+    }
+
+    @Override
+    public final boolean isSupported( TemporalUnit unit )
+    {
+        return temporal().isSupported( unit );
+    }
+
+    @Override
+    @SuppressWarnings( "unchecked" )
+    public final V with( TemporalField field, long newValue )
+    {
+        return replacement( (T) temporal().with( field, newValue ) );
+    }
+
+    @Override
+    @SuppressWarnings( "unchecked" )
+    public final V plus( long amountToAdd, TemporalUnit unit )
+    {
+        return replacement( (T) temporal().plus( amountToAdd, unit ) );
+    }
+
+    @Override
+    public final long until( Temporal endExclusive, TemporalUnit unit )
+    {
+        return temporal().until( endExclusive, unit );
+    }
+
+    @Override
+    public final ValueRange range( TemporalField field )
+    {
+        return temporal().range( field );
+    }
+
+    @Override
+    public final int get( TemporalField field )
+    {
+        return temporal().get( field );
+    }
+
+    @Override
+    public <R> R query( TemporalQuery<R> query )
+    {
+        return temporal().query( query );
+    }
+
+    @Override
+    public final boolean isSupported( TemporalField field )
+    {
+        return temporal().isSupported( field );
+    }
+
+    @Override
+    public final long getLong( TemporalField field )
+    {
+        return temporal().getLong( field );
+    }
+
+    @Override
+    public final NumberType numberType()
+    {
+        return NO_NUMBER;
+    }
+
+    @Override
+    public final String toString()
+    {
+        return getClass().getSimpleName() + "<" + prettyPrint() + ">";
+    }
+
+    @Override
+    public final boolean equals( boolean x )
+    {
+        return false;
+    }
+
+    @Override
+    public final boolean equals( long x )
+    {
+        return false;
+    }
+
+    @Override
+    public final boolean equals( double x )
+    {
+        return false;
+    }
+
+    @Override
+    public final boolean equals( char x )
+    {
+        return false;
+    }
+
+    @Override
+    public final boolean equals( String x )
+    {
+        return false;
+    }
+
+    static <VALUE> VALUE parse( Class<VALUE> type, Pattern pattern, Function<Matcher,VALUE> parser, CharSequence text )
+    {
+        Matcher matcher = pattern.matcher( text );
+        VALUE result = matcher.matches() ? parser.apply( matcher ) : null;
+        if ( result == null )
+        {
+            throw new DateTimeParseException(
+                    "Text cannot be parsed to a " + valueName( type ), text, 0 );
+        }
+        return result;
+    }
+
+    static <VALUE> VALUE parse( Class<VALUE> type, Pattern pattern, Function<Matcher,VALUE> parser, TextValue text )
+    {
+        Matcher matcher = text.matcher( pattern );
+        VALUE result = matcher != null && matcher.matches() ? parser.apply( matcher ) : null;
+        if ( result == null )
+        {
+            throw new DateTimeParseException(
+                    "Text cannot be parsed to a " + valueName( type ), text.stringValue(), 0 );
+        }
+        return result;
+    }
+
+    static <VALUE> VALUE parse(
+            Class<VALUE> type,
+            Pattern pattern,
+            BiFunction<Matcher,Supplier<ZoneId>,VALUE> parser,
+            CharSequence text,
+            Supplier<ZoneId> defaultZone )
+    {
+        Matcher matcher = pattern.matcher( text );
+        VALUE result = matcher.matches() ? parser.apply( matcher, defaultZone ) : null;
+        if ( result == null )
+        {
+            throw new DateTimeParseException(
+                    "Text cannot be parsed to a " + valueName( type ), text, 0 );
+        }
+        return result;
+    }
+
+    static <VALUE> VALUE parse(
+            Class<VALUE> type,
+            Pattern pattern,
+            BiFunction<Matcher,Supplier<ZoneId>,VALUE> parser,
+            TextValue text,
+            Supplier<ZoneId> defaultZone )
+    {
+        Matcher matcher = text.matcher( pattern );
+        VALUE result = matcher != null && matcher.matches() ? parser.apply( matcher, defaultZone ) : null;
+        if ( result == null )
+        {
+            throw new DateTimeParseException(
+                    "Text cannot be parsed to a " + valueName( type ), text.stringValue(), 0 );
+        }
+        return result;
+    }
+
+    private static <VALUE> String valueName( Class<VALUE> type )
+    {
+        String name = type.getSimpleName();
+        return name.substring( 0, name.length() - /*"Value" is*/5/*characters*/ );
+    }
+}

--- a/community/values/src/main/java/org/neo4j/values/storable/TemporalValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TemporalValue.java
@@ -39,6 +39,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.neo4j.values.AnyValue;
+import org.neo4j.values.StructureBuilder;
 
 import static org.neo4j.values.storable.DateTimeValue.parseZoneName;
 import static org.neo4j.values.storable.NumberType.NO_NUMBER;
@@ -259,7 +260,7 @@ public abstract class TemporalValue<T extends Temporal, V extends TemporalValue<
         return name.substring( 0, name.length() - /*"Value" is*/5/*characters*/ );
     }
 
-    abstract static class Builder<Input, Result> extends StructureBuilder<Input,Result>
+    abstract static class Builder<Input, Result> implements StructureBuilder<Input,Result>
     {
         private BuilderState<Input> state;
         private Input timezone;

--- a/community/values/src/main/java/org/neo4j/values/storable/TextArray.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TextArray.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.values.storable;
 
+import org.neo4j.values.ValueMapper;
+
 public abstract class TextArray extends ArrayValue
 {
     public abstract String stringValue( int offset );

--- a/community/values/src/main/java/org/neo4j/values/storable/TextValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TextValue.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.values.storable;
 
+import org.neo4j.values.ValueMapper;
 import org.neo4j.values.virtual.ListValue;
 
 import static org.neo4j.values.storable.Values.stringArray;
@@ -93,5 +94,11 @@ public abstract class TextValue extends ScalarValue
     public NumberType numberType()
     {
         return NumberType.NO_NUMBER;
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapText( this );
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/TextValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TextValue.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.values.storable;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.neo4j.values.ValueMapper;
 import org.neo4j.values.virtual.ListValue;
 
@@ -101,4 +104,6 @@ public abstract class TextValue extends ScalarValue
     {
         return mapper.mapText( this );
     }
+
+    abstract Matcher matcher( Pattern pattern );
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/TimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TimeValue.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.storable;
+
+import java.time.Instant;
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
+import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.neo4j.values.ValueMapper;
+
+import static java.lang.Integer.parseInt;
+import static java.time.ZoneOffset.UTC;
+import static java.util.Objects.requireNonNull;
+import static org.neo4j.values.storable.DurationValue.SECONDS_PER_DAY;
+import static org.neo4j.values.storable.LocalTimeValue.optInt;
+import static org.neo4j.values.storable.LocalTimeValue.parseTime;
+
+public final class TimeValue extends TemporalValue<OffsetTime,TimeValue>
+{
+    public static TimeValue time( OffsetTime time )
+    {
+        return new TimeValue( requireNonNull( time, "OffsetTime" ) );
+    }
+
+    public static TimeValue time( int hour, int minute, int second, int nanosOfSecond, ZoneOffset offset )
+    {
+        return new TimeValue( OffsetTime.of( hour, minute, second, nanosOfSecond, offset ) );
+    }
+
+    public static TimeValue time( long nanosOfDayUTC, ZoneOffset offset )
+    {
+        return new TimeValue( OffsetTime.ofInstant( Instant.ofEpochSecond( 0, nanosOfDayUTC ), offset ) );
+    }
+
+    public static TimeValue parse( CharSequence text, Supplier<ZoneId> defaultZone )
+    {
+        return parse( TimeValue.class, PATTERN, TimeValue::parse, text, defaultZone );
+    }
+
+    public static TimeValue parse( TextValue text, Supplier<ZoneId> defaultZone )
+    {
+        return parse( TimeValue.class, PATTERN, TimeValue::parse, text, defaultZone );
+    }
+
+    private final OffsetTime value;
+
+    private TimeValue( OffsetTime value )
+    {
+        this.value = value;
+    }
+
+    @Override
+    OffsetTime temporal()
+    {
+        return value;
+    }
+
+    @Override
+    public boolean equals( Value other )
+    {
+        // TODO: do we want equality to be this permissive?
+        // This means that time("14:30+0100") = time("15:30+0200")
+        return other instanceof TimeValue && value.isEqual( ((TimeValue) other).value );
+    }
+
+    @Override
+    public <E extends Exception> void writeTo( ValueWriter<E> writer ) throws E
+    {
+        throw new UnsupportedOperationException( "not implemented" );
+    }
+
+    @Override
+    public String prettyPrint()
+    {
+        return value.format( DateTimeFormatter.ISO_TIME );
+    }
+
+    @Override
+    public ValueGroup valueGroup()
+    {
+        return ValueGroup.ZONED_TIME;
+    }
+
+    @Override
+    protected int computeHash()
+    {
+        return Long.hashCode( value.toLocalTime().toNanoOfDay() - value.getOffset().getTotalSeconds() * 1000_000_000L );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapTime( this );
+    }
+
+    @Override
+    public TimeValue add( DurationValue duration )
+    {
+        return replacement( value.plusNanos( duration.nanosOfDay() ) );
+    }
+
+    @Override
+    public TimeValue sub( DurationValue duration )
+    {
+        return replacement( value.minusNanos( duration.nanosOfDay() ) );
+    }
+
+    @Override
+    TimeValue replacement( OffsetTime time )
+    {
+        return time == value ? this : new TimeValue( time );
+    }
+
+    private static final String OFFSET_PATTERN = "(?<zone>Z|[+-](?<zoneHour>[0-9]{2})(?::?(?<zoneMinute>[0-9]{2}))?)";
+    static final String TIME_PATTERN = LocalTimeValue.TIME_PATTERN + "(?:" + OFFSET_PATTERN + ")?";
+    private static final Pattern PATTERN = Pattern.compile( "(?:T)?" + TIME_PATTERN );
+
+    static ZoneOffset parseOffset( Matcher matcher )
+    {
+        String zone = matcher.group( "zone" );
+        if ( null == zone )
+        {
+            return null;
+        }
+        if ( "Z".equalsIgnoreCase( zone ) )
+        {
+            return UTC;
+        }
+        int factor = zone.charAt( 0 ) == '+' ? 1 : -1;
+        int hours = parseInt( matcher.group( "zoneHour" ) );
+        int minutes = optInt( matcher.group( "zoneMinute" ) );
+        return ZoneOffset.ofHoursMinutes( factor * hours, factor * minutes );
+    }
+
+    private static TimeValue parse( Matcher matcher, Supplier<ZoneId> defaultZone )
+    {
+        return new TimeValue( OffsetTime.of( parseTime( matcher ), zoneOffset( parseOffset( matcher, defaultZone ) ) ) );
+    }
+
+    private static ZoneId parseOffset( Matcher matcher, Supplier<ZoneId> defaultZone )
+    {
+        ZoneOffset offset = parseOffset( matcher );
+        return offset != null ? offset : defaultZone.get();
+    }
+
+    private static ZoneOffset zoneOffset( ZoneId zoneId )
+    {
+        return zoneId instanceof ZoneOffset ? (ZoneOffset) zoneId : zoneId.getRules().getOffset( Instant.now() );
+    }
+}

--- a/community/values/src/main/java/org/neo4j/values/storable/TimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TimeValue.java
@@ -89,7 +89,11 @@ public final class TimeValue extends TemporalValue<OffsetTime,TimeValue>
     @Override
     public <E extends Exception> void writeTo( ValueWriter<E> writer ) throws E
     {
-        throw new UnsupportedOperationException( "not implemented" );
+        int offset = value.getOffset().getTotalSeconds();
+        long seconds = value.getLong( ChronoField.SECOND_OF_DAY );
+        seconds = ((-offset % SECONDS_PER_DAY) + seconds + SECONDS_PER_DAY) % SECONDS_PER_DAY;
+        long nano = seconds * DurationValue.NANOS_PER_SECOND + value.getNano();
+        writer.writeTime( nano, offset );
     }
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/storable/TimeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/TimeValue.java
@@ -19,16 +19,21 @@
  */
 package org.neo4j.values.storable;
 
+import java.lang.invoke.MethodHandle;
+import java.time.Clock;
+import java.time.DateTimeException;
 import java.time.Instant;
 import java.time.OffsetTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoField;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.neo4j.values.AnyValue;
 import org.neo4j.values.ValueMapper;
 
 import static java.lang.Integer.parseInt;
@@ -63,6 +68,60 @@ public final class TimeValue extends TemporalValue<OffsetTime,TimeValue>
     public static TimeValue parse( TextValue text, Supplier<ZoneId> defaultZone )
     {
         return parse( TimeValue.class, PATTERN, TimeValue::parse, text, defaultZone );
+    }
+
+    public static StructureBuilder<AnyValue,TimeValue> builder( Supplier<ZoneId> defaultZone )
+    {
+        return new TimeBuilder<AnyValue,TimeValue>()
+        {
+            @Override
+            protected ZoneId timezone( AnyValue timezone )
+            {
+                return timezone == null ? defaultZone.get() : timezoneOf( timezone );
+            }
+
+            @Override
+            protected TimeValue selectTime( AnyValue temporal )
+            {
+                OffsetTime time = offsetTime( temporal );
+                return time != null ? time( time ) : null;
+            }
+
+            @Override
+            protected TimeValue constructTime(
+                    AnyValue hour,
+                    AnyValue minute,
+                    AnyValue second,
+                    AnyValue millisecond,
+                    AnyValue microsecond,
+                    AnyValue nanosecond )
+            {
+                throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            private OffsetTime offsetTime( AnyValue value )
+            {
+                if ( value instanceof TemporalValue )
+                {
+                    try
+                    {
+                        return OffsetTime.from( ((TemporalValue) value).temporal() );
+                    }
+                    catch ( DateTimeException e )
+                    {
+                        return null;
+                    }
+                }
+                else
+                {
+                    return null;
+                }
+            }
+        };
+    }
+
+    public abstract static class Compiler<Input> extends TimeBuilder<Input,MethodHandle>
+    {
     }
 
     private final OffsetTime value;
@@ -173,5 +232,168 @@ public final class TimeValue extends TemporalValue<OffsetTime,TimeValue>
     private static ZoneOffset zoneOffset( ZoneId zoneId )
     {
         return zoneId instanceof ZoneOffset ? (ZoneOffset) zoneId : zoneId.getRules().getOffset( Instant.now() );
+    }
+
+    abstract static class TimeBuilder<Input, Result> extends Builder<Input,Result>
+    {
+        @Override
+        protected final boolean supportsDate()
+        {
+            return false;
+        }
+
+        @Override
+        protected final boolean supportsTime()
+        {
+            return true;
+        }
+
+        @Override
+        protected Result selectDateTime( Input temporal )
+        {
+            throw new IllegalStateException( "date not supported" );
+        }
+
+        @Override
+        protected Result selectDateAndTime( Input date, Input time )
+        {
+            throw new IllegalStateException( "date not supported" );
+        }
+
+        @Override
+        protected Result selectDateWithConstructedTime(
+                Input date,
+                Input hour,
+                Input minute,
+                Input second,
+                Input millisecond,
+                Input microsecond,
+                Input nanosecond )
+        {
+            throw new IllegalStateException( "date not supported" );
+        }
+
+        @Override
+        protected Result selectDate( Input temporal )
+        {
+            throw new IllegalStateException( "date not supported" );
+        }
+
+        @Override
+        protected Result constructYear( Input year )
+        {
+            throw new IllegalStateException( "date not supported" );
+        }
+
+        @Override
+        protected Result constructCalendarDate( Input year, Input month, Input day )
+        {
+            throw new IllegalStateException( "date not supported" );
+        }
+
+        @Override
+        protected Result constructCalendarDateWithSelectedTime( Input year, Input month, Input day, Input time )
+        {
+            throw new IllegalStateException( "date not supported" );
+        }
+
+        @Override
+        protected Result constructCalendarDateWithConstructedTime(
+                Input year,
+                Input month,
+                Input day,
+                Input hour,
+                Input minute,
+                Input second,
+                Input millisecond,
+                Input microsecond,
+                Input nanosecond )
+        {
+            throw new IllegalStateException( "date not supported" );
+        }
+
+        @Override
+        protected Result constructWeekDate( Input year, Input week, Input dayOfWeek )
+        {
+            throw new IllegalStateException( "date not supported" );
+        }
+
+        @Override
+        protected Result constructWeekDateWithSelectedTime( Input year, Input week, Input dayOfWeek, Input time )
+        {
+            throw new IllegalStateException( "date not supported" );
+        }
+
+        @Override
+        protected Result constructWeekDateWithConstructedTime(
+                Input year,
+                Input week,
+                Input dayOfWeek,
+                Input hour,
+                Input minute,
+                Input second,
+                Input millisecond,
+                Input microsecond,
+                Input nanosecond )
+        {
+            throw new IllegalStateException( "date not supported" );
+        }
+
+        @Override
+        protected Result constructQuarterDate( Input year, Input quarter, Input dayOfQuarter )
+        {
+            throw new IllegalStateException( "date not supported" );
+        }
+
+        @Override
+        protected Result constructQuarterDateWithSelectedTime(
+                Input year,
+                Input quarter,
+                Input dayOfQuarter,
+                Input time )
+        {
+            throw new IllegalStateException( "date not supported" );
+        }
+
+        @Override
+        protected Result constructQuarterDateWithConstructedTime(
+                Input year,
+                Input quarter,
+                Input dayOfQuarter,
+                Input hour,
+                Input minute,
+                Input second,
+                Input millisecond,
+                Input microsecond,
+                Input nanosecond )
+        {
+            throw new IllegalStateException( "date not supported" );
+        }
+
+        @Override
+        protected Result constructOrdinalDate( Input year, Input ordinalDay )
+        {
+            throw new IllegalStateException( "date not supported" );
+        }
+
+        @Override
+        protected Result constructOrdinalDateWithSelectedTime( Input year, Input ordinalDay, Input time )
+        {
+            throw new IllegalStateException( "date not supported" );
+        }
+
+        @Override
+        protected Result constructOrdinalDateWithConstructedTime(
+                Input year,
+                Input ordinalDay,
+                Input hour,
+                Input minute,
+                Input second,
+                Input millisecond,
+                Input microsecond,
+                Input nanosecond )
+        {
+            throw new IllegalStateException( "date not supported" );
+        }
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/storable/UTF8StringValue.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/UTF8StringValue.java
@@ -20,6 +20,8 @@
 package org.neo4j.values.storable;
 
 import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /*
  * Just as a normal StringValue but is backed by a byte array and does string
@@ -362,6 +364,12 @@ public final class UTF8StringValue extends StringValue
         }
 
         return length() - other.length();
+    }
+
+    @Override
+    Matcher matcher( Pattern pattern )
+    {
+        return pattern.matcher( value() ); // TODO: can we do better here?
     }
 
     private int codePointAt( byte[] bytes, int i )

--- a/community/values/src/main/java/org/neo4j/values/storable/ValueWriter.java
+++ b/community/values/src/main/java/org/neo4j/values/storable/ValueWriter.java
@@ -30,7 +30,6 @@ import java.nio.charset.StandardCharsets;
  */
 public interface ValueWriter<E extends Exception>
 {
-
     enum ArrayType
     {
         BYTE,
@@ -77,6 +76,20 @@ public interface ValueWriter<E extends Exception>
     void writeByteArray( byte[] value ) throws E;
 
     void writePoint( CoordinateReferenceSystem crs, double[] coordinate ) throws E;
+
+    void writeDuration( long months, long days, long seconds, int nanos ) throws E;
+
+    void writeDate( long epochDay ) throws E;
+
+    void writeLocalTime( long nanoOfDay ) throws E;
+
+    void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws E;
+
+    void writeLocalDateTime( long epochSecond, int nano ) throws E;
+
+    void writeDateTime( long epochSecondUTC, int nano, int offsetSeconds ) throws E;
+
+    void writeDateTime( long epochSecondUTC, int nano, String zoneId ) throws E;
 
     class Adapter<E extends Exception> implements ValueWriter<E>
     {
@@ -147,6 +160,41 @@ public interface ValueWriter<E extends Exception>
 
         @Override
         public void writePoint( CoordinateReferenceSystem crs, double[] coordinate ) throws E
+        {   // no-op
+        }
+
+        @Override
+        public void writeDuration( long months, long days, long seconds, int nanos )
+        {   // no-op
+        }
+
+        @Override
+        public void writeDate( long epochDay ) throws E
+        {   // no-op
+        }
+
+        @Override
+        public void writeLocalTime( long nanoOfDay ) throws E
+        {   // no-op
+        }
+
+        @Override
+        public void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws E
+        {   // no-op
+        }
+
+        @Override
+        public void writeLocalDateTime( long epochSecond, int nano ) throws E
+        {   // no-op
+        }
+
+        @Override
+        public void writeDateTime( long epochSecondUTC, int nano, int offsetSeconds ) throws E
+        {   // no-op
+        }
+
+        @Override
+        public void writeDateTime( long epochSecondUTC, int nano, String zoneId ) throws E
         {   // no-op
         }
     }

--- a/community/values/src/main/java/org/neo4j/values/utils/PrettyPrinter.java
+++ b/community/values/src/main/java/org/neo4j/values/utils/PrettyPrinter.java
@@ -165,6 +165,80 @@ public class PrettyPrinter implements AnyValueWriter<RuntimeException>
     }
 
     @Override
+    public void writeDuration( long months, long days, long seconds, int nanos ) throws RuntimeException
+    {
+        append( "{duration: {months: " );
+        append( Long.toString( months ) );
+        append( ", days: " );
+        append( Long.toString( days ) );
+        append( ", seconds: " );
+        append( Long.toString( seconds ) );
+        append( ", nanos: " );
+        append( Long.toString( nanos ) );
+        append( "}}" );
+    }
+
+    @Override
+    public void writeDate( long epochDay ) throws RuntimeException
+    {
+        append( "{date: {epochDay: " );
+        append( Long.toString( epochDay ) );
+        append( "}}" );
+    }
+
+    @Override
+    public void writeLocalTime( long nanoOfDay ) throws RuntimeException
+    {
+        append( "{localTime: {nanosOfDay: " );
+        append( Long.toString( nanoOfDay ) );
+        append( "}}" );
+    }
+
+    @Override
+    public void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws RuntimeException
+    {
+        append( "{time: {nanosOfDay: " );
+        append( Long.toString( nanosOfDayUTC ) );
+        append( ", offsetSeconds: " );
+        append( Long.toString( offsetSeconds ) );
+        append( "}}" );
+    }
+
+    @Override
+    public void writeLocalDateTime( long epochSecond, int nano ) throws RuntimeException
+    {
+        append( "{localDateTime: {epochDay: " );
+        append( Long.toString( epochSecond ) );
+        append( ", nanosOfDay: " );
+        append( Long.toString( nano ) );
+        append( "}}" );
+    }
+
+    @Override
+    public void writeDateTime( long epochSecondUTC, int nano, int offsetSeconds ) throws RuntimeException
+    {
+        append( "{datetime: {epochDay: " );
+        append( Long.toString( epochSecondUTC ) );
+        append( ", nanosOfDay: " );
+        append( Long.toString( nano ) );
+        append( ", offsetSeconds: " );
+        append( Long.toString( offsetSeconds ) );
+        append( "}}" );
+    }
+
+    @Override
+    public void writeDateTime( long epochSecondUTC, int nano, String zoneId ) throws RuntimeException
+    {
+        append( "{datetime: {epochDay: " );
+        append( Long.toString( epochSecondUTC ) );
+        append( ", nanosOfDay: " );
+        append( Long.toString( nano ) );
+        append( ", timezone: \"" );
+        append( zoneId );
+        append( "\"}}" );
+    }
+
+    @Override
     public void writeNull()
     {
         append( "<null>" );

--- a/community/values/src/main/java/org/neo4j/values/virtual/ListValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/ListValue.java
@@ -29,6 +29,7 @@ import java.util.function.Function;
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.AnyValueWriter;
 import org.neo4j.values.SequenceValue;
+import org.neo4j.values.ValueMapper;
 import org.neo4j.values.VirtualValue;
 import org.neo4j.values.storable.ArrayValue;
 import org.neo4j.values.storable.Values;
@@ -86,6 +87,12 @@ public abstract class ListValue extends VirtualValue implements SequenceValue, I
     public boolean isSequenceValue()
     {
         return true;
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapSequence( this );
     }
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/virtual/MapValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/MapValue.java
@@ -27,6 +27,7 @@ import java.util.function.BiConsumer;
 
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.AnyValueWriter;
+import org.neo4j.values.ValueMapper;
 import org.neo4j.values.VirtualValue;
 import org.neo4j.values.storable.Values;
 
@@ -164,6 +165,12 @@ public final class MapValue extends VirtualValue
             }
         }
         return equalityResult;
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapMap( this );
     }
 
     public void foreach( BiConsumer<String,AnyValue> f )

--- a/community/values/src/main/java/org/neo4j/values/virtual/MapValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/MapValue.java
@@ -73,8 +73,13 @@ public final class MapValue extends VirtualValue
 
     public ListValue keys()
     {
-        String[] strings = map.keySet().toArray( new String[map.size()] );
+        String[] strings = keySet().toArray( new String[map.size()] );
         return VirtualValues.fromArray( Values.stringArray( strings ) );
+    }
+
+    public Set<String> keySet()
+    {
+        return map.keySet();
     }
 
     @Override
@@ -95,7 +100,7 @@ public final class MapValue extends VirtualValue
         int compare = Integer.compare( size(), otherMap.size() );
         if ( compare == 0 )
         {
-            String[] thisKeys = map.keySet().toArray( new String[size] );
+            String[] thisKeys = keySet().toArray( new String[size] );
             Arrays.sort( thisKeys, String::compareTo );
             String[] thatKeys = otherMap.keySet().toArray( new String[size] );
             Arrays.sort( thatKeys, String::compareTo );
@@ -138,7 +143,7 @@ public final class MapValue extends VirtualValue
         {
             return false;
         }
-        String[] thisKeys = map.keySet().toArray( new String[size] );
+        String[] thisKeys = keySet().toArray( new String[size] );
         Arrays.sort( thisKeys, String::compareTo );
         String[] thatKeys = otherMap.keySet().toArray( new String[size] );
         Arrays.sort( thatKeys, String::compareTo );

--- a/community/values/src/main/java/org/neo4j/values/virtual/PathValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/PathValue.java
@@ -24,6 +24,7 @@ import java.util.Comparator;
 
 import org.neo4j.values.AnyValue;
 import org.neo4j.values.AnyValueWriter;
+import org.neo4j.values.ValueMapper;
 import org.neo4j.values.VirtualValue;
 
 public final class PathValue extends VirtualValue
@@ -86,6 +87,12 @@ public final class PathValue extends VirtualValue
     public <E extends Exception> void writeTo( AnyValueWriter<E> writer ) throws E
     {
         writer.writePath( nodes, relationships );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapPath( this );
     }
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/virtual/VirtualNodeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/VirtualNodeValue.java
@@ -23,6 +23,7 @@ package org.neo4j.values.virtual;
 import java.util.Comparator;
 
 import org.neo4j.values.AnyValue;
+import org.neo4j.values.ValueMapper;
 import org.neo4j.values.VirtualValue;
 
 public abstract class VirtualNodeValue extends VirtualValue
@@ -45,6 +46,12 @@ public abstract class VirtualNodeValue extends VirtualValue
     public int computeHash()
     {
         return Long.hashCode( id() );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapNode( this );
     }
 
     @Override

--- a/community/values/src/main/java/org/neo4j/values/virtual/VirtualRelationshipValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/VirtualRelationshipValue.java
@@ -23,6 +23,7 @@ package org.neo4j.values.virtual;
 import java.util.Comparator;
 
 import org.neo4j.values.AnyValue;
+import org.neo4j.values.ValueMapper;
 import org.neo4j.values.VirtualValue;
 
 public abstract class VirtualRelationshipValue extends VirtualValue
@@ -45,6 +46,12 @@ public abstract class VirtualRelationshipValue extends VirtualValue
     public int computeHash()
     {
         return Long.hashCode( id() );
+    }
+
+    @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        return mapper.mapRelationship( this );
     }
 
     @Override

--- a/community/values/src/test/java/org/neo4j/values/MyVirtualValue.java
+++ b/community/values/src/test/java/org/neo4j/values/MyVirtualValue.java
@@ -57,6 +57,12 @@ public class MyVirtualValue extends VirtualValue
     }
 
     @Override
+    public <T> T map( ValueMapper<T> mapper )
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void writeTo( AnyValueWriter writer )
     {
     }

--- a/community/values/src/test/java/org/neo4j/values/ValueMapperTest.java
+++ b/community/values/src/test/java/org/neo4j/values/ValueMapperTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.neo4j.graphdb.spatial.Point;
+import org.neo4j.values.storable.Value;
+import org.neo4j.values.storable.Values;
+import org.neo4j.values.virtual.NodeValue;
+import org.neo4j.values.virtual.PathValue;
+import org.neo4j.values.virtual.RelationshipValue;
+import org.neo4j.values.virtual.VirtualNodeValue;
+import org.neo4j.values.virtual.VirtualRelationshipValue;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.values.storable.CoordinateReferenceSystem.Cartesian;
+import static org.neo4j.values.storable.CoordinateReferenceSystem.WGS84;
+import static org.neo4j.values.storable.Values.NO_VALUE;
+import static org.neo4j.values.storable.Values.booleanArray;
+import static org.neo4j.values.storable.Values.booleanValue;
+import static org.neo4j.values.storable.Values.byteArray;
+import static org.neo4j.values.storable.Values.byteValue;
+import static org.neo4j.values.storable.Values.charArray;
+import static org.neo4j.values.storable.Values.charValue;
+import static org.neo4j.values.storable.Values.doubleArray;
+import static org.neo4j.values.storable.Values.doubleValue;
+import static org.neo4j.values.storable.Values.floatArray;
+import static org.neo4j.values.storable.Values.floatValue;
+import static org.neo4j.values.storable.Values.intArray;
+import static org.neo4j.values.storable.Values.intValue;
+import static org.neo4j.values.storable.Values.longArray;
+import static org.neo4j.values.storable.Values.longValue;
+import static org.neo4j.values.storable.Values.numberValue;
+import static org.neo4j.values.storable.Values.pointArray;
+import static org.neo4j.values.storable.Values.pointValue;
+import static org.neo4j.values.storable.Values.shortArray;
+import static org.neo4j.values.storable.Values.shortValue;
+import static org.neo4j.values.storable.Values.stringArray;
+import static org.neo4j.values.storable.Values.stringValue;
+import static org.neo4j.values.virtual.VirtualValues.emptyMap;
+import static org.neo4j.values.virtual.VirtualValues.fromList;
+import static org.neo4j.values.virtual.VirtualValues.list;
+import static org.neo4j.values.virtual.VirtualValues.map;
+import static org.neo4j.values.virtual.VirtualValues.nodeValue;
+import static org.neo4j.values.virtual.VirtualValues.path;
+import static org.neo4j.values.virtual.VirtualValues.relationshipValue;
+
+@RunWith( Parameterized.class )
+public class ValueMapperTest
+{
+    @Parameterized.Parameters( name = "{0}" )
+    public static Iterable<Object[]> parameters()
+    {
+        NodeValue node1 = nodeValue( 1, stringArray(), emptyMap() );
+        NodeValue node2 = nodeValue( 2, stringArray(), emptyMap() );
+        NodeValue node3 = nodeValue( 3, stringArray(), emptyMap() );
+        RelationshipValue relationship1 = relationshipValue( 100, node1, node2, stringValue( "ONE" ), emptyMap() );
+        RelationshipValue relationship2 = relationshipValue( 200, node2, node2, stringValue( "TWO" ), emptyMap() );
+        return Arrays.asList(
+                new Object[] {node1},
+                new Object[] {relationship1},
+                new Object[] {
+                        path(
+                                new NodeValue[] {node1, node2, node3},
+                                new RelationshipValue[] {relationship1, relationship2} )},
+                new Object[] {
+                        map(
+                                new String[] {"alpha", "beta"},
+                                new AnyValue[] {stringValue( "one" ), numberValue( 2 )} )},
+                new Object[] {NO_VALUE},
+                new Object[] {list( numberValue( 1 ), stringValue( "fine" ), node2 )},
+                new Object[] {stringValue( "hello world" )},
+                new Object[] {stringArray( "hello", "brave", "new", "world" )},
+                new Object[] {booleanValue( false )},
+                new Object[] {booleanArray( new boolean[] {true, false, true} )},
+                new Object[] {charValue( '\n' )},
+                new Object[] {charArray( new char[] {'h', 'e', 'l', 'l', 'o'} )},
+                new Object[] {byteValue( (byte) 3 )},
+                new Object[] {byteArray( new byte[] {0x00, (byte) 0x99, (byte) 0xcc} )},
+                new Object[] {shortValue( (short) 42 )},
+                new Object[] {shortArray( new short[] {1337, (short) 0xcafe, (short) 0xbabe} )},
+                new Object[] {intValue( 987654321 )},
+                new Object[] {intArray( new int[] {42, 11} )},
+                new Object[] {longValue( 9876543210L )},
+                new Object[] {longArray( new long[] {0xcafebabe, 0x1ee7} )},
+                new Object[] {floatValue( Float.MAX_VALUE )},
+                new Object[] {floatArray( new float[] {Float.NEGATIVE_INFINITY, Float.MIN_VALUE} )},
+                new Object[] {doubleValue( Double.MIN_NORMAL )},
+                new Object[] {doubleArray( new double[] {Double.POSITIVE_INFINITY, Double.MAX_VALUE} )},
+                new Object[] {pointValue( Cartesian, 11, 32 )},
+                new Object[] {
+                        pointArray( new Point[] {pointValue( Cartesian, 11, 32 ), pointValue( WGS84, 13, 56 )} )} );
+    }
+
+    private final AnyValue value;
+
+    public ValueMapperTest( AnyValue value )
+    {
+        this.value = value;
+    }
+
+    @Test
+    public void shouldMapToJavaObject() throws Exception
+    {
+        // given
+        ValueMapper<Object> mapper = new Mapper();
+
+        // when
+        Object mapped = value.map( mapper );
+
+        // then
+        assertEquals( value, valueOf( mapped ) );
+    }
+
+    private static AnyValue valueOf( Object obj )
+    {
+        if ( obj instanceof MappedGraphType )
+        {
+            return ((MappedGraphType) obj).value;
+        }
+        Value value = Values.unsafeOf( obj, true );
+        if ( value != null )
+        {
+            return value;
+        }
+        if ( obj instanceof List<?> )
+        {
+            return fromList( ((List<?>) obj).stream().map( ValueMapperTest::valueOf ).collect( toList() ) );
+        }
+        if ( obj instanceof Map<?,?> )
+        {
+            @SuppressWarnings( "unchecked" )
+            Map<String,?> map = (Map<String,?>) obj;
+            return map( map.entrySet().stream()
+                    .map( e -> new Entry( e.getKey(), valueOf( e.getValue() ) ) )
+                    .collect( toMap( e -> e.key, e -> e.value ) ) );
+        }
+        throw new AssertionError( "cannot convert: " + obj + " (a " + obj.getClass().getName() + ")" );
+    }
+
+    private static class Mapper extends ValueMapper.JavaMapper
+    {
+        @Override
+        public Object mapPath( PathValue value )
+        {
+            return new MappedGraphType( value );
+        }
+
+        @Override
+        public Object mapNode( VirtualNodeValue value )
+        {
+            return new MappedGraphType( value );
+        }
+
+        @Override
+        public Object mapRelationship( VirtualRelationshipValue value )
+        {
+            return new MappedGraphType( value );
+        }
+    }
+
+    private static class MappedGraphType
+    {
+        private final VirtualValue value;
+
+        MappedGraphType( VirtualValue value )
+        {
+
+            this.value = value;
+        }
+    }
+
+    private static class Entry
+    {
+        final String key;
+        final AnyValue value;
+
+        private Entry( String key, AnyValue value )
+        {
+            this.key = key;
+            this.value = value;
+        }
+    }
+}

--- a/community/values/src/test/java/org/neo4j/values/ValueMapperTest.java
+++ b/community/values/src/test/java/org/neo4j/values/ValueMapperTest.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.values;
 
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +43,12 @@ import static java.util.stream.Collectors.toMap;
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.values.storable.CoordinateReferenceSystem.Cartesian;
 import static org.neo4j.values.storable.CoordinateReferenceSystem.WGS84;
+import static org.neo4j.values.storable.DateTimeValue.datetime;
+import static org.neo4j.values.storable.DateValue.date;
+import static org.neo4j.values.storable.DurationValue.duration;
+import static org.neo4j.values.storable.LocalDateTimeValue.localDateTime;
+import static org.neo4j.values.storable.LocalTimeValue.localTime;
+import static org.neo4j.values.storable.TimeValue.time;
 import static org.neo4j.values.storable.Values.NO_VALUE;
 import static org.neo4j.values.storable.Values.booleanArray;
 import static org.neo4j.values.storable.Values.booleanValue;
@@ -113,6 +121,12 @@ public class ValueMapperTest
                 new Object[] {floatArray( new float[] {Float.NEGATIVE_INFINITY, Float.MIN_VALUE} )},
                 new Object[] {doubleValue( Double.MIN_NORMAL )},
                 new Object[] {doubleArray( new double[] {Double.POSITIVE_INFINITY, Double.MAX_VALUE} )},
+                new Object[] {datetime( 2018, 1, 16, 10, 36, 43, 123456788, ZoneId.of( "Europe/Stockholm" ) )},
+                new Object[] {localDateTime( 2018, 1, 16, 10, 36, 43, 123456788 )},
+                new Object[] {date( 2018, 1, 16 )},
+                new Object[] {time( 10, 36, 43, 123456788, ZoneOffset.ofHours( 1 ) )},
+                new Object[] {localTime( 10, 36, 43, 123456788 )},
+                new Object[] {duration( 399, 4, 48424, 133701337 )},
                 new Object[] {pointValue( Cartesian, 11, 32 )},
                 new Object[] {
                         pointArray( new Point[] {pointValue( Cartesian, 11, 32 ), pointValue( WGS84, 13, 56 )} )} );

--- a/community/values/src/test/java/org/neo4j/values/storable/AssertingStructureBuilder.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/AssertingStructureBuilder.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.storable;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public final class AssertingStructureBuilder<Input, Result> extends StructureBuilder<Input,Result>
+{
+    public static <I, O> AssertingStructureBuilder<I,O> asserting( StructureBuilder<I,O> builder )
+    {
+        return new AssertingStructureBuilder<>( builder );
+    }
+
+    public static Matcher<Exception> exception( Class<? extends Exception> type, String message )
+    {
+        return exception( type, equalTo( message ) );
+    }
+
+    public static Matcher<Exception> exception( Class<? extends Exception> type, Matcher<String> message )
+    {
+        return new TypeSafeMatcher<Exception>( type )
+        {
+            @Override
+            protected boolean matchesSafely( Exception item )
+            {
+                return message.matches( item.getMessage() );
+            }
+
+            @Override
+            public void describeTo( Description description )
+            {
+                description.appendText( "Exception of type " ).appendValue( type.getName() )
+                        .appendText( " with message " ).appendDescriptionOf( message );
+            }
+        };
+    }
+
+    private final Map<String,Input> input = new LinkedHashMap<>();
+    private final StructureBuilder<Input,Result> builder;
+
+    private AssertingStructureBuilder( StructureBuilder<Input,Result> builder )
+    {
+        this.builder = builder;
+    }
+
+    public void assertThrows( Class<? extends Exception> type, String message )
+    {
+        assertThrows( exception( type, message ) );
+    }
+
+    public void assertThrows( Class<? extends Exception> type, Matcher<String> message )
+    {
+        assertThrows( exception( type, message ) );
+    }
+
+    public void assertThrows( Matcher<Exception> matches )
+    {
+        try
+        {
+            for ( Map.Entry<String,Input> entry : input.entrySet() )
+            {
+                builder.add( entry.getKey(), entry.getValue() );
+            }
+            builder.build();
+        }
+        catch ( Exception expected )
+        {
+            assertThat( expected, matches );
+            return;
+        }
+        fail( "expected exception" );
+    }
+
+    @Override
+    public AssertingStructureBuilder<Input,Result> add( String field, Input value )
+    {
+        input.put( field, value );
+        return this;
+    }
+
+    @Override
+    public Result build()
+    {
+        throw new UnsupportedOperationException( "do not use this method" );
+    }
+}

--- a/community/values/src/test/java/org/neo4j/values/storable/AssertingStructureBuilder.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/AssertingStructureBuilder.java
@@ -26,11 +26,13 @@ import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
+import org.neo4j.values.StructureBuilder;
+
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
-public final class AssertingStructureBuilder<Input, Result> extends StructureBuilder<Input,Result>
+public final class AssertingStructureBuilder<Input, Result> implements StructureBuilder<Input,Result>
 {
     public static <I, O> AssertingStructureBuilder<I,O> asserting( StructureBuilder<I,O> builder )
     {

--- a/community/values/src/test/java/org/neo4j/values/storable/BufferValueWriter.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/BufferValueWriter.java
@@ -21,6 +21,8 @@ package org.neo4j.values.storable;
 
 import org.hamcrest.Matchers;
 
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -173,6 +175,48 @@ public class BufferValueWriter implements ValueWriter<RuntimeException>
     public void writeByteArray( byte[] value ) throws RuntimeException
     {
         buffer.add( Specials.byteArray( value ) );
+    }
+
+    @Override
+    public void writeDuration( long months, long days, long seconds, int nanos )
+    {
+        buffer.add( DurationValue.duration( months, days, seconds, nanos ) );
+    }
+
+    @Override
+    public void writeDate( long epochDay ) throws RuntimeException
+    {
+        buffer.add( DateValue.epochDate( epochDay ) );
+    }
+
+    @Override
+    public void writeLocalTime( long nanoOfDay ) throws RuntimeException
+    {
+        buffer.add( LocalTimeValue.localTime( nanoOfDay ) );
+    }
+
+    @Override
+    public void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws RuntimeException
+    {
+        buffer.add( TimeValue.time( nanosOfDayUTC, ZoneOffset.ofTotalSeconds( offsetSeconds ) ) );
+    }
+
+    @Override
+    public void writeLocalDateTime( long epochSecond, int nano ) throws RuntimeException
+    {
+        buffer.add( LocalDateTimeValue.localDateTime( epochSecond, nano ) );
+    }
+
+    @Override
+    public void writeDateTime( long epochSecondUTC, int nano, int offsetSeconds ) throws RuntimeException
+    {
+        buffer.add( DateTimeValue.datetime( epochSecondUTC, nano, ZoneOffset.ofTotalSeconds( offsetSeconds ) ) );
+    }
+
+    @Override
+    public void writeDateTime( long epochSecondUTC, int nano, String zoneId ) throws RuntimeException
+    {
+        buffer.add( DateTimeValue.datetime( epochSecondUTC, nano, ZoneId.of( zoneId ) ) );
     }
 
     @SuppressWarnings( "WeakerAccess" )

--- a/community/values/src/test/java/org/neo4j/values/storable/DateTimeValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DateTimeValueTest.java
@@ -259,8 +259,8 @@ public class DateTimeValueTest
                 .add( "minute", 5 )
                 .add( "second", 5 )
                 .add( "millisecond", 1 )
-                .add( "nanosecond", 1 )
-                .assertThrows( IllegalArgumentException.class, "Cannot assign ..." );
+                .add( "nanosecond", 1000 )
+                .assertThrows( IllegalArgumentException.class, "Invalid nanosecond: 1000" );
     }
 
     @Test

--- a/community/values/src/test/java/org/neo4j/values/storable/DateTimeValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DateTimeValueTest.java
@@ -283,8 +283,6 @@ public class DateTimeValueTest
                 datetime( date( 2018, 2, 28 ), time( 0, 0, 0, 0, UTC ) ).add( DurationValue.duration( -1, 0, 0, 0 ) ) );
     }
 
-
-
     @Test
     public void shouldReuseInstanceInArithmetics() throws Exception
     {

--- a/community/values/src/test/java/org/neo4j/values/storable/DateTimeValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DateTimeValueTest.java
@@ -196,7 +196,7 @@ public class DateTimeValueTest
         assertEqualTemporal(
                 datetime( ZonedDateTime.now( clock ) ),
                 builder( clock ).add( "datetime", datetime( ZonedDateTime.now( clock ) ) ).build() );
-        assertEqualTemporal( // TODO: change some stuff here...
+        assertEqualTemporal(
                 datetime( ZonedDateTime.now( clock ) ),
                 builder( clock )
                         .add( "datetime", localDateTime( LocalDateTime.now( clock ) ) )
@@ -222,6 +222,89 @@ public class DateTimeValueTest
                         .add( "hour", 10 )
                         .add( "minute", 35 )
                         .add( "second", 57 )
+                        .build() );
+        assertEqualTemporal(
+                parse( "2018-01-10T10:35:57.999999999", clock::getZone ),
+                fromValues( builder( clock ) )
+                        .add( "year", 2018 )
+                        .add( "month", 1 )
+                        .add( "day", 10 )
+                        .add( "hour", 10 )
+                        .add( "minute", 35 )
+                        .add( "second", 57 )
+                        .add( "nanosecond", 999999999 )
+                        .build() );
+        assertEqualTemporal(
+                parse( "2018-01-10T10:35:57.999999", clock::getZone ),
+                fromValues( builder( clock ) )
+                        .add( "year", 2018 )
+                        .add( "month", 1 )
+                        .add( "day", 10 )
+                        .add( "hour", 10 )
+                        .add( "minute", 35 )
+                        .add( "second", 57 )
+                        .add( "microsecond", 999999 )
+                        .build() );
+        assertEqualTemporal(
+                parse( "2018-01-10T10:35:57.999", clock::getZone ),
+                fromValues( builder( clock ) )
+                        .add( "year", 2018 )
+                        .add( "month", 1 )
+                        .add( "day", 10 )
+                        .add( "hour", 10 )
+                        .add( "minute", 35 )
+                        .add( "second", 57 )
+                        .add( "millisecond", 999 )
+                        .build() );
+        assertEqualTemporal(
+                parse( "2018-01-10T10:35:57.001999999", clock::getZone ),
+                fromValues( builder( clock ) )
+                        .add( "year", 2018 )
+                        .add( "month", 1 )
+                        .add( "day", 10 )
+                        .add( "hour", 10 )
+                        .add( "minute", 35 )
+                        .add( "second", 57 )
+                        .add( "millisecond", 1 )
+                        .add( "microsecond", 999 )
+                        .add( "nanosecond", 999 )
+                        .build() );
+        assertEqualTemporal(
+                parse( "2018-01-10T10:35:57.000001999", clock::getZone ),
+                fromValues( builder( clock ) )
+                        .add( "year", 2018 )
+                        .add( "month", 1 )
+                        .add( "day", 10 )
+                        .add( "hour", 10 )
+                        .add( "minute", 35 )
+                        .add( "second", 57 )
+                        .add( "microsecond", 1 )
+                        .add( "nanosecond", 999 )
+                        .build() );
+        assertEqualTemporal(
+                parse( "2018-01-10T10:35:57.001999", clock::getZone ),
+                fromValues( builder( clock ) )
+                        .add( "year", 2018 )
+                        .add( "month", 1 )
+                        .add( "day", 10 )
+                        .add( "hour", 10 )
+                        .add( "minute", 35 )
+                        .add( "second", 57 )
+                        .add( "millisecond", 1 )
+                        .add( "microsecond", 999 )
+                        .build() );
+        assertEqualTemporal(
+                parse( "2018-01-10T10:35:57.001999999", clock::getZone ),
+                fromValues( builder( clock ) )
+                        .add( "year", 2018 )
+                        .add( "month", 1 )
+                        .add( "day", 10 )
+                        .add( "hour", 10 )
+                        .add( "minute", 35 )
+                        .add( "second", 57 )
+                        .add( "millisecond", 1 )
+                        .add( "microsecond", 999 )
+                        .add( "nanosecond", 999 )
                         .build() );
     }
 
@@ -253,12 +336,81 @@ public class DateTimeValueTest
                 .assertThrows( IllegalArgumentException.class, "Cannot assign dayOfWeek to ordinal date." );
         asserting( fromValues( builder( clock ) ) )
                 .add( "year", 2018 )
-                .add( "month", 12 )
-                .add( "day", 5 )
-                .add( "hour", 5 )
-                .add( "minute", 5 )
-                .add( "second", 5 )
+                .add( "month", 1 )
+                .add( "day", 10 )
+                .add( "hour", 10 )
+                .add( "minute", 35 )
+                .add( "second", 57 )
+                .add( "nanosecond", 1000000000 )
+                .assertThrows( IllegalArgumentException.class, "Invalid nanosecond: 1000000000" );
+        asserting( fromValues( builder( clock ) ))
+                .add( "year", 2018 )
+                .add( "month", 1 )
+                .add( "day", 10 )
+                .add( "hour", 10 )
+                .add( "minute", 35 )
+                .add( "second", 57 )
+                .add( "microsecond", 1000000 )
+                .assertThrows( IllegalArgumentException.class, "Invalid microsecond: 1000000" );
+        asserting( fromValues( builder( clock ) ))
+                .add( "year", 2018 )
+                .add( "month", 1 )
+                .add( "day", 10 )
+                .add( "hour", 10 )
+                .add( "minute", 35 )
+                .add( "second", 57 )
+                .add( "millisecond", 1000 )
+                .assertThrows( IllegalArgumentException.class, "Invalid millisecond: 1000" );
+        asserting( fromValues( builder( clock ) ))
+                .add( "year", 2018 )
+                .add( "month", 1 )
+                .add( "day", 10 )
+                .add( "hour", 10 )
+                .add( "minute", 35 )
+                .add( "second", 57 )
                 .add( "millisecond", 1 )
+                .add( "nanosecond", 1000000 )
+                .assertThrows( IllegalArgumentException.class, "Invalid nanosecond: 1000000" );
+        asserting( fromValues( builder( clock ) ))
+                .add( "year", 2018 )
+                .add( "month", 1 )
+                .add( "day", 10 )
+                .add( "hour", 10 )
+                .add( "minute", 35 )
+                .add( "second", 57 )
+                .add( "microsecond", 1 )
+                .add( "nanosecond", 1000 )
+                .assertThrows( IllegalArgumentException.class, "Invalid nanosecond: 1000" );
+        asserting( fromValues( builder( clock ) ))
+                .add( "year", 2018 )
+                .add( "month", 1 )
+                .add( "day", 10 )
+                .add( "hour", 10 )
+                .add( "minute", 35 )
+                .add( "second", 57 )
+                .add( "millisecond", 1 )
+                .add( "microsecond", 1000 )
+                .assertThrows( IllegalArgumentException.class, "Invalid microsecond: 1000" );
+        asserting( fromValues( builder( clock ) ))
+                .add( "year", 2018 )
+                .add( "month", 1 )
+                .add( "day", 10 )
+                .add( "hour", 10 )
+                .add( "minute", 35 )
+                .add( "second", 57 )
+                .add( "millisecond", 1 )
+                .add( "microsecond", 1000 )
+                .add( "nanosecond", 999 )
+                .assertThrows( IllegalArgumentException.class, "Invalid microsecond: 1000" );
+        asserting( fromValues( builder( clock ) ))
+                .add( "year", 2018 )
+                .add( "month", 1 )
+                .add( "day", 10 )
+                .add( "hour", 10 )
+                .add( "minute", 35 )
+                .add( "second", 57 )
+                .add( "millisecond", 1 )
+                .add( "microsecond", 999 )
                 .add( "nanosecond", 1000 )
                 .assertThrows( IllegalArgumentException.class, "Invalid nanosecond: 1000" );
     }

--- a/community/values/src/test/java/org/neo4j/values/storable/DateTimeValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DateTimeValueTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.storable;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import static java.time.ZoneOffset.UTC;
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.values.storable.DateTimeValue.datetime;
+import static org.neo4j.values.storable.DateTimeValue.parse;
+import static org.neo4j.values.storable.DateValue.date;
+import static org.neo4j.values.storable.TimeValue.time;
+import static org.neo4j.values.storable.TimeValueTest.inUTC;
+import static org.neo4j.values.storable.TimeValueTest.orFail;
+
+public class DateTimeValueTest
+{
+    @Rule
+    public final FrozenClockRule clock = new FrozenClockRule();
+
+    @Test
+    public void shouldParseDateTime() throws Exception
+    {
+        assertEquals(
+                datetime( date( 2017, 12, 17 ), time( 17, 14, 35, 123456789, UTC ) ),
+                parse( "2017-12-17T17:14:35.123456789", inUTC ) );
+        assertEquals(
+                datetime( date( 2017, 12, 17 ), time( 17, 14, 35, 123456789, UTC ) ),
+                parse( "2017-12-17T17:14:35.123456789Z", orFail ) );
+        assertEquals(
+                datetime( date( 2017, 12, 17 ), time( 17, 14, 35, 123456789, UTC ) ),
+                parse( "2017-12-17T17:14:35.123456789+0000", orFail ) );
+    }
+}

--- a/community/values/src/test/java/org/neo4j/values/storable/DateTimeValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DateTimeValueTest.java
@@ -36,6 +36,7 @@ import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.neo4j.values.storable.AssertingStructureBuilder.asserting;
 import static org.neo4j.values.storable.DateTimeValue.builder;
 import static org.neo4j.values.storable.DateTimeValue.datetime;
@@ -265,18 +266,41 @@ public class DateTimeValueTest
     @Test
     public void shouldRejectInvalidComponentValues() throws Exception
     {
-        asserting( fromValues( builder( clock ) ) )
-                .add( "year", 2018 )
-                .add( "moment", 12 )
-                .assertThrows( IllegalArgumentException.class, "No such field: moment" );
-        asserting( fromValues( builder( clock ) ) )
-                .add( "year", 2018 )
-                .add( "month", 12 )
-                .add( "day", 5 )
-                .add( "hour", 5 )
-                .add( "minute", 5 )
-                .add( "second", 5 )
-                .add( "picosecond", 12 )
-                .assertThrows( IllegalArgumentException.class, "No such field: picosecond" );
+        asserting( fromValues( builder( clock ) ) ).add( "year", 2018 ).add( "moment", 12 ).assertThrows( IllegalArgumentException.class,
+                "No such field: moment" );
+        asserting( fromValues( builder( clock ) ) ).add( "year", 2018 ).add( "month", 12 ).add( "day", 5 ).add( "hour", 5 ).add( "minute", 5 ).add( "second",
+                5 ).add( "picosecond", 12 ).assertThrows( IllegalArgumentException.class, "No such field: picosecond" );
+    }
+
+    @Test
+    public void shouldAddDurationToDateTimes() throws Exception
+    {
+        assertEquals( datetime( date( 2018, 2, 1 ), time( 1, 17, 3, 0, UTC ) ),
+                datetime( date( 2018, 1, 1 ), time( 1, 2, 3, 0, UTC ) ).add( DurationValue.duration( 1, 0, 900, 0 ) ) );
+        assertEquals( datetime( date( 2018, 2, 28 ), time( 0, 0, 0, 0, UTC ) ),
+                datetime( date( 2018, 1, 31 ), time( 0, 0, 0, 0, UTC ) ).add( DurationValue.duration( 1, 0, 0, 0 ) ) );
+        assertEquals( datetime( date( 2018, 1, 28 ), time( 0, 0, 0, 0, UTC ) ),
+                datetime( date( 2018, 2, 28 ), time( 0, 0, 0, 0, UTC ) ).add( DurationValue.duration( -1, 0, 0, 0 ) ) );
+    }
+
+
+
+    @Test
+    public void shouldReuseInstanceInArithmetics() throws Exception
+    {
+        final DateTimeValue datetime = datetime( date( 2018, 2, 1 ), time( 1, 17, 3, 0, UTC ) );
+        assertSame( datetime,
+                datetime.add( DurationValue.duration( 0, 0, 0, 0 ) ) );
+    }
+
+    @Test
+    public void shouldSubtractDurationFromDateTimes() throws Exception
+    {
+        assertEquals( datetime( date( 2018, 1, 1 ), time( 1, 2, 3, 0, UTC ) ),
+                datetime( date( 2018, 2, 1 ), time( 1, 17, 3, 0, UTC ) ).sub( DurationValue.duration( 1, 0, 900, 0 ) ) );
+        assertEquals( datetime( date( 2018, 1, 28 ), time( 0, 0, 0, 0, UTC ) ),
+                datetime( date( 2018, 2, 28 ), time( 0, 0, 0, 0, UTC ) ).sub( DurationValue.duration( 1, 0, 0, 0 ) ) );
+        assertEquals( datetime( date( 2018, 2, 28 ), time( 0, 0, 0, 0, UTC ) ),
+                datetime( date( 2018, 1, 31 ), time( 0, 0, 0, 0, UTC ) ).sub( DurationValue.duration( -1, 0, 0, 0 ) ) );
     }
 }

--- a/community/values/src/test/java/org/neo4j/values/storable/DateValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DateValueTest.java
@@ -23,14 +23,18 @@ import java.time.DateTimeException;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.IsoFields;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.Supplier;
 
 import org.junit.Test;
 
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 import static org.neo4j.values.storable.DateValue.date;
+import static org.neo4j.values.storable.DateValue.epochDate;
 import static org.neo4j.values.storable.DateValue.ordinalDate;
 import static org.neo4j.values.storable.DateValue.parse;
 import static org.neo4j.values.storable.DateValue.quarterDate;
@@ -158,6 +162,33 @@ public class DateValueTest
     {
         assertCannotParse( "2015W54" ); // no year should have more than 53 weeks (2015 had 53 weeks)
         assertCannotParse( "2017W53" ); // 2017 only has 52 weeks
+    }
+
+    @Test
+    public void shouldWriteDate() throws Exception
+    {
+        // given
+        for ( DateValue value : new DateValue[] {
+                date( 2016, 2, 29 ),
+                date( 2017, 12, 22 ),
+        } )
+        {
+            List<DateValue> values = new ArrayList<>( 1 );
+            ValueWriter<RuntimeException> writer = new ThrowingValueWriter.AssertOnly()
+            {
+                @Override
+                public void writeDate( long epochDay ) throws RuntimeException
+                {
+                    values.add( epochDate( epochDay ) );
+                }
+            };
+
+            // when
+            value.writeTo( writer );
+
+            // then
+            assertEquals( singletonList( value ), values );
+        }
     }
 
     @SuppressWarnings( "UnusedReturnValue" )

--- a/community/values/src/test/java/org/neo4j/values/storable/DateValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DateValueTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 import static org.neo4j.values.storable.DateValue.date;
@@ -49,6 +50,8 @@ public class DateValueTest
         assertEquals( date( 2015, 1, 1 ), parse( "2015" ) );
         assertEquals( date( 2015, 1, 1 ), parse( "+2015" ) );
         assertEquals( date( 2015, 1, 1 ), parse( "+0002015" ) );
+        assertCannotParse( "10000" );
+        assertCannotParse( "2K18" );
     }
 
     @Test
@@ -58,6 +61,8 @@ public class DateValueTest
         assertEquals( date( 2015, 3, 1 ), parse( "2015-03" ) );
         assertEquals( date( 2015, 3, 1 ), parse( "2015-3" ) );
         assertEquals( date( 2015, 3, 1 ), parse( "+2015-03" ) );
+        assertCannotParse( "2018-00" );
+        assertCannotParse( "2018-13" );
     }
 
     @Test
@@ -79,6 +84,8 @@ public class DateValueTest
         assertEquals( quarterDate( 2017, 3, 1 ), parse( "2017Q3" ) );
         assertEquals( quarterDate( 2017, 3, 1 ), parse( "2017-Q3" ) );
         assertEquals( quarterDate( 2017, 3, 1 ), parse( "+2017-Q3" ) );
+        assertCannotParse( "2015Q0" );
+        assertCannotParse( "2015Q5" );
     }
 
     @Test
@@ -87,6 +94,8 @@ public class DateValueTest
         assertEquals( date( 2016, 1, 27 ), parse( "20160127" ) );
         assertEquals( date( 2016, 1, 27 ), parse( "+2016-01-27" ) );
         assertEquals( date( 2016, 1, 27 ), parse( "+2016-1-27" ) );
+        assertCannotParse( "2015-01-32" );
+        assertCannotParse( "2015-01-00" );
     }
 
     @Test
@@ -116,6 +125,7 @@ public class DateValueTest
         assertCannotParse( "20173" );
         assertEquals( ordinalDate( 2017, 3 ), parse( "2017-003" ) );
         assertEquals( ordinalDate( 2017, 3 ), parse( "+2017-003" ) );
+        assertCannotParse( "2017-366" );
     }
 
     @Test
@@ -189,6 +199,40 @@ public class DateValueTest
             // then
             assertEquals( singletonList( value ), values );
         }
+    }
+
+    @Test
+    public void shouldAddDurationToDates() throws Exception
+    {
+        assertEquals( date( 2018, 2, 1 ),
+                date( 2018, 1, 1 ).add( DurationValue.duration( 1, 0, 900, 0 ) ) );
+        assertEquals(date( 2018, 2, 28 ),
+                date( 2018, 1, 31 ).add( DurationValue.duration( 1, 0, 0, 0 ) ) );
+        assertEquals(date( 2018, 1, 28 ),
+                date( 2018, 2, 28 ).add( DurationValue.duration( -1, 0, 0, 0 ) ) );
+    }
+
+    @Test
+    public void shouldReuseInstanceInArithmetics() throws Exception
+    {
+        final DateValue date = date( 2018, 2, 1 );
+        assertSame( date,
+                date.add( DurationValue.duration( 0, 0, 0, 0 ) ) );
+        assertSame( date,
+                date.add( DurationValue.duration( 0, 0, 1, 1 ) ) );
+        assertSame( date,
+                date.add( DurationValue.duration( -0, 0, 1, -1 ) ) );
+    }
+
+    @Test
+    public void shouldSubtractDurationFromDates() throws Exception
+    {
+        assertEquals( date( 2018, 1, 1 ),
+                date( 2018, 2, 1 ).sub( DurationValue.duration( 1, 0, 900, 0 ) ) );
+        assertEquals( date( 2018, 1, 28 ),
+                date( 2018, 2, 28 ).sub( DurationValue.duration( 1, 0, 0, 0 ) ) );
+        assertEquals( date( 2018, 2, 28 ),
+                date( 2018, 1, 31 ).sub( DurationValue.duration( -1, 0, 0, 0 ) ) );
     }
 
     @SuppressWarnings( "UnusedReturnValue" )

--- a/community/values/src/test/java/org/neo4j/values/storable/DateValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DateValueTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.storable;
+
+import java.time.DateTimeException;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.IsoFields;
+import java.util.function.Supplier;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+import static org.neo4j.values.storable.DateValue.date;
+import static org.neo4j.values.storable.DateValue.ordinalDate;
+import static org.neo4j.values.storable.DateValue.parse;
+import static org.neo4j.values.storable.DateValue.quarterDate;
+import static org.neo4j.values.storable.DateValue.weekDate;
+
+@SuppressWarnings( "ThrowableNotThrown" )
+public class DateValueTest
+{
+    @Test
+    public void shouldParseYear() throws Exception
+    {
+        assertEquals( date( 2015, 1, 1 ), parse( "2015" ) );
+        assertEquals( date( 2015, 1, 1 ), parse( "+2015" ) );
+        assertEquals( date( 2015, 1, 1 ), parse( "+0002015" ) );
+    }
+
+    @Test
+    public void shouldParseYearMonth() throws Exception
+    {
+        assertEquals( date( 2015, 3, 1 ), parse( "201503" ) );
+        assertEquals( date( 2015, 3, 1 ), parse( "2015-03" ) );
+        assertEquals( date( 2015, 3, 1 ), parse( "2015-3" ) );
+        assertEquals( date( 2015, 3, 1 ), parse( "+2015-03" ) );
+    }
+
+    @Test
+    public void shouldParseYearWeek() throws Exception
+    {
+        assertEquals( weekDate( 2015, 5, 1 ), parse( "2015W05" ) );
+        assertEquals( weekDate( 2015, 53, 1 ), parse( "2015W53" ) ); // 2015 had 53 weeks
+        assertCannotParse( "2015W5" );
+        assertEquals( weekDate( 2015, 5, 1 ), parse( "2015-W05" ) );
+        assertEquals( weekDate( 2015, 5, 1 ), parse( "2015-W5" ) );
+        assertEquals( weekDate( 2015, 5, 1 ), parse( "+2015-W05" ) );
+        assertCannotParse( "+2015W05" );
+    }
+
+    @Test
+    public void shouldParseYearQuarter() throws Exception
+    {
+        assumeTrue( DateValue.QUARTER_DATES );
+        assertEquals( quarterDate( 2017, 3, 1 ), parse( "2017Q3" ) );
+        assertEquals( quarterDate( 2017, 3, 1 ), parse( "2017-Q3" ) );
+        assertEquals( quarterDate( 2017, 3, 1 ), parse( "+2017-Q3" ) );
+    }
+
+    @Test
+    public void shouldParseCalendarDate() throws Exception
+    {
+        assertEquals( date( 2016, 1, 27 ), parse( "20160127" ) );
+        assertEquals( date( 2016, 1, 27 ), parse( "+2016-01-27" ) );
+        assertEquals( date( 2016, 1, 27 ), parse( "+2016-1-27" ) );
+    }
+
+    @Test
+    public void shouldParseWeekDate() throws Exception
+    {
+        assertEquals( weekDate( 2015, 5, 6 ), parse( "2015W056" ) );
+        assertCannotParse( "+2015W056" );
+        assertEquals( weekDate( 2015, 5, 6 ), parse( "2015-W05-6" ) );
+        assertEquals( weekDate( 2015, 5, 6 ), parse( "+2015-W05-6" ) );
+        assertEquals( weekDate( 2015, 5, 6 ), parse( "2015-W5-6" ) );
+        assertEquals( weekDate( 2015, 5, 6 ), parse( "+2015-W5-6" ) );
+    }
+
+    @Test
+    public void shouldParseQuarterDate() throws Exception
+    {
+        assumeTrue( DateValue.QUARTER_DATES );
+        assertEquals( quarterDate( 2017, 3, 92 ), parse( "2017Q392" ) );
+        assertEquals( quarterDate( 2017, 3, 92 ), parse( "2017-Q3-92" ) );
+        assertEquals( quarterDate( 2017, 3, 92 ), parse( "+2017-Q3-92" ) );
+    }
+
+    @Test
+    public void shouldParseOrdinalDate() throws Exception
+    {
+        assertEquals( ordinalDate( 2017, 3 ), parse( "2017003" ) );
+        assertCannotParse( "20173" );
+        assertEquals( ordinalDate( 2017, 3 ), parse( "2017-003" ) );
+        assertEquals( ordinalDate( 2017, 3 ), parse( "+2017-003" ) );
+    }
+
+    @Test
+    public void shouldEnforceStrictWeekRanges() throws Exception
+    {
+        LocalDate localDate = weekDate( 2017, 52, 7 ).temporal();
+        assertEquals( "Sunday is the seventh day of the week.", DayOfWeek.SUNDAY, localDate.getDayOfWeek() );
+        assertEquals( 52, localDate.get( IsoFields.WEEK_OF_WEEK_BASED_YEAR ) );
+        assertEquals( localDate, date( 2017, 12, 31 ).temporal() );
+        try
+        {
+            DateValue value = weekDate( 2017, 53, 1 );
+            fail( String.format(
+                    "2017 does not have 53 weeks, %s is week %s of %s", value,
+                    value.temporal().get( IsoFields.WEEK_OF_WEEK_BASED_YEAR ),
+                    value.temporal().get( IsoFields.WEEK_BASED_YEAR ) ) );
+        }
+        catch ( DateTimeException expected )
+        {
+            assertEquals( "Year 2017 does not contain 53 weeks.", expected.getMessage() );
+        }
+        assertEquals( date( 2016, 1, 1 ), weekDate( 2015, 53, 5 ) );
+    }
+
+    @Test
+    public void shouldEnforceStrictQuarterRanges() throws Exception
+    {
+        assertEquals( date( 2017, 3, 31 ), quarterDate( 2017, 1, 90 ) );
+        assertThrows( DateTimeException.class, () -> quarterDate( 2017, 1, 0 ) );
+        assertThrows( DateTimeException.class, () -> quarterDate( 2017, 2, 0 ) );
+        assertThrows( DateTimeException.class, () -> quarterDate( 2017, 3, 0 ) );
+        assertThrows( DateTimeException.class, () -> quarterDate( 2017, 4, 0 ) );
+        assertThrows( DateTimeException.class, () -> quarterDate( 2017, 4, 93 ) );
+        assertThrows( DateTimeException.class, () -> quarterDate( 2017, 3, 93 ) );
+        assertThrows( DateTimeException.class, () -> quarterDate( 2017, 2, 92 ) );
+        assertThrows( DateTimeException.class, () -> quarterDate( 2017, 1, 92 ) );
+        assertThrows( DateTimeException.class, () -> quarterDate( 2017, 1, 91 ) );
+        assertEquals( date( 2016, 3, 31 ), quarterDate( 2016, 1, 91 ) );
+        assertThrows( DateTimeException.class, () -> quarterDate( 2016, 1, 92 ) );
+    }
+
+    @Test
+    public void shouldNotParseInvalidDates() throws Exception
+    {
+        assertCannotParse( "2015W54" ); // no year should have more than 53 weeks (2015 had 53 weeks)
+        assertCannotParse( "2017W53" ); // 2017 only has 52 weeks
+    }
+
+    @SuppressWarnings( "UnusedReturnValue" )
+    private DateTimeException assertCannotParse( String text )
+    {
+        DateValue value;
+        try
+        {
+            value = parse( text );
+        }
+        catch ( DateTimeException e )
+        {
+            return e;
+        }
+        throw new AssertionError( String.format( "'%s' parsed to %s", text, value ) );
+    }
+
+    private static <X extends Exception, T> X assertThrows( Class<X> exception, Supplier<T> thunk )
+    {
+        T value;
+        try
+        {
+            value = thunk.get();
+        }
+        catch ( Exception e )
+        {
+            if ( exception.isInstance( e ) )
+            {
+                return exception.cast( e );
+            }
+            else
+            {
+                throw new AssertionError( "Expected " + exception.getName(), e );
+            }
+        }
+        throw new AssertionError( "Expected " + exception.getName() + " but returned: " + value );
+    }
+}

--- a/community/values/src/test/java/org/neo4j/values/storable/DateValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DateValueTest.java
@@ -19,15 +19,14 @@
  */
 package org.neo4j.values.storable;
 
+import org.junit.Test;
+
 import java.time.DateTimeException;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.IsoFields;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Supplier;
-
-import org.junit.Test;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
@@ -39,6 +38,7 @@ import static org.neo4j.values.storable.DateValue.ordinalDate;
 import static org.neo4j.values.storable.DateValue.parse;
 import static org.neo4j.values.storable.DateValue.quarterDate;
 import static org.neo4j.values.storable.DateValue.weekDate;
+import static org.neo4j.values.utils.AnyValueTestUtil.assertThrows;
 
 @SuppressWarnings( "ThrowableNotThrown" )
 public class DateValueTest
@@ -204,26 +204,5 @@ public class DateValueTest
             return e;
         }
         throw new AssertionError( String.format( "'%s' parsed to %s", text, value ) );
-    }
-
-    private static <X extends Exception, T> X assertThrows( Class<X> exception, Supplier<T> thunk )
-    {
-        T value;
-        try
-        {
-            value = thunk.get();
-        }
-        catch ( Exception e )
-        {
-            if ( exception.isInstance( e ) )
-            {
-                return exception.cast( e );
-            }
-            else
-            {
-                throw new AssertionError( "Expected " + exception.getName(), e );
-            }
-        }
-        throw new AssertionError( "Expected " + exception.getName() + " but returned: " + value );
     }
 }

--- a/community/values/src/test/java/org/neo4j/values/storable/DurationBuilderTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DurationBuilderTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.storable;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.helpers.collection.MapUtil.entry;
+import static org.neo4j.values.storable.DurationValue.build;
+import static org.neo4j.values.storable.DurationValue.parse;
+import static org.neo4j.values.storable.Values.of;
+
+public class DurationBuilderTest
+{
+    @Test
+    public void shouldBuildDuration() throws Exception
+    {
+        assertEquals( parse( "P17Y" ), build( entry( "years", of( 17 ) ).create() ) );
+        assertEquals( parse( "P3M" ), build( entry( "months", of( 3 ) ).create() ) );
+        assertEquals( parse( "P18W" ), build( entry( "weeks", of( 18 ) ).create() ) );
+        assertEquals( parse( "P7D" ), build( entry( "days", of( 7 ) ).create() ) );
+        assertEquals( parse( "PT5H" ), build( entry( "hours", of( 5 ) ).create() ) );
+        assertEquals( parse( "PT7M" ), build( entry( "minutes", of( 7 ) ).create() ) );
+        assertEquals( parse( "PT2352S" ), build( entry( "seconds", of( 2352 ) ).create() ) );
+        assertEquals( parse( "PT0.001S" ), build( entry( "milliseconds", of( 1 ) ).create() ) );
+        assertEquals( parse( "PT0.000001S" ), build( entry( "microseconds", of( 1 ) ).create() ) );
+        assertEquals( parse( "PT0.000000001S" ), build( entry( "nanoseconds", of( 1 ) ).create() ) );
+        assertEquals( parse( "PT4.003002001S" ), build(
+                entry( "nanoseconds", of( 1 ) )
+                        .entry( "microseconds", of( 2 ) )
+                        .entry( "milliseconds", of( 3 ) )
+                        .entry( "seconds", of( 4 ) )
+                        .create() ) );
+        assertEquals( parse( "P1Y2M3W4DT5H6M7.800000009S" ), build(
+                entry( "years", of( 1 ) )
+                        .entry( "months", of( 2 ) )
+                        .entry( "weeks", of( 3 ) )
+                        .entry( "days", of( 4 ) )
+                        .entry( "hours", of( 5 ) )
+                        .entry( "minutes", of( 6 ) )
+                        .entry( "seconds", of( 7 ) )
+                        .entry( "milliseconds", of( 800 ) )
+                        .entry( "microseconds", of( -900_000 ) )
+                        .entry( "nanoseconds", of( 900_000_009 ) )
+                        .create() ) );
+    }
+}

--- a/community/values/src/test/java/org/neo4j/values/storable/DurationBuilderTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DurationBuilderTest.java
@@ -26,6 +26,7 @@ import static org.neo4j.helpers.collection.MapUtil.entry;
 import static org.neo4j.values.storable.DurationValue.build;
 import static org.neo4j.values.storable.DurationValue.parse;
 import static org.neo4j.values.storable.Values.of;
+import static org.neo4j.values.utils.AnyValueTestUtil.assertThrows;
 
 public class DurationBuilderTest
 {
@@ -60,5 +61,19 @@ public class DurationBuilderTest
                         .entry( "microseconds", of( -900_000 ) )
                         .entry( "nanoseconds", of( 900_000_009 ) )
                         .create() ) );
+    }
+
+    @Test
+    public void shouldRejectUnknownKeys() throws Exception
+    {
+        assertEquals( "Unknown field: millenia",
+                assertThrows( IllegalStateException.class, () -> build( entry( "millenia", of( 2 ) ).create() ) ).getMessage() );
+    }
+
+    @Test
+    public void shouldAcceptOverlapping() throws Exception
+    {
+        assertEquals( parse( "PT1H90M" ), build( entry( "hours", of( 1 ) ).entry( "minutes", of( 90 ) ).create() ) );
+        assertEquals( parse( "P1DT30H" ), build( entry( "days", of( 1 ) ).entry( "hours", of( 30 ) ).create() ) );
     }
 }

--- a/community/values/src/test/java/org/neo4j/values/storable/DurationValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DurationValueTest.java
@@ -32,8 +32,14 @@ import org.neo4j.helpers.collection.Pair;
 
 import static java.time.ZoneOffset.UTC;
 import static java.time.ZoneOffset.ofHours;
+import static java.time.temporal.ChronoUnit.DAYS;
+import static java.time.temporal.ChronoUnit.HOURS;
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static java.time.temporal.ChronoUnit.MONTHS;
 import static java.time.temporal.ChronoUnit.NANOS;
 import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.time.temporal.ChronoUnit.WEEKS;
+import static java.time.temporal.ChronoUnit.YEARS;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -409,8 +415,8 @@ public class DurationValueTest
         assertEquals( duration( 0, 0, -10623, 0 ), durationBetween(
                 localTime( 14, 27, 55, 0 ), time( 11, 30, 52, 0, ofHours( 17 ) ) ) );
 
-        //        assertEquals( duration( 0, 1, 0, 0 ), days.between(
-        //                time( 14, 30, 22, 0, ofHours( -12 ) ), time( 14, 30, 22, 0, ofHours( 12 ) ) ) );
+        //        assertEquals( duration( 0, 1, 0, 0 ), between(
+        //                DAYS, time( 14, 30, 22, 0, ofHours( -12 ) ), time( 14, 30, 22, 0, ofHours( 12 ) ) ) );
     }
 
     @Test

--- a/community/values/src/test/java/org/neo4j/values/storable/DurationValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DurationValueTest.java
@@ -368,7 +368,6 @@ public class DurationValueTest
         assertEquals( duration( 0, 693, 0, 0 ), between(WEEKS, date( 2016, 1, 27 ), date( 2017, 12, 20 ) ) );
         assertEquals( duration( 22, 0, 0, 0 ), between(MONTHS, date( 2016, 1, 27 ), date( 2017, 12, 20 ) ) );
         assertEquals( duration( 12, 0, 0, 0 ), between(YEARS, date( 2016, 1, 27 ), date( 2017, 12, 20 ) ) );
-        //        assertEquals( duration( 0, 0, 0, 0 ), between( HOURS, date( 2016, 1, 27 ), date( 2017, 12, 20 ) ) );
     }
 
     @Test
@@ -376,8 +375,6 @@ public class DurationValueTest
     {
         assertEquals( duration( 0, 0, 10623, 0 ), durationBetween(
                 localTime( 11, 30, 52, 0 ), localTime( 14, 27, 55, 0 ) ) );
-        //        assertEquals( duration( 0,0,0,0 ), between(
-        //                DAYS, localTime( 11, 30, 52, 0 ), localTime( 14, 27, 55, 0 ) ) );
         assertEquals( duration( 0, 0, 7200, 0 ), between(
                 HOURS, localTime( 11, 30, 52, 0 ), localTime( 14, 27, 55, 0 ) ) );
         assertEquals( duration( 0, 0, 10620, 0 ), between(
@@ -391,8 +388,6 @@ public class DurationValueTest
     {
         assertEquals( duration( 0, 0, 140223, 0 ), durationBetween(
                 time( 11, 30, 52, 0, ofHours( 18 ) ), time( 14, 27, 55, 0, ofHours( -18 ) ) ) );
-        //        assertEquals( duration( 0,0,0,0 ), days.between(
-        //                time( 11, 30, 52, 0, UTC ), time( 14, 27, 55, 0, UTC ) ) );
         assertEquals( duration( 0, 0, 0, 0 ), between(
                 HOURS, time( 11, 30, 52, 0, ofHours( -1 ) ), time( 14, 27, 55, 0, ofHours( 1 ) ) ) );
         assertEquals( duration( 0, 0, 3420, 0 ), between(
@@ -408,9 +403,6 @@ public class DurationValueTest
                 localTime( 14, 27, 55, 0 ), time( 11, 30, 52, 0, UTC ) ) );
         assertEquals( duration( 0, 0, -10623, 0 ), durationBetween(
                 localTime( 14, 27, 55, 0 ), time( 11, 30, 52, 0, ofHours( 17 ) ) ) );
-
-        //        assertEquals( duration( 0, 1, 0, 0 ), between(
-        //                DAYS, time( 14, 30, 22, 0, ofHours( -12 ) ), time( 14, 30, 22, 0, ofHours( 12 ) ) ) );
     }
 
     @Test
@@ -433,14 +425,28 @@ public class DurationValueTest
                 datetime( date( 2017, 12, 21 ), time( 6, 52, 11, 0, UTC ) ), localTime( 14, 32, 11, 0 ) ) );
         assertEquals( parse( "PT-8H+20M" ), durationBetween(
                 localTime( 14, 32, 11, 0 ), datetime( date( 2017, 12, 21 ), time( 6, 52, 11, 0, UTC ) ) ) );
-        //
-        //assertEquals( parse( "-PT14H32M11S" ), durationBetween( localTime( 14, 32, 11, 0 ), date( 2017, 12, 21 ) ) );
-        //assertEquals( parse( "PT14H32M11S" ), durationBetween( date( 2017, 12, 21 ), time( 14, 32, 11, 0, UTC ) ) );
-        //assertEquals( parse( "-PT14H32M11S" ), durationBetween( time( 14, 32, 11, 0, UTC ), date( 2017, 12, 21 ) ) );
-        //assertEquals( parse( "PT14H32M11S" ), durationBetween(
-        //        date( 2017, 12, 21 ), time( 14, 32, 11, 0, ofHours( -12 ) ) ) );
-        //assertEquals( parse( "-PT14H32M11S" ), durationBetween(
-        //        time( 14, 32, 11, 0, ofHours( -12 ) ), date( 2017, 12, 21 ) ) );
+
+        assertEquals( parse( "-PT14H32M11S" ), durationBetween( localTime( 14, 32, 11, 0 ), date( 2017, 12, 21 ) ) );
+        assertEquals( parse( "PT14H32M11S" ), durationBetween( date( 2017, 12, 21 ), time( 14, 32, 11, 0, UTC ) ) );
+        assertEquals( parse( "-PT14H32M11S" ), durationBetween( time( 14, 32, 11, 0, UTC ), date( 2017, 12, 21 ) ) );
+        assertEquals( parse( "PT14H32M11S" ), durationBetween(
+                date( 2017, 12, 21 ), time( 14, 32, 11, 0, ofHours( -12 ) ) ) );
+        assertEquals( parse( "-PT14H32M11S" ), durationBetween(
+                time( 14, 32, 11, 0, ofHours( -12 ) ), date( 2017, 12, 21 ) ) );
+    }
+
+    @Test
+    public void shouldComputeDurationBetweenDateTimeAndDateTime() throws Exception
+    {
+        assertEquals( parse( "PT1H" ), durationBetween(
+                datetime( date( 2017, 12, 21 ), time( 6, 52, 11, 0, UTC ) ),
+                datetime( date( 2017, 12, 21 ), time( 7, 52, 11, 0, UTC ) ) ) );
+        assertEquals( parse( "P1D" ), durationBetween(
+                datetime( date( 2017, 12, 21 ), time( 6, 52, 11, 0, UTC ) ),
+                datetime( date( 2017, 12, 22 ), time( 6, 52, 11, 0, UTC ) ) ) );
+        assertEquals( parse( "P1DT1H" ), durationBetween(
+                datetime( date( 2017, 12, 21 ), time( 6, 52, 11, 0, UTC ) ),
+                datetime( date( 2017, 12, 22 ), time( 7, 52, 11, 0, UTC ) ) ) );
     }
 
     @Test

--- a/community/values/src/test/java/org/neo4j/values/storable/DurationValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DurationValueTest.java
@@ -23,6 +23,8 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.Temporal;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -32,6 +34,7 @@ import static java.time.ZoneOffset.UTC;
 import static java.time.ZoneOffset.ofHours;
 import static java.time.temporal.ChronoUnit.NANOS;
 import static java.time.temporal.ChronoUnit.SECONDS;
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
@@ -216,6 +219,36 @@ public class DurationValueTest
             return;
         }
         fail( "should not be able to parse: " + text );
+    }
+
+    @Test
+    public void shouldWriteDuration() throws Exception
+    {
+        // given
+        for ( DurationValue duration : new DurationValue[] {
+                duration( 0, 0, 0, 0 ),
+                duration( 1, 0, 0, 0 ),
+                duration( 0, 1, 0, 0 ),
+                duration( 0, 0, 1, 0 ),
+                duration( 0, 0, 0, 1 ),
+        } )
+        {
+            List<DurationValue> values = new ArrayList<>( 1 );
+            ValueWriter<RuntimeException> writer = new ThrowingValueWriter.AssertOnly()
+            {
+                @Override
+                public void writeDuration( long months, long days, long seconds, int nanos )
+                {
+                    values.add( duration( months, days, seconds, nanos ) );
+                }
+            };
+
+            // when
+            duration.writeTo( writer );
+
+            // then
+            assertEquals( singletonList( duration ), values );
+        }
     }
 
     @Test

--- a/community/values/src/test/java/org/neo4j/values/storable/DurationValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DurationValueTest.java
@@ -1,0 +1,449 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.storable;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.Temporal;
+
+import org.junit.Test;
+
+import org.neo4j.helpers.collection.Pair;
+
+import static java.time.ZoneOffset.UTC;
+import static java.time.ZoneOffset.ofHours;
+import static java.time.temporal.ChronoUnit.NANOS;
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.fail;
+import static org.neo4j.helpers.collection.Pair.pair;
+import static org.neo4j.values.storable.DateTimeValue.datetime;
+import static org.neo4j.values.storable.DateValue.date;
+import static org.neo4j.values.storable.DurationValue.Difference.days;
+import static org.neo4j.values.storable.DurationValue.Difference.hours;
+import static org.neo4j.values.storable.DurationValue.Difference.minutes;
+import static org.neo4j.values.storable.DurationValue.Difference.months;
+import static org.neo4j.values.storable.DurationValue.Difference.seconds;
+import static org.neo4j.values.storable.DurationValue.Difference.weeks;
+import static org.neo4j.values.storable.DurationValue.Difference.years;
+import static org.neo4j.values.storable.DurationValue.duration;
+import static org.neo4j.values.storable.DurationValue.durationBetween;
+import static org.neo4j.values.storable.DurationValue.parse;
+import static org.neo4j.values.storable.LocalTimeValue.localTime;
+import static org.neo4j.values.storable.TimeValue.time;
+import static org.neo4j.values.storable.Values.doubleValue;
+import static org.neo4j.values.storable.Values.longValue;
+
+public class DurationValueTest
+{
+    @Test
+    public void shouldNormalizeNanoseconds()
+    {
+        // given
+        DurationValue evenPos = duration( 0, 0, 0, 1_000_000_000 );
+        DurationValue evenNeg = duration( 0, 0, 0, -1_000_000_000 );
+        DurationValue pos = duration( 0, 0, 0, 1_500_000_000 );
+        DurationValue neg = duration( 0, 0, 0, -1_400_000_000 );
+
+        // then
+        assertEquals( "+nanos", 500_000_000, pos.get( NANOS ) );
+        assertEquals( "+seconds", 1, pos.get( SECONDS ) );
+        assertEquals( "-nanos", -400_000_000, neg.get( NANOS ) );
+        assertEquals( "-seconds", -1, neg.get( SECONDS ) );
+
+        assertEquals( "+nanos", 0, evenPos.get( NANOS ) );
+        assertEquals( "+seconds", 1, evenPos.get( SECONDS ) );
+        assertEquals( "-nanos", 0, evenNeg.get( NANOS ) );
+        assertEquals( "-seconds", -1, evenNeg.get( SECONDS ) );
+    }
+
+    @Test
+    public void shouldNormalizeSecondsAndNanos()
+    {
+        // given
+        DurationValue pos = duration( 0, 0, 5, -1_400_000_000 );
+        DurationValue neg = duration( 0, 0, -5, 1_500_000_000 );
+        DurationValue x = duration( 0, 0, 1, -1_400_000_000 );
+
+        // then
+        assertEquals( "+nanos", 600_000_000, pos.get( NANOS ) );
+        assertEquals( "+seconds", 3, pos.get( SECONDS ) );
+        assertEquals( "-nanos", -500_000_000, neg.get( NANOS ) );
+        assertEquals( "-seconds", -3, neg.get( SECONDS ) );
+        assertEquals( "-nanos", -400_000_000, x.get( NANOS ) );
+        assertEquals( "-seconds", 0, x.get( SECONDS ) );
+    }
+
+    @Test
+    public void shouldFormatAsPrettyString()
+    {
+        assertEquals( "P1Y", prettyPrint( 12, 0, 0, 0 ) );
+        assertEquals( "P5M", prettyPrint( 5, 0, 0, 0 ) );
+        assertEquals( "P84D", prettyPrint( 0, 84, 0, 0 ) );
+        assertEquals( "P2Y4M11D", prettyPrint( 28, 11, 0, 0 ) );
+        assertEquals( "PT5S", prettyPrint( 0, 0, 5, 0 ) );
+        assertEquals( "PT30H22M8S", prettyPrint( 0, 0, 109328, 0 ) );
+        assertEquals( "PT7.123456789S", prettyPrint( 0, 0, 7, 123_456_789 ) );
+        assertEquals( "PT0.000000001S", prettyPrint( 0, 0, 0, 1 ) );
+        assertEquals( "PT0.1S", prettyPrint( 0, 0, 0, 100_000_000 ) );
+        assertEquals( "PT0S", prettyPrint( 0, 0, 0, 0 ) );
+    }
+
+    private static String prettyPrint( long months, long days, long seconds, int nanos )
+    {
+        return duration( months, days, seconds, nanos ).prettyPrint();
+    }
+
+    @Test
+    public void shouldParseDuration()
+    {
+        assertEquals(
+                duration( 14, 25, 18367, 800_000_000 ),
+                parse( "+P1Y2M3W4DT5H6M7.8S" ) );
+
+        assertEquals( duration( 0, 0, 0, -100000000 ), parse( "PT-0.1S" ) );
+        assertEquals( duration( 0, 0, 0, -20000000 ), parse( "PT-0.02S" ) );
+        assertEquals( duration( 0, 0, 0, -3000000 ), parse( "PT-0.003S" ) );
+        assertEquals( duration( 0, 0, 0, -400000 ), parse( "PT-0.0004S" ) );
+        assertEquals( duration( 0, 0, 0, -50000 ), parse( "PT-0.00005S" ) );
+        assertEquals( duration( 0, 0, 0, -6000 ), parse( "PT-0.000006S" ) );
+        assertEquals( duration( 0, 0, 0, -700 ), parse( "PT-0.0000007S" ) );
+        assertEquals( duration( 0, 0, 0, -80 ), parse( "PT-0.00000008S" ) );
+        assertEquals( duration( 0, 0, 0, -9 ), parse( "PT-0.000000009S" ) );
+
+        assertEquals( duration( 0, 0, 0, 900_000_000 ), parse( "PT0.900000000S" ) );
+        assertEquals( duration( 0, 0, 0, 800_000_000 ), parse( "PT0.80000000S" ) );
+        assertEquals( duration( 0, 0, 0, 700_000_000 ), parse( "PT0.7000000S" ) );
+        assertEquals( duration( 0, 0, 0, 600_000_000 ), parse( "PT0.600000S" ) );
+        assertEquals( duration( 0, 0, 0, 500_000_000 ), parse( "PT0.50000S" ) );
+        assertEquals( duration( 0, 0, 0, 400_000_000 ), parse( "PT0.4000S" ) );
+        assertEquals( duration( 0, 0, 0, 300_000_000 ), parse( "PT0.300S" ) );
+        assertEquals( duration( 0, 0, 0, 200_000_000 ), parse( "PT0.20S" ) );
+        assertEquals( duration( 0, 0, 0, 100_000_000 ), parse( "PT0.1S" ) );
+
+        assertParsesOne( "P", "Y", 12, 0, 0 );
+        assertParsesOne( "P", "M", 1, 0, 0 );
+        assertParsesOne( "P", "W", 0, 7, 0 );
+        assertParsesOne( "P", "D", 0, 1, 0 );
+        assertParsesOne( "PT", "H", 0, 0, 3600 );
+        assertParsesOne( "PT", "M", 0, 0, 60 );
+        assertParsesOne( "PT", "S", 0, 0, 1 );
+
+        assertEquals( duration( 0, 0, -1, -100_000_000 ), parse( "PT-1,1S" ) );
+
+        assertEquals( duration( 10, 0, 0, 0 ), parse( "P1Y-2M" ) );
+        assertEquals( duration( 0, 20, 0, 0 ), parse( "P3W-1D" ) );
+        assertEquals( duration( 0, 0, 3000, 0 ), parse( "PT1H-10M" ) );
+        assertEquals( duration( 0, 0, 3000, 0 ), parse( "PT1H-600S" ) );
+        assertEquals( duration( 0, 0, 50, 0 ), parse( "PT1M-10S" ) );
+    }
+
+    private void assertParsesOne( String prefix, String suffix, int months, int days, int seconds )
+    {
+        assertEquals( duration( months, days, seconds, 0 ), parse( prefix + "1" + suffix ) );
+        assertEquals( duration( months, days, seconds, 0 ), parse( "+" + prefix + "1" + suffix ) );
+        assertEquals( duration( months, days, seconds, 0 ), parse( prefix + "+1" + suffix ) );
+        assertEquals( duration( months, days, seconds, 0 ), parse( "+" + prefix + "+1" + suffix ) );
+
+        assertEquals( duration( -months, -days, -seconds, 0 ), parse( "-" + prefix + "1" + suffix ) );
+        assertEquals( duration( -months, -days, -seconds, 0 ), parse( prefix + "-1" + suffix ) );
+        assertEquals( duration( -months, -days, -seconds, 0 ), parse( "+" + prefix + "-1" + suffix ) );
+        assertEquals( duration( -months, -days, -seconds, 0 ), parse( "-" + prefix + "+1" + suffix ) );
+
+        assertEquals( duration( months, days, seconds, 0 ), parse( "-" + prefix + "-1" + suffix ) );
+    }
+
+    @Test
+    public void shouldParseDateBasedDuration()
+    {
+        assertEquals( duration( 14, 17, 45252, 123400000 ), parse( "P0001-02-17T12:34:12.1234" ) );
+        assertEquals( duration( 14, 17, 45252, 123400000 ), parse( "P00010217T123412.1234" ) );
+    }
+
+    @Test
+    public void shouldNotParseInvalidDurationStrings()
+    {
+        assertNotParsable( "" );
+        assertNotParsable( "P" );
+        assertNotParsable( "PT" );
+        assertNotParsable( "PT.S" );
+        assertNotParsable( "PT,S" );
+        assertNotParsable( "PT.0S" );
+        assertNotParsable( "PT,0S" );
+        assertNotParsable( "PT0.S" );
+        assertNotParsable( "PT0,S" );
+        assertNotParsable( "PT1,-1S" );
+        assertNotParsable( "PT1.-1S" );
+        for ( String s : new String[] {"Y", "M", "W", "D"} )
+        {
+            assertNotParsable( "P-" + s );
+            assertNotParsable( "P1" + s + "T" );
+        }
+        for ( String s : new String[] {"H", "M", "S"} )
+        {
+            assertNotParsable( "PT-" + s );
+            assertNotParsable( "T1" + s );
+        }
+    }
+
+    private void assertNotParsable( String text )
+    {
+        try
+        {
+            parse( text );
+        }
+        catch ( DateTimeParseException e )
+        {
+            return;
+        }
+        fail( "should not be able to parse: " + text );
+    }
+
+    @Test
+    public void shouldAddToLocalDate()
+    {
+        assertEquals( "seconds", LocalDate.of( 2017, 12, 5 ), LocalDate.of( 2017, 12, 4 ).plus( parse( "PT24H" ) ) );
+        assertEquals( "seconds", LocalDate.of( 2017, 12, 3 ), LocalDate.of( 2017, 12, 4 ).minus( parse( "PT24H" ) ) );
+        assertEquals( "seconds", LocalDate.of( 2017, 12, 4 ), LocalDate.of( 2017, 12, 4 ).plus( parse( "PT24H-1S" ) ) );
+        assertEquals(
+                "seconds",
+                LocalDate.of( 2017, 12, 4 ),
+                LocalDate.of( 2017, 12, 4 ).minus( parse( "PT24H-1S" ) ) );
+        assertEquals( "days", LocalDate.of( 2017, 12, 5 ), LocalDate.of( 2017, 12, 4 ).plus( parse( "P1D" ) ) );
+        assertEquals( "days", LocalDate.of( 2017, 12, 3 ), LocalDate.of( 2017, 12, 4 ).minus( parse( "P1D" ) ) );
+    }
+
+    @Test
+    public void shouldHaveSensibleHashCode()
+    {
+        assertEquals( 0, duration( 0, 0, 0, 0 ).computeHash() );
+
+        assertNotEquals(
+                duration( 0, 0, 0, 1 ).computeHash(),
+                duration( 0, 0, 0, 2 ).computeHash() );
+        assertNotEquals(
+                duration( 0, 0, 0, 1 ).computeHash(),
+                duration( 0, 0, 1, 0 ).computeHash() );
+        assertNotEquals(
+                duration( 0, 0, 0, 1 ).computeHash(),
+                duration( 0, 1, 0, 0 ).computeHash() );
+        assertNotEquals(
+                duration( 0, 0, 0, 1 ).computeHash(),
+                duration( 1, 0, 0, 0 ).computeHash() );
+
+        assertNotEquals(
+                duration( 0, 0, 1, 0 ).computeHash(),
+                duration( 0, 0, 2, 0 ).computeHash() );
+        assertNotEquals(
+                duration( 0, 0, 1, 0 ).computeHash(),
+                duration( 0, 0, 0, 1 ).computeHash() );
+        assertNotEquals(
+                duration( 0, 0, 1, 0 ).computeHash(),
+                duration( 0, 1, 0, 0 ).computeHash() );
+        assertNotEquals(
+                duration( 0, 0, 1, 0 ).computeHash(),
+                duration( 1, 0, 0, 0 ).computeHash() );
+
+        assertNotEquals(
+                duration( 0, 1, 0, 0 ).computeHash(),
+                duration( 0, 2, 0, 0 ).computeHash() );
+        assertNotEquals(
+                duration( 0, 1, 0, 0 ).computeHash(),
+                duration( 0, 0, 0, 1 ).computeHash() );
+        assertNotEquals(
+                duration( 0, 1, 0, 0 ).computeHash(),
+                duration( 0, 0, 1, 0 ).computeHash() );
+        assertNotEquals(
+                duration( 0, 1, 0, 0 ).computeHash(),
+                duration( 1, 0, 0, 0 ).computeHash() );
+
+        assertNotEquals(
+                duration( 1, 0, 0, 0 ).computeHash(),
+                duration( 2, 0, 0, 0 ).computeHash() );
+        assertNotEquals(
+                duration( 1, 0, 0, 0 ).computeHash(),
+                duration( 0, 0, 0, 1 ).computeHash() );
+        assertNotEquals(
+                duration( 1, 0, 0, 0 ).computeHash(),
+                duration( 0, 0, 1, 0 ).computeHash() );
+        assertNotEquals(
+                duration( 1, 0, 0, 0 ).computeHash(),
+                duration( 0, 1, 0, 0 ).computeHash() );
+    }
+
+    @Test
+    public void shouldMultiplyDurationByInteger()
+    {
+        assertEquals( duration( 2, 0, 0, 0 ), duration( 1, 0, 0, 0 ).mul( longValue( 2 ) ) );
+        assertEquals( duration( 0, 2, 0, 0 ), duration( 0, 1, 0, 0 ).mul( longValue( 2 ) ) );
+        assertEquals( duration( 0, 0, 2, 0 ), duration( 0, 0, 1, 0 ).mul( longValue( 2 ) ) );
+        assertEquals( duration( 0, 0, 0, 2 ), duration( 0, 0, 0, 1 ).mul( longValue( 2 ) ) );
+
+        assertEquals( duration( 0, 40, 0, 0 ), duration( 0, 20, 0, 0 ).mul( longValue( 2 ) ) );
+        assertEquals(
+                duration( 0, 0, 100_000, 0 ),
+                duration( 0, 0, 50_000, 0 ).mul( longValue( 2 ) ) );
+        assertEquals(
+                duration( 0, 0, 1, 0 ),
+                duration( 0, 0, 0, 500_000_000 ).mul( longValue( 2 ) ) );
+    }
+
+    @Test
+    public void shouldMultiplyDurationByFloat()
+    {
+        assertEquals(
+                duration( 0, 0, 0, 500_000_000 ),
+                duration( 0, 0, 1, 0 ).mul( doubleValue( 0.5 ) ) );
+        assertEquals( duration( 0, 0, 43200, 0 ), duration( 0, 1, 0, 0 ).mul( doubleValue( 0.5 ) ) );
+        assertEquals( duration( 0, 15, 18900, 0 ), duration( 1, 0, 0, 0 ).mul( doubleValue( 0.5 ) ) );
+    }
+
+    @Test
+    public void shouldDivideDuration()
+    {
+        assertEquals(
+                duration( 0, 0, 0, 500_000_000 ),
+                duration( 0, 0, 1, 0 ).div( longValue( 2 ) ) );
+        assertEquals( duration( 0, 0, 43200, 0 ), duration( 0, 1, 0, 0 ).div( longValue( 2 ) ) );
+        assertEquals( duration( 0, 15, 18900, 0 ), duration( 1, 0, 0, 0 ).div( longValue( 2 ) ) );
+    }
+
+    @Test
+    public void shouldComputeDurationBetweenDates() throws Exception
+    {
+        assertEquals( duration( 22, 23, 0, 0 ), durationBetween( date( 2016, 1, 27 ), date( 2017, 12, 20 ) ) );
+        assertEquals( duration( 0, 693, 0, 0 ), days.between( date( 2016, 1, 27 ), date( 2017, 12, 20 ) ) );
+        assertEquals( duration( 0, 693, 0, 0 ), weeks.between( date( 2016, 1, 27 ), date( 2017, 12, 20 ) ) );
+        assertEquals( duration( 22, 0, 0, 0 ), months.between( date( 2016, 1, 27 ), date( 2017, 12, 20 ) ) );
+        assertEquals( duration( 12, 0, 0, 0 ), years.between( date( 2016, 1, 27 ), date( 2017, 12, 20 ) ) );
+        //        assertEquals( duration( 0, 0, 0, 0 ), hours.between( date( 2016, 1, 27 ), date( 2017, 12, 20 ) ) );
+    }
+
+    @Test
+    public void shouldComputeDurationBetweenLocalTimes() throws Exception
+    {
+        assertEquals( duration( 0, 0, 10623, 0 ), durationBetween(
+                localTime( 11, 30, 52, 0 ), localTime( 14, 27, 55, 0 ) ) );
+        //        assertEquals( duration( 0,0,0,0 ), days.between(
+        //                localTime( 11, 30, 52, 0 ), localTime( 14, 27, 55, 0 ) ) );
+        assertEquals( duration( 0, 0, 7200, 0 ), hours.between(
+                localTime( 11, 30, 52, 0 ), localTime( 14, 27, 55, 0 ) ) );
+        assertEquals( duration( 0, 0, 10620, 0 ), minutes.between(
+                localTime( 11, 30, 52, 0 ), localTime( 14, 27, 55, 0 ) ) );
+        assertEquals( duration( 0, 0, 10623, 0 ), seconds.between(
+                localTime( 11, 30, 52, 0 ), localTime( 14, 27, 55, 0 ) ) );
+    }
+
+    @Test
+    public void shouldComputeDurationBetweenTimes() throws Exception
+    {
+        assertEquals( duration( 0, 0, 140223, 0 ), durationBetween(
+                time( 11, 30, 52, 0, ofHours( 18 ) ), time( 14, 27, 55, 0, ofHours( -18 ) ) ) );
+        //        assertEquals( duration( 0,0,0,0 ), days.between(
+        //                time( 11, 30, 52, 0, UTC ), time( 14, 27, 55, 0, UTC ) ) );
+        assertEquals( duration( 0, 0, 0, 0 ), hours.between(
+                time( 11, 30, 52, 0, ofHours( -1 ) ), time( 14, 27, 55, 0, ofHours( 1 ) ) ) );
+        assertEquals( duration( 0, 0, 3420, 0 ), minutes.between(
+                time( 11, 30, 52, 0, ofHours( 2 ) ), time( 14, 27, 55, 0, ofHours( 4 ) ) ) );
+        assertEquals( duration( 0, 0, 10623, 0 ), seconds.between(
+                time( 11, 30, 52, 0, UTC ), time( 14, 27, 55, 0, UTC ) ) );
+
+        assertEquals( duration( 0, 0, 10623, 0 ), durationBetween(
+                time( 11, 30, 52, 0, UTC ), localTime( 14, 27, 55, 0 ) ) );
+        assertEquals( duration( 0, 0, 10623, 0 ), durationBetween(
+                time( 11, 30, 52, 0, ofHours( 17 ) ), localTime( 14, 27, 55, 0 ) ) );
+        assertEquals( duration( 0, 0, -10623, 0 ), durationBetween(
+                localTime( 14, 27, 55, 0 ), time( 11, 30, 52, 0, UTC ) ) );
+        assertEquals( duration( 0, 0, -10623, 0 ), durationBetween(
+                localTime( 14, 27, 55, 0 ), time( 11, 30, 52, 0, ofHours( 17 ) ) ) );
+
+        //        assertEquals( duration( 0, 1, 0, 0 ), days.between(
+        //                time( 14, 30, 22, 0, ofHours( -12 ) ), time( 14, 30, 22, 0, ofHours( 12 ) ) ) );
+    }
+
+    @Test
+    public void shouldComputeDurationBetweenDateAndTime() throws Exception
+    {
+        assertEquals( parse( "PT14H32M11S" ), durationBetween( date( 2017, 12, 21 ), localTime( 14, 32, 11, 0 ) ) );
+        assertEquals( parse( "-PT14H32M11S" ), durationBetween( localTime( 14, 32, 11, 0 ), date( 2017, 12, 21 ) ) );
+        assertEquals( parse( "PT14H32M11S" ), durationBetween( date( 2017, 12, 21 ), time( 14, 32, 11, 0, UTC ) ) );
+        assertEquals( parse( "-PT14H32M11S" ), durationBetween( time( 14, 32, 11, 0, UTC ), date( 2017, 12, 21 ) ) );
+        assertEquals( parse( "PT14H32M11S" ), durationBetween(
+                date( 2017, 12, 21 ), time( 14, 32, 11, 0, ofHours( -12 ) ) ) );
+        assertEquals( parse( "-PT14H32M11S" ), durationBetween(
+                time( 14, 32, 11, 0, ofHours( -12 ) ), date( 2017, 12, 21 ) ) );
+    }
+
+    @Test
+    public void shouldComputeDurationBetweenDateTimeAndTime() throws Exception
+    {
+        assertEquals( parse( "PT8H-20M" ), durationBetween(
+                datetime( date( 2017, 12, 21 ), time( 6, 52, 11, 0, UTC ) ), localTime( 14, 32, 11, 0 ) ) );
+        assertEquals( parse( "PT-8H+20M" ), durationBetween(
+                localTime( 14, 32, 11, 0 ), datetime( date( 2017, 12, 21 ), time( 6, 52, 11, 0, UTC ) ) ) );
+        //
+        //assertEquals( parse( "-PT14H32M11S" ), durationBetween( localTime( 14, 32, 11, 0 ), date( 2017, 12, 21 ) ) );
+        //assertEquals( parse( "PT14H32M11S" ), durationBetween( date( 2017, 12, 21 ), time( 14, 32, 11, 0, UTC ) ) );
+        //assertEquals( parse( "-PT14H32M11S" ), durationBetween( time( 14, 32, 11, 0, UTC ), date( 2017, 12, 21 ) ) );
+        //assertEquals( parse( "PT14H32M11S" ), durationBetween(
+        //        date( 2017, 12, 21 ), time( 14, 32, 11, 0, ofHours( -12 ) ) ) );
+        //assertEquals( parse( "-PT14H32M11S" ), durationBetween(
+        //        time( 14, 32, 11, 0, ofHours( -12 ) ), date( 2017, 12, 21 ) ) );
+    }
+
+    @Test
+    public void shouldGetSameInstantWhenAddingDurationBetweenToInstant() throws Exception
+    {
+        // given
+        @SuppressWarnings( "unchecked" )
+        Pair<Temporal,Temporal>[] input = new Pair[] {
+                pair( // change from CET to CEST - second time of day after first
+                        datetime( date( 2017, 3, 20 ), localTime( 13, 37, 0, 0 ), ZoneId.of( "Europe/Stockholm" ) ),
+                        datetime( date( 2017, 3, 26 ), localTime( 19, 40, 0, 0 ), ZoneId.of( "Europe/Stockholm" ) ) ),
+                pair( // change from CET to CEST - second time of day before first
+                        datetime( date( 2017, 3, 20 ), localTime( 13, 37, 0, 0 ), ZoneId.of( "Europe/Stockholm" ) ),
+                        datetime( date( 2017, 3, 26 ), localTime( 11, 40, 0, 0 ), ZoneId.of( "Europe/Stockholm" ) ) ),
+                pair( // change from CEST to CET - second time of day after first
+                        datetime( date( 2017, 10, 20 ), localTime( 13, 37, 0, 0 ), ZoneId.of( "Europe/Stockholm" ) ),
+                        datetime( date( 2017, 10, 29 ), localTime( 19, 40, 0, 0 ), ZoneId.of( "Europe/Stockholm" ) ) ),
+                pair( // change from CEST to CET - second time of day before first
+                        datetime( date( 2017, 10, 20 ), localTime( 13, 37, 0, 0 ), ZoneId.of( "Europe/Stockholm" ) ),
+                        datetime( date( 2017, 10, 29 ), localTime( 11, 40, 0, 0 ), ZoneId.of( "Europe/Stockholm" ) ) ),
+        };
+        for ( Pair<Temporal,Temporal> pair : input )
+        {
+            Temporal a = pair.first(), b = pair.other();
+
+            // when
+            DurationValue diffAB = durationBetween( a, b );
+            DurationValue diffBA = durationBetween( b, a );
+            DurationValue diffABs = seconds.between( a, b );
+            DurationValue diffBAs = seconds.between( b, a );
+
+            // then
+            assertEquals( diffAB.prettyPrint(), b, a.plus( diffAB ) );
+            assertEquals( diffBA.prettyPrint(), a, b.plus( diffBA ) );
+            assertEquals( diffABs.prettyPrint(), b, a.plus( diffABs ) );
+            assertEquals( diffBAs.prettyPrint(), a, b.plus( diffBAs ) );
+        }
+    }
+}

--- a/community/values/src/test/java/org/neo4j/values/storable/DurationValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/DurationValueTest.java
@@ -47,13 +47,7 @@ import static org.junit.Assert.fail;
 import static org.neo4j.helpers.collection.Pair.pair;
 import static org.neo4j.values.storable.DateTimeValue.datetime;
 import static org.neo4j.values.storable.DateValue.date;
-import static org.neo4j.values.storable.DurationValue.Difference.days;
-import static org.neo4j.values.storable.DurationValue.Difference.hours;
-import static org.neo4j.values.storable.DurationValue.Difference.minutes;
-import static org.neo4j.values.storable.DurationValue.Difference.months;
-import static org.neo4j.values.storable.DurationValue.Difference.seconds;
-import static org.neo4j.values.storable.DurationValue.Difference.weeks;
-import static org.neo4j.values.storable.DurationValue.Difference.years;
+import static org.neo4j.values.storable.DurationValue.between;
 import static org.neo4j.values.storable.DurationValue.duration;
 import static org.neo4j.values.storable.DurationValue.durationBetween;
 import static org.neo4j.values.storable.DurationValue.parse;
@@ -370,11 +364,11 @@ public class DurationValueTest
     public void shouldComputeDurationBetweenDates() throws Exception
     {
         assertEquals( duration( 22, 23, 0, 0 ), durationBetween( date( 2016, 1, 27 ), date( 2017, 12, 20 ) ) );
-        assertEquals( duration( 0, 693, 0, 0 ), days.between( date( 2016, 1, 27 ), date( 2017, 12, 20 ) ) );
-        assertEquals( duration( 0, 693, 0, 0 ), weeks.between( date( 2016, 1, 27 ), date( 2017, 12, 20 ) ) );
-        assertEquals( duration( 22, 0, 0, 0 ), months.between( date( 2016, 1, 27 ), date( 2017, 12, 20 ) ) );
-        assertEquals( duration( 12, 0, 0, 0 ), years.between( date( 2016, 1, 27 ), date( 2017, 12, 20 ) ) );
-        //        assertEquals( duration( 0, 0, 0, 0 ), hours.between( date( 2016, 1, 27 ), date( 2017, 12, 20 ) ) );
+        assertEquals( duration( 0, 693, 0, 0 ), between(DAYS, date( 2016, 1, 27 ), date( 2017, 12, 20 ) ) );
+        assertEquals( duration( 0, 693, 0, 0 ), between(WEEKS, date( 2016, 1, 27 ), date( 2017, 12, 20 ) ) );
+        assertEquals( duration( 22, 0, 0, 0 ), between(MONTHS, date( 2016, 1, 27 ), date( 2017, 12, 20 ) ) );
+        assertEquals( duration( 12, 0, 0, 0 ), between(YEARS, date( 2016, 1, 27 ), date( 2017, 12, 20 ) ) );
+        //        assertEquals( duration( 0, 0, 0, 0 ), between( HOURS, date( 2016, 1, 27 ), date( 2017, 12, 20 ) ) );
     }
 
     @Test
@@ -382,14 +376,14 @@ public class DurationValueTest
     {
         assertEquals( duration( 0, 0, 10623, 0 ), durationBetween(
                 localTime( 11, 30, 52, 0 ), localTime( 14, 27, 55, 0 ) ) );
-        //        assertEquals( duration( 0,0,0,0 ), days.between(
-        //                localTime( 11, 30, 52, 0 ), localTime( 14, 27, 55, 0 ) ) );
-        assertEquals( duration( 0, 0, 7200, 0 ), hours.between(
-                localTime( 11, 30, 52, 0 ), localTime( 14, 27, 55, 0 ) ) );
-        assertEquals( duration( 0, 0, 10620, 0 ), minutes.between(
-                localTime( 11, 30, 52, 0 ), localTime( 14, 27, 55, 0 ) ) );
-        assertEquals( duration( 0, 0, 10623, 0 ), seconds.between(
-                localTime( 11, 30, 52, 0 ), localTime( 14, 27, 55, 0 ) ) );
+        //        assertEquals( duration( 0,0,0,0 ), between(
+        //                DAYS, localTime( 11, 30, 52, 0 ), localTime( 14, 27, 55, 0 ) ) );
+        assertEquals( duration( 0, 0, 7200, 0 ), between(
+                HOURS, localTime( 11, 30, 52, 0 ), localTime( 14, 27, 55, 0 ) ) );
+        assertEquals( duration( 0, 0, 10620, 0 ), between(
+                MINUTES, localTime( 11, 30, 52, 0 ), localTime( 14, 27, 55, 0 ) ) );
+        assertEquals( duration( 0, 0, 10623, 0 ), between(
+                SECONDS, localTime( 11, 30, 52, 0 ), localTime( 14, 27, 55, 0 ) ) );
     }
 
     @Test
@@ -399,12 +393,12 @@ public class DurationValueTest
                 time( 11, 30, 52, 0, ofHours( 18 ) ), time( 14, 27, 55, 0, ofHours( -18 ) ) ) );
         //        assertEquals( duration( 0,0,0,0 ), days.between(
         //                time( 11, 30, 52, 0, UTC ), time( 14, 27, 55, 0, UTC ) ) );
-        assertEquals( duration( 0, 0, 0, 0 ), hours.between(
-                time( 11, 30, 52, 0, ofHours( -1 ) ), time( 14, 27, 55, 0, ofHours( 1 ) ) ) );
-        assertEquals( duration( 0, 0, 3420, 0 ), minutes.between(
-                time( 11, 30, 52, 0, ofHours( 2 ) ), time( 14, 27, 55, 0, ofHours( 4 ) ) ) );
-        assertEquals( duration( 0, 0, 10623, 0 ), seconds.between(
-                time( 11, 30, 52, 0, UTC ), time( 14, 27, 55, 0, UTC ) ) );
+        assertEquals( duration( 0, 0, 0, 0 ), between(
+                HOURS, time( 11, 30, 52, 0, ofHours( -1 ) ), time( 14, 27, 55, 0, ofHours( 1 ) ) ) );
+        assertEquals( duration( 0, 0, 3420, 0 ), between(
+                MINUTES, time( 11, 30, 52, 0, ofHours( 2 ) ), time( 14, 27, 55, 0, ofHours( 4 ) ) ) );
+        assertEquals( duration( 0, 0, 10623, 0 ), between(
+                SECONDS, time( 11, 30, 52, 0, UTC ), time( 14, 27, 55, 0, UTC ) ) );
 
         assertEquals( duration( 0, 0, 10623, 0 ), durationBetween(
                 time( 11, 30, 52, 0, UTC ), localTime( 14, 27, 55, 0 ) ) );
@@ -475,8 +469,8 @@ public class DurationValueTest
             // when
             DurationValue diffAB = durationBetween( a, b );
             DurationValue diffBA = durationBetween( b, a );
-            DurationValue diffABs = seconds.between( a, b );
-            DurationValue diffBAs = seconds.between( b, a );
+            DurationValue diffABs = between( SECONDS, a, b );
+            DurationValue diffBAs = between( SECONDS, b, a );
 
             // then
             assertEquals( diffAB.prettyPrint(), b, a.plus( diffAB ) );

--- a/community/values/src/test/java/org/neo4j/values/storable/FrozenClockRule.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/FrozenClockRule.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.storable;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAdjuster;
+import java.time.temporal.TemporalField;
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import static java.time.ZoneOffset.UTC;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class FrozenClockRule extends Clock implements TestRule
+{
+    @Target( ElementType.METHOD )
+    @Retention( RetentionPolicy.RUNTIME )
+    @interface TimeZone
+    {
+        String[] value();
+    }
+
+    public static final TemporalAdjuster SECOND_PRECISION = temporal -> temporal.with( ChronoField.NANO_OF_SECOND, 0 );
+    public static final TemporalAdjuster MILLISECOND_PRECISION = temporal -> temporal
+            .with( ChronoField.NANO_OF_SECOND, temporal.get( ChronoField.MILLI_OF_SECOND ) * 1000_000 );
+    private Instant instant;
+    private ZoneId zone;
+
+    @Override
+    public ZoneId getZone()
+    {
+        return zone;
+    }
+
+    public Clock withZone( String zoneId )
+    {
+        return withZone( ZoneId.of( zoneId ) );
+    }
+
+    @Override
+    public Clock withZone( ZoneId zone )
+    {
+        return fixed( instant, zone );
+    }
+
+    @Override
+    public Instant instant()
+    {
+        return instant;
+    }
+
+    @Override
+    public long millis()
+    {
+        return instant.toEpochMilli();
+    }
+
+    public Clock at( LocalDateTime datetime )
+    {
+        return at( datetime.atZone( zone ) );
+    }
+
+    public Clock at( OffsetDateTime datetime )
+    {
+        return fixed( datetime.toInstant(), datetime.getOffset() );
+    }
+
+    public Clock at( ZonedDateTime datetime )
+    {
+        return fixed( datetime.toInstant(), datetime.getZone() );
+    }
+
+    public Clock with( TemporalAdjuster adjuster )
+    {
+        return fixed( instant.with( adjuster ), zone );
+    }
+
+    public Clock with( TemporalField field, long newValue )
+    {
+        return fixed( instant.with( field, newValue ), zone );
+    }
+
+    @Override
+    public Statement apply( Statement base, Description description )
+    {
+        return new Statement()
+        {
+            @Override
+            public void evaluate() throws Throwable
+            {
+                try
+                {
+                    for ( ZoneId zoneId : zonesOf( description ) )
+                    {
+                        instant = Instant.now();
+                        zone = zoneId;
+                        base.evaluate();
+                    }
+                }
+                finally
+                {
+                    instant = null;
+                    zone = null;
+                }
+            }
+
+            private ZoneId[] zonesOf( Description description )
+            {
+                TimeZone zone = description.getAnnotation( TimeZone.class );
+                String[] ids = zone == null ? null : zone.value();
+                if ( ids == null || ids.length == 0 )
+                {
+                    return new ZoneId[] {UTC};
+                }
+                else
+                {
+                    ZoneId[] zones = new ZoneId[ids.length];
+                    for ( int i = 0; i < zones.length; i++ )
+                    {
+                        zones[i] = ZoneId.of( ids[i] );
+                    }
+                    return zones;
+                }
+            }
+        };
+    }
+
+    static <V extends TemporalValue<?,V>> void assertEqualTemporal( V expected, V actual )
+    {
+        assertThat( actual, allOf(
+                equalTo( expected ),
+                equalOn( "timezone", FrozenClockRule::timezone, expected ),
+                equalOn( "temporal", TemporalValue::temporal, expected ) ) );
+    }
+
+    private static ZoneId timezone( TemporalValue<?,?> temporal )
+    {
+        if ( temporal instanceof DateTimeValue )
+        {
+            return ((DateTimeValue) temporal).temporal().getZone();
+        }
+        if ( temporal instanceof TimeValue )
+        {
+            return ((TimeValue) temporal).temporal().getOffset();
+        }
+        return null;
+    }
+
+    private static <T, U> Matcher<T> equalOn( String trait, Function<T,U> mapping, T expected )
+    {
+        return new TypeSafeDiagnosingMatcher<T>( expected.getClass() )
+        {
+            @Override
+            protected boolean matchesSafely( T actual, org.hamcrest.Description mismatchDescription )
+            {
+                U e = mapping.apply( expected );
+                U a = mapping.apply( actual );
+                if ( Objects.equals( e, a ) )
+                {
+                    return true;
+                }
+                mismatchDescription.appendText( "- " );
+                mismatchDescription.appendText( "expected: " ).appendValue( e );
+                mismatchDescription.appendText( " but was: " ).appendValue( a );
+                return false;
+            }
+
+            @Override
+            public void describeTo( org.hamcrest.Description description )
+            {
+                description.appendText( trait ).appendText( " should be equal" );
+            }
+        };
+    }
+}

--- a/community/values/src/test/java/org/neo4j/values/storable/FrozenClockRule.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/FrozenClockRule.java
@@ -34,6 +34,7 @@ import java.time.temporal.TemporalAdjuster;
 import java.time.temporal.TemporalField;
 import java.util.Objects;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
@@ -46,7 +47,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-public class FrozenClockRule extends Clock implements TestRule
+public class FrozenClockRule extends Clock implements TestRule, Function<String,Clock>, Supplier<ZoneId>
 {
     @Target( ElementType.METHOD )
     @Retention( RetentionPolicy.RUNTIME )
@@ -113,6 +114,18 @@ public class FrozenClockRule extends Clock implements TestRule
     public Clock with( TemporalField field, long newValue )
     {
         return fixed( instant.with( field, newValue ), zone );
+    }
+
+    @Override
+    public Clock apply( String when )
+    {
+        return this;
+    }
+
+    @Override
+    public ZoneId get()
+    {
+        return zone;
     }
 
     @Override

--- a/community/values/src/test/java/org/neo4j/values/storable/InputMappingStructureBuilder.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/InputMappingStructureBuilder.java
@@ -21,7 +21,9 @@ package org.neo4j.values.storable;
 
 import java.util.function.Function;
 
-public final class InputMappingStructureBuilder<Input, Internal, Result> extends StructureBuilder<Input,Result>
+import org.neo4j.values.StructureBuilder;
+
+public final class InputMappingStructureBuilder<Input, Internal, Result> implements StructureBuilder<Input,Result>
 {
     public static <R> StructureBuilder<Object,R> fromValues( StructureBuilder<? super Value,R> builder )
     {

--- a/community/values/src/test/java/org/neo4j/values/storable/InputMappingStructureBuilder.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/InputMappingStructureBuilder.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.storable;
+
+import java.util.function.Function;
+
+public final class InputMappingStructureBuilder<Input, Internal, Result> extends StructureBuilder<Input,Result>
+{
+    public static <R> StructureBuilder<Object,R> fromValues( StructureBuilder<? super Value,R> builder )
+    {
+        return mapping( Values::of, builder );
+    }
+
+    public static <I, N, O> StructureBuilder<I,O> mapping( Function<I,N> mapping, StructureBuilder<N,O> builder )
+    {
+        return new InputMappingStructureBuilder<>( mapping, builder );
+    }
+
+    private final Function<Input,Internal> mapping;
+    private final StructureBuilder<Internal,Result> builder;
+
+    private InputMappingStructureBuilder( Function<Input,Internal> mapping, StructureBuilder<Internal,Result> builder )
+    {
+        this.mapping = mapping;
+        this.builder = builder;
+    }
+
+    @Override
+    public StructureBuilder<Input,Result> add( String field, Input value )
+    {
+        builder.add( field, mapping.apply( value ) );
+        return this;
+    }
+
+    @Override
+    public Result build()
+    {
+        return builder.build();
+    }
+}

--- a/community/values/src/test/java/org/neo4j/values/storable/LocalDateTimeValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/LocalDateTimeValueTest.java
@@ -19,30 +19,21 @@
  */
 package org.neo4j.values.storable;
 
-/**
- * The ValueGroup is the logical group or type of a Value. For example byte, short, int and long are all attempting
- * to represent mathematical integers, meaning that for comparison purposes they should be treated the same.
- *
- * The order here is defined in <a href="https://github.com/opencypher/openCypher/blob/master/cip/1.accepted/CIP2016-06-14-Define-comparability-and-equality-as-well-as-orderability-and-equivalence.adoc">
- *   The Cypher CIP defining orderability
- * </a>
- */
-public enum ValueGroup
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.values.storable.DateValue.date;
+import static org.neo4j.values.storable.LocalDateTimeValue.localDateTime;
+import static org.neo4j.values.storable.LocalDateTimeValue.parse;
+import static org.neo4j.values.storable.LocalTimeValue.localTime;
+
+public class LocalDateTimeValueTest
 {
-    UNKNOWN,
-    GEOMETRY_ARRAY,
-    TEXT_ARRAY,
-    BOOLEAN_ARRAY,
-    NUMBER_ARRAY,
-    GEOMETRY,
-    ZONED_DATE_TIME,
-    LOCAL_DATE_TIME,
-    DATE,
-    ZONED_TIME,
-    LOCAL_TIME,
-    DURATION,
-    TEXT,
-    BOOLEAN,
-    NUMBER,
-    NO_VALUE,
+    @Test
+    public void shouldParseDate() throws Exception
+    {
+        assertEquals(
+                localDateTime( date( 2017, 12, 17 ), localTime( 17, 14, 35, 123456789 ) ),
+                parse( "2017-12-17T17:14:35.123456789" ) );
+    }
 }

--- a/community/values/src/test/java/org/neo4j/values/storable/LocalDateTimeValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/LocalDateTimeValueTest.java
@@ -19,8 +19,12 @@
  */
 package org.neo4j.values.storable;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Test;
 
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.values.storable.DateValue.date;
 import static org.neo4j.values.storable.LocalDateTimeValue.localDateTime;
@@ -35,5 +39,36 @@ public class LocalDateTimeValueTest
         assertEquals(
                 localDateTime( date( 2017, 12, 17 ), localTime( 17, 14, 35, 123456789 ) ),
                 parse( "2017-12-17T17:14:35.123456789" ) );
+    }
+
+    @Test
+    public void shouldWriteDateTime() throws Exception
+    {
+        // given
+        for ( LocalDateTimeValue value : new LocalDateTimeValue[] {
+                localDateTime( date( 2017, 3, 26 ), localTime( 1, 0, 0, 0 ) ),
+                localDateTime( date( 2017, 3, 26 ), localTime( 2, 0, 0, 0 ) ),
+                localDateTime( date( 2017, 3, 26 ), localTime( 3, 0, 0, 0 ) ),
+                localDateTime( date( 2017, 10, 29 ), localTime( 2, 0, 0, 0 ) ),
+                localDateTime( date( 2017, 10, 29 ), localTime( 3, 0, 0, 0 ) ),
+                localDateTime( date( 2017, 10, 29 ), localTime( 4, 0, 0, 0 ) ),
+        } )
+        {
+            List<LocalDateTimeValue> values = new ArrayList<>( 1 );
+            ValueWriter<RuntimeException> writer = new ThrowingValueWriter.AssertOnly()
+            {
+                @Override
+                public void writeLocalDateTime( long epochSecond, int nano ) throws RuntimeException
+                {
+                    values.add( localDateTime( epochSecond, nano ) );
+                }
+            };
+
+            // when
+            value.writeTo( writer );
+
+            // then
+            assertEquals( singletonList( value ), values );
+        }
     }
 }

--- a/community/values/src/test/java/org/neo4j/values/storable/LocalTimeValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/LocalTimeValueTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.storable;
+
+import java.time.DateTimeException;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.values.storable.LocalTimeValue.localTime;
+import static org.neo4j.values.storable.LocalTimeValue.parse;
+
+public class LocalTimeValueTest
+{
+    @Test
+    public void shouldParseTimeWithOnlyHour() throws Exception
+    {
+        assertEquals( localTime( 14, 0, 0, 0 ), parse( "14" ) );
+        assertEquals( localTime( 4, 0, 0, 0 ), parse( "4" ) );
+        assertEquals( localTime( 4, 0, 0, 0 ), parse( "04" ) );
+    }
+
+    @Test
+    public void shouldParseTimeWithHourAndMinute() throws Exception
+    {
+        assertEquals( localTime( 14, 5, 0, 0 ), parse( "1405" ) );
+        assertEquals( localTime( 14, 5, 0, 0 ), parse( "14:5" ) );
+        assertEquals( localTime( 4, 15, 0, 0 ), parse( "4:15" ) );
+        assertEquals( localTime( 9, 7, 0, 0 ), parse( "9:7" ) );
+        assertEquals( localTime( 3, 4, 0, 0 ), parse( "03:04" ) );
+    }
+
+    @Test
+    public void shouldParseTimeWithHourMinuteAndSecond() throws Exception
+    {
+        assertEquals( localTime( 14, 5, 17, 0 ), parse( "140517" ) );
+        assertEquals( localTime( 14, 5, 17, 0 ), parse( "14:5:17" ) );
+        assertEquals( localTime( 4, 15, 4, 0 ), parse( "4:15:4" ) );
+        assertEquals( localTime( 9, 7, 19, 0 ), parse( "9:7:19" ) );
+        assertEquals( localTime( 3, 4, 1, 0 ), parse( "03:04:01" ) );
+    }
+
+    @Test
+    public void shouldParseTimeWithHourMinuteSecondAndFractions() throws Exception
+    {
+        assertEquals( localTime( 14, 5, 17, 123000000 ), parse( "140517.123" ) );
+        assertEquals( localTime( 14, 5, 17, 1 ), parse( "14:5:17.000000001" ) );
+        assertEquals( localTime( 4, 15, 4, 0 ), parse( "4:15:4.000" ) );
+        assertEquals( localTime( 9, 7, 19, 999999999 ), parse( "9:7:19.999999999" ) );
+        assertEquals( localTime( 3, 4, 1, 123456789 ), parse( "03:04:01.123456789" ) );
+    }
+
+    @Test
+    @SuppressWarnings( "ThrowableNotThrown" )
+    public void shouldFailToParseTimeOutOfRange() throws Exception
+    {
+        assertCannotParse( "24" );
+        assertCannotParse( "1760" );
+        assertCannotParse( "173260" );
+        assertCannotParse( "173250.0000000001" );
+    }
+
+    @SuppressWarnings( "UnusedReturnValue" )
+    private DateTimeException assertCannotParse( String text )
+    {
+        try
+        {
+            parse( text );
+        }
+        catch ( DateTimeException e )
+        {
+            return e;
+        }
+        throw new AssertionError( text );
+    }
+}

--- a/community/values/src/test/java/org/neo4j/values/storable/LocalTimeValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/LocalTimeValueTest.java
@@ -20,9 +20,12 @@
 package org.neo4j.values.storable;
 
 import java.time.DateTimeException;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Test;
 
+import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.neo4j.values.storable.LocalTimeValue.localTime;
 import static org.neo4j.values.storable.LocalTimeValue.parse;
@@ -75,6 +78,35 @@ public class LocalTimeValueTest
         assertCannotParse( "1760" );
         assertCannotParse( "173260" );
         assertCannotParse( "173250.0000000001" );
+    }
+
+    @Test
+    public void shouldWriteLocalTime() throws Exception
+    {
+        // given
+        for ( LocalTimeValue value : new LocalTimeValue[] {
+                localTime( 0, 0, 0, 0 ),
+                localTime( 11, 22, 33, 123456789 ),
+                localTime( 2, 3, 4, 5 ),
+                localTime( 23, 59, 59, 999999999 ),
+        } )
+        {
+            List<LocalTimeValue> values = new ArrayList<>( 1 );
+            ValueWriter<RuntimeException> writer = new ThrowingValueWriter.AssertOnly()
+            {
+                @Override
+                public void writeLocalTime( long nanoOfDay ) throws RuntimeException
+                {
+                    values.add( localTime( nanoOfDay ) );
+                }
+            };
+
+            // when
+            value.writeTo( writer );
+
+            // then
+            assertEquals( singletonList( value ), values );
+        }
     }
 
     @SuppressWarnings( "UnusedReturnValue" )

--- a/community/values/src/test/java/org/neo4j/values/storable/ThrowingValueWriter.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/ThrowingValueWriter.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.storable;
+
+import java.util.function.Supplier;
+
+public abstract class ThrowingValueWriter<E extends Exception> implements ValueWriter<E>
+{
+    protected abstract E exception( String method );
+
+    public static <E extends Exception> ValueWriter<E> throwing( Supplier<E> exception )
+    {
+        return new ThrowingValueWriter<E>()
+        {
+            @Override
+            protected E exception( String method )
+            {
+                return exception.get();
+            }
+        };
+    }
+
+    public abstract static class AssertOnly extends ThrowingValueWriter<RuntimeException>
+    {
+        @Override
+        protected RuntimeException exception( String method )
+        {
+            throw new AssertionError( method );
+        }
+    }
+
+    @Override
+    public void writeNull() throws E
+    {
+        throw exception( "writeNull" );
+    }
+
+    @Override
+    public void writeBoolean( boolean value ) throws E
+    {
+        throw exception( "writeBoolean" );
+    }
+
+    @Override
+    public void writeInteger( byte value ) throws E
+    {
+        throw exception( "writeInteger" );
+    }
+
+    @Override
+    public void writeInteger( short value ) throws E
+    {
+        throw exception( "writeInteger" );
+    }
+
+    @Override
+    public void writeInteger( int value ) throws E
+    {
+        throw exception( "writeInteger" );
+    }
+
+    @Override
+    public void writeInteger( long value ) throws E
+    {
+        throw exception( "writeInteger" );
+    }
+
+    @Override
+    public void writeFloatingPoint( float value ) throws E
+    {
+        throw exception( "writeFloatingPoint" );
+    }
+
+    @Override
+    public void writeFloatingPoint( double value ) throws E
+    {
+        throw exception( "writeFloatingPoint" );
+    }
+
+    @Override
+    public void writeString( String value ) throws E
+    {
+        throw exception( "writeString" );
+    }
+
+    @Override
+    public void writeString( char value ) throws E
+    {
+        throw exception( "writeString" );
+    }
+
+    @Override
+    public void beginArray( int size, ArrayType arrayType ) throws E
+    {
+        throw exception( "beginArray" );
+    }
+
+    @Override
+    public void endArray() throws E
+    {
+        throw exception( "endArray" );
+    }
+
+    @Override
+    public void writeByteArray( byte[] value ) throws E
+    {
+        throw exception( "writeByteArray" );
+    }
+
+    @Override
+    public void writePoint( CoordinateReferenceSystem crs, double[] coordinate ) throws E
+    {
+        throw exception( "writePoint" );
+    }
+
+    @Override
+    public void writeDuration( long months, long days, long seconds, int nanos ) throws E
+    {
+        throw exception( "writeDuration" );
+    }
+
+    @Override
+    public void writeDate( long epochDay ) throws E
+    {
+        throw exception( "writeDate" );
+    }
+
+    @Override
+    public void writeLocalTime( long nanoOfDay ) throws E
+    {
+        throw exception( "writeLocalTime" );
+    }
+
+    @Override
+    public void writeTime( long nanosOfDayUTC, int offsetSeconds ) throws E
+    {
+        throw exception( "writeTime" );
+    }
+
+    @Override
+    public void writeLocalDateTime( long epochSecond, int nano ) throws E
+    {
+        throw exception( "writeLocalDateTime" );
+    }
+
+    @Override
+    public void writeDateTime( long epochSecondUTC, int nano, int offsetSeconds ) throws E
+    {
+        throw exception( "writeDateTime" );
+    }
+
+    @Override
+    public void writeDateTime( long epochSecondUTC, int nano, String zoneId ) throws E
+    {
+        throw exception( "writeDateTime" );
+    }
+}

--- a/community/values/src/test/java/org/neo4j/values/storable/ThrowingValueWriterTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/ThrowingValueWriterTest.java
@@ -23,6 +23,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import static org.neo4j.values.storable.ThrowingValueWriter.throwing;
+
 public class ThrowingValueWriterTest
 {
     @Rule
@@ -33,7 +35,7 @@ public class ThrowingValueWriterTest
     {
         // Given
         Value value = Values.of( "This is a value" );
-        ThrowingValueWriter writer = new ThrowingValueWriter();
+        ValueWriter<TestException> writer = throwing( TestException::new );
 
         // Expect
         exception.expect( TestException.class );
@@ -44,93 +46,5 @@ public class ThrowingValueWriterTest
 
     private static class TestException extends Exception
     {
-    }
-
-    private static class ThrowingValueWriter implements ValueWriter<TestException>
-    {
-
-        @Override
-        public void writeNull() throws TestException
-        {
-            throw new TestException();
-        }
-
-        @Override
-        public void writeBoolean( boolean value ) throws TestException
-        {
-            throw new TestException();
-        }
-
-        @Override
-        public void writeInteger( byte value ) throws TestException
-        {
-            throw new TestException();
-        }
-
-        @Override
-        public void writeInteger( short value ) throws TestException
-        {
-            throw new TestException();
-        }
-
-        @Override
-        public void writeInteger( int value ) throws TestException
-        {
-            throw new TestException();
-        }
-
-        @Override
-        public void writeInteger( long value ) throws TestException
-        {
-            throw new TestException();
-        }
-
-        @Override
-        public void writeFloatingPoint( float value ) throws TestException
-        {
-            throw new TestException();
-        }
-
-        @Override
-        public void writeFloatingPoint( double value ) throws TestException
-        {
-            throw new TestException();
-        }
-
-        @Override
-        public void writeString( String value ) throws TestException
-        {
-            throw new TestException();
-        }
-
-        @Override
-        public void writeString( char value ) throws TestException
-        {
-            throw new TestException();
-        }
-
-        @Override
-        public void beginArray( int size, ArrayType arrayType ) throws TestException
-        {
-            throw new TestException();
-        }
-
-        @Override
-        public void endArray() throws TestException
-        {
-            throw new TestException();
-        }
-
-        @Override
-        public void writeByteArray( byte[] value ) throws TestException
-        {
-            throw new TestException();
-        }
-
-        @Override
-        public void writePoint( CoordinateReferenceSystem crs, double[] coordinate ) throws TestException
-        {
-            throw new TestException();
-        }
     }
 }

--- a/community/values/src/test/java/org/neo4j/values/storable/TimeValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/TimeValueTest.java
@@ -32,6 +32,7 @@ import static java.time.ZoneOffset.UTC;
 import static java.time.ZoneOffset.ofHours;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
 import static org.neo4j.values.storable.LocalTimeValue.inUTC;
 import static org.neo4j.values.storable.LocalTimeValue.localTime;
 import static org.neo4j.values.storable.TimeValue.parse;
@@ -124,6 +125,40 @@ public class TimeValueTest
             assertEquals( singletonList( time ), values );
             assertEquals( singletonList( inUTC( time ) ), locals );
         }
+    }
+
+    @Test
+    public void shouldAddDurationToTimes() throws Exception
+    {
+        assertEquals( time(12, 15, 0, 0, UTC),
+                time(12, 0, 0, 0, UTC).add( DurationValue.duration( 1, 1, 900, 0 ) ) );
+        assertEquals( time(12, 0, 2, 0, UTC),
+                time(12, 0, 0, 0, UTC).add( DurationValue.duration( 0, 0, 1, 1_000_000_000 ) ) );
+        assertEquals( time(12, 0, 0, 0, UTC),
+                time(12, 0, 0, 0, UTC).add( DurationValue.duration( 0, 0, 1, -1_000_000_000 ) ) );
+    }
+
+    @Test
+    public void shouldReuseInstanceInArithmetics() throws Exception
+    {
+        final TimeValue noon = time( 12, 0, 0, 0, UTC );
+        assertSame( noon,
+                noon.add( DurationValue.duration( 0, 0, 0, 0 ) ) );
+        assertSame( noon,
+                noon.add( DurationValue.duration( 1, 1, 0, 0 ) ) );
+        assertSame( noon,
+                noon.add( DurationValue.duration( -1, 1, 0, -0 ) ) );
+    }
+
+    @Test
+    public void shouldSubtractDurationFromTimes() throws Exception
+    {
+        assertEquals( time(12, 0, 0, 0, UTC),
+                time(12, 15, 0, 0, UTC).sub( DurationValue.duration( 1, 1, 900, 0 ) ) );
+        assertEquals( time(12, 0, 0, 0, UTC),
+                time(12, 0, 2, 0, UTC).sub( DurationValue.duration( 0, 0, 1, 1_000_000_000 ) ) );
+        assertEquals( time(12, 0, 0, 0, UTC),
+                time(12, 0, 0, 0, UTC).sub( DurationValue.duration( 0, 0, 1, -1_000_000_000 ) ) );
     }
 
     @SuppressWarnings( "UnusedReturnValue" )

--- a/community/values/src/test/java/org/neo4j/values/storable/TimeValueTest.java
+++ b/community/values/src/test/java/org/neo4j/values/storable/TimeValueTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.values.storable;
+
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import java.util.function.Supplier;
+
+import org.junit.Test;
+
+import static java.time.ZoneOffset.UTC;
+import static org.junit.Assert.assertEquals;
+import static org.neo4j.values.storable.TimeValue.parse;
+import static org.neo4j.values.storable.TimeValue.time;
+
+public class TimeValueTest
+{
+    static final Supplier<ZoneId> inUTC = () -> UTC;
+    static final Supplier<ZoneId> orFail = () ->
+    {
+        throw new AssertionError( "should not request timezone" );
+    };
+
+    @Test
+    public void shouldParseTimeWithOnlyHour() throws Exception
+    {
+        assertEquals( time( 14, 0, 0, 0, UTC ), parse( "14", inUTC ) );
+        assertEquals( time( 4, 0, 0, 0, UTC ), parse( "4", inUTC ) );
+        assertEquals( time( 4, 0, 0, 0, UTC ), parse( "04", inUTC ) );
+    }
+
+    @Test
+    public void shouldParseTimeWithHourAndMinute() throws Exception
+    {
+        assertEquals( time( 14, 5, 0, 0, UTC ), parse( "1405", inUTC ) );
+        assertEquals( time( 14, 5, 0, 0, UTC ), parse( "14:5", inUTC ) );
+        assertEquals( time( 4, 15, 0, 0, UTC ), parse( "4:15", inUTC ) );
+        assertEquals( time( 9, 7, 0, 0, UTC ), parse( "9:7", inUTC ) );
+        assertEquals( time( 3, 4, 0, 0, UTC ), parse( "03:04", inUTC ) );
+    }
+
+    @Test
+    public void shouldParseTimeWithHourMinuteAndSecond() throws Exception
+    {
+        assertEquals( time( 14, 5, 17, 0, UTC ), parse( "140517", inUTC ) );
+        assertEquals( time( 14, 5, 17, 0, UTC ), parse( "14:5:17", inUTC ) );
+        assertEquals( time( 4, 15, 4, 0, UTC ), parse( "4:15:4", inUTC ) );
+        assertEquals( time( 9, 7, 19, 0, UTC ), parse( "9:7:19", inUTC ) );
+        assertEquals( time( 3, 4, 1, 0, UTC ), parse( "03:04:01", inUTC ) );
+    }
+
+    @Test
+    public void shouldParseTimeWithHourMinuteSecondAndFractions() throws Exception
+    {
+        assertEquals( time( 14, 5, 17, 123000000, UTC ), parse( "140517.123", inUTC ) );
+        assertEquals( time( 14, 5, 17, 1, UTC ), parse( "14:5:17.000000001", inUTC ) );
+        assertEquals( time( 4, 15, 4, 0, UTC ), parse( "4:15:4.000", inUTC ) );
+        assertEquals( time( 9, 7, 19, 999999999, UTC ), parse( "9:7:19.999999999", inUTC ) );
+        assertEquals( time( 3, 4, 1, 123456789, UTC ), parse( "03:04:01.123456789", inUTC ) );
+    }
+
+    @Test
+    @SuppressWarnings( "ThrowableNotThrown" )
+    public void shouldFailToParseTimeOutOfRange() throws Exception
+    {
+        assertCannotParse( "24" );
+        assertCannotParse( "1760" );
+        assertCannotParse( "173260" );
+        assertCannotParse( "173250.0000000001" );
+    }
+
+    @SuppressWarnings( "UnusedReturnValue" )
+    private DateTimeException assertCannotParse( String text )
+    {
+        try
+        {
+            parse( text, inUTC );
+        }
+        catch ( DateTimeException e )
+        {
+            return e;
+        }
+        throw new AssertionError( text );
+    }
+}

--- a/community/values/src/test/java/org/neo4j/values/utils/AnyValueTestUtil.java
+++ b/community/values/src/test/java/org/neo4j/values/utils/AnyValueTestUtil.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.values.utils;
 
+import java.util.function.Supplier;
+
 import org.neo4j.values.AnyValue;
 
 import static org.junit.Assert.assertFalse;
@@ -67,5 +69,26 @@ public class AnyValueTestUtil
         assertFalse( b + " should not be equivalent to " + a, b.equals( a ) );
         assertNull( a + " should be incomparable to " + b, a.ternaryEquals( b ) );
         assertNull( b + " should be incomparable to " + a, b.ternaryEquals( a ) );
+    }
+
+    public static <X extends Exception, T> X assertThrows( Class<X> exception, Supplier<T> thunk )
+    {
+        T value;
+        try
+        {
+            value = thunk.get();
+        }
+        catch ( Exception e )
+        {
+            if ( exception.isInstance( e ) )
+            {
+                return exception.cast( e );
+            }
+            else
+            {
+                throw new AssertionError( "Expected " + exception.getName(), e );
+            }
+        }
+        throw new AssertionError( "Expected " + exception.getName() + " but returned: " + value );
     }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
@@ -36,7 +36,7 @@ import org.neo4j.graphdb.config.Setting
 import org.neo4j.graphdb.factory.GraphDatabaseSettings
 import org.neo4j.helpers.Exceptions
 import org.neo4j.internal.cypher.acceptance.NewRuntimeMonitor.{NewPlanSeen, NewRuntimeMonitorCall, UnableToCompileQuery}
-import org.neo4j.test.TestEnterpriseGraphDatabaseFactory
+import org.neo4j.test.{TestEnterpriseGraphDatabaseFactory, TestGraphDatabaseFactory}
 import org.neo4j.values.storable.{CoordinateReferenceSystem, Values}
 import org.scalatest.Assertions
 import org.scalatest.matchers.{MatchResult, Matcher}
@@ -53,9 +53,7 @@ trait CypherComparisonSupport extends CypherTestSupport {
     Map(GraphDatabaseSettings.cypher_hints_error -> "true")
   }
 
-  override protected def createGraphDatabase(config: collection.Map[Setting[_], String] = databaseConfig()): GraphDatabaseCypherService = {
-    new GraphDatabaseCypherService(new TestEnterpriseGraphDatabaseFactory().newImpermanentDatabase(config.asJava))
-  }
+  override protected def createDatabaseFactory(): TestGraphDatabaseFactory = new TestEnterpriseGraphDatabaseFactory()
 
   /**
     * Get rid of Arrays and java.util.Map to make it easier to compare results by equality.

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionCallSupportAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/FunctionCallSupportAcceptanceTest.scala
@@ -22,15 +22,16 @@ package org.neo4j.internal.cypher.acceptance
 import java.util
 
 import org.neo4j.kernel.api.proc.Neo4jTypes
+import org.neo4j.kernel.impl.util.ValueUtils
 
 class FunctionCallSupportAcceptanceTest extends ProcedureCallAcceptanceTest {
 
   test("should return correctly typed map result (even if converting to and from scala representation internally)") {
-    val value = new util.HashMap[String, Any]()
+    val value = new util.HashMap [String, Any]()
     value.put("name", "Cypher")
     value.put("level", 9001)
 
-    registerUserFunction(value)
+    registerUserFunction(ValueUtils.of(value))
 
     // Using graph execute to get a Java value
     graph.execute("RETURN my.first.value()").stream().toArray.toList should equal(List(
@@ -43,7 +44,7 @@ class FunctionCallSupportAcceptanceTest extends ProcedureCallAcceptanceTest {
     value.add("Norris")
     value.add("Strange")
 
-    registerUserFunction(value)
+    registerUserFunction(ValueUtils.of(value))
 
     // Using graph execute to get a Java value
     graph.execute("RETURN my.first.value() AS out").stream().toArray.toList should equal(List(
@@ -57,7 +58,7 @@ class FunctionCallSupportAcceptanceTest extends ProcedureCallAcceptanceTest {
     value.add("Strange")
     val stream = value.stream()
 
-    registerUserFunction(stream)
+    registerUserFunction(ValueUtils.of(value))
 
     // Using graph execute to get a Java value
     graph.execute("RETURN my.first.value() AS out").stream().toArray.toList should equal(List(
@@ -70,7 +71,7 @@ class FunctionCallSupportAcceptanceTest extends ProcedureCallAcceptanceTest {
     value.add("Norris")
     value.add("Strange")
 
-    registerUserFunction(value)
+    registerUserFunction(ValueUtils.of(value))
 
     // Using graph execute to get a Java value
     val returned = graph.execute("RETURN my.first.value() AS out").next().get("out")
@@ -85,7 +86,7 @@ class FunctionCallSupportAcceptanceTest extends ProcedureCallAcceptanceTest {
     value.add("Norris")
     value.add(inner)
 
-    registerUserFunction(value)
+    registerUserFunction(ValueUtils.of(value))
 
     // Using graph execute to get a Java value
     val returned = graph.execute("RETURN my.first.value() AS out").next().get("out")
@@ -99,7 +100,7 @@ class FunctionCallSupportAcceptanceTest extends ProcedureCallAcceptanceTest {
     value.add(1)
     value.add(3)
 
-    registerUserFunction(value, Neo4jTypes.NTList(Neo4jTypes.NTInteger))
+    registerUserFunction(ValueUtils.of(value), Neo4jTypes.NTList(Neo4jTypes.NTInteger))
 
     // Using graph execute to get a Java value
     val returned = graph.execute("WITH my.first.value() AS list RETURN list[0] + list[1] AS out")

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ManualIndexProcsIT.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ManualIndexProcsIT.scala
@@ -515,12 +515,7 @@ class ManualIndexProcsIT extends ExecutionEngineFunSuite {
     result1.head("config").asInstanceOf[Map[String, String]] should contain("provider" -> "lucene")
     intercept[Exception] {
       execute("CALL db.index.explicit.forNodes('usernames', {type: 'fulltext', provider: 'lucene'}) YIELD type, name, config").toList
-    }.getMessage should be(
-      """Failed to invoke procedure `db.index.explicit.forNodes`: Caused by: java.lang.IllegalArgumentException: Supplied index configuration:
-        |{type=fulltext, provider=lucene}
-        |doesn't match stored config in a valid way:
-        |{type=exact, provider=lucene}
-        |for 'usernames'""".stripMargin)
+    }.getMessage should include("doesn't match stored config in a valid way")
 
     //And Then
     assertNodeIndexExists("usernames", true)
@@ -593,12 +588,7 @@ class ManualIndexProcsIT extends ExecutionEngineFunSuite {
     result1.head("config").asInstanceOf[Map[String, String]] should contain("provider" -> "lucene")
     intercept[Exception] {
       execute("CALL db.index.explicit.forRelationships('relIndex', {type: 'fulltext', provider: 'lucene'}) YIELD type, name, config").toList
-    }.getMessage should be(
-      """Failed to invoke procedure `db.index.explicit.forRelationships`: Caused by: java.lang.IllegalArgumentException: Supplied index configuration:
-        |{type=fulltext, provider=lucene}
-        |doesn't match stored config in a valid way:
-        |{type=exact, provider=lucene}
-        |for 'relIndex'""".stripMargin)
+    }.getMessage should include("doesn't match stored config in a valid way")
 
     //And Then
     assertRelationshipIndexExists("relIndex", true)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProcedureCallAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ProcedureCallAcceptanceTest.scala
@@ -28,6 +28,7 @@ import org.neo4j.kernel.api.proc.CallableUserFunction.BasicUserFunction
 import org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature
 import org.neo4j.kernel.api.proc.UserFunctionSignature.functionSignature
 import org.neo4j.kernel.api.proc.{Context, Neo4jTypes, ProcedureSignature}
+import org.neo4j.values.AnyValue
 
 abstract class ProcedureCallAcceptanceTest extends ExecutionEngineFunSuite {
 
@@ -57,13 +58,13 @@ abstract class ProcedureCallAcceptanceTest extends ExecutionEngineFunSuite {
       }
     }
 
-  protected def registerUserFunction(value: AnyRef, typ: Neo4jTypes.AnyType = Neo4jTypes.NTAny) =
+  protected def registerUserFunction(value: AnyValue, typ: Neo4jTypes.AnyType = Neo4jTypes.NTAny) =
     registerUserDefinedFunction("my.first.value") { builder =>
       val builder = functionSignature(Array("my", "first"), "value")
       builder.out(typ)
 
       new BasicUserFunction(builder.build) {
-        override def apply(ctx: Context, input: Array[AnyRef]): AnyRef = value
+        override def apply(ctx: Context, input: Array[AnyValue]): AnyValue = value
       }
     }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TemporalFunctionsAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TemporalFunctionsAcceptanceTest.scala
@@ -19,7 +19,7 @@
  */
 package org.neo4j.internal.cypher.acceptance
 
-import java.time.ZonedDateTime
+import java.time._
 
 import org.neo4j.cypher.{ExecutionEngineFunSuite, FakeClock}
 import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
@@ -36,12 +36,44 @@ class TemporalFunctionsAcceptanceTest extends ExecutionEngineFunSuite with Cyphe
     now shouldBe a[ZonedDateTime]
   }
 
-  test("should get current 'reawltime' datetime") {
+  test("should get current 'realtime' datetime") {
     val result = executeWith(supported, "RETURN datetime.realtime() as now")
 
     val now = single(result.columnAs[ZonedDateTime]("now"))
 
     now shouldBe a[ZonedDateTime]
+  }
+
+  test("should get current default localdatetime") {
+    val result = executeWith(supported, "RETURN localdatetime() as now")
+
+    val now = single(result.columnAs[LocalDateTime]("now"))
+
+    now shouldBe a[LocalDateTime]
+  }
+
+  test("should get current default date") {
+    val result = executeWith(supported, "RETURN date() as now")
+
+    val now = single(result.columnAs[LocalDate]("now"))
+
+    now shouldBe a[LocalDate]
+  }
+
+  test("should get current default time") {
+    val result = executeWith(supported, "RETURN time() as now")
+
+    val now = single(result.columnAs[OffsetTime]("now"))
+
+    now shouldBe a[OffsetTime]
+  }
+
+  test("should get current default localtime") {
+    val result = executeWith(supported, "RETURN localtime() as now")
+
+    val now = single(result.columnAs[LocalTime]("now"))
+
+    now shouldBe a[LocalTime]
   }
 
   def single[T](values: Iterator[T]):T = {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TemporalFunctionsAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/TemporalFunctionsAcceptanceTest.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import java.time.ZonedDateTime
+
+import org.neo4j.cypher.{ExecutionEngineFunSuite, FakeClock}
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
+
+class TemporalFunctionsAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport with FakeClock {
+
+  val supported = (Configs.Version3_4 + Configs.Version3_3 + Configs.Version3_1) - Configs.Compiled
+
+  test("should get current default datetime") {
+    val result = executeWith(supported, "RETURN datetime() as now")
+
+    val now = single(result.columnAs[ZonedDateTime]("now"))
+
+    now shouldBe a[ZonedDateTime]
+  }
+
+  test("should get current 'reawltime' datetime") {
+    val result = executeWith(supported, "RETURN datetime.realtime() as now")
+
+    val now = single(result.columnAs[ZonedDateTime]("now"))
+
+    now shouldBe a[ZonedDateTime]
+  }
+
+  def single[T](values: Iterator[T]):T = {
+    val value = values.next()
+    values.hasNext shouldBe false
+    value
+  }
+}

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ToStringAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ToStringAcceptanceTest.scala
@@ -61,14 +61,18 @@ class ToStringAcceptanceTest extends ExecutionEngineFunSuite with Matchers {
   test("Path should provide sensible toString") {
     val data = makeModel()
     val result = graph.execute("MATCH p = (:A)-->(:B)-->(:C) RETURN p")
-    result.columnAs("p").next().toString should be(s"(?)-[?,${data("ab")}]-(?)-[?,${data("bc")}]-(?)")
+    result.columnAs("p").next().toString should (
+      be(s"(?)-[?,${data("ab")}]-(?)-[?,${data("bc")}]-(?)") or
+        be(s"(${data("a")})-[${data("ab")}:KNOWS]->(${data("b")})-[${data("bc")}:KNOWS]->(${data("c")})"))
   }
 
   test("Path should provide sensible toString within transactions") {
     val data = makeModel()
     graph.inTx {
       val result = graph.execute("MATCH p = (:A)-->(:B)-->(:C) RETURN p")
-      result.columnAs("p").next().toString should be(s"(${data("a")})-[KNOWS,${data("ab")}]->(${data("b")})-[KNOWS,${data("bc")}]->(${data("c")})")
+      result.columnAs("p").next().toString should (
+        be(s"(${data("a")})-[KNOWS,${data("ab")}]->(${data("b")})-[KNOWS,${data("bc")}]->(${data("c")})") or
+          be(s"(${data("a")})-[${data("ab")}:KNOWS]->(${data("b")})-[${data("bc")}:KNOWS]->(${data("c")})"))
     }
   }
 

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/TransactionStatusResultTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/TransactionStatusResultTest.java
@@ -162,7 +162,7 @@ public class TransactionStatusResultTest
         return new ExecutingQuery( queryId, getTestConnectionInfo(), "testUser", "testQuery", VirtualValues.EMPTY_MAP,
                 Collections.emptyMap(), () -> 1L, PageCursorTracer.NULL,
                 Thread.currentThread().getId(), Thread.currentThread().getName(),
-                new CountingSystemNanoClock(), new CountingCpuClock(), new CountingHeapAllocation() );
+                new CountingNanoClock(), new CountingCpuClock(), new CountingHeapAllocation() );
     }
 
     private HttpConnectionInfo getTestConnectionInfo()
@@ -215,7 +215,7 @@ public class TransactionStatusResultTest
         }
     }
 
-    private static class CountingSystemNanoClock extends SystemNanoClock
+    private static class CountingNanoClock extends SystemNanoClock
     {
         private long time;
 

--- a/integrationtests/src/test/java/org/neo4j/procedure/UserFunctionIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/UserFunctionIT.java
@@ -826,26 +826,46 @@ public class UserFunctionIT
                 "--------------------------------------------------------------------------------------------------" +
                 "--------------------------------------------------------------------------------------------------" +
                 "----------------------------------+%n" +
+                "| \"date\"                                              | \"date(input = null :: ANY?) :: " +
+                "(DATE?)\"                                                                                 " +
+                "                                     | \"Create a Date instant.\"                         " +
+                "                                                                |%n" +
+                "| \"date.realtime\"                                     | \"date.realtime(timezone = null " +
+                ":: STRING?) :: (DATE?)\"                                                                  " +
+                "                                     | \"Get the current Date instant using the realtime " +
+                "clock.\"                                                         |%n" +
+                "| \"date.statement\"                                    | \"date.statement(timezone = null" +
+                " :: STRING?) :: (DATE?)\"                                                                 " +
+                "                                     | \"Get the current Date instant using the statement " +
+                "clock.\"                                                        |%n" +
+                "| \"date.transaction\"                                  | \"date.transaction(timezone = " +
+                "null :: STRING?) :: (DATE?)\"                                                             " +
+                "                                       | \"Get the current Date instant using the " +
+                "transaction clock.\"                                                      |%n" +
+                "| \"date.truncate\"                                     | \"date.truncate(unit :: STRING?," +
+                " input :: ANY?, fields = null :: MAP?) :: (DATE?)\"                                       " +
+                "                                     | \"Truncate the input temporal value to a Date " +
+                "instant using the specified unit.\"                                  |%n" +
                 "| \"datetime\"                                          | \"datetime(input = null :: ANY?) :: " +
                 "(DATETIME?)\"                                                                                     " +
-                "                         | \"Construct a DateTime instant.\"                                      " +
+                "                         | \"Create a DateTime instant.\"                                         " +
                 "                                            |%n" +
                 "| \"datetime.realtime\"                                 | \"datetime.realtime(timezone = null :: " +
                 "STRING?) :: (DATETIME?)\"                                                                         " +
-                "                      | \"Get the current DateTime instant.\"                                     " +
+                "                      | \"Get the current DateTime instant using the realtime clock.\"            " +
                 "                                         |%n" +
                 "| \"datetime.statement\"                                | \"datetime.statement(timezone = null :: " +
                 "STRING?) :: (DATETIME?)\"                                                                         " +
-                "                     | \"Get the current DateTime instant.\"                                      " +
+                "                     | \"Get the current DateTime instant using the statement clock.\"            " +
                 "                                        |%n" +
                 "| \"datetime.transaction\"                              | \"datetime.transaction(timezone = null " +
                 ":: STRING?) :: (DATETIME?)\"                                                                      " +
-                "                      | \"Get the current DateTime instant.\"                                     " +
+                "                      | \"Get the current DateTime instant using the transaction clock.\"         " +
                 "                                         |%n" +
                 "| \"datetime.truncate\"                                 | \"datetime.truncate(unit :: STRING?, " +
                 "input :: ANY?, fields = null :: MAP?) :: (DATETIME?)\"                                            " +
-                "                        | \"Truncate to a DateTime instant.\"                                     " +
-                "                                           |%n" +
+                "                        | \"Truncate the input temporal value to a DateTime instant using the " +
+                "specified unit.\"                              |%n" +
                 "| \"duration\"                                          | \"duration(input :: ANY?) :: (DURATION?)" +
                 "\"                                                                                                " +
                 "                     | \"Construct a Duration value.\"                                            " +
@@ -886,6 +906,46 @@ public class UserFunctionIT
                 "ANY?) :: (DURATION?)\"                                                                            " +
                 "                        | \"Compute the duration between the 'form' instant (inclusive) and the " +
                 "'to' instant (exclusive) in years.\"         |%n" +
+                "| \"localdatetime\"                                     | \"localdatetime(input = null :: " +
+                "ANY?) :: (LOCALDATETIME?)\"                                                               " +
+                "                                     | \"Create a LocalDateTime instant.\"                " +
+                "                                                                |%n" +
+                "| \"localdatetime.realtime\"                            | \"localdatetime.realtime" +
+                "(timezone = null :: STRING?) :: (LOCALDATETIME?)\"                                        " +
+                "                                             | \"Get the current LocalDateTime instant " +
+                "using the realtime clock.\"                                                |%n" +
+                "| \"localdatetime.statement\"                           | \"localdatetime.statement" +
+                "(timezone = null :: STRING?) :: (LOCALDATETIME?)\"                                        " +
+                "                                            | \"Get the current LocalDateTime instant " +
+                "using the statement clock.\"                                               |%n" +
+                "| \"localdatetime.transaction\"                         | \"localdatetime.transaction" +
+                "(timezone = null :: STRING?) :: (LOCALDATETIME?)\"                                        " +
+                "                                          | \"Get the current LocalDateTime instant using " +
+                "the transaction clock.\"                                             |%n" +
+                "| \"localdatetime.truncate\"                            | \"localdatetime.truncate(unit ::" +
+                " STRING?, input :: ANY?, fields = null :: MAP?) :: (LOCALDATETIME?)\"                     " +
+                "                                     | \"Truncate the input temporal value to a " +
+                "LocalDateTime instant using the specified unit.\"                         |%n" +
+                "| \"localtime\"                                         | \"localtime(input = null :: " +
+                "ANY?) :: (LOCALTIME?)\"                                                                   " +
+                "                                         | \"Create a LocalTime instant.\"                " +
+                "                                                                    |%n" +
+                "| \"localtime.realtime\"                                | \"localtime.realtime(timezone = " +
+                "null :: STRING?) :: (LOCALTIME?)\"                                                        " +
+                "                                     | \"Get the current LocalTime instant using the " +
+                "realtime clock.\"                                                    |%n" +
+                "| \"localtime.statement\"                               | \"localtime.statement(timezone =" +
+                " null :: STRING?) :: (LOCALTIME?)\"                                                       " +
+                "                                     | \"Get the current LocalTime instant using the " +
+                "statement clock.\"                                                   |%n" +
+                "| \"localtime.transaction\"                             | \"localtime.transaction(timezone" +
+                " = null :: STRING?) :: (LOCALTIME?)\"                                                     " +
+                "                                     | \"Get the current LocalTime instant using the " +
+                "transaction clock.\"                                                 |%n" +
+                "| \"localtime.truncate\"                                | \"localtime.truncate(unit :: " +
+                "STRING?, input :: ANY?, fields = null :: MAP?) :: (LOCALTIME?)\"                          " +
+                "                                        | \"Truncate the input temporal value to a " +
+                "LocalTime instant using the specified unit.\"                             |%n" +
                 "| \"org.neo4j.procedure.avgDoubleList\"                 | \"org.neo4j.procedure.avgDoubleList" +
                 "(someValue :: LIST? OF FLOAT?) :: (FLOAT?)\"                                                      " +
                 "                          | \"\"                                                                  " +
@@ -994,11 +1054,31 @@ public class UserFunctionIT
                 " OF NUMBER?) :: (NUMBER?)\"                                                                       " +
                 "                     | \"\"                                                                       " +
                 "                                        |%n" +
+                "| \"time\"                                              | \"time(input = null :: ANY?) :: " +
+                "(TIME?)\"                                                                                 " +
+                "                                     | \"Create a Time instant.\"                         " +
+                "                                                                |%n" +
+                "| \"time.realtime\"                                     | \"time.realtime(timezone = null " +
+                ":: STRING?) :: (TIME?)\"                                                                  " +
+                "                                     | \"Get the current Time instant using the realtime " +
+                "clock.\"                                                         |%n" +
+                "| \"time.statement\"                                    | \"time.statement(timezone = null" +
+                " :: STRING?) :: (TIME?)\"                                                                 " +
+                "                                     | \"Get the current Time instant using the statement " +
+                "clock.\"                                                        |%n" +
+                "| \"time.transaction\"                                  | \"time.transaction(timezone = " +
+                "null :: STRING?) :: (TIME?)\"                                                             " +
+                "                                       | \"Get the current Time instant using the " +
+                "transaction clock.\"                                                      |%n" +
+                "| \"time.truncate\"                                     | \"time.truncate(unit :: STRING?," +
+                " input :: ANY?, fields = null :: MAP?) :: (TIME?)\"                                       " +
+                "                                     | \"Truncate the input temporal value to a Time " +
+                "instant using the specified unit.\"                                  |%n" +
                 "+-------------------------------------------------------------------------------------------------" +
                 "--------------------------------------------------------------------------------------------------" +
                 "--------------------------------------------------------------------------------------------------" +
                 "----------------------------------+%n" +
-                "42 rows%n" );
+                "62 rows%n" );
 
         assertThat( res.resultAsString(), equalTo(expected) );
     }

--- a/integrationtests/src/test/java/org/neo4j/procedure/UserFunctionIT.java
+++ b/integrationtests/src/test/java/org/neo4j/procedure/UserFunctionIT.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import javax.ws.rs.HEAD;
 
 import org.neo4j.function.Predicates;
 import org.neo4j.graphdb.GraphDatabaseService;
@@ -65,6 +66,7 @@ import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.logging.Log;
+import org.neo4j.shell.kernel.apps.cypher.Cypher;
 import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static java.util.Collections.singletonList;
@@ -812,100 +814,191 @@ public class UserFunctionIT
         Result res = db.execute( "CALL dbms.functions()" );
 
         String expected = String.format(
-                "+------------------------------------------------------------------------------------------------" +
-                "-------------------------------------------------------------------------------------------------" +
-                "------------------------------------------------+%n" +
-                "| name                                                | signature                             " +
-                "                                                                                              " +
-                "                         | description                |%n" +
-                "+------------------------------------------------------------------------------------------------" +
-                "-------------------------------------------------------------------------------------------------" +
-                "------------------------------------------------+%n" +
+                "+-------------------------------------------------------------------------------------------------" +
+                "--------------------------------------------------------------------------------------------------" +
+                "--------------------------------------------------------------------------------------------------" +
+                "----------------------------------+%n" +
+                "| name                                                | signature                                 " +
+                "                                                                                                  " +
+                "                 | description                                                                    " +
+                "                                  |%n" +
+                "+-------------------------------------------------------------------------------------------------" +
+                "--------------------------------------------------------------------------------------------------" +
+                "--------------------------------------------------------------------------------------------------" +
+                "----------------------------------+%n" +
+                "| \"datetime\"                                          | \"datetime(input = null :: ANY?) :: " +
+                "(DATETIME?)\"                                                                                     " +
+                "                         | \"Construct a DateTime instant.\"                                      " +
+                "                                            |%n" +
+                "| \"datetime.realtime\"                                 | \"datetime.realtime(timezone = null :: " +
+                "STRING?) :: (DATETIME?)\"                                                                         " +
+                "                      | \"Get the current DateTime instant.\"                                     " +
+                "                                         |%n" +
+                "| \"datetime.statement\"                                | \"datetime.statement(timezone = null :: " +
+                "STRING?) :: (DATETIME?)\"                                                                         " +
+                "                     | \"Get the current DateTime instant.\"                                      " +
+                "                                        |%n" +
+                "| \"datetime.transaction\"                              | \"datetime.transaction(timezone = null " +
+                ":: STRING?) :: (DATETIME?)\"                                                                      " +
+                "                      | \"Get the current DateTime instant.\"                                     " +
+                "                                         |%n" +
+                "| \"datetime.truncate\"                                 | \"datetime.truncate(unit :: STRING?, " +
+                "input :: ANY?, fields = null :: MAP?) :: (DATETIME?)\"                                            " +
+                "                        | \"Truncate to a DateTime instant.\"                                     " +
+                "                                           |%n" +
+                "| \"duration\"                                          | \"duration(input :: ANY?) :: (DURATION?)" +
+                "\"                                                                                                " +
+                "                     | \"Construct a Duration value.\"                                            " +
+                "                                        |%n" +
+                "| \"duration.between\"                                  | \"duration.between(from :: ANY?, to :: " +
+                "ANY?) :: (DURATION?)\"                                                                            " +
+                "                      | \"Compute the duration between the 'form' instant (inclusive) and the 'to'" +
+                " instant (exclusive) in logical units.\" |%n" +
+                "| \"duration.days\"                                     | \"duration.days(from :: ANY?, to :: " +
+                "ANY?) :: (DURATION?)\"                                                                            " +
+                "                         | \"Compute the duration between the 'form' instant (inclusive) and the " +
+                "'to' instant (exclusive) in days.\"          |%n" +
+                "| \"duration.hours\"                                    | \"duration.hours(from :: ANY?, to :: " +
+                "ANY?) :: (DURATION?)\"                                                                            " +
+                "                        | \"Compute the duration between the 'form' instant (inclusive) and the " +
+                "'to' instant (exclusive) in hours.\"         |%n" +
+                "| \"duration.minutes\"                                  | \"duration.minutes(from :: ANY?, to :: " +
+                "ANY?) :: (DURATION?)\"                                                                            " +
+                "                      | \"Compute the duration between the 'form' instant (inclusive) and the 'to'" +
+                " instant (exclusive) in minutes.\"       |%n" +
+                "| \"duration.months\"                                   | \"duration.months(from :: ANY?, to :: " +
+                "ANY?) :: (DURATION?)\"                                                                            " +
+                "                       | \"Compute the duration between the 'form' instant (inclusive) and the " +
+                "'to' instant (exclusive) in months.\"        |%n" +
+                "| \"duration.quarters\"                                 | \"duration.quarters(from :: ANY?, to :: " +
+                "ANY?) :: (DURATION?)\"                                                                            " +
+                "                     | \"Compute the duration between the 'form' instant (inclusive) and the 'to' " +
+                "instant (exclusive) in quarters.\"      |%n" +
+                "| \"duration.seconds\"                                  | \"duration.seconds(from :: ANY?, to :: " +
+                "ANY?) :: (DURATION?)\"                                                                            " +
+                "                      | \"Compute the duration between the 'form' instant (inclusive) and the 'to'" +
+                " instant (exclusive) in seconds.\"       |%n" +
+                "| \"duration.weeks\"                                    | \"duration.weeks(from :: ANY?, to :: " +
+                "ANY?) :: (DURATION?)\"                                                                            " +
+                "                        | \"Compute the duration between the 'form' instant (inclusive) and the " +
+                "'to' instant (exclusive) in weeks.\"         |%n" +
+                "| \"duration.years\"                                    | \"duration.years(from :: ANY?, to :: " +
+                "ANY?) :: (DURATION?)\"                                                                            " +
+                "                        | \"Compute the duration between the 'form' instant (inclusive) and the " +
+                "'to' instant (exclusive) in years.\"         |%n" +
                 "| \"org.neo4j.procedure.avgDoubleList\"                 | \"org.neo4j.procedure.avgDoubleList" +
-                "(someValue :: LIST? OF FLOAT?) :: (FLOAT?)\"                                                  " +
-                "                              | \"\"                         |%n" +
+                "(someValue :: LIST? OF FLOAT?) :: (FLOAT?)\"                                                      " +
+                "                          | \"\"                                                                  " +
+                "                                             |%n" +
                 "| \"org.neo4j.procedure.avgNumberList\"                 | \"org.neo4j.procedure.avgNumberList" +
-                "(someValue :: LIST? OF NUMBER?) :: (FLOAT?)\"                                                 " +
-                "                              | \"\"                         |%n" +
+                "(someValue :: LIST? OF NUMBER?) :: (FLOAT?)\"                                                     " +
+                "                          | \"\"                                                                  " +
+                "                                             |%n" +
                 "| \"org.neo4j.procedure.defaultValues\"                 | \"org.neo4j.procedure.defaultValues" +
-                "(string = a string :: STRING?, integer = 42 :: INTEGER?, float = 3.14 :: FLOAT?, boolean = " +
-                "true :: BOOLEAN?) :: (STRING?)\" | \"\"                         |%n" +
-                "| \"org.neo4j.procedure.delegatingFunction\"            | \"org.neo4j.procedure" +
-                ".delegatingFunction(someValue :: INTEGER?) :: (INTEGER?)\"                                    " +
-                "                                            | \"\"                         |%n" +
-                "| \"org.neo4j.procedure.genericArguments\"              | \"org.neo4j.procedure" +
-                ".genericArguments(strings :: LIST? OF LIST? OF STRING?, longs :: LIST? OF LIST? OF LIST? OF " +
-                "INTEGER?) :: (INTEGER?)\"                     | \"\"                         |%n" +
-                "| \"org.neo4j.procedure.indexOutOfBounds\"              | \"org.neo4j.procedure" +
-                ".indexOutOfBounds() :: (INTEGER?)\"                                                           " +
-                "                                            | \"\"                         |%n" +
-                "| \"org.neo4j.procedure.integrationTestMe\"             | \"org.neo4j.procedure" +
-                ".integrationTestMe() :: (INTEGER?)\"                                                          " +
-                "                                            | \"\"                         |%n" +
+                "(string = a string :: STRING?, integer = 42 :: INTEGER?, float = 3.14 :: FLOAT?, boolean = true ::" +
+                " BOOLEAN?) :: (STRING?)\" | \"\"                                                                  " +
+                "                                             |%n" +
+                "| \"org.neo4j.procedure.delegatingFunction\"            | \"org.neo4j.procedure.delegatingFunction" +
+                "(someValue :: INTEGER?) :: (INTEGER?)\"                                                           " +
+                "                     | \"\"                                                                       " +
+                "                                        |%n" +
+                "| \"org.neo4j.procedure.genericArguments\"              | \"org.neo4j.procedure.genericArguments" +
+                "(strings :: LIST? OF LIST? OF STRING?, longs :: LIST? OF LIST? OF LIST? OF INTEGER?) :: (INTEGER?)" +
+                "\"                     | \"\"                                                                     " +
+                "                                          |%n" +
+                "| \"org.neo4j.procedure.indexOutOfBounds\"              | \"org.neo4j.procedure.indexOutOfBounds()" +
+                " :: (INTEGER?)\"                                                                                  " +
+                "                     | \"\"                                                                       " +
+                "                                        |%n" +
+                "| \"org.neo4j.procedure.integrationTestMe\"             | \"org.neo4j.procedure.integrationTestMe" +
+                "() :: (INTEGER?)\"                                                                                " +
+                "                      | \"\"                                                                      " +
+                "                                         |%n" +
                 "| \"org.neo4j.procedure.listCoolPeopleInDatabase\"      | \"org.neo4j.procedure" +
-                ".listCoolPeopleInDatabase() :: (LIST? OF ANY?)\"                                              " +
-                "                                            | \"\"                         |%n" +
-                "| \"org.neo4j.procedure.logAround\"                     | \"org.neo4j.procedure.logAround() ::" +
-                " (INTEGER?)\"                                                                                 " +
-                "                             | \"\"                         |%n" +
-                "| \"org.neo4j.procedure.mapArgument\"                   | \"org.neo4j.procedure.mapArgument" +
-                "(map :: MAP?) :: (INTEGER?)\"                                                                 " +
-                "                                | \"\"                         |%n" +
+                ".listCoolPeopleInDatabase() :: (LIST? OF ANY?)\"                                                  " +
+                "                                        | \"\"                                                    " +
+                "                                                           |%n" +
+                "| \"org.neo4j.procedure.logAround\"                     | \"org.neo4j.procedure.logAround() :: " +
+                "(INTEGER?)\"                                                                                      " +
+                "                        | \"\"                                                                    " +
+                "                                           |%n" +
+                "| \"org.neo4j.procedure.mapArgument\"                   | \"org.neo4j.procedure.mapArgument(map ::" +
+                " MAP?) :: (INTEGER?)\"                                                                            " +
+                "                     | \"\"                                                                       " +
+                "                                        |%n" +
                 "| \"org.neo4j.procedure.node\"                          | \"org.neo4j.procedure.node(id :: " +
-                "INTEGER?) :: (NODE?)\"                                                                        " +
-                "                                | \"\"                         |%n" +
-                "| \"org.neo4j.procedure.nodeListArgument\"              | \"org.neo4j.procedure" +
-                ".nodeListArgument(nodes :: LIST? OF NODE?) :: (INTEGER?)\"                                    " +
-                "                                            | \"\"                         |%n" +
+                "INTEGER?) :: (NODE?)\"                                                                            " +
+                "                            | \"\"                                                                " +
+                "                                               |%n" +
+                "| \"org.neo4j.procedure.nodeListArgument\"              | \"org.neo4j.procedure.nodeListArgument" +
+                "(nodes :: LIST? OF NODE?) :: (INTEGER?)\"                                                         " +
+                "                       | \"\"                                                                     " +
+                "                                          |%n" +
                 "| \"org.neo4j.procedure.nodePaths\"                     | \"org.neo4j.procedure.nodePaths" +
-                "(someValue :: NODE?) :: (PATH?)\"                                                             " +
-                "                                  | \"\"                         |%n" +
+                "(someValue :: NODE?) :: (PATH?)\"                                                                 " +
+                "                              | \"\"                                                              " +
+                "                                                 |%n" +
                 "| \"org.neo4j.procedure.nodeWithDescription\"           | \"org.neo4j.procedure" +
-                ".nodeWithDescription(someValue :: NODE?) :: (NODE?)\"                                         " +
-                "                                            | \"This is a description\"    |%n" +
+                ".nodeWithDescription(someValue :: NODE?) :: (NODE?)\"                                             " +
+                "                                        | \"This is a description\"                               " +
+                "                                                           |%n" +
                 "| \"org.neo4j.procedure.readOnlyCallingWriteFunction\"  | \"org.neo4j.procedure" +
-                ".readOnlyCallingWriteFunction() :: (NODE?)\"                                                  " +
-                "                                            | \"\"                         |%n" +
+                ".readOnlyCallingWriteFunction() :: (NODE?)\"                                                      " +
+                "                                        | \"\"                                                    " +
+                "                                                           |%n" +
                 "| \"org.neo4j.procedure.readOnlyCallingWriteProcedure\" | \"org.neo4j.procedure" +
-                ".readOnlyCallingWriteProcedure() :: (INTEGER?)\"                                              " +
-                "                                            | \"\"                         |%n" +
+                ".readOnlyCallingWriteProcedure() :: (INTEGER?)\"                                                  " +
+                "                                        | \"\"                                                    " +
+                "                                                           |%n" +
                 "| \"org.neo4j.procedure.readOnlyTryingToWrite\"         | \"org.neo4j.procedure" +
-                ".readOnlyTryingToWrite() :: (NODE?)\"                                                         " +
-                "                                            | \"\"                         |%n" +
+                ".readOnlyTryingToWrite() :: (NODE?)\"                                                             " +
+                "                                        | \"\"                                                    " +
+                "                                                           |%n" +
                 "| \"org.neo4j.procedure.readOnlyTryingToWriteSchema\"   | \"org.neo4j.procedure" +
-                ".readOnlyTryingToWriteSchema() :: (STRING?)\"                                                 " +
-                "                                            | \"\"                         |%n" +
+                ".readOnlyTryingToWriteSchema() :: (STRING?)\"                                                     " +
+                "                                        | \"\"                                                    " +
+                "                                                           |%n" +
                 "| \"org.neo4j.procedure.recursiveSum\"                  | \"org.neo4j.procedure.recursiveSum" +
-                "(someValue :: INTEGER?) :: (INTEGER?)\"                                                       " +
-                "                               | \"\"                         |%n" +
+                "(someValue :: INTEGER?) :: (INTEGER?)\"                                                           " +
+                "                           | \"\"                                                                 " +
+                "                                              |%n" +
                 "| \"org.neo4j.procedure.shutdown\"                      | \"org.neo4j.procedure.shutdown() :: " +
-                "(STRING?)\"                                                                                   " +
-                "                             | \"\"                         |%n" +
+                "(STRING?)\"                                                                                       " +
+                "                         | \"\"                                                                   " +
+                "                                            |%n" +
                 "| \"org.neo4j.procedure.simpleArgument\"                | \"org.neo4j.procedure.simpleArgument" +
-                "(someValue :: INTEGER?) :: (INTEGER?)\"                                                       " +
-                "                             | \"\"                         |%n" +
+                "(someValue :: INTEGER?) :: (INTEGER?)\"                                                           " +
+                "                         | \"\"                                                                   " +
+                "                                            |%n" +
                 "| \"org.neo4j.procedure.squareDouble\"                  | \"org.neo4j.procedure.squareDouble" +
-                "(someValue :: FLOAT?) :: (FLOAT?)\"                                                           " +
-                "                               | \"\"                         |%n" +
+                "(someValue :: FLOAT?) :: (FLOAT?)\"                                                               " +
+                "                           | \"\"                                                                 " +
+                "                                              |%n" +
                 "| \"org.neo4j.procedure.squareLong\"                    | \"org.neo4j.procedure.squareLong" +
-                "(someValue :: INTEGER?) :: (INTEGER?)\"                                                       " +
-                "                                 | \"\"                         |%n" +
+                "(someValue :: INTEGER?) :: (INTEGER?)\"                                                           " +
+                "                             | \"\"                                                               " +
+                "                                                |%n" +
                 "| \"org.neo4j.procedure.throwsExceptionInStream\"       | \"org.neo4j.procedure" +
-                ".throwsExceptionInStream() :: (INTEGER?)\"                                                    " +
-                "                                            | \"\"                         |%n" +
-                "| \"org.neo4j.procedure.unsupportedFunction\"           | \"org.neo4j.procedure." +
-                "unsupportedFunction() :: (STRING?)\"                                                          " +
-                "                                           | \"\"                         |%n" +
-                "| \"randomUUID\"                                        | \"randomUUID() :: (STRING?)\"     " +
-                "                                                                                          " +
-                "                                   | \"Generates a random UUID.\" |%n" +
-                "| \"this.is.test.only.sum\"                             | \"this.is.test.only.sum(numbers :: " +
-                "LIST? OF NUMBER?) :: (NUMBER?)\"                                                              " +
-                "                              | \"\"                         |%n" +
-                "+-----------------------------------------------------------------------------------------------" +
-                "----------------------------------------------------------------------------------" +
-                "----------------------------------------------------------------+%n" +
-                "27 rows%n");
+                ".throwsExceptionInStream() :: (INTEGER?)\"                                                        " +
+                "                                        | \"\"                                                    " +
+                "                                                           |%n" +
+                "| \"org.neo4j.procedure.unsupportedFunction\"           | \"org.neo4j.procedure" +
+                ".unsupportedFunction() :: (STRING?)\"                                                             " +
+                "                                        | \"\"                                                    " +
+                "                                                           |%n" +
+                "| \"randomUUID\"                                        | \"randomUUID() :: (STRING?)\"           " +
+                "                                                                                                  " +
+                "                     | \"Generates a random UUID.\"                                               " +
+                "                                        |%n" +
+                "| \"this.is.test.only.sum\"                             | \"this.is.test.only.sum(numbers :: LIST?" +
+                " OF NUMBER?) :: (NUMBER?)\"                                                                       " +
+                "                     | \"\"                                                                       " +
+                "                                        |%n" +
+                "+-------------------------------------------------------------------------------------------------" +
+                "--------------------------------------------------------------------------------------------------" +
+                "--------------------------------------------------------------------------------------------------" +
+                "----------------------------------+%n" +
+                "42 rows%n" );
 
         assertThat( res.resultAsString(), equalTo(expected) );
     }


### PR DESCRIPTION
This introduces temporal `Value` types and the beginning of functions for creating an manipulating them through Cypher.

These functions are defined as built in functions in the database, and not "special cases" in the parser. In order to further support this, the `CallableUserFunction` interface has been updated to work with `Value` objects, moving the conversion to embedded types to the reflective function implementation (that conversion happened on a higher level before, so this means that we can avoid the conversion for non-reflective functions).