### PR TITLE
Improve performace of SpaceFillingCurve queries.

### DIFF
--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/planDescription/LogicalPlan2PlanDescription.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/planDescription/LogicalPlan2PlanDescription.scala
@@ -395,17 +395,15 @@ case class LogicalPlan2PlanDescription(readOnly: Boolean, cardinalities: Cardina
             (name, PrefixIndex(label.name, propertyKey, range.prefix))
           case InequalitySeekRangeWrapper(RangeLessThan(bounds)) =>
             (name, InequalityIndex(label.name, propertyKey,
-                                   bounds.map(bound => s"<${bound.inequalitySignSuffix} ${bound.endPoint.asCanonicalStringVal}")
-                                     .toIndexedSeq))
+              bounds.map(bound => s"<${bound.inequalitySignSuffix} ${bound.endPoint.asCanonicalStringVal}").toIndexedSeq))
           case InequalitySeekRangeWrapper(RangeGreaterThan(bounds)) =>
             (name, InequalityIndex(label.name, propertyKey,
-                                   bounds.map(bound => s">${bound.inequalitySignSuffix} ${bound.endPoint.asCanonicalStringVal}")
-                                     .toIndexedSeq))
+              bounds.map(bound => s">${bound.inequalitySignSuffix} ${bound.endPoint.asCanonicalStringVal}").toIndexedSeq))
           case InequalitySeekRangeWrapper(RangeBetween(greaterThanBounds, lessThanBounds)) =>
-            val greaterThanBoundsText = greaterThanBounds.bounds
-              .map(bound => s">${bound.inequalitySignSuffix} ${bound.endPoint.asCanonicalStringVal}").toIndexedSeq
-            val lessThanBoundsText = lessThanBounds.bounds
-              .map(bound => s"<${bound.inequalitySignSuffix} ${bound.endPoint.asCanonicalStringVal}").toIndexedSeq
+            val greaterThanBoundsText = greaterThanBounds.bounds.map(bound =>
+              s">${bound.inequalitySignSuffix} ${bound.endPoint.asCanonicalStringVal}").toIndexedSeq
+            val lessThanBoundsText = lessThanBounds.bounds.map(bound =>
+              s"<${bound.inequalitySignSuffix} ${bound.endPoint.asCanonicalStringVal}").toIndexedSeq
             (name, InequalityIndex(label.name, propertyKey, greaterThanBoundsText ++ lessThanBoundsText))
           case _ => throw new InternalException("This should never happen. Missing a case?")
         }

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SearchEnvelope.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SearchEnvelope.java
@@ -26,9 +26,9 @@ import org.neo4j.gis.spatial.index.Envelope;
  */
 class SearchEnvelope
 {
-    long[] min; // inclusive lower bounds
-    long[] max; // exclusive upper bounds
-    int nbrDim;
+    private long[] min; // inclusive lower bounds
+    private long[] max; // exclusive upper bounds
+    private int nbrDim;
 
     SearchEnvelope( SpaceFillingCurve curve, Envelope referenceEnvelope )
     {
@@ -37,6 +37,7 @@ class SearchEnvelope
         this.nbrDim = referenceEnvelope.getDimension();
         for ( int i = 0; i < nbrDim; i++ )
         {
+            // getNormalizedCoord gives inclusive bounds. Need to increment to make the upper exclusive.
             this.max[i] += 1;
         }
     }
@@ -99,12 +100,16 @@ class SearchEnvelope
         return true;
     }
 
