### PR TITLE
Refine bolt channel throttling with auto-read limiter and connection halting

### DIFF
--- a/community/bolt/LICENSES.txt
+++ b/community/bolt/LICENSES.txt
@@ -4,6 +4,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
   Apache Commons Compress
+  Apache Commons Lang
   Apache Commons Text
   Caffeine cache
   ConcurrentLinkedHashMap

--- a/community/bolt/NOTICE.txt
+++ b/community/bolt/NOTICE.txt
@@ -27,6 +27,7 @@ Third-party licenses
 
 Apache Software License, Version 2.0
   Apache Commons Compress
+  Apache Commons Lang
   Apache Commons Text
   Caffeine cache
   ConcurrentLinkedHashMap

--- a/community/bolt/pom.xml
+++ b/community/bolt/pom.xml
@@ -86,6 +86,11 @@
       <artifactId>annotations</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
+
     <!--Test dependencies-->
     <dependency>
       <groupId>junit</groupId>
@@ -166,11 +171,6 @@
     <dependency>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>websocket-client</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
@@ -148,7 +148,7 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
         WorkerFactory workerFactory = createWorkerFactory( boltFactory, scheduler, dependencies, logService, clock );
         ConnectorPortRegister connectionRegister = dependencies.connectionRegister();
 
-        TransportThrottleGroup throttleGroup = new TransportThrottleGroup( config );
+        TransportThrottleGroup throttleGroup = new TransportThrottleGroup( config, clock );
         BoltProtocolHandlerFactory handlerFactory = createHandlerFactory( workerFactory, throttleGroup, logService );
 
         Map<BoltConnector, ProtocolInitializer> connectors = config.enabledBoltConnectors().stream()

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/DefaultBoltProtocolHandlerFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/DefaultBoltProtocolHandlerFactory.java
@@ -21,6 +21,7 @@ package org.neo4j.bolt.transport;
 
 import org.neo4j.bolt.BoltChannel;
 import org.neo4j.bolt.v1.messaging.Neo4jPackV1;
+import org.neo4j.bolt.v1.runtime.BoltChannelAutoReadLimiter;
 import org.neo4j.bolt.v1.runtime.BoltWorker;
 import org.neo4j.bolt.v1.runtime.WorkerFactory;
 import org.neo4j.bolt.v1.transport.BoltMessagingProtocolV1Handler;
@@ -45,7 +46,9 @@ public class DefaultBoltProtocolHandlerFactory implements BoltProtocolHandlerFac
     {
         if ( protocolVersion == BoltMessagingProtocolV1Handler.VERSION )
         {
-            BoltWorker worker = workerFactory.newWorker( channel );
+            BoltChannelAutoReadLimiter limiter =
+                    new BoltChannelAutoReadLimiter( channel.rawChannel(), logService.getInternalLog( BoltChannelAutoReadLimiter.class ) );
+            BoltWorker worker = workerFactory.newWorker( channel, limiter );
             return new BoltMessagingProtocolV1Handler( channel, new Neo4jPackV1(), worker, throttleGroup, logService );
         }
         else

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportThrottle.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportThrottle.java
@@ -35,8 +35,9 @@ public interface TransportThrottle
      * Apply throttling logic for the given channel..
      *
      * @param channel the netty channel to which this throttling logic should be applied
+     * @throws TransportThrottleException when throttle decides this connection should be halted
      */
-    void acquire( Channel channel );
+    void acquire( Channel channel ) throws TransportThrottleException;
 
     /**
      * Release throttling for the given channel (if applied)..

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportThrottleException.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportThrottleException.java
@@ -17,15 +17,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.bolt.v1.runtime;
+package org.neo4j.bolt.transport;
 
-/**
- * Indicates that bolt connection has been fatally misused and therefore the server should close the connection.
- */
-public class BoltConnectionFatality extends Exception
+import org.neo4j.bolt.v1.runtime.BoltConnectionFatality;
+
+public class TransportThrottleException extends BoltConnectionFatality
 {
-    protected BoltConnectionFatality( String message )
+
+    public TransportThrottleException( String message )
     {
         super( message );
     }
+
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportThrottleGroup.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportThrottleGroup.java
@@ -20,10 +20,8 @@
 package org.neo4j.bolt.transport;
 
 import io.netty.channel.Channel;
-import io.netty.util.AttributeKey;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.time.Clock;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.configuration.Config;
@@ -45,9 +43,9 @@ public class TransportThrottleGroup
         this.writeThrottle = NoOpTransportThrottle.INSTANCE;
     }
 
-    public TransportThrottleGroup( Config config )
+    public TransportThrottleGroup( Config config, Clock clock )
     {
-        this.writeThrottle = createWriteThrottle( config );
+        this.writeThrottle = createWriteThrottle( config, clock );
     }
 
     public TransportThrottle writeThrottle()
@@ -65,12 +63,13 @@ public class TransportThrottleGroup
         writeThrottle.uninstall( channel );
     }
 
-    private static TransportThrottle createWriteThrottle( Config config )
+    private static TransportThrottle createWriteThrottle( Config config, Clock clock )
     {
         if ( config.get( GraphDatabaseSettings.bolt_write_throttle ) )
         {
             return new TransportWriteThrottle( config.get( GraphDatabaseSettings.bolt_write_buffer_low_water_mark ),
-                    config.get( GraphDatabaseSettings.bolt_write_buffer_high_water_mark ) );
+                    config.get( GraphDatabaseSettings.bolt_write_buffer_high_water_mark ), clock,
+                    config.get( GraphDatabaseSettings.bolt_write_throttle_max_duration ) );
         }
 
         return NoOpTransportThrottle.INSTANCE;

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportWriteThrottle.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportWriteThrottle.java
@@ -76,6 +76,8 @@ public class TransportWriteThrottle implements TransportThrottle
     @Override
     public void acquire( Channel channel ) throws TransportThrottleException
     {
+        // if this channel's max lock duration is already exceeded, we'll allow the protocol to
+        // (at least) try to communicate the error to the client before aborting the connection
         if ( !isDurationAlreadyExceeded( channel ) )
         {
             ThrottleLock lock = channel.attr( LOCK_KEY ).get();
@@ -110,6 +112,7 @@ public class TransportWriteThrottle implements TransportThrottle
                 catch ( InterruptedException ex )
                 {
                     Thread.currentThread().interrupt();
+                    throw new RuntimeException( ex );
                 }
             }
         }

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportWriteThrottle.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/TransportWriteThrottle.java
@@ -26,7 +26,10 @@ import io.netty.channel.ChannelInboundHandler;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.WriteBufferWaterMark;
 import io.netty.util.AttributeKey;
+import org.apache.commons.lang3.time.DurationFormatUtils;
 
