### PR TITLE
Making test resources public to allow benchmarking

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/SeekCursor.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/SeekCursor.java
@@ -140,7 +140,7 @@ import static org.neo4j.index.internal.gbptree.TreeNode.Type.LEAF;
  * suddenly another key when he goes there he knows that he could have missed some keys and he needs to go back until
  * he find the place where he left off, K4.
  */
-class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hit<KEY,VALUE>
+public class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hit<KEY,VALUE>
 {
     /**
      * Cursor for reading from tree nodes and also will be moved around when following pointers.

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/misc/AdaptableKey.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/misc/AdaptableKey.java
@@ -17,15 +17,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.index.internal.gbptree;
+package org.neo4j.index.internal.gbptree.misc;
 
-interface KeyValueSeeder<KEY, VALUE>
+public class AdaptableKey
 {
-    KEY key( long seed );
+    static int SIZE = Long.BYTES;
+    long value;
 
-    VALUE value( long seed );
-
-    long keySeed( KEY key );
-
-    long valueSeed( VALUE value );
+    @Override
+    public String toString()
+    {
+        return Long.toString(  value );
+    }
 }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/misc/AdaptableLayout.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/misc/AdaptableLayout.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index.internal.gbptree.misc;
+
+import org.neo4j.io.pagecache.PageCursor;
+
+public abstract class AdaptableLayout extends TestLayout<AdaptableKey,AdaptableValue>
+{
+    private final int keySize;
+    private final int valueSize;
+    private final int keyPadding;
+
+    AdaptableLayout( int keySize, int valueSize )
+    {
+        if ( keySize < AdaptableKey.SIZE )
+        {
+            throw new IllegalArgumentException( "Key size need to be at least " + AdaptableKey.SIZE + ", was " + keySize );
+        }
+        this.keySize = keySize;
+        this.valueSize = valueSize;
+        this.keyPadding = keySize - AdaptableKey.SIZE;
+    }
+
+    @Override
+    public String toString()
+    {
+        return layoutString() + "[keySize=" + keySize + ",valueSize=" + valueSize + "]";
+    }
+
+    /**
+     * Dynamic or fixed?
+     */
+    abstract String layoutString();
+
+    @Override
+    public AdaptableKey newKey()
+    {
+        return new AdaptableKey();
+    }
+
+    @Override
+    public AdaptableKey copyKey( AdaptableKey adaptableKey, AdaptableKey into )
+    {
+        into.value = adaptableKey.value;
+        return into;
+    }
+
+    @Override
+    public AdaptableValue newValue()
+    {
+        return new AdaptableValue();
+    }
+
+    @Override
+    public int keySize( AdaptableKey adaptableKey )
+    {
+        return keySize;
+    }
+
+    @Override
+    public int valueSize( AdaptableValue adaptableValue )
+    {
+        return valueSize;
+    }
+
+    @Override
+    public void writeKey( PageCursor cursor, AdaptableKey adaptableKey )
+    {
+        cursor.putLong( adaptableKey.value );
+        writePadding( cursor, keyPadding );
+    }
+
+    @Override
+    public void writeValue( PageCursor cursor, AdaptableValue adaptableValue )
+    {
+        writePadding( cursor, valueSize );
+    }
+
+    private void writePadding( PageCursor cursor, int toPad )
+    {
+        for ( int i = 0; i < toPad; i++ )
+        {
+            // We just want to write something. Don't care about what.
+            cursor.putByte( (byte) i );
+        }
+    }
+
+    @Override
+    public void readKey( PageCursor cursor, AdaptableKey into, int keySize )
+    {
+        into.value = cursor.getLong();
+        readPadding( cursor, keyPadding );
+    }
+
+    @Override
+    public void readValue( PageCursor cursor, AdaptableValue into, int valueSize )
+    {
+        readPadding( cursor, valueSize );
+    }
+
+    private void readPadding( PageCursor cursor, int toRead )
+    {
+        for ( int i = 0; i < keyPadding; i++ )
+        {
+            // Just read the byte, don't care about what we do with it
+            cursor.getByte();
+        }
+    }
+
+    @Override
+    public AdaptableKey keyWithSeed( AdaptableKey adaptableKey, long seed )
+    {
+        adaptableKey.value = seed;
+        return adaptableKey;
+    }
+
+    @Override
+    public AdaptableValue valueWithSeed( AdaptableValue adaptableValue, long seed )
+    {
+        return adaptableValue;
+    }
+
+    @Override
+    public AdaptableKey key( long seed )
+    {
+        AdaptableKey adaptableKey = newKey();
+        adaptableKey.value = seed;
+        return adaptableKey;
+    }
+
+    @Override
+    public AdaptableValue value( long seed )
+    {
+        return newValue();
+    }
+
+    @Override
+    public long keySeed( AdaptableKey adaptableKey )
+    {
+        return adaptableKey.value;
+    }
+
+    @Override
+    public long valueSeed( AdaptableValue adaptableValue )
+    {
+        return 0;
+    }
+
+    @Override
+    public int compareValue( AdaptableValue v1, AdaptableValue v2 )
+    {
+        return 0;
+    }
+
+    @Override
+    public int compare( AdaptableKey o1, AdaptableKey o2 )
+    {
+        return Long.compare( o1.value, o2.value );
+    }
+
+    @Override
+    public long identifier()
+    {
+        return 10000 * keySize + valueSize;
+    }
+
+    @Override
+    public int majorVersion()
+    {
+        return 0;
+    }
+
+    @Override
+    public int minorVersion()
+    {
+        return 0;
+    }
+}

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/misc/AdaptableLayoutDynamic.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/misc/AdaptableLayoutDynamic.java
@@ -17,9 +17,28 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.index.internal.gbptree;
+package org.neo4j.index.internal.gbptree.misc;
 
