### PR TITLE
Composite transaction state

### DIFF
--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/DelegatingQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/DelegatingQueryContext.scala
@@ -27,15 +27,16 @@ import org.neo4j.cypher.internal.runtime._
 import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection
 import org.neo4j.cypher.internal.v3_4.logical.plans.QualifiedName
 import org.neo4j.graphdb.{Node, Path, PropertyContainer}
-import org.neo4j.internal.kernel.api.{CursorFactory, IndexReference, Read, Write}
+import org.neo4j.internal.kernel.api._
 import org.neo4j.kernel.api.ReadOperations
 import org.neo4j.kernel.api.dbms.DbmsOperations
+import org.neo4j.kernel.api.txstate.TransactionStateController
 import org.neo4j.kernel.impl.api.store.RelationshipIterator
 import org.neo4j.kernel.impl.core.NodeManager
 import org.neo4j.kernel.impl.factory.DatabaseInfo
 import org.neo4j.values.AnyValue
 import org.neo4j.values.storable.Value
-import org.neo4j.values.virtual.{RelationshipValue, ListValue, NodeValue}
+import org.neo4j.values.virtual.{ListValue, NodeValue, RelationshipValue}
 
 import scala.collection.Iterator
 
@@ -299,4 +300,8 @@ class DelegatingQueryTransactionalContext(val inner: QueryTransactionalContext) 
   override def dataRead: Read = inner.dataRead
 
   override def dataWrite: Write = inner.dataWrite
+
+  override def transactionStateController: TransactionStateController = inner.transactionStateController
+
+  override def stableDataRead: Read = inner.stableDataRead
 }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionalContextWrapper.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionalContextWrapper.scala
@@ -28,7 +28,7 @@ import org.neo4j.kernel.GraphDatabaseQueryService
 import org.neo4j.kernel.api.KernelTransaction.Revertable
 import org.neo4j.kernel.api.dbms.DbmsOperations
 import org.neo4j.kernel.api.query.PlannerInfo
-import org.neo4j.kernel.api.txstate.TxStateHolder
+import org.neo4j.kernel.api.txstate.{TransactionStateController, TxStateHolder}
 import org.neo4j.kernel.api.{KernelTransaction, ReadOperations, Statement}
 import org.neo4j.kernel.impl.factory.DatabaseInfo
 import org.neo4j.kernel.impl.query.TransactionalContext
@@ -57,7 +57,11 @@ case class TransactionalContextWrapper(tc: TransactionalContext) extends QueryTr
 
   override def dataRead: Read = tc.kernelTransaction().dataRead()
 
+  override def stableDataRead: Read = tc.kernelTransaction().stableDataRead()
+
   override def dataWrite: Write = tc.kernelTransaction().dataWrite()
