### PR TITLE
Extend Kernel API with stable/active transaction state

### DIFF
--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Modes.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Modes.java
@@ -19,16 +19,15 @@
  */
 package org.neo4j.internal.kernel.api;
 
-import org.neo4j.internal.kernel.api.security.SecurityContext;
-
 /**
- * The Kernel.
+ * Define Kernel modes.
  */
-public interface Kernel
+public interface Modes
 {
-    CursorFactory cursors();
-
-    Session beginSession( SecurityContext securityContext );
-
-    Modes modes();
+    /**
+     * True if the kernel supports the two-layer transaction state. If false, both {@link Transaction#dataRead()}
+     * and {@link Transaction#stableDataRead()} will refer to the same active instance, and
+     * {@link Transaction#markAsStable()} will be ignored.
+     */
+    boolean twoLayerTransactionState();
 }

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Transaction.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Transaction.java
@@ -56,12 +56,23 @@ public interface Transaction extends AutoCloseable
     void failure();
 
     /**
-     * @return The Read operations of the graph.
+     * @return The Read operations of the graph. The returned instance targets the active transaction state layer.
      */
     Read dataRead();
 
     /**
-     * @return The Write operations of the graph.
+     * @return The Read operations of the graph. The returned instance targets the stable transaction state layer.
+     */
+    Read stableDataRead();
+
+    /**
+     * Stabilize the active transaction state. This moves all changes up until this point to the stable
+     * transaction state layer. Any further changes will be added to the (now empty) active transaction state.
+     */
+    void markAsStable();
+
+    /**
+     * @return The Write operations of the graph. The returned instance writes to the active transaction state layer.
      * @throws InvalidTransactionTypeKernelException when transaction cannot be upgraded to a write transaction. This
      * can happen when there have been schema modifications.
      */

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/KernelAPIWriteTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/KernelAPIWriteTestBase.java
@@ -50,6 +50,7 @@ public abstract class KernelAPIWriteTestBase<WriteSupport extends KernelAPIWrite
     protected static final TemporaryFolder folder = new TemporaryFolder();
     protected static KernelAPIWriteTestSupport testSupport;
     protected Session session;
+    protected Modes modes;
     protected ManagedTestCursors cursors;
     protected static GraphDatabaseService graphDb;
 
@@ -74,6 +75,7 @@ public abstract class KernelAPIWriteTestBase<WriteSupport extends KernelAPIWrite
         testSupport.clearGraph();
         Kernel kernel = testSupport.kernelToTest();
         session = kernel.beginSession( SecurityContext.AUTH_DISABLED );
