### PR TITLE
Property level security

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/security/auth/AuthenticationResult.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/security/auth/AuthenticationResult.java
@@ -19,20 +19,20 @@
  */
 package org.neo4j.bolt.security.auth;
 
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 
 public interface AuthenticationResult
 {
-    SecurityContext getSecurityContext();
+    LoginContext getLoginContext();
 
     boolean credentialsExpired();
 
     AuthenticationResult AUTH_DISABLED = new AuthenticationResult()
     {
         @Override
-        public SecurityContext getSecurityContext()
+        public LoginContext getLoginContext()
         {
-            return SecurityContext.AUTH_DISABLED;
+            return LoginContext.AUTH_DISABLED;
         }
 
         @Override

--- a/community/bolt/src/main/java/org/neo4j/bolt/security/auth/BasicAuthentication.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/security/auth/BasicAuthentication.java
@@ -23,11 +23,11 @@ import java.io.IOException;
 import java.util.Map;
 
 import org.neo4j.graphdb.security.AuthorizationViolationException;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.security.AuthManager;
 import org.neo4j.kernel.api.security.AuthToken;
 import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.security.UserManagerSupplier;
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 
@@ -53,7 +53,7 @@ public class BasicAuthentication implements Authentication
     {
         if ( authToken.containsKey( NEW_CREDENTIALS ) )
         {
-            return update( authToken, false );
+            return update( authToken );
         }
         else
         {
@@ -65,9 +65,9 @@ public class BasicAuthentication implements Authentication
     {
         try
         {
-            SecurityContext securityContext = authManager.login( authToken );
+            LoginContext loginContext = authManager.login( authToken );
 
-            switch ( securityContext.subject().getAuthenticationResult() )
+            switch ( loginContext.subject().getAuthenticationResult() )
             {
             case SUCCESS:
             case PASSWORD_CHANGE_REQUIRED:
@@ -78,7 +78,7 @@ public class BasicAuthentication implements Authentication
                 throw new AuthenticationException( Status.Security.Unauthorized );
             }
 
-            return new BasicAuthenticationResult( securityContext );
+            return new BasicAuthenticationResult( loginContext );
         }
         catch ( InvalidAuthTokenException e )
         {
@@ -86,28 +86,28 @@ public class BasicAuthentication implements Authentication
         }
     }
 
-    private AuthenticationResult update( Map<String,Object> authToken, boolean requiresPasswordChange )
+    private AuthenticationResult update( Map<String,Object> authToken )
             throws AuthenticationException
     {
         try
         {
-            SecurityContext securityContext = authManager.login( authToken );
+            LoginContext loginContext = authManager.login( authToken );
 
-            switch ( securityContext.subject().getAuthenticationResult() )
+            switch ( loginContext.subject().getAuthenticationResult() )
             {
             case SUCCESS:
             case PASSWORD_CHANGE_REQUIRED:
                 String newPassword = AuthToken.safeCast( NEW_CREDENTIALS, authToken );
                 String username = AuthToken.safeCast( PRINCIPAL, authToken );
-                userManagerSupplier.getUserManager( securityContext )
-                        .setUserPassword( username, newPassword, requiresPasswordChange );
-                securityContext.subject().setPasswordChangeNoLongerRequired();
+                userManagerSupplier.getUserManager( loginContext.subject(), false )
+                        .setUserPassword( username, newPassword, false );
+                loginContext.subject().setPasswordChangeNoLongerRequired();
                 break;
             default:
                 throw new AuthenticationException( Status.Security.Unauthorized );
             }
 
-            return new BasicAuthenticationResult( securityContext );
+            return new BasicAuthenticationResult( loginContext );
         }
         catch ( AuthorizationViolationException | InvalidArgumentsException | InvalidAuthTokenException e )
         {

--- a/community/bolt/src/main/java/org/neo4j/bolt/security/auth/BasicAuthenticationResult.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/security/auth/BasicAuthenticationResult.java
@@ -19,27 +19,27 @@
  */
 package org.neo4j.bolt.security.auth;
 
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 
 public class BasicAuthenticationResult implements AuthenticationResult
 {
-    private SecurityContext securityContext;
+    private LoginContext loginContext;
 
-    public BasicAuthenticationResult( SecurityContext securityContext )
+    public BasicAuthenticationResult( LoginContext loginContext )
     {
-        this.securityContext = securityContext;
+        this.loginContext = loginContext;
     }
 
     @Override
-    public SecurityContext getSecurityContext()
+    public LoginContext getLoginContext()
     {
-        return securityContext;
+        return loginContext;
     }
 
     @Override
     public boolean credentialsExpired()
     {
-        return securityContext.subject().getAuthenticationResult() ==
+        return loginContext.subject().getAuthenticationResult() ==
                 org.neo4j.internal.kernel.api.security.AuthenticationResult.PASSWORD_CHANGE_REQUIRED;
     }
 }

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachine.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachine.java
@@ -31,8 +31,8 @@ import org.neo4j.cypher.InvalidSemanticsException;
 import org.neo4j.function.ThrowingAction;
 import org.neo4j.function.ThrowingConsumer;
 import org.neo4j.graphdb.TransactionTerminatedException;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
@@ -195,7 +195,7 @@ public class TransactionStateMachine implements StatementProcessor
                     {
                         if ( BEGIN.matcher( statement ).matches() )
                         {
-                            ctx.currentTransaction = spi.beginTransaction( ctx.securityContext );
+                            ctx.currentTransaction = spi.beginTransaction( ctx.loginContext );
 
                             Bookmark bookmark = Bookmark.fromParamsOrNull( params );
                             if ( bookmark != null )
@@ -241,7 +241,7 @@ public class TransactionStateMachine implements StatementProcessor
                             }
                             else
                             {
-                                ctx.currentTransaction = spi.beginTransaction( ctx.securityContext );
+                                ctx.currentTransaction = spi.beginTransaction( ctx.loginContext );
                                 BoltResultHandle resultHandle = execute( ctx, spi, statement, params );
                                 ctx.currentResultHandle = resultHandle;
                                 ctx.currentResult = resultHandle.start();
@@ -407,7 +407,7 @@ public class TransactionStateMachine implements StatementProcessor
                                                   MapValue params, ThrowingAction<KernelException> onFail )
             throws QueryExecutionKernelException
     {
-        return spi.executeQuery( ctx.querySource, ctx.securityContext, statement, params, onFail );
+        return spi.executeQuery( ctx.querySource, ctx.loginContext, statement, params, onFail );
     }
 
     /**
@@ -424,7 +424,7 @@ public class TransactionStateMachine implements StatementProcessor
     static class MutableTransactionState
     {
         /** The current session security context to be used for starting transactions */
-        final SecurityContext securityContext;
+        final LoginContext loginContext;
 
         /** The current transaction, if present */
         KernelTransaction currentTransaction;
@@ -455,7 +455,7 @@ public class TransactionStateMachine implements StatementProcessor
         private MutableTransactionState( AuthenticationResult authenticationResult, Clock clock )
         {
             this.clock = clock;
-            this.securityContext = authenticationResult.getSecurityContext();
+            this.loginContext = authenticationResult.getLoginContext();
         }
     }
 
@@ -465,7 +465,7 @@ public class TransactionStateMachine implements StatementProcessor
 
         long newestEncounteredTxId();
 
-        KernelTransaction beginTransaction( SecurityContext securityContext );
+        KernelTransaction beginTransaction( LoginContext loginContext );
 
         void bindTransactionToCurrentThread( KernelTransaction tx );
 
@@ -474,7 +474,7 @@ public class TransactionStateMachine implements StatementProcessor
         boolean isPeriodicCommit( String query );
 
         BoltResultHandle executeQuery( BoltQuerySource querySource,
-                SecurityContext securityContext,
+                LoginContext loginContext,
                 String statement,
                 MapValue params,
                 ThrowingAction<KernelException> onFail ) throws QueryExecutionKernelException;

--- a/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineSPI.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/v1/runtime/TransactionStateMachineSPI.java
@@ -28,12 +28,12 @@ import org.neo4j.bolt.v1.runtime.spi.BoltResult;
 import org.neo4j.cypher.internal.javacompat.ExecutionResult;
 import org.neo4j.cypher.result.QueryResult;
 import org.neo4j.function.ThrowingAction;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.txtracking.TransactionIdTracker;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
@@ -97,9 +97,9 @@ class TransactionStateMachineSPI implements TransactionStateMachine.SPI
     }
 
     @Override
-    public KernelTransaction beginTransaction( SecurityContext securityContext )
+    public KernelTransaction beginTransaction( LoginContext loginContext )
     {
-        db.beginTransaction( KernelTransaction.Type.explicit, securityContext );
+        db.beginTransaction( KernelTransaction.Type.explicit, loginContext );
         return txBridge.getKernelTransactionBoundToThisThread( false );
     }
 
@@ -123,11 +123,11 @@ class TransactionStateMachineSPI implements TransactionStateMachine.SPI
 
     @Override
     public BoltResultHandle executeQuery( BoltQuerySource querySource,
-            SecurityContext securityContext,
+            LoginContext loginContext,
             String statement,
             MapValue params, ThrowingAction<KernelException> onFail ) throws QueryExecutionKernelException
     {
-        InternalTransaction internalTransaction = queryService.beginTransaction( implicit, securityContext );
+        InternalTransaction internalTransaction = queryService.beginTransaction( implicit, loginContext );
         ClientConnectionInfo sourceDetails = new BoltConnectionInfo( querySource.principalName,
                 querySource.clientName,
                 querySource.connectionDescriptor.clientAddress(),

--- a/community/bolt/src/test/java/org/neo4j/bolt/security/auth/BasicAuthenticationTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/security/auth/BasicAuthenticationTest.java
@@ -60,8 +60,7 @@ public class BasicAuthenticationTest
                 authentication.authenticate( map( "scheme", "basic", "principal", "mike", "credentials", "secret2" ) );
 
         // Then
-        assertThat(result.getSecurityContext().mode(), equalTo( AccessMode.Static.FULL));
-        assertThat( result.getSecurityContext().subject().username(), equalTo( "mike" ) );
+        assertThat( result.getLoginContext().subject().username(), equalTo( "mike" ) );
     }
 
     @Test

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/ManyMergesStressTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/ManyMergesStressTest.java
@@ -32,9 +32,9 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.Pair;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.test.rule.EmbeddedDatabaseRule;
 
@@ -93,7 +93,7 @@ public class ManyMergesStressTest
             String query =
                 format( "MERGE (%s:Person {id: %s}) ON CREATE SET %s.name = \"%s\";", ident, id, ident, name );
 
-            try ( InternalTransaction tx = graph.beginTransaction( KernelTransaction.Type.implicit, SecurityContext.AUTH_DISABLED ) )
+            try ( InternalTransaction tx = graph.beginTransaction( KernelTransaction.Type.implicit, LoginContext.AUTH_DISABLED ) )
             {
                 Result result = db.execute( query );
                 result.close();

--- a/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionEngineTest.java
+++ b/community/cypher/cypher/src/test/java/org/neo4j/cypher/internal/javacompat/ExecutionEngineTest.java
@@ -28,9 +28,9 @@ import java.util.Map;
 
 import org.neo4j.cypher.internal.CommunityCompatibilityFactory;
 import org.neo4j.graphdb.Result;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.kernel.impl.coreapi.PropertyContainerLocker;
 import org.neo4j.kernel.impl.query.Neo4jTransactionalContextFactory;
@@ -66,7 +66,7 @@ public class ExecutionEngineTest
 
         Result result;
         try ( InternalTransaction tx = graph
-                .beginTransaction( KernelTransaction.Type.implicit, SecurityContext.AUTH_DISABLED ) )
+                .beginTransaction( KernelTransaction.Type.implicit, LoginContext.AUTH_DISABLED ) )
         {
             String query = "RETURN { key : 'Value' , collectionKey: [{ inner: 'Map1' }, { inner: 'Map2' }]}";
             TransactionalContext tc = createTransactionContext( graph, tx, query );

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/KillQueryTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/KillQueryTest.scala
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import org.neo4j.cypher.internal.{CommunityCompatibilityFactory, ExecutionEngine}
 import org.neo4j.graphdb.{TransactionTerminatedException, TransientTransactionFailureException}
 import org.neo4j.internal.kernel.api.Transaction.Type
-import org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED
+import org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED
 import org.neo4j.kernel.impl.coreapi.PropertyContainerLocker
 import org.neo4j.kernel.impl.query.clientconnection.ClientConnectionInfo
 import org.neo4j.kernel.impl.query.{Neo4jTransactionalContextFactory, TransactionalContext, TransactionalContextFactory}

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ActualCostCalculationTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiler/v3_4/ActualCostCalculationTest.scala
@@ -38,7 +38,7 @@ import org.neo4j.cypher.internal.v3_4.expressions.{LabelToken, PropertyKeyToken,
 import org.neo4j.cypher.internal.v3_4.logical.plans.SingleQueryExpression
 import org.neo4j.graphdb._
 import org.neo4j.internal.kernel.api.Transaction.Type
-import org.neo4j.internal.kernel.api.security.SecurityContext
+import org.neo4j.internal.kernel.api.security.LoginContext
 import org.neo4j.kernel.GraphDatabaseQueryService
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge
 import org.neo4j.kernel.impl.coreapi.{InternalTransaction, PropertyContainerLocker}
@@ -344,7 +344,7 @@ class ActualCostCalculationTest extends CypherFunSuite {
     val gds = graph.asInstanceOf[GraphDatabaseCypherService].getGraphDatabaseService
 
     def withTx[T](f: InternalTransaction => T): T = {
-      val tx = graph.beginTransaction(Type.explicit, SecurityContext.AUTH_DISABLED)
+      val tx = graph.beginTransaction(Type.explicit, LoginContext.AUTH_DISABLED)
       try {
         val result = f(tx)
         tx.success()

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/CypherReductionSupport.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/queryReduction/CypherReductionSupport.scala
@@ -24,7 +24,6 @@ import org.neo4j.cypher.internal.compatibility.v3_4.WrappedMonitors
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime._
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.executionplan.procs.ProcedureCallOrSchemaCommandExecutionPlanBuilder
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.phases.CompilationState
-import org.neo4j.cypher.internal.planner.v3_4.spi.PlanningAttributes.{Cardinalities, Solveds}
 import org.neo4j.cypher.internal.compiler.v3_4._
 import org.neo4j.cypher.internal.compiler.v3_4.phases.{CompilationContains, LogicalPlanState}
 import org.neo4j.cypher.internal.compiler.v3_4.planner.logical.idp.{IDPQueryGraphSolver, IDPQueryGraphSolverMonitor, SingleComponentPlanner, cartesianProductsOrValueJoins}
@@ -37,16 +36,17 @@ import org.neo4j.cypher.internal.frontend.v3_4.phases._
 import org.neo4j.cypher.internal.frontend.v3_4.prettifier.{ExpressionStringifier, Prettifier}
 import org.neo4j.cypher.internal.frontend.v3_4.semantics.SemanticState
 import org.neo4j.cypher.internal.javacompat.GraphDatabaseCypherService
+import org.neo4j.cypher.internal.planner.v3_4.spi.PlanningAttributes.{Cardinalities, Solveds}
 import org.neo4j.cypher.internal.planner.v3_4.spi.{IDPPlannerName, PlanContext, PlannerNameFor}
 import org.neo4j.cypher.internal.queryReduction.DDmin.Oracle
 import org.neo4j.cypher.internal.runtime.interpreted.TransactionBoundQueryContext.IndexSearchMonitor
 import org.neo4j.cypher.internal.runtime.interpreted.{TransactionBoundPlanContext, TransactionBoundQueryContext, TransactionalContextWrapper, ValueConversion}
 import org.neo4j.cypher.internal.runtime.{InternalExecutionResult, NormalMode}
-import org.neo4j.cypher.internal.util.v3_4.attribution.{IdGen, SequentialIdGen}
+import org.neo4j.cypher.internal.util.v3_4.attribution.SequentialIdGen
 import org.neo4j.cypher.internal.util.v3_4.test_helpers.{CypherFunSuite, CypherTestSupport}
 import org.neo4j.cypher.internal.{CompilerEngineDelegator, ExecutionPlan, RewindableExecutionResult}
 import org.neo4j.internal.kernel.api.Transaction
-import org.neo4j.internal.kernel.api.security.SecurityContext
+import org.neo4j.internal.kernel.api.security.LoginContext
 import org.neo4j.kernel.impl.coreapi.{InternalTransaction, PropertyContainerLocker}
 import org.neo4j.kernel.impl.query.clientconnection.ClientConnectionInfo.EMBEDDED_CONNECTION
 import org.neo4j.kernel.impl.query.{Neo4jTransactionalContextFactory, TransactionalContextFactory}
@@ -148,8 +148,8 @@ trait CypherReductionSupport extends CypherTestSupport with GraphIcing {
                             statement: Statement,
                             parsingBaseState: BaseState,
                             executeBefore: Option[String]): InternalExecutionResult = {
-    val explicitTx = graph.beginTransaction(Transaction.Type.explicit, SecurityContext.AUTH_DISABLED)
-    val implicitTx = graph.beginTransaction(Transaction.Type.`implicit`, SecurityContext.AUTH_DISABLED)
+    val explicitTx = graph.beginTransaction(Transaction.Type.explicit, LoginContext.AUTH_DISABLED)
+    val implicitTx = graph.beginTransaction(Transaction.Type.`implicit`, LoginContext.AUTH_DISABLED)
     try {
       executeBefore match {
         case None =>

--- a/community/cypher/interpreted-runtime/src/main/java/org/neo4j/cypher/internal/javacompat/GraphDatabaseCypherService.java
+++ b/community/cypher/interpreted-runtime/src/main/java/org/neo4j/cypher/internal/javacompat/GraphDatabaseCypherService.java
@@ -28,10 +28,10 @@ import org.neo4j.graphdb.Label;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.security.URLAccessValidationError;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.dbms.DbmsOperations;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 
@@ -53,16 +53,16 @@ public class GraphDatabaseCypherService implements GraphDatabaseQueryService
     }
 
     @Override
-    public InternalTransaction beginTransaction( KernelTransaction.Type type, SecurityContext securityContext )
+    public InternalTransaction beginTransaction( KernelTransaction.Type type, LoginContext loginContext )
     {
-        return graph.beginTransaction( type, securityContext );
+        return graph.beginTransaction( type, loginContext );
     }
 
     @Override
-    public InternalTransaction beginTransaction( KernelTransaction.Type type, SecurityContext securityContext,
+    public InternalTransaction beginTransaction( KernelTransaction.Type type, LoginContext loginContext,
             long timeout, TimeUnit unit )
     {
-        return graph.beginTransaction( type, securityContext, timeout, unit );
+        return graph.beginTransaction( type, loginContext, timeout, unit );
     }
 
     @Override

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/QueryStateTestSupport.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/QueryStateTestSupport.scala
@@ -22,7 +22,7 @@ package org.neo4j.cypher.internal.runtime.interpreted
 import org.neo4j.cypher.GraphDatabaseTestSupport
 import org.neo4j.cypher.internal.runtime.interpreted.pipes.QueryState
 import org.neo4j.internal.kernel.api.Transaction.Type
-import org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED
+import org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED
 import org.neo4j.values.virtual.VirtualValues.EMPTY_MAP
 
 trait QueryStateTestSupport {

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundPlanContextTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundPlanContextTest.scala
@@ -25,7 +25,7 @@ import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
 import org.neo4j.cypher.internal.util.v3_4.{Cardinality, LabelId, RelTypeId}
 import org.neo4j.graphdb.{GraphDatabaseService, Label, RelationshipType}
 import org.neo4j.internal.kernel.api.Transaction.Type._
-import org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED
+import org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED
 import org.neo4j.kernel.impl.coreapi.{InternalTransaction, PropertyContainerLocker}
 import org.neo4j.kernel.impl.query.Neo4jTransactionalContextFactory
 import org.neo4j.kernel.impl.query.clientconnection.ClientConnectionInfo

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContextTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContextTest.scala
@@ -33,7 +33,7 @@ import org.neo4j.graphdb._
 import org.neo4j.graphdb.config.Setting
 import org.neo4j.graphdb.factory.GraphDatabaseSettings
 import org.neo4j.internal.kernel.api.Transaction.Type
-import org.neo4j.internal.kernel.api.security.SecurityContext
+import org.neo4j.internal.kernel.api.security.LoginContext
 import org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier
 import org.neo4j.kernel.GraphDatabaseQueryService
@@ -195,7 +195,7 @@ class TransactionBoundQueryContextTest extends CypherFunSuite {
     creator.success()
     creator.close()
 
-    val tx = graph.beginTransaction(Type.explicit, SecurityContext.AUTH_DISABLED)
+    val tx = graph.beginTransaction(Type.explicit, LoginContext.AUTH_DISABLED)
     val transactionalContext = TransactionalContextWrapper(createTransactionContext(graph, tx))
     val context = new TransactionBoundQueryContext(transactionalContext)(indexSearchMonitor)
 

--- a/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/PruningVarLengthExpandPipeTest.scala
+++ b/community/cypher/interpreted-runtime/src/test/scala/org/neo4j/cypher/internal/runtime/interpreted/pipes/PruningVarLengthExpandPipeTest.scala
@@ -28,11 +28,11 @@ import org.neo4j.cypher.internal.runtime.interpreted.commands.predicates.{Equals
 import org.neo4j.cypher.internal.runtime.interpreted.commands.values.UnresolvedProperty
 import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection
 import org.neo4j.graphdb.Node
-import org.neo4j.internal.kernel.api.security.SecurityContext
 import org.neo4j.internal.kernel.api.Transaction.Type
+import org.neo4j.internal.kernel.api.security.LoginContext
 import org.neo4j.kernel.impl.util.ValueUtils._
 import org.neo4j.values.virtual.VirtualValues.EMPTY_MAP
-import org.neo4j.values.virtual.{RelationshipValue, NodeValue}
+import org.neo4j.values.virtual.{NodeValue, RelationshipValue}
 
 import scala.collection.immutable.IndexedSeq
 import scala.util.Random
@@ -315,7 +315,7 @@ class PruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
   private def setUpGraph(seed: Long, POPULATION: Int, friendCount: Int = 50): IndexedSeq[Node] = {
     val r = new Random(seed)
 
-    var tx = graph.beginTransaction(Type.`implicit`, SecurityContext.AUTH_DISABLED)
+    var tx = graph.beginTransaction(Type.`implicit`, LoginContext.AUTH_DISABLED)
     var count = 0
 
     def checkAndSwitch() = {
@@ -323,7 +323,7 @@ class PruningVarLengthExpandPipeTest extends GraphDatabaseFunSuite {
       if (count == 1000) {
         tx.success()
         tx.close()
-        tx = graph.beginTransaction(Type.`implicit`, SecurityContext.AUTH_DISABLED)
+        tx = graph.beginTransaction(Type.`implicit`, LoginContext.AUTH_DISABLED)
         count = 0
       }
     }

--- a/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/internal/javacompat/GraphDatabaseCypherService.java
+++ b/community/cypher/runtime-util/src/main/java/org/neo4j/cypher/internal/javacompat/GraphDatabaseCypherService.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.security.URLAccessValidationError;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.dbms.DbmsOperations;
@@ -50,16 +50,16 @@ public class GraphDatabaseCypherService implements GraphDatabaseQueryService
     }
 
     @Override
-    public InternalTransaction beginTransaction( KernelTransaction.Type type, SecurityContext securityContext )
+    public InternalTransaction beginTransaction( KernelTransaction.Type type, LoginContext loginContext )
     {
-        return graph.beginTransaction( type, securityContext );
+        return graph.beginTransaction( type, loginContext );
     }
 
     @Override
-    public InternalTransaction beginTransaction( KernelTransaction.Type type, SecurityContext securityContext,
+    public InternalTransaction beginTransaction( KernelTransaction.Type type, LoginContext loginContext,
             long timeout, TimeUnit unit )
     {
-        return graph.beginTransaction( type, securityContext, timeout, unit );
+        return graph.beginTransaction( type, loginContext, timeout, unit );
     }
 
     @Override

--- a/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/GraphIcing.scala
+++ b/community/cypher/runtime-util/src/test/scala/org/neo4j/cypher/GraphIcing.scala
@@ -29,7 +29,7 @@ import org.neo4j.graphdb._
 import org.neo4j.kernel.GraphDatabaseQueryService
 import org.neo4j.internal.kernel.api.Transaction.Type
 import org.neo4j.kernel.api.Statement
-import org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED
+import org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge
 import org.neo4j.kernel.impl.coreapi.{InternalTransaction, PropertyContainerLocker}
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Kernel.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/Kernel.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.internal.kernel.api;
 
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 
 /**
  * The Kernel.
@@ -28,7 +28,7 @@ public interface Kernel
 {
     CursorFactory cursors();
 
-    Session beginSession( SecurityContext securityContext );
+    Session beginSession( LoginContext loginContext );
 
     Modes modes();
 }

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/AccessMode.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/AccessMode.java
@@ -103,7 +103,7 @@ public interface AccessMode
         }
 
         @Override
-        public boolean allowsPropertyReads( String name )
+        public boolean allowsPropertyReads( int propertyKey )
         {
             return property;
         }
@@ -126,7 +126,7 @@ public interface AccessMode
     boolean allowsTokenCreates();
     boolean allowsSchemaWrites();
 
-    boolean allowsPropertyReads( String name );
+    boolean allowsPropertyReads( int propertyKey );
 
     /**
      * Determines whether this mode allows execution of a procedure with the parameter string array in its

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/AccessMode.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/AccessMode.java
@@ -28,9 +28,9 @@ public interface AccessMode
     enum Static implements AccessMode
     {
         /** No reading or writing allowed. */
-        NONE( false, false, false, false, false ),
+        NONE( false, false, false, false, false, false ),
         /** No reading or writing allowed because of expired credentials. */
-        CREDENTIALS_EXPIRED( false, false, false, false, false )
+        CREDENTIALS_EXPIRED( false, false, false, false, false, false )
                 {
                     @Override
                     public AuthorizationViolationException onViolation( String msg )
@@ -51,29 +51,31 @@ public interface AccessMode
                 },
 
         /** Allows reading data and schema, but not writing. */
-        READ( true, false, false, false, false ),
+        READ( true, false, false, false, false, true ),
         /** Allows writing data */
-        WRITE_ONLY( false, true, false, false, false ),
+        WRITE_ONLY( false, true, false, false, false, true ),
         /** Allows reading and writing data, but not schema. */
-        WRITE( true, true, false, false, false ),
+        WRITE( true, true, false, false, false, true ),
         /** Allows reading and writing data and creating new tokens, but not schema. */
-        TOKEN_WRITE( true, true, true, false, false ),
+        TOKEN_WRITE( true, true, true, false, false, true ),
         /** Allows all operations. */
-        FULL( true, true, true, true, true );
+        FULL( true, true, true, true, true, true );
 
         private final boolean read;
         private final boolean write;
         private final boolean token;
         private final boolean schema;
         private final boolean procedure;
+        private final boolean property;
 
-        Static( boolean read, boolean write, boolean token, boolean schema, boolean procedure )
+        Static( boolean read, boolean write, boolean token, boolean schema, boolean procedure, boolean property )
         {
             this.read = read;
             this.write = write;
             this.token = token;
             this.schema = schema;
             this.procedure = procedure;
+            this.property = property;
         }
 
         @Override
@@ -101,6 +103,12 @@ public interface AccessMode
         }
 
         @Override
+        public boolean allowsPropertyReads( String name )
+        {
+            return property;
+        }
+
+        @Override
         public boolean allowsProcedureWith( String[] allowed )
         {
             return procedure;
@@ -117,6 +125,8 @@ public interface AccessMode
     boolean allowsWrites();
     boolean allowsTokenCreates();
     boolean allowsSchemaWrites();
+
+    boolean allowsPropertyReads( String name );
 
     /**
      * Determines whether this mode allows execution of a procedure with the parameter string array in its

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/LoginContext.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/LoginContext.java
@@ -22,8 +22,9 @@ package org.neo4j.internal.kernel.api.security;
 import org.neo4j.internal.kernel.api.Token;
 
 /**
- * The LoginContext hold the executing authenticated user (subject). By calling {@link #freeze(Token)} the user is also authorized, and a
- * full SecurityContext is returned, which can be used to assert user permissions during query execution.
+ * The LoginContext hold the executing authenticated user (subject).
+ * By calling {@link #authorize(Token)} the user is also authorized, and a full SecurityContext is returned,
+ * which can be used to assert user permissions during query execution.
  */
 public interface LoginContext
 {
@@ -38,7 +39,7 @@ public interface LoginContext
      * @param token token lookup, used to compile property level security verification
      * @return the security context
      */
-    SecurityContext freeze( Token token );
+    SecurityContext authorize( Token token );
 
     LoginContext AUTH_DISABLED = new LoginContext()
     {
@@ -49,7 +50,7 @@ public interface LoginContext
         }
 
         @Override
-        public SecurityContext freeze( Token token )
+        public SecurityContext authorize( Token token )
         {
             return SecurityContext.AUTH_DISABLED;
         }

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/LoginContext.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/LoginContext.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.kernel.api.security;
+
+import org.neo4j.internal.kernel.api.Token;
+
+/**
+ * The LoginContext hold the executing authenticated user (subject). By calling {@link #freeze(Token)} the user is also authorized, and a
+ * full SecurityContext is returned, which can be used to assert user permissions during query execution.
+ */
+public interface LoginContext
+{
+    /**
+     * Get the authenticated user.
+     */
+    AuthSubject subject();
+
+    /**
+     * Authorize the user and return a SecurityContext.
+     *
+     * @param token token lookup, used to compile property level security verification
+     * @return the security context
+     */
+    SecurityContext freeze( Token token );
+
+    LoginContext AUTH_DISABLED = new LoginContext()
+    {
+        @Override
+        public AuthSubject subject()
+        {
+            return AuthSubject.AUTH_DISABLED;
+        }
+
+        @Override
+        public SecurityContext freeze( Token token )
+        {
+            return SecurityContext.AUTH_DISABLED;
+        }
+    };
+}

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/SecurityContext.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/SecurityContext.java
@@ -28,24 +28,54 @@ import static org.neo4j.graphdb.security.AuthorizationViolationException.PERMISS
  *
  * Must extend LoginContext to handle procedures creating internal transactions, periodic commit and the parallel cypher prototype.
  */
-public interface SecurityContext extends LoginContext
+public class SecurityContext implements LoginContext
 {
+    protected final AuthSubject subject;
+    protected final AccessMode mode;
+
+    public SecurityContext( AuthSubject subject, AccessMode mode )
+    {
+        this.subject = subject;
+        this.mode = mode;
+    }
+
     /**
      * Get the authorization data of the user. This is immutable.
      */
-    AccessMode mode();
+    public AccessMode mode()
+    {
+        return mode;
+    }
 
     /**
      * Check whether the user is an admin.
      */
-    boolean isAdmin();
+    public boolean isAdmin()
+    {
+        return true;
+    }
+
+    @Override
+    public AuthSubject subject()
+    {
+        return subject;
+    }
+
+    @Override
+    public SecurityContext authorize( Token token )
+    {
+        return this;
+    }
 
     /**
      * Create a copy of this SecurityContext with the provided mode.
      */
-    SecurityContext withMode( AccessMode mode );
+    public SecurityContext withMode( AccessMode mode )
+    {
+        return new SecurityContext( subject, mode );
+    }
 
-    default void assertCredentialsNotExpired()
+    public void assertCredentialsNotExpired()
     {
         if ( subject().getAuthenticationResult().equals( AuthenticationResult.PASSWORD_CHANGE_REQUIRED ) )
         {
@@ -53,110 +83,41 @@ public interface SecurityContext extends LoginContext
         }
     }
 
-    default String description()
+    public String description()
     {
         return String.format( "user '%s' with %s", subject().username(), mode().name() );
     }
 
-    default String defaultString( String name )
+    protected String defaultString( String name )
     {
         return String.format( "%s{ username=%s, accessMode=%s }", name, subject().username(), mode() );
     }
 
     /** Allows all operations. */
-    SecurityContext AUTH_DISABLED = new AuthDisabled( AccessMode.Static.FULL );
+    public static final SecurityContext AUTH_DISABLED = authDisabled( AccessMode.Static.FULL );
 
-    final class AuthDisabled implements SecurityContext
+    private static SecurityContext authDisabled( AccessMode mode )
     {
-        private final AccessMode mode;
-
-        private AuthDisabled( AccessMode mode )
+        return new SecurityContext( AuthSubject.AUTH_DISABLED, mode )
         {
-            this.mode = mode;
-        }
 
-        @Override
-        public AccessMode mode()
-        {
-            return mode;
-        }
+            @Override
+            public SecurityContext withMode( AccessMode mode )
+            {
+                return authDisabled( mode );
+            }
 
-        @Override
-        public AuthSubject subject()
-        {
-            return AuthSubject.AUTH_DISABLED;
-        }
+            @Override
+            public String description()
+            {
+                return "AUTH_DISABLED with " + mode().name();
+            }
 
-        @Override
-        public boolean isAdmin()
-        {
-            return true;
-        }
-
-        @Override
-        public String toString()
-        {
-            return defaultString( "auth-disabled" );
-        }
-
-        @Override
-        public String description()
-        {
-            return "AUTH_DISABLED with " + mode.name();
-        }
-
-        @Override
-        public SecurityContext freeze( Token token )
-        {
-            return this;
-        }
-
-        @Override
-        public SecurityContext withMode( AccessMode mode )
-        {
-            return new AuthDisabled( mode );
-        }
-    }
-
-    final class Frozen implements SecurityContext
-    {
-        private final AuthSubject subject;
-        private final AccessMode mode;
-
-        public Frozen( AuthSubject subject, AccessMode mode )
-        {
-            this.subject = subject;
-            this.mode = mode;
-        }
-
-        @Override
-        public AccessMode mode()
-        {
-            return mode;
-        }
-
-        @Override
-        public AuthSubject subject()
-        {
-            return subject;
-        }
-
-        @Override
-        public boolean isAdmin()
-        {
-            return true;
-        }
-
-        @Override
-        public SecurityContext freeze( Token token )
-        {
-            return this;
-        }
-
-        @Override
-        public SecurityContext withMode( AccessMode mode )
-        {
-            return new Frozen( subject, mode );
-        }
+            @Override
+            public String toString()
+            {
+                return defaultString( "auth-disabled" );
+            }
+        };
     }
 }

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/SecurityContext.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/security/SecurityContext.java
@@ -19,16 +19,30 @@
  */
 package org.neo4j.internal.kernel.api.security;
 
+import org.neo4j.internal.kernel.api.Token;
+
 import static org.neo4j.graphdb.security.AuthorizationViolationException.PERMISSION_DENIED;
 
-/** Controls the capabilities of a KernelTransaction. */
-public interface SecurityContext
+/**
+ * Controls the capabilities of a KernelTransaction, including the authenticated user and authorization data.
+ *
+ * Must extend LoginContext to handle procedures creating internal transactions, periodic commit and the parallel cypher prototype.
+ */
+public interface SecurityContext extends LoginContext
 {
+    /**
+     * Get the authorization data of the user. This is immutable.
+     */
     AccessMode mode();
-    AuthSubject subject();
+
+    /**
+     * Check whether the user is an admin.
+     */
     boolean isAdmin();
 
-    SecurityContext freeze();
+    /**
+     * Create a copy of this SecurityContext with the provided mode.
+     */
     SecurityContext withMode( AccessMode mode );
 
     default void assertCredentialsNotExpired()
@@ -92,7 +106,7 @@ public interface SecurityContext
         }
 
         @Override
-        public SecurityContext freeze()
+        public SecurityContext freeze( Token token )
         {
             return this;
         }
@@ -134,7 +148,7 @@ public interface SecurityContext
         }
 
         @Override
-        public SecurityContext freeze()
+        public SecurityContext freeze( Token token )
         {
             return this;
         }

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/KernelAPIReadTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/KernelAPIReadTestBase.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 
 /**
  * KernelAPIReadTestBase is the basis of read tests targeting the Kernel API.
@@ -78,7 +78,7 @@ public abstract class KernelAPIReadTestBase<ReadSupport extends KernelAPIReadTes
             testSupport.setup( folder.getRoot(), this::createTestGraph );
         }
         Kernel kernel = testSupport.kernelToTest();
-        session = kernel.beginSession( SecurityContext.AUTH_DISABLED );
+        session = kernel.beginSession( LoginContext.AUTH_DISABLED );
         cursors = new ManagedTestCursors( kernel.cursors() );
         tx = session.beginTransaction( Transaction.Type.explicit );
         token = session.token();

--- a/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/KernelAPIWriteTestBase.java
+++ b/community/kernel-api/src/test/java/org/neo4j/internal/kernel/api/KernelAPIWriteTestBase.java
@@ -28,7 +28,7 @@ import org.junit.rules.TemporaryFolder;
 import java.io.IOException;
 
 import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 
 /**
  * KernelAPIWriteTestBase is the basis of write tests targeting the Kernel API.
@@ -71,7 +71,7 @@ public abstract class KernelAPIWriteTestBase<WriteSupport extends KernelAPIWrite
         }
         testSupport.clearGraph();
         Kernel kernel = testSupport.kernelToTest();
-        session = kernel.beginSession( SecurityContext.AUTH_DISABLED );
+        session = kernel.beginSession( LoginContext.AUTH_DISABLED );
         modes = kernel.modes();
         cursors = new ManagedTestCursors( kernel.cursors() );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/GraphDatabaseQueryService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/GraphDatabaseQueryService.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.security.URLAccessValidationError;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.dbms.DbmsOperations;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
@@ -41,21 +41,21 @@ public interface GraphDatabaseQueryService
      * Begin new internal transaction with with default timeout.
      *
      * @param type transaction type
-     * @param securityContext transaction security context
+     * @param loginContext transaction login context
      * @return internal transaction
      */
-    InternalTransaction beginTransaction( KernelTransaction.Type type, SecurityContext securityContext );
+    InternalTransaction beginTransaction( KernelTransaction.Type type, LoginContext loginContext );
 
     /**
      * Begin new internal transaction with specified timeout in milliseconds.
      *
      * @param type transaction type
-     * @param securityContext transaction security context
+     * @param loginContext transaction login context
      * @param timeout transaction timeout
      * @param unit time unit of timeout argument
      * @return internal transaction
      */
-    InternalTransaction beginTransaction( KernelTransaction.Type type, SecurityContext securityContext, long timeout,
+    InternalTransaction beginTransaction( KernelTransaction.Type type, LoginContext loginContext, long timeout,
             TimeUnit unit );
 
     URL validateURLAccess( URL url ) throws URLAccessValidationError;

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/InwardKernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/InwardKernel.java
@@ -20,19 +20,19 @@
 package org.neo4j.kernel.api;
 
 import org.neo4j.internal.kernel.api.Kernel;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.proc.CallableProcedure;
 import org.neo4j.kernel.api.proc.CallableUserAggregationFunction;
 import org.neo4j.kernel.api.proc.CallableUserFunction;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 
 /**
  * The main API through which access to the Neo4j kernel is made, both read
  * and write operations are supported as well as creating transactions.
  *
  * Changes to the graph (i.e. write operations) are performed via a
- * {@link #newTransaction(KernelTransaction.Type, SecurityContext) transaction context} where changes done
+ * {@link #newTransaction(KernelTransaction.Type, LoginContext) transaction context} where changes done
  * inside the transaction are visible in read operations for {@link Statement statements}
  * executed within that transaction context.
  */
@@ -43,19 +43,19 @@ public interface InwardKernel extends Kernel
      * underlying graph.
      *
      * @param type the type of the new transaction: implicit (internally created) or explicit (created by the user)
-     * @param securityContext transaction security context
+     * @param loginContext transaction login context
      */
-    KernelTransaction newTransaction( KernelTransaction.Type type, SecurityContext securityContext ) throws TransactionFailureException;
+    KernelTransaction newTransaction( KernelTransaction.Type type, LoginContext loginContext ) throws TransactionFailureException;
 
     /**
      * Creates and returns a new {@link KernelTransaction} capable of modifying the
      * underlying graph with custom timeout in milliseconds.
      *
      * @param type the type of the new transaction: implicit (internally created) or explicit (created by the user)
-     * @param securityContext transaction security context
+     * @param loginContext transaction login context
      * @param timeout transaction timeout in millisiseconds
      */
-    KernelTransaction newTransaction( KernelTransaction.Type type, SecurityContext securityContext, long timeout )
+    KernelTransaction newTransaction( KernelTransaction.Type type, LoginContext loginContext, long timeout )
             throws TransactionFailureException;
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import org.neo4j.internal.kernel.api.NodeCursor;
 import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.Transaction;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
@@ -158,7 +159,7 @@ public interface KernelTransaction extends Transaction
 
     /**
      * @return start time of this transaction, i.e. basically {@link System#currentTimeMillis()} when user called
-     * {@link Kernel#newTransaction(Type, SecurityContext)}.
+     * {@link Kernel#newTransaction(Type, LoginContext)}.
      */
     long startTime();
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransactionHandle.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransactionHandle.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.query.ExecutingQuery;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
@@ -51,7 +52,7 @@ public interface KernelTransactionHandle
 
     /**
      * The start time of the underlying transaction. I.e. basically {@link System#currentTimeMillis()} when user
-     * called {@link Kernel#newTransaction(KernelTransaction.Type, SecurityContext)}.
+     * called {@link Kernel#newTransaction(KernelTransaction.Type, LoginContext)}.
      *
      * @return the transaction start time.
      */

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/AnonymousContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/AnonymousContext.java
@@ -67,8 +67,8 @@ public class AnonymousContext implements LoginContext
     }
 
     @Override
-    public SecurityContext freeze( Token token )
+    public SecurityContext authorize( Token token )
     {
-        return new SecurityContext.Frozen( subject(), accessMode );
+        return new SecurityContext( subject(), accessMode );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/AnonymousContext.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/AnonymousContext.java
@@ -19,12 +19,14 @@
  */
 package org.neo4j.kernel.api.security;
 
+import org.neo4j.internal.kernel.api.Token;
 import org.neo4j.internal.kernel.api.security.AccessMode;
 import org.neo4j.internal.kernel.api.security.AuthSubject;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 
 /** Controls the capabilities of a KernelTransaction. */
-public class AnonymousContext implements SecurityContext
+public class AnonymousContext implements LoginContext
 {
     private final AccessMode accessMode;
 
@@ -65,32 +67,8 @@ public class AnonymousContext implements SecurityContext
     }
 
     @Override
-    public boolean isAdmin()
+    public SecurityContext freeze( Token token )
     {
-        return false;
-    }
-
-    @Override
-    public SecurityContext freeze()
-    {
-        return this;
-    }
-
-    @Override
-    public SecurityContext withMode( AccessMode mode )
-    {
-        return new Frozen( subject(), mode );
-    }
-
-    @Override
-    public AccessMode mode()
-    {
-        return accessMode;
-    }
-
-    @Override
-    public String toString()
-    {
-        return defaultString( "anonymous" );
+        return new SecurityContext.Frozen( subject(), accessMode );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthManager.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/AuthManager.java
@@ -21,7 +21,7 @@ package org.neo4j.kernel.api.security;
 
 import java.util.Map;
 
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 
@@ -36,7 +36,7 @@ public interface AuthManager extends Lifecycle
      * @return An AuthSubject representing the newly logged-in user
      * @throws InvalidAuthTokenException if the authentication token is malformed
      */
-    SecurityContext login( Map<String,Object> authToken ) throws InvalidAuthTokenException;
+    LoginContext login( Map<String,Object> authToken ) throws InvalidAuthTokenException;
 
     /**
      * Implementation that does no authentication.
@@ -64,9 +64,9 @@ public interface AuthManager extends Lifecycle
         }
 
         @Override
-        public SecurityContext login( Map<String,Object> authToken )
+        public LoginContext login( Map<String,Object> authToken )
         {
-            return SecurityContext.AUTH_DISABLED;
+            return LoginContext.AUTH_DISABLED;
         }
     };
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/security/UserManagerSupplier.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/security/UserManagerSupplier.java
@@ -19,12 +19,12 @@
  */
 package org.neo4j.kernel.api.security;
 
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.AuthSubject;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 
 public interface UserManagerSupplier extends Lifecycle
 {
-    UserManager getUserManager( SecurityContext securityContext );
+    UserManager getUserManager( AuthSubject authSubject, boolean isUserManager );
 
     UserManager getUserManager();
 
@@ -51,7 +51,7 @@ public interface UserManagerSupplier extends Lifecycle
         }
 
         @Override
-        public UserManager getUserManager( SecurityContext securityContext )
+        public UserManager getUserManager( AuthSubject authSubject, boolean isUserManager )
         {
             return UserManager.NO_AUTH;
         }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/Kernel.java
@@ -24,7 +24,7 @@ import org.neo4j.internal.kernel.api.CursorFactory;
 import org.neo4j.internal.kernel.api.Modes;
 import org.neo4j.internal.kernel.api.Session;
 import org.neo4j.internal.kernel.api.Transaction;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.InwardKernel;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.TransactionHook;
@@ -93,18 +93,18 @@ public class Kernel extends LifecycleAdapter implements InwardKernel
     }
 
     @Override
-    public KernelTransaction newTransaction( Transaction.Type type, SecurityContext securityContext )
+    public KernelTransaction newTransaction( Transaction.Type type, LoginContext loginContext )
             throws TransactionFailureException
     {
-        return newTransaction( type, securityContext, config.get( transaction_timeout ).toMillis() );
+        return newTransaction( type, loginContext, config.get( transaction_timeout ).toMillis() );
     }
 
     @Override
-    public KernelTransaction newTransaction( Transaction.Type type, SecurityContext securityContext, long timeout ) throws
+    public KernelTransaction newTransaction( Transaction.Type type, LoginContext loginContext, long timeout ) throws
             TransactionFailureException
     {
         health.assertHealthy( TransactionFailureException.class );
-        KernelTransaction transaction = transactions.newInstance( type, securityContext, timeout );
+        KernelTransaction transaction = transactions.newInstance( type, loginContext, timeout );
         transactionMonitor.transactionStarted();
         return transaction;
     }
@@ -152,9 +152,9 @@ public class Kernel extends LifecycleAdapter implements InwardKernel
     }
 
     @Override
-    public Session beginSession( SecurityContext securityContext )
+    public Session beginSession( LoginContext loginContext )
     {
-        return newKernel.beginSession( securityContext );
+        return newKernel.beginSession( loginContext );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
@@ -31,6 +31,7 @@ import org.neo4j.collection.pool.MarshlandPool;
 import org.neo4j.function.Factory;
 import org.neo4j.graphdb.DatabaseShutdownException;
 import org.neo4j.graphdb.TransactionFailureException;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.api.KernelTransaction;
@@ -171,10 +172,10 @@ public class KernelTransactions extends LifecycleAdapter implements Supplier<Ker
         return explicitIndexTxStateSupplier;
     }
 
-    public KernelTransaction newInstance( KernelTransaction.Type type, SecurityContext securityContext, long timeout )
+    public KernelTransaction newInstance( KernelTransaction.Type type, LoginContext loginContext, long timeout )
     {
         assertCurrentThreadIsNotBlockingNewTransactions();
-        SecurityContext frozenSecurityContext = securityContext.freeze();
+        SecurityContext securityContext = loginContext.freeze( token );
         try
         {
             while ( !newTransactionsLock.readLock().tryLock( 1, TimeUnit.SECONDS ) )
@@ -188,7 +189,7 @@ public class KernelTransactions extends LifecycleAdapter implements Supplier<Ker
                 KernelTransactionImplementation tx = localTxPool.acquire();
                 StatementLocks statementLocks = statementLocksFactory.newInstance();
                 tx.initialize( lastCommittedTransaction.transactionId(), lastCommittedTransaction.commitTimestamp(),
-                        statementLocks, type, frozenSecurityContext, timeout, userTransactionIdCounter.incrementAndGet() );
+                        statementLocks, type, securityContext, timeout, userTransactionIdCounter.incrementAndGet() );
                 return tx;
             }
             finally

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
@@ -175,7 +175,7 @@ public class KernelTransactions extends LifecycleAdapter implements Supplier<Ker
     public KernelTransaction newInstance( KernelTransaction.Type type, LoginContext loginContext, long timeout )
     {
         assertCurrentThreadIsNotBlockingNewTransactions();
-        SecurityContext securityContext = loginContext.freeze( token );
+        SecurityContext securityContext = loginContext.authorize( token );
         try
         {
             while ( !newTransactionsLock.readLock().tryLock( 1, TimeUnit.SECONDS ) )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/OperationsFacade.java
@@ -34,6 +34,7 @@ import org.neo4j.collection.primitive.PrimitiveLongResourceCollections;
 import org.neo4j.collection.primitive.PrimitiveLongResourceIterator;
 import org.neo4j.cursor.Cursor;
 import org.neo4j.graphdb.Direction;
+import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.internal.kernel.api.IndexQuery;
 import org.neo4j.internal.kernel.api.InternalIndexState;
 import org.neo4j.internal.kernel.api.exceptions.InvalidTransactionTypeKernelException;
@@ -690,7 +691,9 @@ public class OperationsFacade
     public Iterator<Token> propertyKeyGetAllTokens()
     {
         statement.assertOpen();
-        return tokenRead().propertyKeyGetAllTokens( statement );
+        AccessMode mode = tx.securityContext().mode();
+        return Iterators.stream( tokenRead().propertyKeyGetAllTokens( statement ) ).
+                filter( propKey -> mode.allowsPropertyReads( propKey.id() ) ).iterator();
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/security/OverriddenAccessMode.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/security/OverriddenAccessMode.java
@@ -57,6 +57,12 @@ public class OverriddenAccessMode extends WrappedAccessMode
     }
 
     @Override
+    public boolean allowsPropertyReads( String name )
+    {
+        return wrapping.allowsPropertyReads( name );
+    }
+
+    @Override
     public boolean allowsProcedureWith( String[] allowed )
     {
         return false;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/security/OverriddenAccessMode.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/security/OverriddenAccessMode.java
@@ -57,9 +57,9 @@ public class OverriddenAccessMode extends WrappedAccessMode
     }
 
     @Override
-    public boolean allowsPropertyReads( String name )
+    public boolean allowsPropertyReads( int propertyKey )
     {
-        return wrapping.allowsPropertyReads( name );
+        return wrapping.allowsPropertyReads( propertyKey );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/security/RestrictedAccessMode.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/security/RestrictedAccessMode.java
@@ -57,9 +57,9 @@ public class RestrictedAccessMode extends WrappedAccessMode
     }
 
     @Override
-    public boolean allowsPropertyReads( String name )
+    public boolean allowsPropertyReads( int propertyKey )
     {
-        return original.allowsPropertyReads( name ) && wrapping.allowsPropertyReads( name );
+        return original.allowsPropertyReads( propertyKey ) && wrapping.allowsPropertyReads( propertyKey );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/security/RestrictedAccessMode.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/security/RestrictedAccessMode.java
@@ -57,6 +57,12 @@ public class RestrictedAccessMode extends WrappedAccessMode
     }
 
     @Override
+    public boolean allowsPropertyReads( String name )
+    {
+        return original.allowsPropertyReads( name ) && wrapping.allowsPropertyReads( name );
+    }
+
+    @Override
     public boolean allowsProcedureWith( String[] allowed )
     {
         return false;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/ConstraintIndexCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/state/ConstraintIndexCreator.java
@@ -53,7 +53,7 @@ import org.neo4j.kernel.impl.locking.Locks.Client;
 import org.neo4j.kernel.monitoring.Monitors;
 
 import static org.neo4j.internal.kernel.api.exceptions.schema.ConstraintValidationException.Phase.VERIFICATION;
-import static org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 import static org.neo4j.internal.kernel.api.exceptions.schema.SchemaKernelException.OperationContext.CONSTRAINT_CREATION;
 import static org.neo4j.kernel.impl.locking.ResourceTypes.LABEL;
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/IsolatedTransactionTokenCreator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/IsolatedTransactionTokenCreator.java
@@ -30,7 +30,7 @@ import org.neo4j.internal.kernel.api.exceptions.schema.IllegalTokenNameException
 import org.neo4j.internal.kernel.api.exceptions.schema.TooManyLabelsException;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 
-import static org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 
 /**
  * Creates a key within its own transaction, such that the command(s) for creating the key

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/ClassicCoreSPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/ClassicCoreSPI.java
@@ -28,11 +28,11 @@ import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.event.KernelEventHandler;
 import org.neo4j.graphdb.event.TransactionEventHandler;
 import org.neo4j.graphdb.security.URLAccessValidationError;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.explicitindex.AutoIndexing;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.coreapi.CoreAPIAvailabilityGuard;
 import org.neo4j.kernel.impl.query.QueryExecutionKernelException;
 import org.neo4j.kernel.impl.query.TransactionalContext;
@@ -180,12 +180,12 @@ class ClassicCoreSPI implements GraphDatabaseFacade.SPI
     }
 
     @Override
-    public KernelTransaction beginTransaction( KernelTransaction.Type type, SecurityContext securityContext, long timeout )
+    public KernelTransaction beginTransaction( KernelTransaction.Type type, LoginContext loginContext, long timeout )
     {
         try
         {
             availability.assertDatabaseAvailable();
-            KernelTransaction kernelTx = dataSource.kernelAPI.get().newTransaction( type, securityContext, timeout );
+            KernelTransaction kernelTx = dataSource.kernelAPI.get().newTransaction( type, loginContext, timeout );
             kernelTx.registerCloseListener(
                     txId -> dataSource.threadToTransactionBridge.unbindTransactionFromCurrentThread() );
             dataSource.threadToTransactionBridge.bindTransactionToCurrentThread( kernelTx );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/ExplicitIndexStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/ExplicitIndexStore.java
@@ -40,7 +40,7 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.spi.explicitindex.IndexImplementation;
 
 import static org.neo4j.graphdb.index.IndexManager.PROVIDER;
-import static org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 
 /**
  * Uses an {@link IndexConfigStore} and puts logic around providers and configuration comparison.

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultPropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultPropertyCursor.java
@@ -136,6 +136,21 @@ public class DefaultPropertyCursor extends PropertyRecord implements PropertyCur
     @Override
     public boolean next()
     {
+        boolean hasNext;
+        do
+        {
+            hasNext = innerNext();
+        } while ( hasNext && !allowed( propertyKey() ) );
+        return hasNext;
+    }
+
+    private boolean allowed( int propertyKey )
+    {
+        return read.ktx.securityContext().mode().allowsPropertyReads( propertyKey );
+    }
+
+    private boolean innerNext()
+    {
         if ( txStateChangedProperties != null )
         {
             if ( txStateChangedProperties.hasNext() )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/KernelSession.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/KernelSession.java
@@ -22,7 +22,7 @@ package org.neo4j.kernel.impl.newapi;
 import org.neo4j.internal.kernel.api.Session;
 import org.neo4j.internal.kernel.api.Transaction;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.InwardKernel;
 import org.neo4j.kernel.api.KernelTransaction;
 
@@ -32,13 +32,13 @@ import org.neo4j.kernel.api.KernelTransaction;
 class KernelSession implements Session
 {
     private final InwardKernel kernel;
-    private final SecurityContext securityContext;
+    private final LoginContext loginContext;
     private final KernelToken token;
 
-    KernelSession( KernelToken token, InwardKernel kernel, SecurityContext securityContext )
+    KernelSession( KernelToken token, InwardKernel kernel, LoginContext loginContext )
     {
         this.kernel = kernel;
-        this.securityContext = securityContext;
+        this.loginContext = loginContext;
         this.token = token;
     }
 
@@ -51,7 +51,7 @@ class KernelSession implements Session
     @Override
     public Transaction beginTransaction( KernelTransaction.Type type ) throws KernelException
     {
-        return kernel.newTransaction( type, securityContext );
+        return kernel.newTransaction( type, loginContext );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NewKernel.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/NewKernel.java
@@ -22,7 +22,7 @@ package org.neo4j.kernel.impl.newapi;
 import org.neo4j.internal.kernel.api.CursorFactory;
 import org.neo4j.internal.kernel.api.Kernel;
 import org.neo4j.internal.kernel.api.Modes;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.InwardKernel;
 import org.neo4j.storageengine.api.StorageEngine;
 import org.neo4j.storageengine.api.StorageStatement;
@@ -58,10 +58,10 @@ public class NewKernel implements Kernel, Modes
     }
 
     @Override
-    public KernelSession beginSession( SecurityContext securityContext )
+    public KernelSession beginSession( LoginContext loginContext )
     {
         assert isRunning : "kernel is not running, so it is not possible to use it";
-        return new KernelSession( token, kernel, securityContext );
+        return new KernelSession( token, kernel, loginContext );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureGDBFacadeSPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/proc/ProcedureGDBFacadeSPI.java
@@ -29,11 +29,12 @@ import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.event.KernelEventHandler;
 import org.neo4j.graphdb.event.TransactionEventHandler;
 import org.neo4j.graphdb.security.URLAccessValidationError;
+import org.neo4j.internal.kernel.api.security.LoginContext;
+import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.explicitindex.AutoIndexing;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.coreapi.CoreAPIAvailabilityGuard;
 import org.neo4j.kernel.impl.factory.DataSourceModule;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
@@ -171,7 +172,7 @@ class ProcedureGDBFacadeSPI implements GraphDatabaseFacade.SPI
     }
 
     @Override
-    public KernelTransaction beginTransaction( KernelTransaction.Type type, SecurityContext ignoredSecurityContext, long timeout )
+    public KernelTransaction beginTransaction( KernelTransaction.Type type, LoginContext ignored, long timeout )
     {
         try
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/internal/GraphDatabaseAPI.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/internal/GraphDatabaseAPI.java
@@ -26,8 +26,8 @@ import java.util.concurrent.TimeUnit;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.security.URLAccessValidationError;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.kernel.impl.store.StoreId;
 
@@ -58,18 +58,18 @@ public interface GraphDatabaseAPI extends GraphDatabaseService
     /**
      * Begin internal transaction with specified type and access mode
      * @param type transaction type
-     * @param securityContext transaction security context
+     * @param loginContext transaction login context
      * @return internal transaction
      */
-    InternalTransaction beginTransaction( KernelTransaction.Type type, SecurityContext securityContext );
+    InternalTransaction beginTransaction( KernelTransaction.Type type, LoginContext loginContext );
 
     /**
      * Begin internal transaction with specified type, access mode and timeout
      * @param type transaction type
-     * @param securityContext transaction security context
+     * @param loginContext transaction login context
      * @param timeout transaction timeout
      * @param unit time unit of timeout argument
      * @return internal transaction
      */
-    InternalTransaction beginTransaction( KernelTransaction.Type type, SecurityContext securityContext, long timeout, TimeUnit unit );
+    InternalTransaction beginTransaction( KernelTransaction.Type type, LoginContext loginContext, long timeout, TimeUnit unit );
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
@@ -107,7 +107,7 @@ public class KernelTransactionFactory
 
         StatementLocks statementLocks = new SimpleStatementLocks( new NoOpClient() );
 
-        transaction.initialize( 0, 0, statementLocks, KernelTransaction.Type.implicit, loginContext.freeze( mock( Token.class ) ), 0L, 1L );
+        transaction.initialize( 0, 0, statementLocks, KernelTransaction.Type.implicit, loginContext.authorize( mock( Token.class ) ), 0L, 1L );
 
         return new Instances( transaction, storageEngine, storeReadLayer, storageStatement );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
@@ -23,7 +23,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import org.neo4j.collection.pool.Pool;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.Token;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier;
 import org.neo4j.kernel.api.explicitindex.AutoIndexing;
 import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
@@ -78,7 +79,7 @@ public class KernelTransactionFactory
     {
     }
 
-    static Instances kernelTransactionWithInternals( SecurityContext securityContext )
+    static Instances kernelTransactionWithInternals( LoginContext loginContext )
     {
         TransactionHeaderInformation headerInformation = new TransactionHeaderInformation( -1, -1, new byte[0] );
         TransactionHeaderInformationFactory headerInformationFactory = mock( TransactionHeaderInformationFactory.class );
@@ -106,13 +107,13 @@ public class KernelTransactionFactory
 
         StatementLocks statementLocks = new SimpleStatementLocks( new NoOpClient() );
 
-        transaction.initialize( 0, 0, statementLocks, KernelTransaction.Type.implicit, securityContext, 0L, 1L );
+        transaction.initialize( 0, 0, statementLocks, KernelTransaction.Type.implicit, loginContext.freeze( mock( Token.class ) ), 0L, 1L );
 
         return new Instances( transaction, storageEngine, storeReadLayer, storageStatement );
     }
 
-    static KernelTransaction kernelTransaction( SecurityContext securityContext )
+    static KernelTransaction kernelTransaction( LoginContext loginContext )
     {
-        return kernelTransactionWithInternals( securityContext ).transaction;
+        return kernelTransactionWithInternals( loginContext ).transaction;
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/TransactionStatementSequenceTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/TransactionStatementSequenceTest.java
@@ -26,7 +26,7 @@ import org.neo4j.kernel.api.security.AnonymousContext;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 import static org.neo4j.kernel.api.KernelTransactionFactory.kernelTransaction;
 
 public class TransactionStatementSequenceTest

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/TransactionStatementSharingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/TransactionStatementSharingTest.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.neo4j.kernel.api.KernelTransactionFactory.kernelTransaction;
-import static org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 
 public class TransactionStatementSharingTest
 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelSchemaStateFlushingTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelSchemaStateFlushingTest.java
@@ -41,7 +41,7 @@ import org.neo4j.test.rule.ImpermanentDatabaseRule;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.junit.Assert.assertEquals;
-import static org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 
 public class KernelSchemaStateFlushingTest
 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationTest.java
@@ -450,7 +450,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
         transaction.close();
         SimpleStatementLocks statementLocks = new SimpleStatementLocks( new NoOpClient() );
         transaction.initialize( 1, BASE_TX_COMMIT_TIMESTAMP, statementLocks, KernelTransaction.Type.implicit,
-                loginContext().freeze( mock( Token.class ) ), 0L, 1L );
+                loginContext().authorize( mock( Token.class ) ), 0L, 1L );
 
         // THEN
         assertEquals( reuseCount + 1, transaction.getReuseCount() );
@@ -671,7 +671,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
 
         Locks.Client locksClient = mock( Locks.Client.class );
         SimpleStatementLocks statementLocks = new SimpleStatementLocks( locksClient );
-        tx.initialize( 42, 42, statementLocks, KernelTransaction.Type.implicit, loginContext().freeze( mock( Token.class ) ), 0L, 0L );
+        tx.initialize( 42, 42, statementLocks, KernelTransaction.Type.implicit, loginContext().authorize( mock( Token.class ) ), 0L, 0L );
 
         assertTrue( tx.markForTermination( reuseCount, terminationReason ) );
 
@@ -691,7 +691,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
 
         Locks.Client locksClient = mock( Locks.Client.class );
         SimpleStatementLocks statementLocks = new SimpleStatementLocks( locksClient );
-        tx.initialize( 42, 42, statementLocks, KernelTransaction.Type.implicit, loginContext().freeze( mock( Token.class ) ), 0L, 0L );
+        tx.initialize( 42, 42, statementLocks, KernelTransaction.Type.implicit, loginContext().authorize( mock( Token.class ) ), 0L, 0L );
 
         assertFalse( tx.markForTermination( nextReuseCount, terminationReason ) );
 
@@ -758,7 +758,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
         for ( int i = 0; i < times; i++ )
         {
             SimpleStatementLocks statementLocks = new SimpleStatementLocks( new NoOpClient() );
-            tx.initialize( i + 10, i + 10, statementLocks, KernelTransaction.Type.implicit, loginContext().freeze( mock( Token.class ) ), 0L, 0L );
+            tx.initialize( i + 10, i + 10, statementLocks, KernelTransaction.Type.implicit, loginContext().authorize( mock( Token.class ) ), 0L, 0L );
             tx.close();
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionImplementationTest.java
@@ -35,6 +35,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import org.neo4j.graphdb.TransactionTerminatedException;
+import org.neo4j.internal.kernel.api.Token;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.io.pagecache.tracing.cursor.DefaultPageCursorTracer;
 import org.neo4j.kernel.api.KernelTransaction;
@@ -74,7 +76,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_COMMIT_TIMESTAMP;
 import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_ID;
 
@@ -116,7 +118,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     public void shouldCommitSuccessfulTransaction() throws Exception
     {
         // GIVEN
-        try ( KernelTransaction transaction = newTransaction( securityContext() ) )
+        try ( KernelTransaction transaction = newTransaction( loginContext() ) )
         {
             // WHEN
             transactionInitializer.accept( transaction );
@@ -132,7 +134,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     public void shouldRollbackUnsuccessfulTransaction() throws Exception
     {
         // GIVEN
-        try ( KernelTransaction transaction = newTransaction( securityContext() ) )
+        try ( KernelTransaction transaction = newTransaction( loginContext() ) )
         {
             // WHEN
             transactionInitializer.accept( transaction );
@@ -147,7 +149,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     public void shouldRollbackFailedTransaction() throws Exception
     {
         // GIVEN
-        try ( KernelTransaction transaction = newTransaction( securityContext() ) )
+        try ( KernelTransaction transaction = newTransaction( loginContext() ) )
         {
             // WHEN
             transactionInitializer.accept( transaction );
@@ -164,7 +166,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     {
         // GIVEN
         boolean exceptionReceived = false;
-        try ( KernelTransaction transaction = newTransaction( securityContext() ) )
+        try ( KernelTransaction transaction = newTransaction( loginContext() ) )
         {
             // WHEN
             transactionInitializer.accept( transaction );
@@ -187,7 +189,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     public void shouldRollbackOnClosingTerminatedTransaction() throws Exception
     {
         // GIVEN
-        KernelTransaction transaction = newTransaction( securityContext() );
+        KernelTransaction transaction = newTransaction( loginContext() );
 
         transactionInitializer.accept( transaction );
         transaction.success();
@@ -213,7 +215,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     @Test
     public void shouldRollbackOnClosingSuccessfulButTerminatedTransaction() throws Exception
     {
-        try ( KernelTransaction transaction = newTransaction( securityContext() ) )
+        try ( KernelTransaction transaction = newTransaction( loginContext() ) )
         {
             // WHEN
             transactionInitializer.accept( transaction );
@@ -231,7 +233,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     public void shouldRollbackOnClosingTerminatedButSuccessfulTransaction() throws Exception
     {
         // GIVEN
-        KernelTransaction transaction = newTransaction( securityContext() );
+        KernelTransaction transaction = newTransaction( loginContext() );
 
         transactionInitializer.accept( transaction );
         transaction.markForTermination( Status.General.UnknownError );
@@ -258,7 +260,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     @Test
     public void shouldNotDowngradeFailureState() throws Exception
     {
-        try ( KernelTransaction transaction = newTransaction( securityContext() ) )
+        try ( KernelTransaction transaction = newTransaction( loginContext() ) )
         {
             // WHEN
             transactionInitializer.accept( transaction );
@@ -276,7 +278,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     @Test
     public void shouldIgnoreTerminateAfterCommit() throws Exception
     {
-        KernelTransaction transaction = newTransaction( securityContext() );
+        KernelTransaction transaction = newTransaction( loginContext() );
         transactionInitializer.accept( transaction );
         transaction.success();
         transaction.close();
@@ -290,7 +292,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     @Test
     public void shouldIgnoreTerminateAfterRollback() throws Exception
     {
-        KernelTransaction transaction = newTransaction( securityContext() );
+        KernelTransaction transaction = newTransaction( loginContext() );
         transactionInitializer.accept( transaction );
         transaction.close();
         transaction.markForTermination( Status.General.UnknownError );
@@ -303,7 +305,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     @Test( expected = TransactionTerminatedException.class )
     public void shouldThrowOnTerminationInCommit() throws Exception
     {
-        KernelTransaction transaction = newTransaction( securityContext() );
+        KernelTransaction transaction = newTransaction( loginContext() );
         transactionInitializer.accept( transaction );
         transaction.success();
         transaction.markForTermination( Status.General.UnknownError );
@@ -314,7 +316,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     @Test
     public void shouldIgnoreTerminationDuringRollback() throws Exception
     {
-        KernelTransaction transaction = newTransaction( securityContext() );
+        KernelTransaction transaction = newTransaction( loginContext() );
         transactionInitializer.accept( transaction );
         transaction.markForTermination( Status.General.UnknownError );
         transaction.close();
@@ -330,7 +332,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     {
         // GIVEN
         final DoubleLatch latch = new DoubleLatch( 1 );
-        final KernelTransaction transaction = newTransaction( securityContext() );
+        final KernelTransaction transaction = newTransaction( loginContext() );
         transactionInitializer.accept( transaction );
 
         Future<?> terminationFuture = Executors.newSingleThreadExecutor().submit( () ->
@@ -382,11 +384,11 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
                 any( ResourceLocker.class ),
                 anyLong() );
 
-        try ( KernelTransactionImplementation transaction = newTransaction( securityContext() ) )
+        try ( KernelTransactionImplementation transaction = newTransaction( loginContext() ) )
         {
             SimpleStatementLocks statementLocks = new SimpleStatementLocks( mock( Locks.Client.class ) );
             transaction.initialize( 5L, BASE_TX_COMMIT_TIMESTAMP, statementLocks, KernelTransaction.Type.implicit,
-                    AUTH_DISABLED, 0L, 1L );
+                    SecurityContext.AUTH_DISABLED, 0L, 1L );
             transaction.txState();
             try ( KernelStatement statement = transaction.acquireStatement() )
             {
@@ -409,7 +411,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     @Test
     public void successfulTxShouldNotifyKernelTransactionsThatItIsClosed() throws TransactionFailureException
     {
-        KernelTransactionImplementation tx = newTransaction( securityContext() );
+        KernelTransactionImplementation tx = newTransaction( loginContext() );
 
         tx.success();
         tx.close();
@@ -420,7 +422,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     @Test
     public void failedTxShouldNotifyKernelTransactionsThatItIsClosed() throws TransactionFailureException
     {
-        KernelTransactionImplementation tx = newTransaction( securityContext() );
+        KernelTransactionImplementation tx = newTransaction( loginContext() );
 
         tx.failure();
         tx.close();
@@ -441,14 +443,14 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     public void shouldIncrementReuseCounterOnReuse() throws Exception
     {
         // GIVEN
-        KernelTransactionImplementation transaction = newTransaction( securityContext() );
+        KernelTransactionImplementation transaction = newTransaction( loginContext() );
         int reuseCount = transaction.getReuseCount();
 
         // WHEN
         transaction.close();
         SimpleStatementLocks statementLocks = new SimpleStatementLocks( new NoOpClient() );
         transaction.initialize( 1, BASE_TX_COMMIT_TIMESTAMP, statementLocks, KernelTransaction.Type.implicit,
-                securityContext(), 0L, 1L );
+                loginContext().freeze( mock( Token.class ) ), 0L, 1L );
 
         // THEN
         assertEquals( reuseCount + 1, transaction.getReuseCount() );
@@ -467,7 +469,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     public void markForTerminationInitializedTransaction()
     {
         Locks.Client locksClient = mock( Locks.Client.class );
-        KernelTransactionImplementation tx = newTransaction( securityContext(), locksClient );
+        KernelTransactionImplementation tx = newTransaction( loginContext(), locksClient );
 
         tx.markForTermination( Status.General.UnknownError );
 
@@ -479,7 +481,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     public void markForTerminationTerminatedTransaction()
     {
         Locks.Client locksClient = mock( Locks.Client.class );
-        KernelTransactionImplementation tx = newTransaction( securityContext(), locksClient );
+        KernelTransactionImplementation tx = newTransaction( loginContext(), locksClient );
         transactionInitializer.accept( tx );
 
         tx.markForTermination( Status.Transaction.Terminated );
@@ -495,7 +497,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     public void terminatedTxMarkedNeitherSuccessNorFailureClosesWithoutThrowing() throws TransactionFailureException
     {
         Locks.Client locksClient = mock( Locks.Client.class );
-        KernelTransactionImplementation tx = newTransaction( securityContext(), locksClient );
+        KernelTransactionImplementation tx = newTransaction( loginContext(), locksClient );
         transactionInitializer.accept( tx );
         tx.markForTermination( Status.General.UnknownError );
 
@@ -509,7 +511,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     public void terminatedTxMarkedForSuccessThrowsOnClose()
     {
         Locks.Client locksClient = mock( Locks.Client.class );
-        KernelTransactionImplementation tx = newTransaction( securityContext(), locksClient );
+        KernelTransactionImplementation tx = newTransaction( loginContext(), locksClient );
         transactionInitializer.accept( tx );
         tx.success();
         tx.markForTermination( Status.General.UnknownError );
@@ -529,7 +531,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     public void terminatedTxMarkedForFailureClosesWithoutThrowing() throws TransactionFailureException
     {
         Locks.Client locksClient = mock( Locks.Client.class );
-        KernelTransactionImplementation tx = newTransaction( securityContext(), locksClient );
+        KernelTransactionImplementation tx = newTransaction( loginContext(), locksClient );
         transactionInitializer.accept( tx );
         tx.failure();
         tx.markForTermination( Status.General.UnknownError );
@@ -544,7 +546,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     public void terminatedTxMarkedForBothSuccessAndFailureThrowsOnClose()
     {
         Locks.Client locksClient = mock( Locks.Client.class );
-        KernelTransactionImplementation tx = newTransaction( securityContext(), locksClient );
+        KernelTransactionImplementation tx = newTransaction( loginContext(), locksClient );
         transactionInitializer.accept( tx );
         tx.success();
         tx.failure();
@@ -565,7 +567,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     public void txMarkedForBothSuccessAndFailureThrowsOnClose()
     {
         Locks.Client locksClient = mock( Locks.Client.class );
-        KernelTransactionImplementation tx = newTransaction( securityContext(), locksClient );
+        KernelTransactionImplementation tx = newTransaction( loginContext(), locksClient );
         tx.success();
         tx.failure();
 
@@ -583,7 +585,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     @Test
     public void initializedTransactionShouldHaveNoTerminationReason() throws Exception
     {
-        KernelTransactionImplementation tx = newTransaction( securityContext() );
+        KernelTransactionImplementation tx = newTransaction( loginContext() );
         assertFalse( tx.getReasonIfTerminated().isPresent() );
     }
 
@@ -591,7 +593,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     public void shouldReportCorrectTerminationReason() throws Exception
     {
         Status status = Status.Transaction.Terminated;
-        KernelTransactionImplementation tx = newTransaction( securityContext() );
+        KernelTransactionImplementation tx = newTransaction( loginContext() );
         tx.markForTermination( status );
         assertSame( status, tx.getReasonIfTerminated().get() );
     }
@@ -599,7 +601,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     @Test
     public void closedTransactionShouldHaveNoTerminationReason() throws Exception
     {
-        KernelTransactionImplementation tx = newTransaction( securityContext() );
+        KernelTransactionImplementation tx = newTransaction( loginContext() );
         tx.markForTermination( Status.Transaction.Terminated );
         tx.close();
         assertFalse( tx.getReasonIfTerminated().isPresent() );
@@ -610,7 +612,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     {
         // given
         AtomicLong closeTxId = new AtomicLong( Long.MIN_VALUE );
-        KernelTransactionImplementation tx = newTransaction( securityContext() );
+        KernelTransactionImplementation tx = newTransaction( loginContext() );
         tx.registerCloseListener( closeTxId::set );
 
         // when
@@ -631,7 +633,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
     {
         // given
         AtomicLong closeTxId = new AtomicLong( Long.MIN_VALUE );
-        KernelTransactionImplementation tx = newTransaction( securityContext() );
+        KernelTransactionImplementation tx = newTransaction( loginContext() );
         tx.registerCloseListener( closeTxId::set );
 
         // when
@@ -669,7 +671,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
 
         Locks.Client locksClient = mock( Locks.Client.class );
         SimpleStatementLocks statementLocks = new SimpleStatementLocks( locksClient );
-        tx.initialize( 42, 42, statementLocks, KernelTransaction.Type.implicit, securityContext(), 0L, 0L );
+        tx.initialize( 42, 42, statementLocks, KernelTransaction.Type.implicit, loginContext().freeze( mock( Token.class ) ), 0L, 0L );
 
         assertTrue( tx.markForTermination( reuseCount, terminationReason ) );
 
@@ -689,7 +691,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
 
         Locks.Client locksClient = mock( Locks.Client.class );
         SimpleStatementLocks statementLocks = new SimpleStatementLocks( locksClient );
-        tx.initialize( 42, 42, statementLocks, KernelTransaction.Type.implicit, securityContext(), 0L, 0L );
+        tx.initialize( 42, 42, statementLocks, KernelTransaction.Type.implicit, loginContext().freeze( mock( Token.class ) ), 0L, 0L );
 
         assertFalse( tx.markForTermination( nextReuseCount, terminationReason ) );
 
@@ -746,7 +748,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
         assertEquals( 0, statistics.getWaitingTimeNanos( 0 ) );
     }
 
-    private SecurityContext securityContext()
+    private LoginContext loginContext()
     {
         return isWriteTx ? AnonymousContext.write() : AnonymousContext.read();
     }
@@ -756,7 +758,7 @@ public class KernelTransactionImplementationTest extends KernelTransactionTestBa
         for ( int i = 0; i < times; i++ )
         {
             SimpleStatementLocks statementLocks = new SimpleStatementLocks( new NoOpClient() );
-            tx.initialize( i + 10, i + 10, statementLocks, KernelTransaction.Type.implicit, securityContext(), 0L, 0L );
+            tx.initialize( i + 10, i + 10, statementLocks, KernelTransaction.Type.implicit, loginContext().freeze( mock( Token.class ) ), 0L, 0L );
             tx.close();
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionSecurityContextTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionSecurityContextTest.java
@@ -30,7 +30,7 @@ import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.security.AnonymousContext;
 
 import static org.junit.Assert.assertNotNull;
-import static org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 
 public class KernelTransactionSecurityContextTest extends KernelTransactionTestBase
 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTestBase.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTestBase.java
@@ -27,7 +27,9 @@ import java.util.function.Supplier;
 
 import org.neo4j.collection.pool.Pool;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.internal.kernel.api.Token;
 import org.neo4j.internal.kernel.api.Transaction.Type;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
@@ -71,7 +73,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 import static org.neo4j.kernel.impl.transaction.log.TransactionIdStore.BASE_TX_COMMIT_TIMESTAMP;
 
 public class KernelTransactionTestBase
@@ -116,32 +118,33 @@ public class KernelTransactionTestBase
         return newTransaction( 0, AUTH_DISABLED, transactionTimeoutMillis );
     }
 
-    public KernelTransactionImplementation newTransaction( SecurityContext securityContext )
+    public KernelTransactionImplementation newTransaction( LoginContext loginContext )
     {
-        return newTransaction( 0, securityContext );
+        return newTransaction( 0, loginContext );
     }
 
-    public KernelTransactionImplementation newTransaction( SecurityContext securityContext, Locks.Client locks )
+    public KernelTransactionImplementation newTransaction( LoginContext loginContext, Locks.Client locks )
     {
-        return newTransaction( 0, securityContext, locks, defaultTransactionTimeoutMillis );
+        return newTransaction( 0, loginContext, locks, defaultTransactionTimeoutMillis );
     }
 
-    public KernelTransactionImplementation newTransaction( long lastTransactionIdWhenStarted, SecurityContext securityContext )
+    public KernelTransactionImplementation newTransaction( long lastTransactionIdWhenStarted, LoginContext loginContext )
     {
-        return newTransaction( lastTransactionIdWhenStarted, securityContext, defaultTransactionTimeoutMillis );
+        return newTransaction( lastTransactionIdWhenStarted, loginContext, defaultTransactionTimeoutMillis );
     }
 
-    public KernelTransactionImplementation newTransaction( long lastTransactionIdWhenStarted, SecurityContext securityContext,
+    public KernelTransactionImplementation newTransaction( long lastTransactionIdWhenStarted, LoginContext loginContext,
             long transactionTimeoutMillis )
     {
-        return newTransaction( lastTransactionIdWhenStarted, securityContext, new NoOpClient(), transactionTimeoutMillis );
+        return newTransaction( lastTransactionIdWhenStarted, loginContext, new NoOpClient(), transactionTimeoutMillis );
     }
 
-    public KernelTransactionImplementation newTransaction( long lastTransactionIdWhenStarted, SecurityContext securityContext,
+    public KernelTransactionImplementation newTransaction( long lastTransactionIdWhenStarted, LoginContext loginContext,
             Locks.Client locks, long transactionTimeout )
     {
         KernelTransactionImplementation tx = newNotInitializedTransaction();
         StatementLocks statementLocks = new SimpleStatementLocks( locks );
+        SecurityContext securityContext = loginContext.freeze( mock( Token.class ) );
         tx.initialize( lastTransactionIdWhenStarted, BASE_TX_COMMIT_TIMESTAMP,statementLocks, Type.implicit,
                 securityContext, transactionTimeout, 1L );
         return tx;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTestBase.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTestBase.java
@@ -144,7 +144,7 @@ public class KernelTransactionTestBase
     {
         KernelTransactionImplementation tx = newNotInitializedTransaction();
         StatementLocks statementLocks = new SimpleStatementLocks( locks );
-        SecurityContext securityContext = loginContext.freeze( mock( Token.class ) );
+        SecurityContext securityContext = loginContext.authorize( mock( Token.class ) );
         tx.initialize( lastTransactionIdWhenStarted, BASE_TX_COMMIT_TIMESTAMP,statementLocks, Type.implicit,
                 securityContext, transactionTimeout, 1L );
         return tx;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitorIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTimeoutMonitorIT.java
@@ -35,8 +35,8 @@ import org.neo4j.concurrent.BinaryLatch;
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.test.rule.DatabaseRule;
 import org.neo4j.test.rule.EmbeddedDatabaseRule;
@@ -144,8 +144,8 @@ public class KernelTransactionTimeoutMonitorIT
     {
         return () ->
         {
-            try ( InternalTransaction transaction = database
-                    .beginTransaction( KernelTransaction.Type.implicit, SecurityContext.AUTH_DISABLED, 1,
+            try ( InternalTransaction ignored = database
+                    .beginTransaction( KernelTransaction.Type.implicit, LoginContext.AUTH_DISABLED, 1,
                             TimeUnit.SECONDS ) )
             {
                 Node node = database.getNodeById( NODE_ID );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
@@ -35,7 +35,7 @@ import java.util.concurrent.atomic.AtomicReferenceArray;
 
 import org.neo4j.graphdb.DatabaseShutdownException;
 import org.neo4j.graphdb.security.AuthorizationExpiredException;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.AvailabilityGuard;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.KernelTransactionHandle;
@@ -103,7 +103,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.neo4j.helpers.collection.Iterators.asSet;
 import static org.neo4j.internal.kernel.api.Transaction.Type.explicit;
-import static org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 import static org.neo4j.kernel.impl.transaction.TransactionHeaderInformationFactory.DEFAULT;
 import static org.neo4j.test.assertion.Assert.assertException;
 
@@ -408,10 +408,10 @@ public class KernelTransactionsTest
     public void shouldNotLeakTransactionOnSecurityContextFreezeFailure() throws Throwable
     {
         KernelTransactions kernelTransactions = newKernelTransactions();
-        SecurityContext securityContext = mock(SecurityContext.class);
-        when( securityContext.freeze() ).thenThrow( new AuthorizationExpiredException( "Freeze failed." ) );
+        LoginContext loginContext = mock( LoginContext.class );
+        when( loginContext.freeze( any() ) ).thenThrow( new AuthorizationExpiredException( "Freeze failed." ) );
 
-        assertException(() -> kernelTransactions.newInstance(KernelTransaction.Type.explicit, securityContext, 0L),
+        assertException(() -> kernelTransactions.newInstance(KernelTransaction.Type.explicit, loginContext, 0L),
                 AuthorizationExpiredException.class, "Freeze failed.");
 
         assertThat("We should not have any transaction", kernelTransactions.activeTransactions(), is(empty()));
@@ -421,19 +421,17 @@ public class KernelTransactionsTest
     public void exceptionWhenStartingNewTransactionOnShutdownInstance() throws Throwable
     {
         KernelTransactions kernelTransactions = newKernelTransactions();
-        SecurityContext securityContext = mock( SecurityContext.class );
 
         availabilityGuard.shutdown();
 
         expectedException.expect( DatabaseShutdownException.class );
-        kernelTransactions.newInstance( KernelTransaction.Type.explicit, securityContext, 0L );
+        kernelTransactions.newInstance( KernelTransaction.Type.explicit, AUTH_DISABLED, 0L );
     }
 
     @Test
     public void exceptionWhenStartingNewTransactionOnStoppedKernelTransactions() throws Throwable
     {
         KernelTransactions kernelTransactions = newKernelTransactions();
-        SecurityContext securityContext = mock( SecurityContext.class );
 
         t2.execute( (OtherThreadExecutor.WorkerCommand<Void,Void>) state ->
         {
@@ -442,19 +440,18 @@ public class KernelTransactionsTest
         } ).get();
 
         expectedException.expect( IllegalStateException.class );
-        kernelTransactions.newInstance( KernelTransaction.Type.explicit, securityContext, 0L );
+        kernelTransactions.newInstance( KernelTransaction.Type.explicit, AUTH_DISABLED, 0L );
     }
 
     @Test
     public void startNewTransactionOnRestartedKErnelTransactions() throws Throwable
     {
         KernelTransactions kernelTransactions = newKernelTransactions();
-        SecurityContext securityContext = mock( SecurityContext.class );
 
         kernelTransactions.stop();
         kernelTransactions.start();
         assertNotNull( "New transaction created by restarted kernel transactions component.",
-                kernelTransactions.newInstance( KernelTransaction.Type.explicit, securityContext, 0L ) );
+                kernelTransactions.newInstance( KernelTransaction.Type.explicit, AUTH_DISABLED, 0L ) );
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
@@ -409,7 +409,7 @@ public class KernelTransactionsTest
     {
         KernelTransactions kernelTransactions = newKernelTransactions();
         LoginContext loginContext = mock( LoginContext.class );
-        when( loginContext.freeze( any() ) ).thenThrow( new AuthorizationExpiredException( "Freeze failed." ) );
+        when( loginContext.authorize( any() ) ).thenThrow( new AuthorizationExpiredException( "Freeze failed." ) );
 
         assertException(() -> kernelTransactions.newInstance(KernelTransaction.Type.explicit, loginContext, 0L),
                 AuthorizationExpiredException.class, "Freeze failed.");

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
@@ -40,6 +40,7 @@ import org.neo4j.internal.kernel.api.TokenRead;
 import org.neo4j.internal.kernel.api.TokenWrite;
 import org.neo4j.internal.kernel.api.Write;
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.InwardKernel;
 import org.neo4j.kernel.api.KernelTransaction;
@@ -325,13 +326,13 @@ public class ConstraintIndexCreatorTest
         private final List<KernelStatement> statements = new ArrayList<>();
 
         @Override
-        public KernelTransaction newTransaction( KernelTransaction.Type type, SecurityContext securityContext )
+        public KernelTransaction newTransaction( KernelTransaction.Type type, LoginContext loginContext )
         {
             return new StubKernelTransaction();
         }
 
         @Override
-        public KernelTransaction newTransaction( KernelTransaction.Type type, SecurityContext securityContext, long timeout )
+        public KernelTransaction newTransaction( KernelTransaction.Type type, LoginContext loginContext, long timeout )
                 throws TransactionFailureException
         {
             return new StubKernelTransaction( timeout );
@@ -369,7 +370,7 @@ public class ConstraintIndexCreatorTest
         }
 
         @Override
-        public Session beginSession( SecurityContext securityContext )
+        public Session beginSession( LoginContext loginContext )
         {
             throw new UnsupportedOperationException();
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexIT.java
@@ -36,18 +36,16 @@ import org.neo4j.graphdb.schema.IndexDefinition;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.Iterators;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
+import org.neo4j.internal.kernel.api.exceptions.schema.SchemaKernelException;
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.TokenWriteOperations;
-import org.neo4j.internal.kernel.api.exceptions.schema.SchemaKernelException;
 import org.neo4j.kernel.api.index.PropertyAccessor;
 import org.neo4j.kernel.api.schema.SchemaDescriptorFactory;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
-import org.neo4j.kernel.api.security.AnonymousContext;
 import org.neo4j.kernel.impl.api.integrationtest.KernelIntegrationTest;
 import org.neo4j.kernel.impl.api.state.ConstraintIndexCreator;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
@@ -61,6 +59,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.neo4j.helpers.collection.Iterators.asSet;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 
 public class IndexIT extends KernelIntegrationTest
 {
@@ -147,7 +146,7 @@ public class IndexIT extends KernelIntegrationTest
         commit();
 
         // WHEN
-        Statement statement = statementInNewTransaction( AnonymousContext.AUTH_DISABLED );
+        Statement statement = statementInNewTransaction( AUTH_DISABLED );
         IndexDescriptor addedRule = statement.schemaWriteOperations()
                                             .indexCreate( SchemaDescriptorFactory.forLabel( labelId, 10 ) );
         Set<IndexDescriptor> indexRulesInTx = asSet( statement.readOperations().indexesGetForLabel( labelId ) );
@@ -262,7 +261,7 @@ public class IndexIT extends KernelIntegrationTest
     public void shouldListConstraintIndexesInTheBeansAPI() throws Exception
     {
         // given
-        Statement statement = statementInNewTransaction( SecurityContext.AUTH_DISABLED );
+        Statement statement = statementInNewTransaction( AUTH_DISABLED );
         statement.schemaWriteOperations().uniquePropertyConstraintCreate(
                 SchemaDescriptorFactory.forLabel(
                         statement.tokenWriteOperations().labelGetOrCreateForName( "Label1" ),

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
@@ -44,7 +44,6 @@ import org.neo4j.internal.kernel.api.InternalIndexState;
 import org.neo4j.internal.kernel.api.exceptions.schema.IllegalTokenNameException;
 import org.neo4j.internal.kernel.api.exceptions.schema.TooManyLabelsException;
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.InwardKernel;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
@@ -97,7 +96,7 @@ import static org.neo4j.helpers.collection.Iterators.asSet;
 import static org.neo4j.helpers.collection.MapUtil.genericMap;
 import static org.neo4j.helpers.collection.MapUtil.map;
 import static org.neo4j.internal.kernel.api.IndexCapability.NO_CAPABILITY;
-import static org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 import static org.neo4j.kernel.api.index.IndexEntryUpdate.add;
 import static org.neo4j.kernel.impl.api.index.IndexingService.NO_MONITOR;
 import static org.neo4j.kernel.impl.api.index.TestSchemaIndexProviderDescriptor.PROVIDER_DESCRIPTOR;
@@ -626,7 +625,7 @@ public class IndexPopulationJobTest
     private IndexDescriptor indexDescriptor( Label label, String propertyKey, boolean constraint )
             throws TransactionFailureException, IllegalTokenNameException, TooManyLabelsException
     {
-        try ( KernelTransaction tx = kernel.newTransaction( KernelTransaction.Type.implicit, SecurityContext.AUTH_DISABLED );
+        try ( KernelTransaction tx = kernel.newTransaction( KernelTransaction.Type.implicit, AUTH_DISABLED );
               Statement statement = tx.acquireStatement() )
         {
             int labelId = statement.tokenWriteOperations().labelGetOrCreateForName( label.name() );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
@@ -268,7 +268,7 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
         {
             // When
             dbmsOperations().procedureCallDbms( procedureName( "dbms", "iDoNotExist" ), new Object[0],
-                    AnonymousContext.none().freeze( mock( Token.class ) ) );
+                    AnonymousContext.none().authorize( mock( Token.class ) ) );
             fail( "This should never get here" );
         }
         catch ( Exception e )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/BuiltInProceduresIT.java
@@ -31,7 +31,7 @@ import java.util.Set;
 import org.neo4j.collection.RawIterator;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.helpers.collection.MapUtil;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.Token;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.TokenWriteOperations;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
@@ -46,7 +46,9 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 import static org.neo4j.helpers.collection.Iterators.asList;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureName;
 import static org.neo4j.kernel.api.schema.SchemaDescriptorFactory.forLabel;
 
@@ -266,7 +268,7 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
         {
             // When
             dbmsOperations().procedureCallDbms( procedureName( "dbms", "iDoNotExist" ), new Object[0],
-                    AnonymousContext.none() );
+                    AnonymousContext.none().freeze( mock( Token.class ) ) );
             fail( "This should never get here" );
         }
         catch ( Exception e )
@@ -296,7 +298,7 @@ public class BuiltInProceduresIT extends KernelIntegrationTest
     public void listAllIndexes() throws Throwable
     {
         // Given
-        Statement statement = statementInNewTransaction( SecurityContext.AUTH_DISABLED );
+        Statement statement = statementInNewTransaction( AUTH_DISABLED );
         int labelId1 = statement.tokenWriteOperations().labelGetOrCreateForName( "Person" );
         int labelId2 = statement.tokenWriteOperations().labelGetOrCreateForName( "Age" );
         int propertyKeyId1 = statement.tokenWriteOperations().propertyKeyGetOrCreateForName( "foo" );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/CompositeUniquenessConstraintValidationIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/CompositeUniquenessConstraintValidationIT.java
@@ -34,14 +34,14 @@ import java.util.Arrays;
 
 import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
+import org.neo4j.internal.kernel.api.exceptions.KernelException;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.InwardKernel;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
-import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.exceptions.schema.UniquePropertyValueValidationException;
 import org.neo4j.kernel.api.schema.constaints.ConstraintDescriptorFactory;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
 import org.neo4j.test.rule.ImpermanentDatabaseRule;
 import org.neo4j.values.storable.Values;
@@ -319,7 +319,7 @@ public class CompositeUniquenessConstraintValidationIT
         {
             fail( "tx already opened" );
         }
-        transaction = kernel.newTransaction( KernelTransaction.Type.implicit, SecurityContext.AUTH_DISABLED );
+        transaction = kernel.newTransaction( KernelTransaction.Type.implicit, LoginContext.AUTH_DISABLED );
         statement = transaction.acquireStatement();
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIT.java
@@ -38,15 +38,14 @@ import org.neo4j.graphdb.Node;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.graphdb.TransactionFailureException;
 import org.neo4j.internal.kernel.api.exceptions.InvalidTransactionTypeKernelException;
+import org.neo4j.internal.kernel.api.exceptions.schema.SchemaKernelException;
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.TokenWriteOperations;
 import org.neo4j.kernel.api.exceptions.EntityNotFoundException;
 import org.neo4j.kernel.api.exceptions.Status;
-import org.neo4j.internal.kernel.api.exceptions.schema.SchemaKernelException;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.impl.transaction.log.TransactionIdStore;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
@@ -62,7 +61,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.neo4j.graphdb.Label.label;
-import static org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 import static org.neo4j.kernel.api.schema.SchemaDescriptorFactory.forLabel;
 import static org.neo4j.test.assertion.Assert.assertEventually;
 
@@ -501,7 +500,7 @@ public class KernelIT extends KernelIntegrationTest
         commit();
 
         // WHEN
-        createIndex( statementInNewTransaction( SecurityContext.AUTH_DISABLED ) );
+        createIndex( statementInNewTransaction( AUTH_DISABLED ) );
         commit();
 
         try ( Transaction tx = db.beginTx() )
@@ -519,7 +518,7 @@ public class KernelIT extends KernelIntegrationTest
     public void schemaStateShouldBeEvictedOnIndexDropped() throws Exception
     {
         // GIVEN
-        IndexDescriptor idx = createIndex( statementInNewTransaction( SecurityContext.AUTH_DISABLED ) );
+        IndexDescriptor idx = createIndex( statementInNewTransaction( AUTH_DISABLED ) );
         commit();
 
         try ( Transaction tx = db.beginTx() )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/KernelIntegrationTest.java
@@ -26,6 +26,7 @@ import org.junit.rules.RuleChain;
 
 import org.neo4j.graphdb.GraphDatabaseService;
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.InwardKernel;
 import org.neo4j.kernel.api.KernelTransaction;
@@ -38,7 +39,6 @@ import org.neo4j.kernel.api.dbms.DbmsOperations;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
 import org.neo4j.kernel.api.security.AnonymousContext;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.api.index.IndexingService;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
@@ -46,7 +46,7 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 
-import static org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 
 public abstract class KernelIntegrationTest
 {
@@ -65,9 +65,9 @@ public abstract class KernelIntegrationTest
     private Statement statement;
     private DbmsOperations dbmsOperations;
 
-    protected Statement statementInNewTransaction( SecurityContext securityContext ) throws KernelException
+    protected Statement statementInNewTransaction( LoginContext loginContext ) throws KernelException
     {
-        transaction = kernel.newTransaction( KernelTransaction.Type.implicit, securityContext );
+        transaction = kernel.newTransaction( KernelTransaction.Type.implicit, loginContext );
         statement = transaction.acquireStatement();
         return statement;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodeGetUniqueFromIndexSeekIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/NodeGetUniqueFromIndexSeekIT.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.DataWriteOperations;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.Statement;
@@ -248,7 +248,7 @@ public class NodeGetUniqueFromIndexSeekIT extends KernelIntegrationTest
 
     private IndexDescriptor createUniquenessConstraint( int labelId, int... propertyIds ) throws Exception
     {
-        Statement statement = statementInNewTransaction( SecurityContext.AUTH_DISABLED );
+        Statement statement = statementInNewTransaction( LoginContext.AUTH_DISABLED );
         LabelSchemaDescriptor descriptor = SchemaDescriptorFactory.forLabel( labelId, propertyIds );
         statement.schemaWriteOperations().uniquePropertyConstraintCreate( descriptor );
         IndexDescriptor result = statement.readOperations().indexGetForSchema( descriptor );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
@@ -346,7 +346,7 @@ public class TxStateTransactionDataViewTest
     @Test
     public void shouldGetEmptyUsernameForAnonymousContext()
     {
-        when( transaction.securityContext() ).thenReturn( AnonymousContext.read().freeze( mock( Token.class ) ) );
+        when( transaction.securityContext() ).thenReturn( AnonymousContext.read().authorize( mock( Token.class ) ) );
 
         TxStateTransactionDataSnapshot transactionDataSnapshot = snapshot();
         assertEquals( "", transactionDataSnapshot.username() );
@@ -358,7 +358,7 @@ public class TxStateTransactionDataViewTest
         AuthSubject authSubject = mock( AuthSubject.class );
         when( authSubject.username() ).thenReturn( "Christof" );
         when( transaction.securityContext() )
-                .thenReturn( new SecurityContext.Frozen( authSubject, AccessMode.Static.FULL ) );
+                .thenReturn( new SecurityContext( authSubject, AccessMode.Static.FULL ) );
 
         TxStateTransactionDataSnapshot transactionDataSnapshot = snapshot();
         assertEquals( "Christof", transactionDataSnapshot.username() );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/coreapi/TxStateTransactionDataViewTest.java
@@ -30,14 +30,15 @@ import org.neo4j.graphdb.PropertyContainer;
 import org.neo4j.graphdb.Relationship;
 import org.neo4j.graphdb.event.LabelEntry;
 import org.neo4j.graphdb.event.PropertyEntry;
+import org.neo4j.internal.kernel.api.Token;
+import org.neo4j.internal.kernel.api.security.AccessMode;
+import org.neo4j.internal.kernel.api.security.AuthSubject;
+import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.AssertOpen;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
 import org.neo4j.kernel.api.properties.PropertyKeyValue;
-import org.neo4j.internal.kernel.api.security.AccessMode;
 import org.neo4j.kernel.api.security.AnonymousContext;
-import org.neo4j.internal.kernel.api.security.AuthSubject;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.txstate.TransactionState;
 import org.neo4j.kernel.impl.api.KernelTransactionImplementation;
 import org.neo4j.kernel.impl.api.state.TxState;
@@ -345,7 +346,7 @@ public class TxStateTransactionDataViewTest
     @Test
     public void shouldGetEmptyUsernameForAnonymousContext()
     {
-        when( transaction.securityContext() ).thenReturn( AnonymousContext.read() );
+        when( transaction.securityContext() ).thenReturn( AnonymousContext.read().freeze( mock( Token.class ) ) );
 
         TxStateTransactionDataSnapshot transactionDataSnapshot = snapshot();
         assertEquals( "", transactionDataSnapshot.username() );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TransactionEventsIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/event/TransactionEventsIT.java
@@ -197,9 +197,9 @@ public class TransactionEventsIT
             }
 
             @Override
-            public SecurityContext freeze( Token token )
+            public SecurityContext authorize( Token token )
             {
-                return new SecurityContext.Frozen( subject, AccessMode.Static.WRITE );
+                return new SecurityContext( subject, AccessMode.Static.WRITE );
             }
         };
         Map<String,Object> metadata = genericMap( "username", "joe" );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/factory/GraphDatabaseFacadeTest.java
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 
 public class GraphDatabaseFacadeTest
 {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueClientFilterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueClientFilterTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import org.neo4j.internal.kernel.api.IndexQuery;
 
+import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
 import org.neo4j.kernel.api.schema.index.IndexDescriptorFactory;
 import org.neo4j.storageengine.api.schema.IndexProgressor;
@@ -37,6 +38,7 @@ import org.neo4j.values.storable.Value;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 import static org.neo4j.kernel.impl.newapi.MockStore.block;
 import static org.neo4j.kernel.impl.store.record.AbstractBaseRecord.NO_ID;
 import static org.neo4j.values.storable.Values.stringValue;
@@ -97,6 +99,7 @@ public class NodeValueClientFilterTest implements IndexProgressor, NodeValueClie
     @Test
     public void shouldAcceptNodeWithMatchingProperty() throws Exception
     {
+        when( store.ktx.securityContext() ).thenReturn( SecurityContext.AUTH_DISABLED );
         // given
         store.node( 17, 1, false, NO_ID, 0 );
         store.property( 1, NO_ID, NO_ID, block( 12, stringValue( "hello" ) ) );
@@ -114,6 +117,7 @@ public class NodeValueClientFilterTest implements IndexProgressor, NodeValueClie
     @Test
     public void shouldNotAcceptNodeWithoutMatchingProperty() throws Exception
     {
+        when( store.ktx.securityContext() ).thenReturn( SecurityContext.AUTH_DISABLED );
         // given
         store.node( 17, 1, false, NO_ID, 0 );
         store.property( 1, NO_ID, NO_ID, block( 7, stringValue( "wrong" ) ) );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/store/NeoStoresTest.java
@@ -109,7 +109,7 @@ import static org.junit.Assert.fail;
 import static org.neo4j.function.Predicates.ALWAYS_TRUE_INT;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.counts_store_rotation_timeout;
 import static org.neo4j.helpers.collection.MapUtil.stringMap;
-import static org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 import static org.neo4j.kernel.api.AssertOpen.ALWAYS_OPEN;
 import static org.neo4j.kernel.impl.locking.LockService.NO_LOCK;
 import static org.neo4j.kernel.impl.store.RecordStore.getRecord;

--- a/community/kernel/src/test/java/org/neo4j/test/rule/DatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/DatabaseRule.java
@@ -51,10 +51,10 @@ import org.neo4j.graphdb.schema.Schema;
 import org.neo4j.graphdb.security.URLAccessValidationError;
 import org.neo4j.graphdb.traversal.BidirectionalTraversalDescription;
 import org.neo4j.graphdb.traversal.TraversalDescription;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.Statement;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
@@ -199,16 +199,16 @@ public abstract class DatabaseRule extends ExternalResource implements GraphData
     }
 
     @Override
-    public InternalTransaction beginTransaction( KernelTransaction.Type type, SecurityContext securityContext )
+    public InternalTransaction beginTransaction( KernelTransaction.Type type, LoginContext loginContext )
     {
-        return getGraphDatabaseAPI().beginTransaction( type, securityContext );
+        return getGraphDatabaseAPI().beginTransaction( type, loginContext );
     }
 
     @Override
-    public InternalTransaction beginTransaction( KernelTransaction.Type type, SecurityContext securityContext, long timeout,
+    public InternalTransaction beginTransaction( KernelTransaction.Type type, LoginContext loginContext, long timeout,
             TimeUnit unit )
     {
-        return getGraphDatabaseAPI().beginTransaction( type, securityContext, timeout, unit );
+        return getGraphDatabaseAPI().beginTransaction( type, loginContext, timeout, unit );
     }
 
     @Override

--- a/community/neo4j/src/test/java/org/neo4j/locking/QueryExecutionLocksIT.java
+++ b/community/neo4j/src/test/java/org/neo4j/locking/QueryExecutionLocksIT.java
@@ -53,6 +53,7 @@ import org.neo4j.internal.kernel.api.exceptions.explicitindex.ExplicitIndexNotFo
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.internal.kernel.api.schema.SchemaDescriptor;
 import org.neo4j.internal.kernel.api.schema.constraints.ConstraintDescriptor;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.kernel.api.ExplicitIndexHits;
@@ -206,7 +207,7 @@ public class QueryExecutionLocksIT
         GraphDatabaseQueryService graph = databaseRule.resolveDependency( GraphDatabaseQueryService.class );
         QueryExecutionEngine executionEngine = databaseRule.resolveDependency( QueryExecutionEngine.class );
         try ( InternalTransaction tx = graph
-                .beginTransaction( KernelTransaction.Type.implicit, SecurityContext.AUTH_DISABLED ) )
+                .beginTransaction( KernelTransaction.Type.implicit, LoginContext.AUTH_DISABLED ) )
         {
             TransactionalContextWrapper context =
                     new TransactionalContextWrapper( createTransactionContext( graph, tx, query ), listeners );

--- a/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/BasicAuthManager.java
@@ -26,13 +26,13 @@ import java.util.Set;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.security.AuthorizationViolationException;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
 import org.neo4j.kernel.api.security.AuthManager;
 import org.neo4j.internal.kernel.api.security.AuthSubject;
 import org.neo4j.kernel.api.security.AuthToken;
 import org.neo4j.internal.kernel.api.security.AuthenticationResult;
 import org.neo4j.kernel.api.security.PasswordPolicy;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.security.UserManager;
 import org.neo4j.kernel.api.security.UserManagerSupplier;
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
@@ -116,7 +116,7 @@ public class BasicAuthManager implements AuthManager, UserManager, UserManagerSu
     }
 
     @Override
-    public BasicSecurityContext login( Map<String,Object> authToken ) throws InvalidAuthTokenException
+    public LoginContext login( Map<String,Object> authToken ) throws InvalidAuthTokenException
     {
         assertValidScheme( authToken );
 
@@ -133,7 +133,7 @@ public class BasicAuthManager implements AuthManager, UserManager, UserManagerSu
                 result = AuthenticationResult.PASSWORD_CHANGE_REQUIRED;
             }
         }
-        return new BasicSecurityContext( this, user, result );
+        return new BasicLoginContext( user, result );
     }
 
     @Override
@@ -224,7 +224,7 @@ public class BasicAuthManager implements AuthManager, UserManager, UserManagerSu
     }
 
     @Override
-    public UserManager getUserManager( SecurityContext securityContext )
+    public UserManager getUserManager( AuthSubject authSubject, boolean isUserManager )
     {
         return this;
     }

--- a/community/security/src/main/java/org/neo4j/server/security/auth/BasicLoginContext.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/BasicLoginContext.java
@@ -19,9 +19,11 @@
  */
 package org.neo4j.server.security.auth;
 
+import org.neo4j.internal.kernel.api.Token;
 import org.neo4j.internal.kernel.api.security.AccessMode;
 import org.neo4j.internal.kernel.api.security.AuthSubject;
 import org.neo4j.internal.kernel.api.security.AuthenticationResult;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.security.User;
 
@@ -29,15 +31,13 @@ import static org.neo4j.internal.kernel.api.security.AuthenticationResult.FAILUR
 import static org.neo4j.internal.kernel.api.security.AuthenticationResult.PASSWORD_CHANGE_REQUIRED;
 import static org.neo4j.internal.kernel.api.security.AuthenticationResult.SUCCESS;
 
-public class BasicSecurityContext implements SecurityContext
+public class BasicLoginContext implements LoginContext
 {
-    private final BasicAuthManager authManager;
     private final BasicAuthSubject authSubject;
     private AccessMode accessMode;
 
-    public BasicSecurityContext( BasicAuthManager authManager, User user, AuthenticationResult authenticationResult )
+    public BasicLoginContext( User user, AuthenticationResult authenticationResult )
     {
-        this.authManager = authManager;
         this.authSubject = new BasicAuthSubject( user, authenticationResult );
 
         switch ( authenticationResult )
@@ -107,33 +107,8 @@ public class BasicSecurityContext implements SecurityContext
     }
 
     @Override
-    public boolean isAdmin()
+    public SecurityContext freeze( Token token )
     {
-        return true;
-    }
-
-    @Override
-    public SecurityContext freeze()
-    {
-        return this;
-    }
-
-    @Override
-    public SecurityContext withMode( AccessMode mode )
-    {
-        return new Frozen( authSubject, mode );
-    }
-
-    @Override
-    public AccessMode mode()
-    {
-        return accessMode;
-    }
-
-    @Override
-    public String toString()
-    {
-        return String.format( "BasicSecurityContext{ securityContext=%s, accessMode=%s }", authSubject.username(),
-                accessMode );
+        return new SecurityContext.Frozen( authSubject, accessMode );
     }
 }

--- a/community/security/src/main/java/org/neo4j/server/security/auth/BasicLoginContext.java
+++ b/community/security/src/main/java/org/neo4j/server/security/auth/BasicLoginContext.java
@@ -107,8 +107,8 @@ public class BasicLoginContext implements LoginContext
     }
 
     @Override
-    public SecurityContext freeze( Token token )
+    public SecurityContext authorize( Token token )
     {
-        return new SecurityContext.Frozen( authSubject, accessMode );
+        return new SecurityContext( authSubject, accessMode );
     }
 }

--- a/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresTest.java
@@ -25,10 +25,12 @@ import org.junit.rules.ExpectedException;
 
 import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.internal.kernel.api.Token;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 import org.neo4j.kernel.api.security.AnonymousContext;
 import org.neo4j.kernel.impl.api.integrationtest.KernelIntegrationTest;
 
+import static org.mockito.Mockito.mock;
 import static org.neo4j.kernel.api.proc.ProcedureSignature.procedureName;
 
 public class AuthProceduresTest extends KernelIntegrationTest
@@ -48,8 +50,8 @@ public class AuthProceduresTest extends KernelIntegrationTest
         exception.expectMessage( "Anonymous cannot change password" );
 
         // When
-        dbmsOperations()
-                .procedureCallDbms( procedureName( "dbms", "changePassword" ), inputArray, AnonymousContext.none() );
+        dbmsOperations().procedureCallDbms( procedureName( "dbms", "changePassword" ), inputArray,
+                AnonymousContext.none().freeze( mock( Token.class ) ) );
     }
 
     @Test
@@ -64,7 +66,8 @@ public class AuthProceduresTest extends KernelIntegrationTest
         exception.expectMessage( "Anonymous cannot change password" );
 
         // When
-        dbmsOperations().procedureCallDbms( procedureName( "dbms", "security", "changePassword" ), inputArray, AnonymousContext.none() );
+        dbmsOperations().procedureCallDbms( procedureName( "dbms", "security", "changePassword" ), inputArray,
+                AnonymousContext.none().freeze( mock( Token.class ) ) );
     }
 
     @Override

--- a/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/AuthProceduresTest.java
@@ -51,7 +51,7 @@ public class AuthProceduresTest extends KernelIntegrationTest
 
         // When
         dbmsOperations().procedureCallDbms( procedureName( "dbms", "changePassword" ), inputArray,
-                AnonymousContext.none().freeze( mock( Token.class ) ) );
+                AnonymousContext.none().authorize( mock( Token.class ) ) );
     }
 
     @Test
@@ -67,7 +67,7 @@ public class AuthProceduresTest extends KernelIntegrationTest
 
         // When
         dbmsOperations().procedureCallDbms( procedureName( "dbms", "security", "changePassword" ), inputArray,
-                AnonymousContext.none().freeze( mock( Token.class ) ) );
+                AnonymousContext.none().authorize( mock( Token.class ) ) );
     }
 
     @Override

--- a/community/security/src/test/java/org/neo4j/server/security/auth/BasicAuthManagerTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/BasicAuthManagerTest.java
@@ -25,7 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.neo4j.internal.kernel.api.security.AuthenticationResult;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
 import org.neo4j.kernel.api.security.AuthManager;
 import org.neo4j.kernel.api.security.AuthToken;
@@ -258,7 +258,7 @@ public class BasicAuthManagerTest extends InitialUserTest
     private void assertLoginGivesResult( String username, String password, AuthenticationResult expectedResult )
             throws InvalidAuthTokenException
     {
-        SecurityContext securityContext = manager.login( authToken( username, password ) );
+        LoginContext securityContext = manager.login( authToken( username, password ) );
         assertThat( securityContext.subject().getAuthenticationResult(), equalTo( expectedResult ) );
     }
 

--- a/community/security/src/test/java/org/neo4j/server/security/auth/SecurityContextDescriptionTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/SecurityContextDescriptionTest.java
@@ -54,7 +54,7 @@ public class SecurityContextDescriptionTest
         manager.init();
         manager.start();
         manager.newUser( "johan", "bar", false );
-        context = manager.login( authToken( "johan", "bar" ) ).freeze( mock( Token.class ) );
+        context = manager.login( authToken( "johan", "bar" ) ).authorize( mock( Token.class ) );
     }
 
     @After

--- a/community/security/src/test/java/org/neo4j/server/security/auth/SecurityContextDescriptionTest.java
+++ b/community/security/src/test/java/org/neo4j/server/security/auth/SecurityContextDescriptionTest.java
@@ -23,6 +23,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.neo4j.internal.kernel.api.Token;
 import org.neo4j.internal.kernel.api.security.AccessMode;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.configuration.Config;
@@ -32,6 +33,7 @@ import org.neo4j.time.Clocks;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.neo4j.server.security.auth.SecurityTestUtils.authToken;
 
 public class SecurityContextDescriptionTest
@@ -52,7 +54,7 @@ public class SecurityContextDescriptionTest
         manager.init();
         manager.start();
         manager.newUser( "johan", "bar", false );
-        context = manager.login( authToken( "johan", "bar" ) );
+        context = manager.login( authToken( "johan", "bar" ) ).freeze( mock( Token.class ) );
     }
 
     @After
@@ -66,13 +68,6 @@ public class SecurityContextDescriptionTest
     public void shouldMakeNiceDescription() throws Throwable
     {
         assertThat( context.description(), equalTo( "user 'johan' with FULL" ) );
-    }
-
-    @Test
-    public void shouldMakeNiceDescriptionFrozen() throws Throwable
-    {
-        SecurityContext frozen = context.freeze();
-        assertThat( frozen.description(), equalTo( "user 'johan' with FULL" ) );
     }
 
     @Test

--- a/community/server/src/main/java/org/neo4j/server/database/CypherExecutor.java
+++ b/community/server/src/main/java/org/neo4j/server/database/CypherExecutor.java
@@ -39,7 +39,7 @@ import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.server.rest.web.HttpConnectionInfoFactory;
 
-import static org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 import static org.neo4j.kernel.impl.util.ValueUtils.asMapValue;
 import static org.neo4j.server.web.HttpHeaderUtils.getTransactionTimeout;
 

--- a/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizationDisabledFilter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizationDisabledFilter.java
@@ -28,7 +28,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.neo4j.graphdb.security.AuthorizationViolationException;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 
 import static javax.servlet.http.HttpServletRequest.BASIC_AUTH;
 
@@ -47,7 +47,7 @@ public class AuthorizationDisabledFilter extends AuthorizationFilter
         try
         {
             filterChain.doFilter(
-                    new AuthorizedRequestWrapper( BASIC_AUTH, "neo4j", request, getAuthDisabledSecurityContext() ),
+                    new AuthorizedRequestWrapper( BASIC_AUTH, "neo4j", request, getAuthDisabledLoginContext() ),
                     servletResponse );
         }
         catch ( AuthorizationViolationException e )
@@ -56,8 +56,8 @@ public class AuthorizationDisabledFilter extends AuthorizationFilter
         }
     }
 
-    protected SecurityContext getAuthDisabledSecurityContext()
+    protected LoginContext getAuthDisabledLoginContext()
     {
-        return SecurityContext.AUTH_DISABLED;
+        return LoginContext.AUTH_DISABLED;
     }
 }

--- a/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizationEnabledFilter.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizationEnabledFilter.java
@@ -37,9 +37,9 @@ import org.neo4j.function.ThrowingConsumer;
 import org.neo4j.graphdb.security.AuthProviderFailedException;
 import org.neo4j.graphdb.security.AuthProviderTimeoutException;
 import org.neo4j.graphdb.security.AuthorizationViolationException;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.security.AuthManager;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
@@ -107,7 +107,7 @@ public class AuthorizationEnabledFilter extends AuthorizationFilter
 
         try
         {
-            SecurityContext securityContext = authenticate( username, password );
+            LoginContext securityContext = authenticate( username, password );
             switch ( securityContext.subject().getAuthenticationResult() )
             {
             case PASSWORD_CHANGE_REQUIRED:
@@ -150,7 +150,7 @@ public class AuthorizationEnabledFilter extends AuthorizationFilter
         }
     }
 
-    private SecurityContext authenticate( String username, String password ) throws InvalidAuthTokenException
+    private LoginContext authenticate( String username, String password ) throws InvalidAuthTokenException
     {
         AuthManager authManager = authManagerSupplier.get();
         Map<String,Object> authToken = newBasicAuthToken( username, password );

--- a/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizedRequestWrapper.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/dbms/AuthorizedRequestWrapper.java
@@ -22,33 +22,33 @@ package org.neo4j.server.rest.dbms;
 import com.sun.jersey.api.core.HttpContext;
 import com.sun.jersey.api.core.HttpRequestContext;
 
+import java.security.Principal;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
-import java.security.Principal;
 
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.security.AnonymousContext;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 
 public class AuthorizedRequestWrapper extends HttpServletRequestWrapper
 {
-    public static SecurityContext getSecurityContextFromHttpServletRequest( HttpServletRequest request )
+    public static LoginContext getLoginContextFromHttpServletRequest( HttpServletRequest request )
     {
         Principal principal = request.getUserPrincipal();
-        return getSecurityContextFromUserPrincipal( principal );
+        return getLoginContextFromUserPrincipal( principal );
     }
 
-    public static SecurityContext getSecurityContextFromHttpContext( HttpContext httpContext )
+    public static LoginContext getLoginContextFromHttpContext( HttpContext httpContext )
     {
         HttpRequestContext requestContext = httpContext.getRequest();
         Principal principal = requestContext.getUserPrincipal();
-        return getSecurityContextFromUserPrincipal( principal );
+        return getLoginContextFromUserPrincipal( principal );
     }
 
-    public static SecurityContext getSecurityContextFromUserPrincipal( Principal principal )
+    public static LoginContext getLoginContextFromUserPrincipal( Principal principal )
     {
         if ( principal instanceof DelegatingPrincipal )
         {
-            return ((DelegatingPrincipal) principal).getSecurityContext();
+            return ((DelegatingPrincipal) principal).getLoginContext();
         }
         // If whitelisted uris can start transactions we cannot throw exception here
         //throw new IllegalArgumentException( "Tried to get access mode on illegal user principal" );
@@ -59,11 +59,11 @@ public class AuthorizedRequestWrapper extends HttpServletRequestWrapper
     private final DelegatingPrincipal principal;
 
     public AuthorizedRequestWrapper( final String authType, final String username, final HttpServletRequest request,
-            SecurityContext securityContext )
+            LoginContext loginContext )
     {
         super( request );
         this.authType = authType;
-        this.principal = new DelegatingPrincipal( username, securityContext );
+        this.principal = new DelegatingPrincipal( username, loginContext );
     }
 
     @Override

--- a/community/server/src/main/java/org/neo4j/server/rest/dbms/DelegatingPrincipal.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/dbms/DelegatingPrincipal.java
@@ -21,17 +21,17 @@ package org.neo4j.server.rest.dbms;
 
 import java.security.Principal;
 
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 
 public class DelegatingPrincipal implements Principal
 {
     private String username;
-    private final SecurityContext securityContext;
+    private final LoginContext loginContext;
 
-    DelegatingPrincipal( String username, SecurityContext securityContext )
+    DelegatingPrincipal( String username, LoginContext loginContext )
     {
         this.username = username;
-        this.securityContext = securityContext;
+        this.loginContext = loginContext;
     }
 
     @Override
@@ -40,9 +40,9 @@ public class DelegatingPrincipal implements Principal
         return username;
     }
 
-    public SecurityContext getSecurityContext()
+    public LoginContext getLoginContext()
     {
-        return securityContext;
+        return loginContext;
     }
 
     @Override

--- a/community/server/src/main/java/org/neo4j/server/rest/dbms/UserService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/dbms/UserService.java
@@ -30,9 +30,9 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
 import org.neo4j.kernel.api.exceptions.Status;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.security.UserManager;
 import org.neo4j.kernel.api.security.UserManagerSupplier;
 import org.neo4j.kernel.impl.security.User;
@@ -44,7 +44,7 @@ import org.neo4j.server.rest.repr.OutputFormat;
 import org.neo4j.server.rest.transactional.error.Neo4jError;
 
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
-import static org.neo4j.server.rest.dbms.AuthorizedRequestWrapper.getSecurityContextFromUserPrincipal;
+import static org.neo4j.server.rest.dbms.AuthorizedRequestWrapper.getLoginContextFromUserPrincipal;
 import static org.neo4j.server.rest.web.CustomStatusType.UNPROCESSABLE;
 
 @Path( "/user" )
@@ -74,8 +74,8 @@ public class UserService
             return output.notFound();
         }
 
-        SecurityContext securityContext = getSecurityContextFromUserPrincipal( principal );
-        UserManager userManager = userManagerSupplier.getUserManager( securityContext );
+        LoginContext loginContext = getLoginContextFromUserPrincipal( principal );
+        UserManager userManager = userManagerSupplier.getUserManager( loginContext.subject(), false );
 
         try
         {
@@ -125,14 +125,14 @@ public class UserService
 
         try
         {
-            SecurityContext securityContext = getSecurityContextFromUserPrincipal( principal );
-            if ( securityContext == null )
+            LoginContext loginContext = getLoginContextFromUserPrincipal( principal );
+            if ( loginContext == null )
             {
                 return output.notFound();
             }
             else
             {
-                UserManager userManager = userManagerSupplier.getUserManager( securityContext );
+                UserManager userManager = userManagerSupplier.getUserManager( loginContext.subject(), false );
                 userManager.setUserPassword( username, newPassword, false );
             }
         }

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionFacade.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionFacade.java
@@ -23,8 +23,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.GraphDatabaseQueryService;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
 import org.neo4j.logging.LogProvider;
 import org.neo4j.server.rest.transactional.error.TransactionLifecycleException;
@@ -69,10 +69,10 @@ public class TransactionFacade
     }
 
     public TransactionHandle newTransactionHandle( TransactionUriScheme uriScheme, boolean implicitTransaction,
-            SecurityContext securityContext, long customTransactionTimeout ) throws TransactionLifecycleException
+            LoginContext loginContext, long customTransactionTimeout ) throws TransactionLifecycleException
     {
         return new TransactionHandle( kernel, engine, queryService, registry, uriScheme, implicitTransaction,
-                securityContext, customTransactionTimeout, logProvider );
+                loginContext, customTransactionTimeout, logProvider );
     }
 
     public TransactionHandle findTransactionHandle( long txId ) throws TransactionLifecycleException

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandle.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionHandle.java
@@ -30,13 +30,13 @@ import org.neo4j.cypher.InvalidSemanticsException;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.security.AuthorizationViolationException;
 import org.neo4j.graphdb.security.WriteOperationsNotAllowedException;
-import org.neo4j.kernel.DeadlockDetectedException;
-import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.internal.kernel.api.Transaction.Type;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
+import org.neo4j.internal.kernel.api.security.LoginContext;
+import org.neo4j.kernel.DeadlockDetectedException;
+import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
 import org.neo4j.kernel.impl.query.QueryExecutionKernelException;
 import org.neo4j.kernel.impl.query.TransactionalContext;
@@ -74,7 +74,7 @@ public class TransactionHandle implements TransactionTerminationHandle
     private final TransactionRegistry registry;
     private final TransactionUriScheme uriScheme;
     private final Type type;
-    private final SecurityContext securityContext;
+    private final LoginContext loginContext;
     private long customTransactionTimeout;
     private final Log log;
     private final long id;
@@ -83,7 +83,7 @@ public class TransactionHandle implements TransactionTerminationHandle
 
     TransactionHandle( TransitionalPeriodTransactionMessContainer txManagerFacade, QueryExecutionEngine engine,
             GraphDatabaseQueryService queryService, TransactionRegistry registry, TransactionUriScheme uriScheme,
-            boolean implicitTransaction, SecurityContext securityContext, long customTransactionTimeout,
+            boolean implicitTransaction, LoginContext loginContext, long customTransactionTimeout,
             LogProvider logProvider )
     {
         this.txManagerFacade = txManagerFacade;
@@ -92,7 +92,7 @@ public class TransactionHandle implements TransactionTerminationHandle
         this.registry = registry;
         this.uriScheme = uriScheme;
         this.type = implicitTransaction ? Type.implicit : Type.explicit;
-        this.securityContext = securityContext;
+        this.loginContext = loginContext;
         this.customTransactionTimeout = customTransactionTimeout;
         this.log = logProvider.getLog( getClass() );
         this.id = registry.begin( this );
@@ -210,7 +210,7 @@ public class TransactionHandle implements TransactionTerminationHandle
         {
             try
             {
-                context = txManagerFacade.newTransaction( type, securityContext, customTransactionTimeout );
+                context = txManagerFacade.newTransaction( type, loginContext, customTransactionTimeout );
             }
             catch ( RuntimeException e )
             {
@@ -318,7 +318,7 @@ public class TransactionHandle implements TransactionTerminationHandle
                     }
 
                     hasPrevious = true;
-                    TransactionalContext tc = txManagerFacade.create( request, queryService, type, securityContext,
+                    TransactionalContext tc = txManagerFacade.create( request, queryService, type, loginContext,
                             statement.statement(), statement.parameters() );
                     Result result = safelyExecute( statement, hasPeriodicCommit, tc );
                     output.statementResult( result, statement.includeStats(), statement.resultDataContents() );

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionalRequestDispatcher.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransactionalRequestDispatcher.java
@@ -23,7 +23,7 @@ import com.sun.jersey.api.core.HttpContext;
 import com.sun.jersey.spi.dispatch.RequestDispatcher;
 
 import org.neo4j.graphdb.Transaction;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.server.database.Database;
@@ -53,14 +53,14 @@ public class TransactionalRequestDispatcher implements RequestDispatcher
     {
         RepresentationWriteHandler representationWriteHandler = DO_NOTHING;
 
-        SecurityContext securityContext = AuthorizedRequestWrapper.getSecurityContextFromHttpContext( httpContext );
+        LoginContext loginContext = AuthorizedRequestWrapper.getLoginContextFromHttpContext( httpContext );
 
         final GraphDatabaseFacade graph = database.getGraph();
         if ( o instanceof RestfulGraphDatabase )
         {
             RestfulGraphDatabase restfulGraphDatabase = (RestfulGraphDatabase) o;
 
-            final Transaction transaction = graph.beginTransaction( KernelTransaction.Type.implicit, securityContext );
+            final Transaction transaction = graph.beginTransaction( KernelTransaction.Type.implicit, loginContext );
 
             restfulGraphDatabase.getOutputFormat().setRepresentationWriteHandler( representationWriteHandler = new
                     CommitOnSuccessfulStatusCodeRepresentationWriteHandler( httpContext, transaction ));
@@ -69,7 +69,7 @@ public class TransactionalRequestDispatcher implements RequestDispatcher
         {
             BatchOperationService batchOperationService = (BatchOperationService) o;
 
-            final Transaction transaction = graph.beginTransaction( KernelTransaction.Type.explicit, securityContext );
+            final Transaction transaction = graph.beginTransaction( KernelTransaction.Type.explicit, loginContext );
 
             batchOperationService.setRepresentationWriteHandler( representationWriteHandler = new
                     CommitOnSuccessfulStatusCodeRepresentationWriteHandler( httpContext, transaction ) );
@@ -78,7 +78,7 @@ public class TransactionalRequestDispatcher implements RequestDispatcher
         {
             CypherService cypherService = (CypherService) o;
 
-            final Transaction transaction = graph.beginTransaction( KernelTransaction.Type.explicit, securityContext );
+            final Transaction transaction = graph.beginTransaction( KernelTransaction.Type.explicit, loginContext );
 
             cypherService.getOutputFormat().setRepresentationWriteHandler( representationWriteHandler = new
                     CommitOnSuccessfulStatusCodeRepresentationWriteHandler( httpContext, transaction ) );
@@ -87,7 +87,7 @@ public class TransactionalRequestDispatcher implements RequestDispatcher
         {
             DatabaseMetadataService databaseMetadataService = (DatabaseMetadataService) o;
 
-            final Transaction transaction = graph.beginTransaction( KernelTransaction.Type.implicit, securityContext );
+            final Transaction transaction = graph.beginTransaction( KernelTransaction.Type.implicit, loginContext );
 
             databaseMetadataService.setRepresentationWriteHandler( representationWriteHandler = new
                     RepresentationWriteHandler()
@@ -122,7 +122,7 @@ public class TransactionalRequestDispatcher implements RequestDispatcher
                 @Override
                 public void onRepresentationStartWriting()
                 {
-                    transaction = graph.beginTransaction( KernelTransaction.Type.implicit, securityContext );
+                    transaction = graph.beginTransaction( KernelTransaction.Type.implicit, loginContext );
                 }
 
                 @Override

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalPeriodTransactionMessContainer.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalPeriodTransactionMessContainer.java
@@ -22,9 +22,9 @@ package org.neo4j.server.rest.transactional;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 
-import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.internal.kernel.api.Transaction.Type;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.LoginContext;
+import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.kernel.impl.coreapi.PropertyContainerLocker;
@@ -49,10 +49,10 @@ public class TransitionalPeriodTransactionMessContainer
         this.txBridge = db.getDependencyResolver().resolveDependency( ThreadToStatementContextBridge.class );
     }
 
-    public TransitionalTxManagementKernelTransaction newTransaction( Type type, SecurityContext securityContext,
+    public TransitionalTxManagementKernelTransaction newTransaction( Type type, LoginContext loginContext,
             long customTransactionTimeout )
     {
-        return new TransitionalTxManagementKernelTransaction( db, type, securityContext, customTransactionTimeout, txBridge );
+        return new TransitionalTxManagementKernelTransaction( db, type, loginContext, customTransactionTimeout, txBridge );
     }
 
     ThreadToStatementContextBridge getBridge()
@@ -64,13 +64,13 @@ public class TransitionalPeriodTransactionMessContainer
             HttpServletRequest request,
             GraphDatabaseQueryService service,
             Type type,
-            SecurityContext securityContext,
+            LoginContext loginContext,
             String query,
             Map<String, Object> queryParameters )
     {
         TransactionalContextFactory contextFactory = Neo4jTransactionalContextFactory.create( service, locker );
         ClientConnectionInfo clientConnection = HttpConnectionInfoFactory.create( request );
-        InternalTransaction transaction = service.beginTransaction( type, securityContext );
+        InternalTransaction transaction = service.beginTransaction( type, loginContext );
         return contextFactory.newContext( clientConnection, transaction, query, ValueUtils.asMapValue( queryParameters ) );
     }
 }

--- a/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalTxManagementKernelTransaction.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/transactional/TransitionalTxManagementKernelTransaction.java
@@ -22,9 +22,9 @@ package org.neo4j.server.rest.transactional;
 import java.util.concurrent.TimeUnit;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.TransactionFailureException;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
@@ -33,7 +33,7 @@ class TransitionalTxManagementKernelTransaction
 {
     private final GraphDatabaseFacade db;
     private final KernelTransaction.Type type;
-    private final SecurityContext securityContext;
+    private final LoginContext loginContext;
     private long customTransactionTimeout;
     private final ThreadToStatementContextBridge bridge;
 
@@ -41,11 +41,11 @@ class TransitionalTxManagementKernelTransaction
     private KernelTransaction suspendedTransaction;
 
     TransitionalTxManagementKernelTransaction( GraphDatabaseFacade db, KernelTransaction.Type type,
-            SecurityContext securityContext, long customTransactionTimeout, ThreadToStatementContextBridge bridge )
+            LoginContext loginContext, long customTransactionTimeout, ThreadToStatementContextBridge bridge )
     {
         this.db = db;
         this.type = type;
-        this.securityContext = securityContext;
+        this.loginContext = loginContext;
         this.customTransactionTimeout = customTransactionTimeout;
         this.bridge = bridge;
         this.tx = startTransaction();
@@ -119,7 +119,7 @@ class TransitionalTxManagementKernelTransaction
     private InternalTransaction startTransaction()
     {
         return customTransactionTimeout > GraphDatabaseSettings.UNSPECIFIED_TIMEOUT ?
-               db.beginTransaction( type, securityContext, customTransactionTimeout, TimeUnit.MILLISECONDS ) :
-               db.beginTransaction( type, securityContext );
+               db.beginTransaction( type, loginContext, customTransactionTimeout, TimeUnit.MILLISECONDS ) :
+               db.beginTransaction( type, loginContext );
     }
 }

--- a/community/server/src/main/java/org/neo4j/server/rest/web/TransactionalService.java
+++ b/community/server/src/main/java/org/neo4j/server/rest/web/TransactionalService.java
@@ -38,7 +38,7 @@ import javax.ws.rs.core.StreamingOutput;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.core.UriInfo;
 
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.logging.Log;
 import org.neo4j.server.rest.dbms.AuthorizedRequestWrapper;
 import org.neo4j.server.rest.transactional.ExecutionResultSerializer;
@@ -83,10 +83,10 @@ public class TransactionalService
         try
         {
             usage.get( features ).flag( http_tx_endpoint );
-            SecurityContext securityContext = AuthorizedRequestWrapper.getSecurityContextFromHttpServletRequest( request );
+            LoginContext loginContext = AuthorizedRequestWrapper.getLoginContextFromHttpServletRequest( request );
             long customTransactionTimeout = HttpHeaderUtils.getTransactionTimeout( request, log );
             TransactionHandle transactionHandle =
-                    facade.newTransactionHandle( uriScheme, false, securityContext, customTransactionTimeout );
+                    facade.newTransactionHandle( uriScheme, false, loginContext, customTransactionTimeout );
             return createdResponse(
                     transactionHandle,
                     executeStatements( input, transactionHandle, uriInfo.getBaseUri(), request )
@@ -147,9 +147,9 @@ public class TransactionalService
         final TransactionHandle transactionHandle;
         try
         {
-            SecurityContext securityContext = AuthorizedRequestWrapper.getSecurityContextFromHttpServletRequest( request );
+            LoginContext loginContext = AuthorizedRequestWrapper.getLoginContextFromHttpServletRequest( request );
             long customTransactionTimeout = HttpHeaderUtils.getTransactionTimeout( request, log );
-            transactionHandle = facade.newTransactionHandle( uriScheme, true, securityContext, customTransactionTimeout );
+            transactionHandle = facade.newTransactionHandle( uriScheme, true, loginContext, customTransactionTimeout );
         }
         catch ( TransactionLifecycleException e )
         {

--- a/community/server/src/test/java/org/neo4j/server/database/CypherExecutorTest.java
+++ b/community/server/src/test/java/org/neo4j/server/database/CypherExecutorTest.java
@@ -28,11 +28,12 @@ import javax.servlet.http.HttpServletRequest;
 
 import org.neo4j.cypher.internal.javacompat.ExecutionEngine;
 import org.neo4j.graphdb.DependencyResolver;
+import org.neo4j.internal.kernel.api.Token;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.QueryRegistryOperations;
 import org.neo4j.kernel.api.Statement;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.kernel.impl.coreapi.TopLevelTransaction;
@@ -44,7 +45,7 @@ import org.neo4j.server.web.HttpHeaderUtils;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 
 public class CypherExecutorTest
 {
@@ -147,20 +148,20 @@ public class CypherExecutorTest
 
         InternalTransaction transaction = new TopLevelTransaction( kernelTransaction, () -> statement );
 
-        SecurityContext securityContext = AUTH_DISABLED;
+        LoginContext loginContext = AUTH_DISABLED;
         KernelTransaction.Type type = KernelTransaction.Type.implicit;
         QueryRegistryOperations registryOperations = mock( QueryRegistryOperations.class );
         when( statement.queryRegistration() ).thenReturn( registryOperations );
         when( statementBridge.get() ).thenReturn( statement );
-        when( kernelTransaction.securityContext() ).thenReturn( securityContext );
+        when( kernelTransaction.securityContext() ).thenReturn( loginContext.freeze( mock( Token.class ) ) );
         when( kernelTransaction.transactionType() ).thenReturn( type  );
         when( database.getGraph() ).thenReturn( databaseFacade );
         when( databaseFacade.getDependencyResolver() ).thenReturn( resolver );
         when( resolver.resolveDependency( QueryExecutionEngine.class ) ).thenReturn( executionEngine );
         when( resolver.resolveDependency( ThreadToStatementContextBridge.class ) ).thenReturn( statementBridge );
         when( resolver.resolveDependency( GraphDatabaseQueryService.class ) ).thenReturn( databaseQueryService );
-        when( databaseQueryService.beginTransaction( type, securityContext ) ).thenReturn( transaction );
-        when( databaseQueryService.beginTransaction( type, securityContext,
+        when( databaseQueryService.beginTransaction( type, loginContext ) ).thenReturn( transaction );
+        when( databaseQueryService.beginTransaction( type, loginContext,
                 CUSTOM_TRANSACTION_TIMEOUT, TimeUnit.MILLISECONDS ) ).thenReturn( transaction );
         when( databaseQueryService.getDependencyResolver() ).thenReturn( resolver );
         when( request.getScheme() ).thenReturn( "http" );

--- a/community/server/src/test/java/org/neo4j/server/database/CypherExecutorTest.java
+++ b/community/server/src/test/java/org/neo4j/server/database/CypherExecutorTest.java
@@ -153,7 +153,7 @@ public class CypherExecutorTest
         QueryRegistryOperations registryOperations = mock( QueryRegistryOperations.class );
         when( statement.queryRegistration() ).thenReturn( registryOperations );
         when( statementBridge.get() ).thenReturn( statement );
-        when( kernelTransaction.securityContext() ).thenReturn( loginContext.freeze( mock( Token.class ) ) );
+        when( kernelTransaction.securityContext() ).thenReturn( loginContext.authorize( mock( Token.class ) ) );
         when( kernelTransaction.transactionType() ).thenReturn( type  );
         when( database.getGraph() ).thenReturn( databaseFacade );
         when( databaseFacade.getDependencyResolver() ).thenReturn( resolver );

--- a/community/server/src/test/java/org/neo4j/server/rest/dbms/AuthorizationFilterTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/dbms/AuthorizationFilterTest.java
@@ -38,7 +38,7 @@ import org.neo4j.internal.kernel.api.security.AuthSubject;
 import org.neo4j.internal.kernel.api.security.AuthenticationResult;
 import org.neo4j.logging.AssertableLogProvider;
 import org.neo4j.server.security.auth.BasicAuthManager;
-import org.neo4j.server.security.auth.BasicSecurityContext;
+import org.neo4j.server.security.auth.BasicLoginContext;
 
 import static javax.servlet.http.HttpServletRequest.BASIC_AUTH;
 import static org.hamcrest.Matchers.containsString;
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
-import static org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 import static org.neo4j.logging.AssertableLogProvider.inLog;
 import static org.neo4j.server.security.auth.SecurityTestUtils.authToken;
 
@@ -170,14 +170,14 @@ public class AuthorizationFilterTest
         // Given
         final AuthorizationEnabledFilter filter = new AuthorizationEnabledFilter( () -> authManager, logProvider );
         String credentials = Base64.encodeBase64String( "foo:bar".getBytes( StandardCharsets.UTF_8 ) );
-        BasicSecurityContext securityContext = mock( BasicSecurityContext.class );
+        BasicLoginContext loginContext = mock( BasicLoginContext.class );
         AuthSubject authSubject = mock( AuthSubject.class );
         when( servletRequest.getMethod() ).thenReturn( "GET" );
         when( servletRequest.getContextPath() ).thenReturn( "/db/data" );
         when( servletRequest.getHeader( HttpHeaders.AUTHORIZATION ) ).thenReturn( "BASIC " + credentials );
         when( servletRequest.getRemoteAddr() ).thenReturn( "remote_ip_address" );
-        when( authManager.login( authToken( "foo", "bar" ) ) ).thenReturn( securityContext );
-        when( securityContext.subject() ).thenReturn( authSubject );
+        when( authManager.login( authToken( "foo", "bar" ) ) ).thenReturn( loginContext );
+        when( loginContext.subject() ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.FAILURE );
 
         // When
@@ -201,13 +201,13 @@ public class AuthorizationFilterTest
         // Given
         final AuthorizationEnabledFilter filter = new AuthorizationEnabledFilter( () -> authManager, logProvider );
         String credentials = Base64.encodeBase64String( "foo:bar".getBytes( StandardCharsets.UTF_8 ) );
-        BasicSecurityContext securityContext = mock( BasicSecurityContext.class );
+        BasicLoginContext loginContext = mock( BasicLoginContext.class );
         AuthSubject authSubject = mock( AuthSubject.class );
         when( servletRequest.getMethod() ).thenReturn( "GET" );
         when( servletRequest.getContextPath() ).thenReturn( "/user/foo" );
         when( servletRequest.getHeader( HttpHeaders.AUTHORIZATION ) ).thenReturn( "BASIC " + credentials );
-        when( authManager.login( authToken( "foo", "bar" ) ) ).thenReturn( securityContext );
-        when( securityContext.subject() ).thenReturn( authSubject );
+        when( authManager.login( authToken( "foo", "bar" ) ) ).thenReturn( loginContext );
+        when( loginContext.subject() ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.PASSWORD_CHANGE_REQUIRED );
 
         // When
@@ -224,15 +224,15 @@ public class AuthorizationFilterTest
         // Given
         final AuthorizationEnabledFilter filter = new AuthorizationEnabledFilter( () -> authManager, logProvider );
         String credentials = Base64.encodeBase64String( "foo:bar".getBytes( StandardCharsets.UTF_8 ) );
-        BasicSecurityContext securityContext = mock( BasicSecurityContext.class );
+        BasicLoginContext loginContext = mock( BasicLoginContext.class );
         AuthSubject authSubject = mock( AuthSubject.class );
         when( servletRequest.getMethod() ).thenReturn( "GET" );
         when( servletRequest.getContextPath() ).thenReturn( "/db/data" );
         when( servletRequest.getRequestURL() ).thenReturn( new StringBuffer( "http://bar.baz:7474/db/data/" ) );
         when( servletRequest.getRequestURI() ).thenReturn( "/db/data/" );
         when( servletRequest.getHeader( HttpHeaders.AUTHORIZATION ) ).thenReturn( "BASIC " + credentials );
-        when( authManager.login( authToken( "foo", "bar" ) ) ).thenReturn( securityContext );
-        when( securityContext.subject() ).thenReturn( authSubject );
+        when( authManager.login( authToken( "foo", "bar" ) ) ).thenReturn( loginContext );
+        when( loginContext.subject() ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.PASSWORD_CHANGE_REQUIRED );
 
         // When
@@ -256,13 +256,13 @@ public class AuthorizationFilterTest
         // Given
         final AuthorizationEnabledFilter filter = new AuthorizationEnabledFilter( () -> authManager, logProvider );
         String credentials = Base64.encodeBase64String( "foo:bar".getBytes( StandardCharsets.UTF_8 ) );
-        BasicSecurityContext securityContext = mock( BasicSecurityContext.class );
+        BasicLoginContext loginContext = mock( BasicLoginContext.class );
         AuthSubject authSubject = mock( AuthSubject.class );
         when( servletRequest.getMethod() ).thenReturn( "GET" );
         when( servletRequest.getContextPath() ).thenReturn( "/db/data" );
         when( servletRequest.getHeader( HttpHeaders.AUTHORIZATION ) ).thenReturn( "BASIC " + credentials );
-        when( authManager.login( authToken( "foo", "bar" ) ) ).thenReturn( securityContext );
-        when( securityContext.subject() ).thenReturn( authSubject );
+        when( authManager.login( authToken( "foo", "bar" ) ) ).thenReturn( loginContext );
+        when( loginContext.subject() ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.TOO_MANY_ATTEMPTS );
 
         // When
@@ -285,13 +285,13 @@ public class AuthorizationFilterTest
         // Given
         final AuthorizationEnabledFilter filter = new AuthorizationEnabledFilter( () -> authManager, logProvider );
         String credentials = Base64.encodeBase64String( "foo:bar".getBytes( StandardCharsets.UTF_8 ) );
-        BasicSecurityContext securityContext = mock( BasicSecurityContext.class );
+        BasicLoginContext loginContext = mock( BasicLoginContext.class );
         AuthSubject authSubject = mock( AuthSubject.class );
         when( servletRequest.getMethod() ).thenReturn( "GET" );
         when( servletRequest.getContextPath() ).thenReturn( "/db/data" );
         when( servletRequest.getHeader( HttpHeaders.AUTHORIZATION ) ).thenReturn( "BASIC " + credentials );
-        when( authManager.login( authToken( "foo", "bar" ) ) ).thenReturn( securityContext );
-        when( securityContext.subject() ).thenReturn( authSubject );
+        when( authManager.login( authToken( "foo", "bar" ) ) ).thenReturn( loginContext );
+        when( loginContext.subject() ).thenReturn( authSubject );
         when( authSubject.getAuthenticationResult() ).thenReturn( AuthenticationResult.SUCCESS );
 
         // When

--- a/community/server/src/test/java/org/neo4j/server/rest/dbms/UserServiceTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/dbms/UserServiceTest.java
@@ -29,10 +29,10 @@ import java.security.Principal;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Response;
 
-import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
 import org.neo4j.internal.kernel.api.security.AuthenticationResult;
+import org.neo4j.internal.kernel.api.security.LoginContext;
+import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
 import org.neo4j.kernel.api.security.PasswordPolicy;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.api.security.UserManager;
 import org.neo4j.kernel.api.security.UserManagerSupplier;
 import org.neo4j.kernel.impl.security.Credential;
@@ -42,7 +42,7 @@ import org.neo4j.server.rest.repr.formats.JsonFormat;
 import org.neo4j.server.security.auth.AuthenticationStrategy;
 import org.neo4j.server.security.auth.BasicAuthManager;
 import org.neo4j.server.security.auth.BasicPasswordPolicy;
-import org.neo4j.server.security.auth.BasicSecurityContext;
+import org.neo4j.server.security.auth.BasicLoginContext;
 import org.neo4j.server.security.auth.InMemoryUserRepository;
 import org.neo4j.server.security.auth.UserRepository;
 import org.neo4j.test.server.EntityOutputFormat;
@@ -64,7 +64,7 @@ public class UserServiceTest
     protected final UserRepository userRepository = new InMemoryUserRepository();
 
     protected UserManagerSupplier userManagerSupplier;
-    protected SecurityContext neo4jContext;
+    protected LoginContext neo4jContext;
     protected Principal neo4jPrinciple;
 
     protected void setupAuthManagerAndSubject()
@@ -73,7 +73,7 @@ public class UserServiceTest
                 mock( AuthenticationStrategy.class), new InMemoryUserRepository() );
 
         userManagerSupplier = basicAuthManager;
-        neo4jContext = new BasicSecurityContext( basicAuthManager, NEO4J_USER, AuthenticationResult.SUCCESS );
+        neo4jContext = new BasicLoginContext( NEO4J_USER, AuthenticationResult.SUCCESS );
     }
 
     @Before

--- a/community/server/src/test/java/org/neo4j/server/rest/domain/GraphDbHelper.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/domain/GraphDbHelper.java
@@ -51,7 +51,7 @@ import static org.neo4j.graphdb.Label.label;
 import static org.neo4j.helpers.collection.Iterables.count;
 import static org.neo4j.helpers.collection.Iterables.single;
 import static org.neo4j.internal.kernel.api.Transaction.Type.implicit;
-import static org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 
 public class GraphDbHelper
 {

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/ConcurrentTransactionAccessTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/ConcurrentTransactionAccessTest.java
@@ -25,9 +25,9 @@ import java.net.URI;
 import java.time.Clock;
 import javax.servlet.http.HttpServletRequest;
 
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.logging.NullLogProvider;
 import org.neo4j.server.rest.transactional.error.InvalidConcurrentTransactionAccess;
 import org.neo4j.server.rest.web.TransactionUriScheme;
@@ -50,12 +50,12 @@ public class ConcurrentTransactionAccessTest
                 new TransactionHandleRegistry( mock( Clock.class), 0, NullLogProvider.getInstance() );
         TransitionalPeriodTransactionMessContainer kernel = mock( TransitionalPeriodTransactionMessContainer.class );
         GraphDatabaseQueryService queryService = mock( GraphDatabaseQueryService.class );
-        when(kernel.newTransaction( any( KernelTransaction.Type.class ), any( SecurityContext.class ), anyLong() ) )
+        when(kernel.newTransaction( any( KernelTransaction.Type.class ), any( LoginContext.class ), anyLong() ) )
                 .thenReturn( mock(TransitionalTxManagementKernelTransaction.class) );
         TransactionFacade actions = new TransactionFacade( kernel, null, queryService, registry, NullLogProvider.getInstance() );
 
         final TransactionHandle transactionHandle =
-                actions.newTransactionHandle( new DisgustingUriScheme(), true, SecurityContext.AUTH_DISABLED, -1 );
+                actions.newTransactionHandle( new DisgustingUriScheme(), true, LoginContext.AUTH_DISABLED, -1 );
 
         final DoubleLatch latch = new DoubleLatch();
 

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/TransactionHandleTest.java
@@ -34,11 +34,11 @@ import javax.servlet.http.HttpServletRequest;
 import org.neo4j.cypher.SyntaxException;
 import org.neo4j.graphdb.Notification;
 import org.neo4j.graphdb.Result;
+import org.neo4j.internal.kernel.api.Transaction.Type;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.DeadlockDetectedException;
 import org.neo4j.kernel.GraphDatabaseQueryService;
-import org.neo4j.internal.kernel.api.Transaction.Type;
 import org.neo4j.kernel.api.exceptions.Status;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.query.QueryExecutionEngine;
 import org.neo4j.kernel.impl.query.QueryExecutionKernelException;
 import org.neo4j.kernel.impl.query.TransactionalContext;
@@ -69,7 +69,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static org.neo4j.helpers.collection.MapUtil.map;
 import static org.neo4j.internal.kernel.api.Transaction.Type.explicit;
-import static org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 import static org.neo4j.server.rest.transactional.StubStatementDeserializer.statements;
 
 public class TransactionHandleTest
@@ -311,7 +311,7 @@ public class TransactionHandleTest
                 mock( HttpServletRequest.class ) );
 
         // then
-        verify( kernel ).newTransaction( any( Type.class ), any( SecurityContext.class ), anyLong() );
+        verify( kernel ).newTransaction( any( Type.class ), any( LoginContext.class ), anyLong() );
 
         InOrder outputOrder = inOrder( output );
         outputOrder.verify( output ).transactionCommitUri( uriScheme.txCommitUri( 1337 ) );
@@ -465,7 +465,7 @@ public class TransactionHandleTest
         // given
         TransitionalPeriodTransactionMessContainer kernel = mockKernel();
         TransitionalTxManagementKernelTransaction tx = mock( TransitionalTxManagementKernelTransaction.class );
-        when( kernel.newTransaction( any( Type.class ), any( SecurityContext.class ), anyLong() ) ).thenReturn( tx );
+        when( kernel.newTransaction( any( Type.class ), any( LoginContext.class ), anyLong() ) ).thenReturn( tx );
         TransactionRegistry registry = mock( TransactionRegistry.class );
         when( registry.begin( any( TransactionHandle.class ) ) ).thenReturn( 1337L );
         QueryExecutionEngine executionEngine = mock( QueryExecutionEngine.class );
@@ -551,7 +551,7 @@ public class TransactionHandleTest
     {
         TransitionalTxManagementKernelTransaction context = mock( TransitionalTxManagementKernelTransaction.class );
         TransitionalPeriodTransactionMessContainer kernel = mock( TransitionalPeriodTransactionMessContainer.class );
-        when( kernel.newTransaction( any( Type.class ), any( SecurityContext.class ), anyLong() ) ).thenReturn( context );
+        when( kernel.newTransaction( any( Type.class ), any( LoginContext.class ), anyLong() ) ).thenReturn( context );
         return kernel;
     }
 
@@ -593,7 +593,7 @@ public class TransactionHandleTest
                         any( HttpServletRequest.class ),
                         any( GraphDatabaseQueryService.class ),
                         any( Type.class ),
-                        any( SecurityContext.class ),
+                        any( LoginContext.class ),
                         any( String.class ),
                         any( Map.class ) ) ).
                 thenReturn( tc );

--- a/community/server/src/test/java/org/neo4j/server/rest/transactional/TransitionalTxManagementKernelTransactionTest.java
+++ b/community/server/src/test/java/org/neo4j/server/rest/transactional/TransitionalTxManagementKernelTransactionTest.java
@@ -23,9 +23,9 @@ import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
 
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.security.AnonymousContext;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.core.ThreadToStatementContextBridge;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 
@@ -38,28 +38,28 @@ public class TransitionalTxManagementKernelTransactionTest
 
     private GraphDatabaseFacade databaseFacade = mock( GraphDatabaseFacade.class );
     private ThreadToStatementContextBridge contextBridge = mock( ThreadToStatementContextBridge.class );
-    private SecurityContext securityContext = AnonymousContext.read();
+    private LoginContext loginContext = AnonymousContext.read();
     private KernelTransaction.Type type = KernelTransaction.Type.implicit;
 
     @Test
     public void reopenStartTransactionWithCustomTimeoutIfSpecified() throws Exception
     {
         TransitionalTxManagementKernelTransaction managementKernelTransaction =
-                new TransitionalTxManagementKernelTransaction( databaseFacade, type, securityContext, 10, contextBridge );
+                new TransitionalTxManagementKernelTransaction( databaseFacade, type, loginContext, 10, contextBridge );
 
         managementKernelTransaction.reopenAfterPeriodicCommit();
 
-        verify( databaseFacade, times( 2 ) ).beginTransaction( type, securityContext, 10, TimeUnit.MILLISECONDS);
+        verify( databaseFacade, times( 2 ) ).beginTransaction( type, loginContext, 10, TimeUnit.MILLISECONDS);
     }
 
     @Test
     public void reopenStartDefaultTransactionIfTimeoutNotSpecified()
     {
         TransitionalTxManagementKernelTransaction managementKernelTransaction =
-                new TransitionalTxManagementKernelTransaction( databaseFacade, type, securityContext, -1, contextBridge );
+                new TransitionalTxManagementKernelTransaction( databaseFacade, type, loginContext, -1, contextBridge );
 
         managementKernelTransaction.reopenAfterPeriodicCommit();
 
-        verify( databaseFacade, times( 2 ) ).beginTransaction( type, securityContext );
+        verify( databaseFacade, times( 2 ) ).beginTransaction( type, loginContext );
     }
 }

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/ReadOnlyGraphDatabaseProxy.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/ReadOnlyGraphDatabaseProxy.java
@@ -59,7 +59,7 @@ import org.neo4j.graphdb.traversal.TraversalDescription;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.helpers.collection.PrefetchingResourceIterator;
 import org.neo4j.helpers.collection.ResourceIterableWrapper;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.kernel.impl.store.StoreId;
@@ -95,16 +95,16 @@ public class ReadOnlyGraphDatabaseProxy implements GraphDatabaseService, GraphDa
     }
 
     @Override
-    public InternalTransaction beginTransaction( KernelTransaction.Type type, SecurityContext securityContext )
+    public InternalTransaction beginTransaction( KernelTransaction.Type type, LoginContext loginContext )
     {
-        return actual.beginTransaction( type, securityContext );
+        return actual.beginTransaction( type, loginContext );
     }
 
     @Override
-    public InternalTransaction beginTransaction( KernelTransaction.Type type, SecurityContext securityContext, long timeout,
+    public InternalTransaction beginTransaction( KernelTransaction.Type type, LoginContext loginContext, long timeout,
             TimeUnit unit )
     {
-        return actual.beginTransaction( type, securityContext, timeout, unit );
+        return actual.beginTransaction( type, loginContext, timeout, unit );
     }
 
     @Override

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/TransactionProvidingApp.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/TransactionProvidingApp.java
@@ -59,7 +59,7 @@ import org.neo4j.shell.util.json.JSONArray;
 import org.neo4j.shell.util.json.JSONException;
 
 import static org.neo4j.internal.kernel.api.Transaction.Type.implicit;
-import static org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 import static org.neo4j.shell.ShellException.stackTraceAsString;
 
 /**

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Dump.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Dump.java
@@ -35,7 +35,7 @@ import org.neo4j.shell.Session;
 import org.neo4j.shell.ShellException;
 
 import static org.neo4j.internal.kernel.api.Transaction.Type.implicit;
-import static org.neo4j.internal.kernel.api.security.SecurityContext.AUTH_DISABLED;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 
 @Service.Implementation( App.class )
 public class Dump extends Start

--- a/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Start.java
+++ b/community/shell/src/main/java/org/neo4j/shell/kernel/apps/cypher/Start.java
@@ -27,9 +27,9 @@ import java.util.Map;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.graphdb.Result;
 import org.neo4j.helpers.Service;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.GraphDatabaseQueryService;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.kernel.impl.coreapi.PropertyContainerLocker;
 import org.neo4j.kernel.impl.query.Neo4jTransactionalContextFactory;
@@ -200,7 +200,7 @@ public class Start extends TransactionProvidingApp
         TransactionalContextFactory contextFactory =
             Neo4jTransactionalContextFactory.create( graph, new PropertyContainerLocker() );
         InternalTransaction transaction =
-            graph.beginTransaction( KernelTransaction.Type.implicit, SecurityContext.AUTH_DISABLED );
+            graph.beginTransaction( KernelTransaction.Type.implicit, LoginContext.AUTH_DISABLED );
         return contextFactory.newContext(
                 new ShellConnectionInfo( session.getId() ),
                 transaction,

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CausalClusteringProceduresIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/CausalClusteringProceduresIT.java
@@ -36,7 +36,7 @@ import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.test.causalclustering.ClusterRule;
 
 import static org.junit.Assert.assertTrue;
-import static org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext.AUTH_DISABLED;
+import static org.neo4j.kernel.enterprise.api.security.EnterpriseLoginContext.AUTH_DISABLED;
 
 public class CausalClusteringProceduresIT
 {

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterFormationIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ClusterFormationIT.java
@@ -35,7 +35,7 @@ import org.neo4j.causalclustering.discovery.ReadReplica;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.Transaction;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseLoginContext;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.test.causalclustering.ClusterRule;
 
@@ -78,7 +78,7 @@ public class ClusterFormationIT
             // (2) BuiltInProcedures from enterprise
             try ( InternalTransaction tx = gdb.beginTransaction(
                     KernelTransaction.Type.explicit,
-                    EnterpriseSecurityContext.AUTH_DISABLED
+                    EnterpriseLoginContext.AUTH_DISABLED
             ) )
             {
                 Result result = gdb.execute( tx, "CALL dbms.listQueries()", EMPTY_MAP );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ServerGroupsIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ServerGroupsIT.java
@@ -40,7 +40,7 @@ import org.neo4j.causalclustering.discovery.HazelcastDiscoveryServiceFactory;
 import org.neo4j.causalclustering.discovery.IpFamily;
 import org.neo4j.graphdb.Result;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseLoginContext;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.kernel.impl.store.format.standard.Standard;
 import org.neo4j.test.rule.TestDirectory;
@@ -192,7 +192,7 @@ public class ServerGroupsIT
     private List<List<String>> getServerGroups( CoreGraphDatabase db )
     {
         List<List<String>> serverGroups = new ArrayList<>();
-        try ( InternalTransaction tx = db.beginTransaction( KernelTransaction.Type.explicit, EnterpriseSecurityContext.AUTH_DISABLED ) )
+        try ( InternalTransaction tx = db.beginTransaction( KernelTransaction.Type.explicit, EnterpriseLoginContext.AUTH_DISABLED ) )
         {
             try ( Result result = db.execute( tx, "CALL dbms.cluster.overview", EMPTY_MAP ) )
             {

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ServerPoliciesLoadBalancingIT.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/scenarios/ServerPoliciesLoadBalancingIT.java
@@ -50,7 +50,7 @@ import org.neo4j.graphdb.Result;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.helpers.collection.MapUtil;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseLoginContext;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.kernel.impl.store.format.standard.Standard;
 import org.neo4j.kernel.impl.util.ValueUtils;
@@ -220,7 +220,7 @@ public class ServerPoliciesLoadBalancingIT
     private LoadBalancingResult getServers( CoreGraphDatabase db, Map<String,String> context )
     {
         LoadBalancingResult lbResult = null;
-        try ( InternalTransaction tx = db.beginTransaction( KernelTransaction.Type.explicit, EnterpriseSecurityContext.AUTH_DISABLED ) )
+        try ( InternalTransaction tx = db.beginTransaction( KernelTransaction.Type.explicit, EnterpriseLoginContext.AUTH_DISABLED ) )
         {
             Map<String,Object> parameters = MapUtil.map( ParameterNames.CONTEXT.parameterName(), context );
             try ( Result result = db.execute( tx, "CALL " + GET_SERVERS_V2.callName(), ValueUtils.asMapValue( parameters )) )

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionResultAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionResultAcceptanceTest.scala
@@ -22,7 +22,7 @@ package org.neo4j.internal.cypher.acceptance
 import org.neo4j.cypher.ExecutionEngineFunSuite
 import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
 import org.neo4j.internal.kernel.api.Transaction.Type
-import org.neo4j.internal.kernel.api.security.SecurityContext._
+import org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 
 class ExecutionResultAcceptanceTest extends ExecutionEngineFunSuite{
 

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/api/security/EnterpriseAuthManager.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/api/security/EnterpriseAuthManager.java
@@ -29,7 +29,7 @@ public interface EnterpriseAuthManager extends AuthManager
     void clearAuthCache();
 
     @Override
-    EnterpriseSecurityContext login( Map<String,Object> authToken ) throws InvalidAuthTokenException;
+    EnterpriseLoginContext login( Map<String,Object> authToken ) throws InvalidAuthTokenException;
 
     /**
      * Implementation that does no authentication.
@@ -37,9 +37,9 @@ public interface EnterpriseAuthManager extends AuthManager
     EnterpriseAuthManager NO_AUTH = new EnterpriseAuthManager()
     {
         @Override
-        public EnterpriseSecurityContext login( Map<String,Object> authToken )
+        public EnterpriseLoginContext login( Map<String,Object> authToken )
         {
-            return EnterpriseSecurityContext.AUTH_DISABLED;
+            return EnterpriseLoginContext.AUTH_DISABLED;
         }
 
         @Override

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/api/security/EnterpriseLoginContext.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/api/security/EnterpriseLoginContext.java
@@ -30,7 +30,7 @@ public interface EnterpriseLoginContext extends LoginContext
 {
     Set<String> roles();
 
-    EnterpriseSecurityContext freeze( Token token );
+    EnterpriseSecurityContext authorize( Token token );
 
     EnterpriseLoginContext AUTH_DISABLED = new EnterpriseLoginContext()
     {
@@ -47,7 +47,7 @@ public interface EnterpriseLoginContext extends LoginContext
         }
 
         @Override
-        public EnterpriseSecurityContext freeze( Token token )
+        public EnterpriseSecurityContext authorize( Token token )
         {
             return EnterpriseSecurityContext.AUTH_DISABLED;
         }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/api/security/EnterpriseLoginContext.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/api/security/EnterpriseLoginContext.java
@@ -17,31 +17,39 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.server.security.enterprise.auth;
+package org.neo4j.kernel.enterprise.api.security;
 
-import java.util.Map;
+import java.util.Collections;
+import java.util.Set;
 
-import org.neo4j.kernel.enterprise.api.security.EnterpriseLoginContext;
+import org.neo4j.internal.kernel.api.Token;
+import org.neo4j.internal.kernel.api.security.AuthSubject;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 
-public class EmbeddedConfiguredProceduresIT extends ConfiguredProceduresTestBase<EnterpriseLoginContext>
+public interface EnterpriseLoginContext extends LoginContext
 {
+    Set<String> roles();
 
-    @Override
-    protected NeoInteractionLevel<EnterpriseLoginContext> setUpNeoServer( Map<String, String> config ) throws Throwable
-    {
-        return new EmbeddedInteraction( config );
-    }
+    EnterpriseSecurityContext freeze( Token token );
 
-    @Override
-    protected Object valueOf( Object obj )
+    EnterpriseLoginContext AUTH_DISABLED = new EnterpriseLoginContext()
     {
-        if ( obj instanceof Integer )
+        @Override
+        public AuthSubject subject()
         {
-            return ((Integer) obj).longValue();
+            return AuthSubject.AUTH_DISABLED;
         }
-        else
+
+        @Override
+        public Set<String> roles()
         {
-            return obj;
+            return Collections.emptySet();
         }
-    }
+
+        @Override
+        public EnterpriseSecurityContext freeze( Token token )
+        {
+            return EnterpriseSecurityContext.AUTH_DISABLED;
+        }
+    };
 }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/api/security/EnterpriseSecurityContext.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/api/security/EnterpriseSecurityContext.java
@@ -22,6 +22,7 @@ package org.neo4j.kernel.enterprise.api.security;
 import java.util.Collections;
 import java.util.Set;
 
+import org.neo4j.internal.kernel.api.Token;
 import org.neo4j.internal.kernel.api.security.AccessMode;
 import org.neo4j.internal.kernel.api.security.AuthSubject;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
@@ -31,8 +32,6 @@ import org.neo4j.internal.kernel.api.security.SecurityContext;
  */
 public interface EnterpriseSecurityContext extends SecurityContext
 {
-    @Override
-    EnterpriseSecurityContext freeze();
 
     @Override
     EnterpriseSecurityContext withMode( AccessMode mode );
@@ -52,7 +51,7 @@ public interface EnterpriseSecurityContext extends SecurityContext
         }
 
         @Override
-        public EnterpriseSecurityContext freeze()
+        public EnterpriseSecurityContext freeze( Token token )
         {
             return this;
         }
@@ -134,7 +133,7 @@ public interface EnterpriseSecurityContext extends SecurityContext
         }
 
         @Override
-        public EnterpriseSecurityContext freeze()
+        public EnterpriseSecurityContext freeze( Token token )
         {
             return this;
         }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/api/security/EnterpriseSecurityContext.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/enterprise/api/security/EnterpriseSecurityContext.java
@@ -28,126 +28,71 @@ import org.neo4j.internal.kernel.api.security.AuthSubject;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
 
 /**
- * A logged in user.
+ * A logged in and authorized user.
  */
-public interface EnterpriseSecurityContext extends SecurityContext
+public class EnterpriseSecurityContext extends SecurityContext
 {
+    private final Set<String> roles;
+    private final boolean isAdmin;
 
-    @Override
-    EnterpriseSecurityContext withMode( AccessMode mode );
-
-    Set<String> roles();
-
-    EnterpriseSecurityContext AUTH_DISABLED = new AuthDisabled( AccessMode.Static.FULL );
-
-    /** Allows all operations. */
-    final class AuthDisabled implements EnterpriseSecurityContext
+    public EnterpriseSecurityContext( AuthSubject subject, AccessMode mode, Set<String> roles, boolean isAdmin )
     {
-        private final AccessMode mode;
-
-        private AuthDisabled( AccessMode mode )
-        {
-            this.mode = mode;
-        }
-
-        @Override
-        public EnterpriseSecurityContext freeze( Token token )
-        {
-            return this;
-        }
-
-        @Override
-        public EnterpriseSecurityContext withMode( AccessMode mode )
-        {
-            return new EnterpriseSecurityContext.AuthDisabled( mode );
-        }
-
-        @Override
-        public Set<String> roles()
-        {
-            return Collections.emptySet();
-        }
-
-        @Override
-        public AuthSubject subject()
-        {
-            return AuthSubject.AUTH_DISABLED;
-        }
-
-        @Override
-        public AccessMode mode()
-        {
-            return mode;
-        }
-
-        @Override
-        public String description()
-        {
-            return "AUTH_DISABLED with " + mode().name();
-        }
-
-        @Override
-        public String toString()
-        {
-            return defaultString( "enterprise-auth-disabled" );
-        }
-
-        @Override
-        public boolean isAdmin()
-        {
-            return true;
-        }
+        super( subject, mode );
+        this.roles = roles;
+        this.isAdmin = isAdmin;
     }
 
-    final class Frozen implements EnterpriseSecurityContext
+    @Override
+    public boolean isAdmin()
     {
-        private final AuthSubject subject;
-        private final AccessMode mode;
-        private final Set<String> roles;
-        private final boolean isAdmin;
+        return isAdmin;
+    }
 
-        public Frozen( AuthSubject subject, AccessMode mode, Set<String> roles, boolean isAdmin )
-        {
-            this.subject = subject;
-            this.mode = mode;
-            this.roles = roles;
-            this.isAdmin = isAdmin;
-        }
+    @Override
+    public EnterpriseSecurityContext authorize( Token token )
+    {
+        return this;
+    }
 
-        @Override
-        public boolean isAdmin()
-        {
-            return isAdmin;
-        }
+    @Override
+    public EnterpriseSecurityContext withMode( AccessMode mode )
+    {
+        return new EnterpriseSecurityContext( subject, mode, roles, isAdmin );
+    }
 
-        @Override
-        public AccessMode mode()
-        {
-            return mode;
-        }
+    /**
+     * Get the roles of the authenticated user.
+     */
+    public Set<String> roles()
+    {
+        return roles;
+    }
 
-        @Override
-        public AuthSubject subject()
-        {
-            return subject;
-        }
+    /** Allows all operations. */
+    public static final EnterpriseSecurityContext AUTH_DISABLED = authDisabled( AccessMode.Static.FULL );
 
-        @Override
-        public EnterpriseSecurityContext freeze( Token token )
+    private static EnterpriseSecurityContext authDisabled( AccessMode mode )
+    {
+        return new EnterpriseSecurityContext( AuthSubject.AUTH_DISABLED, mode, Collections.emptySet(), true )
         {
-            return this;
-        }
 
-        @Override
-        public EnterpriseSecurityContext withMode( AccessMode mode )
-        {
-            return new EnterpriseSecurityContext.Frozen( subject, mode, roles, isAdmin );
-        }
+            @Override
+            public EnterpriseSecurityContext withMode( AccessMode mode )
+            {
+                return authDisabled( mode );
+            }
 
-        @Override
-        public Set<String> roles()
-        {
-            return roles;
-        }
+            @Override
+            public String description()
+            {
+                return "AUTH_DISABLED with " + mode().name();
+            }
+
+            @Override
+            public String toString()
+            {
+                return defaultString( "enterprise-auth-disabled" );
+            }
+        };
     }
 }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/AbstractConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/AbstractConstraintCreationIT.java
@@ -64,6 +64,7 @@ import static org.junit.Assert.fail;
 import static org.neo4j.helpers.collection.Iterators.asCollection;
 import static org.neo4j.helpers.collection.Iterators.asSet;
 import static org.neo4j.helpers.collection.Iterators.single;
+import static org.neo4j.internal.kernel.api.security.LoginContext.AUTH_DISABLED;
 
 public abstract class AbstractConstraintCreationIT<Constraint extends ConstraintDescriptor, DESCRIPTOR extends SchemaDescriptor>
         extends KernelIntegrationTest
@@ -113,7 +114,7 @@ public abstract class AbstractConstraintCreationIT<Constraint extends Constraint
     public void shouldBeAbleToStoreAndRetrieveConstraint() throws Exception
     {
         // given
-        Statement statement = statementInNewTransaction( SecurityContext.AUTH_DISABLED );
+        Statement statement = statementInNewTransaction( AUTH_DISABLED );
 
         // when
         ConstraintDescriptor constraint = createConstraint( statement.schemaWriteOperations(), descriptor );
@@ -137,7 +138,7 @@ public abstract class AbstractConstraintCreationIT<Constraint extends Constraint
     public void shouldBeAbleToStoreAndRetrieveConstraintAfterRestart() throws Exception
     {
         // given
-        Statement statement = statementInNewTransaction( SecurityContext.AUTH_DISABLED );
+        Statement statement = statementInNewTransaction( AUTH_DISABLED );
 
         // when
         ConstraintDescriptor constraint = createConstraint( statement.schemaWriteOperations(), descriptor );
@@ -182,7 +183,7 @@ public abstract class AbstractConstraintCreationIT<Constraint extends Constraint
     public void shouldNotStoreConstraintThatIsRemovedInTheSameTransaction() throws Exception
     {
         // given
-        try ( Statement statement = statementInNewTransaction( SecurityContext.AUTH_DISABLED ) )
+        try ( Statement statement = statementInNewTransaction( AUTH_DISABLED ) )
         {
 
             Constraint constraint = createConstraint( statement.schemaWriteOperations(), descriptor );

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintCreationIT.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/api/integrationtest/UniquenessConstraintCreationIT.java
@@ -31,7 +31,7 @@ import org.neo4j.internal.kernel.api.exceptions.KernelException;
 import org.neo4j.internal.kernel.api.exceptions.schema.ConstraintValidationException;
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.internal.kernel.api.schema.constraints.ConstraintDescriptor;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.api.ReadOperations;
 import org.neo4j.kernel.api.SchemaWriteOperations;
 import org.neo4j.kernel.api.Statement;
@@ -188,7 +188,7 @@ public class UniquenessConstraintCreationIT
     public void shouldDropCreatedConstraintIndexWhenRollingBackConstraintCreation() throws Exception
     {
         // given
-        Statement statement = statementInNewTransaction( SecurityContext.AUTH_DISABLED );
+        Statement statement = statementInNewTransaction( LoginContext.AUTH_DISABLED );
         statement.schemaWriteOperations().uniquePropertyConstraintCreate( descriptor );
         assertEquals( asSet( uniqueIndex ), asSet( statement.readOperations().indexesGetAll() ) );
 
@@ -265,7 +265,7 @@ public class UniquenessConstraintCreationIT
     public void shouldDropConstraintIndexWhenDroppingConstraint() throws Exception
     {
         // given
-        Statement statement = statementInNewTransaction( SecurityContext.AUTH_DISABLED );
+        Statement statement = statementInNewTransaction( LoginContext.AUTH_DISABLED );
         UniquenessConstraintDescriptor constraint =
                 statement.schemaWriteOperations().uniquePropertyConstraintCreate( descriptor );
         assertEquals( asSet( uniqueIndex ), asSet( statement.readOperations().indexesGetAll() ) );

--- a/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
+++ b/enterprise/query-logging/src/test/java/org/neo4j/kernel/impl/query/QueryLoggerIT.java
@@ -53,7 +53,7 @@ import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.security.AuthToken;
 import org.neo4j.kernel.configuration.Settings;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthManager;
-import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseLoginContext;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.kernel.impl.query.clientconnection.ClientConnectionInfo;
@@ -128,14 +128,14 @@ public class QueryLoggerIT
         db.getLocalUserManager().addRoleToUser( "architect", "mats" );
         db.getLocalUserManager().addRoleToUser( "reader", "andres" );
 
-        EnterpriseSecurityContext mats = db.login( "mats", "neo4j" );
+        EnterpriseLoginContext mats = db.login( "mats", "neo4j" );
 
         // run query
         db.executeQuery( mats, "UNWIND range(0, 10) AS i CREATE (:Foo {p: i})", Collections.emptyMap(), ResourceIterator::close );
         db.executeQuery( mats, "CREATE (:Label)", Collections.emptyMap(), ResourceIterator::close );
 
         // switch user, run query
-        EnterpriseSecurityContext andres = db.login( "andres", "neo4j" );
+        EnterpriseLoginContext andres = db.login( "andres", "neo4j" );
         db.executeQuery( andres, "MATCH (n:Label) RETURN n", Collections.emptyMap(), ResourceIterator::close );
 
         db.tearDown();
@@ -160,7 +160,7 @@ public class QueryLoggerIT
 
         db.getLocalUserManager().setUserPassword( "neo4j", "123", false );
 
-        EnterpriseSecurityContext subject = db.login( "neo4j", "123" );
+        EnterpriseLoginContext subject = db.login( "neo4j", "123" );
         db.executeQuery( subject, "UNWIND range(0, 10) AS i CREATE (:Foo {p: i})", Collections.emptyMap(),
                 ResourceIterator::close );
 
@@ -386,7 +386,7 @@ public class QueryLoggerIT
                 .newGraphDatabase();
 
         EnterpriseAuthManager authManager = database.getDependencyResolver().resolveDependency( EnterpriseAuthManager.class );
-        EnterpriseSecurityContext neo = authManager.login( AuthToken.newBasicAuthToken( "neo4j", "neo4j" ) );
+        EnterpriseLoginContext neo = authManager.login( AuthToken.newBasicAuthToken( "neo4j", "neo4j" ) );
 
         String query = "CALL dbms.security.changePassword('abc123')";
         try ( InternalTransaction tx = database

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/AuthProceduresBase.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/AuthProceduresBase.java
@@ -64,7 +64,7 @@ public class AuthProceduresBase
         }
         catch ( Exception e )
         {
-            securityLog.error( securityContext, "failed to terminate running transaction and bolt connections for " +
+            securityLog.error( securityContext.subject(), "failed to terminate running transaction and bolt connections for " +
                     "user `%s` following %s: %s", username, reason, e.getMessage() );
             throw e;
         }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthAndUserManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseAuthAndUserManager.java
@@ -19,14 +19,14 @@
  */
 package org.neo4j.server.security.enterprise.auth;
 
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.AuthSubject;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthManager;
 import org.neo4j.kernel.api.security.UserManagerSupplier;
 
 public interface EnterpriseAuthAndUserManager extends EnterpriseAuthManager, UserManagerSupplier
 {
     @Override
-    EnterpriseUserManager getUserManager( SecurityContext securityContext );
+    EnterpriseUserManager getUserManager( AuthSubject authSubject, boolean isUserManager );
 
     @Override
     EnterpriseUserManager getUserManager();

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
@@ -25,8 +25,10 @@ import org.apache.shiro.realm.Realm;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -171,7 +173,8 @@ public class EnterpriseSecurityModule extends SecurityModule
         }
 
         return new MultiRealmAuthManager( internalRealm, orderedActiveRealms, createCacheManager( config ),
-                securityLog, config.get( SecuritySettings.security_log_successful_authentication ) );
+                securityLog, config.get( SecuritySettings.security_log_successful_authentication ),
+                securityConfig.propertyAuthorization, securityConfig.propertyBlacklist );
     }
 
     private static List<Realm> selectOrderedActiveRealms( List<String> configuredRealms, List<Realm> availableRealms )
@@ -318,12 +321,12 @@ public class EnterpriseSecurityModule extends SecurityModule
         return new FileUserRepository( fileSystem, getDefaultAdminRepositoryFile( config ), logProvider );
     }
 
-    public static File getRoleRepositoryFile( Config config )
+    private static File getRoleRepositoryFile( Config config )
     {
         return new File( config.get( DatabaseManagementSystemSettings.auth_store_directory ), ROLE_STORE_FILENAME );
     }
 
-    public static File getDefaultAdminRepositoryFile( Config config )
+    private static File getDefaultAdminRepositoryFile( Config config )
     {
         return new File( config.get( DatabaseManagementSystemSettings.auth_store_directory ),
                 DEFAULT_ADMIN_STORE_FILENAME );
@@ -334,7 +337,7 @@ public class EnterpriseSecurityModule extends SecurityModule
         return new IllegalArgumentException( "Illegal configuration: " + message );
     }
 
-    class SecurityConfig
+    static class SecurityConfig
     {
         final List<String> authProviders;
         final boolean hasNativeProvider;
@@ -346,6 +349,9 @@ public class EnterpriseSecurityModule extends SecurityModule
         final boolean ldapAuthorization;
         final boolean pluginAuthentication;
         final boolean pluginAuthorization;
+        final boolean propertyAuthorization;
+        private final String propertyAuthMapping;
+        final Map<String,List<String>> propertyBlacklist = new HashMap<>();
 
         SecurityConfig( Config config )
         {
@@ -362,6 +368,8 @@ public class EnterpriseSecurityModule extends SecurityModule
             ldapAuthorization = config.get( SecuritySettings.ldap_authorization_enabled );
             pluginAuthentication = config.get( SecuritySettings.plugin_authentication_enabled );
             pluginAuthorization = config.get( SecuritySettings.plugin_authorization_enabled );
+            propertyAuthorization = config.get( SecuritySettings.property_level_authorization_enabled );
+            propertyAuthMapping = config.get( SecuritySettings.property_level_authorization_permissions );
         }
 
         void validate()
@@ -393,6 +401,48 @@ public class EnterpriseSecurityModule extends SecurityModule
                 throw illegalConfiguration(
                         "Plugin auth provider configured, but both authentication and authorization are disabled." );
             }
+            if ( propertyAuthorization && !parsePropertyPermissions() )
+            {
+                throw illegalConfiguration(
+                        "Property level authorization is enabled but there is a error in the permissions mapping." );
+            }
+        }
+
+        private boolean parsePropertyPermissions()
+        {
+            if ( propertyAuthMapping != null && !propertyAuthMapping.isEmpty() )
+            {
+                String rolePattern = "\\s*[a-zA-Z0-9_]+\\s*";
+                String propertyPattern = "\\s*[a-zA-Z0-9_]+\\s*";
+                String roleToPerm = rolePattern + "=" + propertyPattern + "(," + propertyPattern + ")*";
+                String multiLine = roleToPerm + "(;" + roleToPerm + ")*";
+
+                boolean valid = propertyAuthMapping.matches( multiLine );
+                if ( !valid )
+                {
+                    return false;
+                }
+
+                for ( String rolesAndPermissions : propertyAuthMapping.split( ";" ) )
+                {
+                    if ( !rolesAndPermissions.isEmpty() )
+                    {
+                        String[] split = rolesAndPermissions.split( "=" );
+                        String role = split[0].trim();
+                        String permissions = split[1];
+                        List<String> permissionsList = new ArrayList<>();
+                        for ( String perm : permissions.split( "," ) )
+                        {
+                            if ( !perm.isEmpty() )
+                            {
+                                permissionsList.add( perm.trim() );
+                            }
+                        }
+                        propertyBlacklist.put( role, permissionsList );
+                    }
+                }
+            }
+            return true;
         }
 
         public boolean onlyPluginAuthentication()

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityModule.java
@@ -109,7 +109,7 @@ public class EnterpriseSecurityModule extends SecurityModule
              || config.get( SecuritySettings.native_authorization_enabled ) )
         {
             procedures.registerComponent( EnterpriseUserManager.class,
-                    ctx -> authManager.getUserManager( asEnterprise( ctx.get( SECURITY_CONTEXT ) ) ), true );
+                    ctx -> authManager.getUserManager( ctx.get( SECURITY_CONTEXT ).subject(), ctx.get( SECURITY_CONTEXT ).isAdmin() ), true );
             if ( config.get( SecuritySettings.auth_providers ).size() > 1 )
             {
                 procedures.registerProcedure( UserManagementProcedures.class, true,

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealm.java
@@ -93,7 +93,7 @@ public class InternalFlatFileRealm extends AuthorizingRealm implements RealmLife
             JobScheduler jobScheduler, UserRepository initialUserRepository,
             UserRepository defaultAdminRepository )
     {
-        this( userRepository, roleRepository, passwordPolicy, authenticationStrategy, true, true,
+        this( userRepository,roleRepository, passwordPolicy, authenticationStrategy, true, true,
                 jobScheduler, initialUserRepository, defaultAdminRepository );
     }
 

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManager.java
@@ -44,6 +44,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.IntPredicate;
 
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveIntSet;
@@ -308,7 +309,7 @@ class MultiRealmAuthManager implements EnterpriseAuthAndUserManager
         return infoList;
     }
 
-    Function<Integer,Boolean> getPropertyPermissions( Set<String> roles, Token token )
+    IntPredicate getPropertyPermissions( Set<String> roles, Token token )
     {
         if ( propertyAuthorization )
         {

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/PersonalUserManager.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/PersonalUserManager.java
@@ -23,8 +23,8 @@ import java.io.IOException;
 import java.util.Set;
 
 import org.neo4j.graphdb.security.AuthorizationViolationException;
+import org.neo4j.internal.kernel.api.security.AuthSubject;
 import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.impl.security.User;
 import org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles;
 import org.neo4j.server.security.enterprise.log.SecurityLog;
@@ -34,14 +34,16 @@ import static org.neo4j.graphdb.security.AuthorizationViolationException.PERMISS
 class PersonalUserManager implements EnterpriseUserManager
 {
     private final EnterpriseUserManager userManager;
-    private final SecurityContext securityContext;
     private final SecurityLog securityLog;
+    private final AuthSubject subject;
+    private final boolean isUserManager;
 
-    PersonalUserManager( EnterpriseUserManager userManager, SecurityContext securityContext, SecurityLog securityLog )
+    PersonalUserManager( EnterpriseUserManager userManager, AuthSubject subject, SecurityLog securityLog, boolean isUserManager )
     {
         this.userManager = userManager;
-        this.securityContext = securityContext;
         this.securityLog = securityLog;
+        this.subject = subject;
+        this.isUserManager = isUserManager;
     }
 
     @Override
@@ -50,15 +52,15 @@ class PersonalUserManager implements EnterpriseUserManager
     {
         try
         {
-            assertAdmin();
+            assertUserManager();
             User user = userManager.newUser( username, initialPassword, requirePasswordChange );
-            securityLog.info( securityContext, "created user `%s`%s", username,
+            securityLog.info( subject, "created user `%s`%s", username,
                     requirePasswordChange ? ", with password change required" : "" );
             return user;
         }
         catch ( AuthorizationViolationException | IOException | InvalidArgumentsException e )
         {
-            securityLog.error( securityContext, "tried to create user `%s`: %s", username, e.getMessage() );
+            securityLog.error( subject, "tried to create user `%s`: %s", username, e.getMessage() );
             throw e;
         }
     }
@@ -69,18 +71,18 @@ class PersonalUserManager implements EnterpriseUserManager
     {
         try
         {
-            assertAdmin();
-            if ( securityContext.subject().hasUsername( username ) )
+            assertUserManager();
+            if ( subject.hasUsername( username ) )
             {
                 throw new InvalidArgumentsException( "Suspending yourself (user '" + username +
                         "') is not allowed." );
             }
             userManager.suspendUser( username );
-            securityLog.info( securityContext, "suspended user `%s`", username );
+            securityLog.info( subject, "suspended user `%s`", username );
         }
         catch ( AuthorizationViolationException | IOException | InvalidArgumentsException e )
         {
-            securityLog.error( securityContext, "tried to suspend user `%s`: %s", username, e.getMessage() );
+            securityLog.error( subject, "tried to suspend user `%s`: %s", username, e.getMessage() );
             throw e;
         }
     }
@@ -91,18 +93,18 @@ class PersonalUserManager implements EnterpriseUserManager
     {
         try
         {
-            assertAdmin();
-            if ( securityContext.subject().hasUsername( username ) )
+            assertUserManager();
+            if ( subject.hasUsername( username ) )
             {
                 throw new InvalidArgumentsException( "Deleting yourself (user '" + username + "') is not allowed." );
             }
             boolean wasDeleted = userManager.deleteUser( username );
-            securityLog.info( securityContext, "deleted user `%s`", username );
+            securityLog.info( subject, "deleted user `%s`", username );
             return wasDeleted;
         }
         catch ( AuthorizationViolationException | IOException | InvalidArgumentsException e )
         {
-            securityLog.error( securityContext, "tried to delete user `%s`: %s", username, e.getMessage() );
+            securityLog.error( subject, "tried to delete user `%s`: %s", username, e.getMessage() );
             throw e;
         }
     }
@@ -113,17 +115,17 @@ class PersonalUserManager implements EnterpriseUserManager
     {
         try
         {
-            assertAdmin();
-            if ( securityContext.subject().hasUsername( username ) )
+            assertUserManager();
+            if ( subject.hasUsername( username ) )
             {
                 throw new InvalidArgumentsException( "Activating yourself (user '" + username + "') is not allowed." );
             }
             userManager.activateUser( username, requirePasswordChange );
-            securityLog.info( securityContext, "activated user `%s`", username );
+            securityLog.info( subject, "activated user `%s`", username );
         }
         catch ( AuthorizationViolationException | IOException | InvalidArgumentsException e )
         {
-            securityLog.error( securityContext, "tried to activate user `%s`: %s", username, e.getMessage() );
+            securityLog.error( subject, "tried to activate user `%s`: %s", username, e.getMessage() );
             throw e;
         }
     }
@@ -146,14 +148,14 @@ class PersonalUserManager implements EnterpriseUserManager
     {
         try
         {
-            assertAdmin();
+            assertUserManager();
             RoleRecord newRole = userManager.newRole( roleName, usernames );
-            securityLog.info( securityContext, "created role `%s`", roleName );
+            securityLog.info( subject, "created role `%s`", roleName );
             return newRole;
         }
         catch ( AuthorizationViolationException | IOException | InvalidArgumentsException e )
         {
-            securityLog.error( securityContext, "tried to create role `%s`: %s", roleName, e.getMessage() );
+            securityLog.error( subject, "tried to create role `%s`: %s", roleName, e.getMessage() );
             throw e;
         }
     }
@@ -164,14 +166,14 @@ class PersonalUserManager implements EnterpriseUserManager
     {
         try
         {
-            assertAdmin();
+            assertUserManager();
             boolean wasDeleted = userManager.deleteRole( roleName );
-            securityLog.info( securityContext, "deleted role `%s`", roleName );
+            securityLog.info( subject, "deleted role `%s`", roleName );
             return wasDeleted;
         }
         catch ( AuthorizationViolationException | IOException | InvalidArgumentsException e )
         {
-            securityLog.error( securityContext, "tried to delete role `%s`: %s", roleName, e.getMessage() );
+            securityLog.error( subject, "tried to delete role `%s`: %s", roleName, e.getMessage() );
             throw e;
         }
     }
@@ -180,17 +182,17 @@ class PersonalUserManager implements EnterpriseUserManager
     public void setUserPassword( String username, String password, boolean requirePasswordChange )
             throws IOException, InvalidArgumentsException, AuthorizationViolationException
     {
-        if ( securityContext.subject().hasUsername( username ) )
+        if ( subject.hasUsername( username ) )
         {
             try
             {
                 userManager.setUserPassword( username, password, requirePasswordChange );
-                securityLog.info( securityContext, "changed password%s",
+                securityLog.info( subject, "changed password%s",
                         requirePasswordChange ? ", with password change required" : "" );
             }
             catch ( AuthorizationViolationException | IOException | InvalidArgumentsException e )
             {
-                securityLog.error( securityContext, "tried to change password: %s", e.getMessage() );
+                securityLog.error( subject, "tried to change password: %s", e.getMessage() );
                 throw e;
             }
         }
@@ -198,14 +200,14 @@ class PersonalUserManager implements EnterpriseUserManager
         {
             try
             {
-                assertAdmin();
+                assertUserManager();
                 userManager.setUserPassword( username, password, requirePasswordChange );
-                securityLog.info( securityContext, "changed password for user `%s`%s", username,
+                securityLog.info( subject, "changed password for user `%s`%s", username,
                         requirePasswordChange ? ", with password change required" : "" );
             }
             catch ( AuthorizationViolationException | IOException | InvalidArgumentsException e )
             {
-                securityLog.error( securityContext, "tried to change password for user `%s`: %s", username,
+                securityLog.error( subject, "tried to change password for user `%s`: %s", username,
                         e.getMessage() );
                 throw e;
             }
@@ -217,12 +219,12 @@ class PersonalUserManager implements EnterpriseUserManager
     {
         try
         {
-            assertAdmin();
+            assertUserManager();
             return userManager.getAllUsernames();
         }
         catch ( AuthorizationViolationException e )
         {
-            securityLog.error( securityContext, "tried to list users: %s", e.getMessage() );
+            securityLog.error( subject, "tried to list users: %s", e.getMessage() );
             throw e;
         }
     }
@@ -245,13 +247,13 @@ class PersonalUserManager implements EnterpriseUserManager
     {
         try
         {
-            assertAdmin();
+            assertUserManager();
             userManager.addRoleToUser( roleName, username );
-            securityLog.info( securityContext, "added role `%s` to user `%s`", roleName, username );
+            securityLog.info( subject, "added role `%s` to user `%s`", roleName, username );
         }
         catch ( AuthorizationViolationException | IOException | InvalidArgumentsException e )
         {
-            securityLog.error( securityContext, "tried to add role `%s` to user `%s`: %s", roleName, username,
+            securityLog.error( subject, "tried to add role `%s` to user `%s`: %s", roleName, username,
                     e.getMessage() );
             throw e;
         }
@@ -263,18 +265,18 @@ class PersonalUserManager implements EnterpriseUserManager
     {
         try
         {
-            assertAdmin();
-            if ( securityContext.subject().hasUsername( username ) && roleName.equals( PredefinedRoles.ADMIN ) )
+            assertUserManager();
+            if ( subject.hasUsername( username ) && roleName.equals( PredefinedRoles.ADMIN ) )
             {
                 throw new InvalidArgumentsException(
                         "Removing yourself (user '" + username + "') from the admin role is not allowed." );
             }
             userManager.removeRoleFromUser( roleName, username );
-            securityLog.info( securityContext, "removed role `%s` from user `%s`", roleName, username );
+            securityLog.info( subject, "removed role `%s` from user `%s`", roleName, username );
         }
         catch ( AuthorizationViolationException | IOException | InvalidArgumentsException e )
         {
-            securityLog.error( securityContext, "tried to remove role `%s` from user `%s`: %s", roleName, username, e
+            securityLog.error( subject, "tried to remove role `%s` from user `%s`: %s", roleName, username, e
                     .getMessage() );
             throw e;
         }
@@ -285,12 +287,12 @@ class PersonalUserManager implements EnterpriseUserManager
     {
         try
         {
-            assertAdmin();
+            assertUserManager();
             return userManager.getAllRoleNames();
         }
         catch ( AuthorizationViolationException e )
         {
-            securityLog.error( securityContext, "tried to list roles: %s", e.getMessage() );
+            securityLog.error( subject, "tried to list roles: %s", e.getMessage() );
             throw e;
         }
     }
@@ -301,12 +303,12 @@ class PersonalUserManager implements EnterpriseUserManager
     {
         try
         {
-            assertSelfOrAdmin( username );
+            assertSelfOrUserManager( username );
             return userManager.getRoleNamesForUser( username );
         }
         catch ( AuthorizationViolationException | InvalidArgumentsException e )
         {
-            securityLog.error( securityContext, "tried to list roles for user `%s`: %s", username, e.getMessage() );
+            securityLog.error( subject, "tried to list roles for user `%s`: %s", username, e.getMessage() );
             throw e;
         }
     }
@@ -323,12 +325,12 @@ class PersonalUserManager implements EnterpriseUserManager
     {
         try
         {
-            assertAdmin();
+            assertUserManager();
             return userManager.getUsernamesForRole( roleName );
         }
         catch ( AuthorizationViolationException | InvalidArgumentsException e )
         {
-            securityLog.error( securityContext, "tried to list users for role `%s`: %s", roleName, e.getMessage() );
+            securityLog.error( subject, "tried to list users for role `%s`: %s", roleName, e.getMessage() );
             throw e;
         }
     }
@@ -339,17 +341,17 @@ class PersonalUserManager implements EnterpriseUserManager
         return userManager.silentlyGetUsernamesForRole( roleName );
     }
 
-    private void assertSelfOrAdmin( String username )
+    private void assertSelfOrUserManager( String username )
     {
-        if ( !securityContext.subject().hasUsername( username ) )
+        if ( !subject.hasUsername( username ) )
         {
-            assertAdmin();
+            assertUserManager();
         }
     }
 
-    private void assertAdmin() throws AuthorizationViolationException
+    private void assertUserManager() throws AuthorizationViolationException
     {
-        if ( !securityContext.isAdmin() )
+        if ( !isUserManager )
         {
             throw new AuthorizationViolationException( PERMISSION_DENIED );
         }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseLoginContext.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseLoginContext.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Function;
+import java.util.function.IntPredicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -106,7 +107,7 @@ class StandardEnterpriseLoginContext implements EnterpriseLoginContext
                 .collect( Collectors.toSet() );
     }
 
-    private Function<Integer,Boolean> queryForPropertyPermissions( Token token )
+    private IntPredicate queryForPropertyPermissions( Token token )
     {
         return authManager.getPropertyPermissions( roles(), token );
     }
@@ -119,10 +120,10 @@ class StandardEnterpriseLoginContext implements EnterpriseLoginContext
         private final boolean allowsTokenCreates;
         private final boolean passwordChangeRequired;
         private final Set<String> roles;
-        private final Function<Integer,Boolean> propertyPermissions;
+        private final IntPredicate propertyPermissions;
 
         StandardAccessMode( boolean allowsReads, boolean allowsWrites, boolean allowsTokenCreates, boolean allowsSchemaWrites,
-                boolean passwordChangeRequired, Set<String> roles, Function<Integer,Boolean> propertyPermissions )
+                boolean passwordChangeRequired, Set<String> roles, IntPredicate propertyPermissions )
         {
             this.allowsReads = allowsReads;
             this.allowsWrites = allowsWrites;
@@ -160,7 +161,7 @@ class StandardEnterpriseLoginContext implements EnterpriseLoginContext
         @Override
         public boolean allowsPropertyReads( int propertyKey )
         {
-            return propertyPermissions.apply( propertyKey );
+            return propertyPermissions.test( propertyKey );
         }
 
         @Override

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseLoginContext.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseLoginContext.java
@@ -36,7 +36,6 @@ import org.neo4j.internal.kernel.api.security.AuthSubject;
 import org.neo4j.internal.kernel.api.security.AuthenticationResult;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseLoginContext;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
-import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext.Frozen;
 
 class StandardEnterpriseLoginContext implements EnterpriseLoginContext
 {
@@ -82,10 +81,10 @@ class StandardEnterpriseLoginContext implements EnterpriseLoginContext
     }
 
     @Override
-    public EnterpriseSecurityContext freeze( Token token )
+    public EnterpriseSecurityContext authorize( Token token )
     {
         StandardAccessMode mode = mode( token );
-        return new Frozen( neoShiroSubject, mode, mode.roles, isAdmin() );
+        return new EnterpriseSecurityContext( neoShiroSubject, mode, mode.roles, isAdmin() );
     }
 
     @Override

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseLoginContext.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/auth/StandardEnterpriseLoginContext.java
@@ -76,7 +76,7 @@ class StandardEnterpriseLoginContext implements EnterpriseLoginContext
                 isAuthenticated && shiroSubject.isPermitted( SCHEMA_READ_WRITE ),
                 shiroSubject.getAuthenticationResult() == AuthenticationResult.PASSWORD_CHANGE_REQUIRED,
                 queryForRoleNames(),
-                queryForPropertyPermissions()
+                queryForPropertyPermissions( token )
             );
     }
 
@@ -106,9 +106,9 @@ class StandardEnterpriseLoginContext implements EnterpriseLoginContext
                 .collect( Collectors.toSet() );
     }
 
-    private Function<String,Boolean> queryForPropertyPermissions()
+    private Function<Integer,Boolean> queryForPropertyPermissions( Token token )
     {
-        return authManager.getPropertyPermissions(roles());
+        return authManager.getPropertyPermissions( roles(), token );
     }
 
     private static class StandardAccessMode implements AccessMode
@@ -119,10 +119,10 @@ class StandardEnterpriseLoginContext implements EnterpriseLoginContext
         private final boolean allowsTokenCreates;
         private final boolean passwordChangeRequired;
         private final Set<String> roles;
-        private final Function<String,Boolean> propertyPermissions;
+        private final Function<Integer,Boolean> propertyPermissions;
 
         StandardAccessMode( boolean allowsReads, boolean allowsWrites, boolean allowsTokenCreates, boolean allowsSchemaWrites,
-                boolean passwordChangeRequired, Set<String> roles, Function<String,Boolean> propertyPermissions )
+                boolean passwordChangeRequired, Set<String> roles, Function<Integer,Boolean> propertyPermissions )
         {
             this.allowsReads = allowsReads;
             this.allowsWrites = allowsWrites;
@@ -158,9 +158,9 @@ class StandardEnterpriseLoginContext implements EnterpriseLoginContext
         }
 
         @Override
-        public boolean allowsPropertyReads( String name )
+        public boolean allowsPropertyReads( int propertyKey )
         {
-            return propertyPermissions.apply( name );
+            return propertyPermissions.apply( propertyKey );
         }
 
         @Override

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/configuration/SecuritySettings.java
@@ -342,4 +342,23 @@ public class SecuritySettings implements LoadableConfig
                   "system account." )
     public static final Setting<Boolean> ldap_authorization_connection_pooling =
             setting( "unsupported.dbms.security.ldap.authorization.connection_pooling", BOOLEAN, "true" );
+
+    //=========================================================================
+    // Property level security settings
+    //=========================================================================
+
+    @Description( "Set to true to enable property level security." )
+    public static final Setting<Boolean> property_level_authorization_enabled =
+            setting( "dbms.security.property_level.enabled", BOOLEAN, "false" );
+
+    @Description( "An authorization mapping for property level access for roles. " +
+            "The map should be formatted as a semicolon separated list of key-value pairs, where the " +
+            "key is the role name and the value is a comma separated list of blacklisted properties. " +
+            "For example: role1=prop1;role2=prop2;role3=prop3,prop4,prop5\n\n" +
+            "You could also use whitespaces and quotes around group names to make this mapping more readable, " +
+            "for example: dbms.security.property_level.blacklist=\\\n" +
+            "         \"role1\"      = ssn;    \\\n" +
+            "         \"role2\"      = ssn,income; \\\n" )
+    public static final Setting<String> property_level_authorization_permissions =
+            setting( "dbms.security.property_level.blacklist", STRING, NO_DEFAULT );
 }

--- a/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/log/SecurityLog.java
+++ b/enterprise/security/src/main/java/org/neo4j/server/security/enterprise/log/SecurityLog.java
@@ -26,7 +26,7 @@ import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.AuthSubject;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
@@ -68,9 +68,9 @@ public class SecurityLog extends LifecycleAdapter implements Log
         inner = log;
     }
 
-    private static String withContext( SecurityContext context, String msg )
+    private static String withSubject( AuthSubject subject, String msg )
     {
-        return "[" + escape( context.subject().username() ) + "]: " + msg;
+        return "[" + escape( subject.username() ) + "]: " + msg;
     }
 
     @Override
@@ -103,9 +103,9 @@ public class SecurityLog extends LifecycleAdapter implements Log
         inner.debug( format, arguments );
     }
 
-    public void debug( SecurityContext context, String format, Object... arguments )
+    public void debug( AuthSubject subject, String format, Object... arguments )
     {
-        inner.debug( withContext( context, format ), arguments );
+        inner.debug( withSubject( subject, format ), arguments );
     }
 
     @Override
@@ -132,14 +132,14 @@ public class SecurityLog extends LifecycleAdapter implements Log
         inner.info( format, arguments );
     }
 
-    public void info( SecurityContext context, String format, Object... arguments )
+    public void info( AuthSubject subject, String format, Object... arguments )
     {
-        inner.info( withContext( context, format ), arguments );
+        inner.info( withSubject( subject, format ), arguments );
     }
 
-    public void info( SecurityContext context, String format )
+    public void info( AuthSubject subject, String format )
     {
-        inner.info( withContext( context, format ) );
+        inner.info( withSubject( subject, format ) );
     }
 
     @Override
@@ -166,9 +166,9 @@ public class SecurityLog extends LifecycleAdapter implements Log
         inner.warn( format, arguments );
     }
 
-    public void warn( SecurityContext context, String format, Object... arguments )
+    public void warn( AuthSubject subject, String format, Object... arguments )
     {
-        inner.warn( withContext( context, format ), arguments );
+        inner.warn( withSubject( subject, format ), arguments );
     }
 
     @Override
@@ -195,9 +195,9 @@ public class SecurityLog extends LifecycleAdapter implements Log
         inner.error( format, arguments );
     }
 
-    public void error( SecurityContext context, String format, Object... arguments )
+    public void error( AuthSubject subject, String format, Object... arguments )
     {
-        inner.error( withContext( context, format ), arguments );
+        inner.error( withSubject( subject, format ), arguments );
     }
 
     @Override

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltInteraction.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/BoltInteraction.java
@@ -45,11 +45,11 @@ import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.helpers.HostnamePort;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.api.exceptions.Status;
 import org.neo4j.internal.kernel.api.security.AuthenticationResult;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthManager;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
@@ -132,8 +132,8 @@ class BoltInteraction implements NeoInteractionLevel<BoltInteraction.BoltSubject
     public InternalTransaction beginLocalTransactionAsUser( BoltSubject subject, KernelTransaction.Type txType )
             throws Throwable
     {
-        SecurityContext securityContext = authManager.login( newBasicAuthToken( subject.username, subject.password ) );
-        return getLocalGraph().beginTransaction( txType, securityContext );
+        LoginContext loginContext = authManager.login( newBasicAuthToken( subject.username, subject.password ) );
+        return getLocalGraph().beginTransaction( txType, loginContext );
     }
 
     @Override

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredAuthScenariosInteractionTestBase.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/ConfiguredAuthScenariosInteractionTestBase.java
@@ -69,7 +69,7 @@ public abstract class ConfiguredAuthScenariosInteractionTestBase<S> extends Proc
                 r -> assertKeyIsMap( r, "username", "roles", valueOf( userList ) ) );
         GraphDatabaseFacade localGraph = neo.getLocalGraph();
         InternalTransaction transaction = localGraph
-                .beginTransaction( KernelTransaction.Type.explicit, StandardEnterpriseSecurityContext.AUTH_DISABLED );
+                .beginTransaction( KernelTransaction.Type.explicit, StandardEnterpriseLoginContext.AUTH_DISABLED );
         Result result =
                 localGraph.execute( transaction, "EXPLAIN CALL dbms.security.listUsers", EMPTY_MAP );
         String description = String.format( "%s (%s)", Status.Procedure.ProcedureWarning.code().description(),
@@ -87,7 +87,7 @@ public abstract class ConfiguredAuthScenariosInteractionTestBase<S> extends Proc
                 r -> assertKeyIsMap( r, "username", "roles", valueOf( userList ) ) );
         GraphDatabaseFacade localGraph = neo.getLocalGraph();
         InternalTransaction transaction = localGraph
-                .beginTransaction( KernelTransaction.Type.explicit, StandardEnterpriseSecurityContext.AUTH_DISABLED );
+                .beginTransaction( KernelTransaction.Type.explicit, StandardEnterpriseLoginContext.AUTH_DISABLED );
         Result result =
                 localGraph.execute( transaction, "EXPLAIN CALL dbms.security.listUsers", EMPTY_MAP );
         String description = String.format( "%s (%s)", Status.Procedure.ProcedureWarning.code().description(),

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedAuthScenariosInteractionIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedAuthScenariosInteractionIT.java
@@ -24,17 +24,17 @@ import org.junit.Rule;
 import java.util.Map;
 
 import org.neo4j.graphdb.mockfs.UncloseableDelegatingFileSystemAbstraction;
-import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseLoginContext;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 
-public class EmbeddedAuthScenariosInteractionIT extends AuthScenariosInteractionTestBase<EnterpriseSecurityContext>
+public class EmbeddedAuthScenariosInteractionIT extends AuthScenariosInteractionTestBase<EnterpriseLoginContext>
 {
 
     @Rule
     public EphemeralFileSystemRule fileSystemRule = new EphemeralFileSystemRule();
 
     @Override
-    protected NeoInteractionLevel<EnterpriseSecurityContext> setUpNeoServer( Map<String, String> config ) throws Throwable
+    protected NeoInteractionLevel<EnterpriseLoginContext> setUpNeoServer( Map<String, String> config ) throws Throwable
     {
         return new EmbeddedInteraction( config, () -> new UncloseableDelegatingFileSystemAbstraction( fileSystemRule.get() ) );
     }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedBuiltInProceduresInteractionIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedBuiltInProceduresInteractionIT.java
@@ -115,9 +115,9 @@ public class EmbeddedBuiltInProceduresInteractionIT extends BuiltInProceduresInt
         return new EnterpriseLoginContext()
         {
             @Override
-            public EnterpriseSecurityContext freeze( Token token )
+            public EnterpriseSecurityContext authorize( Token token )
             {
-                return new EnterpriseSecurityContext.Frozen( subject(), inner.mode(), Collections.emptySet(), false );
+                return new EnterpriseSecurityContext( subject(), inner.mode(), Collections.emptySet(), false );
             }
 
             @Override
@@ -126,7 +126,7 @@ public class EmbeddedBuiltInProceduresInteractionIT extends BuiltInProceduresInt
                 return Collections.emptySet();
             }
 
-            SecurityContext inner = AnonymousContext.none().freeze( mock( Token.class ) );
+            SecurityContext inner = AnonymousContext.none().authorize( mock( Token.class ) );
 
             @Override
             public AuthSubject subject()

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedConfiguredAuthScenariosInteractionIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedConfiguredAuthScenariosInteractionIT.java
@@ -24,16 +24,16 @@ import org.junit.Rule;
 import java.util.Map;
 
 import org.neo4j.graphdb.mockfs.UncloseableDelegatingFileSystemAbstraction;
-import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseLoginContext;
 import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
 
-public class EmbeddedConfiguredAuthScenariosInteractionIT extends ConfiguredAuthScenariosInteractionTestBase<EnterpriseSecurityContext>
+public class EmbeddedConfiguredAuthScenariosInteractionIT extends ConfiguredAuthScenariosInteractionTestBase<EnterpriseLoginContext>
 {
     @Rule
     public EphemeralFileSystemRule fileSystemRule = new EphemeralFileSystemRule();
 
     @Override
-    protected NeoInteractionLevel<EnterpriseSecurityContext> setUpNeoServer( Map<String, String> config ) throws Throwable
+    protected NeoInteractionLevel<EnterpriseLoginContext> setUpNeoServer( Map<String, String> config ) throws Throwable
     {
         return new EmbeddedInteraction( config, () -> new UncloseableDelegatingFileSystemAbstraction( fileSystemRule.get() ) );
     }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedInteraction.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedInteraction.java
@@ -29,14 +29,14 @@ import org.neo4j.graphdb.factory.GraphDatabaseBuilder;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.graphdb.mockfs.EphemeralFileSystemAbstraction;
 import org.neo4j.helpers.HostnamePort;
+import org.neo4j.internal.kernel.api.security.AuthenticationResult;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.internal.kernel.api.security.AuthenticationResult;
 import org.neo4j.kernel.configuration.BoltConnector;
 import org.neo4j.kernel.configuration.ConnectorPortRegister;
 import org.neo4j.kernel.configuration.ssl.LegacySslPolicyConfig;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthManager;
-import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseLoginContext;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
@@ -46,7 +46,7 @@ import static org.junit.Assert.assertThat;
 import static org.neo4j.kernel.configuration.BoltConnector.EncryptionLevel.OPTIONAL;
 import static org.neo4j.server.security.auth.SecurityTestUtils.authToken;
 
-public class EmbeddedInteraction implements NeoInteractionLevel<EnterpriseSecurityContext>
+public class EmbeddedInteraction implements NeoInteractionLevel<EnterpriseLoginContext>
 {
     private GraphDatabaseFacade db;
     private EnterpriseAuthManager authManager;
@@ -113,17 +113,17 @@ public class EmbeddedInteraction implements NeoInteractionLevel<EnterpriseSecuri
     }
 
     @Override
-    public InternalTransaction beginLocalTransactionAsUser( EnterpriseSecurityContext subject,
+    public InternalTransaction beginLocalTransactionAsUser( EnterpriseLoginContext loginContext,
             KernelTransaction.Type txType ) throws Throwable
     {
-        return db.beginTransaction( txType, subject );
+        return db.beginTransaction( txType, loginContext );
     }
 
     @Override
-    public String executeQuery( EnterpriseSecurityContext subject, String call, Map<String,Object> params,
+    public String executeQuery( EnterpriseLoginContext loginContext, String call, Map<String,Object> params,
             Consumer<ResourceIterator<Map<String, Object>>> resultConsumer )
     {
-        try ( InternalTransaction tx = db.beginTransaction( KernelTransaction.Type.implicit, subject ) )
+        try ( InternalTransaction tx = db.beginTransaction( KernelTransaction.Type.implicit, loginContext ) )
         {
             Map<String,Object> p = (params == null) ? Collections.emptyMap() : params;
             resultConsumer.accept( db.execute( call, p ) );
@@ -137,26 +137,26 @@ public class EmbeddedInteraction implements NeoInteractionLevel<EnterpriseSecuri
     }
 
     @Override
-    public EnterpriseSecurityContext login( String username, String password ) throws Exception
+    public EnterpriseLoginContext login( String username, String password ) throws Exception
     {
         return authManager.login( authToken( username, password ) );
     }
 
     @Override
-    public void logout( EnterpriseSecurityContext securityContext )
+    public void logout( EnterpriseLoginContext loginContext )
     {
-        securityContext.subject().logout();
+        loginContext.subject().logout();
     }
 
     @Override
-    public void updateAuthToken( EnterpriseSecurityContext subject, String username, String password )
+    public void updateAuthToken( EnterpriseLoginContext subject, String username, String password )
     {
     }
 
     @Override
-    public String nameOf( EnterpriseSecurityContext securityContext )
+    public String nameOf( EnterpriseLoginContext loginContext )
     {
-        return securityContext.subject().username();
+        return loginContext.subject().username();
     }
 
     @Override
@@ -166,25 +166,25 @@ public class EmbeddedInteraction implements NeoInteractionLevel<EnterpriseSecuri
     }
 
     @Override
-    public void assertAuthenticated( EnterpriseSecurityContext securityContext )
+    public void assertAuthenticated( EnterpriseLoginContext loginContext )
     {
-        assertThat( securityContext.subject().getAuthenticationResult(), equalTo( AuthenticationResult.SUCCESS ) );
+        assertThat( loginContext.subject().getAuthenticationResult(), equalTo( AuthenticationResult.SUCCESS ) );
     }
 
     @Override
-    public void assertPasswordChangeRequired( EnterpriseSecurityContext securityContext )
+    public void assertPasswordChangeRequired( EnterpriseLoginContext loginContext )
     {
-        assertThat( securityContext.subject().getAuthenticationResult(), equalTo( AuthenticationResult.PASSWORD_CHANGE_REQUIRED ) );
+        assertThat( loginContext.subject().getAuthenticationResult(), equalTo( AuthenticationResult.PASSWORD_CHANGE_REQUIRED ) );
     }
 
     @Override
-    public void assertInitFailed( EnterpriseSecurityContext securityContext )
+    public void assertInitFailed( EnterpriseLoginContext loginContext )
     {
-        assertThat( securityContext.subject().getAuthenticationResult(), equalTo( AuthenticationResult.FAILURE ) );
+        assertThat( loginContext.subject().getAuthenticationResult(), equalTo( AuthenticationResult.FAILURE ) );
     }
 
     @Override
-    public void assertSessionKilled( EnterpriseSecurityContext subject )
+    public void assertSessionKilled( EnterpriseLoginContext loginContext )
     {
         // There is no session that could have been killed
     }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedUserManagementProceduresInteractionIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EmbeddedUserManagementProceduresInteractionIT.java
@@ -22,15 +22,15 @@ package org.neo4j.server.security.enterprise.auth;
 import java.util.List;
 import java.util.Map;
 
-import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseLoginContext;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
-public class EmbeddedUserManagementProceduresInteractionIT extends AuthProceduresInteractionTestBase<EnterpriseSecurityContext>
+public class EmbeddedUserManagementProceduresInteractionIT extends AuthProceduresInteractionTestBase<EnterpriseLoginContext>
 {
     @Override
-    protected NeoInteractionLevel<EnterpriseSecurityContext> setUpNeoServer( Map<String, String> config )
+    protected NeoInteractionLevel<EnterpriseLoginContext> setUpNeoServer( Map<String, String> config )
             throws Throwable
     {
         return new EmbeddedInteraction( config );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityContextDescriptionTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/EnterpriseSecurityContextDescriptionTest.java
@@ -124,6 +124,6 @@ public class EnterpriseSecurityContextDescriptionTest
 
     private EnterpriseSecurityContext context() throws Exception
     {
-        return authManagerRule.getManager().login( authToken( "mats", "foo" ) ).freeze( token );
+        return authManagerRule.getManager().login( authToken( "mats", "foo" ) ).authorize( token );
     }
 }

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmTest.java
@@ -43,7 +43,6 @@ import org.neo4j.kernel.api.exceptions.InvalidArgumentsException;
 import org.neo4j.kernel.api.security.PasswordPolicy;
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseLoginContext;
-import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
 import org.neo4j.kernel.impl.security.Credential;
 import org.neo4j.kernel.impl.security.User;
 import org.neo4j.scheduler.JobScheduler;
@@ -128,11 +127,11 @@ public class InternalFlatFileRealmTest
         EnterpriseLoginContext mike = authManager.login( authToken( "mike", "123" ) );
         assertThat( mike.subject().getAuthenticationResult(), equalTo( AuthenticationResult.SUCCESS ) );
 
-        mike.freeze( token ).mode().allowsReads();
+        mike.authorize( token ).mode().allowsReads();
         assertThat( "Test realm did not receive a call", testRealm.takeAuthorizationFlag(), is( true ) );
 
         // When
-        mike.freeze( token ).mode().allowsWrites();
+        mike.authorize( token ).mode().allowsWrites();
 
         // Then
         assertThat( "Test realm did not receive a call", testRealm.takeAuthorizationFlag(), is( true ) );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/InternalFlatFileRealmTest.java
@@ -93,7 +93,7 @@ public class InternalFlatFileRealmTest
         List<Realm> realms = listOf( testRealm );
 
         authManager = new MultiRealmAuthManager( testRealm, realms, new MemoryConstrainedCacheManager(),
-                mock( SecurityLog.class ), true );
+                mock( SecurityLog.class ), true, false, Collections.emptyMap() );
 
         authManager.init();
         authManager.start();

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapCachingTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapCachingTest.java
@@ -125,11 +125,11 @@ public class LdapCachingTest
     {
         // Given
         EnterpriseLoginContext mike = authManager.login( authToken( "mike", "123" ) );
-        mike.freeze( token ).mode().allowsReads();
+        mike.authorize( token ).mode().allowsReads();
         assertThat( "Test realm did not receive a call", testRealm.takeAuthorizationFlag(), is( true ) );
 
         // When
-        mike.freeze( token ).mode().allowsWrites();
+        mike.authorize( token ).mode().allowsWrites();
 
         // Then
         assertThat( "Test realm received a call", testRealm.takeAuthorizationFlag(), is( false ) );
@@ -140,19 +140,19 @@ public class LdapCachingTest
     {
         // Given
         EnterpriseLoginContext mike = authManager.login( authToken( "mike", "123" ) );
-        mike.freeze( token ).mode().allowsReads();
+        mike.authorize( token ).mode().allowsReads();
         assertThat( "Test realm did not receive a call", testRealm.takeAuthorizationFlag(), is( true ) );
 
         // When
         fakeTicker.advance( 99, TimeUnit.MILLISECONDS );
-        mike.freeze( token ).mode().allowsWrites();
+        mike.authorize( token ).mode().allowsWrites();
 
         // Then
         assertThat( "Test realm received a call", testRealm.takeAuthorizationFlag(), is( false ) );
 
         // When
         fakeTicker.advance( 2, TimeUnit.MILLISECONDS );
-        mike.freeze( token ).mode().allowsWrites();
+        mike.authorize( token ).mode().allowsWrites();
 
         // Then
         assertThat( "Test realm did not received a call", testRealm.takeAuthorizationFlag(), is( true ) );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapCachingTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapCachingTest.java
@@ -41,12 +41,12 @@ import java.util.concurrent.TimeUnit;
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
+import org.neo4j.server.security.enterprise.configuration.SecuritySettings;
+import org.neo4j.server.security.enterprise.log.SecurityLog;
 import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.server.security.auth.BasicPasswordPolicy;
 import org.neo4j.server.security.auth.InMemoryUserRepository;
 import org.neo4j.server.security.auth.RateLimitedAuthenticationStrategy;
-import org.neo4j.server.security.enterprise.configuration.SecuritySettings;
-import org.neo4j.server.security.enterprise.log.SecurityLog;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -82,7 +82,7 @@ public class LdapCachingTest
 
         fakeTicker = new FakeTicker();
         authManager = new MultiRealmAuthManager( internalFlatFileRealm, realms,
-                new ShiroCaffeineCache.Manager( fakeTicker::read, 100, 10, true ), securityLog, false );
+                new ShiroCaffeineCache.Manager( fakeTicker::read, 100, 10, true ), securityLog, false, false, Collections.emptyMap() );
         authManager.init();
         authManager.start();
 

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapCachingTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/LdapCachingTest.java
@@ -38,15 +38,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.neo4j.internal.kernel.api.Token;
 import org.neo4j.kernel.api.security.exception.InvalidAuthTokenException;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
-import org.neo4j.server.security.enterprise.configuration.SecuritySettings;
-import org.neo4j.server.security.enterprise.log.SecurityLog;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseLoginContext;
 import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.server.security.auth.BasicPasswordPolicy;
 import org.neo4j.server.security.auth.InMemoryUserRepository;
 import org.neo4j.server.security.auth.RateLimitedAuthenticationStrategy;
+import org.neo4j.server.security.enterprise.configuration.SecuritySettings;
+import org.neo4j.server.security.enterprise.log.SecurityLog;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -61,9 +62,12 @@ public class LdapCachingTest
     private TestRealm testRealm;
     private FakeTicker fakeTicker;
 
+    private Token token;
+
     @Before
     public void setup() throws Throwable
     {
+        token = mock( Token.class );
         SecurityLog securityLog = mock( SecurityLog.class );
         InternalFlatFileRealm internalFlatFileRealm =
             new InternalFlatFileRealm(
@@ -120,12 +124,12 @@ public class LdapCachingTest
     public void shouldCacheAuthorizationInfo() throws InvalidAuthTokenException
     {
         // Given
-        EnterpriseSecurityContext mike = authManager.login( authToken( "mike", "123" ) );
-        mike.mode().allowsReads();
+        EnterpriseLoginContext mike = authManager.login( authToken( "mike", "123" ) );
+        mike.freeze( token ).mode().allowsReads();
         assertThat( "Test realm did not receive a call", testRealm.takeAuthorizationFlag(), is( true ) );
 
         // When
-        mike.mode().allowsWrites();
+        mike.freeze( token ).mode().allowsWrites();
 
         // Then
         assertThat( "Test realm received a call", testRealm.takeAuthorizationFlag(), is( false ) );
@@ -135,20 +139,20 @@ public class LdapCachingTest
     public void shouldInvalidateAuthorizationCacheAfterTTL() throws InvalidAuthTokenException
     {
         // Given
-        EnterpriseSecurityContext mike = authManager.login( authToken( "mike", "123" ) );
-        mike.mode().allowsReads();
+        EnterpriseLoginContext mike = authManager.login( authToken( "mike", "123" ) );
+        mike.freeze( token ).mode().allowsReads();
         assertThat( "Test realm did not receive a call", testRealm.takeAuthorizationFlag(), is( true ) );
 
         // When
         fakeTicker.advance( 99, TimeUnit.MILLISECONDS );
-        mike.mode().allowsWrites();
+        mike.freeze( token ).mode().allowsWrites();
 
         // Then
         assertThat( "Test realm received a call", testRealm.takeAuthorizationFlag(), is( false ) );
 
         // When
         fakeTicker.advance( 2, TimeUnit.MILLISECONDS );
-        mike.mode().allowsWrites();
+        mike.freeze( token ).mode().allowsWrites();
 
         // Then
         assertThat( "Test realm did not received a call", testRealm.takeAuthorizationFlag(), is( true ) );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerRule.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerRule.java
@@ -81,7 +81,7 @@ public class MultiRealmAuthManagerRule implements TestRule
                     );
 
         manager = new MultiRealmAuthManager( internalFlatFileRealm, Collections.singleton( internalFlatFileRealm ),
-                new MemoryConstrainedCacheManager(), securityLog, true );
+                new MemoryConstrainedCacheManager(), securityLog, true, false, Collections.emptyMap() );
         manager.init();
     }
 

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerRule.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerRule.java
@@ -30,10 +30,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.neo4j.internal.kernel.api.security.SecurityContext;
-import org.neo4j.scheduler.JobScheduler;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.logging.FormattedLog;
 import org.neo4j.logging.Log;
+import org.neo4j.scheduler.JobScheduler;
 import org.neo4j.server.security.auth.AuthenticationStrategy;
 import org.neo4j.server.security.auth.BasicPasswordPolicy;
 import org.neo4j.server.security.auth.InMemoryUserRepository;
@@ -90,9 +90,9 @@ public class MultiRealmAuthManagerRule implements TestRule
         return manager;
     }
 
-    public SecurityContext makeSecurityContext( ShiroSubject shiroSubject )
+    public LoginContext makeLoginContext( ShiroSubject shiroSubject )
     {
-        return new StandardEnterpriseSecurityContext( manager, shiroSubject );
+        return new StandardEnterpriseLoginContext( manager, shiroSubject );
     }
 
     @Override

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerTest.java
@@ -108,7 +108,8 @@ public class MultiRealmAuthManagerTest extends InitialUserTest
                     );
 
         manager = new MultiRealmAuthManager( internalFlatFileRealm, Collections.singleton( internalFlatFileRealm ),
-                new MemoryConstrainedCacheManager(), new SecurityLog( log ), logSuccessfulAuthentications );
+                new MemoryConstrainedCacheManager(), new SecurityLog( log ), logSuccessfulAuthentications,
+                false, Collections.emptyMap() );
 
         manager.init();
         return manager;

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/MultiRealmAuthManagerTest.java
@@ -562,12 +562,12 @@ public class MultiRealmAuthManagerTest extends InitialUserTest
         setMockAuthenticationStrategyResult( "neo4j", "neo4j", AuthenticationResult.SUCCESS );
 
         // When
-        SecurityContext securityContext = manager.login( authToken( "neo4j", "neo4j" ) ).freeze( token );
+        SecurityContext securityContext = manager.login( authToken( "neo4j", "neo4j" ) ).authorize( token );
         userManager.setUserPassword( "neo4j", "1234", false );
         securityContext.subject().logout();
 
         setMockAuthenticationStrategyResult( "neo4j", "1234", AuthenticationResult.SUCCESS );
-        securityContext = manager.login( authToken( "neo4j", "1234" ) ).freeze( token );
+        securityContext = manager.login( authToken( "neo4j", "1234" ) ).authorize( token );
 
         // Then
         assertTrue( securityContext.mode().allowsReads() );
@@ -583,7 +583,7 @@ public class MultiRealmAuthManagerTest extends InitialUserTest
         manager.start();
 
         // When
-        SecurityContext securityContext = manager.login( authToken( "morpheus", "abc123" ) ).freeze( token );
+        SecurityContext securityContext = manager.login( authToken( "morpheus", "abc123" ) ).authorize( token );
 
         // Then
         assertTrue( securityContext.mode().allowsReads() );
@@ -599,7 +599,7 @@ public class MultiRealmAuthManagerTest extends InitialUserTest
         manager.start();
 
         // When
-        SecurityContext securityContext = manager.login( authToken( "trinity", "abc123" ) ).freeze( token );
+        SecurityContext securityContext = manager.login( authToken( "trinity", "abc123" ) ).authorize( token );
 
         // Then
         assertTrue( securityContext.mode().allowsReads() );
@@ -615,7 +615,7 @@ public class MultiRealmAuthManagerTest extends InitialUserTest
         manager.start();
 
         // When
-        SecurityContext securityContext = manager.login( authToken( "tank", "abc123" ) ).freeze( token );
+        SecurityContext securityContext = manager.login( authToken( "tank", "abc123" ) ).authorize( token );
 
         // Then
         assertTrue( "should allow reads", securityContext.mode().allowsReads() );
@@ -631,7 +631,7 @@ public class MultiRealmAuthManagerTest extends InitialUserTest
         manager.start();
 
         // When
-        SecurityContext securityContext = manager.login( authToken( "neo", "abc123" ) ).freeze( token );
+        SecurityContext securityContext = manager.login( authToken( "neo", "abc123" ) ).authorize( token );
 
         // Then
         assertTrue( securityContext.mode().allowsReads() );
@@ -647,7 +647,7 @@ public class MultiRealmAuthManagerTest extends InitialUserTest
         manager.start();
 
         // When
-        SecurityContext securityContext = manager.login( authToken( "smith", "abc123" ) ).freeze( token );
+        SecurityContext securityContext = manager.login( authToken( "smith", "abc123" ) ).authorize( token );
 
         // Then
         assertFalse( securityContext.mode().allowsReads() );
@@ -664,14 +664,14 @@ public class MultiRealmAuthManagerTest extends InitialUserTest
 
         // When
         LoginContext loginContext = manager.login( authToken( "morpheus", "abc123" ) );
-        SecurityContext securityContext = loginContext.freeze( token );
+        SecurityContext securityContext = loginContext.authorize( token );
         assertTrue( securityContext.mode().allowsReads() );
         assertTrue( securityContext.mode().allowsWrites() );
         assertTrue( securityContext.mode().allowsSchemaWrites() );
 
         loginContext.subject().logout();
 
-        securityContext = loginContext.freeze( token );
+        securityContext = loginContext.authorize( token );
         // Then
         assertFalse( securityContext.mode().allowsReads() );
         assertFalse( securityContext.mode().allowsWrites() );

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/PersonalUserManagerTest.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/PersonalUserManagerTest.java
@@ -75,7 +75,7 @@ public class PersonalUserManagerTest
                         new InternalFlatFileRealmIT.TestJobScheduler(), new InMemoryUserRepository(),
                         new InMemoryUserRepository() ) );
         log = spy( Log.class );
-        userManager = new PersonalUserManager( evilUserManager, SecurityContext.AUTH_DISABLED, new SecurityLog( log ) );
+        userManager = new PersonalUserManager( evilUserManager, AuthSubject.AUTH_DISABLED, new SecurityLog( log ), true );
     }
 
     private String withSubject( AuthSubject subject, String msg )

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/LdapAuthIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/integration/bolt/LdapAuthIT.java
@@ -57,9 +57,9 @@ import javax.naming.ldap.LdapContext;
 import org.neo4j.bolt.v1.transport.integration.TransportTestUtil;
 import org.neo4j.bolt.v1.transport.socket.client.TransportConnection;
 import org.neo4j.graphdb.config.Setting;
+import org.neo4j.internal.kernel.api.security.AuthSubject;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.exceptions.Status;
-import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.internal.GraphDatabaseAPI;
@@ -454,7 +454,7 @@ public class LdapAuthIT extends EnterpriseAuthenticationTestBase
         EnterpriseAuthAndUserManager authManager =
                 gds.getDependencyResolver().resolveDependency( EnterpriseAuthAndUserManager.class );
 
-        authManager.getUserManager( EnterpriseSecurityContext.AUTH_DISABLED )
+        authManager.getUserManager( AuthSubject.AUTH_DISABLED, true )
                 .newUser( ldapReaderUser, nativePassword, false );
 
         // Then

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/PropertyLevelSecurityIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/PropertyLevelSecurityIT.java
@@ -1,0 +1,514 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.server.security.enterprise.auth.plugin;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.neo4j.graphdb.ResourceIterator;
+import org.neo4j.graphdb.Result;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthManager;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
+import org.neo4j.kernel.impl.coreapi.InternalTransaction;
+import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
+import org.neo4j.kernel.impl.util.ValueUtils;
+import org.neo4j.server.security.enterprise.auth.EnterpriseAuthAndUserManager;
+import org.neo4j.server.security.enterprise.auth.EnterpriseUserManager;
+import org.neo4j.server.security.enterprise.auth.plugin.api.PredefinedRoles;
+import org.neo4j.server.security.enterprise.configuration.SecuritySettings;
+import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.neo4j.internal.kernel.api.Transaction.Type.explicit;
+import static org.neo4j.server.security.auth.SecurityTestUtils.authToken;
+
+public class PropertyLevelSecurityIT
+{
+    @Rule
+    public TemporaryFolder tmpdir = new TemporaryFolder();
+
+    private GraphDatabaseFacade db;
+    private EnterpriseAuthAndUserManager authManager;
+    private EnterpriseSecurityContext neo;
+    private EnterpriseSecurityContext smith;
+    private EnterpriseSecurityContext morpheus;
+
+    @Before
+    public void setUp() throws Throwable
+    {
+        TestGraphDatabaseFactory s = new TestEnterpriseGraphDatabaseFactory();
+        db = (GraphDatabaseFacade) s.newImpermanentDatabaseBuilder( tmpdir.getRoot() )
+                .setConfig( SecuritySettings.property_level_authorization_enabled, "true" )
+                .setConfig( SecuritySettings.property_level_authorization_permissions, "Agent=alias,secret" )
+                .setConfig( GraphDatabaseSettings.auth_enabled, "true" )
+                .newGraphDatabase();
+        authManager = (EnterpriseAuthAndUserManager) db.getDependencyResolver().resolveDependency( EnterpriseAuthManager.class );
+        EnterpriseUserManager userManager = authManager.getUserManager();
+        userManager.newUser( "Neo", "eon", false );
+        userManager.newUser( "Smith", "mr", false );
+        userManager.addRoleToUser( PredefinedRoles.ARCHITECT, "Neo" );
+        userManager.newRole( "Agent", "Smith" );
+        userManager.addRoleToUser( PredefinedRoles.READER, "Smith" );
+        userManager.newUser( "Morpheus", "dealwithit", false );
+        userManager.addRoleToUser( PredefinedRoles.READER, "Morpheus" );
+
+        neo = authManager.login( authToken( "Neo", "eon" ) );
+        smith = authManager.login( authToken( "Smith", "mr" ) );
+        morpheus = authManager.login( authToken( "Morpheus", "dealwithit" ) );
+    }
+
+    @Test
+    public void shouldNotShowRestrictedTokensForRestrictedUser() throws Throwable
+    {
+        Result result = execute( neo, "CREATE (n {name: 'Andersson', alias: 'neo'}) ", Collections.emptyMap() );
+        assertThat( result.getQueryStatistics().getNodesCreated(), equalTo( 1 ) );
+        assertThat( result.getQueryStatistics().getPropertiesSet(), equalTo( 2 ) );
+        result.close();
+        execute( smith, "MATCH (n) WHERE n.name = 'Andersson' RETURN n, n.alias as alias", Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "alias" ), equalTo( null ) );
+        } );
+    }
+
+    @Test
+    public void shouldShowRestrictedTokensForUnrestrictedUser() throws Throwable
+    {
+        Result result = execute( neo, "CREATE (n {name: 'Andersson', alias: 'neo'}) ", Collections.emptyMap() );
+        assertThat( result.getQueryStatistics().getNodesCreated(), equalTo( 1 ) );
+        assertThat( result.getQueryStatistics().getPropertiesSet(), equalTo( 2 ) );
+        result.close();
+        execute( morpheus, "MATCH (n) WHERE n.name = 'Andersson' RETURN n, n.alias as alias", Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "alias" ), equalTo( "neo" ) );
+        } );
+    }
+
+    @Test
+    public void shouldBehaveLikeDataIsMissing() throws Throwable
+    {
+        execute( neo, "CREATE (n {name: 'Andersson'}) ", Collections.emptyMap() ).close();
+
+        String query = "MATCH (n) WHERE n.name = 'Andersson' RETURN n.alias as alias";
+
+        execute( neo, query, Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "alias" ), equalTo( null ) );
+        } );
+
+        execute( neo, "MATCH (n {name: 'Andersson'}) SET n.alias = 'neo' ", Collections.emptyMap() ).close();
+
+        execute( smith, query, Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "alias" ), equalTo( null ) );
+        } );
+    }
+
+    @Test
+    public void shouldBehaveLikeDataIsMissingWhenFiltering() throws Throwable
+    {
+        execute( neo, "CREATE (n {name: 'Andersson'}) ", Collections.emptyMap() ).close();
+
+        String query = "MATCH (n) WHERE n.alias = 'neo' RETURN n";
+
+        execute( neo, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( false ) ) );
+
+        execute( neo, "MATCH (n {name: 'Andersson'}) SET n.alias = 'neo' ", Collections.emptyMap() ).close();
+
+        execute( smith, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( false ) ) );
+        execute( neo, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( true ) ) );
+    }
+
+    @Test
+    public void shouldBehaveLikeDataIsMissingForKeys() throws Throwable
+    {
+        execute( neo, "CREATE (n {name: 'Andersson'}) ", Collections.emptyMap() ).close();
+
+        String query = "MATCH (n) RETURN keys(n) AS keys";
+
+        execute( neo, query, Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "keys" ), equalTo( Collections.singletonList( "name" ) ) );
+        } );
+
+        execute( neo, "MATCH (n {name: 'Andersson'}) SET n.alias = 'neo' ", Collections.emptyMap() ).close();
+
+        execute( smith, query, Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "keys" ), equalTo( Collections.singletonList( "name" ) ) );
+        } );
+
+        execute( neo, query, Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( (Iterable<String>) r.next().get( "keys" ), contains( "name", "alias" ) );
+        } );
+    }
+
+    @Test
+    public void shouldBehaveLikeDataIsMissingForProperties() throws Throwable
+    {
+        execute( neo, "CREATE (n {name: 'Andersson'}) ", Collections.emptyMap() ).close();
+
+        String query = "MATCH (n) RETURN properties(n) AS props";
+
+        execute( neo, query, Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "props" ), equalTo( Collections.singletonMap( "name", "Andersson" ) ) );
+        } );
+
+        execute( neo, "MATCH (n {name: 'Andersson'}) SET n.alias = 'neo' ", Collections.emptyMap() ).close();
+
+        execute( smith, query, Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "props" ), equalTo( Collections.singletonMap( "name", "Andersson" ) ) );
+        } );
+
+        Map<String, String> expected = new HashMap<>(  );
+        expected.put( "name", "Andersson" );
+        expected.put( "alias", "neo" );
+        execute( neo, query, Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "props" ), equalTo( expected ) );
+        } );
+    }
+
+    @Test
+    public void shouldBehaveLikeDataIsMissingForExists() throws Throwable
+    {
+        execute( neo, "CREATE (n:Person {name: 'Andersson'}) ", Collections.emptyMap() ).close();
+
+        String query = "MATCH (n:Person) WHERE exists(n.alias) RETURN n.alias";
+
+        execute( neo, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( false ) ) );
+
+        execute( neo, "MATCH (n {name: 'Andersson'}) SET n.alias = 'neo' ", Collections.emptyMap() ).close();
+
+        execute( neo, query, Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "n.alias" ), equalTo( "neo" ) );
+        } );
+
+        execute( smith, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( false ) ) );
+    }
+
+    @Test
+    public void shouldBehaveLikeDataIsMissingForStringBegins() throws Throwable
+    {
+        execute( neo, "CREATE (n:Person {name: 'Andersson'}) ", Collections.emptyMap() ).close();
+
+        String query = "MATCH (n:Person) WHERE n.alias starts with 'n' RETURN n.alias";
+
+        execute( neo, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( false ) ) );
+
+        execute( neo, "MATCH (n {name: 'Andersson'}) SET n.alias = 'neo' ", Collections.emptyMap() ).close();
+
+        execute( neo, query, Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "n.alias" ), equalTo( "neo" ) );
+        } );
+
+        execute( smith, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( false ) ) );
+    }
+
+    @Test
+    public void shouldBehaveLikeDataIsMissingForNotContains() throws Throwable
+    {
+        execute( neo, "CREATE (n:Person {name: 'Andersson'}) ", Collections.emptyMap() ).close();
+
+        String query = "MATCH (n:Person) WHERE NOT n.alias contains 'eo' RETURN n.alias, n.name";
+
+        execute( neo, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( false ) ) );
+
+        execute( neo, "MATCH (n {name: 'Andersson'}) SET n.alias = 'neo' ", Collections.emptyMap() ).close();
+        execute( neo, "CREATE (n:Person {name: 'Betasson', alias: 'beta'}) ", Collections.emptyMap() ).close();
+        execute( neo, "CREATE (n:Person {name: 'Cetasson'}) ", Collections.emptyMap() ).close();
+
+        execute( neo, query, Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            Map<String,Object> next = r.next();
+            assertThat( next.get( "n.alias" ), equalTo( "beta" ) );
+            assertThat( next.get( "n.name" ), equalTo( "Betasson" ) );
+            assertThat( r.hasNext(), equalTo( false ) );
+        } );
+
+        execute( smith, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( false ) ) );
+    }
+
+    @Test
+    public void shouldBehaveLikeDataIsMissingForRange() throws Throwable
+    {
+        execute( neo, "CREATE (n:Person {name: 'Andersson'}) ", Collections.emptyMap() ).close();
+
+        String query = "MATCH (n:Person) WHERE n.secret > 10 RETURN n.secret";
+
+        execute( neo, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( false ) ) );
+
+        execute( neo, "MATCH (n {name: 'Andersson'}) SET n.secret = 42 ", Collections.emptyMap() ).close();
+
+        execute( neo, query, Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "n.secret" ), equalTo( 42L ) );
+        } );
+
+        execute( smith, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( false ) ) );
+    }
+
+    @Test
+    public void shouldBehaveLikeDataIsMissingForCompositeQuery() throws Throwable
+    {
+        execute( neo, "CREATE (n:Person {name: 'Andersson'}) ", Collections.emptyMap() ).close();
+
+        String query = "MATCH (n:Person) WHERE n.name = 'Andersson' and n.alias = 'neo' RETURN n.alias";
+
+        execute( neo, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( false ) ) );
+
+        execute( neo, "MATCH (n {name: 'Andersson'}) SET n.alias = 'neo' ", Collections.emptyMap() ).close();
+
+        execute( neo, query, Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "n.alias" ), equalTo( "neo" ) );
+        } );
+
+        execute( smith, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( false ) ) );
+    }
+
+    // INDEX
+
+    @Test
+    public void shouldBehaveLikeDataIsMissingWhenFilteringWithIndex() throws Throwable
+    {
+        execute( neo, "CREATE (n:Person {name: 'Andersson'})", Collections.emptyMap() ).close();
+        execute( neo, "CREATE INDEX ON :Person(alias)", Collections.emptyMap() ).close();
+        execute( neo, "CALL db.awaitIndexes", Collections.emptyMap() ).close();
+
+        String query = "MATCH (n:Person) USING INDEX n:Person(alias) WHERE n.alias = 'neo' RETURN n";
+
+        execute( neo, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( false ) ) );
+
+        execute( neo, "MATCH (n {name: 'Andersson'}) SET n.alias = 'neo' ", Collections.emptyMap() ).close();
+
+        execute( smith, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( false ) ) );
+
+        execute( neo, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( true ) ) );
+    }
+
+    @Test
+    public void shouldBehaveLikeDataIsMissingForExistsWithIndex() throws Throwable
+    {
+        execute( neo, "CREATE INDEX ON :Person(alias)", Collections.emptyMap() ).close();
+        execute( neo, "CALL db.awaitIndexes", Collections.emptyMap() ).close();
+        execute( neo, "CREATE (n:Person {name: 'Andersson'}) ", Collections.emptyMap() ).close();
+
+        String query = "MATCH (n:Person) WHERE exists(n.alias) RETURN n.alias";
+
+        execute( neo, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( false ) ) );
+
+        execute( neo, "MATCH (n {name: 'Andersson'}) SET n.alias = 'neo' ", Collections.emptyMap() ).close();
+
+        execute( neo, query, Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "n.alias" ), equalTo( "neo" ) );
+        } );
+
+        execute( smith, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( false ) ) );
+    }
+
+    @Test
+    public void shouldBehaveLikeDataIsMissingForStringBeginsWithIndex() throws Throwable
+    {
+        execute( neo, "CREATE INDEX ON :Person(alias)", Collections.emptyMap() ).close();
+        execute( neo, "CALL db.awaitIndexes", Collections.emptyMap() ).close();
+        execute( neo, "CREATE (n:Person {name: 'Andersson'}) ", Collections.emptyMap() ).close();
+
+        String query = "MATCH (n:Person) USING INDEX n:Person(alias) WHERE n.alias starts with 'n' RETURN n.alias";
+
+        execute( neo, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( false ) ) );
+
+        execute( neo, "MATCH (n {name: 'Andersson'}) SET n.alias = 'neo' ", Collections.emptyMap() ).close();
+
+        execute( neo, query, Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "n.alias" ), equalTo( "neo" ) );
+        } );
+
+        execute( smith, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( false ) ) );
+    }
+
+    @Test
+    public void shouldBehaveLikeDataIsMissingForRangeWithIndex() throws Throwable
+    {
+        execute( neo, "CREATE INDEX ON :Person(alias)", Collections.emptyMap() ).close();
+        execute( neo, "CALL db.awaitIndexes", Collections.emptyMap() ).close();
+        execute( neo, "CREATE (n:Person {name: 'Andersson'}) ", Collections.emptyMap() ).close();
+
+        String query = "MATCH (n:Person) USING INDEX n:Person(secret) WHERE n.secret > 10 RETURN n.secret";
+
+        execute( neo, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( false ) ) );
+
+        execute( neo, "MATCH (n {name: 'Andersson'}) SET n.secret = 42 ", Collections.emptyMap() ).close();
+
+        execute( neo, query, Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "n.secret" ), equalTo( 42L ) );
+        } );
+
+        execute( smith, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( false ) ) );
+    }
+
+    @Test
+    public void shouldBehaveLikeDataIsMissingForCompositeWithIndex() throws Throwable
+    {
+        execute( neo, "CREATE INDEX ON :Person(name , alias)", Collections.emptyMap() ).close();
+        execute( neo, "CREATE INDEX ON :Person(name)", Collections.emptyMap() ).close();
+        execute( neo, "CALL db.awaitIndexes", Collections.emptyMap() ).close();
+        execute( neo, "CREATE (n:Person {name: 'Andersson'}) ", Collections.emptyMap() ).close();
+
+        String query = "MATCH (n:Person) USING INDEX n:Person(name, alias) WHERE n.name = 'Andersson' and n.alias = 'neo' RETURN n.alias";
+
+        execute( neo, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( false ) ) );
+
+        execute( neo, "MATCH (n {name: 'Andersson'}) SET n.alias = 'neo' ", Collections.emptyMap() ).close();
+
+        execute( neo, query, Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "n.alias" ), equalTo( "neo" ) );
+        } );
+
+        execute( smith, query, Collections.emptyMap(), r -> assertThat( r.hasNext(), equalTo( false ) ) );
+    }
+
+    // RELATIONSHIPS
+
+    @Test
+    public void shouldBehaveLikeDataIsMissingForRelationshipProperties() throws Throwable
+    {
+        execute( neo, "CREATE (n {name: 'Andersson'}) CREATE (m { name: 'Betasson'}) CREATE (n)-[:Neighbour]->(m)", Collections.emptyMap() ).close();
+
+        String query = "MATCH (n)-[r]->(m) WHERE n.name = 'Andersson' AND m.name = 'Betasson' RETURN properties(r) AS props";
+
+        execute( neo, query, Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "props" ), equalTo( Collections.emptyMap() ) );
+        } );
+
+        execute( neo, "MATCH (n {name: 'Andersson'})-[r]->({name: 'Betasson'}) SET r.secret = 'lovers' ", Collections.emptyMap() ).close();
+
+        execute( smith, query, Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "props" ), equalTo( Collections.emptyMap() ) );
+        } );
+
+        execute( neo, query, Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "props" ), equalTo( Collections.singletonMap( "secret", "lovers" ) ) );
+        } );
+    }
+
+    // PROCS
+
+    @Test
+    public void shouldBehaveWithProcedures() throws Throwable
+    {
+        execute( neo, "CREATE (n:Person {name: 'Andersson'}) ", Collections.emptyMap() ).close();
+
+        String query = "CALL db.propertyKeys() YIELD propertyKey RETURN propertyKey ORDER BY propertyKey";
+
+        execute( neo, query, Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "propertyKey" ), equalTo( "name" ) );
+            assertThat( r.hasNext(), equalTo( false ) );
+        } );
+
+        execute( neo, "MATCH (n {name: 'Andersson'}) SET n.alias = 'neo' ", Collections.emptyMap() ).close();
+
+        execute( smith, query, Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "propertyKey" ), equalTo( "name" ) );
+            assertThat( r.hasNext(), equalTo( false ) );
+        } );
+
+        execute( neo, query, Collections.emptyMap(), r ->
+        {
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "propertyKey" ), equalTo( "alias" ) );
+            assertThat( r.hasNext(), equalTo( true ) );
+            assertThat( r.next().get( "propertyKey" ), equalTo( "name" ) );
+            assertThat( r.hasNext(), equalTo( false ) );
+        } );
+    }
+
+    private void execute( SecurityContext subject, String query, Map<String,Object> params, Consumer<ResourceIterator<Map<String,Object>>> consumer )
+    {
+        Result result;
+        try ( InternalTransaction tx = db.beginTransaction( explicit, subject ) )
+        {
+            result = db.execute( tx, query, ValueUtils.asMapValue( params ) );
+            consumer.accept( result );
+            tx.success();
+            result.close();
+        }
+    }
+
+    private Result execute( SecurityContext subject, String query, Map<String,Object> params )
+    {
+        Result result;
+        try ( InternalTransaction tx = db.beginTransaction( explicit, subject ) )
+        {
+            result = db.execute( tx, query, ValueUtils.asMapValue( params ) );
+            tx.success();
+        }
+        return result;
+    }
+}

