### PR TITLE
Ability to configure memory usage of PageCacheRule

### DIFF
--- a/community/io/src/test/java/org/neo4j/test/rule/PageCacheRule.java
+++ b/community/io/src/test/java/org/neo4j/test/rule/PageCacheRule.java
@@ -49,6 +49,7 @@ public class PageCacheRule extends ExternalResource
         protected PageCacheTracer tracer;
         protected PageCursorTracerSupplier pageCursorTracerSupplier;
         private boolean accessChecks;
+        private String memory;
 
         private PageCacheConfig()
         {
@@ -131,6 +132,18 @@ public class PageCacheRule extends ExternalResource
             this.accessChecks = accessChecks;
             return this;
         }
+
+        /**
+         * Overrides default memory setting, which is a standard test size of '8 MiB'.
+         *
+         * @param memory memory setting to use for this page cache.
+         * @return this instance.
+         */
+        public PageCacheConfig withMemory( String memory )
+        {
+            this.memory = memory;
+            return this;
+        }
     }
 
     /**
@@ -180,7 +193,7 @@ public class PageCacheRule extends ExternalResource
         SingleFilePageSwapperFactory factory = new SingleFilePageSwapperFactory();
         factory.open( fs, Configuration.EMPTY );
 
-        MemoryAllocator mman = MemoryAllocator.createAllocator( "8 MiB" );
+        MemoryAllocator mman = MemoryAllocator.createAllocator( selectConfig( baseConfig.memory, overriddenConfig.memory, "8 MiB" ) );
         if ( pageSize != null )
         {
             pageCache = new MuninnPageCache( factory, mman, pageSize, cacheTracer, cursorTracerSupplier );


### PR DESCRIPTION
PageCacheRule is quite convenient (even more so inside PageCacheAndDependenciesRule).
This convenience is nice to have also when running bigger loads where you'd
want to have more memory assigned to the page cache.

This commit adds PageCacheConfig#withMemory to be able to change the default '8 MiB'