### PR TITLE
Dev-Nullifying debug.log messages from backup client

### DIFF
--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.backup;
 
+import org.apache.commons.lang3.SystemUtils;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -266,9 +268,24 @@ class BackupService
     {
         Map<String,String> tempDbConfig = new HashMap<>();
         tempDbConfig.put( OnlineBackupSettings.online_backup_enabled.name(), Settings.FALSE );
+
+        sendLogsToDevNullSoItWillNotInterfereWithLocalRunningNeo4jServer( tempDbConfig );
+
         // In case someone deleted the logical log from a full backup
         tempDbConfig.put( GraphDatabaseSettings.keep_logical_logs.name(), Settings.TRUE );
         return tempDbConfig;
+    }
+
+    private void sendLogsToDevNullSoItWillNotInterfereWithLocalRunningNeo4jServer( Map<String,String> tempDbConfig )
+    {
+        if ( SystemUtils.IS_OS_WINDOWS )
+        {
+            tempDbConfig.put( GraphDatabaseSettings.store_internal_log_path.name(), System.getProperty( "java.io.tmpdir" ) + File.separatorChar + "nul" );
+        }
+        else
+        {
+            tempDbConfig.put( GraphDatabaseSettings.store_internal_log_path.name(), "/dev/null" );
+        }
     }
 
     BackupOutcome doIncrementalBackupOrFallbackToFull( String sourceHostNameOrIp, int sourcePort, File targetDirectory,

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -269,24 +269,11 @@ class BackupService
         Map<String,String> tempDbConfig = new HashMap<>();
         tempDbConfig.put( OnlineBackupSettings.online_backup_enabled.name(), Settings.FALSE );
 
-        sendLogsToDevNullSoItWillNotInterfereWithLocalRunningNeo4jServer( tempDbConfig );
-
         // In case someone deleted the logical log from a full backup
         tempDbConfig.put( GraphDatabaseSettings.keep_logical_logs.name(), Settings.TRUE );
         return tempDbConfig;
     }
 
-    private void sendLogsToDevNullSoItWillNotInterfereWithLocalRunningNeo4jServer( Map<String,String> tempDbConfig )
-    {
-        if ( SystemUtils.IS_OS_WINDOWS )
-        {
-            tempDbConfig.put( GraphDatabaseSettings.store_internal_log_path.name(), System.getProperty( "java.io.tmpdir" ) + File.separatorChar + "nul" );
-        }
-        else
-        {
-            tempDbConfig.put( GraphDatabaseSettings.store_internal_log_path.name(), "/dev/null" );
-        }
-    }
 
     BackupOutcome doIncrementalBackupOrFallbackToFull( String sourceHostNameOrIp, int sourcePort, File targetDirectory,
             ConsistencyCheck consistencyCheck, Config config, long timeout, boolean forensics )

--- a/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/BackupService.java
@@ -274,7 +274,6 @@ class BackupService
         return tempDbConfig;
     }
 