-    /** Only valid for intersecting envelopes
+    /**
+     * Calculates the faction of the overlapping area between {@code this} and {@code} other compared
+     * to the area of {@code this}.
+     *
+     * Must only be called for intersecting envelopes
      */
     double fractionOf( SearchEnvelope other )
     {
         double fraction = 1.0;
-        for ( int i = 0; i < min.length; i++ )
+        for ( int i = 0; i < nbrDim; i++ )
         {
             long min = Math.max( this.min[i], other.min[i] );
             long max = Math.min( this.max[i], other.max[i] );
@@ -120,7 +125,7 @@ class SearchEnvelope
     public long getArea()
     {
         long area = 1;
-        for ( int i = 0; i < min.length; i++ )
+        for ( int i = 0; i < nbrDim; i++ )
         {
             area *= max[i] - min[i];
         }

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SearchEnvelope.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SearchEnvelope.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.gis.spatial.index.curves;
+
+import org.neo4j.gis.spatial.index.Envelope;
+
+/**
+ * N-dimensional searchEnvelope
+ */
+class SearchEnvelope
+{
+    long[] min; // inclusive lower bounds
+    long[] max; // exclusive upper bounds
+    int nbrDim;
+
+    SearchEnvelope( SpaceFillingCurve curve, Envelope referenceEnvelope )
+    {
+        this.min = curve.getNormalizedCoord( referenceEnvelope.getMin() );
+        this.max = curve.getNormalizedCoord( referenceEnvelope.getMax() );
+        this.nbrDim = referenceEnvelope.getDimension();
+        for ( int i = 0; i < nbrDim; i++ )
+        {
+            this.max[i] += 1;
+        }
+    }
+
+    private SearchEnvelope( long[] min, long[] max )
+    {
+        this.min = min;
+        this.max = max;
+        this.nbrDim = min.length;
+    }
+
+    SearchEnvelope( long min, long max, int nbrDim )
+    {
+        this.nbrDim = nbrDim;
+        this.min = new long[nbrDim];
+        this.max = new long[nbrDim];
+
+        for ( int dim = 0; dim < nbrDim; dim++ )
+        {
+            this.min[dim] = min;
+            this.max[dim] = max;
+        }
+    }
+
+    SearchEnvelope quadrant( int[] quadNbrs )
+    {
+        long[] newMin = new long[nbrDim];
+        long[] newMax = new long[nbrDim];
+
+        for ( int dim = 0; dim < nbrDim; dim++ )
+        {
+            long extent = (max[dim] - min[dim]) / 2;
+            newMin[dim] = this.min[dim] + quadNbrs[dim] * extent;
+            newMax[dim] = this.min[dim] + (quadNbrs[dim] + 1) * extent;
+        }
+        return new SearchEnvelope( newMin, newMax );
+    }
+
+    boolean contains( long[] coord )
+    {
+        for ( int dim = 0; dim < nbrDim; dim++ )
+        {
+            if ( coord[dim] < min[dim] || coord[dim] >= max[dim] )
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    boolean intersects( SearchEnvelope other )
+    {
+        for ( int dim = 0; dim < nbrDim; dim++ )
+        {
+            if ( this.max[dim] <= other.min[dim] || other.max[dim] <= this.min[dim] )
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    double fractionOf( SearchEnvelope other )
+    {
+        double fraction = 1.0;
+        for ( int i = 0; i < min.length; i++ )
+        {
+            long min = Math.max( this.min[i], other.min[i] );
+            long max = Math.min( this.max[i], other.max[i] );
+            final double innerFraction = (double) (max - min) / (double) (other.max[i] - other.min[i]);
+            fraction *= innerFraction;
+        }
+        return fraction;
+    }
+}

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SearchEnvelope.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SearchEnvelope.java
@@ -99,6 +99,8 @@ class SearchEnvelope
         return true;
     }
 
+    /** Only valid for intersecting envelopes
+     */
     double fractionOf( SearchEnvelope other )
     {
         double fraction = 1.0;

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SearchEnvelope.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SearchEnvelope.java
@@ -113,4 +113,17 @@ class SearchEnvelope
         }
         return fraction;
     }
+
+    /**
+     * The smallest possible envelope has unit area 1
+     */
+    public long getArea()
+    {
+        long area = 1;
+        for ( int i = 0; i < min.length; i++ )
+        {
+            area *= max[i] - min[i];
+        }
+        return area;
+    }
 }

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurve.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurve.java
@@ -269,6 +269,11 @@ public abstract class SpaceFillingCurve
         SearchEnvelope wholeExtent = new SearchEnvelope( 0, this.getWidth(), nbrDim );
         ArrayList<LongRange> results = new ArrayList<>(1000);
 
+        if ( monitor != null )
+        {
+            monitor.registerSearchArea( search.getArea() );
+        }
+
         addTilesIntersectingEnvelopeAt( config, monitor, 0, config.maxDepth( referenceEnvelope, this.range, nbrDim, maxLevel ), search,
                 wholeExtent, rootCurve(), 0, this.getValueWidth(), results );
         return results;
@@ -295,10 +300,11 @@ public abstract class SpaceFillingCurve
                     current = new LongRange( left );
                     results.add( current );
                 }
-            }
-            if(monitor != null)
-            {
-                monitor.addRangeAtDepth( depth );
+                if ( monitor != null )
+                {
+                    monitor.addRangeAtDepth( depth );
+                    monitor.addToCoveredArea( currentExtent.getArea() );
+                }
             }
         }
         else if ( search.intersects( currentExtent ) )
@@ -323,6 +329,7 @@ public abstract class SpaceFillingCurve
                 if(monitor != null)
                 {
                     monitor.addRangeAtDepth( depth );
+                    monitor.addToCoveredArea( currentExtent.getArea() );
                 }
             }
             else