+
+  override def transactionStateController: TransactionStateController = tc.stateView().transactionStateController()
 
   override def readOperations: ReadOperations = tc.readOperations()
 

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryContext.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryContext.scala
@@ -26,15 +26,16 @@ import org.neo4j.cypher.internal.planner.v3_4.spi.{IdempotentResult, IndexDescri
 import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection
 import org.neo4j.cypher.internal.v3_4.logical.plans.QualifiedName
 import org.neo4j.graphdb.{Node, Path, PropertyContainer}
-import org.neo4j.internal.kernel.api.{CursorFactory, IndexReference, Read, Write}
+import org.neo4j.internal.kernel.api._
 import org.neo4j.kernel.api.ReadOperations
 import org.neo4j.kernel.api.dbms.DbmsOperations
+import org.neo4j.kernel.api.txstate.TransactionStateController
 import org.neo4j.kernel.impl.api.store.RelationshipIterator
 import org.neo4j.kernel.impl.core.NodeManager
 import org.neo4j.kernel.impl.factory.DatabaseInfo
 import org.neo4j.values.AnyValue
 import org.neo4j.values.storable.Value
-import org.neo4j.values.virtual.{RelationshipValue, ListValue, NodeValue}
+import org.neo4j.values.virtual.{ListValue, NodeValue, RelationshipValue}
 
 import scala.collection.Iterator
 
@@ -244,7 +245,11 @@ trait QueryTransactionalContext extends CloseableResource {
 
   def dataRead: Read
 
+  def stableDataRead: Read
+
   def dataWrite: Write
+
+  def transactionStateController: TransactionStateController
 
   def readOperations: ReadOperations
 

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Transaction.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Transaction.java
@@ -61,6 +61,11 @@ public interface Transaction extends AutoCloseable
     Read dataRead();
 
     /**
+     * @return Read operations on top of stable fixed transaction state
+     */
+    Read stableDataRead();
+
+    /**
      * @return The Write operations of the graph.
      * @throws InvalidTransactionTypeKernelException when transaction cannot be upgraded to a write transaction. This
      * can happen when there have been schema modifications.

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionStateController.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionStateController.java
@@ -19,13 +19,9 @@
  */
 package org.neo4j.kernel.api.txstate;
 
-public interface TxStateHolder
+public interface TransactionStateController
 {
-    TransactionState txState();
+    void combine();
 
-    TransactionStateController transactionStateController();
-
-    ExplicitIndexTransactionState explicitIndexTxState();
-
-    boolean hasTxStateWithChanges();
+    void split();
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ExplicitBatchIndexApplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ExplicitBatchIndexApplier.java
@@ -61,8 +61,7 @@ public class ExplicitBatchIndexApplier extends BatchTransactionApplier.Adapter
             // Cache transactionApplier because it has some expensive lookups
             if ( txApplier == null )
             {
-                txApplier = new ExplicitIndexTransactionApplier( applierLookup, indexConfigStore, mode,
-                        transactionOrdering );
+                txApplier = new ExplicitIndexTransactionApplier( applierLookup, indexConfigStore, mode, transactionOrdering );
             }
 
             if ( transaction.requiresApplicationOrdering() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelStatement.java
@@ -47,6 +47,7 @@ import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.query.ExecutingQuery;
 import org.neo4j.kernel.api.txstate.ExplicitIndexTransactionState;
 import org.neo4j.kernel.api.txstate.TransactionState;
+import org.neo4j.kernel.api.txstate.TransactionStateController;
 import org.neo4j.kernel.api.txstate.TxStateHolder;
 import org.neo4j.kernel.impl.factory.AccessCapability;
 import org.neo4j.kernel.impl.locking.LockTracer;
@@ -173,6 +174,12 @@ public class KernelStatement implements TxStateHolder, Statement, AssertOpen
     public TransactionState txState()
     {
         return txStateHolder.txState();
+    }
+
+    @Override
+    public TransactionStateController transactionStateController()
+    {
+        return txStateHolder.transactionStateController();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -214,7 +214,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
                         new IndexTxStateUpdater( storageEngine.storeReadLayer(), allStoreHolder, matcher ),
                         storageStatement,
                         this, cursors, autoIndexing, matcher );
-        this.transactionStatesContainer = new TransactionStatesContainer();
+        this.transactionStatesContainer = new TransactionStatesContainer( transactionMonitor );
     }
 
     /**
@@ -414,11 +414,11 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     @Override
     public TransactionState txState()
     {
-        if ( !transactionStatesContainer.hasState() )
-        {
-            transactionMonitor.upgradeToWriteTransaction();
-        }
-        return transactionStateController().global();
+//        if ( !transactionStatesContainer.hasState() )
+//        {
+//            transactionMonitor.upgradeToWriteTransaction();
+//        }
+        return transactionStatesContainer.global();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -414,10 +414,6 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     @Override
     public TransactionState txState()
     {
-//        if ( !transactionStatesContainer.hasState() )
-//        {
-//            transactionMonitor.upgradeToWriteTransaction();
-//        }
         return transactionStatesContainer.global();
     }
 
@@ -499,7 +495,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
 
     private boolean hasDataChanges()
     {
-        return hasTxStateWithChanges() && transactionStatesContainer.hasDataChanges();
+        return transactionStatesContainer.hasDataChanges();
     }
 
     @Override
@@ -585,8 +581,7 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
         try ( CommitEvent commitEvent = transactionEvent.beginCommitEvent() )
         {
             // Trigger transaction "before" hooks.
-            transactionStatesContainer.validateForCommit();
-            transactionState = transactionStatesContainer.global();
+            transactionState = transactionStatesContainer.prepareForCommit();
             if ( hasDataChanges() )
             {
                 try

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/CombinedTxState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/CombinedTxState.java
@@ -1,0 +1,541 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.state;
+
+import java.util.Iterator;
+
+import org.neo4j.collection.primitive.PrimitiveIntSet;
+import org.neo4j.collection.primitive.PrimitiveLongCollections;
+import org.neo4j.collection.primitive.PrimitiveLongIterator;
+import org.neo4j.collection.primitive.PrimitiveLongResourceIterator;
+import org.neo4j.cursor.Cursor;
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.internal.kernel.api.exceptions.schema.ConstraintValidationException;
+import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
+import org.neo4j.internal.kernel.api.schema.SchemaDescriptor;
+import org.neo4j.internal.kernel.api.schema.constraints.ConstraintDescriptor;
+import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
+import org.neo4j.kernel.api.schema.constaints.IndexBackedConstraintDescriptor;
+import org.neo4j.kernel.api.schema.index.IndexDescriptor;
+import org.neo4j.kernel.api.txstate.TransactionState;
+import org.neo4j.kernel.impl.api.RelationshipVisitor;
+import org.neo4j.kernel.impl.api.store.RelationshipIterator;
+import org.neo4j.storageengine.api.Direction;
+import org.neo4j.storageengine.api.NodeItem;
+import org.neo4j.storageengine.api.PropertyItem;
+import org.neo4j.storageengine.api.RelationshipItem;
+import org.neo4j.storageengine.api.StorageProperty;
+import org.neo4j.storageengine.api.txstate.NodeState;
+import org.neo4j.storageengine.api.txstate.PrimitiveLongReadableDiffSets;
+import org.neo4j.storageengine.api.txstate.PropertyContainerState;
+import org.neo4j.storageengine.api.txstate.ReadableDiffSets;
+import org.neo4j.storageengine.api.txstate.ReadableRelationshipDiffSets;
+import org.neo4j.storageengine.api.txstate.RelationshipState;
+import org.neo4j.storageengine.api.txstate.TxStateVisitor;
+import org.neo4j.values.storable.Value;
+import org.neo4j.values.storable.ValueTuple;
+
+public class CombinedTxState implements TransactionState, RelationshipVisitor.Home
+{
+    private final TxState stableTxState;
+    private final TxState currentTxState;
+
+    CombinedTxState( TxState stableTxState, TxState currentTxState )
+    {
+        this.stableTxState = stableTxState;
+        this.currentTxState = currentTxState;
+    }
+
+    @Override
+    public Iterable<NodeState> modifiedNodes()
+    {
+        return Iterables.concat( currentTxState.modifiedNodes(), stableTxState.modifiedNodes() );
+    }
+
+    @Override
+    public ReadableDiffSets<Integer> nodeStateLabelDiffSets( long nodeId )
+    {
+        return currentTxState.nodeStateLabelDiffSets( nodeId );
+    }
+
+    @Override
+    public Iterator<StorageProperty> augmentGraphProperties( Iterator<StorageProperty> original )
+    {
+        return currentTxState.augmentGraphProperties( original );
+    }
+
+    @Override
+    public boolean nodeIsAddedInThisTx( long nodeId )
+    {
+        return currentTxState.nodeIsAddedInThisTx( nodeId );
+    }
+
+    @Override
+    public boolean relationshipIsAddedInThisTx( long relationshipId )
+    {
+        return currentTxState.relationshipIsAddedInThisTx( relationshipId );
+    }
+
+    @Override
+    public void nodeDoCreate( long id )
+    {
+        currentTxState.nodeDoCreate( id );
+    }
+
+    @Override
+    public void nodeDoDelete( long nodeId )
+    {
+        currentTxState.nodeDoDelete( nodeId );
+    }
+
+    @Override
+    public void relationshipDoCreate( long id, int relationshipTypeId, long startNodeId, long endNodeId )
+    {
+        currentTxState.relationshipDoCreate( id, relationshipTypeId, startNodeId, endNodeId );
+    }
+
+    @Override
+    public boolean nodeIsDeletedInThisTx( long nodeId )
+    {
+        return currentTxState.nodeIsDeletedInThisTx( nodeId );
+    }
+
+    @Override
+    public boolean nodeModifiedInThisTx( long nodeId )
+    {
+        return currentTxState.nodeModifiedInThisTx( nodeId );
+    }
+
+    @Override
+    public void relationshipDoDelete( long id, int type, long startNodeId, long endNodeId )
+    {
+        currentTxState.relationshipDoDelete( id, type, startNodeId, endNodeId );
+    }
+
+    @Override
+    public void relationshipDoDeleteAddedInThisTx( long relationshipId )
+    {
+        currentTxState.relationshipDoDeleteAddedInThisTx( relationshipId );
+    }
+
+    @Override
+    public boolean relationshipIsDeletedInThisTx( long relationshipId )
+    {
+        return currentTxState.relationshipIsDeletedInThisTx( relationshipId );
+    }
+
+    @Override
+    public void nodeDoAddProperty( long nodeId, int newPropertyKeyId, Value value )
+    {
+        currentTxState.nodeDoAddProperty( nodeId, newPropertyKeyId, value );
+    }
+
+    @Override
+    public void nodeDoChangeProperty( long nodeId, int propertyKeyId, Value replacedValue, Value newValue )
+    {
+        currentTxState.nodeDoChangeProperty( nodeId, propertyKeyId, replacedValue, newValue );
+    }
+
+    @Override
+    public void relationshipDoReplaceProperty( long relationshipId, int propertyKeyId, Value replacedValue,
+            Value newValue )
+    {
+        currentTxState.relationshipDoReplaceProperty( relationshipId, propertyKeyId, replacedValue, newValue );
+    }
+
+    @Override
+    public void graphDoReplaceProperty( int propertyKeyId, Value replacedValue, Value newValue )
+    {
+        currentTxState.graphDoReplaceProperty( propertyKeyId, replacedValue, newValue );
+    }
+
+    @Override
+    public void nodeDoRemoveProperty( long nodeId, int propertyKeyId, Value removedValue )
+    {
+        currentTxState.nodeDoRemoveProperty( nodeId, propertyKeyId, removedValue );
+    }
+
+    @Override
+    public void relationshipDoRemoveProperty( long relationshipId, int propertyKeyId, Value removedValue )
+    {
+        currentTxState.relationshipDoRemoveProperty( relationshipId, propertyKeyId, removedValue );
+    }
+
+    @Override
+    public void graphDoRemoveProperty( int propertyKeyId, Value removedValue )
+    {
+        currentTxState.graphDoRemoveProperty( propertyKeyId, removedValue );
+    }
+
+    @Override
+    public void nodeDoAddLabel( int labelId, long nodeId )
+    {
+        currentTxState.nodeDoAddLabel( labelId, nodeId );
+    }
+
+    @Override
+    public void nodeDoRemoveLabel( int labelId, long nodeId )
+    {
+        currentTxState.nodeDoRemoveLabel( labelId, nodeId );
+    }
+
+    @Override
+    public void labelDoCreateForName( String labelName, int id )
+    {
+        currentTxState.labelDoCreateForName( labelName, id );
+    }
+
+    @Override
+    public void propertyKeyDoCreateForName( String propertyKeyName, int id )
+    {
+        currentTxState.propertyKeyDoCreateForName( propertyKeyName, id );
+    }
+
+    @Override
+    public void relationshipTypeDoCreateForName( String labelName, int id )
+    {
+        currentTxState.relationshipTypeDoCreateForName( labelName, id );
+    }
+
+    @Override
+    public NodeState getNodeState( long id )
+    {
+        return currentTxState.getNodeState( id );
+    }
+
+    @Override
+    public RelationshipState getRelationshipState( long id )
+    {
+        return currentTxState.getRelationshipState( id );
+    }
+
+    @Override
+    public Cursor<NodeItem> augmentSingleNodeCursor( Cursor<NodeItem> cursor, long nodeId )
+    {
+        return currentTxState.augmentSingleNodeCursor( cursor, nodeId );
+    }
+
+    @Override
+    public Cursor<PropertyItem> augmentPropertyCursor( Cursor<PropertyItem> cursor,
+            PropertyContainerState propertyContainerState )
+    {
+        return currentTxState.augmentPropertyCursor( cursor, propertyContainerState );
+    }
+
+    @Override
+    public Cursor<PropertyItem> augmentSinglePropertyCursor( Cursor<PropertyItem> cursor,
+            PropertyContainerState propertyContainerState, int propertyKeyId )
+    {
+        return currentTxState.augmentSinglePropertyCursor( cursor, propertyContainerState, propertyKeyId );
+    }
+
+    @Override
+    public PrimitiveIntSet augmentLabels( PrimitiveIntSet labels, NodeState nodeState )
+    {
+        return currentTxState.augmentLabels( labels, nodeState );
+    }
+
+    @Override
+    public Cursor<RelationshipItem> augmentSingleRelationshipCursor( Cursor<RelationshipItem> cursor,
+            long relationshipId )
+    {
+        return currentTxState.augmentSingleRelationshipCursor( cursor, relationshipId );
+    }
+
+    @Override
+    public Cursor<RelationshipItem> augmentNodeRelationshipCursor( Cursor<RelationshipItem> cursor, NodeState nodeState,
+            Direction direction )
+    {
+        return currentTxState.augmentNodeRelationshipCursor( cursor, nodeState, direction );
+    }
+
+    @Override
+    public Cursor<RelationshipItem> augmentNodeRelationshipCursor( Cursor<RelationshipItem> cursor, NodeState nodeState,
+            Direction direction, int[] relTypes )
+    {
+        return currentTxState.augmentNodeRelationshipCursor( cursor, nodeState, direction, relTypes );
+    }
+
+    @Override
+    public Cursor<RelationshipItem> augmentRelationshipsGetAllCursor( Cursor<RelationshipItem> cursor )
+    {
+        return currentTxState.augmentRelationshipsGetAllCursor( cursor );
+    }
+
+    @Override
+    public ReadableDiffSets<Long> nodesWithLabelChanged( int labelId )
+    {
+        return currentTxState.nodesWithLabelChanged( labelId );
+    }
+
+    @Override
+    public void indexRuleDoAdd( IndexDescriptor descriptor )
+    {
+        currentTxState.indexRuleDoAdd( descriptor );
+    }
+
+    @Override
+    public void indexDoDrop( IndexDescriptor descriptor )
+    {
+        currentTxState.indexDoDrop( descriptor );
+    }
+
+    @Override
+    public boolean indexDoUnRemove( IndexDescriptor descriptor )
+    {
+        throw new UnsupportedOperationException( "Operation not supported." );
+    }
+
+    @Override
+    public ReadableDiffSets<IndexDescriptor> indexDiffSetsByLabel( int labelId )
+    {
+        return currentTxState.indexDiffSetsByLabel( labelId );
+    }
+
+    @Override
+    public ReadableDiffSets<IndexDescriptor> indexChanges()
+    {
+        return currentTxState.indexChanges();
+    }
+
+    @Override
+    public ReadableDiffSets<Long> addedAndRemovedNodes()
+    {
+        return currentTxState.addedAndRemovedNodes();
+    }
+
+    @Override
+    public int augmentNodeDegree( long nodeId, int degree, Direction direction )
+    {
+        return currentTxState.augmentNodeDegree( nodeId, degree, direction );
+    }
+
+    @Override
+    public int augmentNodeDegree( long nodeId, int degree, Direction direction, int typeId )
+    {
+        return currentTxState.augmentNodeDegree( nodeId, degree, direction, typeId );
+    }
+
+    @Override
+    public PrimitiveIntSet nodeRelationshipTypes( long nodeId )
+    {
+        return currentTxState.nodeRelationshipTypes( nodeId );
+    }
+
+    @Override
+    public ReadableRelationshipDiffSets<Long> addedAndRemovedRelationships()
+    {
+        return currentTxState.addedAndRemovedRelationships();
+    }
+
+    @Override
+    public Iterable<RelationshipState> modifiedRelationships()
+    {
+        return currentTxState.modifiedRelationships();
+    }
+
+    @Override
+    public void constraintDoAdd( IndexBackedConstraintDescriptor constraint, long indexId )
+    {
+        currentTxState.constraintDoAdd( constraint, indexId );
+    }
+
+    @Override
+    public void constraintDoAdd( ConstraintDescriptor constraint )
+    {
+        currentTxState.constraintDoAdd( constraint );
+    }
+
+    @Override
+    public ReadableDiffSets<ConstraintDescriptor> constraintsChangesForLabel( int labelId )
+    {
+        return currentTxState.constraintsChangesForLabel( labelId );
+    }
+
+    @Override
+    public ReadableDiffSets<ConstraintDescriptor> constraintsChangesForSchema( SchemaDescriptor descriptor )
+    {
+        return currentTxState.constraintsChangesForSchema( descriptor );
+    }
+
+    @Override
+    public ReadableDiffSets<ConstraintDescriptor> constraintsChangesForRelationshipType( int relTypeId )
+    {
+        return currentTxState.constraintsChangesForRelationshipType( relTypeId );
+    }
+
+    @Override
+    public ReadableDiffSets<ConstraintDescriptor> constraintsChanges()
+    {
+        return currentTxState.constraintsChanges();
+    }
+
+    @Override
+    public void constraintDoDrop( ConstraintDescriptor constraint )
+    {
+        currentTxState.constraintDoDrop( constraint );
+    }
+
+    @Override
+    public boolean constraintDoUnRemove( ConstraintDescriptor constraint )
+    {
+        return currentTxState.constraintDoUnRemove( constraint );
+    }
+
+    @Override
+    public Iterable<IndexDescriptor> constraintIndexesCreatedInTx()
+    {
+        return currentTxState.constraintIndexesCreatedInTx();
+    }
+
+    @Override
+    public Long indexCreatedForConstraint( ConstraintDescriptor constraint )
+    {
+        return currentTxState.indexCreatedForConstraint( constraint );
+    }
+
+    @Override
+    public PrimitiveLongReadableDiffSets indexUpdatesForScan( IndexDescriptor descriptor )
+    {
+        return currentTxState.indexUpdatesForScan( descriptor );
+    }
+
+    @Override
+    public PrimitiveLongReadableDiffSets indexUpdatesForSeek( IndexDescriptor descriptor, ValueTuple values )
+    {
+        return currentTxState.indexUpdatesForSeek( descriptor, values );
+    }
+
+    @Override
+    public PrimitiveLongReadableDiffSets indexUpdatesForRangeSeekByNumber( IndexDescriptor descriptor, Number lower,
+            boolean includeLower, Number upper, boolean includeUpper )
+    {
+        return currentTxState
+                .indexUpdatesForRangeSeekByNumber( descriptor, lower, includeLower, upper, includeUpper );
+    }
+
+    @Override
+    public PrimitiveLongReadableDiffSets indexUpdatesForRangeSeekByString( IndexDescriptor descriptor, String lower,
+            boolean includeLower, String upper, boolean includeUpper )
+    {
+        return currentTxState
+                .indexUpdatesForRangeSeekByString( descriptor, lower, includeLower, upper, includeUpper );
+    }
+
+    @Override
+    public PrimitiveLongReadableDiffSets indexUpdatesForRangeSeekByPrefix( IndexDescriptor descriptor, String prefix )
+    {
+        return currentTxState.indexUpdatesForRangeSeekByPrefix( descriptor, prefix );
+    }
+
+    @Override
+    public void indexDoUpdateEntry( LabelSchemaDescriptor descriptor, long nodeId, ValueTuple propertiesBefore,
+            ValueTuple propertiesAfter )
+    {
+        currentTxState.indexDoUpdateEntry( descriptor, nodeId, propertiesBefore, propertiesAfter );
+    }
+
+    @Override
+    public PrimitiveLongResourceIterator augmentNodesGetAll( PrimitiveLongIterator committed )
+    {
+        PrimitiveLongCollections.concat( currentTxState.augmentNodesGetAll( committed ), stableTxState
+                .augmentNodesGetAll( PrimitiveLongCollections.emptyIterator() ) );
+        return null;
+    }
+
+    @Override
+    public RelationshipIterator augmentRelationshipsGetAll( RelationshipIterator committed )
+    {
+        return currentTxState.augmentRelationshipsGetAll( committed );
+    }
+
+    @Override
+    public <EX extends Exception> boolean relationshipVisit( long relId, RelationshipVisitor<EX> visitor ) throws EX
+    {
+        throw new UnsupportedOperationException( "Can't visit combined state. Merge states before." );
+    }
+
+    @Override
+    public void accept( TxStateVisitor visitor ) throws ConstraintValidationException, CreateConstraintFailureException
+    {
+        throw new UnsupportedOperationException( "Can't visit combined state. Merge states before." );
+    }
+
+    @Override
+    public boolean hasChanges()
+    {
+        return stableTxState.hasChanges() || currentTxState.hasChanges();
+    }
+
+    @Override
+    public boolean hasDataChanges()
+    {
+        return stableTxState.hasDataChanges() || currentTxState.hasDataChanges();
+    }
+
+    public TransactionState merge()
+    {
+        // TODO: any way we can reuse current visitor mechanism?
+        if ( currentTxState.hasDataChanges() )
+        {
+            ReadableDiffSets<Long> addedRemovedNodes = currentTxState.addedAndRemovedNodes();
+            if ( !addedRemovedNodes.isEmpty() )
+            {
+                for ( Long added : addedRemovedNodes.getAdded() )
+                {
+                    stableTxState.nodeDoCreate( added );
+                }
+                for ( Long removed : addedRemovedNodes.getRemoved() )
+                {
+                    stableTxState.nodeDoDelete( removed );
+                }
+            }
+
+            for ( NodeState nodeState : currentTxState.modifiedNodes() )
+            {
+                ReadableDiffSets<Integer> addedRemovedLabels = nodeState.labelDiffSets();
+                if ( !addedRemovedLabels.isEmpty() )
+                {
+                    for ( Integer addedLabel : addedRemovedLabels.getAdded() )
+                    {
+                        stableTxState.nodeDoAddLabel( addedLabel, nodeState.getId() );
+                    }
+                    for ( Integer removed : addedRemovedLabels.getRemoved() )
+                    {
+                        stableTxState.nodeDoAddLabel( removed, nodeState.getId() );
+                    }
+
+                }
+                if ( nodeState.hasPropertyChanges() )
+                {
+                    // TODO: only handles newly created properties atm
+                    Iterator<StorageProperty> addedProperties = nodeState.addedProperties();
+                    while ( addedProperties.hasNext() )
+                    {
+                        StorageProperty storageProperty = addedProperties.next();
+                        stableTxState.nodeDoAddProperty( nodeState.getId(), storageProperty.propertyKeyId(),
+                                storageProperty.value() );
+                    }
+                }
+            }
+        }
+        return stableTxState;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/CombinedTxState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/CombinedTxState.java
@@ -78,19 +78,19 @@ public class CombinedTxState implements TransactionState, RelationshipVisitor.Ho
     @Override
     public Iterator<StorageProperty> augmentGraphProperties( Iterator<StorageProperty> original )
     {
-        return currentTxState.augmentGraphProperties( original );
+        return stableTxState.augmentGraphProperties( currentTxState.augmentGraphProperties( original ) );
     }
 
     @Override
     public boolean nodeIsAddedInThisTx( long nodeId )
     {
-        return currentTxState.nodeIsAddedInThisTx( nodeId );
+        return stableTxState.nodeIsAddedInThisTx( nodeId ) || currentTxState.nodeIsAddedInThisTx( nodeId );
     }
 
     @Override
     public boolean relationshipIsAddedInThisTx( long relationshipId )
     {
-        return currentTxState.relationshipIsAddedInThisTx( relationshipId );
+        return stableTxState.relationshipIsAddedInThisTx( relationshipId ) || currentTxState.relationshipIsAddedInThisTx( relationshipId );
     }
 
     @Override
@@ -114,13 +114,13 @@ public class CombinedTxState implements TransactionState, RelationshipVisitor.Ho
     @Override
     public boolean nodeIsDeletedInThisTx( long nodeId )
     {
-        return currentTxState.nodeIsDeletedInThisTx( nodeId );
+        return stableTxState.nodeIsDeletedInThisTx( nodeId ) || currentTxState.nodeIsDeletedInThisTx( nodeId );
     }
 
     @Override
     public boolean nodeModifiedInThisTx( long nodeId )
     {
-        return currentTxState.nodeModifiedInThisTx( nodeId );
+        return stableTxState.nodeModifiedInThisTx( nodeId ) || currentTxState.nodeModifiedInThisTx( nodeId );
     }
 
     @Override
@@ -132,13 +132,15 @@ public class CombinedTxState implements TransactionState, RelationshipVisitor.Ho
     @Override
     public void relationshipDoDeleteAddedInThisTx( long relationshipId )
     {
+        //TODO hm...
         currentTxState.relationshipDoDeleteAddedInThisTx( relationshipId );
     }
 
     @Override
     public boolean relationshipIsDeletedInThisTx( long relationshipId )
     {
-        return currentTxState.relationshipIsDeletedInThisTx( relationshipId );
+        return stableTxState.relationshipIsDeletedInThisTx(relationshipId) ||
+               currentTxState.relationshipIsDeletedInThisTx( relationshipId );
     }
 
     @Override
@@ -199,19 +201,19 @@ public class CombinedTxState implements TransactionState, RelationshipVisitor.Ho
     @Override
     public void labelDoCreateForName( String labelName, int id )
     {
-        currentTxState.labelDoCreateForName( labelName, id );
+        throw new UnsupportedOperationException( "Operation not supported." );
     }
 
     @Override
     public void propertyKeyDoCreateForName( String propertyKeyName, int id )
     {
-        currentTxState.propertyKeyDoCreateForName( propertyKeyName, id );
+        throw new UnsupportedOperationException( "Operation not supported." );
     }
 
     @Override
     public void relationshipTypeDoCreateForName( String labelName, int id )
     {
-        currentTxState.relationshipTypeDoCreateForName( labelName, id );
+        throw new UnsupportedOperationException( "Operation not supported." );
     }
 
     @Override
@@ -276,7 +278,8 @@ public class CombinedTxState implements TransactionState, RelationshipVisitor.Ho
     @Override
     public Cursor<RelationshipItem> augmentRelationshipsGetAllCursor( Cursor<RelationshipItem> cursor )
     {
-        return currentTxState.augmentRelationshipsGetAllCursor( cursor );
+        return stableTxState
+                .augmentRelationshipsGetAllCursor( currentTxState.augmentRelationshipsGetAllCursor( cursor ) );
     }
 
     @Override
@@ -288,13 +291,13 @@ public class CombinedTxState implements TransactionState, RelationshipVisitor.Ho
     @Override
     public void indexRuleDoAdd( IndexDescriptor descriptor )
     {
-        currentTxState.indexRuleDoAdd( descriptor );
+        throw new UnsupportedOperationException( "Operation not supported." );
     }
 
     @Override
     public void indexDoDrop( IndexDescriptor descriptor )
     {
-        currentTxState.indexDoDrop( descriptor );
+        throw new UnsupportedOperationException( "Operation not supported." );
     }
 
     @Override
@@ -354,13 +357,13 @@ public class CombinedTxState implements TransactionState, RelationshipVisitor.Ho
     @Override
     public void constraintDoAdd( IndexBackedConstraintDescriptor constraint, long indexId )
     {
-        currentTxState.constraintDoAdd( constraint, indexId );
+        throw new UnsupportedOperationException( "Operation not supported." );
     }
 
     @Override
     public void constraintDoAdd( ConstraintDescriptor constraint )
     {
-        currentTxState.constraintDoAdd( constraint );
+        throw new UnsupportedOperationException( "Operation not supported." );
     }
 
     @Override
@@ -390,25 +393,25 @@ public class CombinedTxState implements TransactionState, RelationshipVisitor.Ho
     @Override
     public void constraintDoDrop( ConstraintDescriptor constraint )
     {
-        currentTxState.constraintDoDrop( constraint );
+        throw new UnsupportedOperationException( "Operation not supported." );
     }
 
     @Override
     public boolean constraintDoUnRemove( ConstraintDescriptor constraint )
     {
-        return currentTxState.constraintDoUnRemove( constraint );
+        throw new UnsupportedOperationException( "Operation not supported." );
     }
 
     @Override
     public Iterable<IndexDescriptor> constraintIndexesCreatedInTx()
     {
-        return currentTxState.constraintIndexesCreatedInTx();
+        throw new UnsupportedOperationException( "Operation not supported." );
     }
 
     @Override
     public Long indexCreatedForConstraint( ConstraintDescriptor constraint )
     {
-        return currentTxState.indexCreatedForConstraint( constraint );
+        throw new UnsupportedOperationException( "Operation not supported." );
     }
 
     @Override
@@ -452,28 +455,28 @@ public class CombinedTxState implements TransactionState, RelationshipVisitor.Ho
         currentTxState.indexDoUpdateEntry( descriptor, nodeId, propertiesBefore, propertiesAfter );
     }
 
+// ----->>>> test arrow is here
+
     @Override
     public PrimitiveLongResourceIterator augmentNodesGetAll( PrimitiveLongIterator committed )
     {
-        PrimitiveLongCollections.concat( currentTxState.augmentNodesGetAll( committed ), stableTxState
-                .augmentNodesGetAll( PrimitiveLongCollections.emptyIterator() ) );
-        return null;
+        return stableTxState.augmentNodesGetAll( currentTxState.augmentNodesGetAll( committed ) );
     }
 
     @Override
     public RelationshipIterator augmentRelationshipsGetAll( RelationshipIterator committed )
     {
-        return currentTxState.augmentRelationshipsGetAll( committed );
+        return stableTxState.augmentRelationshipsGetAll( currentTxState.augmentRelationshipsGetAll( committed ) );
     }
 
     @Override
-    public <EX extends Exception> boolean relationshipVisit( long relId, RelationshipVisitor<EX> visitor ) throws EX
+    public <EX extends Exception> boolean relationshipVisit( long relId, RelationshipVisitor<EX> visitor )
     {
         throw new UnsupportedOperationException( "Can't visit combined state. Merge states before." );
     }
 
     @Override
-    public void accept( TxStateVisitor visitor ) throws ConstraintValidationException, CreateConstraintFailureException
+    public void accept( TxStateVisitor visitor )
     {
         throw new UnsupportedOperationException( "Can't visit combined state. Merge states before." );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/ExplicitIndexTransactionStateImpl.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/ExplicitIndexTransactionStateImpl.java
@@ -156,19 +156,11 @@ public class ExplicitIndexTransactionStateImpl implements ExplicitIndexTransacti
         List<IndexCommand> commands = null;
         if ( command.getEntityType() == IndexEntityType.Node.id() )
         {
-            commands = nodeCommands.get( indexName );
-            if ( commands == null )
-            {
-                nodeCommands.put( indexName, commands = new ArrayList<>() );
-            }
+            commands = nodeCommands.computeIfAbsent( indexName, k -> new ArrayList<>() );
         }
         else if ( command.getEntityType() == IndexEntityType.Relationship.id() )
         {
-            commands = relationshipCommands.get( indexName );
-            if ( commands == null )
-            {
-                relationshipCommands.put( indexName, commands = new ArrayList<>() );
-            }
+            commands = relationshipCommands.computeIfAbsent( indexName, k -> new ArrayList<>() );
         }
         else
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TransactionStatesContainer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TransactionStatesContainer.java
@@ -27,7 +27,7 @@ import static org.neo4j.unsafe.impl.internal.dragons.FeatureToggles.flag;
 
 public class TransactionStatesContainer implements TransactionStateController
 {
-    private static final boolean MULTI_STATE = flag( TransactionStatesContainer.class, "multiState", false );
+    static boolean MULTI_STATE = flag( TransactionStatesContainer.class, "multiState", false );
 
     private final TransactionMonitor transactionMonitor;
     private TransactionState globalTransactionState;
@@ -66,12 +66,13 @@ public class TransactionStatesContainer implements TransactionStateController
         return stableTransactionState;
     }
 
-    public void validateForCommit()
+    public TransactionState prepareForCommit()
     {
         if ( globalTransactionState instanceof CombinedTxState )
         {
             throw new IllegalStateException( "Commit of splitted transaction state is not supported." );
         }
+        return globalTransactionState;
     }
 
     public TransactionState global()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TransactionStatesContainer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TransactionStatesContainer.java
@@ -21,14 +21,22 @@ package org.neo4j.kernel.impl.api.state;
 
 import org.neo4j.kernel.api.txstate.TransactionState;
 import org.neo4j.kernel.api.txstate.TransactionStateController;
+import org.neo4j.kernel.impl.transaction.TransactionMonitor;
 
 import static org.neo4j.unsafe.impl.internal.dragons.FeatureToggles.flag;
 
 public class TransactionStatesContainer implements TransactionStateController
 {
     private static final boolean MULTI_STATE = flag( TransactionStatesContainer.class, "multiState", false );
+
+    private final TransactionMonitor transactionMonitor;
     private TransactionState globalTransactionState;
     private TxState stableTransactionState;
+
+    public TransactionStatesContainer( TransactionMonitor transactionMonitor )
+    {
+        this.transactionMonitor = transactionMonitor;
+    }
 
     public boolean hasChanges()
     {
@@ -70,6 +78,7 @@ public class TransactionStatesContainer implements TransactionStateController
     {
         if ( globalTransactionState == null )
         {
+            transactionMonitor.upgradeToWriteTransaction();
             globalTransactionState = new TxState();
         }
         return globalTransactionState;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TransactionStatesContainer.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/TransactionStatesContainer.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.state;
+
+import org.neo4j.kernel.api.txstate.TransactionState;
+import org.neo4j.kernel.api.txstate.TransactionStateController;
+
+import static org.neo4j.unsafe.impl.internal.dragons.FeatureToggles.flag;
+
+public class TransactionStatesContainer implements TransactionStateController
+{
+    private static final boolean MULTI_STATE = flag( TransactionStatesContainer.class, "multiState", false );
+    private TransactionState globalTransactionState;
+    private TxState stableTransactionState;
+
+    public boolean hasChanges()
+    {
+        return hasState() && globalTransactionState.hasChanges();
+    }
+
+    public boolean hasState()
+    {
+        return globalTransactionState != null;
+    }
+
+    public boolean hasDataChanges()
+    {
+        return hasChanges() && globalTransactionState.hasDataChanges();
+    }
+
+    public TransactionState stable()
+    {
+        if ( !MULTI_STATE )
+        {
+            return global();
+        }
+        if ( stableTransactionState == null )
+        {
+            split();
+        }
+        return stableTransactionState;
+    }
+
+    public void validateForCommit()
+    {
+        if ( globalTransactionState instanceof CombinedTxState )
+        {
+            throw new IllegalStateException( "Commit of splitted transaction state is not supported." );
+        }
+    }
+
+    public TransactionState global()
+    {
+        if ( globalTransactionState == null )
+        {
+            globalTransactionState = new TxState();
+        }
+        return globalTransactionState;
+    }
+
+    @Override
+    public void combine()
+    {
+        if ( !MULTI_STATE )
+        {
+            return;
+        }
+        if ( globalTransactionState == null )
+        {
+            throw new IllegalStateException( "Can't combine state that was never splitted." );
+        }
+        if ( globalTransactionState instanceof CombinedTxState )
+        {
+            globalTransactionState = ((CombinedTxState) globalTransactionState).merge();
+        }
+        else
+        {
+            throw new IllegalStateException( "Merge should be performed only after transaction state split." );
+        }
+        stableTransactionState = null;
+    }
+
+    @Override
+    public void split()
+    {
+        if ( !MULTI_STATE )
+        {
+            return;
+        }
+        stableTransactionState = (TxState) global();
+        globalTransactionState = new CombinedTxState( stableTransactionState, new TxState() );
+    }
+
+    public void clear()
+    {
+        stableTransactionState = null;
+        globalTransactionState = null;
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
@@ -78,6 +78,7 @@ public class Operations implements Write, ExplicitIndexWrite
     private final KernelTransactionImplementation ktx;
     private final AllStoreHolder allStoreHolder;
     private final StorageStatement statement;
+    private final StableStoreHolder stableStoreHolder;
     private final AutoIndexing autoIndexing;
     private org.neo4j.kernel.impl.newapi.NodeCursor nodeCursor;
     private final IndexTxStateUpdater updater;
@@ -85,13 +86,11 @@ public class Operations implements Write, ExplicitIndexWrite
     private final Cursors cursors;
     private final NodeSchemaMatcher schemaMatcher;
 
-    public Operations(
-            AllStoreHolder allStoreHolder,
-            IndexTxStateUpdater updater,
-            StorageStatement statement,
-            KernelTransactionImplementation ktx,
+    public Operations( AllStoreHolder allStoreHolder, StableStoreHolder stableStoreHolder, IndexTxStateUpdater updater,
+            StorageStatement statement, KernelTransactionImplementation ktx,
             Cursors cursors, AutoIndexing autoIndexing, NodeSchemaMatcher schemaMatcher )
     {
+        this.stableStoreHolder = stableStoreHolder;
         this.autoIndexing = autoIndexing;
         this.allStoreHolder = allStoreHolder;
         this.ktx = ktx;
@@ -594,5 +593,10 @@ public class Operations implements Write, ExplicitIndexWrite
     public PropertyCursor propertyCursor()
     {
         return propertyCursor;
+    }
+
+    public Read stableDataRead()
+    {
+        return stableStoreHolder;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Read.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Read.java
@@ -33,6 +33,7 @@ import org.neo4j.kernel.api.ExplicitIndexHits;
 import org.neo4j.kernel.api.exceptions.index.IndexNotApplicableKernelException;
 import org.neo4j.kernel.api.txstate.ExplicitIndexTransactionState;
 import org.neo4j.kernel.api.txstate.TransactionState;
+import org.neo4j.kernel.api.txstate.TransactionStateController;
 import org.neo4j.kernel.api.txstate.TxStateHolder;
 import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
 import org.neo4j.kernel.impl.store.RecordCursor;
@@ -479,6 +480,12 @@ abstract class Read implements TxStateHolder,
     public TransactionState txState()
     {
         return ktx.txState();
+    }
+
+    @Override
+    public TransactionStateController transactionStateController()
+    {
+        return ktx.transactionStateController();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/StableStoreHolder.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/StableStoreHolder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.newapi;
+
+import org.neo4j.kernel.api.txstate.TransactionState;
+import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
+import org.neo4j.kernel.impl.index.ExplicitIndexStore;
+import org.neo4j.storageengine.api.StorageEngine;
+import org.neo4j.storageengine.api.StorageStatement;
+
+public class StableStoreHolder extends AllStoreHolder
+{
+    public StableStoreHolder( StorageEngine engine, StorageStatement statement, KernelTransactionImplementation ktx,
+            Cursors cursors, ExplicitIndexStore explicitIndexStore )
+    {
+        super( engine, statement, ktx, cursors, explicitIndexStore );
+    }
+
+    @Override
+    public TransactionState txState()
+    {
+        return ktx.transactionStateController().stable();
+    }
+
+    @Override
+    public boolean hasTxStateWithChanges()
+    {
+        return txState().hasChanges();
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/PrimitiveLongDiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/diffsets/PrimitiveLongDiffSets.java
@@ -116,7 +116,18 @@ public class PrimitiveLongDiffSets<T extends PrimitiveLongIterator> implements P
     @Override
     public PrimitiveLongIterator augment( PrimitiveLongIterator source )
     {
-        return (T) new DiffApplyingPrimitiveLongIterator( source, addedElements, removedElements );
+        return new DiffApplyingPrimitiveLongIterator( source, addedElements, removedElements );
+    }
+
+    @Override
+    public PrimitiveLongReadableDiffSets combine( PrimitiveLongReadableDiffSets diffSets )
+    {
+        if ( diffSets.isEmpty() )
+        {
+            return this;
+        }
+
+        return new CombinedPrimitiveLongDiffSets( this, diffSets );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/PrimitiveLongReadableDiffSets.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/txstate/PrimitiveLongReadableDiffSets.java
@@ -81,4 +81,12 @@ public interface PrimitiveLongReadableDiffSets
      * @return iterator that will iterate over augmented elements as well as over diff set
      */
     PrimitiveLongIterator augment( PrimitiveLongIterator elements );
+
+    /**
+     * Create new diffSets that contains additions and removals from 2 sets
+     * TODO: mention combine rules
+     * @param additional set to combine with.
+     * @return combined sets view
+     */
+    PrimitiveLongReadableDiffSets combine( PrimitiveLongReadableDiffSets additional );
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/StubKernelTransaction.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/StubKernelTransaction.java
@@ -74,6 +74,12 @@ public class StubKernelTransaction implements KernelTransaction
     }
 
     @Override
+    public Read stableDataRead()
+    {
+        return null;
+    }
+
+    @Override
     public Write dataWrite()
     {
         throw new UnsupportedOperationException( "not implemented" );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/LockingStatementOperationsTest.java
@@ -40,6 +40,7 @@ import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
 import org.neo4j.kernel.api.txstate.ExplicitIndexTransactionState;
 import org.neo4j.kernel.api.txstate.TransactionState;
+import org.neo4j.kernel.api.txstate.TransactionStateController;
 import org.neo4j.kernel.api.txstate.TxStateHolder;
 import org.neo4j.kernel.impl.api.TwoPhaseNodeForRelationshipLockingTest.RelationshipData;
 import org.neo4j.kernel.impl.api.operations.EntityReadOperations;
@@ -503,6 +504,12 @@ public class LockingStatementOperationsTest
         public TransactionState txState()
         {
             return txState;
+        }
+
+        @Override
+        public TransactionStateController transactionStateController()
+        {
+            return null;
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
@@ -80,7 +80,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
-
 import static org.neo4j.kernel.impl.api.StatementOperationsTestHelper.mockedParts;
 import static org.neo4j.kernel.impl.api.StatementOperationsTestHelper.mockedState;
 
@@ -399,6 +398,12 @@ public class ConstraintIndexCreatorTest
             public Read dataRead()
             {
                 throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            public Read stableDataRead()
+            {
+                return null;
             }
 
             @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/CombinedTxStateIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/state/CombinedTxStateIT.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.state;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.collection.primitive.PrimitiveLongCollections;
+import org.neo4j.collection.primitive.PrimitiveLongResourceIterator;
+import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.helpers.ArrayUtil;
+import org.neo4j.helpers.collection.Iterators;
+import org.neo4j.internal.kernel.api.exceptions.schema.ConstraintValidationException;
+import org.neo4j.kernel.api.exceptions.schema.CreateConstraintFailureException;
+import org.neo4j.kernel.api.txstate.TransactionState;
+import org.neo4j.kernel.api.txstate.TransactionStateController;
+import org.neo4j.kernel.impl.api.KernelStatement;
+import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
+import org.neo4j.kernel.impl.api.RelationshipDataExtractor;
+import org.neo4j.kernel.impl.api.RelationshipVisitor;
+import org.neo4j.kernel.impl.api.store.RelationshipIterator;
+import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
+import org.neo4j.storageengine.api.txstate.TxStateVisitor;
+import org.neo4j.test.rule.DatabaseRule;
+import org.neo4j.test.rule.EmbeddedDatabaseRule;
+import org.neo4j.unsafe.impl.internal.dragons.FeatureToggles;
+
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.neo4j.collection.primitive.PrimitiveLongCollections.iterator;
+
+public class CombinedTxStateIT
+{
+
+    @Rule
+    public DatabaseRule databaseRule = new EmbeddedDatabaseRule();
+
+    @Before
+    public void setUp() throws Exception
+    {
+        FeatureToggles.set( TransactionStatesContainer.class, "multiState", true );
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        FeatureToggles.clear( TransactionStatesContainer.class, "multiState" );
+    }
+
+    @Test
+    public void combinedStateHasChangesWhenStableIsModified()
+    {
+        try ( Transaction ignored = databaseRule.beginTx() )
+        {
+            databaseRule.createNode();
+            TransactionStateController stateController = txStateController();
+            stateController.split();
+            TransactionState transactionState = getTransactionState();
+
+            assertCombinedTxState( transactionState );
+            assertTrue( transactionState.hasDataChanges() );
+            assertTrue( transactionState.hasChanges() );
+
+            stateController.combine();
+        }
+    }
+
+    @Test
+    public void combinedStateHasChangesWhenStableIsNotModified()
+    {
+        try ( Transaction ignored = databaseRule.beginTx() )
+        {
+            TransactionStateController stateController = txStateController();
+            stateController.split();
+            databaseRule.createNode();
+            TransactionState transactionState = getTransactionState();
+
+            assertCombinedTxState( transactionState );
+            assertTrue( transactionState.hasDataChanges() );
+            assertTrue( transactionState.hasChanges() );
+
+            stateController.combine();
+        }
+    }
+
+    @Test( expected = UnsupportedOperationException.class )
+    public void combinedStateVisitingIsNotSupported()
+            throws ConstraintValidationException, CreateConstraintFailureException
+    {
+        try ( Transaction ignored = databaseRule.beginTx() )
+        {
+            TransactionStateController stateController = txStateController();
+            stateController.split();
+            databaseRule.createNode();
+            TransactionState transactionState = getTransactionState();
+            transactionState.accept( new TxStateVisitor.Adapter() );
+        }
+    }
+
+    private TransactionState getTransactionState()
+    {
+        KernelTransactionImplementation kernelTransaction = kernelTransaction();
+        return kernelTransaction.txState();
+    }
+
+    @Test( expected = UnsupportedOperationException.class )
+    public void combinedStateRelationshipVisitingIsNotSupported()
+    {
+        try ( Transaction ignored = databaseRule.beginTx() )
+        {
+            TransactionStateController stateController = txStateController();
+            stateController.split();
+            databaseRule.createNode();
+            TransactionState transactionState = getTransactionState();
+            transactionState.relationshipVisit( 1, new RelationshipDataExtractor() );
+        }
+    }
+
+    @Test
+    public void augmentAllRelationshipsFromStableAndNewStateOnRead()
+    {
+        RelationshipType relationshipType = RelationshipType.withName( "any" );
+        try ( Transaction ignored = databaseRule.beginTx() )
+        {
+            TransactionStateController stateController = txStateController();
+            Node node1Before = databaseRule.createNode();
+            Node node2Before = databaseRule.createNode();
+            long relationshipIdBeforeSplit = node1Before.createRelationshipTo( node2Before, relationshipType ).getId();
+
+            stateController.split();
+
+            Node node1After = databaseRule.createNode();
+            Node node2After = databaseRule.createNode();
+            long relationshipIdAfterSplit = node1After.createRelationshipTo( node2After, relationshipType ).getId();
+
+            TransactionState transactionState = getTransactionState();
+            long augmentedRelationshipId = 12;
+            RelationshipIterator combinedRelationshipIterator =
+                    transactionState.augmentRelationshipsGetAll( new ArrayRelationshipVisitor( new long[]{augmentedRelationshipId} ) );
+            long[] ids = PrimitiveLongCollections.asArray( combinedRelationshipIterator );
+
+            assertEquals( 3, ids.length );
+            assertTrue( ArrayUtils.contains( ids, relationshipIdBeforeSplit ) );
+            assertTrue( ArrayUtils.contains( ids, relationshipIdAfterSplit ) );
+            assertTrue( ArrayUtils.contains( ids, augmentedRelationshipId ) );
+
+            stateController.combine();
+        }
+    }
+
+    @Test
+    public void augmentAllNodesFromStableAndNewStateOnRead()
+    {
+        try ( Transaction ignored = databaseRule.beginTx() )
+        {
+            TransactionStateController stateController = txStateController();
+            Node node1Before = databaseRule.createNode();
+            Node node2Before = databaseRule.createNode();
+            Node node3Before = databaseRule.createNode();
+            stateController.split();
+
+            Node node1After = databaseRule.createNode();
+            Node node2After = databaseRule.createNode();
+
+            TransactionState transactionState = getTransactionState();
+            long augmentedNodeId = 12;
+            PrimitiveLongResourceIterator nodesGetAll = transactionState.augmentNodesGetAll( iterator( augmentedNodeId ) );
+            long[] ids = PrimitiveLongCollections.asArray( nodesGetAll );
+
+            assertEquals( 6, ids.length );
+            assertTrue( ArrayUtils.contains( ids, augmentedNodeId ) );
+            assertTrue( ArrayUtils.contains( ids, node1Before.getId() ) );
+            assertTrue( ArrayUtils.contains( ids, node2Before.getId() ) );
+            assertTrue( ArrayUtils.contains( ids, node3Before.getId() ) );
+            assertTrue( ArrayUtils.contains( ids, node1After.getId() ) );
+            assertTrue( ArrayUtils.contains( ids, node2After.getId() ) );
+
+            stateController.combine();
+        }
+    }
+
+    private void assertCombinedTxState( TransactionState transactionState )
+    {
+        assertThat( transactionState, instanceOf( CombinedTxState.class ) );
+    }
+
+    private TransactionStateController txStateController()
+    {
+        KernelStatement statement = getKernelStatement();
+        return statement.transactionStateController();
+    }
+
+    private KernelTransactionImplementation kernelTransaction()
+    {
+        KernelStatement statement = getKernelStatement();
+        return statement.getTransaction();
+    }
+
+    private KernelStatement getKernelStatement()
+    {
+        DependencyResolver dependencyResolver = databaseRule.getDependencyResolver();
+        return (KernelStatement) dependencyResolver.resolveDependency( ThreadToStatementContextBridge.class ).get();
+    }
+
+    private static class ArrayRelationshipVisitor extends RelationshipIterator.BaseIterator
+    {
+        private final long[] ids;
+        private int position;
+
+        ArrayRelationshipVisitor( long[] ids )
+        {
+            this.ids = ids;
+        }
+
+        @Override
+        protected boolean fetchNext()
+        {
+            return ids.length > position && next( ids[position++] );
+        }
+
+        @Override
+        public <EXCEPTION extends Exception> boolean relationshipVisit( long relationshipId,
+                RelationshipVisitor<EXCEPTION> visitor ) throws EXCEPTION
+        {
+            visitor.visit( relationshipId, 1, 1L, 1L );
+            return false;
+        }
+    }
+}

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/OperationsLockTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/OperationsLockTest.java
@@ -81,6 +81,7 @@ public class OperationsLockTest
     private PropertyCursor propertyCursor;
     private TransactionState txState;
     private AllStoreHolder allStoreHolder;
+    private StableStoreHolder stableStoreHolder;
     private final LabelSchemaDescriptor descriptor = SchemaDescriptorFactory.forLabel( 123, 456 );
     private StoreReadLayer storeReadLayer;
 
@@ -109,7 +110,9 @@ public class OperationsLockTest
         when( engine.storeReadLayer() ).thenReturn( storeReadLayer );
         allStoreHolder = new AllStoreHolder( engine, storageStatement,  transaction, cursors, mock(
                 ExplicitIndexStore.class ) );
-        operations = new Operations( allStoreHolder, mock( IndexTxStateUpdater.class ),
+        stableStoreHolder = new StableStoreHolder( engine, storageStatement,  transaction, cursors, mock(
+                ExplicitIndexStore.class ) );
+        operations = new Operations( allStoreHolder, stableStoreHolder, mock( IndexTxStateUpdater.class ),
                 storageStatement, transaction, cursors, autoindexing,
                 mock( NodeSchemaMatcher.class ) );
         operations.initialize();

--- a/community/neo4j/src/test/java/query/CypherIterationIT.java
+++ b/community/neo4j/src/test/java/query/CypherIterationIT.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package query;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.helpers.collection.Iterators;
+import org.neo4j.kernel.impl.api.state.TransactionStatesContainer;
+import org.neo4j.test.rule.DatabaseRule;
+import org.neo4j.test.rule.EmbeddedDatabaseRule;
+import org.neo4j.unsafe.impl.internal.dragons.FeatureToggles;
+
+import static org.junit.Assert.assertEquals;
+
+public class CypherIterationIT
+{
+    @Rule
+    public final DatabaseRule database = new EmbeddedDatabaseRule();
+    private final int NODES = 500_0;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        FeatureToggles.set( TransactionStatesContainer.class, "multiState", true );
+    }
+
+    @After
+    public void tearDown() throws Exception
+    {
+        FeatureToggles.clear( TransactionStatesContainer.class, "multiState" );
+    }
+
+    @Test
+    public void createEmptyNodeFromMatchAll()
+    {
+        createFiveNodes();
+
+        try ( Transaction transaction = database.beginTx() )
+        {
+            database.execute( "MATCH(n) CREATE()" );
+            transaction.success();
+        }
+
+        countNodes( 2 * NODES );
+    }
+
+    @Test
+    public void createLabeledNodesFromMatchAll()
+    {
+        createFiveNodes();
+
+        try ( Transaction transaction = database.beginTx() )
+        {
+            database.execute( "MATCH(n) CREATE(m:HUMAN:OPERATOR)" );
+            transaction.success();
+        }
+
+        countNodes( 2 * NODES );
+        countNodesWithLabel( Label.label( "HUMAN" ), NODES );
+        countNodesWithLabel( Label.label( "OPERATOR" ), NODES );
+    }
+
+    @Test
+    public void createNodesWithPropertisFromMatchAll()
+    {
+        createFiveNodes();
+
+        try ( Transaction transaction = database.beginTx() )
+        {
+            database.execute( "MATCH(n) CREATE(m:ROBOT {name: 'Bender'})" );
+            transaction.success();
+        }
+
+        countNodes( 2 * NODES );
+        countNodesWithLabelAndPropertyValue( Label.label( "ROBOT" ), "name", "Bender", NODES );
+    }
+
+    private void createFiveNodes()
+    {
+        int step = 1000;
+        for ( int created = 0; created < NODES; created += step )
+        {
+            try ( Transaction transaction = database.beginTx() )
+            {
+                for ( int j = 0; j < step; j++ )
+                {
+                    database.createNode();
+                }
+                transaction.success();
+            }
+        }
+    }
+
+    private void countNodes( int expectedNodes )
+    {
+        try ( Transaction transaction = database.beginTx() )
+        {
+            assertEquals( expectedNodes, Iterables.count( database.getAllNodes() ) );
+            transaction.success();
+        }
+    }
+
+    private void countNodesWithLabel( Label label, int expectedNodes )
+    {
+        try ( Transaction transaction = database.beginTx() )
+        {
+            assertEquals( expectedNodes, Iterators.count( database.findNodes( label ) ) );
+            transaction.success();
+        }
+    }
+
+    private void countNodesWithLabelAndPropertyValue( Label label, String propertyName, Object propertyValue, int expectedNodes )
+    {
+        try ( Transaction transaction = database.beginTx() )
+        {
+            assertEquals( expectedNodes, Iterators.count( database.findNodes( label, propertyName, propertyValue ) ) );
+            transaction.success();
+        }
+    }
+}

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/CombinePrimitiveLongSet.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/CombinePrimitiveLongSet.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.collection.primitive;
+
+public class CombinePrimitiveLongSet implements PrimitiveLongSet
+{
+    private final PrimitiveLongSet setA;
+    private final PrimitiveLongSet setB;
+
+    public CombinePrimitiveLongSet( PrimitiveLongSet setA, PrimitiveLongSet setB )
+    {
+        this.setA = setA;
+        this.setB = setB;
+    }
+
+    @Override
+    public boolean add( long value )
+    {
+        throw new UnsupportedOperationException( "Modification is not supported in " + getClass() );
+    }
+
+    @Override
+    public boolean addAll( PrimitiveLongIterator values )
+    {
+        throw new UnsupportedOperationException( "Modification is not supported in " + getClass() );
+    }
+
+    @Override
+    public boolean contains( long value )
+    {
+        return setA.contains( value ) || setB.contains( value );
+    }
+
+    @Override
+    public boolean remove( long value )
+    {
+        throw new UnsupportedOperationException( "Modification is not supported in " + getClass() );
+    }
+
+    @Override
+    public boolean test( long value )
+    {
+        return setA.test( value ) || setB.test( value );
+    }
+
+    @Override
+    public <E extends Exception> void visitKeys( PrimitiveLongVisitor<E> visitor ) throws E
+    {
+
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return setA.isEmpty() && setB.isEmpty();
+    }
+
+    @Override
+    public void clear()
+    {
+        throw new UnsupportedOperationException( "Modification is not supported in " + getClass() );
+    }
+
+    @Override
+    public int size()
+    {
+        return setA.size() + setB.size();
+    }
+
+    @Override
+    public void close()
+    {
+
+    }
+
+    @Override
+    public PrimitiveLongIterator iterator()
+    {
+        return PrimitiveLongCollections.concat( setA.iterator(), setB.iterator() );
+    }
+}

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/StubKernelTransaction.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/StubKernelTransaction.java
@@ -69,6 +69,12 @@ class StubKernelTransaction implements KernelTransaction
     }
 
     @Override
+    public Read stableDataRead()
+    {
+        return null;
+    }
+
+    @Override
     public Write dataWrite()
     {
         return null;

--- a/enterprise/kernel/src/test/scala/org/neo4j/internal/cypher/acceptance/PropertyExistenceConstraintAcceptanceTest.scala
+++ b/enterprise/kernel/src/test/scala/org/neo4j/internal/cypher/acceptance/PropertyExistenceConstraintAcceptanceTest.scala
@@ -19,14 +19,9 @@
  */
 package org.neo4j.internal.cypher.acceptance
 
-import java.io.File
-
 import org.neo4j.cypher._
 import org.neo4j.cypher.internal.compiler.v3_4.helpers.ListSupport
-import org.neo4j.graphdb.Transaction
-import org.neo4j.graphdb.factory.GraphDatabaseFactory
 import org.neo4j.kernel.api.exceptions.Status
-import org.neo4j.test.TestEnterpriseGraphDatabaseFactory
 
 
 class PropertyExistenceConstraintAcceptanceTest


### PR DESCRIPTION
Introduce possibility to split transactions state into multiple
to allow stable view of the state in some moment of a transaction lifespan.
Introduce version of Read API that performs read over stable version.
Introduce API to control split/combine of transaction state.
Ability to create composable states is disabled by default
and can be allowed by TransactionStatesContainer multiState feature flag.