### PR TITLE
Launder clothes, not exceptions

### DIFF
--- a/community/common/src/main/java/org/neo4j/helpers/Exceptions.java
+++ b/community/common/src/main/java/org/neo4j/helpers/Exceptions.java
@@ -25,6 +25,7 @@ import java.lang.Thread.State;
 import java.lang.Thread.UncaughtExceptionHandler;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Objects;
 import java.util.function.Predicate;
 
 import org.neo4j.function.Predicates;
@@ -37,6 +38,89 @@ public class Exceptions
 
     private static final String UNEXPECTED_MESSAGE = "Unexpected Exception";
 
+    private Exceptions()
+    {
+        throw new AssertionError( "No instances" );
+    }
+
+    /**
+     * Rethrows {@code exception} if it is an instance of {@link RuntimeException} or {@link Error}. Typical usage is:
+     *
+     * <pre>
+     * catch (Throwable e) {
+     *   ......common code......
+     *   throwIfUnchecked(e);
+     *   throw new RuntimeException(e);
+     * }
+     * </pre>
+     *
+     * This will only wrap checked exception in a {@code RuntimeException}. Do note that if the segment {@code common code}
+     * is missing, it's preferable to use this instead:
+     *
+     * <pre>
+     * catch (RuntimeException | Error e) {
+     *   throw e;
+     * }
+     * catch (Throwable e) {
+     *   throw new RuntimeException(e);
+     * }
+     * </pre>
+     *
+     * @param exception to rethrow.
+     */
+    public static void throwIfUnchecked( Throwable exception )
+    {
+        Objects.requireNonNull( exception );
+        if ( exception instanceof RuntimeException )
+        {
+            throw (RuntimeException) exception;
+        }
+        if ( exception instanceof Error )
+        {
+            throw (Error) exception;
+        }
+    }
+
+    /**
+     * Will rethrow the provided {@code exception} if it is an instance of {@code clazz}. Typical usage is:
+     *
+     * <pre>
+     * catch (Throwable e) {
+     *   ......common code......
+     *   throwIfInstanceOf(e, BarException.class);
+     *   throw new RuntimeException(e);
+     * }
+     * </pre>
+     *
+     * This will filter out all {@code BarExceptions} and wrap the rest in {@code RuntimeException}. Do note that if the
+     * segment {@code common code} is missing, it's preferable to use this instead:
+     *
+     * <pre>
+     * catch (BarException e) {
+     *   throw e;
+     * } catch (Throwable e) {
+     *   threw new RuntimeException(e);
+     * }
+     * </pre>
+     *
+     * @param exception to rethrow.
+     * @param clazz a {@link Class} instance to check against.
+     * @param <T> type thrown, if thrown at all.
+     * @throws T if {@code exception} is an instance of {@code clazz}.
+     */
+    public static <T extends Throwable> void throwIfInstanceOf( Throwable exception, Class<T> clazz ) throws T
+    {
+        Objects.requireNonNull( exception );
+        if ( clazz.isInstance( exception ) )
+        {
+            throw clazz.cast( exception );
+        }
+    }
+
+    /**
+     * @deprecated Use {@link Throwable#initCause(Throwable)} instead.
+     */
+    @Deprecated
     public static <T extends Throwable> T withCause( T exception, Throwable cause )
     {
         try
@@ -50,6 +134,10 @@ public class Exceptions
         return exception;
     }
 
+    /**
+     * @deprecated Use {@link Throwable#addSuppressed(Throwable)} instead.
+     */
+    @Deprecated
     public static <T extends Throwable> T withSuppressed( T exception, Throwable... suppressed )
     {
         if ( suppressed != null )
@@ -62,21 +150,42 @@ public class Exceptions
         return exception;
     }
 
+    /**
+     * @deprecated See {@link #launderedException(Class, String, Throwable)}.
+     */
+    @Deprecated
     public static RuntimeException launderedException( Throwable exception )
     {
-        return launderedException( UNEXPECTED_MESSAGE, exception );
+        return launderedException( RuntimeException.class, UNEXPECTED_MESSAGE, exception );
     }
 
+    /**
+     * @deprecated See {@link #launderedException(Class, String, Throwable)}.
+     */
+    @Deprecated
     public static RuntimeException launderedException( String messageForUnexpected, Throwable exception )
     {
         return launderedException( RuntimeException.class, messageForUnexpected, exception );
     }
 
+    /**
+     * @deprecated See {@link #launderedException(Class, String, Throwable)}.
+     */
+    @Deprecated
     public static <T extends Throwable> T launderedException( Class<T> type, Throwable exception )
     {
         return launderedException( type, UNEXPECTED_MESSAGE, exception );
     }
 
+    /**
+     * @deprecated use {@code throw e} or {@code throw new RuntimeException(e)} directly. Prefer multi-caches if applicable.
+     * For more elaborate scenarios, have a look at {@link #throwIfUnchecked(Throwable)} and
+     * {@link #throwIfInstanceOf(Throwable, Class)}
+     * <p>
+     * For a more furrow explanation take a look at the very similar case:
+     * <a href="https://goo.gl/Ivn2kc">Why we deprecated {@code Throwables.propagate}</a>
+     */
+    @Deprecated
     public static <T extends Throwable> T launderedException( Class<T> type, String messageForUnexpected,
             Throwable exception )
     {
@@ -131,11 +240,13 @@ public class Exceptions
         return exception;
     }
 
-    private Exceptions()
-    {
-        // no instances
-    }
-
+    /**
+     * Returns the root cause of an exception.
+     *
+     * @param caughtException exception to find the root cause of.
+     * @return the root cause.
+     * @throws IllegalArgumentException if the provided exception is null.
+     */
     public static Throwable rootCause( Throwable caughtException )
     {
         if ( null == caughtException )
@@ -143,11 +254,9 @@ public class Exceptions
             throw new IllegalArgumentException( "Cannot obtain rootCause from (null)" );
         }
         Throwable root  = caughtException;
-        Throwable cause = root.getCause();
-        while ( null != cause )
+        while ( root.getCause() != null )
         {
-            root  = cause;
-            cause = cause.getCause();
+            root = root.getCause();
         }
         return root;
     }
@@ -171,10 +280,12 @@ public class Exceptions
                 " prio=" + thread.getPriority() +
                 " tid=" + thread.getId() +
                 " " + thread.getState().name().toLowerCase() + "\n" );
-        builder.append( "   " + State.class.getName() + ": " + thread.getState().name().toUpperCase() + "\n" );
+        builder.append( "   " ).append( State.class.getName() ).append( ": " )
+                .append( thread.getState().name().toUpperCase() ).append( "\n" );
         for ( StackTraceElement element : elements )
         {
-            builder.append( "      at " + element.getClassName() + "." + element.getMethodName() );
+            builder.append( "      at " ).append( element.getClassName() ).append( "." )
+                    .append( element.getMethodName() );
             if ( element.isNativeMethod() )
             {
                 builder.append( "(Native method)" );
@@ -185,7 +296,8 @@ public class Exceptions
             }
             else
             {
-                builder.append( "(" + element.getFileName() + ":" + element.getLineNumber() + ")" );
+                builder.append( "(" ).append( element.getFileName() ).append( ":" ).append( element.getLineNumber() )
+                        .append( ")" );
             }
             builder.append( "\n" );
         }
@@ -200,6 +312,7 @@ public class Exceptions
                                 anyOfClasses.test( item ) );
     }
 