--- a/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/PropertyLevelSecurityIT.java
+++ b/enterprise/security/src/test/java/org/neo4j/server/security/enterprise/auth/plugin/PropertyLevelSecurityIT.java
@@ -32,9 +32,8 @@ import java.util.function.Consumer;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.Result;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.kernel.enterprise.api.security.EnterpriseAuthManager;
-import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.kernel.impl.factory.GraphDatabaseFacade;
 import org.neo4j.kernel.impl.util.ValueUtils;
@@ -58,9 +57,9 @@ public class PropertyLevelSecurityIT
 
     private GraphDatabaseFacade db;
     private EnterpriseAuthAndUserManager authManager;
-    private EnterpriseSecurityContext neo;
-    private EnterpriseSecurityContext smith;
-    private EnterpriseSecurityContext morpheus;
+    private LoginContext neo;
+    private LoginContext smith;
+    private LoginContext morpheus;
 
     @Before
     public void setUp() throws Throwable
@@ -489,7 +488,7 @@ public class PropertyLevelSecurityIT
         } );
     }
 
-    private void execute( SecurityContext subject, String query, Map<String,Object> params, Consumer<ResourceIterator<Map<String,Object>>> consumer )
+    private void execute( LoginContext subject, String query, Map<String,Object> params, Consumer<ResourceIterator<Map<String,Object>>> consumer )
     {
         Result result;
         try ( InternalTransaction tx = db.beginTransaction( explicit, subject ) )
@@ -501,7 +500,7 @@ public class PropertyLevelSecurityIT
         }
     }
 
