### PR TITLE
Solve flaky RaftMessageProcessingMetricTest

### DIFF
--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/source/causalclustering/RaftMessageProcessingMetricTest.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/source/causalclustering/RaftMessageProcessingMetricTest.java
@@ -52,7 +52,7 @@ public class RaftMessageProcessingMetricTest
             assertEquals( durationNanos, metric.timer( type ).getSnapshot().getMean(), 0 );
         }
         assertEquals( RaftMessages.Type.values().length, metric.timer().getCount() );
-        assertEquals( 0, metric.timer().getSnapshot().getMean(), durationNanos );
+        assertEquals( durationNanos, metric.timer().getSnapshot().getMean(), 0.0002 );
     }
 
     @Test


### PR DESCRIPTION
Value is time dependant and so its possible that it goes above 5
if there is for example a GC pause.