+    @SuppressWarnings( "rawtypes" )
     public static boolean contains( Throwable cause, Class... anyOfTheseClasses )
     {
         return contains( cause, org.neo4j.function.Predicates.instanceOfAny( anyOfTheseClasses ) );
@@ -218,6 +331,11 @@ public class Exceptions
         return false;
     }
 
+    /**
+     * @deprecated Use {@link Throwable#addSuppressed(Throwable)} and {@link Throwable#initCause(Throwable)} where
+     * appropriate instead.
+     */
+    @Deprecated
     public static <E extends Throwable> E combine( E first, E second )
     {
         if ( first == null )

--- a/community/common/src/main/java/org/neo4j/helpers/TextUtil.java
+++ b/community/common/src/main/java/org/neo4j/helpers/TextUtil.java
@@ -186,18 +186,17 @@ public class TextUtil
             {
                 token = token.trim();
             }
-            if ( token.length() == 0 )
+            if ( token.length() != 0 )
             {
-                // Skip it
-            }
-            else if ( inside )
-            {
-                // Don't split
-                result.add( token );
-            }
-            else
-            {
-                Collections.addAll( result, TextUtil.splitAndKeepEscapedSpaces( token, preserveEscapeCharacters ) );
+                if ( inside )
+                {
+                    // Don't split
+                    result.add( token );
+                }
+                else
+                {
+                    Collections.addAll( result, TextUtil.splitAndKeepEscapedSpaces( token, preserveEscapeCharacters ) );
+                }
             }
             inside = !inside;
         }

--- a/community/common/src/test/java/org/neo4j/test/Race.java
+++ b/community/common/src/test/java/org/neo4j/test/Race.java
@@ -28,8 +28,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.BooleanSupplier;
 
-import org.neo4j.helpers.Exceptions;
-
 import static java.lang.System.currentTimeMillis;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
@@ -118,7 +116,7 @@ public class Race
             }
             catch ( Throwable e )
             {
-                throw Exceptions.launderedException( e );
+                throw new RuntimeException( e );
             }
         };
     }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/RecordDistributor.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/RecordDistributor.java
@@ -92,7 +92,7 @@ public class RecordDistributor
                 worker.done();
             }
 
-            workers.awaitAndThrowOnError( RuntimeException.class );
+            workers.awaitAndThrowOnError();
         }
         catch ( InterruptedException e )
         {

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/RecordScanner.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/RecordScanner.java
@@ -20,7 +20,6 @@
 package org.neo4j.consistency.checking.full;
 
 import org.neo4j.consistency.statistics.Statistics;
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.collection.BoundedIterable;
 import org.neo4j.helpers.progress.ProgressListener;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
@@ -70,7 +69,7 @@ abstract class RecordScanner<RECORD> extends ConsistencyCheckerTask
             catch ( Exception e )
             {
                 progress.failed( e );
-                throw Exceptions.launderedException( e );
+                throw new RuntimeException( e );
             }
             finally
             {

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/StoreProcessorTask.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/StoreProcessorTask.java
@@ -22,7 +22,6 @@ package org.neo4j.consistency.checking.full;
 import org.neo4j.consistency.checking.cache.CacheAccess;
 import org.neo4j.consistency.checking.full.QueueDistribution.QueueDistributor;
 import org.neo4j.consistency.statistics.Statistics;
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.progress.ProgressListener;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.kernel.impl.store.RecordStore;
@@ -101,7 +100,7 @@ public class StoreProcessorTask<R extends AbstractBaseRecord> extends Consistenc
         catch ( Throwable e )
         {
             progressListener.failed( e );
-            throw Exceptions.launderedException( e );
+            throw new RuntimeException( e );
         }
         finally
         {

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReporter.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReporter.java
@@ -21,7 +21,6 @@ package org.neo4j.consistency.report;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationHandler;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.HashMap;
@@ -51,9 +50,7 @@ import org.neo4j.kernel.impl.store.record.RelationshipRecord;
 import org.neo4j.kernel.impl.store.record.RelationshipTypeTokenRecord;
 
 import static java.util.Arrays.asList;
-import static org.neo4j.helpers.Exceptions.launderedException;
 import static org.neo4j.helpers.Exceptions.stringify;
-import static org.neo4j.helpers.Exceptions.withCause;
 
 public class ConsistencyReporter implements ConsistencyReport.Reporter
 {
@@ -490,7 +487,7 @@ public class ConsistencyReporter implements ConsistencyReport.Reporter
             }
             catch ( NoSuchMethodException e )
             {
-                throw withCause( new LinkageError( "Cannot access Proxy constructor for " + type.getName() ), e );
+                throw new LinkageError( "Cannot access Proxy constructor for " + type.getName(), e );
             }
         }
 
@@ -511,13 +508,9 @@ public class ConsistencyReporter implements ConsistencyReport.Reporter
             {
                 return constructor.newInstance( handler );
             }
-            catch ( InvocationTargetException e )
-            {
-                throw launderedException( e );
-            }
             catch ( Exception e )
             {
-                throw new LinkageError( "Failed to create proxy instance" );
+                throw new LinkageError( "Failed to create proxy instance", e );
             }
         }
 

--- a/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
+++ b/community/import-tool/src/main/java/org/neo4j/tooling/ImportTool.java
@@ -76,10 +76,9 @@ import org.neo4j.unsafe.impl.batchimport.staging.ExecutionMonitors;
 import static java.lang.String.format;
 import static java.nio.charset.Charset.defaultCharset;
 import static java.util.Arrays.asList;
-
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.logs_directory;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.store_internal_log_path;
-import static org.neo4j.helpers.Exceptions.launderedException;
+import static org.neo4j.helpers.Exceptions.throwIfUnchecked;
 import static org.neo4j.helpers.Format.bytes;
 import static org.neo4j.helpers.Strings.TAB;
 import static org.neo4j.helpers.TextUtil.tokenizeStringWithQuotes;
@@ -830,7 +829,8 @@ public class ImportTool
         {
             /* Shhhh */
         } );
-        return launderedException( e ); // throw in order to have process exit with !0
+        throwIfUnchecked( e );
+        return new RuntimeException( e ); // throw in order to have process exit with !0
     }
 
     private static void printErrorMessage( String string, Exception e, boolean stackTrace, PrintStream err )

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/CrashGenerationCleaner.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/CrashGenerationCleaner.java
@@ -34,7 +34,6 @@ import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.System.currentTimeMillis;
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.neo4j.helpers.Exceptions.launderedException;
 
 /**
  * Scans the entire tree and checks all GSPPs, replacing all CRASH gen GSPs with zeros.
@@ -108,7 +107,7 @@ class CrashGenerationCleaner
         Throwable finalError = error.get();
         if ( finalError != null )
         {
-            throw launderedException( IOException.class, finalError );
+            throw new IOException( finalError );
         }
 
         long endTime = currentTimeMillis();

--- a/community/kernel/src/main/java/org/neo4j/helpers/RunCarefully.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/RunCarefully.java
@@ -19,7 +19,9 @@
  */
 package org.neo4j.helpers;
 
-import static org.neo4j.helpers.Exceptions.combine;
+import java.util.LinkedList;
+import java.util.List;
+
 import static org.neo4j.helpers.collection.Iterables.asArray;
 
 public class RunCarefully
