### PR TITLE
Fix bugs with nested pattern comprehensions

### DIFF
--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ExecutionContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ExecutionContext.scala
@@ -156,15 +156,15 @@ case class MapExecutionContext(m: MutableMap[String, AnyValue])
   }
 
   override def boundEntities(materializeNode: Long => AnyValue, materializeRelationship: Long => AnyValue): Map[String, AnyValue] =
-    collect {
-      case kv: (String, NodeValue) =>
-        kv
-      case kv: (String, RelationshipValue) =>
-        kv
-      case (k: String, v: NodeReference) =>
-        (k, materializeNode(v.id()))
-      case (k: String, v: RelationshipReference) =>
-        (k, materializeRelationship(v.id()))
+    m.collect {
+      case kv => kv._2 match {
+        case _: NodeValue | _: RelationshipValue =>
+          kv
+        case v: NodeReference =>
+          (kv._1, materializeNode(v.id()))
+        case v: RelationshipReference =>
+          (kv._1, materializeRelationship(v.id()))
+      }
     }.toMap
 
   override def isNull(key: String): Boolean =

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ExecutionContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ExecutionContext.scala
@@ -21,6 +21,7 @@ package org.neo4j.cypher.internal.runtime.interpreted
 
 import org.neo4j.cypher.internal.util.v3_4.InternalException
 import org.neo4j.values.AnyValue
+import org.neo4j.values.storable.Values
 import org.neo4j.values.virtual._
 
 import scala.collection.mutable.{Map => MutableMap}
@@ -60,6 +61,8 @@ trait ExecutionContext extends MutableMap[String, AnyValue] {
   // Needed by legacy pattern matcher. Returns a map of all bound nodes/relationships in the context.
   // Entities that are only references (ids) are materialized with the provided materialization functions
   def boundEntities(materializeNode: Long => AnyValue, materializeRelationship: Long => AnyValue): Map[String, AnyValue]
+
+  def isNull(key: String): Boolean
 }
 
 case class MapExecutionContext(m: MutableMap[String, AnyValue])
@@ -163,4 +166,10 @@ case class MapExecutionContext(m: MutableMap[String, AnyValue])
       case (k: String, v: RelationshipReference) =>
         (k, materializeRelationship(v.id()))
     }.toMap
+
+  override def isNull(key: String): Boolean =
+    get(key) match {
+      case Some(Values.NO_VALUE) => true
+      case _ => false
+    }
 }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/PathExpression.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/PathExpression.scala