-
     BackupOutcome doIncrementalBackupOrFallbackToFull( String sourceHostNameOrIp, int sourcePort, File targetDirectory,
             ConsistencyCheck consistencyCheck, Config config, long timeout, boolean forensics )
     {

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
@@ -79,8 +79,9 @@ public class OnlineBackupCommand implements AdminCommand
             .withArgument( new OptionalBooleanArg( "cc-label-scan-store", true,
                     "Perform consistency checks on the label scan store." ) )
             .withArgument( new OptionalBooleanArg( "cc-property-owners", false,
-                    "Perform additional consistency checks on property ownership. This check is *very* expensive in " +
-                            "time and memory." ) );
+                    "Perform additional consistency checks on property ownership. This check is *very* expensive in time and memory." ) )
+            .withArgument( new OptionalCanonicalPath( "backup-log", "backup-log-file-path",
+                    "disabled", "Enable backup client logging and direct log entries to the specified file." ) );
 
     public static Arguments arguments()
     {
@@ -96,9 +97,7 @@ public class OnlineBackupCommand implements AdminCommand
     private ConsistencyCheckService consistencyCheckService;
     private final OutsideWorld outsideWorld;
 
-    public OnlineBackupCommand( BackupService backupService, Path homeDir, Path configDir,
-            ConsistencyCheckService consistencyCheckService,
-            OutsideWorld outsideWorld )
+    OnlineBackupCommand( BackupService backupService, Path homeDir, Path configDir, ConsistencyCheckService consistencyCheckService, OutsideWorld outsideWorld )
     {
         this.backupService = backupService;
         this.homeDir = homeDir;

--- a/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/OnlineBackupCommand.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.backup;
 
+import org.apache.commons.lang3.SystemUtils;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -122,6 +124,7 @@ public class OnlineBackupCommand implements AdminCommand
         final boolean checkIndexes;
         final boolean checkLabelScanStore;
         final boolean checkPropertyOwners;
+        final Optional<Path> backupLogFile;
 
         try
         {
@@ -136,6 +139,7 @@ public class OnlineBackupCommand implements AdminCommand
             additionalConfig = arguments.getOptionalPath( "additional-config" );
             reportDir = arguments.getOptionalPath( "cc-report-dir" ).orElseThrow( () ->
                     new IllegalArgumentException( "cc-report-dir must be a path" ) );
+            backupLogFile = arguments().getOptionalPath( "backup-log" );
         }
         catch ( IllegalArgumentException e )
         {
@@ -192,6 +196,22 @@ public class OnlineBackupCommand implements AdminCommand
             else
             {
                 checkPropertyOwners = config.get( ConsistencyCheckSettings.consistency_check_property_owners );
+            }
+            if ( backupLogFile.isPresent() )
+            {
+                config.augment( "backup-log", backupLogFile.get().toAbsolutePath().toString() );
+            }
+            else
+            {
+                // Write backup log output to null file
+                if ( SystemUtils.IS_OS_WINDOWS )
+                {
+                    config.augment( GraphDatabaseSettings.store_internal_log_path.name(), System.getProperty( "java.io.tmpdir" ) + File.separatorChar + "nul" );
+                }
+                else
+                {
+                    config.augment( GraphDatabaseSettings.store_internal_log_path.name(), "/dev/null" );
+                }
             }
         }
         catch ( IllegalArgumentException e )

--- a/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
@@ -197,7 +197,7 @@ public class OnlineBackupCommandTest
 
     @Test
     public void shouldNotAskForConsistencyCheckIfNotSpecified()
-            throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
+            throws CommandFailed, IncorrectUsage
     {
         execute( "--check-consistency=false", backupDir(), "--name=mybackup" );
 
@@ -542,9 +542,7 @@ public class OnlineBackupCommandTest
     }
 
     @Test
-    public void shouldReadStandardConfig() throws IOException, CommandFailed, IncorrectUsage, BackupTool
-            .ToolFailureException
-
+    public void shouldReadStandardConfig() throws IOException, CommandFailed, IncorrectUsage
     {
         Files.write( configDir.resolve( Config.DEFAULT_CONFIG_FILE_NAME ), singletonList( cypher_planner.name() + "=RULE" ) );
         ArgumentCaptor<Config> config = ArgumentCaptor.forClass( Config.class );
@@ -558,7 +556,7 @@ public class OnlineBackupCommandTest
 
     @Test
     public void shouldAugmentConfig()
-            throws IOException, CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
+            throws IOException, CommandFailed, IncorrectUsage
     {
         Path extraConf = testDirectory.directory( "someOtherDir" ).toPath().resolve( "extra.conf" );
         Files.write( extraConf, singletonList( cypher_planner.name() + "=RULE" ) );
@@ -572,8 +570,7 @@ public class OnlineBackupCommandTest
     }
 
     @Test
-    public void shouldDefaultTimeoutToTwentyMinutes()
-            throws BackupTool.ToolFailureException, CommandFailed, IncorrectUsage
+    public void shouldDefaultTimeoutToTwentyMinutes() throws CommandFailed, IncorrectUsage
     {
         execute( backupDir(), "--name=mybackup" );
 
@@ -583,8 +580,7 @@ public class OnlineBackupCommandTest
     }
 
     @Test
-    public void shouldInterpretAUnitlessTimeoutAsSeconds()
-            throws BackupTool.ToolFailureException, CommandFailed, IncorrectUsage
+    public void shouldInterpretAUnitlessTimeoutAsSeconds() throws CommandFailed, IncorrectUsage
     {
         execute( "--timeout=10", backupDir(), "--name=mybackup" );
 
@@ -594,8 +590,7 @@ public class OnlineBackupCommandTest
     }
 
     @Test
-    public void shouldParseATimeoutWithUnits()
-            throws BackupTool.ToolFailureException, CommandFailed, IncorrectUsage
+    public void shouldParseATimeoutWithUnits() throws CommandFailed, IncorrectUsage
     {
         execute( "--timeout=10h", backupDir(), "--name=mybackup" );
 

--- a/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
@@ -104,7 +104,7 @@ public class OnlineBackupCommandTest
     }
 
     @Test
-    public void shouldNotRequestForensics() throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
+    public void shouldNotRequestForensics() throws CommandFailed, IncorrectUsage
     {
         execute( backupDir(), "--name=mybackup" );
 
@@ -113,7 +113,7 @@ public class OnlineBackupCommandTest
 
     @Test
     public void shouldDefaultFromToDefaultBackupAddress()
-            throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
+            throws CommandFailed, IncorrectUsage
     {
         execute( backupDir(), "--name=mybackup" );
 
@@ -122,7 +122,7 @@ public class OnlineBackupCommandTest
     }
 
     @Test
-    public void shouldDefaultPortAndPassHost() throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
+    public void shouldDefaultPortAndPassHost() throws CommandFailed, IncorrectUsage
     {
         execute( "--from=foo.bar.server", backupDir(), "--name=mybackup" );
 
@@ -132,7 +132,7 @@ public class OnlineBackupCommandTest
 
     @Test
     public void shouldAcceptAHostWithATrailingColon()
-            throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
+            throws CommandFailed, IncorrectUsage
     {
         execute( "--from=foo.bar.server:", backupDir(), "--name=mybackup" );
 
@@ -141,7 +141,7 @@ public class OnlineBackupCommandTest
     }
 
     @Test
-    public void shouldDefaultHostAndPassPort() throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
+    public void shouldDefaultHostAndPassPort() throws CommandFailed, IncorrectUsage
     {
         execute( "--from=:1234", backupDir(), "--name=mybackup" );
 
@@ -150,7 +150,7 @@ public class OnlineBackupCommandTest
     }
 
     @Test
-    public void shouldPassHostAndPort() throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
+    public void shouldPassHostAndPort() throws CommandFailed, IncorrectUsage
     {
         execute( "--from=foo.bar.server:1234", backupDir(), "--name=mybackup" );
 
@@ -159,7 +159,7 @@ public class OnlineBackupCommandTest
     }
 
     @Test
-    public void shouldPassDestination() throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
+    public void shouldPassDestination() throws CommandFailed, IncorrectUsage
     {
         final Path dest = Paths.get( "/" );
         execute( backupDir( path( dest.toString() ) ), "--name=mybackup" );
@@ -170,7 +170,7 @@ public class OnlineBackupCommandTest
     }
 
     @Test
-    public void nonExistingBackupDirThrows() throws CommandFailed, IncorrectUsage, BackupTool.ToolFailureException
+    public void nonExistingBackupDirThrows() throws CommandFailed, IncorrectUsage
     {
         final String path = path( "/Idontexist/sasdfasdfa" );
         expected.expect( CommandFailed.class );
@@ -625,6 +625,7 @@ public class OnlineBackupCommandTest
                             "                          [--cc-indexes[=<true|false>]]%n" +
                             "                          [--cc-label-scan-store[=<true|false>]]%n" +
                             "                          [--cc-property-owners[=<true|false>]]%n" +
+                            "                          [--backup-log=<backup-log-file-path>]%n" +
                             "%n" +
                             "environment variables:%n" +
                             "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
@@ -676,7 +677,10 @@ public class OnlineBackupCommandTest
                             "  --cc-property-owners=<true|false>        Perform additional consistency checks%n" +
                             "                                           on property ownership. This check is%n" +
                             "                                           *very* expensive in time and memory.%n" +
-                            "                                           [default:false]%n" ),
+                            "                                           [default:false]%n" +
+                            "  --backup-log=<backup-log-file-path>      Enable backup client logging and%n" +
+                            "                                           direct log entries to the specified%n" +
+                            "                                           file. [default:disabled]%n" ),
                     baos.toString() );
         }
     }
@@ -691,7 +695,7 @@ public class OnlineBackupCommandTest
      * @param path to transform to platform independent absolute path
      * @return platform independent absolute path
      */
-    static String path( String path )
+    private static String path( String path )
     {
         return Paths.get( path ).toFile().getAbsolutePath();
     }
@@ -699,7 +703,7 @@ public class OnlineBackupCommandTest
     /**
      * @return a backup-dir argument with a path suitable for each platform
      */
-    static String backupDir()
+    private static String backupDir()
     {
         return backupDir( "/" );
     }
@@ -707,7 +711,7 @@ public class OnlineBackupCommandTest
     /**
      * @return the backup-dir argument with a path suitable for each platform
      */
-    static String backupDir( String path )
+    private static String backupDir( String path )
     {
         return "--backup-dir=" + path( path );
     }


### PR DESCRIPTION
Backup client brings up an embedded neo4j instance which, if run
locally with the production instance will spam its debug.log with
starting and stopping messages. These look scary to an operator.

This commit changes behavior so that when neo4j-admin backup is run,
that all debug.log output from its embedded instance goes to dev/null
or equivalent on Windows.