-abstract class TestLayout<KEY,VALUE> extends Layout.Adapter<KEY,VALUE> implements KeyValueSeeder<KEY,VALUE>
+/**
+ * USED BY EXTERNAL BENCHMARKING
+ */
+@SuppressWarnings( "unused" )
+public class AdaptableLayoutDynamic extends AdaptableLayout
 {
-    abstract int compareValue( VALUE v1, VALUE v2 );
+    public AdaptableLayoutDynamic( int keySize, int valueSize )
+    {
+        super( keySize, valueSize );
+    }
+
+    @Override
+    String layoutString()
+    {
+        return "DynamicLayout";
+    }
+
+    @Override
+    public boolean fixedSize()
+    {
+        return false;
+    }
 }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/misc/AdaptableLayoutFixed.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/misc/AdaptableLayoutFixed.java
@@ -17,16 +17,28 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.index.internal.gbptree;
+package org.neo4j.index.internal.gbptree.misc;
 
-import org.neo4j.index.internal.gbptree.misc.TestLayout;
-import org.neo4j.test.rule.RandomRule;
-
-public class GBPTreeRecoveryDynamicSizeIT extends GBPTreeRecoveryITBase<RawBytes,RawBytes>
+/**
+ * USED BY EXTERNAL BENCHMARKING
+ */
+@SuppressWarnings( "unused" )
+public class AdaptableLayoutFixed extends AdaptableLayout
 {
-    @Override
-    protected TestLayout<RawBytes,RawBytes> getLayout( RandomRule random )
+    public AdaptableLayoutFixed( int keySize, int valueSize )
     {
-        return new SimpleByteArrayLayout();
+        super( keySize, valueSize );
+    }
+
+    @Override
+    String layoutString()
+    {
+        return "FixedLayout";
+    }
+
+    @Override
+    public boolean fixedSize()
+    {
+        return true;
     }
 }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/misc/AdaptableValue.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/misc/AdaptableValue.java
@@ -17,16 +17,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.index.internal.gbptree;
+package org.neo4j.index.internal.gbptree.misc;
 
-import org.neo4j.index.internal.gbptree.misc.TestLayout;
-import org.neo4j.test.rule.RandomRule;
-
-public class GBPTreeRecoveryDynamicSizeIT extends GBPTreeRecoveryITBase<RawBytes,RawBytes>
+public class AdaptableValue
 {
-    @Override
-    protected TestLayout<RawBytes,RawBytes> getLayout( RandomRule random )
-    {
-        return new SimpleByteArrayLayout();
-    }
 }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/misc/KeyValueSeeder.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/misc/KeyValueSeeder.java
@@ -17,16 +17,19 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.index.internal.gbptree;
+package org.neo4j.index.internal.gbptree.misc;
 