-    private Result execute( SecurityContext subject, String query, Map<String,Object> params )
+    private Result execute( LoginContext subject, String query, Map<String,Object> params )
     {
         Result result;
         try ( InternalTransaction tx = db.beginTransaction( explicit, subject ) )

--- a/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/dbms/EnterpriseAuthorizationDisabledFilter.java
+++ b/enterprise/server-enterprise/src/main/java/org/neo4j/server/rest/dbms/EnterpriseAuthorizationDisabledFilter.java
@@ -19,14 +19,13 @@
  */
 package org.neo4j.server.rest.dbms;
 
-import org.neo4j.internal.kernel.api.security.SecurityContext;
-import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseLoginContext;
 
 public class EnterpriseAuthorizationDisabledFilter extends AuthorizationDisabledFilter
 {
     @Override
-    protected SecurityContext getAuthDisabledSecurityContext()
+    protected EnterpriseLoginContext getAuthDisabledLoginContext()
     {
-        return EnterpriseSecurityContext.AUTH_DISABLED;
+        return EnterpriseLoginContext.AUTH_DISABLED;
     }
 }

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/AbstractRESTInteraction.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/AbstractRESTInteraction.java
@@ -37,10 +37,10 @@ import javax.ws.rs.core.HttpHeaders;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.HostnamePort;
+import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.kernel.api.KernelTransaction;
-import org.neo4j.internal.kernel.api.security.SecurityContext;
 import org.neo4j.kernel.configuration.BoltConnector;
 import org.neo4j.kernel.configuration.ConnectorPortRegister;
 import org.neo4j.kernel.configuration.ssl.LegacySslPolicyConfig;
@@ -130,8 +130,8 @@ abstract class AbstractRESTInteraction extends CommunityServerTestBase implement
     public InternalTransaction beginLocalTransactionAsUser( RESTSubject subject, KernelTransaction.Type txType )
             throws Throwable
     {
-        SecurityContext securityContext = authManager.login( newBasicAuthToken( subject.username, subject.password ) );
-        return getLocalGraph().beginTransaction( txType, securityContext );
+        LoginContext loginContext = authManager.login( newBasicAuthToken( subject.username, subject.password ) );
+        return getLocalGraph().beginTransaction( txType, loginContext );
     }
 
     @Override

--- a/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/EnterpriseUserServiceTest.java
+++ b/enterprise/server-enterprise/src/test/java/org/neo4j/server/rest/security/EnterpriseUserServiceTest.java
@@ -45,7 +45,7 @@ public class EnterpriseUserServiceTest extends UserServiceTest
 
         ShiroSubject shiroSubject = mock( ShiroSubject.class );
         when( shiroSubject.getPrincipal() ).thenReturn( "neo4j" );
-        neo4jContext = authManagerRule.makeSecurityContext( shiroSubject );
+        neo4jContext = authManagerRule.makeLoginContext( shiroSubject );
     }
 
     @Test

