### PR TITLE
Tx-state aware RelationshipTraversalCursor

### DIFF
--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/TokenRead.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/TokenRead.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.internal.kernel.api;
 
+import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.internal.kernel.api.exceptions.LabelNotFoundKernelException;
 import org.neo4j.internal.kernel.api.exceptions.PropertyKeyIdNotFoundKernelException;
 
@@ -53,6 +54,14 @@ public interface TokenRead
      * @return the relationship type id, or NO_TOKEN
      */
     int relationshipType( String name );
+
+    /**
+     * Returns the name of a relationship type given its id
+     *
+     * @param relationshipTypeId The id of the relationship type
+     * @return The name of the relationship type
+     */
+    String relationshipTypeName( int relationshipTypeId ) throws KernelException;
 
     /**
      * Return the id of the provided property key, or NO_TOKEN if the property isn't known to the graph.

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeData.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/NodeData.java
@@ -23,13 +23,13 @@ import java.util.Map;
 
 import org.neo4j.values.storable.Value;
 
-class Node
+class NodeData
 {
     final long id;
     private final long[] labels;
     final Map<Integer,Value> properties;
 
-    Node( long id, long[] labels, Map<Integer,Value> properties )
+    NodeData( long id, long[] labels, Map<Integer,Value> properties )
     {
         this.id = id;
         this.labels = labels;

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTestSupport.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTestSupport.java
@@ -25,7 +25,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
-import org.neo4j.graphdb.*;
+import org.neo4j.graphdb.Direction;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTransactionStateTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/RelationshipTransactionStateTestBase.java
@@ -21,9 +21,15 @@ package org.neo4j.internal.kernel.api;
 
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.neo4j.internal.kernel.api.RelationshipTestSupport.assertCounts;
+import static org.neo4j.internal.kernel.api.RelationshipTestSupport.count;
 
 @SuppressWarnings( "Duplicates" )
 public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWriteTestSupport> extends KernelAPIWriteTestBase<G>
@@ -185,6 +191,113 @@ public abstract class RelationshipTransactionStateTestBase<G extends KernelAPIWr
                 assertFalse( "should not find relationship added after cursor init", relationship.next() );
             }
             tx.success();
+        }
+    }
+
+//    @Test
+//    public void shouldTraverseSparseNodeViaGroups() throws Exception
+//    {
+//        traverseViaGroups( RelationshipTestSupport.sparse( graphDb ), false );
+//    }
+//
+//    @Test
+//    public void shouldTraverseDenseNodeViaGroups() throws Exception
+//    {
+//        traverseViaGroups( RelationshipTestSupport.dense( graphDb ), false );
+//    }
+//
+//    @Test
+//    public void shouldTraverseSparseNodeViaGroupsWithDetachedReferences() throws Exception
+//    {
+//        traverseViaGroups( RelationshipTestSupport.sparse( graphDb ), true );
+//    }
+//
+//    @Test
+//    public void shouldTraverseDenseNodeViaGroupsWithDetachedReferences() throws Exception
+//    {
+//        traverseViaGroups( RelationshipTestSupport.dense( graphDb ), true );
+//    }
+
+    @Test
+    public void shouldTraverseSparseNodeWithoutGroups() throws Exception
+    {
+        traverseWithoutGroups( RelationshipTestSupport.sparse( graphDb ), false );
+    }
+
+    @Test
+    public void shouldTraverseDenseNodeWithoutGroups() throws Exception
+    {
+        traverseWithoutGroups( RelationshipTestSupport.dense( graphDb ), false );
+    }
+
+    @Test
+    public void shouldTraverseSparseNodeWithoutGroupsWithDetachedReferences() throws Exception
+    {
+        traverseWithoutGroups( RelationshipTestSupport.sparse( graphDb ), true );
+    }
+
+    @Test
+    public void shouldTraverseDenseNodeWithoutGroupsWithDetachedReferences() throws Exception
+    {
+        traverseWithoutGroups( RelationshipTestSupport.dense( graphDb ), true );
+    }
+
+    private void traverseWithoutGroups( RelationshipTestSupport.StartNode start, boolean detached ) throws Exception
+    {
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            Map<String, Integer> expectedCounts = new HashMap<>();
+            for ( Map.Entry<String,List<RelationshipTestSupport.R>> kv : start.relationships.entrySet() )
+            {
+                List<RelationshipTestSupport.R> r = kv.getValue();
+                RelationshipTestSupport.R head = r.get( 0 );
+                int label = session.token().relationshipType( head.type.name() );
+                switch ( head.direction )
+                {
+                case INCOMING:
+                    tx.dataWrite().relationshipCreate( tx.dataWrite().nodeCreate(), label, start.id );
+                    tx.dataWrite().relationshipCreate( tx.dataWrite().nodeCreate(), label, start.id );
+                    break;
+                case OUTGOING:
+                    tx.dataWrite().relationshipCreate( start.id, label, tx.dataWrite().nodeCreate() );
+                    tx.dataWrite().relationshipCreate( start.id, label, tx.dataWrite().nodeCreate() );
+                    break;
+                case BOTH:
+                    tx.dataWrite().relationshipCreate( start.id, label, start.id );
+                    tx.dataWrite().relationshipCreate( start.id, label, start.id );
+                    break;
+                    default:
+                        throw new IllegalStateException( "Oh ye be cursed, foul checkstyle!" );
+                }
+                tx.dataWrite().relationshipDelete( head.id );
+                expectedCounts.put( kv.getKey(), r.size() + 1 );
+            }
+
+            // given
+            try ( NodeCursor node = cursors.allocateNodeCursor();
+                    RelationshipTraversalCursor relationship = cursors.allocateRelationshipTraversalCursor() )
+            {
+                // when
+                tx.dataRead().singleNode( start.id, node );
+
+                assertTrue( "access node", node.next() );
+                if ( detached )
+                {
+                    tx.dataRead().relationships( start.id, node.allRelationshipsReference(), relationship );
+                }
+                else
+                {
+                    node.allRelationships( relationship );
+                }
+
+                Map<String,Integer> counts = new HashMap<>();
+                count( session, relationship, counts, false );
+
+                // then
+                assertCounts( expectedCounts, counts );
+            }
+
+            tx.failure();
         }
     }
 }

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/StubNodeCursor.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/StubNodeCursor.java
@@ -29,7 +29,7 @@ import org.neo4j.values.storable.Value;
 public class StubNodeCursor implements NodeCursor
 {
     private int offset = -1;
-    private List<Node> nodes = new ArrayList<>();
+    private List<NodeData> nodes = new ArrayList<>();
 
     void single( long reference )
     {
@@ -50,19 +50,19 @@ public class StubNodeCursor implements NodeCursor
 
     public StubNodeCursor withNode( long id )
     {
-        nodes.add( new Node( id, new long[]{}, Collections.emptyMap() ) );
+        nodes.add( new NodeData( id, new long[]{}, Collections.emptyMap() ) );
         return this;
     }
 
     public StubNodeCursor withNode( long id, long... labels )
     {
-        nodes.add( new Node( id, labels, Collections.emptyMap() ) );
+        nodes.add( new NodeData( id, labels, Collections.emptyMap() ) );
         return this;
     }
 
     public StubNodeCursor withNode( long id, long[] labels, Map<Integer,Value> properties )
     {
-        nodes.add( new Node( id, labels, properties ) );
+        nodes.add( new NodeData( id, labels, properties ) );
         return this;
     }
 
@@ -119,7 +119,7 @@ public class StubNodeCursor implements NodeCursor
     {
         if ( offset >= 0 && offset < nodes.size() )
         {
-            Node node = nodes.get( offset );
+            NodeData node = nodes.get( offset );
             if ( !node.properties.isEmpty() )
             {
                 return node.id;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TxState.java
@@ -697,7 +697,7 @@ public class TxState implements TransactionState, RelationshipVisitor.Home
             NodeState nodeState,
             Direction direction )
     {
-        return nodeState.hasPropertyChanges() || nodeState.hasRelationshipChanges()
+        return nodeState.hasRelationshipChanges()
                ? iteratorRelationshipCursor.get().init( cursor, nodeState.getAddedRelationships( direction ) )
                : cursor;
     }
@@ -707,7 +707,7 @@ public class TxState implements TransactionState, RelationshipVisitor.Home
             Direction direction,
             int[] relTypes )
     {
-        return nodeState.hasPropertyChanges() || nodeState.hasRelationshipChanges()
+        return nodeState.hasRelationshipChanges()
                ? iteratorRelationshipCursor.get().init( cursor, nodeState.getAddedRelationships( direction, relTypes ) )
                : cursor;
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/AllStoreHolder.java
@@ -35,6 +35,7 @@ import org.neo4j.internal.kernel.api.schema.SchemaUtil;
 import org.neo4j.internal.kernel.api.schema.constraints.ConstraintDescriptor;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.kernel.api.ExplicitIndex;
+import org.neo4j.kernel.api.exceptions.RelationshipTypeIdNotFoundKernelException;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
 import org.neo4j.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/KernelToken.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/KernelToken.java
@@ -24,6 +24,7 @@ import org.neo4j.internal.kernel.api.exceptions.LabelNotFoundKernelException;
 import org.neo4j.internal.kernel.api.exceptions.PropertyKeyIdNotFoundKernelException;
 import org.neo4j.internal.kernel.api.exceptions.schema.IllegalTokenNameException;
 import org.neo4j.internal.kernel.api.exceptions.schema.TooManyLabelsException;
+import org.neo4j.kernel.api.exceptions.RelationshipTypeIdNotFoundKernelException;
 import org.neo4j.storageengine.api.StoreReadLayer;
 
 public class KernelToken implements Token
@@ -69,6 +70,12 @@ public class KernelToken implements Token
     public int relationshipType( String name )
     {
         return store.relationshipTypeGetForName( name );
+    }
+
+    @Override
+    public String relationshipTypeName( int relationshipTypeId ) throws RelationshipTypeIdNotFoundKernelException
+    {
+        return store.relationshipTypeGetName( relationshipTypeId );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NodeCursor.java
@@ -176,10 +176,11 @@ class NodeCursor extends NodeRecord implements org.neo4j.internal.kernel.api.Nod
             reset();
             return false;
         }
+
         // Check tx state
         boolean hasChanges = hasChanges();
-
         TransactionState txs = hasChanges ? read.txState() : null;
+
         do
         {
             if ( hasChanges && containsNode( txs ) )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Read.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Read.java
@@ -252,7 +252,7 @@ abstract class Read implements TxStateHolder,
     public final void relationships(
             long nodeReference, long reference, org.neo4j.internal.kernel.api.RelationshipTraversalCursor cursor )
     {
-        /* TODO: There are actually five (5!) different ways a relationship traversal cursor can be initialized:
+        /* There are 5 different ways a relationship traversal cursor can be initialized:
          *
          * 1. From a batched group in a detached way. This happens when the user manually retrieves the relationships
          *    references from the group cursor and passes it to this method and if the group cursor was based on having
@@ -282,7 +282,8 @@ abstract class Read implements TxStateHolder,
         ktx.assertOpen();
         if ( reference == NO_ID ) // there are no relationships for this node
         {
-            cursor.close();
+            // still initiate cursor in case there are tx-state additions
+            ((RelationshipTraversalCursor) cursor).chain( nodeReference, reference, this );
         }
         else if ( hasGroupFlag( reference ) ) // this reference is actually to a group record
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
@@ -19,19 +19,14 @@
  */
 package org.neo4j.kernel.impl.newapi;
 