-import org.neo4j.index.internal.gbptree.misc.TestLayout;
-import org.neo4j.test.rule.RandomRule;
-
-public class GBPTreeRecoveryDynamicSizeIT extends GBPTreeRecoveryITBase<RawBytes,RawBytes>
+interface KeyValueSeeder<KEY, VALUE>
 {
-    @Override
-    protected TestLayout<RawBytes,RawBytes> getLayout( RandomRule random )
-    {
-        return new SimpleByteArrayLayout();
-    }
+    KEY keyWithSeed( KEY key, long seed );
+
+    VALUE valueWithSeed( VALUE value, long seed );
+
+    KEY key( long seed );
+
+    VALUE value( long seed );
+
+    long keySeed( KEY key );
+
+    long valueSeed( VALUE value );
 }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/misc/TestLayout.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/misc/TestLayout.java
@@ -17,16 +17,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.index.internal.gbptree;
+package org.neo4j.index.internal.gbptree.misc;
 
-import org.neo4j.index.internal.gbptree.misc.TestLayout;
-import org.neo4j.test.rule.RandomRule;
+import org.neo4j.index.internal.gbptree.Layout;
 
-public class GBPTreeRecoveryDynamicSizeIT extends GBPTreeRecoveryITBase<RawBytes,RawBytes>
+public abstract class TestLayout<KEY,VALUE> extends Layout.Adapter<KEY,VALUE> implements KeyValueSeeder<KEY,VALUE>
 {
-    @Override
-    protected TestLayout<RawBytes,RawBytes> getLayout( RandomRule random )
-    {
-        return new SimpleByteArrayLayout();
-    }
+    public abstract int compareValue( VALUE v1, VALUE v2 );
 }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyDynamicSizeIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyDynamicSizeIT.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.index.internal.gbptree;
 
+import org.neo4j.index.internal.gbptree.misc.TestLayout;
 import org.neo4j.test.rule.RandomRule;
 
 public class GBPTreeConcurrencyDynamicSizeIT extends GBPTreeConcurrencyITBase<RawBytes,RawBytes>

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyFIxedSizeIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyFIxedSizeIT.java
@@ -21,6 +21,7 @@ package org.neo4j.index.internal.gbptree;
 
 import org.apache.commons.lang3.mutable.MutableLong;
 
+import org.neo4j.index.internal.gbptree.misc.TestLayout;
 import org.neo4j.test.rule.RandomRule;
 
 public class GBPTreeConcurrencyFIxedSizeIT extends GBPTreeConcurrencyITBase<MutableLong,MutableLong>

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyITBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeConcurrencyITBase.java
@@ -46,6 +46,7 @@ import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
 import org.neo4j.cursor.RawCursor;
+import org.neo4j.index.internal.gbptree.misc.TestLayout;
 import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.test.rule.PageCacheRule;

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeDynamixSizeIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeDynamixSizeIT.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.index.internal.gbptree;
 
+import org.neo4j.index.internal.gbptree.misc.TestLayout;
 import org.neo4j.test.rule.RandomRule;
 
 public class GBPTreeDynamixSizeIT extends GBPTreeITBase<RawBytes,RawBytes>

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeFixedSizeIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeFixedSizeIT.java
@@ -21,6 +21,7 @@ package org.neo4j.index.internal.gbptree;
 
 import org.apache.commons.lang3.mutable.MutableLong;
 
+import org.neo4j.index.internal.gbptree.misc.TestLayout;
 import org.neo4j.test.rule.RandomRule;
 
 public class GBPTreeFixedSizeIT extends GBPTreeITBase<MutableLong,MutableLong>

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeITBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeITBase.java
@@ -32,6 +32,7 @@ import java.util.Random;
 import java.util.TreeMap;
 
 import org.neo4j.cursor.RawCursor;
+import org.neo4j.index.internal.gbptree.misc.TestLayout;
 import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.test.rule.PageCacheRule;

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeReadWriteDynamicSizeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeReadWriteDynamicSizeTest.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.index.internal.gbptree;
 