+        modes = kernel.modes();
         cursors = new ManagedTestCursors( kernel.cursors() );
     }
 

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/TwoLayerTxStateTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/TwoLayerTxStateTestBase.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.kernel.api;
+
+import org.junit.Assume;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.neo4j.values.storable.Value;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.neo4j.values.storable.Values.booleanValue;
+import static org.neo4j.values.storable.Values.intValue;
+import static org.neo4j.values.storable.Values.stringValue;
+
+public abstract class TwoLayerTxStateTestBase<G extends KernelAPIWriteTestSupport> extends KernelAPIWriteTestBase<G>
+{
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void shouldNotSeeCreatedNodeInStableState() throws Exception
+    {
+        Assume.assumeTrue( modes.twoLayerTransactionState() );
+
+        long node;
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            node = tx.dataWrite().nodeCreate();
+
+            try ( NodeCursor cursor = cursors.allocateNodeCursor() )
+            {
+                tx.stableDataRead().singleNode( node, cursor );
+                assertFalse( "not in stable tx state", cursor.next() );
+
+                tx.dataRead().singleNode( node, cursor );
+                assertTrue( "in active tx state", cursor.next() );
+                assertEquals( node, cursor.nodeReference() );
+
+                assertFalse( "only single node in active tx state", cursor.next() );
+            }
+        }
+    }
+
+    @Test
+    public void shouldSeeStabilizedCreatedNodeInStableState() throws Exception
+    {
+        Assume.assumeTrue( modes.twoLayerTransactionState() );
+
+        long node;
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            node = tx.dataWrite().nodeCreate();
+
+            tx.markAsStable();
+
+            try ( NodeCursor cursor = cursors.allocateNodeCursor() )
+            {
+                tx.dataRead().singleNode( node, cursor );
+                assertTrue( "in active tx state", cursor.next() );
+
+                tx.stableDataRead().singleNode( node, cursor );
+                assertTrue( "in stable tx state", cursor.next() );
+                assertEquals( node, cursor.nodeReference() );
+
+                assertFalse( "only single node in stable tx state", cursor.next() );
+            }
+        }
+    }
+
+    @Test
+    public void shouldNotSeeRemovedNodeInActiveState() throws Exception
+    {
+        Assume.assumeTrue( modes.twoLayerTransactionState() );
+
+        long n1;
+        // given
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            n1 = tx.dataWrite().nodeCreate();
+            tx.success();
+        }
+
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            // and given
+            long n2 = tx.dataWrite().nodeCreate();
+            long n3 = tx.dataWrite().nodeCreate();
+
+            tx.markAsStable();
+
+            tx.dataWrite().nodeDelete( n2 );
+
+            // then
+            assertAllNodes( tx.stableDataRead(), n1, n2, n3 );
+            assertAllNodes( tx.dataRead(), n1, n3 );
+        }
+    }
+
+    @Test
+    public void shouldSeparateRelationshipWritesIntoLayers() throws Exception
+    {
+        Assume.assumeTrue( modes.twoLayerTransactionState() );
+
+        final int TYPE = 0;
+        long n1, n2, r1, r2;
+        // given
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            n1 = tx.dataWrite().nodeCreate();
+            n2 = tx.dataWrite().nodeCreate();
+            r1 = tx.dataWrite().relationshipCreate( n1, TYPE, n2 );
+            r2 = tx.dataWrite().relationshipCreate( n1, TYPE, n2 );
+            tx.success();
+        }
+
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            // and given
+            long r3 = tx.dataWrite().relationshipCreate( n1, TYPE, n2 );
+            long r4 = tx.dataWrite().relationshipCreate( n1, TYPE, n2 );
+            tx.dataWrite().relationshipDelete( r2 );
+
+            tx.markAsStable();
+
+            long r5 = tx.dataWrite().relationshipCreate( n1, TYPE, n2 );
+            tx.dataWrite().relationshipDelete( r4 );
+
+            // then
+            assertExpandNode( tx.stableDataRead(), n1, r1, r3, r4 );
+            assertExpandNode( tx.dataRead(), n1, r1, r3, r5 );
+        }
+    }
+
+    @Test
+    public void shouldSeparatePropertyWritesIntoLayers() throws Exception
+    {
+        Assume.assumeTrue( modes.twoLayerTransactionState() );
+
+        final int prop1 = 0;
+        final int prop2 = 1;
+        final int prop3 = 2;
+        final int prop4 = 2;
+        final int prop5 = 2;
+        final int prop6 = 2;
+        long n1;
+
+        // given
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            n1 = tx.dataWrite().nodeCreate();
+            tx.dataWrite().nodeSetProperty( n1, prop1, intValue( 1 ) );
+            tx.dataWrite().nodeSetProperty( n1, prop2, stringValue( "yo1" ) );
+            tx.dataWrite().nodeSetProperty( n1, prop3, booleanValue( true ) );
+            tx.success();
+        }
+
+        try ( Transaction tx = session.beginTransaction() )
+        {
+            // and given
+            tx.dataWrite().nodeSetProperty( n1, prop2, stringValue( "yo2" ) );
+            tx.dataWrite().nodeSetProperty( n1, prop4, intValue( 2 ) );
+            tx.dataWrite().nodeSetProperty( n1, prop5, stringValue( "onlyInStable" ) );
+            tx.dataWrite().nodeRemoveProperty( n1, prop3 );
+
+            tx.markAsStable();
+
+            tx.dataWrite().nodeSetProperty( n1, prop2, stringValue( "yo3" ) );
+            tx.dataWrite().nodeRemoveProperty( n1, prop5 );
+            tx.dataWrite().nodeSetProperty( n1, prop6, intValue( 3 ) );
+
+            // then
+            assertNode( tx.stableDataRead(), n1 )
+                    .hasProperty( prop1, intValue( 1 ) )
+                    .hasProperty( prop2, stringValue( "yo2" ) )
+                    .hasProperty( prop4, intValue( 2 ) )
+                    .hasProperty( prop5, stringValue( "onlyInStable" ) )
+                    .andNothingElse();
+
+            assertNode( tx.dataRead(), n1 )
+                    .hasProperty( prop1, intValue( 1 ) )
+                    .hasProperty( prop2, stringValue( "yo3" ) )
+                    .hasProperty( prop4, intValue( 2 ) )
+                    .hasProperty( prop6, intValue( 3 ) )
+                    .andNothingElse();
+        }
+    }
+
+    private void assertAllNodes( Read read, long... nodes )
+    {
+        Set<Long> expectedSet = Arrays.stream( nodes ).boxed().collect( Collectors.toSet() );
+        try ( NodeCursor node = cursors.allocateNodeCursor() )
+        {
+            int count = 0;
+            read.allNodesScan( node );
+            while ( node.next() )
+            {
+                assertTrue( expectedSet.contains( node.nodeReference() ) );
+                count++;
+            }
+            assertEquals( expectedSet.size(), count );
+        }
+    }
+
+    private void assertExpandNode( Read read, long nodeId, long... relationshipIds )
+    {
+        Set<Long> expectedSet = Arrays.stream( relationshipIds ).boxed().collect( Collectors.toSet() );
+        try ( NodeCursor node = cursors.allocateNodeCursor();
+                RelationshipTraversalCursor relationship = cursors.allocateRelationshipTraversalCursor() )
+        {
+            int count = 0;
+            read.singleNode( nodeId, node );
+            assertTrue( node.next() );
+
+            node.allRelationships( relationship );
+            while ( relationship.next() )
+            {
+                assertTrue( expectedSet.contains( relationship.relationshipReference() ) );
+                count++;
+            }
+            assertEquals( expectedSet.size(), count );
+        }
+    }
+
+    private NodeProperties assertNode( Read read, long nodeId )
+    {
+        Map<Integer,Value> properties = new HashMap<>();
+        try ( NodeCursor node = cursors.allocateNodeCursor();
+              PropertyCursor property = cursors.allocatePropertyCursor() )
+        {
+            read.singleNode( nodeId, node );
+            assertTrue( node.next() );
+
+            node.properties( property );
+            while ( property.next() )
+            {
+                properties.put( property.propertyKey(), property.propertyValue() );
+            }
+        }
+        return new NodeProperties( properties );
+    }
+
+    static class NodeProperties
+    {
+        final Map<Integer,Value> properties;
+
+        NodeProperties( Map<Integer,Value> properties )
+        {
+            this.properties = properties;
+        }
+
+        NodeProperties hasProperty( Integer key, Value value )
+        {
+            assertTrue( properties.containsKey( key ) );
+            assertEquals( properties.get( key ), value );
+            properties.remove( key );
+            return this;
+        }
+
+        void andNothingElse()
+        {
+            assertTrue( properties.isEmpty() );
+        }
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.api;
 
 
 import org.neo4j.internal.kernel.api.CursorFactory;
+import org.neo4j.internal.kernel.api.Modes;
 import org.neo4j.internal.kernel.api.Session;
 import org.neo4j.internal.kernel.api.Transaction;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
@@ -154,5 +155,11 @@ public class Kernel extends LifecycleAdapter implements InwardKernel
     public Session beginSession( SecurityContext securityContext )
     {
         return newKernel.beginSession( securityContext );
+    }
+
+    @Override
+    public Modes modes()
+    {
+        return newKernel;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactionImplementation.java
@@ -721,6 +721,19 @@ public class KernelTransactionImplementation implements KernelTransaction, TxSta
     }
 
     @Override
+    public Read stableDataRead()
+    {
+        currentStatement.assertAllows( AccessMode::allowsReads, "Read" );
+        return operations.dataRead();
+    }
+
+    @Override
+    public void markAsStable()
+    {
+        // ignored until 2-layer tx-state is supported
+    }
+
+    @Override
     public Write dataWrite() throws InvalidTransactionTypeKernelException
     {
         accessCapability.assertCanWrite();

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NewKernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NewKernel.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.newapi;
 
 import org.neo4j.internal.kernel.api.CursorFactory;
 import org.neo4j.internal.kernel.api.Kernel;
+import org.neo4j.internal.kernel.api.Modes;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.InwardKernel;
 import org.neo4j.storageengine.api.StorageEngine;
@@ -30,7 +31,7 @@ import org.neo4j.storageengine.api.StorageStatement;
  * This is a temporary implementation of the Kernel API, used to enable early testing. The plan is to merge this
  * class with org.neo4j.kernel.impl.api.Kernel.
  */
-public class NewKernel implements Kernel
+public class NewKernel implements Kernel, Modes
 {
     private final StorageEngine engine;
     private final KernelToken token;
@@ -63,6 +64,12 @@ public class NewKernel implements Kernel
         return new KernelSession( token, kernel, securityContext );
     }
 
+    @Override
+    public Modes modes()
+    {
+        return this;
+    }
+
     public void start()
     {
         statement = engine.storeReadLayer().newStatement();
@@ -79,5 +86,11 @@ public class NewKernel implements Kernel
         statement.close();
         isRunning = false;
         this.cursors = null;
+    }
+
+    @Override
+    public boolean twoLayerTransactionState()
+    {
+        return false;
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/StubKernelTransaction.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/StubKernelTransaction.java
@@ -74,6 +74,18 @@ public class StubKernelTransaction implements KernelTransaction
     }
 
     @Override
+    public Read stableDataRead()
+    {
+        return null;
+    }
+
+    @Override
+    public void markAsStable()
+    {
+
+    }
+
+    @Override
     public Write dataWrite()
     {
         throw new UnsupportedOperationException( "not implemented" );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
@@ -29,6 +29,7 @@ import org.neo4j.internal.kernel.api.CursorFactory;
 import org.neo4j.internal.kernel.api.ExplicitIndexRead;
 import org.neo4j.internal.kernel.api.ExplicitIndexWrite;
 import org.neo4j.internal.kernel.api.Locks;
+import org.neo4j.internal.kernel.api.Modes;
 import org.neo4j.internal.kernel.api.NodeCursor;
 import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.Read;
@@ -374,6 +375,12 @@ public class ConstraintIndexCreatorTest
             throw new UnsupportedOperationException();
         }
 
+        @Override
+        public Modes modes()
+        {
+            return null;
+        }
+
         private class StubKernelTransaction implements KernelTransaction
         {
             private long timeout;
@@ -401,6 +408,18 @@ public class ConstraintIndexCreatorTest
             public Read dataRead()
             {
                 throw new UnsupportedOperationException( "not implemented" );
+            }
+
+            @Override
+            public Read stableDataRead()
+            {
+                return null;
+            }
+
+            @Override
+            public void markAsStable()
+            {
+
             }
 
             @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/TwoLayerTxStateTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/TwoLayerTxStateTest.java
@@ -17,18 +17,15 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.internal.kernel.api;
+package org.neo4j.kernel.impl.newapi;
 
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.TwoLayerTxStateTestBase;
 
-/**
- * The Kernel.
- */
-public interface Kernel
+public class TwoLayerTxStateTest extends TwoLayerTxStateTestBase<WriteTestSupport>
 {
-    CursorFactory cursors();
-
-    Session beginSession( SecurityContext securityContext );
-
-    Modes modes();
+    @Override
+    public WriteTestSupport newTestSupport()
+    {
+        return new WriteTestSupport();
+    }
 }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/StubKernelTransaction.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/StubKernelTransaction.java
@@ -69,6 +69,18 @@ class StubKernelTransaction implements KernelTransaction
     }
 
     @Override
+    public Read stableDataRead()
+    {
+        return null;
+    }
+
+    @Override
+    public void markAsStable()
+    {
+
+    }
+
+    @Override
     public Write dataWrite()
     {
         return null;


### PR DESCRIPTION
The transaction now has two Read entry points: dataRead() and stableDataRead(). The
instance returned by stableDataRead() will not see any in-transaction writes which
have happened since the last Transaction.markAsStable(). To allow Cypher to code
against this functionality before the implementation exists, a feature toggle is
added to the Kernel API in Kernel.Modes.twoLayerTransactionState().

This commit also adds feature toggle dependent test of some of the expected
functionality in TwoLayerTxStateTestBase.