### PR TITLE
Instantiates PageAwareByteArrayCursor in @Before

### DIFF
--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/FreeListIdProviderTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/FreeListIdProviderTest.java
@@ -52,7 +52,7 @@ public class FreeListIdProviderTest
     private static final long GENERATION_FOUR = GENERATION_THREE + 1;
     private static final long BASE_ID = 5;
 
-    private final PageAwareByteArrayCursor cursor = new PageAwareByteArrayCursor( PAGE_SIZE );
+    private PageAwareByteArrayCursor cursor;
     private final PagedFile pagedFile = mock( PagedFile.class );
     private final FreelistPageMonitor monitor = new FreelistPageMonitor();
     private final FreeListIdProvider freelist = new FreeListIdProvider( pagedFile, PAGE_SIZE, BASE_ID, monitor );
@@ -63,6 +63,7 @@ public class FreeListIdProviderTest
     @Before
     public void setUpPagedFile() throws IOException
     {
+        cursor = new PageAwareByteArrayCursor( PAGE_SIZE );
         when( pagedFile.io( anyLong(), anyInt() ) ).thenAnswer(
                 invocation -> cursor.duplicate( invocation.getArgument( 0 ) ) );
         freelist.initialize( BASE_ID + 1, BASE_ID + 1, BASE_ID + 1, 0, 0 );

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTestBase.java
@@ -33,7 +33,6 @@ import java.util.List;
 
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.test.rule.RandomRule;
-
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
@@ -57,9 +56,9 @@ import static org.neo4j.index.internal.gbptree.ValueMergers.overwrite;
 public abstract class InternalTreeLogicTestBase<KEY,VALUE>
 {
     private final int pageSize = 256;
-    private final PageAwareByteArrayCursor cursor = new PageAwareByteArrayCursor( pageSize );
-    private final PageAwareByteArrayCursor readCursor = cursor.duplicate();
-    private final SimpleIdProvider id = new SimpleIdProvider( cursor::duplicate );
+    private PageAwareByteArrayCursor cursor;
+    private PageAwareByteArrayCursor readCursor;
+    private SimpleIdProvider id;
 
     private TestLayout<KEY,VALUE> layout;
     private TreeNode<KEY,VALUE> node;
@@ -102,6 +101,10 @@ public abstract class InternalTreeLogicTestBase<KEY,VALUE>
     @Before
     public void setUp() throws IOException
     {
+        cursor = new PageAwareByteArrayCursor( pageSize );
+        readCursor = cursor.duplicate();
+        id = new SimpleIdProvider( cursor::duplicate );
+
         id.reset();
         long newId = id.acquireNewId( stableGeneration, unstableGeneration );
         goTo( cursor, newId );

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTestBase.java
@@ -73,9 +73,9 @@ public abstract class SeekCursorTestBase<KEY, VALUE>
     private InternalTreeLogic<KEY,VALUE> treeLogic;
     private StructurePropagation<KEY> structurePropagation;
 
-    private final PageAwareByteArrayCursor cursor = new PageAwareByteArrayCursor( PAGE_SIZE );
-    private final PageAwareByteArrayCursor utilCursor = cursor.duplicate();
-    private final SimpleIdProvider id = new SimpleIdProvider( cursor::duplicate );
+    private PageAwareByteArrayCursor cursor;
+    private PageAwareByteArrayCursor utilCursor;
+    private SimpleIdProvider id;
 
     private static long stableGeneration = GenerationSafePointer.MIN_GENERATION;
     private static long unstableGeneration = stableGeneration + 1;
@@ -86,6 +86,10 @@ public abstract class SeekCursorTestBase<KEY, VALUE>
     @Before
     public void setUp() throws IOException
     {
+        cursor = new PageAwareByteArrayCursor( PAGE_SIZE );
+        utilCursor = cursor.duplicate();
+        id = new SimpleIdProvider( cursor::duplicate );
+
         layout = getLayout();
         node = getTreeNode( PAGE_SIZE, layout );
         treeLogic = new InternalTreeLogic<>( id, node, layout );

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeTestBase.java
@@ -51,7 +51,7 @@ public abstract class TreeNodeTestBase<KEY,VALUE>
     private static final int HIGH_GENERATION = 4;
 
     private static final int PAGE_SIZE = 512;
-    final PageCursor cursor = new PageAwareByteArrayCursor( PAGE_SIZE );
+    PageCursor cursor;
 
     private TestLayout<KEY,VALUE> layout;
     private TreeNode<KEY,VALUE> node;
@@ -62,6 +62,7 @@ public abstract class TreeNodeTestBase<KEY,VALUE>
     @Before
     public void prepareCursor() throws IOException
     {
+        cursor = new PageAwareByteArrayCursor( PAGE_SIZE );
         cursor.next();
         layout = getLayout();
         node = getNode( PAGE_SIZE, layout );

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeStatePairTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeStatePairTest.java
@@ -20,6 +20,7 @@
 package org.neo4j.index.internal.gbptree;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -104,7 +105,13 @@ public class TreeStatePairTest
     @Parameterized.Parameter( 3 )
     public Selected expectedOldest;
 
-    private final PageAwareByteArrayCursor cursor = new PageAwareByteArrayCursor( 256 );
+    private PageAwareByteArrayCursor cursor;
+
+    @Before
+    public void setUp()
+    {
+        cursor = new PageAwareByteArrayCursor( 256 );
+    }
 
     @Test
     public void shouldCorrectSelectNewestAndOldestState() throws Exception

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeStateTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeStateTest.java
@@ -34,11 +34,12 @@ import static org.junit.Assert.fail;
 public class TreeStateTest
 {
     private final int pageSize = 256;
-    private final PageAwareByteArrayCursor cursor = new PageAwareByteArrayCursor( pageSize );
+    private PageAwareByteArrayCursor cursor;
 
     @Before
     public void initiateCursor() throws IOException
     {
+        cursor = new PageAwareByteArrayCursor( pageSize );
         cursor.next();
     }
 


### PR DESCRIPTION
instead of in field initialization, because it would have the potential to
leave old data affecting other tests, where pointers would be observed as BROKEN