--- a/integrationtests/src/test/java/org/neo4j/ha/HAClusterStartupIT.java
+++ b/integrationtests/src/test/java/org/neo4j/ha/HAClusterStartupIT.java
@@ -38,7 +38,7 @@ import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileUtils;
 import org.neo4j.kernel.api.KernelTransaction;
 import org.neo4j.kernel.configuration.Settings;
-import org.neo4j.kernel.enterprise.api.security.EnterpriseSecurityContext;
+import org.neo4j.kernel.enterprise.api.security.EnterpriseLoginContext;
 import org.neo4j.kernel.ha.HighlyAvailableGraphDatabase;
 import org.neo4j.kernel.impl.coreapi.InternalTransaction;
 import org.neo4j.kernel.impl.enterprise.configuration.OnlineBackupSettings;
@@ -106,7 +106,7 @@ public class HAClusterStartupIT
                     // (2) BuiltInProcedures from enterprise
                     try ( InternalTransaction tx = gdb.beginTransaction(
                         KernelTransaction.Type.explicit,
-                        EnterpriseSecurityContext.AUTH_DISABLED
+                        EnterpriseLoginContext.AUTH_DISABLED
                     ) )
                     {
                         Result result = gdb.execute( tx, "CALL dbms.listQueries()", EMPTY_MAP );


### PR DESCRIPTION
Added ability to blacklist property reading for specified roles.

Currently only properties on nodes are filtered due to relationship not using the `PropertyCursor` yet.

Also clears up intent of `SecurityContext` by splitting it into `LoginContext` which handles authentication and a `SecurityContext` that holds the authorization of a user.