### PR TITLE
remove initial heapsize settings for neo4j scripts

### DIFF
--- a/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
+++ b/community/command-line/src/main/java/org/neo4j/commandline/admin/Usage.java
@@ -67,7 +67,7 @@ public class Usage
         output.accept( "    NEO4J_CONF    Path to directory which contains neo4j.conf." );
         output.accept( "    NEO4J_DEBUG   Set to anything to enable debug output." );
         output.accept( "    NEO4J_HOME    Neo4j home directory." );
-        output.accept( "    HEAP_SIZE     Set size of JVM heap during command execution." );
+        output.accept( "    HEAP_SIZE     Set JVM maximum heap size during command execution." );
         output.accept( "                  Takes a number and a unit, for example 512m." );
         output.accept( "" );
     }

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/HelpCommandTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/HelpCommandTest.java
@@ -124,7 +124,7 @@ public class HelpCommandTest
                             "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
                             "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
                             "    NEO4J_HOME    Neo4j home directory.%n" +
-                            "    HEAP_SIZE     Set size of JVM heap during command execution.%n" +
+                            "    HEAP_SIZE     Set JVM maximum heap size during command execution.%n" +
                             "                  Takes a number and a unit, for example 512m.%n" +
                             "%n" +
                             "available commands:%n" +
@@ -168,7 +168,7 @@ public class HelpCommandTest
                             "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
                             "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
                             "    NEO4J_HOME    Neo4j home directory.%n" +
-                            "    HEAP_SIZE     Set size of JVM heap during command execution.%n" +
+                            "    HEAP_SIZE     Set JVM maximum heap size during command execution.%n" +
                             "                  Takes a number and a unit, for example 512m.%n" +
                             "%n" +
                             "This is a description of the foobar command.%n" +

--- a/community/command-line/src/test/java/org/neo4j/commandline/admin/UsageTest.java
+++ b/community/command-line/src/test/java/org/neo4j/commandline/admin/UsageTest.java
@@ -65,6 +65,8 @@ public class UsageTest
         ordered.verify( out ).accept( "    NEO4J_CONF    Path to directory which contains neo4j.conf." );
         ordered.verify( out ).accept( "    NEO4J_DEBUG   Set to anything to enable debug output." );
         ordered.verify( out ).accept( "    NEO4J_HOME    Neo4j home directory." );
+        ordered.verify( out ).accept( "    HEAP_SIZE     Set JVM maximum heap size during command execution." );
+        ordered.verify( out ).accept( "                  Takes a number and a unit, for example 512m." );
         ordered.verify( out ).accept( "" );
         ordered.verify( out ).accept( "description" );
     }
@@ -87,6 +89,8 @@ public class UsageTest
         ordered.verify( out ).accept( "    NEO4J_CONF    Path to directory which contains neo4j.conf." );
         ordered.verify( out ).accept( "    NEO4J_DEBUG   Set to anything to enable debug output." );
         ordered.verify( out ).accept( "    NEO4J_HOME    Neo4j home directory." );
+        ordered.verify( out ).accept( "    HEAP_SIZE     Set JVM maximum heap size during command execution." );
+        ordered.verify( out ).accept( "                  Takes a number and a unit, for example 512m." );
         ordered.verify( out ).accept( "" );
 
         ordered.verify( out ).accept( "available commands:" );
@@ -117,6 +121,8 @@ public class UsageTest
         ordered.verify( out ).accept( "    NEO4J_CONF    Path to directory which contains neo4j.conf." );
         ordered.verify( out ).accept( "    NEO4J_DEBUG   Set to anything to enable debug output." );
         ordered.verify( out ).accept( "    NEO4J_HOME    Neo4j home directory." );
+        ordered.verify( out ).accept( "    HEAP_SIZE     Set JVM maximum heap size during command execution." );
+        ordered.verify( out ).accept( "                  Takes a number and a unit, for example 512m." );
         ordered.verify( out ).accept( "" );
 
         ordered.verify( out ).accept( "available commands:" );

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/CheckConsistencyCommandTest.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/CheckConsistencyCommandTest.java
@@ -335,7 +335,7 @@ public class CheckConsistencyCommandTest
                             "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
                             "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
                             "    NEO4J_HOME    Neo4j home directory.%n" +
