### PR TITLE
Add "Page cache usage" metric

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -258,6 +258,9 @@ public class MuninnPageCache implements PageCache
         verifyCachePageSizeIsPowerOfTwo( cachePageSize );
         int maxPages = calculatePageCount( memoryAllocator, cachePageSize );
 
+        // Expose the total number of pages
+        pageCacheTracer.maxPages( maxPages );
+
         this.pageCacheId = pageCacheIdCounter.incrementAndGet();
         this.swapperFactory = swapperFactory;
         this.cachePageSize = cachePageSize;

--- a/community/io/src/main/java/org/neo4j/io/pagecache/monitoring/PageCacheCounters.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/monitoring/PageCacheCounters.java
@@ -84,4 +84,10 @@ public interface PageCacheCounters
      * @return The cache hit ratio observed thus far.
      */
     double hitRatio();
+
+    /**
+     * @return The current usage ration of number of used pages to the total number of pages or {@code NaN} if it cannot
+     * be determined.
+     */
+    double usageRatio();
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/DefaultPageCacheTracer.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/DefaultPageCacheTracer.java
@@ -21,6 +21,7 @@ package org.neo4j.io.pagecache.tracing;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 
 import org.neo4j.helpers.MathUtil;
@@ -42,6 +43,7 @@ public class DefaultPageCacheTracer implements PageCacheTracer
     protected final LongAdder filesMapped = new LongAdder();
     protected final LongAdder filesUnmapped = new LongAdder();
     protected final LongAdder evictionExceptions = new LongAdder();
+    protected final AtomicLong maxPages = new AtomicLong();
 
     private final FlushEvent flushEvent = new FlushEvent()
     {
@@ -238,6 +240,12 @@ public class DefaultPageCacheTracer implements PageCacheTracer
     }
 
     @Override
+    public double usageRatio()
+    {
+        return (faults.sum() - evictions.sum()) / (double) maxPages.get();
+    }
+
+    @Override
     public void pins( long pins )
     {
         this.pins.add( pins );
@@ -289,5 +297,11 @@ public class DefaultPageCacheTracer implements PageCacheTracer
     public void flushes( long flushes )
     {
         this.flushes.add( flushes );
+    }
+
+    @Override
+    public void maxPages( long maxPages )
+    {
+        this.maxPages.set( maxPages );
     }
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/tracing/PageCacheTracer.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/tracing/PageCacheTracer.java
@@ -137,6 +137,12 @@ public interface PageCacheTracer extends PageCacheCounters
         }
 
         @Override
+        public double usageRatio()
+        {
+            return 0d;
+        }
+
+        @Override
         public void pins( long pins )
         {
         }
@@ -178,6 +184,11 @@ public interface PageCacheTracer extends PageCacheCounters
 
         @Override
         public void flushes( long flushes )
+        {
+        }
+
+        @Override
+        public void maxPages( long maxPages )
         {
         }
 
@@ -270,4 +281,10 @@ public interface PageCacheTracer extends PageCacheCounters
      * @param flushes number of flushes
      */
     void flushes( long flushes );
+
+    /**
+     * Sets the number of available pages.
+     * @param maxPages the total number of available pages.
+     */
+    void maxPages( long maxPages );
 }

--- a/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialPageCache.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialPageCache.java
@@ -74,11 +74,7 @@ public class AdversarialPageCache implements PageCache
     {
         adversary.injectFailure( IOException.class, SecurityException.class );
         final Optional<PagedFile> optional = delegate.getExistingMapping( file );
-        if ( optional.isPresent() )
-        {
-            return Optional.of( new AdversarialPagedFile( optional.get(), adversary ) );
-        }
-        return optional;
+        return optional.map( pagedFile -> new AdversarialPagedFile( pagedFile, adversary ) );
     }
 
     @Override

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DefaultPageCacheTracerTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DefaultPageCacheTracerTest.java
@@ -124,6 +124,7 @@ public class DefaultPageCacheTracerTest
     @Test
     public void usageRatio()
     {
+        assertThat( tracer.usageRatio(), is( Double.NaN ) );
         tracer.maxPages( 10 );
         assertThat( tracer.usageRatio(), closeTo( 0d, 0.0001 ) );
         tracer.faults( 5 );

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DefaultPageCacheTracerTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DefaultPageCacheTracerTest.java
@@ -121,6 +121,20 @@ public class DefaultPageCacheTracerTest
         assertThat( "hitRation", tracer.hitRatio(), closeTo( 3.0 / 10, 0.0001 ) );
     }
 