+import org.neo4j.index.internal.gbptree.misc.TestLayout;
+
 public class GBPTreeReadWriteDynamicSizeTest extends GBPTreeReadWriteTestBase<RawBytes,RawBytes>
 {
     @Override

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeReadWriteFixedSizeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeReadWriteFixedSizeTest.java
@@ -21,6 +21,8 @@ package org.neo4j.index.internal.gbptree;
 
 import org.apache.commons.lang3.mutable.MutableLong;
 
+import org.neo4j.index.internal.gbptree.misc.TestLayout;
+
 public class GBPTreeReadWriteFixedSizeTest extends GBPTreeReadWriteTestBase<MutableLong,MutableLong>
 {
     @Override

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeReadWriteTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeReadWriteTestBase.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.neo4j.cursor.RawCursor;
+import org.neo4j.index.internal.gbptree.misc.TestLayout;
 import org.neo4j.test.rule.PageCacheAndDependenciesRule;
 import org.neo4j.test.rule.RandomRule;
 

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryFixedSizeIT.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryFixedSizeIT.java
@@ -21,6 +21,7 @@ package org.neo4j.index.internal.gbptree;
 
 import org.apache.commons.lang3.mutable.MutableLong;
 
+import org.neo4j.index.internal.gbptree.misc.TestLayout;
 import org.neo4j.test.rule.RandomRule;
 
 public class GBPTreeRecoveryFixedSizeIT extends GBPTreeRecoveryITBase<MutableLong,MutableLong>

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryITBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeRecoveryITBase.java
@@ -37,6 +37,7 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import org.neo4j.cursor.RawCursor;
+import org.neo4j.index.internal.gbptree.misc.TestLayout;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.test.rule.PageCacheRule;
 import org.neo4j.test.rule.RandomRule;

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicDynamicSizeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicDynamicSizeTest.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.index.internal.gbptree;
 
+import org.neo4j.index.internal.gbptree.misc.TestLayout;
+
 public class InternalTreeLogicDynamicSizeTest extends InternalTreeLogicTestBase<RawBytes,RawBytes>
 {
     private SimpleByteArrayLayout layout = new SimpleByteArrayLayout();

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicFixedSizeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicFixedSizeTest.java
@@ -21,6 +21,8 @@ package org.neo4j.index.internal.gbptree;
 
 import org.apache.commons.lang3.mutable.MutableLong;
 
+import org.neo4j.index.internal.gbptree.misc.TestLayout;
+
 public class InternalTreeLogicFixedSizeTest extends InternalTreeLogicTestBase<MutableLong,MutableLong>
 {
     SimpleLongLayout layout = new SimpleLongLayout();

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTestBase.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 
+import org.neo4j.index.internal.gbptree.misc.TestLayout;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.test.rule.RandomRule;
 

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorDynamicSizeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorDynamicSizeTest.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.index.internal.gbptree;
 
+import org.neo4j.index.internal.gbptree.misc.TestLayout;
+
 public class SeekCursorDynamicSizeTest extends SeekCursorTestBase<RawBytes,RawBytes>
 {
     @Override

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorFixedSizeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorFixedSizeTest.java
@@ -21,6 +21,8 @@ package org.neo4j.index.internal.gbptree;
 
 import org.apache.commons.lang3.mutable.MutableLong;
 
+import org.neo4j.index.internal.gbptree.misc.TestLayout;
+
 public class SeekCursorFixedSizeTest extends SeekCursorTestBase<MutableLong,MutableLong>
 {
     @Override

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTestBase.java
@@ -33,6 +33,7 @@ import java.util.function.Consumer;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 
+import org.neo4j.index.internal.gbptree.misc.TestLayout;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.impl.DelegatingPageCursor;
 

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleByteArrayLayout.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleByteArrayLayout.java
@@ -21,6 +21,7 @@ package org.neo4j.index.internal.gbptree;
 
 import java.nio.ByteBuffer;
 
+import org.neo4j.index.internal.gbptree.misc.TestLayout;
 import org.neo4j.io.pagecache.PageCursor;
 
 public class SimpleByteArrayLayout extends TestLayout<RawBytes,RawBytes>
@@ -133,7 +134,7 @@ public class SimpleByteArrayLayout extends TestLayout<RawBytes,RawBytes>
     }
 
     @Override
-    int compareValue( RawBytes v1, RawBytes v2 )
+    public int compareValue( RawBytes v1, RawBytes v2 )
     {
         return compare( v1, v2 );
     }
@@ -167,6 +168,20 @@ public class SimpleByteArrayLayout extends TestLayout<RawBytes,RawBytes>
             return 1;
         }
         return 0;
+    }
+
+    @Override
+    public RawBytes keyWithSeed( RawBytes rawBytes, long seed )
+    {
+        rawBytes.bytes = fromSeed( seed );
+        return rawBytes;
+    }
+
+    @Override
+    public RawBytes valueWithSeed( RawBytes rawBytes, long seed )
+    {
+        rawBytes.bytes = fromSeed( seed );
+        return rawBytes;
     }
 
     @Override

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleLongLayout.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SimpleLongLayout.java
@@ -21,6 +21,7 @@ package org.neo4j.index.internal.gbptree;
 
 import org.apache.commons.lang3.mutable.MutableLong;
 
+import org.neo4j.index.internal.gbptree.misc.TestLayout;
 import org.neo4j.io.pagecache.PageCursor;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -53,7 +54,7 @@ class SimpleLongLayout extends TestLayout<MutableLong,MutableLong>
     }
 
     @Override
-    int compareValue( MutableLong v1, MutableLong v2 )
+    public int compareValue( MutableLong v1, MutableLong v2 )
     {
         return compare( v1, v2 );
     }
@@ -191,6 +192,20 @@ class SimpleLongLayout extends TestLayout<MutableLong,MutableLong>
         byte[] bytes = new byte[length];
         cursor.getBytes( bytes );
         return new String( bytes, UTF_8 );
+    }
+
+    @Override
+    public MutableLong keyWithSeed( MutableLong key, long seed )
+    {
+        key.setValue( seed );
+        return key;
+    }
+
+    @Override
+    public MutableLong valueWithSeed( MutableLong value, long seed )
+    {
+        value.setValue( seed );
+        return value;
     }
 
     @Override

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeDynamicSizeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeDynamicSizeTest.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.index.internal.gbptree;
 
+import org.neo4j.index.internal.gbptree.misc.TestLayout;
 import org.neo4j.io.pagecache.PageCursor;
 
 import static org.junit.Assert.assertEquals;

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeFixedSizeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeFixedSizeTest.java
@@ -21,6 +21,7 @@ package org.neo4j.index.internal.gbptree;
 
 import org.apache.commons.lang3.mutable.MutableLong;
 
+import org.neo4j.index.internal.gbptree.misc.TestLayout;
 import org.neo4j.io.pagecache.PageCursor;
 
 public class TreeNodeFixedSizeTest extends TreeNodeTestBase<MutableLong,MutableLong>

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeTestBase.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.neo4j.index.internal.gbptree.TreeNode.Overflow;
+import org.neo4j.index.internal.gbptree.misc.TestLayout;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.test.rule.RandomRule;
 

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/misc/AdaptableLayoutTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/misc/AdaptableLayoutTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.index.internal.gbptree.misc;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.neo4j.test.rule.RandomRule;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith( Parameterized.class )
+public class AdaptableLayoutTest
+{
+    @Rule
+    public RandomRule random = new RandomRule();
+
+    @Parameterized.Parameters( name = "{0}" )
+    public static Iterable<Object[]> data()
+    {
+        return Arrays.asList( new Object[][]{
+                {"Fixed", new AdaptableLayoutFixed( 8, 0 )},
+                {"Dynamic", new AdaptableLayoutDynamic( 8, 0 )}} );
+    }
+
+    @Parameterized.Parameter( 0 )
+    public String name;
+
+    @Parameterized.Parameter( 1 )
+    public AdaptableLayout layout;
+
+    @Test
+    public void keySortOrderMustAlignWithSeed() throws Exception
+    {
+        // given
+        int nbrOfSeeds = 10_000;
+        List<Long> seeds = new ArrayList<>( nbrOfSeeds );
+        List<AdaptableKey> keys = new ArrayList<>( nbrOfSeeds );
+        for ( int i = 0; i < nbrOfSeeds; i++ )
+        {
+            long seed = random.nextLong();
+            seeds.add( seed );
+            keys.add( layout.key( seed ) );
+        }
+
+        // when
+        seeds.sort( Long::compareTo );
+        keys.sort( layout );
+
+        // then
+        for ( int i = 0; i < nbrOfSeeds; i++ )
+        {
+            long expected = seeds.get( i );
+            long actual = keys.get( i ).value;
+            assertTrue( String.format( "Sort order differs on position%d, expected=%d, actual=%d", i, expected, actual ),
+                    expected == actual );
+        }
+    }
+}


### PR DESCRIPTION
Move TestLayout to internal public package to allow access
from jmh benchmarking.

Add AdaptableLayout as a util for benchmarking.

Interesting classes:
- TestLayout
- AdaptableLayout
- AdaptableLayoutFixed
- AdaptableLayoutDynamic
- AdaptableKey
- AdaptableValue
- KeyValueSeeder

The rest is just imports.