-                            "    HEAP_SIZE     Set size of JVM heap during command execution.%n" +
+                            "    HEAP_SIZE     Set JVM maximum heap size during command execution.%n" +
                             "                  Takes a number and a unit, for example 512m.%n" +
                             "%n" +
                             "This command allows for checking the consistency of a database or a backup%n" +

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/DumpCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/DumpCommandTest.java
@@ -362,7 +362,7 @@ public class DumpCommandTest
                             "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
                             "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
                             "    NEO4J_HOME    Neo4j home directory.%n" +
-                            "    HEAP_SIZE     Set size of JVM heap during command execution.%n" +
+                            "    HEAP_SIZE     Set JVM maximum heap size during command execution.%n" +
                             "                  Takes a number and a unit, for example 512m.%n" +
                             "%n" +
                             "Dump a database into a single-file archive. The archive can be used by the load%n" +

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/ImportCommandTest.java
@@ -221,7 +221,7 @@ public class ImportCommandTest
                             "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
                             "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
                             "    NEO4J_HOME    Neo4j home directory.%n" +
-                            "    HEAP_SIZE     Set size of JVM heap during command execution.%n" +
+                            "    HEAP_SIZE     Set JVM maximum heap size during command execution.%n" +
                             "                  Takes a number and a unit, for example 512m.%n" +
                             "%n" +
                             "Import a collection of CSV files with --mode=csv (default), or a database from a%n" +

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/LoadCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/LoadCommandTest.java
@@ -313,7 +313,7 @@ public class LoadCommandTest
                             "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
                             "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
                             "    NEO4J_HOME    Neo4j home directory.%n" +
-                            "    HEAP_SIZE     Set size of JVM heap during command execution.%n" +
+                            "    HEAP_SIZE     Set JVM maximum heap size during command execution.%n" +
                             "                  Takes a number and a unit, for example 512m.%n" +
                             "%n" +
                             "Load a database from an archive. <archive-path> must be an archive created with%n" +

--- a/community/dbms/src/test/java/org/neo4j/commandline/dbms/StoreInfoCommandTest.java
+++ b/community/dbms/src/test/java/org/neo4j/commandline/dbms/StoreInfoCommandTest.java
@@ -94,7 +94,7 @@ public class StoreInfoCommandTest
                             "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
                             "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
                             "    NEO4J_HOME    Neo4j home directory.%n" +
-                            "    HEAP_SIZE     Set size of JVM heap during command execution.%n" +
+                            "    HEAP_SIZE     Set JVM maximum heap size during command execution.%n" +
                             "                  Takes a number and a unit, for example 512m.%n" +
                             "%n" +
                             "Prints information about a Neo4j database store, such as what version of Neo4j%n" +

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandIT.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandIT.java
@@ -140,7 +140,7 @@ public class SetDefaultAdminCommandIT
         verify( out ).stdErrLine( String.format( "    NEO4J_CONF    Path to directory which contains neo4j.conf." ) );
         verify( out ).stdErrLine( String.format( "    NEO4J_DEBUG   Set to anything to enable debug output." ) );
         verify( out ).stdErrLine( String.format( "    NEO4J_HOME    Neo4j home directory." ) );