-import java.util.Set;
-
 import org.neo4j.internal.kernel.api.RelationshipDataAccessor;
 import org.neo4j.kernel.impl.api.RelationshipVisitor;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
-
-import static java.util.Collections.emptySet;
 
 abstract class RelationshipCursor extends RelationshipRecord implements RelationshipDataAccessor, RelationshipVisitor<RuntimeException>
 {
     Read read;
     private HasChanges hasChanges = HasChanges.MAYBE;
-    Set<Long> addedRelationships;
 
     RelationshipCursor()
     {
@@ -42,7 +37,6 @@ abstract class RelationshipCursor extends RelationshipRecord implements Relation
     {
         this.read = read;
         this.hasChanges = HasChanges.MAYBE;
-        this.addedRelationships = emptySet();
     }
 
     @Override
@@ -99,7 +93,7 @@ abstract class RelationshipCursor extends RelationshipRecord implements Relation
         return getNextProp();
     }
 
-    protected abstract boolean shouldGetAddedTxStateSnapshot();
+    protected abstract void collectAddedTxStateSnapshot();
 
     /**
      * RelationshipCursor should only see changes that are there from the beginning
@@ -113,10 +107,7 @@ abstract class RelationshipCursor extends RelationshipRecord implements Relation
             boolean changes = read.hasTxStateWithChanges();
             if ( changes )
             {
-                if ( shouldGetAddedTxStateSnapshot() )
-                {
-                    addedRelationships = read.txState().addedAndRemovedRelationships().getAddedSnapshot();
-                }
+                collectAddedTxStateSnapshot();
                 hasChanges = HasChanges.YES;
             }
             else

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipTraversalCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipTraversalCursor.java
@@ -213,11 +213,6 @@ class RelationshipTraversalCursor extends RelationshipCursor
     @Override
     public boolean next()
     {
-        if ( traversingDenseNode() )
-        {
-            traverseDenseNode();
-        }
-
         if ( hasBufferedData() )
         {   //We have buffered data, iterate the chain of buffered records
             return nextBufferedData();
@@ -238,10 +233,13 @@ class RelationshipTraversalCursor extends RelationshipCursor
             return true;
         }
 
-        // Not a group, nothing buffered, no filtering.
-        // Just a plain old traversal.
         do
         {
+            if ( traversingDenseNode() )
+            {
+                traverseDenseNode();
+            }
+
             if ( next == NO_ID )
             {
                 reset();
@@ -368,8 +366,8 @@ class RelationshipTraversalCursor extends RelationshipCursor
                 boolean hasNext = group.next();
                 if ( !hasNext )
                 {
-                    reset();
-                    return;
+                    assert next == NO_ID;
+                    return; // no more groups nor relationships
                 }
                 next = group.incomingReference();
                 if ( pageCursor == null )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipTraversalCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipTraversalCursor.java
@@ -19,10 +19,13 @@
  */
 package org.neo4j.kernel.impl.newapi;
 
+import org.neo4j.collection.primitive.PrimitiveLongCollections;
+import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.internal.kernel.api.NodeCursor;
 import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.kernel.api.txstate.TransactionState;
 import org.neo4j.kernel.impl.store.record.RelationshipRecord;
-
+import org.neo4j.storageengine.api.Direction;
 
 class RelationshipTraversalCursor extends RelationshipCursor
         implements org.neo4j.internal.kernel.api.RelationshipTraversalCursor
@@ -90,6 +93,8 @@ class RelationshipTraversalCursor extends RelationshipCursor
     private FilterState filterState;
     private int filterType = NO_ID;
 
+    private PrimitiveLongIterator addedRelationships;
+
     RelationshipTraversalCursor( RelationshipGroupCursor group )
     {
         this.group = group;
@@ -97,7 +102,7 @@ class RelationshipTraversalCursor extends RelationshipCursor
 
     /*
      * Cursor being called as a group, use the buffered records in Record
-     * instead.
+     * instead. These are guaranteed to all have the same type and direction.
      */
     void buffered( long nodeReference, Record record, Read read )
     {
@@ -106,11 +111,12 @@ class RelationshipTraversalCursor extends RelationshipCursor
         this.groupState = GroupState.NONE;
         this.filterState = FilterState.NONE;
         this.filterType = NO_ID;
-        this.read = read;
+        init( read );
+        this.addedRelationships = PrimitiveLongCollections.emptyIterator();
     }
 
     /*
-     * Normal traversal.
+     * Normal traversal. Mixed types and directions.
      */
     void chain( long nodeReference, long reference, Read read )
     {
@@ -124,11 +130,12 @@ class RelationshipTraversalCursor extends RelationshipCursor
         filterType = NO_ID;
         originNodeReference = nodeReference;
         next = reference;
-        this.read = read;
+        init( read );
+        this.addedRelationships = PrimitiveLongCollections.emptyIterator();
     }
 
     /*
-     * Reference to a group record
+     * Reference to a group record. Mixed types and directions, but grouped.
      */
     void groups( long nodeReference, long groupReference, Read read )
     {
@@ -139,9 +146,13 @@ class RelationshipTraversalCursor extends RelationshipCursor
         filterType = NO_ID;
         originNodeReference = nodeReference;
         read.relationshipGroups( nodeReference, groupReference, group );
-        this.read = read;
+        init( read );
+        this.addedRelationships = PrimitiveLongCollections.emptyIterator();
     }
 
+    /*
+     * Grouped traversal of non-dense node. Same type and direction as first read relationship.
+     */
     void filtered( long nodeReference, long reference, Read read )
     {
         if ( pageCursor == null )
@@ -153,7 +164,8 @@ class RelationshipTraversalCursor extends RelationshipCursor
         filterState = FilterState.NOT_INITIALIZED;
         originNodeReference = nodeReference;
         next = reference;
-        this.read = read;
+        init( read );
+        this.addedRelationships = PrimitiveLongCollections.emptyIterator();
     }
 
     @Override
@@ -216,16 +228,30 @@ class RelationshipTraversalCursor extends RelationshipCursor
             return nextFilteredData();
         }
 
-        if ( next == NO_ID )
+        // Check tx state
+        boolean hasChanges = hasChanges();
+        TransactionState txs = hasChanges ? read.txState() : null;
+
+        if ( hasChanges && addedRelationships.hasNext() )
         {
-            reset();
-            return false;
+            loadFromTxState( addedRelationships.next() );
+            return true;
         }
 
-        //Not a group, nothing buffered, no filtering.
-        //Just a plain old traversal.
-        read.relationship( this, next, pageCursor );
-        computeNext();
+        // Not a group, nothing buffered, no filtering.
+        // Just a plain old traversal.
+        do
+        {
+            if ( next == NO_ID )
+            {
+                reset();
+                return false;
+            }
+
+            read.relationship( this, next, pageCursor );
+            computeNext();
+        } while ( hasChanges && txs.relationshipIsDeletedInThisTx( getId() ) );
+
         return true;
     }
 