+    @Test
+    public void usageRatio()
+    {
+        tracer.maxPages( 10 );
+        assertThat( tracer.usageRatio(), closeTo( 0d, 0.0001 ) );
+        tracer.faults( 5 );
+        assertThat( tracer.usageRatio(), closeTo( 0.5, 0.0001 ) );
+        tracer.faults( 5 );
+        tracer.evictions( 5 );
+        assertThat( tracer.usageRatio(), closeTo( 0.5, 0.0001 ) );
+        tracer.faults( 5 );
+        assertThat( tracer.usageRatio(), closeTo( 1d, 0.0001 ) );
+    }
+
     private void assertCounts( long pins, long unpins, long hits, long faults, long evictions, long evictionExceptions,
             long flushes, long bytesRead, long bytesWritten, long filesMapped, long filesUnmapped, double hitRatio )
     {

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DelegatingPageCacheTracer.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/DelegatingPageCacheTracer.java
@@ -116,6 +116,12 @@ public class DelegatingPageCacheTracer implements PageCacheTracer
     }
 
     @Override
+    public double usageRatio()
+    {
+        return delegate.usageRatio();
+    }
+
+    @Override
     public void pins( long pins )
     {
         delegate.pins( pins );
@@ -167,6 +173,12 @@ public class DelegatingPageCacheTracer implements PageCacheTracer
     public void flushes( long flushes )
     {
         delegate.flushes( flushes );
+    }
+
+    @Override
+    public void maxPages( long maxPages )
+    {
+        delegate.maxPages( maxPages );
     }
 
     @Override

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/LinearHistoryPageCacheTracer.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/linear/LinearHistoryPageCacheTracer.java
@@ -151,6 +151,12 @@ public final class LinearHistoryPageCacheTracer implements PageCacheTracer
     }
 
     @Override
+    public double usageRatio()
+    {
+        return 0d;
+    }
+
+    @Override
     public void pins( long pins )
     {
     }
@@ -192,6 +198,11 @@ public final class LinearHistoryPageCacheTracer implements PageCacheTracer
 
     @Override
     public void flushes( long flushes )
+    {
+    }
+
+    @Override
+    public void maxPages( long maxPages )
     {
     }
 }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/tracing/recording/RecordingPageCacheTracer.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/tracing/recording/RecordingPageCacheTracer.java
@@ -156,6 +156,12 @@ public class RecordingPageCacheTracer extends RecordingTracer implements PageCac
     }
 
     @Override
+    public double usageRatio()
+    {
+        return 0d;
+    }
+
+    @Override
     public void pins( long pins )
     {
         this.pins.getAndAdd( pins );
@@ -200,6 +206,11 @@ public class RecordingPageCacheTracer extends RecordingTracer implements PageCac
 
     @Override
     public void flushes( long flushes )
+    {
+    }
+
+    @Override
+    public void maxPages( long maxPages )
     {
     }
 

--- a/enterprise/management/src/main/java/org/neo4j/management/PageCache.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/PageCache.java
@@ -58,6 +58,9 @@ public interface PageCache
                   "Otherwise it could indicate drive failure, storage space, or permission problems." )
     long getEvictionExceptions();
 
-    @Description( "The percentage of used pages." )
-    double getUsageRatio();
+    @Description( "The percentage of used pages. Will return NaN if it cannot be determined." )
+    default double getUsageRatio()
+    {
+        return Double.NaN;
+    }
 }

--- a/enterprise/management/src/main/java/org/neo4j/management/PageCache.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/PageCache.java
@@ -57,4 +57,7 @@ public interface PageCache
                   "This number should be zero, or at least not growing, in a healthy database. " +
                   "Otherwise it could indicate drive failure, storage space, or permission problems." )
     long getEvictionExceptions();
+
+    @Description( "The percentage of used pages." )
+    double getUsageRatio();
 }

--- a/enterprise/management/src/main/java/org/neo4j/management/impl/PageCacheBean.java
+++ b/enterprise/management/src/main/java/org/neo4j/management/impl/PageCacheBean.java
@@ -21,14 +21,12 @@ package org.neo4j.management.impl;
 
 import javax.management.NotCompliantMBeanException;
 