@@ -38,7 +40,7 @@ public class RunCarefully
 
     public void run()
     {
-        Throwable error = null;
+        List<Throwable> errors = new LinkedList<>();
 
         for ( Runnable o : operations )
         {
@@ -48,13 +50,15 @@ public class RunCarefully
             }
             catch ( RuntimeException e )
             {
-                error = combine( error, e );
+                errors.add( e );
             }
         }
 
-        if ( error != null )
+        if ( !errors.isEmpty() )
         {
-            throw new RuntimeException( error );
+            RuntimeException exception = new RuntimeException();
+            errors.forEach( exception::addSuppressed );
+            throw exception;
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/helpers/RunCarefully.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/RunCarefully.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.helpers;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.neo4j.helpers.collection.Iterables.asArray;
@@ -40,7 +40,7 @@ public class RunCarefully
 
     public void run()
     {
-        List<Throwable> errors = new LinkedList<>();
+        List<Throwable> errors = new ArrayList<>();
 
         for ( Runnable o : operations )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -33,7 +33,6 @@ import java.util.function.Supplier;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
 import org.neo4j.internal.kernel.api.TokenNameLookup;
 import org.neo4j.io.fs.FileSystemAbstraction;
@@ -165,6 +164,8 @@ import org.neo4j.storageengine.api.StoreFileMetadata;
 import org.neo4j.storageengine.api.StoreReadLayer;
 import org.neo4j.time.SystemNanoClock;
 import org.neo4j.unsafe.impl.internal.dragons.FeatureToggles;
+
+import static org.neo4j.helpers.Exceptions.throwIfUnchecked;
 
 public class NeoStoreDataSource implements Lifecycle, IndexProviders
 {
@@ -490,7 +491,8 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
             {
                 msgLog.error( "Couldn't close neostore after startup failure", closeException );
             }
-            throw Exceptions.launderedException( e );
+            throwIfUnchecked( e );
+            throw new RuntimeException( e );
         }
 
         // NOTE: please make sure this is performed after having added everything to the life, in fact we would like
@@ -515,7 +517,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
             {
                 msgLog.error( "Couldn't close neostore after startup failure", closeException );
             }
-            throw Exceptions.launderedException( e );
+            throw new RuntimeException( e );
         }
         /*
          * At this point recovery has completed and the datasource is ready for use. Whatever panic might have

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -68,7 +68,6 @@ import org.neo4j.scheduler.JobScheduler;
 
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MINUTES;
-import static org.neo4j.helpers.Exceptions.launderedException;
 import static org.neo4j.helpers.collection.Iterables.asList;
 import static org.neo4j.internal.kernel.api.InternalIndexState.FAILED;
 import static org.neo4j.kernel.impl.api.index.IndexPopulationFailure.failure;
@@ -488,7 +487,7 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
                 }
                 catch ( Exception e )
                 {
-                    throw launderedException( e );
+                    throw new RuntimeException( e );
                 }
             }
             return indexMap;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeFactory.java
@@ -29,7 +29,6 @@ import org.neo4j.configuration.Internal;
 import org.neo4j.configuration.LoadableConfig;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.graphdb.security.URLAccessRule;
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.NeoStoreDataSource;
 import org.neo4j.kernel.configuration.Config;
@@ -198,7 +197,7 @@ public class GraphDatabaseFacadeFactory
             }
         } );
 
-        Throwable error = null;
+        RuntimeException error = null;
         try
         {
             // Done after create to avoid a redundant
@@ -222,7 +221,7 @@ public class GraphDatabaseFacadeFactory
                 }
                 catch ( Throwable shutdownError )
                 {
-                    error = Exceptions.withSuppressed( shutdownError, error );
+                    error.addSuppressed( shutdownError );
                 }
             }
         }
@@ -230,7 +229,7 @@ public class GraphDatabaseFacadeFactory
         if ( error != null )
         {
             msgLog.log( "Failed to start database", error );
-            throw Exceptions.launderedException( error );
+            throw error;
         }
 
         return graphDatabaseFacade;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaIndexPopulator.java
@@ -28,7 +28,6 @@ import java.util.concurrent.ExecutionException;
 
 import org.neo4j.concurrent.Work;
 import org.neo4j.concurrent.WorkSync;
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.index.internal.gbptree.GBPTree;
 import org.neo4j.index.internal.gbptree.Layout;
 import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
@@ -189,7 +188,7 @@ public abstract class NativeSchemaIndexPopulator<KEY extends NativeSchemaKey, VA
         }
         catch ( ExecutionException e )
         {
-            throw Exceptions.launderedException( IOException.class, e );
+            throw new IOException( e );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/CommonAbstractStore.java
@@ -49,7 +49,7 @@ import org.neo4j.logging.Logger;
 
 import static java.nio.file.StandardOpenOption.DELETE_ON_CLOSE;
 import static org.neo4j.helpers.ArrayUtil.contains;
-import static org.neo4j.helpers.Exceptions.launderedException;
+import static org.neo4j.helpers.Exceptions.throwIfUnchecked;
 import static org.neo4j.io.pagecache.PageCacheOpenOptions.ANY_PAGE_SIZE;
 import static org.neo4j.io.pagecache.PagedFile.PF_READ_AHEAD;
 import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_READ_LOCK;
@@ -76,7 +76,7 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord,HEAD
     protected final RecordFormat<RECORD> recordFormat;
     private IdGenerator idGenerator;
     private boolean storeOk = true;
-    private Throwable causeOfStoreNotOk;
+    private RuntimeException causeOfStoreNotOk;
     private final String typeDescriptor;
     protected int recordSize;
 
@@ -153,7 +153,8 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord,HEAD
                 e.addSuppressed( failureToClose );
             }
         }
-        throw launderedException( e );
+        throwIfUnchecked( e );
+        throw new RuntimeException( e );
     }
 
     /**
@@ -547,7 +548,7 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord,HEAD
     /**
      * Marks this store as "not ok".
      */
-    void setStoreNotOk( Throwable cause )
+    void setStoreNotOk( RuntimeException cause )
     {
         storeOk = false;
         causeOfStoreNotOk = cause;
@@ -571,7 +572,7 @@ public abstract class CommonAbstractStore<RECORD extends AbstractBaseRecord,HEAD
     {
         if ( !storeOk )
         {
-            throw launderedException( causeOfStoreNotOk );
+            throw causeOfStoreNotOk;
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/RotationState.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/kvstore/RotationState.java
@@ -26,7 +26,6 @@ import java.util.Optional;
 import java.util.concurrent.locks.Lock;
 import java.util.function.Consumer;
 
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.collection.Pair;
 
 abstract class RotationState<Key> extends ProgressiveState<Key>
@@ -84,7 +83,8 @@ abstract class RotationState<Key> extends ProgressiveState<Key>
                     }
                     catch ( InterruptedException e )
                     {
-                        throw Exceptions.withCause( new InterruptedIOException( "Rotation was interrupted." ), e );
+                        throw (InterruptedIOException) new InterruptedIOException( "Rotation was interrupted." )
+                                .initCause( e );
                     }
                 }
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/storemigration/StoreUpgrader.java
@@ -28,7 +28,6 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.io.fs.FileHandle;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
@@ -230,10 +229,6 @@ public class StoreUpgrader
         catch ( IOException | UncheckedIOException e )
         {
             throw new UnableToUpgradeException( "Failure doing migration", e );
-        }
-        catch ( Exception e )
-        {
-            throw Exceptions.launderedException( e );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/StoreCopyCheckPointMutex.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/checkpoint/StoreCopyCheckPointMutex.java
@@ -24,12 +24,11 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+
 import org.neo4j.function.ThrowingAction;
 import org.neo4j.graphdb.Resource;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-
-import static org.neo4j.helpers.Exceptions.launderedException;
 
 /**
  * Mutex between {@link #storeCopy(ThrowingAction) store-copy} and {@link #checkPoint() check-point}.
@@ -111,10 +110,15 @@ public class StoreCopyCheckPointMutex
                 {
                     beforeFirstConcurrentStoreCopy.apply();
                 }
+                catch ( IOException e )
+                {
+                    storeCopyActionError = e;
+                    throw e;
+                }
                 catch ( Throwable e )
                 {
                     storeCopyActionError = e;
-                    throw launderedException( IOException.class, e );
+                    throw new IOException( e );
                 }
                 storeCopyActionCompleted = true;
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFiles.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/files/TransactionLogFiles.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.function.LongSupplier;
 
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.fs.OpenMode;
 import org.neo4j.io.fs.StoreChannel;
@@ -210,8 +209,8 @@ public class TransactionLogFiles extends LifecycleAdapter implements LogFiles
         }
         catch ( FileNotFoundException cause )
         {
-            throw Exceptions.withCause( new FileNotFoundException(
-                    format( "File could not be opened [%s]", fileToOpen.getCanonicalPath() ) ), cause );
+            throw (FileNotFoundException) new FileNotFoundException(
+                    format( "File could not be opened [%s]", fileToOpen.getCanonicalPath() ) ).initCause( cause );
         }
         catch ( Throwable unexpectedError )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/reverse/ReverseTransactionCursorLoggingMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/reverse/ReverseTransactionCursorLoggingMonitor.java
@@ -33,7 +33,7 @@ public class ReverseTransactionCursorLoggingMonitor implements ReversedTransacti
     }
 
     @Override
-    public void transactionalLogRecordReadFailure( Throwable t, long[] transactionOffsets, int transactionIndex, long logVersion )
+    public void transactionalLogRecordReadFailure( long[] transactionOffsets, int transactionIndex, long logVersion )
     {
         log.warn( transactionIndex > 0 ?
                format( "Fail to read transaction log version %d. Last valid transaction start offset is: %d.",

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/reverse/ReversedSingleFileTransactionCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/reverse/ReversedSingleFileTransactionCursor.java
@@ -24,7 +24,6 @@ import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Deque;
 
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.LogPosition;
 import org.neo4j.kernel.impl.transaction.log.LogVersionBridge;
@@ -34,6 +33,7 @@ import org.neo4j.kernel.impl.transaction.log.ReadAheadLogChannel;
 import org.neo4j.kernel.impl.transaction.log.ReadableClosablePositionAwareChannel;
 import org.neo4j.kernel.impl.transaction.log.TransactionCursor;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryReader;
+import org.neo4j.kernel.impl.transaction.log.entry.UnsupportedLogVersionException;
 
 /**
  * Returns transactions in reverse order in a log file. It tries to keep peak memory consumption to a minimum
@@ -113,12 +113,12 @@ public class ReversedSingleFileTransactionCursor implements TransactionCursor
                 startOffset = channel.position();
             }
         }
-        catch ( Throwable t )
+        catch ( IOException | UnsupportedLogVersionException e )
         {
-            monitor.transactionalLogRecordReadFailure( t, offsets, offsetCursor, logVersion );
+            monitor.transactionalLogRecordReadFailure( offsets, offsetCursor, logVersion );
             if ( failOnCorruptedLogFiles )
             {
-                throw Exceptions.launderedException( t );
+                throw e;
             }
         }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/reverse/ReversedTransactionCursorMonitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/transaction/log/reverse/ReversedTransactionCursorMonitor.java
@@ -21,5 +21,5 @@ package org.neo4j.kernel.impl.transaction.log.reverse;
 
 public interface ReversedTransactionCursorMonitor
 {
-    void transactionalLogRecordReadFailure( Throwable t, long[] offsets, int offsetCursor, long logVersion );
+    void transactionalLogRecordReadFailure( long[] offsets, int offsetCursor, long logVersion );
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/DatabaseHealth.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/DatabaseHealth.java
@@ -24,8 +24,6 @@ import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.impl.core.DatabasePanicEventGenerator;
 import org.neo4j.logging.Log;
 
-import static org.neo4j.helpers.Exceptions.withCause;
-
 public class DatabaseHealth
 {
     private static final String panicMessage = "The database has encountered a critical error, " +
@@ -64,8 +62,14 @@ public class DatabaseHealth
                 }
                 catch ( NoSuchMethodException e )
                 {
-                    exception = withCause( panicDisguise.getConstructor( String.class )
-                            .newInstance( panicMessage ), causeOfPanic );
+                    exception = panicDisguise.getConstructor( String.class ).newInstance( panicMessage );
+                    try
+                    {
+                        exception.initCause( causeOfPanic );
+                    }
+                    catch ( IllegalStateException ignored )
+                    {
+                    }
                 }
             }
             catch ( Exception e )

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/LogTailScanner.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/LogTailScanner.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.recovery;
 
 import java.io.IOException;
 
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.impl.store.UnderlyingStorageException;
 import org.neo4j.kernel.impl.transaction.log.LogEntryCursor;
 import org.neo4j.kernel.impl.transaction.log.LogPosition;
@@ -38,6 +37,7 @@ import org.neo4j.kernel.impl.transaction.log.entry.LogEntryVersion;
 import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
 import org.neo4j.kernel.monitoring.Monitors;
 
+import static org.neo4j.helpers.Exceptions.throwIfUnchecked;
 import static org.neo4j.kernel.impl.transaction.log.LogVersionRepository.INITIAL_LOG_VERSION;
 
 /**
@@ -138,7 +138,8 @@ public class LogTailScanner
                 monitor.corruptedLogFile( version, t );
                 if ( failOnCorruptedLogFiles )
                 {
-                    throw Exceptions.launderedException( t );
+                    throwIfUnchecked( t );
+                    throw new RuntimeException( t );
                 }
                 corruptedTransactionLogs = true;
             }

--- a/community/kernel/src/main/java/org/neo4j/kernel/recovery/Recovery.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/recovery/Recovery.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.recovery;
 
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.impl.core.StartupStatisticsProvider;
 import org.neo4j.kernel.impl.transaction.CommittedTransactionRepresentation;
 import org.neo4j.kernel.impl.transaction.log.LogPosition;
@@ -29,6 +28,7 @@ import org.neo4j.kernel.impl.transaction.log.entry.LogEntryCommit;
 import org.neo4j.kernel.impl.util.monitoring.ProgressReporter;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
+import static org.neo4j.helpers.Exceptions.throwIfUnchecked;
 import static org.neo4j.storageengine.api.TransactionApplicationMode.RECOVERY;
 import static org.neo4j.storageengine.api.TransactionApplicationMode.REVERSE_RECOVERY;
 
@@ -118,7 +118,8 @@ public class Recovery extends LifecycleAdapter
         {
             if ( failOnCorruptedLogFiles )
             {
-                throw Exceptions.launderedException( t );
+                throwIfUnchecked( t );
+                throw new RuntimeException( t );
             }
             if ( lastTransaction != null )
             {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ExhaustingEntityImporterRunnable.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/ExhaustingEntityImporterRunnable.java
@@ -19,12 +19,11 @@
  */
 package org.neo4j.unsafe.impl.batchimport;
 
+import java.io.IOException;
 import java.util.concurrent.atomic.LongAdder;
 
 import org.neo4j.unsafe.impl.batchimport.input.InputChunk;
 import org.neo4j.unsafe.impl.batchimport.staging.StageControl;
-
-import static org.neo4j.helpers.Exceptions.launderedException;
 
 /**
  * Allocates its own {@link InputChunk} and loops, getting input data, importing input data into store
@@ -62,10 +61,15 @@ class ExhaustingEntityImporterRunnable implements Runnable
                 roughEntityCountProgress.add( count );
             }
         }
+        catch ( IOException e )
+        {
+            control.panic( e );
+            throw new RuntimeException( e );
+        }
         catch ( Throwable e )
         {
             control.panic( e );
-            throw launderedException( e );
+            throw e;
         }
         finally
         {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
@@ -22,15 +22,15 @@ package org.neo4j.unsafe.impl.batchimport.cache;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
 
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.io.pagecache.PageCache;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
-
-import static org.neo4j.helpers.Exceptions.launderedException;
 import static org.neo4j.helpers.Format.bytes;
 import static org.neo4j.helpers.Numbers.safeCastLongToInt;
 
@@ -138,7 +138,7 @@ public interface NumberArrayFactory
      */
     static NumberArrayFactory[] allocationAlternatives( boolean allowHeapAllocation, NumberArrayFactory... additional )
     {
-        List<NumberArrayFactory> result = new ArrayList<>( asList( OFF_HEAP ) );
+        List<NumberArrayFactory> result = new ArrayList<>( Collections.singletonList( OFF_HEAP ) );
         if ( allowHeapAllocation )
         {
             result.add( HEAP );
@@ -164,14 +164,39 @@ public interface NumberArrayFactory
         @Override
         public LongArray newLongArray( long length, long defaultValue, long base )
         {
-            Throwable error = null;
+            return tryAllocate( length, 8, f -> f.newLongArray( length, defaultValue, base ) );
+        }
+
+        @Override
+        public IntArray newIntArray( long length, int defaultValue, long base )
+        {
+            return tryAllocate( length, 4, f -> f.newIntArray( length, defaultValue, base ) );
+        }
+
+        @Override
+        public ByteArray newByteArray( long length, byte[] defaultValue, long base )
+        {
+            return tryAllocate( length, defaultValue.length, f -> f.newByteArray( length, defaultValue, base ) );
+        }
+
+        private <T extends NumberArray<? extends T>> T tryAllocate( long length, int itemSize,
+                Function<NumberArrayFactory,T> allocator )
+        {
+            OutOfMemoryError error = null;
             for ( NumberArrayFactory candidate : candidates )
             {
                 try
                 {
-                    return candidate.newLongArray( length, defaultValue, base );
+                    try
+                    {
+                        return allocator.apply( candidate );
+                    }
+                    catch ( ArithmeticException e )
+                    {
+                        throw new OutOfMemoryError( e.getMessage() );
+                    }
                 }
-                catch ( Throwable e )
+                catch ( OutOfMemoryError e )
                 {   // Alright let's try the next one
                     if ( error == null )
                     {
@@ -184,45 +209,10 @@ public interface NumberArrayFactory
                     }
                 }
             }
-            throw launderedException( error( length, 8, error ) );
+            throw error( length, itemSize, error );
         }
 
-        @Override
-        public IntArray newIntArray( long length, int defaultValue, long base )
-        {
-            Throwable error = null;
-            for ( NumberArrayFactory candidate : candidates )
-            {
-                try
-                {
-                    return candidate.newIntArray( length, defaultValue, base );
-                }
-                catch ( Throwable e )
-                {   // Allright let's try the next one
-                    error = e;
-                }
-            }
-            throw launderedException( error( length, 4, error ) );
-        }
-
-        @Override
-        public ByteArray newByteArray( long length, byte[] defaultValue, long base )
-        {
-            Throwable error = null;
-            for ( NumberArrayFactory candidate : candidates )
-            {
-                try
-                {
-                    return candidate.newByteArray( length, defaultValue, base );
-                }
-                catch ( Throwable e )
-                {   // Allright let's try the next one
-                    error = e;
-                }
-            }
-            throw launderedException( error( length, defaultValue.length, error ) );
-        }
-        private Throwable error( long length, int itemSize, Throwable error )
+        private OutOfMemoryError error( long length, int itemSize, OutOfMemoryError error )
         {
             return Exceptions.withMessage( error, format( "%s: Not enough memory available for allocating %s, tried %s",
                     error.getMessage(), bytes( length * itemSize ), Arrays.toString( candidates ) ) );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/EncodingIdMapper.java
@@ -437,7 +437,7 @@ public class EncodingIdMapper implements IdMapper
             toExclusive = last ? totalCount : toExclusive + stride;
             workers.start( new DetectWorker( fromInclusive, toExclusive, last, progress ) );
         }
-        workers.awaitAndThrowOnErrorStrict( RuntimeException.class );
+        workers.awaitAndThrowOnErrorStrict();
 
         long numberOfCollisions = 0;
         for ( DetectWorker detectWorker : workers )

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/ParallelSort.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/ParallelSort.java
@@ -85,7 +85,7 @@ public class ParallelSort
         }
         try
         {
-            sortWorkers.awaitAndThrowOnError( RuntimeException.class );
+            sortWorkers.awaitAndThrowOnError();
         }
         finally
         {

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Workers.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/Workers.java
@@ -24,14 +24,13 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.collection.Iterators;
 
 /**
  * Utility for running a handful of {@link Runnable} in parallel, each in its own thread.
  * {@link Runnable} instances are {@link #start(Runnable) added and started} and the caller can
  * {@link #await()} them all to finish, returning a {@link Throwable error} if any thread encountered one so
- * that the caller can decide how to handle that error. Or caller can use {@link #awaitAndThrowOnError(Class)}
+ * that the caller can decide how to handle that error. Or caller can use {@link #awaitAndThrowOnError()}
  * where error from any worker would be thrown from that method.
  *
  * It's basically like using an {@link ExecutorService}, but without that "baggage" and an easier usage
@@ -87,22 +86,20 @@ public class Workers<R extends Runnable> implements Iterable<R>
         }
     }
 
-    public <EXCEPTION extends Throwable> void awaitAndThrowOnError( Class<EXCEPTION> launderingException )
-            throws EXCEPTION, InterruptedException
+    public void awaitAndThrowOnError() throws InterruptedException
     {
         Throwable error = await();
         if ( error != null )
         {
-            throw Exceptions.launderedException( launderingException, error );
+            throw new RuntimeException( error );
         }
     }
 
-    public <EXCEPTION extends Throwable> void awaitAndThrowOnErrorStrict( Class<EXCEPTION> launderingException )
-            throws EXCEPTION
+    public void awaitAndThrowOnErrorStrict( )
     {
         try
         {
-            awaitAndThrowOnError( launderingException );
+            awaitAndThrowOnError();
         }
         catch ( InterruptedException e )
         {
@@ -143,7 +140,7 @@ public class Workers<R extends Runnable> implements Iterable<R>
             catch ( Throwable t )
             {
                 error = t;
-                throw Exceptions.launderedException( t );
+                throw new RuntimeException( t );
             }
         }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/DynamicTaskExecutor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/executor/DynamicTaskExecutor.java
@@ -31,9 +31,7 @@ import org.neo4j.function.Suppliers;
 import static java.lang.Integer.max;
 import static java.lang.Integer.min;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-
 import static org.neo4j.helpers.Exceptions.SILENT_UNCAUGHT_EXCEPTION_HANDLER;
-import static org.neo4j.helpers.Exceptions.launderedException;
 
 /**
  * Implementation of {@link TaskExecutor} with a maximum queue size and where each processor is a dedicated
@@ -235,7 +233,7 @@ public class DynamicTaskExecutor<LOCAL> implements TaskExecutor<LOCAL>
                     {
                         receivePanic( e );
                         close();
-                        throw launderedException( e );
+                        throw new RuntimeException( e );
                     }
                 }
             }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/AbstractStep.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/AbstractStep.java
@@ -27,7 +27,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 
 import org.neo4j.concurrent.WorkSync;
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.impl.util.MovingAverage;
 import org.neo4j.unsafe.impl.batchimport.Configuration;
 import org.neo4j.unsafe.impl.batchimport.executor.ParkStrategy;
@@ -148,7 +147,7 @@ public abstract class AbstractStep<T> implements Step<T>
         control.panic( cause );
         if ( rethrow )
         {
-            throw Exceptions.launderedException( cause );
+            throw new RuntimeException( cause );
         }
     }
 
@@ -156,7 +155,7 @@ public abstract class AbstractStep<T> implements Step<T>
     {
         if ( isPanic() )
         {
-            throw Exceptions.launderedException( panic );
+            throw new RuntimeException( panic );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Stage.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/Stage.java
@@ -24,8 +24,6 @@ import java.util.List;
 
 import org.neo4j.unsafe.impl.batchimport.Configuration;
 
-import static org.neo4j.helpers.Exceptions.launderedException;
-
 /**
  * A stage of processing, mainly consisting of one or more {@link Step steps} that batches of data to
  * process flows through.
@@ -95,7 +93,7 @@ public class Stage
         execution.close();
         if ( exception != null )
         {
-            throw launderedException( exception );
+            throw new RuntimeException( exception );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/StageExecution.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/staging/StageExecution.java
@@ -34,7 +34,7 @@ import org.neo4j.unsafe.impl.batchimport.stats.Key;
 import org.neo4j.unsafe.impl.batchimport.stats.Stat;
 
 import static java.lang.System.currentTimeMillis;
-import static org.neo4j.helpers.Exceptions.launderedException;
+import static org.neo4j.helpers.Exceptions.throwIfUnchecked;
 
 /**
  * Default implementation of {@link StageControl}
@@ -187,7 +187,8 @@ public class StageExecution implements StageControl, AutoCloseable
     {
         if ( panic != null )
         {
-            throw launderedException( panic );
+            throwIfUnchecked( panic );
+            throw new RuntimeException( panic );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/PageCacheFlusher.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/PageCacheFlusher.java
@@ -22,7 +22,7 @@ package org.neo4j.unsafe.impl.batchimport.store;
 import org.neo4j.concurrent.BinaryLatch;
 import org.neo4j.io.pagecache.PageCache;
 
-import static org.neo4j.helpers.Exceptions.launderedException;
+import static org.neo4j.helpers.Exceptions.throwIfUnchecked;
 
 /**
  * A dedicated thread which constantly call {@link PageCache#flushAndForce()} until a call to {@link #halt()} is made.
@@ -76,7 +76,8 @@ class PageCacheFlusher extends Thread
         halt.await();
         if ( error != null )
         {
-            throw launderedException( error );
+            throwIfUnchecked( error );
+            throw new RuntimeException(  error );
         }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/helpers/TestExceptions.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/TestExceptions.java
@@ -23,10 +23,8 @@ import org.junit.Test;
 
 import org.neo4j.function.Predicates;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class TestExceptions
@@ -96,23 +94,6 @@ public class TestExceptions
 
         // THEN
         assertEquals( prependedMessage, exception.getMessage() );
-    }
-
-    @Test
-    public void shouldAddSuppressedExceptions()
-    {
-        // Given
-        RuntimeException exception = new RuntimeException();
-
-        RuntimeException suppressed1 = new RuntimeException();
-        RuntimeException suppressed2 = new RuntimeException();
-
-        // When
-        RuntimeException result = Exceptions.withSuppressed( exception, suppressed1, suppressed2 );
-
-        // Then
-        assertSame( exception, result );
-        assertArrayEquals( new Throwable[]{suppressed1, suppressed2}, result.getSuppressed() );
     }
 
     private static class LevelOneException extends Exception

--- a/community/kernel/src/test/java/org/neo4j/kernel/GraphDatabaseFacadeFactoryTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/GraphDatabaseFacadeFactoryTest.java
@@ -45,6 +45,7 @@ import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_MOCKS;
@@ -110,8 +111,9 @@ public class GraphDatabaseFacadeFactoryTest
         catch ( RuntimeException exception )
         {
             // Then
-            assertEquals( shutdownError, exception );
-            assertEquals( startupError, Exceptions.rootCause( exception.getSuppressed()[0] ) );
+            assertTrue( exception.getMessage().startsWith( "Error starting " ) );
+            assertEquals( startupError, exception.getCause() );
+            assertEquals( shutdownError, exception.getSuppressed()[0] );
         }
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/TransactionRepresentationCommitProcessIT.java
@@ -104,7 +104,7 @@ public class TransactionRepresentationCommitProcessIT
 
         Thread.sleep( SECONDS.toMillis( 2 ) );
         done.set( true );
-        workers.awaitAndThrowOnError( RuntimeException.class );
+        workers.awaitAndThrowOnError();
 
         NeoStores neoStores = getDependency(RecordStorageEngine.class).testAccessNeoStores();
         assertThat( "Count store should be rotated once at least", neoStores.getCounts().txId(), greaterThan( 0L ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreBehaviourTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/CommonAbstractStoreBehaviourTest.java
@@ -321,7 +321,7 @@ public class CommonAbstractStoreBehaviourTest
     {
         config.augment( CommonAbstractStore.Configuration.rebuild_idgenerators_fast, "false" );
         createStore();
-        store.setStoreNotOk( new Exception() );
+        store.setStoreNotOk( new RuntimeException() );
         IntRecord record = new IntRecord( 200 );
         record.value = 0xCAFEBABE;
         store.updateRecord( record );
@@ -333,7 +333,7 @@ public class CommonAbstractStoreBehaviourTest
     public void scanForHighIdMustThrowOnPageOverflow() throws Exception
     {
         createStore();
-        store.setStoreNotOk( new Exception() );
+        store.setStoreNotOk( new RuntimeException() );
         IntRecord record = new IntRecord( 200 );
         record.value = 0xCAFEBABE;
         store.updateRecord( record );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/IndexWorkSyncTransactionApplicationStressIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/transaction/command/IndexWorkSyncTransactionApplicationStressIT.java
@@ -117,7 +117,7 @@ public class IndexWorkSyncTransactionApplicationStressIT
         end.set( true );
 
         // THEN (assertions as part of the workers applying transactions)
-        workers.awaitAndThrowOnError( RuntimeException.class );
+        workers.awaitAndThrowOnError();
     }
 
     private void awaitOnline( IndexProxy index ) throws InterruptedException

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/util/Neo4jJobSchedulerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/util/Neo4jJobSchedulerTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.locks.LockSupport;
 import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.scheduler.JobScheduler.JobHandle;
+
 import static java.lang.Thread.sleep;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -47,7 +48,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.neo4j.helpers.Exceptions.launderedException;
 import static org.neo4j.scheduler.JobScheduler.Groups.indexPopulation;
 import static org.neo4j.test.ReflectionUtil.replaceValueInPrivateField;
 
@@ -57,18 +57,7 @@ public class Neo4jJobSchedulerTest
     private final LifeSupport life = new LifeSupport();
     private final Neo4jJobScheduler scheduler = life.add( new Neo4jJobScheduler() );
 
-    private final Runnable countInvocationsJob = () ->
-    {
-        try
-        {
-            invocations.incrementAndGet();
-        }
-        catch ( Throwable e )
-        {
-            e.printStackTrace();
-            throw launderedException( e );
-        }
-    };
+    private final Runnable countInvocationsJob = invocations::incrementAndGet;
 
     @After
     public void stopScheduler() throws Throwable

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/SimpleStageControl.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/staging/SimpleStageControl.java
@@ -21,7 +21,7 @@ package org.neo4j.unsafe.impl.batchimport.staging;
 
 import java.util.function.Supplier;
 
-import org.neo4j.helpers.Exceptions;
+import static org.neo4j.helpers.Exceptions.throwIfUnchecked;
 
 /**
  * A simple {@link StageControl} for tests with multiple steps and where an error or assertion failure
@@ -53,7 +53,8 @@ public class SimpleStageControl implements StageControl
     {
         if ( panic != null )
         {
-            throw Exceptions.launderedException( panic );
+            throwIfUnchecked( panic );
+            throw new RuntimeException( panic );
         }
     }
 

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/AbstractLuceneIndex.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/index/AbstractLuceneIndex.java
@@ -36,7 +36,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.helpers.ArrayUtil;
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.io.IOUtils;
 import org.neo4j.kernel.api.impl.index.backup.WritableIndexSnapshotFileIterator;
@@ -278,7 +277,7 @@ public abstract class AbstractLuceneIndex
                 }
                 catch ( IOException ex )
                 {
-                    throw Exceptions.withCause( ex, e );
+                    e.addSuppressed( ex );
                 }
             }
             throw e;

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueLuceneIndexPopulator.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/populator/NonUniqueLuceneIndexPopulator.java
@@ -40,7 +40,6 @@ public class NonUniqueLuceneIndexPopulator extends LuceneIndexPopulator
 {
     private final IndexSamplingConfig samplingConfig;
     private NonUniqueIndexSampler sampler;
-    private boolean updateSampling;
 
     public NonUniqueLuceneIndexPopulator( SchemaIndex luceneIndex, IndexSamplingConfig samplingConfig )
     {

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/AbstractInProcessServerBuilder.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/AbstractInProcessServerBuilder.java
@@ -35,7 +35,6 @@ import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.config.Setting;
 import org.neo4j.harness.ServerControls;
 import org.neo4j.harness.TestServerBuilder;
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.GraphDatabaseDependencies;
@@ -157,13 +156,13 @@ public abstract class AbstractInProcessServerBuilder implements TestServerBuilde
             catch ( Exception e )
             {
                 controls.close();
-                throw Exceptions.launderedException( e );
+                throw e;
             }
             return controls;
         }
         catch ( IOException e )
         {
-            throw Exceptions.launderedException( e );
+            throw new RuntimeException( e );
         }
     }
 

--- a/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/InProcessServerControls.java
+++ b/community/neo4j-harness/src/main/java/org/neo4j/harness/internal/InProcessServerControls.java
@@ -28,7 +28,6 @@ import java.util.Optional;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.config.Configuration;
 import org.neo4j.harness.ServerControls;
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.HostnamePort;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.configuration.ConnectorPortRegister;
@@ -82,9 +81,9 @@ public class InProcessServerControls implements ServerControls
         {
             additionalClosable.close();
         }
-        catch ( Throwable e )
+        catch ( IOException e )
         {
-            throw Exceptions.launderedException( e );
+            throw new RuntimeException( e );
         }
         try
         {

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/MapRow.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/MapRow.java
@@ -27,8 +27,6 @@ import org.neo4j.graphdb.Path;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.Result;
 
-import static org.neo4j.helpers.Exceptions.withCause;
-
 public class MapRow implements Result.ResultRow
 {
     private final Map<String, Object> map;
@@ -54,7 +52,8 @@ public class MapRow implements Result.ResultRow
         }
         catch ( ClassCastException e )
         {
-            throw withCause( new NoSuchElementException( "Element '" + key + "' is not a " + type.getSimpleName() ), e );
+            throw (NoSuchElementException) new NoSuchElementException(
+                    "Element '" + key + "' is not a " + type.getSimpleName() ).initCause( e );
         }
     }
 

--- a/community/shell/src/main/java/org/neo4j/shell/ShellException.java
+++ b/community/shell/src/main/java/org/neo4j/shell/ShellException.java
@@ -41,7 +41,7 @@ public class ShellException extends Exception
         this( message, (String) null );
     }
 
-    private ShellException( String message, Throwable cause )
+    public ShellException( String message, Throwable cause )
     {
         super( message, cause );
         this.stackTraceAsString = null;

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Dump.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Dump.java
@@ -34,7 +34,6 @@ import org.neo4j.shell.Output;
 import org.neo4j.shell.Session;
 import org.neo4j.shell.ShellException;
 
-import static org.neo4j.helpers.Exceptions.launderedException;
 import static org.neo4j.internal.kernel.api.Transaction.Type.implicit;
 import static org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED;
 
@@ -89,7 +88,7 @@ public class Dump extends Start
         }
         catch ( Exception e )
         {
-            throw launderedException( ShellException.class, "Error parsing input " + line, e );
+            throw new ShellException( "Error parsing input " + line, e );
         }
     }
 

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupDelegator.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupDelegator.java
@@ -31,7 +31,6 @@ import org.neo4j.causalclustering.catchup.storecopy.StoreIdDownloadFailedExcepti
 import org.neo4j.causalclustering.catchup.storecopy.StreamingTransactionsFailedException;
 import org.neo4j.causalclustering.identity.StoreId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 
 /**
@@ -57,9 +56,9 @@ class BackupDelegator extends LifecycleAdapter
         {
             remoteStore.copy( fromAddress, expectedStoreId, destDir.toFile() );
         }
-        catch ( StreamingTransactionsFailedException | StoreCopyFailedException e )
+        catch ( StreamingTransactionsFailedException e )
         {
-            throw Exceptions.launderedException( StoreCopyFailedException.class, e );
+            throw new StoreCopyFailedException( e );
         }
     }
 

--- a/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupProtocolService.java
+++ b/enterprise/backup/src/main/java/org/neo4j/backup/impl/BackupProtocolService.java
@@ -48,7 +48,6 @@ import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.factory.GraphDatabaseFactory;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.CancellationRequest;
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.Service;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
@@ -138,7 +137,7 @@ public class BackupProtocolService
         }
         catch ( IOException e )
         {
-            throw Exceptions.launderedException( e );
+            throw new RuntimeException( e );
         }
     }
 
@@ -172,9 +171,13 @@ public class BackupProtocolService
             clearIdFiles( fileSystem, targetDirectory );
             return new BackupOutcome( lastCommittedTx, consistent );
         }
+        catch ( RuntimeException e )
+        {
+            throw e;
+        }
         catch ( Exception e )
         {
-            throw Exceptions.launderedException( e );
+            throw new RuntimeException( e );
         }
     }
 
@@ -190,7 +193,7 @@ public class BackupProtocolService
         }
         catch ( IOException e )
         {
-            throw Exceptions.launderedException( e );
+            throw new RuntimeException( e );
         }
     }
 
@@ -228,7 +231,7 @@ public class BackupProtocolService
         }
         catch ( IOException e )
         {
-            throw Exceptions.launderedException( e );
+            throw new RuntimeException( e );
         }
     }
 
@@ -309,7 +312,7 @@ public class BackupProtocolService
         }
         catch ( IOException io )
         {
-            throw Exceptions.launderedException( io );
+            throw new RuntimeException( io );
         }
     }
 

--- a/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupCommandCcIT.java
+++ b/enterprise/backup/src/test/java/org/neo4j/backup/impl/OnlineBackupCommandCcIT.java
@@ -57,7 +57,6 @@ import org.neo4j.util.TestHelpers;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeFalse;
-import static org.neo4j.helpers.Exceptions.launderedException;
 
 @RunWith( Parameterized.class )
 public class OnlineBackupCommandCcIT
@@ -198,7 +197,7 @@ public class OnlineBackupCommandCcIT
         }
         catch ( Exception e )
         {
-            throw launderedException( e );
+            throw new RuntimeException( e );
         }
         return DbRepresentation.of( clusterLeader( cluster ).database() );
     }

--- a/enterprise/com/src/main/java/org/neo4j/com/Server.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/Server.java
@@ -49,7 +49,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import org.neo4j.com.monitor.RequestMonitor;
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.HostnamePort;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.impl.store.StoreId;
@@ -272,7 +271,7 @@ public abstract class Server<T, R> extends SimpleChannelHandler implements Chann
 
             ctx.getChannel().close();
             tryToCloseChannel( ctx.getChannel() );
-            throw Exceptions.launderedException( e );
+            throw e;
         }
     }
 
@@ -590,7 +589,7 @@ public abstract class Server<T, R> extends SimpleChannelHandler implements Chann
                 targetBuffer.clear( true );
                 writeFailureResponse( e, targetBuffer );
                 tryToFinishOffChannel( channel, context );
-                throw Exceptions.launderedException( e );
+                throw new RuntimeException( e );
             }
             finally
             {

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/SlaveImpl.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/com/slave/SlaveImpl.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.ha.com.slave;
 
 import org.neo4j.com.Response;
 import org.neo4j.com.storecopy.TransactionObligationFulfiller;
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.kernel.ha.com.master.Slave;
 
 public class SlaveImpl implements Slave
@@ -42,7 +41,7 @@ public class SlaveImpl implements Slave
         }
         catch ( InterruptedException e )
         {
-            throw Exceptions.launderedException( e );
+            throw new RuntimeException( e );
         }
         return Response.EMPTY;
     }

--- a/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/LegacyDatabaseImpl.java
+++ b/enterprise/ha/src/test/java/org/neo4j/ha/upgrade/LegacyDatabaseImpl.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -53,7 +52,6 @@ import static org.junit.Assert.fail;
 import static org.neo4j.ha.upgrade.RollingUpgradeIT.type1;
 import static org.neo4j.ha.upgrade.RollingUpgradeIT.type2;
 import static org.neo4j.ha.upgrade.Utils.execJava;
-import static org.neo4j.helpers.Exceptions.launderedException;
 
 public class LegacyDatabaseImpl extends UnicastRemoteObject implements LegacyDatabase
 {
@@ -333,9 +331,9 @@ public class LegacyDatabaseImpl extends UnicastRemoteObject implements LegacyDat
         {
             db.getDependencyResolver().resolveDependency( UpdatePuller.class ).pullUpdates();
         }
-        catch ( Exception e )
+        catch ( InterruptedException e )
         {
-            throw launderedException( e );
+            throw new RuntimeException( e );
         }
 
         try ( Transaction tx = db.beginTx() )

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TestMasterCommittingAtSlave.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/TestMasterCommittingAtSlave.java
@@ -34,7 +34,6 @@ import org.neo4j.com.ResourceReleaser;
 import org.neo4j.com.Response;
 import org.neo4j.com.TransactionStream;
 import org.neo4j.com.TransactionStreamResponse;
-import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.ha.com.master.Slave;
@@ -233,7 +232,7 @@ public class TestMasterCommittingAtSlave
         }
         catch ( Throwable e )
         {
-            throw Exceptions.launderedException( e );
+            throw new RuntimeException( e );
         }
         return result;
     }

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/transaction/TransactionThroughMasterSwitchStressIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/transaction/TransactionThroughMasterSwitchStressIT.java
@@ -151,7 +151,7 @@ public class TransactionThroughMasterSwitchStressIT
             Thread.sleep( 100 );
         }
         end.set( true );
-        transactors.awaitAndThrowOnError( RuntimeException.class );
+        transactors.awaitAndThrowOnError();
 
         // THEN verify that the count is equal to the number of successful transactions
         assertEquals( successes.get(), getNodePropertyValue( master, nodeId, key ) );

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ParallelLifecycle.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/impl/ha/ParallelLifecycle.java
@@ -115,25 +115,17 @@ class ParallelLifecycle extends LifecycleAdapter
             }
             catch ( InterruptedException | ExecutionException e )
             {
-                exception = combine( exception, e );
+                if ( exception == null )
+                {
+                    exception = new RuntimeException();
+                }
+                exception.addSuppressed( e );
             }
         }
         if ( exception != null )
         {
             throw exception;
         }
-    }
-
-    private static <E extends Throwable> E combine( E first, E second )
-    {
-        Throwable current = first;
-        while ( current.getCause() != null )
-        {
-            current = current.getCause();
-        }
-
-        current.initCause( second );
-        return first;
     }
 
     private interface Action

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/builtinprocs/EnterpriseBuiltInDbmsProcedures.java
@@ -401,7 +401,7 @@ public class EnterpriseBuiltInDbmsProcedures
             {
                 for ( String id : idTexts )
                 {
-                    if ( !terminatedQuerys.stream().anyMatch( query -> query.queryId.equals( id ) ) )
+                    if ( terminatedQuerys.stream().noneMatch( query -> query.queryId.equals( id ) ) )
                     {
                         terminatedQuerys.add( new QueryFailedTerminationResult( fromExternalString( id ) ) );
                     }


### PR DESCRIPTION
Removes `Exceptions.launderedExceptions()`
* It hides important logic, very hard to derive what exceptions are actually thrown.
* It facilitates catching `Throwable`, which should be avoided and painful if you have to do it.
* More furrow description of why this pattern is bad: [Why we deprecated Throwables.propagate](https://github.com/google/guava/wiki/Why-we-deprecated-Throwables.propagate)

Removes `Exceptions.withSuppressed()`
* `.addSuppressed()` can be used instead.

Removes `Exception.withCause()`
* `.initCause()` can be used instead.

Removes `Exceptions.combine()`
* Hard to derive the actual outcome of the resulting message and cause chain.
* `.addSuppressed()` or `.initCause()` is most likely more appropriate.