### PR TITLE
DirectedRelationshipByIdSeekPipe -> DirectedRelationshipByIdSeek 

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/LogicalPlan2PlanDescription.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/LogicalPlan2PlanDescription.scala
@@ -74,7 +74,7 @@ case class LogicalPlan2PlanDescription(idMap: Map[LogicalPlan, Id], readOnly: Bo
 
       case DirectedRelationshipByIdSeek(_, relIds, _, _, _) =>
         val entityByIdRhs = EntityByIdRhs(relIds.asCommandSeekArgs)
-        PlanDescriptionImpl(id, "DirectedRelationshipByIdSeekPipe", NoChildren, Seq(entityByIdRhs), variables)
+        PlanDescriptionImpl(id, "DirectedRelationshipByIdSeek", NoChildren, Seq(entityByIdRhs), variables)
 
       case _: LegacyNodeIndexSeek | _: LegacyRelationshipIndexSeek =>
         PlanDescriptionImpl(id, "LegacyIndexSeek", NoChildren, Seq.empty, variables)


### PR DESCRIPTION
This change only applies to the display name, to harmonize with all the other operators when viewing an execution plan.