-import org.neo4j.helpers.Service;
 import org.neo4j.io.pagecache.monitoring.PageCacheCounters;
 import org.neo4j.jmx.impl.ManagementBeanProvider;
 import org.neo4j.jmx.impl.ManagementData;
 import org.neo4j.jmx.impl.Neo4jMBean;
 import org.neo4j.management.PageCache;
 
-@Service.Implementation( ManagementBeanProvider.class )
 public final class PageCacheBean extends ManagementBeanProvider
 {
     public PageCacheBean()
@@ -104,6 +102,12 @@ public final class PageCacheBean extends ManagementBeanProvider
         public long getEvictionExceptions()
         {
             return pageCacheCounters.evictionExceptions();
+        }
+
+        @Override
+        public double getUsageRatio()
+        {
+            return pageCacheCounters.usageRatio();
         }
     }
 }

--- a/enterprise/metrics/src/main/java/org/neo4j/metrics/source/db/PageCacheMetrics.java
+++ b/enterprise/metrics/src/main/java/org/neo4j/metrics/source/db/PageCacheMetrics.java
@@ -49,6 +49,8 @@ public class PageCacheMetrics extends LifecycleAdapter
     public static final String PC_HITS = name( PAGE_CACHE_PREFIX, "hits" );
     @Documented( "The ratio of hits to the total number of lookups in the page cache" )
     public static final String PC_HIT_RATIO = name( PAGE_CACHE_PREFIX, "hit_ratio" );
+    @Documented( "The ratio of number of used pages to total number of available pages" )
+    public static final String PC_USAGE_RATIO = name( PAGE_CACHE_PREFIX, "usage_ratio" );
 
     private final MetricRegistry registry;
     private final PageCacheCounters pageCacheCounters;
@@ -70,6 +72,7 @@ public class PageCacheMetrics extends LifecycleAdapter
         registry.register( PC_FLUSHES, (Gauge<Long>) pageCacheCounters::flushes );
         registry.register( PC_EVICTION_EXCEPTIONS, (Gauge<Long>) pageCacheCounters::evictionExceptions );
         registry.register( PC_HIT_RATIO, (Gauge<Double>) pageCacheCounters::hitRatio );
+        registry.register( PC_USAGE_RATIO, (Gauge<Double>) pageCacheCounters::usageRatio );
     }
 
     @Override
@@ -83,5 +86,6 @@ public class PageCacheMetrics extends LifecycleAdapter
         registry.remove( PC_FLUSHES );
         registry.remove( PC_EVICTION_EXCEPTIONS );
         registry.remove( PC_HIT_RATIO );
+        registry.remove( PC_USAGE_RATIO );
     }
 }

--- a/enterprise/metrics/src/test/java/org/neo4j/metrics/PageCacheMetricsIT.java
+++ b/enterprise/metrics/src/test/java/org/neo4j/metrics/PageCacheMetricsIT.java
@@ -55,6 +55,7 @@ import static org.neo4j.metrics.source.db.PageCacheMetrics.PC_HIT_RATIO;
 import static org.neo4j.metrics.source.db.PageCacheMetrics.PC_PAGE_FAULTS;
 import static org.neo4j.metrics.source.db.PageCacheMetrics.PC_PINS;
 import static org.neo4j.metrics.source.db.PageCacheMetrics.PC_UNPINS;
+import static org.neo4j.metrics.source.db.PageCacheMetrics.PC_USAGE_RATIO;
 import static org.neo4j.test.assertion.Assert.assertEventually;
 
 public class PageCacheMetricsIT
@@ -112,6 +113,12 @@ public class PageCacheMetricsIT
         assertEventually(
                 "Metrics report should include page cache hit ratio",
                 () -> readDoubleValue( metricsCsv( metricsDirectory, PC_HIT_RATIO ) ),
+                lessThanOrEqualTo( 1.0 ),
+                5, SECONDS );
+
+        assertEventually(
+                "Metrics report should include page cache usage ratio",
+                () -> readDoubleValue( metricsCsv( metricsDirectory, PC_USAGE_RATIO ) ),
                 lessThanOrEqualTo( 1.0 ),
                 5, SECONDS );
     }


### PR DESCRIPTION
Add monitoring of "page cache usage" that will help with tuning of the page cache size.

- This adds the metric `neo4j.page_cache.usage_ratio` that returns a number between `0.0` and `1.0`. For example, a value of `0.5` means that half of the pages are used and the rest are available for data without evictions. 
- It's also exposed the same metric through the JMX bean "Page cache" with the method `getUsageRatio()`.