+import java.time.Clock;
+import java.time.Duration;
 import java.util.function.Supplier;
 
 /**
@@ -36,21 +39,26 @@ import java.util.function.Supplier;
  */
 public class TransportWriteThrottle implements TransportThrottle
 {
-    private static final AttributeKey<ThrottleLock> LOCK_KEY = AttributeKey.valueOf( "BOLT.WRITE_THROTTLE.LOCK" );
+    static final AttributeKey<ThrottleLock> LOCK_KEY = AttributeKey.valueOf( "BOLT.WRITE_THROTTLE.LOCK" );
+    static final AttributeKey<Boolean> MAX_DURATION_EXCEEDED_KEY = AttributeKey.valueOf( "BOLT.WRITE_THROTTLE.MAX_DURATION_EXCEEDED" );
     private final int lowWaterMark;
     private final int highWaterMark;
+    private final Clock clock;
+    private final long maxLockDuration;
     private final Supplier<ThrottleLock> lockSupplier;
     private final ChannelInboundHandler listener;
 
-    public TransportWriteThrottle( int lowWaterMark, int highWaterMark )
+    public TransportWriteThrottle( int lowWaterMark, int highWaterMark, Clock clock, Duration maxLockDuration )
     {
-        this( lowWaterMark, highWaterMark, () -> new DefaultThrottleLock() );
+        this( lowWaterMark, highWaterMark, clock, maxLockDuration, () -> new DefaultThrottleLock() );
     }
 
-    public TransportWriteThrottle( int lowWaterMark, int highWaterMark, Supplier<ThrottleLock> lockSupplier )
+    public TransportWriteThrottle( int lowWaterMark, int highWaterMark, Clock clock, Duration maxLockDuration, Supplier<ThrottleLock> lockSupplier )
     {
         this.lowWaterMark = lowWaterMark;
         this.highWaterMark = highWaterMark;
+        this.clock = clock;
+        this.maxLockDuration = maxLockDuration.toMillis();
         this.lockSupplier = lockSupplier;
         this.listener = new ChannelStatusListener();
     }
@@ -66,19 +74,43 @@ public class TransportWriteThrottle implements TransportThrottle
     }
 
     @Override
-    public void acquire( Channel channel )
+    public void acquire( Channel channel ) throws TransportThrottleException
     {
-        ThrottleLock lock = channel.attr( LOCK_KEY ).get();
-
-        while ( channel.isOpen() && !channel.isWritable() )
+        if ( !isDurationAlreadyExceeded( channel ) )
         {
-            try
+            ThrottleLock lock = channel.attr( LOCK_KEY ).get();
+
+            long startTimeMillis = 0;
+            while ( channel.isOpen() && !channel.isWritable() )
             {
-                lock.lock( channel, 1000 );
-            }
-            catch ( InterruptedException ex )
-            {
-                Thread.currentThread().interrupt();
+                if ( maxLockDuration > 0 )
+                {
+                    long currentTimeMillis = clock.millis();
+                    if ( startTimeMillis == 0 )
+                    {
+                        startTimeMillis = currentTimeMillis;
+                    }
+                    else
+                    {
+                        if ( currentTimeMillis - startTimeMillis > maxLockDuration )
+                        {
+                            setDurationExceeded( channel );
+
+                            throw new TransportThrottleException( String.format(
+                                    "Bolt connection [%s] will be closed because the client did not consume outgoing buffers for %s which is not expected.",
+                                    channel.remoteAddress(), DurationFormatUtils.formatDurationHMS( maxLockDuration ) ) );
+                        }
+                    }
+                }
+
+                try
+                {
+                    lock.lock( channel, 1000 );
+                }
+                catch ( InterruptedException ex )
+                {
+                    Thread.currentThread().interrupt();
+                }
             }
         }
     }
