### PR TITLE
PageCursor shiftBytes

### DIFF
--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/PageAwareByteArrayCursor.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/PageAwareByteArrayCursor.java
@@ -27,8 +27,8 @@ import java.util.List;
 import org.neo4j.io.pagecache.CursorException;
 import org.neo4j.io.pagecache.PageCursor;
 
-import static org.neo4j.io.pagecache.ByteArrayPageCursor.wrap;
 import static java.lang.String.format;
+import static org.neo4j.io.pagecache.ByteArrayPageCursor.wrap;
 
 class PageAwareByteArrayCursor extends PageCursor
 {
@@ -139,6 +139,12 @@ class PageAwareByteArrayCursor extends PageCursor
             targetCursor.putByte( targetOffset + i, getByte( sourceOffset + i ) );
         }
         return bytesToCopy;
+    }
+
+    @Override
+    public void shiftBytes( int sourceOffset, int length, int shift )
+    {
+        current.shiftBytes( sourceOffset, length, shift );
     }
 
     private void assertPages()

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageCursor.java
@@ -306,6 +306,19 @@ public abstract class PageCursor implements AutoCloseable
     public abstract int copyTo( int sourceOffset, PageCursor targetCursor, int targetOffset, int lengthInBytes );
 
     /**
+     * Shift the specified number of bytes starting from given offset the specified number of bytes to the left or right. The area
+     * left behind after the shift is not padded and thus is left with garbage.
+     * <p>
+     * Out of bounds flag is raised if either start or end of either source range or target range fall outside end of this cursor
+     * or if length is negative.
+     *
+     * @param sourceOffset The offset into this page to start moving from.
+     * @param length The number of bytes to move.
+     * @param shift How many steps, in terms of number of bytes, to shift. Can be both positive and negative.
+     */
+    public abstract void shiftBytes( int sourceOffset, int length, int shift );
+
+    /**
      * Discern whether an out-of-bounds access has occurred since the last call to {@link #next()} or
      * {@link #next(long)}, or since the last call to {@link #shouldRetry()} that returned {@code true}, or since the
      * last call to this method.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/CompositePageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/CompositePageCursor.java
@@ -451,7 +451,7 @@ public class CompositePageCursor extends PageCursor
     @Override
     public void shiftBytes( int sourceOffset, int length, int shift )
     {
-        throw new UnsupportedOperationException( "Composite cursor does not support copyTo functionality." );
+        throw new UnsupportedOperationException( "Composite cursor does not support shiftBytes functionality... yet." );
     }
 
     @Override

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/CompositePageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/CompositePageCursor.java
@@ -449,6 +449,12 @@ public class CompositePageCursor extends PageCursor
     }
 
     @Override
+    public void shiftBytes( int sourceOffset, int length, int shift )
+    {
+        throw new UnsupportedOperationException( "Composite cursor does not support copyTo functionality." );
+    }
+
+    @Override
     public boolean checkAndClearBoundsFlag()
     {
         boolean bounds = outOfBounds | first.checkAndClearBoundsFlag() | second.checkAndClearBoundsFlag();

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/DelegatingPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/DelegatingPageCursor.java
@@ -45,6 +45,12 @@ public class DelegatingPageCursor extends PageCursor
     }
 
     @Override
+    public void shiftBytes( int sourceOffset, int length, int shift )
+    {
+        delegate.shiftBytes( sourceOffset, length, shift );
+    }
+
+    @Override
     public void putInt( int value )
     {
         delegate.putInt( value );

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnReadPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnReadPageCursor.java
@@ -185,6 +185,12 @@ final class MuninnReadPageCursor extends MuninnPageCursor
     }
 
     @Override
+    public void shiftBytes( int sourceStart, int length, int shift )
+    {
+        throw new IllegalStateException( "Cannot write to read-locked page" );
+    }
+
+    @Override
     public void zapPage()
     {
         throw new IllegalStateException( "Cannot write to read-locked page" );

--- a/community/io/src/test/java/org/neo4j/io/pagecache/ByteArrayPageCursor.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/ByteArrayPageCursor.java
@@ -257,6 +257,18 @@ public class ByteArrayPageCursor extends PageCursor
     }
 
     @Override
+    public void shiftBytes( int sourceOffset, int length, int shift )
+    {
+        int currentOffset = getOffset();
+        setOffset( sourceOffset );
+        byte[] bytes = new byte[length];
+        getBytes( bytes );
+        setOffset( sourceOffset + shift );
+        putBytes( bytes );
+        setOffset( currentOffset );
+    }
+
+    @Override
     public boolean checkAndClearBoundsFlag()
     {
         return false;

--- a/community/io/src/test/java/org/neo4j/io/pagecache/StubPageCursor.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/StubPageCursor.java
@@ -130,6 +130,12 @@ public class StubPageCursor extends PageCursor
     }
 
     @Override
+    public void shiftBytes( int sourceOffset, int length, int shift )
+    {
+        throw new UnsupportedOperationException( "Stub cursor does not support this method... yet" );
+    }
+
+    @Override
     public boolean checkAndClearBoundsFlag()
     {
         boolean overflow = observedOverflow;


### PR DESCRIPTION
An efficient way to shift bytes within one page.

co-author: @chrisvest 