### PR TITLE
Backport of #10810 to fix planner bug with joins in 3.2

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/LogicalPlanProducer.scala
@@ -312,9 +312,9 @@ case class LogicalPlanProducer(cardinalityModel: CardinalityModel) extends ListS
     Optional(inputPlan, ids)(solved)
   }
 
-  def planOuterHashJoin(nodes: Set[IdName], left: LogicalPlan, right: LogicalPlan)
+  def planOuterHashJoin(nodes: Set[IdName], left: LogicalPlan, right: LogicalPlan, hints: Set[UsingJoinHint])
                        (implicit context: LogicalPlanningContext): LogicalPlan = {
-    val solved = left.solved.amendQueryGraph(_.withAddedOptionalMatch(right.solved.queryGraph))
+    val solved = left.solved.amendQueryGraph(_.withAddedOptionalMatch(right.solved.queryGraph.addHints(hints)))
     OuterHashJoin(nodes, left, right)(solved)
   }
 

--- a/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/OuterHashJoinTest.scala
+++ b/community/cypher/cypher-compiler-3.2/src/test/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/steps/OuterHashJoinTest.scala
@@ -21,7 +21,7 @@ package org.neo4j.cypher.internal.compiler.v3_2.planner.logical.steps
 
 import org.mockito.Mockito._
 import org.neo4j.cypher.internal.frontend.v3_2.SemanticDirection
-import org.neo4j.cypher.internal.frontend.v3_2.ast.PatternExpression
+import org.neo4j.cypher.internal.frontend.v3_2.ast.{Hint, PatternExpression, UsingJoinHint, Variable}
 import org.neo4j.cypher.internal.compiler.v3_2.planner._
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.Metrics.QueryGraphSolverInput
 import org.neo4j.cypher.internal.compiler.v3_2.planner.logical.plans._
@@ -68,5 +68,35 @@ class OuterHashJoinTest extends CypherFunSuite with LogicalPlanningTestSupport {
     val plans = outerHashJoin(optionalQg, left)
 
     plans should equal(Some(OuterHashJoin(Set(aNode), left, innerPlan)(solved)))
+  }
+
+  test("solve optional match with hint") {
+    val theHint: Set[Hint] = Set(UsingJoinHint(Seq(Variable("a")(pos)))(pos))
+    // MATCH a OPTIONAL MATCH a-->b
+    val optionalQg = QueryGraph(
+      patternNodes = Set(aNode, bNode),
+      patternRelationships = Set(r1Rel),
+      hints = theHint,
+      argumentIds = Set(aNode)
+    )
+
+    val factory = newMockedMetricsFactory
+    when(factory.newCostModel()).thenReturn((plan: LogicalPlan, input: QueryGraphSolverInput) => plan match {
+      case AllNodesScan(IdName("b"), _) => Cost(1) // Make sure we start the inner plan using b
+      case _ => Cost(1000)
+    })
+
+    val innerPlan = newMockedLogicalPlan("b")
+
+    implicit val context = newMockedLogicalPlanningContext(
+      planContext = newMockedPlanContext,
+      strategy = newMockedStrategy(innerPlan),
+      metrics = factory.newMetrics(hardcodedStatistics)
+    )
+    val left = newMockedLogicalPlanWithPatterns(Set(aNode))
+    val plan = outerHashJoin(optionalQg, left).getOrElse(fail("No result from outerHashJoin"))
+
+    plan should equal(OuterHashJoin(Set(aNode), left, innerPlan)(solved))
+    plan.solved.lastQueryGraph.allHints should equal(theHint)
   }
 }

--- a/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/PlannerQuery.scala
+++ b/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/PlannerQuery.scala
@@ -60,10 +60,7 @@ sealed trait PlannerQuery {
     case None => queryGraph.allHints
   }
 
-  def numHints: Int = tail match {
-    case Some(tailPlannerQuery) => queryGraph.numHints + tailPlannerQuery.numHints
-    case None => queryGraph.numHints
-  }
+  def numHints: Int = allHints.size
 
   def amendQueryGraph(f: QueryGraph => QueryGraph): PlannerQuery = withQueryGraph(f(queryGraph))
 

--- a/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/QueryGraph.scala
+++ b/community/cypher/ir-3.2/src/main/scala/org/neo4j/cypher/internal/ir/v3_2/QueryGraph.scala
@@ -251,8 +251,6 @@ case class QueryGraph(// !!! If you change anything here, make sure to update th
   val allHints: Set[Hint] =
     if (optionalMatches.isEmpty) hints else hints ++ optionalMatches.flatMap(_.allHints)
 
-  def numHints: Int = allHints.size
-
   def ++(other: QueryGraph): QueryGraph =
     QueryGraph(
       selections = selections ++ other.selections,

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/HintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/HintAcceptanceTest.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import org.neo4j.cypher.ExecutionEngineFunSuite
+
+import scala.collection.Map
+
+class HintAcceptanceTest
+  extends ExecutionEngineFunSuite {
+
+  test("should use a simple hint") {
+    val query = "MATCH (a)--(b)--(c) USING JOIN ON b RETURN a,b,c"
+    val result = execute(query)
+    result should use("NodeHashJoin")
+  }
+
+  test("should not plan multiple joins for one hint") {
+    val a = createLabeledNode(Map[String, Any]("name" -> "a"), "A")
+    for(i <- 0 until 10) {
+      val b = createLabeledNode(Map[String, Any]("name" -> s"${i}b"), "B")
+      relate(a, b)
+    }
+
+    val query = """MATCH (a:A)
+                  |OPTIONAL MATCH (a)-->(b:B)
+                  |USING JOIN ON a
+                  |RETURN a.name, b.name""".stripMargin
+
+    val result = execute(query)
+    result should use("NodeOuterHashJoin")
+    result shouldNot use("NodeHashJoin")
+  }
+}

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/JoinAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/JoinAcceptanceTest.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.internal.cypher.acceptance
+
+import org.neo4j.cypher._
+
+class JoinAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport {
+
+  test("optional match join should not crash") {
+    val query =
+      """MATCH (a:A)-->(b:B)-->(c:C)
+        |OPTIONAL MATCH (h)<--(g:G)<--(c)
+        |USING JOIN ON c
+        |RETURN a,b,c,g,h""".stripMargin
+    graph.execute(query) // should not crash
+  }
+
+}


### PR DESCRIPTION
Backport of  #10810. This one will be a little bit tricky to forward merge.

To 3.3, we want want to keep everything. Be careful with `IdName`, which was removed in 3.3. The content of `HintAcceptanceTest` could be using `CypherComparisonSupport` in 3.3, to match how it looks in 3.4. Not strictly necessary, though.

To 3.4, we want to do a null-forward-merge EXCEPT for the added test in `JoinAcceptanceTest`. Happy merging!

changelog:
Fixes planner bug with join hints on optional matches.