### PR TITLE
Fixes an issue switching chunk in StringCollisionValues

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/StringCollisionValuesTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/cache/idmapping/string/StringCollisionValuesTest.java
@@ -49,7 +49,7 @@ public class StringCollisionValuesTest
         @Override
         public int stringMaxLength()
         {
-            return 1 << Short.SIZE;
+            return (1 << Short.SIZE) - 1;
         }
     } );
 


### PR DESCRIPTION
StringCollisionValuesTest was randomly failing because of it