-        verify( out ).stdErrLine( String.format( "    HEAP_SIZE     Set size of JVM heap during command execution." ) );
+        verify( out ).stdErrLine( String.format( "    HEAP_SIZE     Set JVM maximum heap size during command execution." ) );
         verify( out ).stdErrLine( String.format( "                  Takes a number and a unit, for example 512m." ) );
         verify( out ).stdErrLine(
                 String.format( "Sets the user to become admin if users but no roles are present, for example%n" +
@@ -164,7 +164,7 @@ public class SetDefaultAdminCommandIT
         verify( out ).stdErrLine( String.format( "    NEO4J_CONF    Path to directory which contains neo4j.conf." ) );
         verify( out ).stdErrLine( String.format( "    NEO4J_DEBUG   Set to anything to enable debug output." ) );
         verify( out ).stdErrLine( String.format( "    NEO4J_HOME    Neo4j home directory." ) );
-        verify( out ).stdErrLine( String.format( "    HEAP_SIZE     Set size of JVM heap during command execution." ) );
+        verify( out ).stdErrLine( String.format( "    HEAP_SIZE     Set JVM maximum heap size during command execution." ) );
         verify( out ).stdErrLine( String.format( "                  Takes a number and a unit, for example 512m." ) );
         verify( out ).stdErrLine(
                 String.format( "Sets the user to become admin if users but no roles are present, for example%n" +

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetDefaultAdminCommandTest.java
@@ -141,7 +141,7 @@ public class SetDefaultAdminCommandTest
                             "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
                             "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
                             "    NEO4J_HOME    Neo4j home directory.%n" +
-                            "    HEAP_SIZE     Set size of JVM heap during command execution.%n" +
+                            "    HEAP_SIZE     Set JVM maximum heap size during command execution.%n" +
                             "                  Takes a number and a unit, for example 512m.%n" +
                             "%n" +
                             "Sets the user to become admin if users but no roles are present, for example%n" +

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandIT.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandIT.java
@@ -118,7 +118,7 @@ public class SetInitialPasswordCommandIT
         verify( out ).stdErrLine( String.format( "    NEO4J_CONF    Path to directory which contains neo4j.conf." ) );
         verify( out ).stdErrLine( String.format( "    NEO4J_DEBUG   Set to anything to enable debug output." ) );
         verify( out ).stdErrLine( String.format( "    NEO4J_HOME    Neo4j home directory." ) );
-        verify( out ).stdErrLine( String.format( "    HEAP_SIZE     Set size of JVM heap during command execution." ) );
+        verify( out ).stdErrLine( String.format( "    HEAP_SIZE     Set JVM maximum heap size during command execution." ) );
         verify( out ).stdErrLine( String.format( "                  Takes a number and a unit, for example 512m." ) );
         verify( out ).stdErrLine( "Sets the initial password of the initial admin user ('neo4j')." );
         verify( out ).exit( 1 );
@@ -139,7 +139,7 @@ public class SetInitialPasswordCommandIT
         verify( out ).stdErrLine( String.format( "    NEO4J_CONF    Path to directory which contains neo4j.conf." ) );
         verify( out ).stdErrLine( String.format( "    NEO4J_DEBUG   Set to anything to enable debug output." ) );
         verify( out ).stdErrLine( String.format( "    NEO4J_HOME    Neo4j home directory." ) );
-        verify( out ).stdErrLine( String.format( "    HEAP_SIZE     Set size of JVM heap during command execution." ) );
+        verify( out ).stdErrLine( String.format( "    HEAP_SIZE     Set JVM maximum heap size during command execution." ) );
         verify( out ).stdErrLine( String.format( "                  Takes a number and a unit, for example 512m." ) );
 
         verify( out ).stdErrLine( "Sets the initial password of the initial admin user ('neo4j')." );

--- a/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandTest.java
+++ b/community/security/src/test/java/org/neo4j/commandline/admin/security/SetInitialPasswordCommandTest.java
@@ -143,7 +143,7 @@ public class SetInitialPasswordCommandTest
                             "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
                             "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
                             "    NEO4J_HOME    Neo4j home directory.%n" +
-                            "    HEAP_SIZE     Set size of JVM heap during command execution.%n" +
+                            "    HEAP_SIZE     Set JVM maximum heap size during command execution.%n" +
                             "                  Takes a number and a unit, for example 512m.%n" +
                             "%n" +
                             "Sets the initial password of the initial admin user ('neo4j').%n" ),

--- a/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/OnlineBackupCommandTest.java
@@ -630,7 +630,7 @@ public class OnlineBackupCommandTest
                             "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
                             "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
                             "    NEO4J_HOME    Neo4j home directory.%n" +
-                            "    HEAP_SIZE     Set size of JVM heap during command execution.%n" +
+                            "    HEAP_SIZE     Set JVM maximum heap size during command execution.%n" +
                             "                  Takes a number and a unit, for example 512m.%n" +
                             "%n" +
                             "Perform an online backup from a running Neo4j enterprise server. Neo4j's backup%n" +

--- a/enterprise/backup/src/test/java/org/neo4j/restore/RestoreDatabaseCommandIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/restore/RestoreDatabaseCommandIT.java
@@ -211,7 +211,7 @@ public class RestoreDatabaseCommandIT
                             "    NEO4J_CONF    Path to directory which contains neo4j.conf.%n" +
                             "    NEO4J_DEBUG   Set to anything to enable debug output.%n" +
                             "    NEO4J_HOME    Neo4j home directory.%n" +
-                            "    HEAP_SIZE     Set size of JVM heap during command execution.%n" +
+                            "    HEAP_SIZE     Set JVM maximum heap size during command execution.%n" +
                             "                  Takes a number and a unit, for example 512m.%n" +
                             "%n" +
                             "Restore a backed up database.%n" +

--- a/integrationtests/src/test/java/org/neo4j/commandline/admin/Neo4jAdminUsageTest.java
+++ b/integrationtests/src/test/java/org/neo4j/commandline/admin/Neo4jAdminUsageTest.java
@@ -48,7 +48,7 @@ public class Neo4jAdminUsageTest
                         "    NEO4J_CONF    Path to directory which contains neo4j.conf.\n" +
                         "    NEO4J_DEBUG   Set to anything to enable debug output.\n" +
                         "    NEO4J_HOME    Neo4j home directory.\n" +
-                        "    HEAP_SIZE     Set size of JVM heap during command execution.\n" +
+                        "    HEAP_SIZE     Set JVM maximum heap size during command execution.\n" +
                         "                  Takes a number and a unit, for example 512m.\n" +
                         "\n" +
                         "available commands:\n" +

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j
@@ -52,7 +52,6 @@ setup_heap() {
   JAVA_MEMORY_OPTS=()
   if [[ -n "${HEAP_SIZE:-}" ]]; then
     JAVA_MEMORY_OPTS+=("-Xmx${HEAP_SIZE}")
-    JAVA_MEMORY_OPTS+=("-Xms${HEAP_SIZE}")
   fi
 }
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-admin
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-admin
@@ -28,7 +28,6 @@ setup_heap() {
   JAVA_MEMORY_OPTS=()
   if [[ -n "${HEAP_SIZE:-}" ]]; then
     JAVA_MEMORY_OPTS+=("-Xmx${HEAP_SIZE}")
-    JAVA_MEMORY_OPTS+=("-Xms${HEAP_SIZE}")
   fi
 }
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-backup
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-backup
@@ -28,7 +28,6 @@ setup_heap() {
   JAVA_MEMORY_OPTS=()
   if [[ -n "${HEAP_SIZE:-}" ]]; then
     JAVA_MEMORY_OPTS+=("-Xmx${HEAP_SIZE}")
-    JAVA_MEMORY_OPTS+=("-Xms${HEAP_SIZE}")
   fi
 }
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-import
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-import
@@ -28,7 +28,6 @@ setup_heap() {
   JAVA_MEMORY_OPTS=()
   if [[ -n "${HEAP_SIZE:-}" ]]; then
     JAVA_MEMORY_OPTS+=("-Xmx${HEAP_SIZE}")
-    JAVA_MEMORY_OPTS+=("-Xms${HEAP_SIZE}")
   fi
 }
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shared.m4
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shared.m4
@@ -26,7 +26,6 @@ setup_heap() {
   JAVA_MEMORY_OPTS=()
   if [[ -n "${HEAP_SIZE:-}" ]]; then
     JAVA_MEMORY_OPTS+=("-Xmx${HEAP_SIZE}")
-    JAVA_MEMORY_OPTS+=("-Xms${HEAP_SIZE}")
   fi
 }
 

--- a/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shell
+++ b/packaging/standalone/src/main/distribution/shell-scripts/bin/neo4j-shell
@@ -28,7 +28,6 @@ setup_heap() {
   JAVA_MEMORY_OPTS=()
   if [[ -n "${HEAP_SIZE:-}" ]]; then
     JAVA_MEMORY_OPTS+=("-Xmx${HEAP_SIZE}")
-    JAVA_MEMORY_OPTS+=("-Xms${HEAP_SIZE}")
   fi
 }
 


### PR DESCRIPTION
Remove setting initial heapsize using HEAP_SIZE environment variable.
Note: It does **not** affect the initial heapsize set by neo4j config during neo4j startup.