### PR TITLE
Fix slotted shortest path predicate planning

### DIFF
--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/PipeLazynessTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/PipeLazynessTest.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.compiler.v3_4
 import org.mockito.Mockito._
 import org.neo4j.cypher.GraphDatabaseFunSuite
 import org.neo4j.cypher.internal.runtime.interpreted.commands.{ShortestPath, SingleNode, SortItem}
-import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.Variable
+import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.{ShortestPathExpression, Variable}
 import org.neo4j.cypher.internal.runtime.interpreted.commands.predicates.True
 import org.neo4j.cypher.internal.runtime.interpreted.pipes._
 import org.neo4j.cypher.internal.runtime.interpreted.QueryStateTestSupport
@@ -80,7 +80,7 @@ class PipeLazynessTest extends GraphDatabaseFunSuite with QueryStateTestSupport 
     when(n1.getRelationships).thenReturn(Iterable.empty[Relationship].asJava)
     val iter = new LazyIterator[Map[String, Any]](10, (_) => Map("start" -> n1, "end" -> n1))
     val src = new FakePipe(iter, "start" -> CTNode, "end" -> CTNode)
-    val pipe = new ShortestPathPipe(src, shortestPath)()
+    val pipe = new ShortestPathPipe(src, ShortestPathExpression(shortestPath))()
     (pipe, iter)
   }
 