@@ -270,7 +296,7 @@ class RelationshipTraversalCursor extends RelationshipCursor
             {
                 read.relationship( this, next, pageCursor );
                 computeNext();
-                if ( predicate() )
+                if ( correctTypeAndDirection() )
                 {
                     return true;
                 }
@@ -386,7 +412,7 @@ class RelationshipTraversalCursor extends RelationshipCursor
         }
     }
 
-    private boolean predicate()
+    private boolean correctTypeAndDirection()
     {
         return filterType == getType() &&
                filterState.check( sourceNodeReference(), targetNodeReference(), originNodeReference );
@@ -439,9 +465,9 @@ class RelationshipTraversalCursor extends RelationshipCursor
     }
 
     @Override
-    protected boolean shouldGetAddedTxStateSnapshot()
+    protected void collectAddedTxStateSnapshot()
     {
-        return true;
+        addedRelationships = read.txState().getNodeState( originNodeReference ).getAddedRelationships( Direction.BOTH );
     }
 
     @Override


### PR DESCRIPTION
Add tx-state awareness for relationship traversal code-paths starting with `NodeCursor.allRelationships` and `NodeCursor.allRelationshipsReference`. Also refactors traversal tests for reuse between tx-state tests and pure store tests.

Builds on #10833, first commit is `efd5695`.