### PR TITLE
Fix in normalizeReturnClauses with same variable names

### DIFF
--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/ast/rewriters/NormalizeReturnClausesTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/ast/rewriters/NormalizeReturnClausesTest.scala
@@ -65,6 +65,14 @@ class NormalizeReturnClausesTest extends CypherFunSuite with RewriteTest with As
         |return `  FRESHID17` as n, `  FRESHID20` as c""".stripMargin)
   }
 
+  test("match (n),(m) return n as m, m as m2 order by m") {
+    assertRewrite(
+      "match (n),(m) return n as m, m as m2 order by m",
+      """match (n), (m)
+        |with n as `  FRESHID21`, m as `  FRESHID29` order by `  FRESHID21`
+        |return `  FRESHID21` as m, `  FRESHID29` as m2""".stripMargin)
+  }
+
   test("rejects use of aggregation in ORDER BY if aggregation is not used in associated RETURN") {
     // Note: aggregations in ORDER BY that don't also appear in WITH are invalid
     try {

--- a/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/ast/rewriters/NormalizeReturnClausesTest.scala
+++ b/community/cypher/cypher-compiler-3.3/src/test/scala/org/neo4j/cypher/internal/compiler/v3_3/ast/rewriters/NormalizeReturnClausesTest.scala
@@ -73,6 +73,14 @@ class NormalizeReturnClausesTest extends CypherFunSuite with RewriteTest with As
         |return `  FRESHID21` as m, `  FRESHID29` as m2""".stripMargin)
   }
 
+  test("match (n),(m) return m as m2, n as m order by m") {
+    assertRewrite(
+      "match (n),(m) return m as m2, n as m order by m",
+      """match (n), (m)
+        |with m as `  FRESHID21`, n as `  FRESHID30` order by `  FRESHID30`
+        |return `  FRESHID21` as m2, `  FRESHID30` as m""".stripMargin)
+  }
+
   test("rejects use of aggregation in ORDER BY if aggregation is not used in associated RETURN") {
     // Note: aggregations in ORDER BY that don't also appear in WITH are invalid
     try {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MiscAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MiscAcceptanceTest.scala
@@ -37,4 +37,17 @@ class MiscAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSu
     result.toList should equal(List(Map("j" -> 1, "i" -> 0), Map("j" -> 0, "i" -> 1)))
   }
 
+  test("order by after projection") {
+    val query =
+      """
+|UNWIND [ 1,2 ] as x
+|UNWIND [ 3,4 ] as y
+|RETURN x AS y, y as y3
+|ORDER BY y
+      """.stripMargin
+
+    val result = innerExecuteDeprecated(query, Map.empty)
+    result.toList should equal(List(Map("y" -> 1, "y3" -> 3), Map("y" -> 1, "y3" -> 4), Map("y" -> 2, "y3" -> 3), Map("y" -> 2, "y3" -> 4)))
+  }
+
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MiscAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MiscAcceptanceTest.scala
@@ -40,13 +40,13 @@ class MiscAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSu
   test("order by after projection") {
     val query =
       """
-|UNWIND [ 1,2 ] as x
-|UNWIND [ 3,4 ] as y
-|RETURN x AS y, y as y3
-|ORDER BY y
+        |UNWIND [ 1,2 ] as x
+        |UNWIND [ 3,4 ] as y
+        |RETURN x AS y, y as y3
+        |ORDER BY y
       """.stripMargin
 
-    val result = innerExecuteDeprecated(query, Map.empty)
+    val result = executeWith(Configs.All, query, expectedDifferentResults = Configs.BackwardsCompatibility + Configs.AllRulePlanners)
     result.toList should equal(List(Map("y" -> 1, "y3" -> 3), Map("y" -> 1, "y3" -> 4), Map("y" -> 2, "y3" -> 3), Map("y" -> 2, "y3" -> 4)))
   }
 


### PR DESCRIPTION
changelog:
Fixes bug with incorrect ordering when aliasing.
Queries such as `match (n),(m) return m as m2, n as m order by m` were rewritten incorrectly to sort by the wrong column `m as m2`. Now, the result is correctly ordered by `n as m`.