@@ -98,6 +130,18 @@ public class TransportWriteThrottle implements TransportThrottle
     public void uninstall( Channel channel )
     {
         channel.attr( LOCK_KEY ).set( null );
+    }
+
+    private static boolean isDurationAlreadyExceeded( Channel channel )
+    {
+        Boolean marker = channel.attr( MAX_DURATION_EXCEEDED_KEY ).get();
+
+        return marker != null && marker.booleanValue();
+    }
+
+    private static void setDurationExceeded( Channel channel )
+    {
+        channel.attr( MAX_DURATION_EXCEEDED_KEY ).set( Boolean.TRUE );
     }
 
     @ChannelHandler.Sharable

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltChannelAutoReadLimiter.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltChannelAutoReadLimiter.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.v1.runtime;
+
+import io.netty.channel.Channel;
+
+import java.util.Collection;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.neo4j.logging.Log;
+import org.neo4j.unsafe.impl.internal.dragons.FeatureToggles;
+
+import static java.util.Objects.requireNonNull;
+
+public class BoltChannelAutoReadLimiter implements BoltWorkerQueueMonitor
+{
+    protected static final String LOW_WATERMARK_NAME = "low_watermark";
+    protected static final String HIGH_WATERMARK_NAME = "high_watermark";
+
+    private final AtomicInteger queueSize = new AtomicInteger( 0 );
+    private final Channel channel;
+    private final Log log;
+    private final int lowWatermark;
+    private final int highWatermark;
+
+    public BoltChannelAutoReadLimiter( Channel channel, Log log )
+    {
+        this( channel, log, FeatureToggles.getInteger( BoltChannelAutoReadLimiter.class, LOW_WATERMARK_NAME, 100 ),
+                FeatureToggles.getInteger( BoltChannelAutoReadLimiter.class, HIGH_WATERMARK_NAME, 300 ) );
+    }
+
+    public BoltChannelAutoReadLimiter( Channel channel, Log log, int lowWatermark, int highWatermark )
+    {
+        if ( highWatermark <= 0 )
+        {
+            throw new IllegalArgumentException( "invalid highWatermark value" );
+        }
+
+        if ( lowWatermark < 0 || lowWatermark >= highWatermark )
+        {
+            throw new IllegalArgumentException( "invalid lowWatermark value" );
+        }
+
+        this.channel = requireNonNull( channel );
+        this.log = log;
+        this.lowWatermark = lowWatermark;
+        this.highWatermark = highWatermark;
+    }
+
+    protected int getLowWatermark()
+    {
+        return lowWatermark;
+    }
+
+    protected int getHighWatermark()
+    {
+        return highWatermark;
+    }
+
+    @Override
+    public void enqueued( Job job )
+    {
+        checkLimitsOnEnqueue( queueSize.incrementAndGet() );
+    }
+
+    @Override
+    public void dequeued( Job job )
+    {
+        checkLimitsOnDequeue( queueSize.decrementAndGet() );
+    }
+
+    @Override
+    public void drained( Collection<Job> jobs )
+    {
+        checkLimitsOnDequeue( queueSize.addAndGet( -jobs.size() ) );
+    }
+
+    private void checkLimitsOnEnqueue( int currentSize )
+    {
+        if ( currentSize > highWatermark && channel.config().isAutoRead() )
+        {
+            if ( log != null )
+            {
+                log.warn( "Channel [%s]: client produced %d messages on the worker queue, auto-read is being disabled.", channel.id(), currentSize );
+            }
+
+            channel.config().setAutoRead( false );
+        }
+    }
+
+    private void checkLimitsOnDequeue( int currentSize )
+    {
+        if ( currentSize <= lowWatermark && !channel.config().isAutoRead() )
+        {
+            if ( log != null )
+            {
+                log.warn( "Channel [%s]: consumed messages on the worker queue below %d, auto-read is being enabled.", channel.id(), currentSize );
+            }
+
+            channel.config().setAutoRead( true );
+        }
+    }
+
+}

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltChannelAutoReadLimiter.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltChannelAutoReadLimiter.java
@@ -98,7 +98,7 @@ public class BoltChannelAutoReadLimiter implements BoltWorkerQueueMonitor
         {
             if ( log != null )
             {
-                log.warn( "Channel [%s]: client produced %d messages on the worker queue, auto-read is being disabled.", channel.id(), currentSize );
+                log.warn( "Channel [%s]: client produced %d messages on the worker queue, auto-read is being disabled.", channel.remoteAddress(), currentSize );
             }
 
             channel.config().setAutoRead( false );
@@ -111,7 +111,7 @@ public class BoltChannelAutoReadLimiter implements BoltWorkerQueueMonitor
         {
             if ( log != null )
             {
-                log.warn( "Channel [%s]: consumed messages on the worker queue below %d, auto-read is being enabled.", channel.id(), currentSize );
+                log.warn( "Channel [%s]: consumed messages on the worker queue below %d, auto-read is being enabled.", channel.remoteAddress(), currentSize );
             }
 
             channel.config().setAutoRead( true );

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltWorkerQueueMonitor.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/BoltWorkerQueueMonitor.java
@@ -19,22 +19,15 @@
  */
 package org.neo4j.bolt.v1.runtime;
 
-import org.neo4j.bolt.BoltChannel;
+import java.util.Collection;
 
-/**
- * Creates {@link BoltWorker}s. Implementations of this interface can decorate queues and their jobs
- * to monitor activity and enforce constraints.
- */
-public interface WorkerFactory
+public interface BoltWorkerQueueMonitor
 {
-    default BoltWorker newWorker( BoltChannel boltChannel )
-    {
-        return newWorker( boltChannel, null );
-    }
 
-    /**
-     * @param boltChannel channel over which Bolt messages can be exchanged
-     * @return a new job queue
-     */
-    BoltWorker newWorker( BoltChannel boltChannel, BoltWorkerQueueMonitor queueMonitor );
+    void enqueued( Job job );
+
+    void dequeued( Job job );
+
+    void drained( Collection<Job> jobs );
+
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/MonitoredWorkerFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/MonitoredWorkerFactory.java
@@ -22,7 +22,6 @@ package org.neo4j.bolt.v1.runtime;
 import java.time.Clock;
 
 import org.neo4j.bolt.BoltChannel;
-import org.neo4j.bolt.BoltConnectionDescriptor;
 import org.neo4j.kernel.monitoring.Monitors;
 
 /**
@@ -47,13 +46,13 @@ public class MonitoredWorkerFactory implements WorkerFactory
     }
 
     @Override
-    public BoltWorker newWorker( BoltChannel boltChannel )
+    public BoltWorker newWorker( BoltChannel boltChannel, BoltWorkerQueueMonitor queueMonitor )
     {
         if ( monitors.hasListeners( SessionMonitor.class ) )
         {
-            return new MonitoredBoltWorker( monitor, delegate.newWorker( boltChannel ), clock );
+            return new MonitoredBoltWorker( monitor, delegate.newWorker( boltChannel, queueMonitor ), clock );
         }
-        return delegate.newWorker( boltChannel );
+        return delegate.newWorker( boltChannel, queueMonitor );
     }
 
     static class MonitoredBoltWorker implements BoltWorker

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/concurrent/RunnableBoltWorker.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/concurrent/RunnableBoltWorker.java
@@ -20,9 +20,11 @@
 package org.neo4j.bolt.v1.runtime.concurrent;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import org.neo4j.bolt.v1.runtime.BoltConnectionAuthFatality;
@@ -30,6 +32,7 @@ import org.neo4j.bolt.v1.runtime.BoltConnectionFatality;
 import org.neo4j.bolt.v1.runtime.BoltProtocolBreachFatality;
 import org.neo4j.bolt.v1.runtime.BoltStateMachine;
 import org.neo4j.bolt.v1.runtime.BoltWorker;
+import org.neo4j.bolt.v1.runtime.BoltWorkerQueueMonitor;
 import org.neo4j.bolt.v1.runtime.Job;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.logging.Log;
@@ -39,21 +42,28 @@ import org.neo4j.logging.Log;
  */
 class RunnableBoltWorker implements Runnable, BoltWorker
 {
-    private static final int workQueueSize = Integer.getInteger( "org.neo4j.bolt.workQueueSize", 100 );
+    private static final int workQueueMaxBatchSize = Integer.getInteger( "org.neo4j.bolt.workQueueMaxBatchSize", 100 );
     static final int workQueuePollDuration =  Integer.getInteger( "org.neo4j.bolt.workQueuePollDuration", 10 );
 
-    private final BlockingQueue<Job> jobQueue = new ArrayBlockingQueue<>( workQueueSize );
+    private final BlockingQueue<Job> jobQueue = new LinkedBlockingQueue<>();
     private final BoltStateMachine machine;
     private final Log log;
     private final Log userLog;
+    private final BoltWorkerQueueMonitor queueMonitor;
 
     private volatile boolean keepRunning = true;
 
     RunnableBoltWorker( BoltStateMachine machine, LogService logging )
     {
+        this( machine, logging, null );
+    }
+
+    RunnableBoltWorker( BoltStateMachine machine, LogService logging, BoltWorkerQueueMonitor queueMonitor )
+    {
         this.machine = machine;
         this.log = logging.getInternalLog( getClass() );
         this.userLog = logging.getUserLog( getClass() );
+        this.queueMonitor = queueMonitor;
     }
 
     /**
@@ -68,6 +78,7 @@ class RunnableBoltWorker implements Runnable, BoltWorker
         try
         {
             jobQueue.put( job );
+            notifyEnqueued( job );
         }
         catch ( InterruptedException e )
         {
@@ -80,7 +91,7 @@ class RunnableBoltWorker implements Runnable, BoltWorker
     @Override
     public void run()
     {
-        List<Job> batch = new ArrayList<>( workQueueSize );
+        List<Job> batch = new ArrayList<>( workQueueMaxBatchSize );
 
         try
         {
@@ -89,11 +100,13 @@ class RunnableBoltWorker implements Runnable, BoltWorker
                 Job job = jobQueue.poll( workQueuePollDuration, TimeUnit.SECONDS );
                 if ( job != null )
                 {
+                    notifyDequeued( job );
                     execute( job );
 
-                    for ( int jobCount = jobQueue.drainTo( batch ); keepRunning && jobCount > 0;
-                          jobCount = jobQueue.drainTo( batch ) )
+                    for ( int jobCount = jobQueue.drainTo( batch, workQueueMaxBatchSize ); keepRunning && jobCount > 0;
+                          jobCount = jobQueue.drainTo( batch, workQueueMaxBatchSize ) )
                     {
+                        notifyDrained( batch );
                         executeBatch( batch );
                     }
                 }
@@ -173,4 +186,29 @@ class RunnableBoltWorker implements Runnable, BoltWorker
             log.error( "Unable to close Bolt session '" + machine.key() + "'", t );
         }
     }
+
+    private void notifyEnqueued( Job job )
+    {
+        if ( queueMonitor != null )
+        {
+            queueMonitor.enqueued( job );
+        }
+    }
+
+    private void notifyDequeued( Job job )
+    {
+        if ( queueMonitor != null )
+        {
+            queueMonitor.dequeued( job );
+        }
+    }
+
+    private void notifyDrained( List<Job> jobs )
+    {
+        if ( queueMonitor != null )
+        {
+            queueMonitor.drained( jobs );
+        }
+    }
+
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/concurrent/ThreadedWorkerFactory.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/concurrent/ThreadedWorkerFactory.java
@@ -25,6 +25,7 @@ import org.neo4j.bolt.BoltChannel;
 import org.neo4j.bolt.v1.runtime.BoltFactory;
 import org.neo4j.bolt.v1.runtime.BoltStateMachine;
 import org.neo4j.bolt.v1.runtime.BoltWorker;
+import org.neo4j.bolt.v1.runtime.BoltWorkerQueueMonitor;
 import org.neo4j.bolt.v1.runtime.WorkerFactory;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.scheduler.JobScheduler;
@@ -60,10 +61,10 @@ public class ThreadedWorkerFactory implements WorkerFactory
     }
 
     @Override
-    public BoltWorker newWorker( BoltChannel boltChannel )
+    public BoltWorker newWorker( BoltChannel boltChannel, BoltWorkerQueueMonitor queueMonitor )
     {
         BoltStateMachine machine = connector.newMachine( boltChannel, clock );
-        RunnableBoltWorker worker = new RunnableBoltWorker( machine, logging );
+        RunnableBoltWorker worker = new RunnableBoltWorker( machine, logging, queueMonitor );
 
         scheduler.schedule( sessionWorker, worker, stringMap( THREAD_ID, machine.key() ) );
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/transport/DefaultBoltProtocolHandlerFactoryTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/transport/DefaultBoltProtocolHandlerFactoryTest.java
@@ -29,8 +29,11 @@ import org.neo4j.bolt.v1.runtime.BoltWorker;
 import org.neo4j.bolt.v1.runtime.WorkerFactory;
 import org.neo4j.kernel.impl.logging.NullLogService;
 
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.RETURNS_MOCKS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -47,7 +50,7 @@ public class DefaultBoltProtocolHandlerFactoryTest
         WorkerFactory workerFactory = mock( WorkerFactory.class );
 
         BoltWorker worker = mock( BoltWorker.class );
-        when( workerFactory.newWorker( boltChannel ) ).thenReturn( worker );
+        when( workerFactory.newWorker( same( boltChannel ), any() ) ).thenReturn( worker );
 
         BoltProtocolHandlerFactory factory = new DefaultBoltProtocolHandlerFactory( workerFactory,
                 TransportThrottleGroup.NO_THROTTLE, NullLogService.getInstance() );
@@ -57,7 +60,7 @@ public class DefaultBoltProtocolHandlerFactoryTest
         // handler is actually created
         assertNotNull( handler );
         // it uses the expected worker
-        verify( workerFactory ).newWorker( boltChannel );
+        verify( workerFactory ).newWorker( same( boltChannel ), any() );
 
         // and halts this same worker when closed
         verify( worker, never() ).halt();

--- a/community/bolt/src/test/java/org/neo4j/bolt/transport/TransportWriteThrottleTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/transport/TransportWriteThrottleTest.java
@@ -32,17 +32,30 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
+import org.w3c.dom.Attr;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.neo4j.bolt.v1.runtime.BoltConnectionFatality;
 import org.neo4j.test.rule.concurrent.OtherThreadRule;
+import org.neo4j.time.Clocks;
+import org.neo4j.time.FakeClock;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
@@ -78,10 +91,15 @@ public class TransportWriteThrottleTest
         lockAttribute = mock( Attribute.class );
         when( lockAttribute.get() ).thenReturn( lock );
 
+        Attribute durationExceedAttribute = mock( Attribute.class );
+        when( durationExceedAttribute.get() ).thenReturn( null );
+
         channel = mock( SocketChannel.class, Answers.RETURNS_MOCKS );
         when( channel.config() ).thenReturn( config );
         when( channel.isOpen() ).thenReturn( true );
-        when( channel.attr( any() ) ).thenReturn( lockAttribute );
+        when( channel.remoteAddress() ).thenReturn( InetSocketAddress.createUnresolved( "localhost", 32000 ) );
+        when( channel.attr( TransportWriteThrottle.LOCK_KEY ) ).thenReturn( lockAttribute );
+        when( channel.attr( TransportWriteThrottle.MAX_DURATION_EXCEEDED_KEY ) ).thenReturn( durationExceedAttribute );
 
         ChannelPipeline pipeline = channel.pipeline();
         when( channel.pipeline() ).thenReturn( pipeline );
@@ -115,7 +133,11 @@ public class TransportWriteThrottleTest
         when( channel.isWritable() ).thenReturn( true );
 
         // when
-        Future future = Executors.newSingleThreadExecutor().submit( () -> throttle.acquire( channel ) );
+        Future future = otherThread.execute( state ->
+        {
+            throttle.acquire( channel );
+            return null;
+        } );
 
         // expect
         try
@@ -140,7 +162,11 @@ public class TransportWriteThrottleTest
         when( channel.isWritable() ).thenReturn( false );
 
         // when
-        Future future = Executors.newSingleThreadExecutor().submit( () -> throttle.acquire( channel ) );
+        Future future = otherThread.execute( state ->
+        {
+            throttle.acquire( channel );
+            return null;
+        } );
 
         // expect
         try
@@ -203,12 +229,45 @@ public class TransportWriteThrottleTest
         assertThat( lockOverride.unlockCallCount(), is( 1 ) );
     }
 
-    private TransportThrottle newThrottle()
+    @Test
+    public void shouldThrowThrottleExceptionWhenMaxDurationIsReached() throws Exception
     {
-        return newThrottle( null );
+        // given
+        TestThrottleLock lockOverride = new TestThrottleLock();
+        FakeClock clock = Clocks.fakeClock( 1, TimeUnit.SECONDS );
+        TransportThrottle throttle = newThrottleAndInstall( channel, lockOverride, clock, Duration.ofSeconds( 5 ) );
+        when( channel.isWritable() ).thenReturn( false );
+
+        // when
+        Future future = otherThread.execute( state ->
+        {
+            throttle.acquire( channel );
+            return null;
+        } );
+
+        otherThread.get().waitUntilWaiting();
+        clock.forward( 6, TimeUnit.SECONDS );
+
+        // expect
+        try
+        {
+            future.get( 1, TimeUnit.MINUTES );
+
+            fail( "expecting ExecutionException" );
+        }
+        catch ( ExecutionException ex )
+        {
+            assertThat( ex.getCause(), instanceOf( TransportThrottleException.class ) );
+            assertThat( ex.getMessage(), containsString( "will be closed because the client did not consume outgoing buffers for" ) );
+        }
     }
 
-    private TransportThrottle newThrottle( ThrottleLock lockOverride )
+    private TransportThrottle newThrottle()
+    {
+        return newThrottle( null, Clocks.systemClock(), Duration.ZERO );
+    }
+
+    private TransportThrottle newThrottle( ThrottleLock lockOverride, Clock clock, Duration maxLockDuration )
     {
         if ( lockOverride != null )
         {
@@ -217,7 +276,7 @@ public class TransportWriteThrottleTest
             when( lockAttribute.get() ).thenReturn( lockOverride );
         }
 
-        return new TransportWriteThrottle( 64, 256, () -> lock );
+        return new TransportWriteThrottle( 64, 256, clock, maxLockDuration, () -> lock );
     }
 
     private TransportThrottle newThrottleAndInstall( Channel channel )
@@ -227,7 +286,12 @@ public class TransportWriteThrottleTest
 
     private TransportThrottle newThrottleAndInstall( Channel channel, ThrottleLock lockOverride )
     {
-        TransportThrottle throttle = newThrottle( lockOverride );
+        return newThrottleAndInstall( channel, lockOverride, Clocks.systemClock(), Duration.ZERO );
+    }
+
+    private TransportThrottle newThrottleAndInstall( Channel channel, ThrottleLock lockOverride, Clock clock, Duration maxLockDuration )
+    {
+        TransportThrottle throttle = newThrottle( lockOverride, clock, maxLockDuration );
 
         throttle.install( channel );
 
@@ -243,7 +307,7 @@ public class TransportWriteThrottleTest
         @Override
         public void lock( Channel channel, long timeout ) throws InterruptedException
         {
-            actualLock.lock( channel, 0 );
+            actualLock.lock( channel, timeout );
             lockCount.incrementAndGet();
         }
 

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltChannelAutoReadLimiterTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltChannelAutoReadLimiterTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.v1.runtime;
+
+import io.netty.channel.Channel;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.neo4j.logging.Log;
+import org.neo4j.unsafe.impl.internal.dragons.FeatureToggles;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.contains;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class BoltChannelAutoReadLimiterTest
+{
+    private static final Job job = s -> s.run( "INIT", null, null );
+    private Channel channel;
+    private Log log;
+
+    @Before
+    public void setup()
+    {
+        this.channel = new EmbeddedChannel();
+        this.log = mock( Log.class );
+    }
+
+    @Test
+    public void shouldUseWatermarksFromSystemProperties()
+    {
+        FeatureToggles.set( BoltChannelAutoReadLimiter.class, BoltChannelAutoReadLimiter.LOW_WATERMARK_NAME, 5 );
+        FeatureToggles.set( BoltChannelAutoReadLimiter.class, BoltChannelAutoReadLimiter.HIGH_WATERMARK_NAME, 10 );
+
+        try
+        {
+           BoltChannelAutoReadLimiter limiter = newLimiterWithDefaults();
+
+           assertThat( limiter.getLowWatermark(), is( 5 ) );
+           assertThat( limiter.getHighWatermark(), is( 10 ) );
+        }
+        finally
+        {
+            FeatureToggles.clear( BoltChannelAutoReadLimiter.class, BoltChannelAutoReadLimiter.LOW_WATERMARK_NAME );
+            FeatureToggles.clear( BoltChannelAutoReadLimiter.class, BoltChannelAutoReadLimiter.HIGH_WATERMARK_NAME );
+        }
+    }
+
+    @Test
+    public void shouldNotDisableAutoReadBelowHighWatermark()
+    {
+        BoltChannelAutoReadLimiter limiter = newLimiter( 1, 2 );
+
+        assertTrue( channel.config().isAutoRead() );
+
+        limiter.enqueued( job );
+
+        assertTrue( channel.config().isAutoRead() );
+        verify( log, never() ).warn( anyString(), any(), any() );
+    }
+
+    @Test
+    public void shouldDisableAutoReadWhenAtHighWatermark()
+    {
+        BoltChannelAutoReadLimiter limiter = newLimiter( 1, 2 );
+
+        assertTrue( channel.config().isAutoRead() );
+
+        limiter.enqueued( job );
+        limiter.enqueued( job );
+        limiter.enqueued( job );
+
+        assertFalse( channel.config().isAutoRead() );
+        verify( log ).warn( contains( "disabled" ), eq( channel.id() ), eq( 3 ) );
+    }
+
+    @Test
+    public void shouldDisableAutoReadOnlyOnceWhenAboveHighWatermark()
+    {
+        BoltChannelAutoReadLimiter limiter = newLimiter( 1, 2 );
+
+        assertTrue( channel.config().isAutoRead() );
+
+        limiter.enqueued( job );
+        limiter.enqueued( job );
+        limiter.enqueued( job );
+        limiter.enqueued( job );
+        limiter.enqueued( job );
+
+        assertFalse( channel.config().isAutoRead() );
+        verify( log, times( 1 ) ).warn( contains( "disabled" ), eq( channel.id() ), eq( 3 ) );
+    }
+
+    @Test
+    public void shouldEnableAutoReadWhenAtLowWatermark()
+    {
+        BoltChannelAutoReadLimiter limiter = newLimiter( 1, 2 );
+
+        assertTrue( channel.config().isAutoRead() );
+
+        limiter.enqueued( job );
+        limiter.enqueued( job );
+        limiter.enqueued( job );
+        limiter.dequeued( job );
+        limiter.dequeued( job );
+
+        assertTrue( channel.config().isAutoRead() );
+        verify( log, times( 1 ) ).warn( contains( "disabled" ), eq( channel.id() ), eq( 3 ) );
+        verify( log, times( 1 ) ).warn( contains( "enabled" ), eq( channel.id() ), eq( 1 ) );
+    }
+
+    @Test
+    public void shouldEnableAutoReadOnlyOnceWhenBelowLowWatermark()
+    {
+        BoltChannelAutoReadLimiter limiter = newLimiter( 1, 2 );
+
+        assertTrue( channel.config().isAutoRead() );
+
+        limiter.enqueued( job );
+        limiter.enqueued( job );
+        limiter.enqueued( job );
+        limiter.dequeued( job );
+        limiter.dequeued( job );
+        limiter.dequeued( job );
+
+        assertTrue( channel.config().isAutoRead() );
+        verify( log, times( 1 ) ).warn( contains( "disabled" ), eq( channel.id() ), eq( 3 ) );
+        verify( log, times( 1 ) ).warn( contains( "enabled" ), eq( channel.id() ), eq( 1 ) );
+    }
+
+    @Test
+    public void shouldNotAcceptNegativeLowWatermark()
+    {
+        try
+        {
+            newLimiter( -1, 5 );
+            fail( "exception expected" );
+        }
+        catch ( IllegalArgumentException exc )
+        {
+            assertThat( exc.getMessage(), startsWith( "invalid lowWatermark value" )  );
+        }
+    }
+
+    @Test
+    public void shouldNotAcceptLowWatermarkEqualToHighWatermark()
+    {
+        try
+        {
+            newLimiter( 5, 5 );
+            fail( "exception expected" );
+        }
+        catch ( IllegalArgumentException exc )
+        {
+            assertThat( exc.getMessage(), startsWith( "invalid lowWatermark value" )  );
+        }
+    }
+
+    @Test
+    public void shouldNotAcceptLowWatermarkLargerThanHighWatermark()
+    {
+        try
+        {
+            newLimiter( 6, 5 );
+            fail( "exception expected" );
+        }
+        catch ( IllegalArgumentException exc )
+        {
+            assertThat( exc.getMessage(), startsWith( "invalid lowWatermark value" )  );
+        }
+    }
+
+    @Test
+    public void shouldNotAcceptZeroHighWatermark()
+    {
+        try
+        {
+            newLimiter( 1, 0 );
+            fail( "exception expected" );
+        }
+        catch ( IllegalArgumentException exc )
+        {
+            assertThat( exc.getMessage(), startsWith( "invalid highWatermark value" )  );
+        }
+    }
+
+    @Test
+    public void shouldNotAcceptNegativeHighWatermark()
+    {
+        try
+        {
+            newLimiter( 1, -1 );
+            fail( "exception expected" );
+        }
+        catch ( IllegalArgumentException exc )
+        {
+            assertThat( exc.getMessage(), startsWith( "invalid highWatermark value" )  );
+        }
+    }
+
+    private BoltChannelAutoReadLimiter newLimiter( int low, int high )
+    {
+        return new BoltChannelAutoReadLimiter( channel, log, low, high );
+    }
+
+    private BoltChannelAutoReadLimiter newLimiterWithDefaults()
+    {
+        return new BoltChannelAutoReadLimiter( channel, log );
+    }
+
+}

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltChannelAutoReadLimiterTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/BoltChannelAutoReadLimiterTest.java
@@ -100,7 +100,7 @@ public class BoltChannelAutoReadLimiterTest
         limiter.enqueued( job );
 
         assertFalse( channel.config().isAutoRead() );
-        verify( log ).warn( contains( "disabled" ), eq( channel.id() ), eq( 3 ) );
+        verify( log ).warn( contains( "disabled" ), eq( channel.remoteAddress() ), eq( 3 ) );
     }
 
     @Test
@@ -117,7 +117,7 @@ public class BoltChannelAutoReadLimiterTest
         limiter.enqueued( job );
 
         assertFalse( channel.config().isAutoRead() );
-        verify( log, times( 1 ) ).warn( contains( "disabled" ), eq( channel.id() ), eq( 3 ) );
+        verify( log, times( 1 ) ).warn( contains( "disabled" ), eq( channel.remoteAddress() ), eq( 3 ) );
     }
 
     @Test
@@ -134,8 +134,8 @@ public class BoltChannelAutoReadLimiterTest
         limiter.dequeued( job );
 
         assertTrue( channel.config().isAutoRead() );
-        verify( log, times( 1 ) ).warn( contains( "disabled" ), eq( channel.id() ), eq( 3 ) );
-        verify( log, times( 1 ) ).warn( contains( "enabled" ), eq( channel.id() ), eq( 1 ) );
+        verify( log, times( 1 ) ).warn( contains( "disabled" ), eq( channel.remoteAddress() ), eq( 3 ) );
+        verify( log, times( 1 ) ).warn( contains( "enabled" ), eq( channel.remoteAddress() ), eq( 1 ) );
     }
 
     @Test
@@ -153,8 +153,8 @@ public class BoltChannelAutoReadLimiterTest
         limiter.dequeued( job );
 
         assertTrue( channel.config().isAutoRead() );
-        verify( log, times( 1 ) ).warn( contains( "disabled" ), eq( channel.id() ), eq( 3 ) );
-        verify( log, times( 1 ) ).warn( contains( "enabled" ), eq( channel.id() ), eq( 1 ) );
+        verify( log, times( 1 ) ).warn( contains( "disabled" ), eq( channel.remoteAddress() ), eq( 3 ) );
+        verify( log, times( 1 ) ).warn( contains( "enabled" ), eq( channel.remoteAddress() ), eq( 1 ) );
     }
 
     @Test

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/MonitoredBoltWorkerFactoryTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/MonitoredBoltWorkerFactoryTest.java
@@ -32,6 +32,8 @@ import org.neo4j.time.FakeClock;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.neo4j.bolt.testing.NullResponseHandler.nullResponseHandler;
@@ -49,7 +51,7 @@ public class MonitoredBoltWorkerFactoryTest
 
         WorkerFactory delegate = mock( WorkerFactory.class );
         BoltStateMachine machine = mock( BoltStateMachine.class );
-        when( delegate.newWorker( boltChannel ) )
+        when( delegate.newWorker( same( boltChannel ), any() ) )
                 .thenReturn( new BoltWorker()
                 {
                     @Override
@@ -132,7 +134,7 @@ public class MonitoredBoltWorkerFactoryTest
         // after monitor listeners are added
         WorkerFactory workerFactory = mock( WorkerFactory.class );
         BoltWorker boltWorker = mock( BoltWorker.class );
-        when( workerFactory.newWorker( boltChannel ) ).thenReturn( boltWorker );
+        when( workerFactory.newWorker( boltChannel, null ) ).thenReturn( boltWorker );
 
         Monitors monitors = new Monitors();
         MonitoredWorkerFactory monitoredWorkerFactory = new MonitoredWorkerFactory( monitors, workerFactory, Clocks.fakeClock() );

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/concurrent/RunnableBoltWorkerTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/runtime/concurrent/RunnableBoltWorkerTest.java
@@ -22,25 +22,42 @@ package org.neo4j.bolt.v1.runtime.concurrent;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
 import org.neo4j.bolt.v1.runtime.BoltConnectionAuthFatality;
 import org.neo4j.bolt.v1.runtime.BoltProtocolBreachFatality;
 import org.neo4j.bolt.v1.runtime.BoltStateMachine;
+import org.neo4j.bolt.v1.runtime.BoltWorkerQueueMonitor;
+import org.neo4j.bolt.v1.runtime.Job;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.logging.NullLogService;
 import org.neo4j.logging.AssertableLogProvider;
 
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyCollection;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -283,6 +300,85 @@ public class RunnableBoltWorkerTest
         workerFuture.get();
 
         verify( machine, atLeastOnce() ).validateTransaction();
+    }
+
+    @Test
+    public void shouldNotNotifyMonitorWhenNothingEnqueued() throws Exception
+    {
+        BoltWorkerQueueMonitor monitor = mock( BoltWorkerQueueMonitor.class );
+        RunnableBoltWorker worker = new RunnableBoltWorker( machine, logService, monitor );
+
+        verify( monitor, never() ).enqueued( any( Job.class ) );
+        verify( monitor, never() ).dequeued( any( Job.class ) );
+        verify( monitor, never() ).drained( any( Collection.class ) );
+    }
+
+    @Test
+    public void shouldNotifyMonitorWhenQueued() throws Exception
+    {
+        BoltWorkerQueueMonitor monitor = mock( BoltWorkerQueueMonitor.class );
+        RunnableBoltWorker worker = new RunnableBoltWorker( machine, logService, monitor );
+        Job job = s -> s.run( "Hello world", null, null );
+
+        worker.enqueue( job );
+
+        verify( monitor ).enqueued( job );
+    }
+
+    @Test
+    public void shouldNotifyMonitorWhenDequeued() throws Exception
+    {
+        BoltWorkerQueueMonitor monitor = mock( BoltWorkerQueueMonitor.class );
+        RunnableBoltWorker worker = new RunnableBoltWorker( machine, logService, monitor );
+        Job job = s -> s.run( "Hello world", null, null );
+
+        worker.enqueue( job );
+        worker.enqueue( s -> worker.halt() );
+        worker.run();
+
+        verify( monitor ).enqueued( job );
+        verify( monitor ).dequeued( job );
+    }
+
+    @Test
+    public void shouldNotifyMonitorWhenDrained() throws Exception
+    {
+        List<Job> drainedJobs = new ArrayList<>();
+        BoltWorkerQueueMonitor monitor = newMonitor( drainedJobs );
+        RunnableBoltWorker worker = new RunnableBoltWorker( machine, logService, monitor );
+        Job job1 = s -> s.run( "Hello world 1", null, null );
+        Job job2 = s -> s.run( "Hello world 1", null, null );
+        Job job3 = s -> s.run( "Hello world 1", null, null );
+        Job haltJob = s -> worker.halt();
+
+        worker.enqueue( job1 );
+        worker.enqueue( job2 );
+        worker.enqueue( job3 );
+        worker.enqueue( haltJob );
+        worker.run();
+
+        verify( monitor ).enqueued( job1 );
+        verify( monitor ).enqueued( job2 );
+        verify( monitor ).enqueued( job3 );
+        verify( monitor ).dequeued( job1 );
+        verify( monitor ).drained( anyCollection() );
+
+        assertThat( drainedJobs, hasSize( 3 ) );
+        assertThat( drainedJobs, contains( job2, job3, haltJob ) );
+    }
+
+    private static BoltWorkerQueueMonitor newMonitor( final List<Job> drained )
+    {
+        BoltWorkerQueueMonitor monitor = mock( BoltWorkerQueueMonitor.class );
+
+        doAnswer( invocation ->
+        {
+            final Collection<Job> jobs = invocation.getArgument( 0 );
+            drained.addAll( jobs );
+            return null;
+        } ).when( monitor ).drained( anyListOf( Job.class ) );
+
+        return monitor;
     }
 
 }

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/BoltChannelAutoReadLimiterIT.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/integration/BoltChannelAutoReadLimiterIT.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.bolt.v1.transport.integration;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hamcrest.CoreMatchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.neo4j.bolt.v1.runtime.BoltChannelAutoReadLimiter;
+import org.neo4j.bolt.v1.transport.socket.client.SecureSocketConnection;
+import org.neo4j.bolt.v1.transport.socket.client.SecureWebSocketConnection;
+import org.neo4j.bolt.v1.transport.socket.client.SocketConnection;
+import org.neo4j.bolt.v1.transport.socket.client.TransportConnection;
+import org.neo4j.bolt.v1.transport.socket.client.WebSocketConnection;
+import org.neo4j.collection.RawIterator;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.HostnamePort;
+import org.neo4j.kernel.api.exceptions.ProcedureException;
+import org.neo4j.kernel.api.exceptions.Status;
+import org.neo4j.kernel.api.proc.CallableProcedure;
+import org.neo4j.kernel.api.proc.Context;
+import org.neo4j.kernel.api.proc.Neo4jTypes;
+import org.neo4j.kernel.api.proc.ProcedureSignature;
+import org.neo4j.kernel.impl.proc.Procedures;
+import org.neo4j.kernel.impl.util.ValueUtils;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.logging.AssertableLogProvider;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.neo4j.bolt.v1.messaging.message.DiscardAllMessage.discardAll;
+import static org.neo4j.bolt.v1.messaging.message.InitMessage.init;
+import static org.neo4j.bolt.v1.messaging.message.RunMessage.run;
+import static org.neo4j.bolt.v1.messaging.util.MessageMatchers.msgSuccess;
+import static org.neo4j.bolt.v1.transport.integration.TransportTestUtil.eventuallyReceives;
+import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureSignature;
+
+@RunWith( Parameterized.class )
+public class BoltChannelAutoReadLimiterIT
+{
+    private AssertableLogProvider logProvider;
+    private EphemeralFileSystemRule fsRule = new EphemeralFileSystemRule();
+    private Neo4jWithSocket server = new Neo4jWithSocket( getClass(), getTestGraphDatabaseFactory(),
+            fsRule::get, getSettingsFunction() );
+
+    @Rule
+    public RuleChain ruleChain = RuleChain.outerRule( fsRule ).around( server );
+
+    @Parameterized.Parameter
+    public TransportConnection connection;
+
+    private HostnamePort address;
+
+    @Parameterized.Parameters
+    public static Collection<TransportConnection> transports()
+    {
+        return asList( new SecureSocketConnection(), new SocketConnection(), new SecureWebSocketConnection(),
+                new WebSocketConnection() );
+    }
+
+    protected TestGraphDatabaseFactory getTestGraphDatabaseFactory()
+    {
+        TestGraphDatabaseFactory factory = new TestGraphDatabaseFactory();
+
+        logProvider = new AssertableLogProvider();
+
+        factory.setInternalLogProvider( logProvider );
+
+        return factory;
+
+    }
+
+    protected Consumer<Map<String, String>> getSettingsFunction()
+    {
+        return settings -> settings.put( GraphDatabaseSettings.auth_enabled.name(), "false" );
+    }
+
+    @Before
+    public void setup() throws Exception
+    {
+        installSleepProcedure( server.graphDatabaseService() );
+
+        address = server.lookupDefaultConnector();
+    }
+
+    @After
+    public void after() throws Exception
+    {
+        if ( connection != null )
+        {
+            connection.disconnect();
+        }
+    }
+
+    @Test
+    public void largeNumberOfSlowRunningJobsShouldChangeAutoReadState() throws Exception
+    {
+        int numberOfRunDiscardPairs = 1000;
+        String largeString = StringUtils.repeat( " ", 8 * 1024  );
+
+        connection.connect( address )
+                .send( TransportTestUtil.acceptedVersions( 1, 0, 0, 0 ) )
+                .send( TransportTestUtil.chunk(
+                        init( "TestClient/1.1", emptyMap() ) ) );
+
+        assertThat( connection, eventuallyReceives( new byte[]{0, 0, 0, 1} ) );
+        assertThat( connection, eventuallyReceives( msgSuccess() ) );
+
+        // when
+        for ( int i = 0; i < numberOfRunDiscardPairs; i++ )
+        {
+            connection.send( TransportTestUtil.chunk(
+                    run( "CALL boltissue.sleep( $data )", ValueUtils.asMapValue( singletonMap( "data", largeString ) ) ),
+                    discardAll()
+            ) );
+        }
+
+        // expect
+        for ( int i = 0; i < numberOfRunDiscardPairs; i++ )
+        {
+            assertThat( connection, eventuallyReceives( msgSuccess(), msgSuccess() ) );
+        }
+
+        logProvider.assertAtLeastOnce(
+                AssertableLogProvider.inLog( BoltChannelAutoReadLimiter.class ).warn( CoreMatchers.containsString( "disabled" ), CoreMatchers.anything(),
+                        CoreMatchers.anything() ) );
+        logProvider.assertAtLeastOnce(
+                AssertableLogProvider.inLog( BoltChannelAutoReadLimiter.class ).warn( CoreMatchers.containsString( "enabled" ), CoreMatchers.anything(),
+                        CoreMatchers.anything() ) );
+    }
+
+    private static void installSleepProcedure( GraphDatabaseService db ) throws ProcedureException
+    {
+        GraphDatabaseAPI dbApi = (GraphDatabaseAPI) db;
+
+        dbApi.getDependencyResolver().resolveDependency( Procedures.class ).register(
+                new CallableProcedure.BasicProcedure(
+                        procedureSignature("boltissue", "sleep")
+                                .in( "data", Neo4jTypes.NTString )
+                                .out( ProcedureSignature.VOID )
+                                .build() )
+                {
+                    @Override
+                    public RawIterator<Object[],ProcedureException> apply( Context context, Object[] objects ) throws ProcedureException
+                    {
+                        try
+                        {
+                            Thread.sleep( 50 );
+                        }
+                        catch ( InterruptedException e )
+                        {
+                            throw new ProcedureException( Status.General.UnknownError, e, "Interrupted" );
+                        }
+                        return RawIterator.empty();
+                    }
+                } );
+    }
+
+}

--- a/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
+++ b/community/common/src/main/java/org/neo4j/kernel/api/exceptions/Status.java
@@ -103,7 +103,9 @@ public interface Status
                 "The client provided a request that was missing required fields, or had values that are not allowed." ),
         TransactionRequired( ClientError,
                 "The request cannot be performed outside of a transaction, and there is no transaction present to " +
-                "use. Wrap your request in a transaction and retry." );
+                "use. Wrap your request in a transaction and retry." ),
+        InvalidUsage( ClientError,  // TODO: see above
+                "The client made a request but did not consume outgoing buffers in a timely fashion." );
         private final Code code;
 
         @Override

--- a/community/common/src/test/java/org/neo4j/test/matchers/CommonMatchers.java
+++ b/community/common/src/test/java/org/neo4j/test/matchers/CommonMatchers.java
@@ -49,6 +49,17 @@ public final class CommonMatchers
     }
 
     /**
+     * Checks that an exception message matches given matcher
+     *
+     * @param matcher
+     * @return
+     */
+    public static Matcher<Throwable> matchesExceptionMessage( Matcher<? super String> matcher )
+    {
+        return new ExceptionMessageMatcher( matcher );
+    }
+
+    /**
      * Checks that exception has expected array or suppressed exceptions.
      *
      * @param expectedSuppressedErrors expected suppressed exceptions.

--- a/community/common/src/test/java/org/neo4j/test/matchers/ExceptionMessageMatcher.java
+++ b/community/common/src/test/java/org/neo4j/test/matchers/ExceptionMessageMatcher.java
@@ -17,15 +17,31 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.bolt.v1.runtime;
+package org.neo4j.test.matchers;
 
-/**
- * Indicates that bolt connection has been fatally misused and therefore the server should close the connection.
- */
-public class BoltConnectionFatality extends Exception
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+public class ExceptionMessageMatcher extends TypeSafeMatcher<Throwable>
 {
-    protected BoltConnectionFatality( String message )
+    private final Matcher<? super String> matcher;
+
+    public ExceptionMessageMatcher( Matcher<? super String> matcher )
     {
-        super( message );
+        this.matcher = matcher;
     }
+
+    @Override
+    protected boolean matchesSafely( Throwable throwable )
+    {
+        return matcher.matches( throwable.getMessage() );
+    }
+
+    @Override
+    public void describeTo( Description description )
+    {
+        description.appendText( "expect message to be " ).appendDescriptionOf( matcher );
+    }
+
 }

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -791,6 +791,13 @@ public class GraphDatabaseSettings implements LoadableConfig
             buildSetting( "unsupported.dbms.bolt.write_throttle.low_watermark", INTEGER, String.valueOf( ByteUnit.kibiBytes( 128 ) ) ).constraint(
                     range( (int) ByteUnit.kibiBytes( 16 ), Integer.MAX_VALUE ) ).build();
 
+    @Description( "When the total time write throttle lock is held exceeds this value, the corresponding bolt channel will be aborted. Setting "
+            + " this to 0 will disable this behaviour." )
+    @Internal
+    public static final Setting<Duration> bolt_write_throttle_max_duration =
+            buildSetting( "unsupported.dbms.bolt.write_throttle.max_duration", DURATION, "15m" ).constraint(
+                    min( Duration.ofSeconds( 30 ) ) ).build();
+
     @Description( "Create an archive of an index before re-creating it if failing to load on startup." )
     @Internal
     public static final Setting<Boolean> archive_failed_index = setting(

--- a/integrationtests/src/test/java/org/neo4j/bolt/BoltFailuresIT.java
+++ b/integrationtests/src/test/java/org/neo4j/bolt/BoltFailuresIT.java
@@ -88,7 +88,7 @@ public class BoltFailuresIT
     public void throwsWhenWorkerCreationFails()
     {
         WorkerFactory workerFactory = mock( WorkerFactory.class );
-        when( workerFactory.newWorker( any() ) ).thenThrow( new IllegalStateException( "Oh!" ) );
+        when( workerFactory.newWorker( any(), any() ) ).thenThrow( new IllegalStateException( "Oh!" ) );
 
         BoltKernelExtension extension = new BoltKernelExtensionWithWorkerFactory( workerFactory );
 


### PR DESCRIPTION
This is a port of #10682 into 3.4 branches. 

Having both auto-read limiter and write throttling in place can result in a situation where client tries to send bolt messages where server stops reading incoming messages (by disabling auto-read) and also since client is not reading any generated server response stops processing messages, i.e. the bolt worker thread is blocked by the transport write throttle and cannot process more messages, where since client still tries to send it cannot move on to the phase where server responses are read.

Given that above condition is a result of wrong usage (sending in messages but not reading the responses), this PR also adds a client connection termination policy where a write throttle is held more than a specified duration (`15m` by default).