### PR TITLE
Optional match or pattern comprehension with writeRead conflicts

### DIFF
--- a/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/UpdateGraph.scala
+++ b/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/UpdateGraph.scala
@@ -228,7 +228,7 @@ trait UpdateGraph {
     val allRelPatternsRead = qg.allPatternRelationshipsRead
 
     //CREATE () MATCH ()-->()
-    (allRelPatternsWritten.nonEmpty && qg.patternRelationships.nonEmpty) && allRelPatternsRead.exists(r => {
+    (allRelPatternsWritten.nonEmpty && allRelPatternsRead.nonEmpty) && allRelPatternsRead.exists(r => {
       val readProps = qg.allKnownPropertiesOnIdentifier(r.name).map(_.propertyKey)
       // CREATE ()-[]->() MATCH ()-[]-()?
       r.types.isEmpty && readProps.isEmpty ||

--- a/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/UpdateGraph.scala
+++ b/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/UpdateGraph.scala
@@ -232,8 +232,12 @@ trait UpdateGraph {
   def createRelationshipOverlapHorizon(allRelPatternsRead: Set[RelationshipPattern]): Boolean = {
     //CREATE () MATCH ()-->()
     (allRelPatternsWrittenNonEmpty && allRelPatternsRead.nonEmpty) && allRelPatternsRead.exists(r => {
-      val readProps = r.properties.map(_.asInstanceOf[MapExpression].items.map(_._1).toSet).get
-      relationshipOverlap(r.types.toSet, readProps)
+      r.properties match {
+        case Some(MapExpression(items)) =>
+          val propKeyNames = items.map(_._1).toSet
+          relationshipOverlap(r.types.toSet, propKeyNames)
+        case _ => false
+      }
     })
   }
 

--- a/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/UpdateGraph.scala
+++ b/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/UpdateGraph.scala
@@ -158,11 +158,16 @@ trait UpdateGraph {
         case p: Property => p
       }.toSet
 
+      val allPatternRelationshipsRead = horizon.dependingExpressions.collect {
+        case p: PatternComprehension => p.pattern.element.relationship
+      }.toSet
+
       val maybeNode: Property => Boolean = maybeType(semanticTable, symbols.CTNode.invariant)
       val maybeRel: Property => Boolean = maybeType(semanticTable, symbols.CTRelationship.invariant)
 
       setNodePropertyOverlap(propertiesReadInHorizon.filter(maybeNode).map(_.propertyKey)) ||
-      setRelPropertyOverlap(propertiesReadInHorizon.filter(maybeRel).map(_.propertyKey))
+      setRelPropertyOverlap(propertiesReadInHorizon.filter(maybeRel).map(_.propertyKey))||
+      createRelationshipOverlapHorizon(allPatternRelationshipsRead)
     } || ((labelsToSet.nonEmpty || removeLabelPatterns.nonEmpty) && usesLabelsFunction(horizon)))
 
   def writeOnlyHeadOverlaps(qg: QueryGraph): Boolean = {
@@ -217,24 +222,37 @@ trait UpdateGraph {
    * and those being created here
    */
   def createRelationshipOverlap(qg: QueryGraph): Boolean = {
+    //CREATE () MATCH ()-->()
+    (allRelPatternsWrittenNonEmpty && qg.allPatternRelationshipsRead.nonEmpty) && qg.allPatternRelationshipsRead.exists(r => {
+      val readProps = qg.allKnownPropertiesOnIdentifier(r.name).map(_.propertyKey)
+      relationshipOverlap(r.types.toSet, readProps)
+    })
+  }
+
+  def createRelationshipOverlapHorizon(allRelPatternsRead: Set[RelationshipPattern]): Boolean = {
+    //CREATE () MATCH ()-->()
+    (allRelPatternsWrittenNonEmpty && allRelPatternsRead.nonEmpty) && allRelPatternsRead.exists(r => {
+      val readProps = r.properties.map(_.asInstanceOf[MapExpression].items.map(_._1).toSet).get
+      relationshipOverlap(r.types.toSet, readProps)
+    })
+  }
+
+  private def allRelPatternsWrittenNonEmpty: Boolean = {
+    val allRelPatternsWritten = createRelationshipPatterns ++ mergeRelationshipPatterns.flatMap(_.createRelPatterns)
+    allRelPatternsWritten.nonEmpty
+  }
+
+  private def relationshipOverlap(readRelTypes: Set[RelTypeName], readRelProperties: Set[PropertyKeyName]): Boolean = {
     def typesOverlap(typesToRead: Set[RelTypeName], typesToWrite: Set[RelTypeName]): Boolean = {
       typesToRead.isEmpty || (typesToRead intersect typesToWrite).nonEmpty
     }
     def propsOverlap(propsToRead: Set[PropertyKeyName], propsToWrite: CreatesPropertyKeys) = {
       propsToRead.isEmpty || propsToRead.exists(propsToWrite.overlaps)
     }
-
-    val allRelPatternsWritten = createRelationshipPatterns ++ mergeRelationshipPatterns.flatMap(_.createRelPatterns)
-    val allRelPatternsRead = qg.allPatternRelationshipsRead
-
-    //CREATE () MATCH ()-->()
-    (allRelPatternsWritten.nonEmpty && allRelPatternsRead.nonEmpty) && allRelPatternsRead.exists(r => {
-      val readProps = qg.allKnownPropertiesOnIdentifier(r.name).map(_.propertyKey)
-      // CREATE ()-[]->() MATCH ()-[]-()?
-      r.types.isEmpty && readProps.isEmpty ||
-        // CREATE ()-[:T {prop:...}]->() MATCH ()-[:T {prop:{}]-()?
-        (typesOverlap(r.types.toSet, createRelTypes) && propsOverlap(readProps, createRelProperties))
-    })
+    // CREATE ()-[]->() MATCH ()-[]-()?
+    readRelTypes.isEmpty && readRelProperties.isEmpty ||
+      // CREATE ()-[:T {prop:...}]->() MATCH ()-[:T {prop:{}]-()?
+      (typesOverlap(readRelTypes, createRelTypes) && propsOverlap(readRelProperties, createRelProperties))
   }
 
 


### PR DESCRIPTION
Two bug fixes in one PR!

Should be forward merged to 3.3 and 3.4

changelog: Fixes bug with missing results when a relationship created in the same transaction was not found by optional match or pattern comprehension