### PR TITLE
Fix a bug where Causal Cluster store-copy or online backup would occasionally get stuck in an infinite loop during recovery of the temporary store. Also makes store copy faster in HA, CC and online backup.

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/PageCacheFlusher.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/PageCacheFlusher.java
@@ -21,6 +21,7 @@ package org.neo4j.io.pagecache.impl;
 
 import java.io.Flushable;
 import java.io.IOException;
+import java.util.Objects;
 
 import org.neo4j.concurrent.BinaryLatch;
 import org.neo4j.io.pagecache.IOLimiter;
@@ -41,6 +42,7 @@ public class PageCacheFlusher extends Thread implements IOLimiter
 
     public PageCacheFlusher( PageCache pageCache )
     {
+        Objects.requireNonNull( pageCache );
         this.pageCache = pageCache;
     }
 

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/PageCacheFlusher.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/PageCacheFlusher.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.unsafe.impl.batchimport.store;
+package org.neo4j.io.pagecache.impl;
 
 import org.neo4j.concurrent.BinaryLatch;
 import org.neo4j.io.pagecache.PageCache;
@@ -28,14 +28,14 @@ import static org.neo4j.helpers.Exceptions.launderedException;
  * A dedicated thread which constantly call {@link PageCache#flushAndForce()} until a call to {@link #halt()} is made.
  * Must be started manually by calling {@link #start()}.
  */
-class PageCacheFlusher extends Thread
+public class PageCacheFlusher extends Thread
 {
     private final PageCache pageCache;
     private final BinaryLatch halt = new BinaryLatch();
     private volatile boolean halted;
     private volatile Throwable error;
 
-    PageCacheFlusher( PageCache pageCache )
+    public PageCacheFlusher( PageCache pageCache )
     {
         this.pageCache = pageCache;
     }
@@ -69,7 +69,7 @@ class PageCacheFlusher extends Thread
      * will complete before exiting this method call. If there was an error in the thread doing the flushes
      * that exception will be thrown from this method as a {@link RuntimeException}.
      */
-    void halt()
+    public void halt()
     {
         halted = true;
         halt.await();

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -578,7 +578,7 @@ public class MuninnPageCache implements PageCache
     {
         if ( limiter == null )
         {
-            throw new IllegalArgumentException( "IOPSLimiter cannot be null" );
+            throw new IllegalArgumentException( "IOLimiter cannot be null" );
         }
         assertNotClosed();
         flushAllPages( limiter );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
@@ -27,6 +27,7 @@ import org.neo4j.helpers.Service;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.io.pagecache.impl.PageCacheFlusher;
 import org.neo4j.io.pagecache.tracing.DefaultPageCacheTracer;
 import org.neo4j.io.pagecache.tracing.PageCacheTracer;
 import org.neo4j.io.pagecache.tracing.cursor.DefaultPageCursorTracerSupplier;

--- a/community/kernel/src/test/java/org/neo4j/io/pagecache/impl/PageCacheFlusherTest.java
+++ b/community/kernel/src/test/java/org/neo4j/io/pagecache/impl/PageCacheFlusherTest.java
@@ -46,12 +46,12 @@ public class PageCacheFlusherTest
         // GIVEN
         PageCache pageCache = mock( PageCache.class );
         Barrier.Control barrier = new Barrier.Control();
+        PageCacheFlusher flusher = new PageCacheFlusher( pageCache );
         doAnswer( invocation ->
         {
             barrier.reached();
             return null;
-        } ).when( pageCache ).flushAndForce();
-        PageCacheFlusher flusher = new PageCacheFlusher( pageCache );
+        } ).when( pageCache ).flushAndForce( flusher );
         flusher.start();
 
         // WHEN

--- a/community/kernel/src/test/java/org/neo4j/io/pagecache/impl/PageCacheFlusherTest.java
+++ b/community/kernel/src/test/java/org/neo4j/io/pagecache/impl/PageCacheFlusherTest.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.unsafe.impl.batchimport.store;
+package org.neo4j.io.pagecache.impl;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,6 +32,9 @@ import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
+/**
+ * This test is in the kernel module because the OtherThreadRule is really convenient here.
+ */
 public class PageCacheFlusherTest
 {
     @Rule

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/TrackingResponseHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/TrackingResponseHandler.java
@@ -35,10 +35,10 @@ import org.neo4j.causalclustering.core.state.snapshot.CoreSnapshot;
 @SuppressWarnings("unchecked")
 class TrackingResponseHandler implements CatchUpResponseHandler
 {
-    private CatchUpResponseCallback delegate;
-    private CompletableFuture<?> requestOutcomeSignal = new CompletableFuture<>();
     private final Clock clock;
-    private Long lastResponseTime;
+    private volatile CatchUpResponseCallback delegate;
+    private volatile CompletableFuture<?> requestOutcomeSignal = new CompletableFuture<>();
+    private volatile Long lastResponseTime;
 
     TrackingResponseHandler( CatchUpResponseCallback delegate, Clock clock )
     {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClient.java
@@ -20,21 +20,15 @@
 package org.neo4j.causalclustering.catchup.storecopy;
 
 import java.io.IOException;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.neo4j.causalclustering.catchup.CatchUpClient;
 import org.neo4j.causalclustering.catchup.CatchUpClientException;
 import org.neo4j.causalclustering.catchup.CatchUpResponseAdaptor;
-import org.neo4j.causalclustering.core.state.snapshot.TopologyLookupException;
-import org.neo4j.causalclustering.discovery.TopologyService;
-import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.identity.StoreId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
-
-import static java.lang.String.format;
 
 public class StoreCopyClient
 {

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStoreTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStoreTest.java
@@ -60,7 +60,7 @@ public class RemoteStoreTest
         TransactionLogCatchUpWriter writer = mock( TransactionLogCatchUpWriter.class );
 
         RemoteStore remoteStore = new RemoteStore( NullLogProvider.getInstance(), mock( FileSystemAbstraction.class ),
-                null, storeCopyClient, txPullClient, factory( writer ), new Monitors() );
+                mock( PageCache.class ), storeCopyClient, txPullClient, factory( writer ), new Monitors() );
 
         // when
         AdvertisedSocketAddress localhost = new AdvertisedSocketAddress( "127.0.0.1", 1234 );
@@ -90,7 +90,7 @@ public class RemoteStoreTest
         TransactionLogCatchUpWriter writer = mock( TransactionLogCatchUpWriter.class );
 
         RemoteStore remoteStore = new RemoteStore( NullLogProvider.getInstance(), mock( FileSystemAbstraction.class ),
-                null, storeCopyClient, txPullClient, factory( writer ), new Monitors() );
+                mock( PageCache.class ), storeCopyClient, txPullClient, factory( writer ), new Monitors() );
 
         // when
         remoteStore.copy( localhost, wantedStoreId, new File( "destination" ) );
@@ -109,8 +109,8 @@ public class RemoteStoreTest
         TxPullClient txPullClient = mock( TxPullClient.class );
         TransactionLogCatchUpWriter writer = mock( TransactionLogCatchUpWriter.class );
 
-        RemoteStore remoteStore = new RemoteStore( NullLogProvider.getInstance(), mock( FileSystemAbstraction.class ),
-                null,
+        RemoteStore remoteStore = new RemoteStore(
+                NullLogProvider.getInstance(), mock( FileSystemAbstraction.class ), mock( PageCache.class ),
                 storeCopyClient, txPullClient, factory( writer ), new Monitors() );
 
         doThrow( StoreCopyFailedException.class ).when( txPullClient )

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToFileStoreWriter.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToFileStoreWriter.java
@@ -31,6 +31,7 @@ import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.impl.store.StoreType;
+import org.neo4j.io.pagecache.impl.PageCacheFlusher;
 
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.WRITE;
@@ -43,6 +44,7 @@ public class ToFileStoreWriter implements StoreWriter
     private final StoreCopyClient.Monitor monitor;
     private final PageCache pageCache;
     private final List<FileMoveAction> fileMoveActions;
+    private final PageCacheFlusher flusherThread;
 
     public ToFileStoreWriter( File graphDbStoreDir, FileSystemAbstraction fs,
             StoreCopyClient.Monitor monitor, PageCache pageCache, List<FileMoveAction> fileMoveActions )
@@ -52,6 +54,8 @@ public class ToFileStoreWriter implements StoreWriter
         this.monitor = monitor;
         this.pageCache = pageCache;
         this.fileMoveActions = fileMoveActions;
+        this.flusherThread = new PageCacheFlusher( pageCache );
+        flusherThread.start();
     }
 
     @Override
@@ -158,6 +162,6 @@ public class ToFileStoreWriter implements StoreWriter
     @Override
     public void close()
     {
-        // Do nothing
+        flusherThread.halt();
     }
 }


### PR DESCRIPTION
The lifecycle of the StreamToDisk and the resources it opens, such as PagedFiles and PagedWritableByteChannels, are managed separately from the threads that are writing file contents through it.

Previously, the StreamToDisk implementation was oblivious to this concurrency, and would freely allow the write threads to race with the closing of the StreamToDisk instance.

This could ultimately lead to write page cursors leaking, as in, not being closed when the StreamToDisk instance was closed.

When a write page cursor was leaked, it would cause a page in the page cache (usually the last page of a file) to be permanently write locked, and this in turn would cause all future read page cursors that would access that page, to get stuck in infinite shouldRetry-loops.

Since this would always happen to the last page in a file, the database would get stuck in these infinite loops on startup, as part of the highId scanning, or the GBPTree crash recovery scanning.

This bug is fixed by making the opening and closing of files in StreamToDisk atomic and mutually exclusive. Furthermore, the writing to a paged file, and the closing of the paged file, are made mutually exclusive. Both of these pairs of operations are protected by each their own monitor locks per file, so the IO parallelism is largely preserved.

Additionally, the fields in the TrackingResponseHandler that are updated when a store copy is initiated, have been made volatile to ensure that their updates are visible to the IO threads that will be doing the writing. This ensures that the network IO ends up with the correct handlers, and thus the current StreamToDisk instance, in case multiple instances end up being juggled at runtime.