@@ -53,12 +53,7 @@ case class PathExpression(pathPattern: Seq[Pattern], predicate: Predicate,
 
   override def apply(ctx: ExecutionContext, state: QueryState): AnyValue = {
     // If any of the points we need is null, the whole expression will return null
-    val returnNull = interestingPoints.exists(key => ctx.get(key) match {
-      case Some(Values.NO_VALUE) => true
-      case None if !allowIntroducingNewIdentifiers =>
-        throw new AssertionError("This execution plan should not exist.")
-      case _ => false
-    })
+    val returnNull = interestingPoints.exists(key => ctx.isNull(key))
 
     if (returnNull) {
       Values.NO_VALUE

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/PatternMatchingBuilder.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/matching/PatternMatchingBuilder.scala
@@ -24,7 +24,7 @@ import org.neo4j.cypher.internal.runtime.interpreted.commands.predicates.Predica
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.QueryState
 import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection
 import org.neo4j.values.AnyValue
-import org.neo4j.values.virtual.{RelationshipValue, NodeValue}
+import org.neo4j.values.virtual.{NodeValue, RelationshipValue}
 
 import scala.collection.Map
 
@@ -32,7 +32,8 @@ class PatternMatchingBuilder(patternGraph: PatternGraph,
                              predicates: Seq[Predicate],
                              variablesInClause: Set[String]) extends MatcherBuilder {
   def getMatches(sourceRow: ExecutionContext, state:QueryState): Traversable[ExecutionContext] = {
-    val bindings: Map[String, AnyValue] = sourceRow.filter(s => s._2.isInstanceOf[NodeValue] || s._2.isInstanceOf[RelationshipValue])
+    val bindings: Map[String, AnyValue] =
+      sourceRow.boundEntities(state.query.nodeOps.getById, state.query.relationshipOps.getById)
     val boundPairs: Map[String, Set[MatchingPair]] = extractBoundMatchingPairs(bindings)
 
     val undirectedBoundRelationships: Iterable[PatternRelationship] = bindings.keys.

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
@@ -45,6 +45,9 @@ Explanation of   in-query procedure call
 Pattern expression inside list comprehension
 Get node degree via length of pattern expression
 Get node degree via length of pattern expression that specifies a relationship type
+Nested pattern comprehensions
+Nested pattern comprehensions 2
+Nested pattern comprehensions 3
 
 //OrderByAcceptance.feature - Unsupported orderability
 ORDER BY nodes should return null results last in ascending order

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -74,6 +74,9 @@ Using `length()` on undirected pattern expression
 Using `length()` on pattern expression with complex relationship predicate
 Returning pattern expression in `exists()`
 Pattern expression inside list comprehension
+Nested pattern comprehensions
+Nested pattern comprehensions 2
+Nested pattern comprehensions 3
 Get node degree via length of pattern expression
 Get node degree via length of pattern expression that specifies a relationship type
 Get node degree via length of pattern expression that specifies multiple relationship types

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
@@ -64,7 +64,7 @@ class PatternComprehensionAcceptanceTest extends ExecutionEngineFunSuite with Cy
         | ][0..5] AS related
       """.stripMargin
 
-    val result = executeWith(expectedToSucceedRestricted - Configs.SlottedInterpreted, query)
+    val result = executeWith(expectedToSucceedRestricted, query)
     result.toList should equal(
       List(Map("related" -> List(Map("tagged" -> Vector(Map("owner" -> Map("name" -> "Michael Hunger"))))))))
   }

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/MorselExecutionContext.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/MorselExecutionContext.scala
@@ -72,4 +72,6 @@ class MorselExecutionContext(morsel: Morsel, longsPerRow: Int, refsPerRow: Int, 
   override def copyWith(key1: String, value1: AnyValue, key2: String, value2: AnyValue, key3: String, value3: AnyValue): ExecutionContext = ???
 
   override def copyWith(newEntries: Seq[(String, AnyValue)]): ExecutionContext = ???
+
+  override def boundEntities(materializeNode: Long => AnyValue, materializeRelationship: Long => AnyValue): Map[String, AnyValue] = ???
 }

--- a/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/MorselExecutionContext.scala
+++ b/enterprise/cypher/morsel-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/vectorized/MorselExecutionContext.scala
@@ -74,4 +74,6 @@ class MorselExecutionContext(morsel: Morsel, longsPerRow: Int, refsPerRow: Int, 
   override def copyWith(newEntries: Seq[(String, AnyValue)]): ExecutionContext = ???
 
   override def boundEntities(materializeNode: Long => AnyValue, materializeRelationship: Long => AnyValue): Map[String, AnyValue] = ???
+
+  override def isNull(key: String): Boolean = ???
 }

--- a/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
+++ b/enterprise/cypher/physical-planning/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/SlotAllocation.scala
@@ -575,19 +575,6 @@ object SlotAllocation {
         }
         slotConfig
 
-      case OuterHashJoin(nodes, _, _) =>
-        // A new pipeline is not strictly needed here unless we have batching/vectorization
-        recordArgument(lp)
-        val result = lhs.copy()
-        rhs.foreachSlotOrdered {
-          case (k, slot) if !nodes(k) =>
-            result.add(k, slot)
-          // If the column is one of the join columns there is no need to add it again
-
-          case _ =>
-        }
-        result
-
       case RollUpApply(_, _, collectionName, _, _) =>
         lhs.newReference(collectionName, nullable, CTList(CTAny))
         lhs

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedExecutionContext.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedExecutionContext.scala
@@ -329,4 +329,16 @@ case class SlottedExecutionContext(slots: SlotConfiguration) extends ExecutionCo
     }
     entities.toMap
   }
+
+  override def isNull(key: String): Boolean =
+    slots.get(key) match {
+      case Some(RefSlot(offset, true, _)) if isRefInitialized(offset) =>
+        getRefAtWithoutCheckingInitialized(offset) == Values.NO_VALUE
+      case Some(LongSlot(offset, true, CTNode)) =>
+        entityIsNull(getLongAt(offset))
+      case Some(LongSlot(offset, true, CTRelationship)) =>
+        entityIsNull(getLongAt(offset))
+      case _ =>
+        false
+    }
 }


### PR DESCRIPTION
- The legacy pattern matcher relied on determining bound entities at
runtime by inspecting the execution context in a way not compatible
with SlottedExecutionContext. This introduces a new method
`boundEntities` on ExecutionContext, with an
implementation that also works for SlottedExecutionContext.

- We now also do slot allocation for the projection expression in
a NestedPlanExpression, since it can contain more nested
plan expressions.