### PR TITLE
Fix pattern comprehension match error

### DIFF
--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ExecutionContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ExecutionContext.scala
@@ -157,14 +157,14 @@ case class MapExecutionContext(m: MutableMap[String, AnyValue])
 
   override def boundEntities(materializeNode: Long => AnyValue, materializeRelationship: Long => AnyValue): Map[String, AnyValue] =
     m.collect {
-      case kv => kv._2 match {
-        case _: NodeValue | _: RelationshipValue =>
-          kv
-        case v: NodeReference =>
-          (kv._1, materializeNode(v.id()))
-        case v: RelationshipReference =>
-          (kv._1, materializeRelationship(v.id()))
-      }
+      case kv @ (_, _: NodeValue) =>
+        kv
+      case kv @ (_, _: RelationshipValue) =>
+        kv
+      case (k, v: NodeReference) =>
+        (k, materializeNode(v.id()))
+      case (k, v: RelationshipReference) =>
+        (k, materializeRelationship(v.id()))
     }.toMap
 
   override def isNull(key: String): Boolean =

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
@@ -48,6 +48,7 @@ Get node degree via length of pattern expression that specifies a relationship t
 Nested pattern comprehensions
 Nested pattern comprehensions 2
 Nested pattern comprehensions 3
+Nested pattern comprehensions 4
 
 //OrderByAcceptance.feature - Unsupported orderability
 ORDER BY nodes should return null results last in ascending order

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -77,6 +77,7 @@ Pattern expression inside list comprehension
 Nested pattern comprehensions
 Nested pattern comprehensions 2
 Nested pattern comprehensions 3
+Nested pattern comprehensions 4
 Get node degree via length of pattern expression
 Get node degree via length of pattern expression that specifies a relationship type
 Get node degree via length of pattern expression that specifies multiple relationship types

--- a/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedExecutionContext.scala
+++ b/enterprise/cypher/slotted-runtime/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/slotted/SlottedExecutionContext.scala
@@ -250,6 +250,7 @@ case class SlottedExecutionContext(slots: SlotConfiguration) extends ExecutionCo
               entities += key -> materializeNode(nodeRef.id())
             case relRef: RelationshipReference =>
               entities += key -> materializeRelationship(relRef.id())
+            case _ => // Do nothing
           }
         }
       case (key, LongSlot(offset, false, CTNode)) =>


### PR DESCRIPTION
Missing a fallback case in SlottedExecutionContext `boundEntities`.