--- a/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Expression.scala
+++ b/community/cypher/expressions-3.4/src/main/scala/org/neo4j/cypher/internal/v3_4/expressions/Expression.scala
@@ -33,7 +33,7 @@ object Expression {
   final case class TreeAcc[A](data: A, stack: Stack[Set[LogicalVariable]] = Stack.empty) {
     def mapData(f: A => A): TreeAcc[A] = copy(data = f(data))
 
-    def inScope(variable: Variable) = stack.exists(_.contains(variable))
+    def inScope(variable: LogicalVariable) = stack.exists(_.contains(variable))
     def variablesInScope: Set[LogicalVariable] = stack.toSet.flatten
 
     def pushScope(newVariable: LogicalVariable): TreeAcc[A] = pushScope(Set(newVariable))
@@ -87,7 +87,7 @@ abstract class Expression extends ASTNode {
         acc =>
           val newAcc = acc.pushScope(scope.introducedVariables)
           (newAcc, Some((x) => x.popScope))
-      case id: Variable => acc => {
+      case id: LogicalVariable => acc => {
         val newAcc = if (acc.inScope(id)) acc else acc.mapData(_ + id)
         (newAcc, Some(identity))
       }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ShortestPathExpression.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/commands/expressions/ShortestPathExpression.scala
@@ -34,11 +34,14 @@ import org.neo4j.values.virtual.{NodeReference, NodeValue, VirtualValues}
 import scala.collection.JavaConverters._
 import scala.collection.Map
 
-case class ShortestPathExpression(shortestPathPattern: ShortestPath, predicates: Seq[Predicate] = Seq.empty,
+case class ShortestPathExpression(shortestPathPattern: ShortestPath,
+                                  perStepPredicates: Seq[Predicate] = Seq.empty,
+                                  fullPathPredicates: Seq[Predicate] = Seq.empty,
                                   withFallBack: Boolean = false, disallowSameNode: Boolean = true) extends Expression {
 
   val pathPattern: Seq[Pattern] = Seq(shortestPathPattern)
   val pathVariables = Set(shortestPathPattern.pathName, shortestPathPattern.relIterator.getOrElse(""))
+  val predicates = perStepPredicates ++ fullPathPredicates
 
   def apply(ctx: ExecutionContext, state: QueryState): AnyValue = {
     if (anyStartpointsContainNull(ctx)) {
@@ -189,34 +192,28 @@ case class ShortestPathExpression(shortestPathPattern: ShortestPath, predicates:
 
   private def addPredicates(ctx: ExecutionContext, relTypeAndDirExpander: Expander, state: QueryState):
   (Expander, Seq[KernelPredicate[PropertyContainer]]) =
-    if (predicates.isEmpty) (relTypeAndDirExpander, Seq())
+    if (perStepPredicates.isEmpty) (relTypeAndDirExpander, Seq())
     else
-      predicates.foldLeft((relTypeAndDirExpander, Seq[KernelPredicate[PropertyContainer]]())) {
+      perStepPredicates.foldLeft((relTypeAndDirExpander, Seq[KernelPredicate[PropertyContainer]]())) {
         case ((currentExpander, currentNodePredicates: Seq[KernelPredicate[PropertyContainer]]), predicate) =>
           predicate match {
-            case NoneInList(RelationshipFunction(_), symbolName, innerPredicate) if doesNotDependOnFullPath(
-              innerPredicate) =>
+            case NoneInList(RelationshipFunction(_), symbolName, innerPredicate) =>
               val expander = addAllOrNoneRelationshipExpander(ctx, currentExpander, all = false, innerPredicate,
                 symbolName, state)
               (expander, currentNodePredicates)
-            case AllInList(RelationshipFunction(_), symbolName, innerPredicate) if doesNotDependOnFullPath(
-              innerPredicate) =>
+            case AllInList(RelationshipFunction(_), symbolName, innerPredicate) =>
               val expander = addAllOrNoneRelationshipExpander(ctx, currentExpander, all = true, innerPredicate,
                 symbolName, state)
               (expander, currentNodePredicates)
-            case NoneInList(NodesFunction(_), symbolName, innerPredicate) if doesNotDependOnFullPath(innerPredicate) =>
+            case NoneInList(NodesFunction(_), symbolName, innerPredicate) =>
               addAllOrNoneNodeExpander(ctx, currentExpander, all = false, innerPredicate, symbolName,
                                        currentNodePredicates, state)
-            case AllInList(NodesFunction(_), symbolName, innerPredicate) if doesNotDependOnFullPath(innerPredicate) =>
+            case AllInList(NodesFunction(_), symbolName, innerPredicate) =>
               addAllOrNoneNodeExpander(ctx, currentExpander, all = true, innerPredicate, symbolName,
                                        currentNodePredicates, state)
             case _ => (currentExpander, currentNodePredicates)
           }
       }
-
-  private def doesNotDependOnFullPath(predicate: Predicate): Boolean = {
-    (predicate.symbolTableDependencies intersect pathVariables).isEmpty
-  }
 }
 
 object ShortestPathExpression {

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ShortestPathPipe.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/ShortestPathPipe.scala
@@ -33,12 +33,12 @@ import scala.collection.JavaConverters._
 /**
  * Shortest pipe inserts a single shortest path between two already found nodes
  */
-case class ShortestPathPipe(source: Pipe, shortestPathCommand: ShortestPath, predicates: Seq[Predicate] = Seq.empty,
+case class ShortestPathPipe(source: Pipe, shortestPathExpression: ShortestPathExpression,
                             withFallBack: Boolean = false, disallowSameNode: Boolean = true)
                            (val id: Id = Id.INVALID_ID)
   extends PipeWithSource(source) {
+  private val shortestPathCommand = shortestPathExpression.shortestPathPattern
   private def pathName = shortestPathCommand.pathName
-  private val shortestPathExpression = ShortestPathExpression(shortestPathCommand, predicates, withFallBack, disallowSameNode)
 
   protected def internalCreateResults(input:Iterator[ExecutionContext], state: QueryState) =
     input.flatMap(ctx => {

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/AllShortestPathsPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/AllShortestPathsPipeTest.scala
@@ -21,6 +21,7 @@ package org.neo4j.cypher.internal.runtime.interpreted.pipes
 
 import org.neo4j.cypher.GraphDatabaseFunSuite
 import org.neo4j.cypher.internal.runtime.interpreted.QueryStateHelper.withQueryState
+import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.ShortestPathExpression
 import org.neo4j.cypher.internal.runtime.interpreted.commands.{ShortestPath, SingleNode}
 import org.neo4j.cypher.internal.util.v3_4.symbols._
 import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection
@@ -36,9 +37,9 @@ class AllShortestPathsPipeTest extends GraphDatabaseFunSuite {
   def runThroughPipeAndGetPath(a: Node, b: Node) = {
     val source = new FakePipe(List(mutable.Map("a" -> a, "b" -> b)), "a" -> CTNode, "b" -> CTNode)
 
-    val pipe = ShortestPathPipe(source, ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq(),
-                                                     SemanticDirection.BOTH, allowZeroLength = false, Some(15),
-                                                     single = false, relIterator = None))()
+    val pipe = ShortestPathPipe(source, ShortestPathExpression(ShortestPath("p", SingleNode("a"), SingleNode("b"), Seq(),
+                                                               SemanticDirection.BOTH, allowZeroLength = false, Some(15),
+                                                               single = false, relIterator = None)))()
     graph.withTx { tx =>
       withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipe.createResults(queryState).toList.map(m => m("p").asInstanceOf[PathValue])

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SingleShortestPathPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/SingleShortestPathPipeTest.scala
@@ -21,6 +21,7 @@ package org.neo4j.cypher.internal.runtime.interpreted.pipes
 
 import org.neo4j.cypher.GraphDatabaseFunSuite
 import org.neo4j.cypher.internal.runtime.interpreted.QueryStateHelper.withQueryState
+import org.neo4j.cypher.internal.runtime.interpreted.commands.expressions.ShortestPathExpression
 import org.neo4j.cypher.internal.runtime.interpreted.commands.{ShortestPath, SingleNode}
 import org.neo4j.cypher.internal.util.v3_4.symbols._
 import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection
@@ -52,7 +53,7 @@ class SingleShortestPathPipeTest extends GraphDatabaseFunSuite {
   private def runThroughPipeAndGetPath(a: Node, b: Node, path: ShortestPath): PathValue = {
     val source = new FakePipe(List(Map("a" -> a, "b" -> b)), "a"-> CTNode, "b"-> CTNode)
 
-    val pipe = ShortestPathPipe(source, path)()
+    val pipe = ShortestPathPipe(source, ShortestPathExpression(path))()
     graph.withTx { tx =>
       withQueryState(graph, tx, EMPTY_MAP, { queryState =>
         pipe.createResults(queryState).next()("p").asInstanceOf[PathValue]

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
@@ -497,7 +497,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p) AS nodes
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
+    val result = executeWith(expectedToSucceed, query)
 
     result.toList should equal(List(Map("nodes" -> List(nodes("source"), nodes("node3"), nodes("node4"), nodes("target")))))
   }
@@ -512,7 +512,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p) as nodes
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
+    val result = executeWith(expectedToSucceed, query)
 
     result.toList should equal(List(Map("nodes" -> List(nodes("Donald"), nodes("Mickey"))),
       Map("nodes" -> List(nodes("Donald"), nodes("Mickey"), nodes("Minnie"))),
@@ -530,7 +530,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
                   |RETURN nodes(p) as nodes
                 """.stripMargin
 
-    val result = executeWith(expectedToSucceed - Configs.SlottedInterpreted, query)
+    val result = executeWith(expectedToSucceed, query)
 
     result.toList should equal(List(Map("nodes" -> List(nodes("Donald"), nodes("Mickey"))),
       Map("nodes" -> List(nodes("Donald"), nodes("Mickey"), nodes("Minnie"))),


### PR DESCRIPTION
Fixes shortest path with predicates that depends on the full path

Computing which predicates has variable dependencies on the full path
of a shortest path expression was done on runtime expressions,
and did not work for slotted runtime. 
This moves the computation to be done on the logical plan expression at pipe building time.

- Update neo4j-cypher-compiler-3.3 compatibility version to 3.3.2