### PR TITLE
Unflake IndexStatisticsTest

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/PopulatingIndexProxy.java
@@ -66,7 +66,7 @@ public class PopulatingIndexProxy implements IndexProxy
                 return new PopulatingIndexUpdater()
                 {
                     @Override
-                    public void process( IndexEntryUpdate<?> update ) throws IOException, IndexEntryConflictException
+                    public void process( IndexEntryUpdate<?> update )
                     {
                         job.update( update );
                     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexStatisticsTest.java
@@ -298,7 +298,8 @@ public class IndexStatisticsTest
         double expectedSelectivity = UNIQUE_NAMES / seenWhilePopulating;
         assertCorrectIndexSelectivity( expectedSelectivity, indexSelectivity( index ) );
         assertCorrectIndexSize( seenWhilePopulating, indexSize( index ) );
-        assertCorrectIndexUpdates( updatesTracker.createdAfterPopulation(), indexUpdates( index ) );
+        int expectedIndexUpdates = updatesTracker.createdAfterPopulation() + updatesTracker.updatedAfterPopulation();
+        assertCorrectIndexUpdates( expectedIndexUpdates, indexUpdates( index ) );
     }
 
     @Test
@@ -617,7 +618,7 @@ public class IndexStatisticsTest
             notifyIfPopulationCompleted( index, updatesTracker );
 
             // delete if allowed
-            if ( allowDeletions && updatesTracker.created() % 5 == 0 )
+            if ( allowDeletions && updatesTracker.created() % 24 == 0 )
             {
                 long nodeId = nodes[random.nextInt( nodes.length )];
                 try
@@ -633,7 +634,7 @@ public class IndexStatisticsTest
             }
 
             // update if allowed
-            if ( allowUpdates && updatesTracker.created() % 5 == 0 )
+            if ( allowUpdates && updatesTracker.created() % 24 == 0 )
             {
                 int randomIndex = random.nextInt( nodes.length );
                 try

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/UpdatesTracker.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/UpdatesTracker.java
@@ -128,6 +128,9 @@ public class UpdatesTracker
                ", createdDuringPopulation=" + createdDuringPopulation +
                ", updatedDuringPopulation=" + updatedDuringPopulation +
                ", deletedDuringPopulation=" + deletedDuringPopulation +
+               ", createdAfterPopulation=" + createdAfterPopulation() +
+               ", updatedAfterPopulation=" + updatedAfterPopulation() +
+               ", deletedAfterPopulation=" + deletedAfterPopulation() +
                ", populationCompleted=" + populationCompleted +
                '}';
     }


### PR DESCRIPTION
There is an optimization in the node.setProperty that does not send an index update if the old and new values are equal. This was not compensated for in the test.