@@ -367,7 +374,7 @@ public abstract class SpaceFillingCurve
             double value = clamp( coord[dim], range.getMin( dim ), range.getMax( dim ) );
             if ( value == range.getMax( dim ) )
             {
-                normalizedCoord[dim] = valueWidth - 1;
+                normalizedCoord[dim] = width - 1;
             }
             else
             {

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurve.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurve.java
@@ -267,7 +267,7 @@ public abstract class SpaceFillingCurve
     {
         SearchEnvelope search = new SearchEnvelope( this, referenceEnvelope );
         SearchEnvelope wholeExtent = new SearchEnvelope( 0, this.getWidth(), nbrDim );
-        ArrayList<LongRange> results = new ArrayList<>(1000);
+        ArrayList<LongRange> results = new ArrayList<>( config.initialRangesListCapacity() );
 
         if ( monitor != null )
         {

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurve.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurve.java
@@ -279,9 +279,6 @@ public abstract class SpaceFillingCurve
         return results;
     }
 
-    private static double TOP_THRESHOLD = 0.99;
-    private static double BOTTOM_THRESHOLD = 0.5;
-
     private void addTilesIntersectingEnvelopeAt( SpaceFillingCurveConfiguration config, SpaceFillingCurveMonitor monitor, int depth, int maxDepth,
             SearchEnvelope search, SearchEnvelope currentExtent, CurveRule curve, long left, long right, ArrayList<LongRange> results )
     {
@@ -309,10 +306,7 @@ public abstract class SpaceFillingCurve
         }
         else if ( search.intersects( currentExtent ) )
         {
-            // TODO remove parts that end up unused
             double overlap = search.fractionOf( currentExtent );
-            double slope = (BOTTOM_THRESHOLD - TOP_THRESHOLD) / maxDepth;
-            double threshold = slope * depth + TOP_THRESHOLD;
             if ( config.stopAtThisDepth( overlap, depth, maxDepth ) )
             {
                 // Note that LongRange upper bound is inclusive, hence the '-1' in several places
@@ -326,7 +320,7 @@ public abstract class SpaceFillingCurve
                     current = new LongRange( left, right - 1 );
                     results.add( current );
                 }
-                if(monitor != null)
+                if ( monitor != null )
                 {
                     monitor.addRangeAtDepth( depth );
                     monitor.addToCoveredArea( currentExtent.getArea() );

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurve.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurve.java
@@ -547,7 +547,7 @@ public abstract class SpaceFillingCurve
          */
         public double getArea()
         {
-            double area = 1.0;
+            long area = 1;
             for ( int i = 0; i < min.length; i++ )
             {
                 area *= max[i] - min[i];
@@ -583,7 +583,7 @@ public abstract class SpaceFillingCurve
                 long[] i_min = new long[this.min.length];
                 long[] i_max = new long[this.min.length];
                 boolean result = true;
-                for ( int i = 0; i < min.length; i++ )
+                for ( int i = 0; i < min.length && result; i++ )
                 {
                     if ( other.min[i] < this.max[i] && this.min[i] < other.max[i] )
                     {

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurve.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurve.java
@@ -372,7 +372,8 @@ public abstract class SpaceFillingCurve
         for ( int dim = 0; dim < nbrDim; dim++ )
         {
             double value = clamp( coord[dim], range.getMin( dim ), range.getMax( dim ) );
-            if ( value == range.getMax( dim ) )
+            // Avoiding awkward rounding errors
+            if ( value - range.getMin( dim ) == range.getMax( dim ) - range.getMin( dim ) )
             {
                 normalizedCoord[dim] = width - 1;
             }

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveConfiguration.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveConfiguration.java
@@ -23,7 +23,6 @@ import org.neo4j.gis.spatial.index.Envelope;
 
 public interface SpaceFillingCurveConfiguration
 {
-
     /**
      * Decides whether to stop at this depth or recurse deeper.
      *

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveConfiguration.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveConfiguration.java
@@ -44,4 +44,9 @@ public interface SpaceFillingCurveConfiguration
      * @return the maximum depth to which the algorithm should recurse in the space filling curve.
      */
     int maxDepth( Envelope referenceEnvelope, Envelope range, int nbrDim, int maxLevel );
+
+    /**
+     * @return the size to use when initializing the ArrayList to store ranges.
+     */
+    int initialRangesListCapacity();
 }

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveConfiguration.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveConfiguration.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.gis.spatial.index.curves;
+
+import org.neo4j.gis.spatial.index.Envelope;
+
+public interface SpaceFillingCurveConfiguration
+{
+
+    /**
+     * Decides whether to stop at this depth or recurse deeper.
+     *
+     * @param overlap the overlap between search space and the current extent
+     * @param depth the current recursion depth
+     * @param maxDepth the maximum depth that was calculated to recurse to,
+     * @return if the algorithm should recurse deeper, returns {@code false}; if the algorithm
+     * should stop at this depth, returns {@code true}
+     */
+    boolean stopAtThisDepth( double overlap, int depth, int maxDepth );
+
+    /**
+     * Decide how deep to recurse at max.
+     *
+     * @param referenceEnvelope the envelope describing the search area
+     * @param range the envelope describing the indexed area
+     * @param nbrDim the number of dimensions
+     * @param maxLevel the depth of the spaceFillingCurve
+     * @return the maximum depth to which the algorithm should recurse in the space filling curve.
+     */
+    int maxDepth( Envelope referenceEnvelope, Envelope range, int nbrDim, int maxLevel );
+}

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveMonitor.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveMonitor.java
@@ -30,4 +30,15 @@ public interface SpaceFillingCurveMonitor
      * @param depth the current recursion depth
      */
     void addRangeAtDepth( int depth );
+
+    /**
+     * Tell the monitor about the size of the search area in normalized space.
+     */
+    void registerSearchArea( long size );
+
+    /**
+     * Tell the monitor that a new area of the search space was covered (with the given size)
+     * by adding a range.
+     */
+    void addToCoveredArea( long size );
 }

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveMonitor.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveMonitor.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.gis.spatial.index.curves;
 
-import org.neo4j.gis.spatial.index.Envelope;
-
 public interface SpaceFillingCurveMonitor
 {
     /**

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveMonitor.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveMonitor.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.gis.spatial.index.curves;
+
+import org.neo4j.gis.spatial.index.Envelope;
+
+public interface SpaceFillingCurveMonitor
+{
+    /**
+     * Tells the monitor that a range was added at a certain depth in the space filling curve.
+     * Can be used to build a historgram showing how many ranges were added at which depth.
+     *
+     * @param depth the current recursion depth
+     */
+    void addRangeAtDepth( int depth );
+}

--- a/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/StandardConfiguration.java
+++ b/community/spatial-index/src/main/java/org/neo4j/gis/spatial/index/curves/StandardConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.gis.spatial.index.curves;
+
+import org.neo4j.gis.spatial.index.Envelope;
+
+public class StandardConfiguration implements SpaceFillingCurveConfiguration
+{
+
+    @Override
+    public boolean stopAtThisDepth( double overlap, int depth, int maxDepth )
+    {
+        return overlap >= 0.99 || depth >= maxDepth;
+    }
+
+    @Override
+    public int maxDepth( Envelope referenceEnvelope, Envelope range, int nbrDim, int maxLevel )
+    {
+        double searchRatio = referenceEnvelope.getArea() / range.getArea();
+        final int i = (int) (Math.log( (1 / searchRatio) ) / Math.log( Math.pow( 2, nbrDim ) )) + 1;
+        return i;
+    }
+}

--- a/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/HistogramMonitor.java
+++ b/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/HistogramMonitor.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.gis.spatial.index.curves;
+
+public class HistogramMonitor implements SpaceFillingCurveMonitor
+{
+    private int[] counts;
+
+    HistogramMonitor( int maxLevel )
+    {
+        this.counts = new int[maxLevel + 1];
+    }
+
+    @Override
+    public void addRangeAtDepth( int depth )
+    {
+        counts[depth]++;
+    }
+
+    public int[] getCounts()
+    {
+        return counts;
+    }
+}

--- a/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/HistogramMonitor.java
+++ b/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/HistogramMonitor.java
@@ -22,6 +22,8 @@ package org.neo4j.gis.spatial.index.curves;
 public class HistogramMonitor implements SpaceFillingCurveMonitor
 {
     private int[] counts;
+    private long searchArea;
+    private long coveredArea = 0;
 
     HistogramMonitor( int maxLevel )
     {
@@ -31,11 +33,33 @@ public class HistogramMonitor implements SpaceFillingCurveMonitor
     @Override
     public void addRangeAtDepth( int depth )
     {
-        counts[depth]++;
+        this.counts[depth]++;
+    }
+
+    @Override
+    public void registerSearchArea( long size )
+    {
+        this.searchArea = size;
+    }
+
+    @Override
+    public void addToCoveredArea( long size )
+    {
+        this.coveredArea += size;
     }
 
     public int[] getCounts()
     {
-        return counts;
+        return this.counts;
+    }
+
+    public long getSearchArea()
+    {
+        return searchArea;
+    }
+
+    public long getCoveredArea()
+    {
+        return coveredArea;
     }
 }

--- a/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/HistogramMonitor.java
+++ b/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/HistogramMonitor.java
@@ -22,6 +22,7 @@ package org.neo4j.gis.spatial.index.curves;
 public class HistogramMonitor implements SpaceFillingCurveMonitor
 {
     private int[] counts;
+    private int highestDepth = 0;
     private long searchArea;
     private long coveredArea = 0;
 
@@ -34,6 +35,10 @@ public class HistogramMonitor implements SpaceFillingCurveMonitor
     public void addRangeAtDepth( int depth )
     {
         this.counts[depth]++;
+        if(depth > highestDepth)
+        {
+            highestDepth = depth;
+        }
     }
 
     @Override
@@ -48,18 +53,23 @@ public class HistogramMonitor implements SpaceFillingCurveMonitor
         this.coveredArea += size;
     }
 
-    public int[] getCounts()
+    int[] getCounts()
     {
         return this.counts;
     }
 
-    public long getSearchArea()
+    long getSearchArea()
     {
         return searchArea;
     }
 
-    public long getCoveredArea()
+    long getCoveredArea()
     {
         return coveredArea;
+    }
+
+    int getHighestDepth()
+    {
+        return highestDepth;
     }
 }

--- a/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/HistogramMonitor.java
+++ b/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/HistogramMonitor.java
@@ -22,9 +22,9 @@ package org.neo4j.gis.spatial.index.curves;
 public class HistogramMonitor implements SpaceFillingCurveMonitor
 {
     private int[] counts;
-    private int highestDepth = 0;
+    private int highestDepth;
     private long searchArea;
-    private long coveredArea = 0;
+    private long coveredArea;
 
     HistogramMonitor( int maxLevel )
     {
@@ -35,7 +35,7 @@ public class HistogramMonitor implements SpaceFillingCurveMonitor
     public void addRangeAtDepth( int depth )
     {
         this.counts[depth]++;
-        if(depth > highestDepth)
+        if ( depth > highestDepth )
         {
             highestDepth = depth;
         }

--- a/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/PartialOverlapConfiguration.java
+++ b/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/PartialOverlapConfiguration.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.gis.spatial.index.curves;
+
+public class PartialOverlapConfiguration extends StandardConfiguration
+{
+    private static double TOP_THRESHOLD = 0.99;
+    private static double BOTTOM_THRESHOLD = 0.5;
+    private double topThreshold;
+    private double bottomThreshold;
+
+    PartialOverlapConfiguration()
+    {
+        this( StandardConfiguration.DEFAULT_EXTRA_LEVELS, TOP_THRESHOLD, BOTTOM_THRESHOLD );
+    }
+
+    PartialOverlapConfiguration( int extraLevels, double topThreshold, double bottomThreshold )
+    {
+        super( extraLevels );
+        this.topThreshold = topThreshold;
+        this.bottomThreshold = bottomThreshold;
+    }
+
+    /**
+     * This simply stops at the maxDepth calculated in the maxDepth() function, or
+     * if the overlap is over by some fraction which is 99% at the top levels, bu reduces
+     * linearly to 0.5 when we get to maxDepth.
+     * <p>
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean stopAtThisDepth( double overlap, int depth, int maxDepth )
+    {
+        double slope = (bottomThreshold - topThreshold) / maxDepth;
+        double threshold = slope * depth + topThreshold;
+        return overlap >= threshold || depth >= maxDepth;
+    }
+
+    @Override
+    public String toString()
+    {
+        return getClass().getSimpleName() + "(" + extraLevels + "," + topThreshold + "," + bottomThreshold + ")";
+    }
+}

--- a/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/PartialOverlapConfiguration.java
+++ b/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/PartialOverlapConfiguration.java
@@ -40,8 +40,8 @@ public class PartialOverlapConfiguration extends StandardConfiguration
 
     /**
      * This simply stops at the maxDepth calculated in the maxDepth() function, or
-     * if the overlap is over by some fraction which is 99% at the top levels, bu reduces
-     * linearly to 0.5 when we get to maxDepth.
+     * if the overlap is over some fraction 99% (by default) at the top levels, but reduces
+     * linearly to 0.5 (by default) when we get to maxDepth.
      * <p>
      * {@inheritDoc}
      */

--- a/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveTest.java
+++ b/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveTest.java
@@ -447,6 +447,7 @@ public class SpaceFillingCurveTest
         final int xmax = 100;
         final int ymin = -100;
         final int ymax = 100;
+        // Chosen to be smaller than 10, and "random" enough to not intersect with tile borders on higher levels.
         final double rectangleStepsPerDimension = 9.789;
         final double extensionFactor = 5;
         String formatHeader1 = "Level  Depth Limitation Configuration                  Area Ratio              Ranges                  Depth";
@@ -478,7 +479,7 @@ public class SpaceFillingCurveTest
                     for ( double yExtent = minExtent; yExtent <= ymax; yExtent *= extensionFactor )
                     {
                         // Filter out very thin rectangles
-                        double aspect = xExtent > yExtent ? xExtent / yExtent : yExtent / xExtent;
+                        double aspect = xExtent > yExtent ? (xExtent / yExtent) : (yExtent / xExtent);
                         if ( aspect < maxAspect )
                         {
                             // For different positions of the rectangle
@@ -527,6 +528,10 @@ public class SpaceFillingCurveTest
         }
     }
 
+    /**
+     * This test can be uses to reproduce a bug with a single search envelope, if {@link #shouldHaveReasonableCoveredArea()}
+     * fails an assertion. It should be ignored by default.
+     */
     @Ignore
     public void debugSingle()
     {

--- a/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveTest.java
+++ b/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveTest.java
@@ -363,13 +363,14 @@ public class SpaceFillingCurveTest
             {
                 Envelope eighth = new Envelope( left, left + eighthWidth, bottom, bottom + eighthHeight );
                 SpaceFillingCurve.RecursionStats stats = new SpaceFillingCurve.RecursionStats( curve.getMaxLevel() );
-                curve.getTilesIntersectingEnvelope( eighth, stats );
+                final List<SpaceFillingCurve.LongRange> ranges = curve.getTilesIntersectingEnvelope( eighth, stats );
                 int expectedMaxDepth = Math.max( 10, level / 1 );
                 assertThat( "Expected to not recurse deeper than " + expectedMaxDepth + " for level " + level, stats.maxDepth,
                         lessThanOrEqualTo( expectedMaxDepth ) );
                 if ( verbose )
                 {
                     System.out.println( "Recursed to max-depth: " + stats.maxDepth );
+                    System.out.println( "Ranges: " + ranges.size() );
                     for ( int i = 0; i <= stats.maxDepth; i++ )
                     {
                         System.out.println( "\t" + i + "\t" + stats.counts[i] );

--- a/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveTest.java
+++ b/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/SpaceFillingCurveTest.java
@@ -398,10 +398,10 @@ public class SpaceFillingCurveTest
 
     private static class MonitorStats
     {
-        long total = 0;
+        long total;
         long min = Long.MAX_VALUE;
-        long max = 0;
-        int count = 0;
+        long max;
+        int count;
 
         void add( long value )
         {
@@ -419,10 +419,10 @@ public class SpaceFillingCurveTest
 
     private static class MonitorDoubleStats
     {
-        double total = 0;
+        double total;
         double min = Double.MAX_VALUE;
-        double max = 0;
-        int count = 0;
+        double max;
+        int count;
 
         void add( double value )
         {
@@ -497,7 +497,8 @@ public class SpaceFillingCurveTest
                                     List<SpaceFillingCurve.LongRange> ranges = curve.getTilesIntersectingEnvelope( searchEnvelope, config, monitor );
                                     final long end = System.currentTimeMillis();
                                     debug( String.format(
-                                            "Results for level %d, with x=[%f,%f] y=[%f,%f]. Search size vs covered size: %d vs %d (%f x). Ranges: %d. Took %d ms\n",
+                                            "Results for level %d, with x=[%f,%f] y=[%f,%f]. " +
+                                                    "Search size vs covered size: %d vs %d (%f x). Ranges: %d. Took %d ms\n",
                                             level, xStart, xEnd, yStart, yEnd, monitor.getSearchArea(), monitor.getCoveredArea(),
                                             (double) (monitor.getCoveredArea()) / monitor.getSearchArea(), ranges.size(), end - start ) );
                                     int[] counts = monitor.getCounts();

--- a/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/TraverseToBottomConfiguration.java
+++ b/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/TraverseToBottomConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.gis.spatial.index.curves;
+
+import org.neo4j.gis.spatial.index.Envelope;
+
+public class TraverseToBottomConfiguration implements SpaceFillingCurveConfiguration
+{
+    @Override
+    public boolean stopAtThisDepth( double overlap, int depth, int maxDepth )
+    {
+        return false;
+    }
+
+    @Override
+    public int maxDepth( Envelope referenceEnvelope, Envelope range, int nbrDim, int maxLevel )
+    {
+        return maxLevel;
+    }
+}

--- a/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/TraverseToBottomConfiguration.java
+++ b/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/TraverseToBottomConfiguration.java
@@ -40,4 +40,12 @@ public class TraverseToBottomConfiguration implements SpaceFillingCurveConfigura
     {
         return getClass().getSimpleName();
     }
+
+    @Override
+    public int initialRangesListCapacity()
+    {
+        // When traversing to bottom, we can get extremely large lists and can't estimate the length.
+        // Thus, we can just as well start with a short list.
+        return 10;
+    }
 }

--- a/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/TraverseToBottomConfiguration.java
+++ b/community/spatial-index/src/test/java/org/neo4j/gis/spatial/index/curves/TraverseToBottomConfiguration.java
@@ -34,4 +34,10 @@ public class TraverseToBottomConfiguration implements SpaceFillingCurveConfigura
     {
         return maxLevel;
     }
+
+    @Override
+    public String toString()
+    {
+        return getClass().getSimpleName();
+    }
 }


### PR DESCRIPTION
This is based on #10702. Only commits including and after b68857562c92aa4ab3a1d82a85de666cc403cd87 should be reviewed here.

This restricts the depth an index query in allowed to go into the SpaceFillingCurve, depending on the ratio of area covered by the indey and area included in the search query. It also includes different configurations to twist that behavior. These are currently used for micro-benchmarks. We should proceed to use them for fullstack-benchmarks as soon is this is merged.