### PR TITLE
Revert "Fix a bug where Causal Cluster store-copy or online backup would occasionally get stuck in an infinite loop during recovery of the temporary store. Also makes store copy faster in HA, CC and online backup."

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -583,7 +583,7 @@ public class MuninnPageCache implements PageCache
     {
         if ( limiter == null )
         {
-            throw new IllegalArgumentException( "IOLimiter cannot be null" );
+            throw new IllegalArgumentException( "IOPSLimiter cannot be null" );
         }
         assertNotClosed();
         flushAllPages( limiter );

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/BatchingNeoStores.java
@@ -27,7 +27,6 @@ import org.neo4j.helpers.Service;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.io.pagecache.PageCache;
-import org.neo4j.io.pagecache.impl.PageCacheFlusher;
 import org.neo4j.io.pagecache.tracing.DefaultPageCacheTracer;
 import org.neo4j.io.pagecache.tracing.PageCacheTracer;
 import org.neo4j.io.pagecache.tracing.cursor.DefaultPageCursorTracerSupplier;

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/PageCacheFlusher.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/store/PageCacheFlusher.java
@@ -17,14 +17,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.io.pagecache.impl;
-
-import java.io.Flushable;
-import java.io.IOException;
-import java.util.Objects;
+package org.neo4j.unsafe.impl.batchimport.store;
 
 import org.neo4j.concurrent.BinaryLatch;
-import org.neo4j.io.pagecache.IOLimiter;
 import org.neo4j.io.pagecache.PageCache;
 
 import static org.neo4j.helpers.Exceptions.launderedException;
@@ -33,16 +28,15 @@ import static org.neo4j.helpers.Exceptions.launderedException;
  * A dedicated thread which constantly call {@link PageCache#flushAndForce()} until a call to {@link #halt()} is made.
  * Must be started manually by calling {@link #start()}.
  */
-public class PageCacheFlusher extends Thread implements IOLimiter
+class PageCacheFlusher extends Thread
 {
     private final PageCache pageCache;
     private final BinaryLatch halt = new BinaryLatch();
     private volatile boolean halted;
     private volatile Throwable error;
 
-    public PageCacheFlusher( PageCache pageCache )
+    PageCacheFlusher( PageCache pageCache )
     {
-        Objects.requireNonNull( pageCache );
         this.pageCache = pageCache;
     }
 
@@ -55,11 +49,7 @@ public class PageCacheFlusher extends Thread implements IOLimiter
             {
                 try
                 {
-                    pageCache.flushAndForce( this );
-                }
-                catch ( HaltFlushException ignore )
-                {
-                    break; // This exception means we've been asked to stop flushing.
+                    pageCache.flushAndForce();
                 }
                 catch ( Throwable e )
                 {
@@ -79,7 +69,7 @@ public class PageCacheFlusher extends Thread implements IOLimiter
      * will complete before exiting this method call. If there was an error in the thread doing the flushes
      * that exception will be thrown from this method as a {@link RuntimeException}.
      */
-    public void halt()
+    void halt()
     {
         halted = true;
         halt.await();
@@ -87,19 +77,5 @@ public class PageCacheFlusher extends Thread implements IOLimiter
         {
             throw launderedException( error );
         }
-    }
-
-    @Override
-    public long maybeLimitIO( long previousStamp, int recentlyCompletedIOs, Flushable flushable ) throws IOException
-    {
-        if ( halted )
-        {
-            throw new HaltFlushException();
-        }
-        return 0;
-    }
-
-    private static final class HaltFlushException extends IOException
-    {
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/PageCacheFlusherTest.java
+++ b/community/kernel/src/test/java/org/neo4j/unsafe/impl/batchimport/store/PageCacheFlusherTest.java
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.io.pagecache.impl;
+package org.neo4j.unsafe.impl.batchimport.store;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,9 +32,6 @@ import static org.junit.Assert.assertSame;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
-/**
- * This test is in the kernel module because the OtherThreadRule is really convenient here.
- */
 public class PageCacheFlusherTest
 {
     @Rule
@@ -46,12 +43,12 @@ public class PageCacheFlusherTest
         // GIVEN
         PageCache pageCache = mock( PageCache.class );
         Barrier.Control barrier = new Barrier.Control();
-        PageCacheFlusher flusher = new PageCacheFlusher( pageCache );
         doAnswer( invocation ->
         {
             barrier.reached();
             return null;
-        } ).when( pageCache ).flushAndForce( flusher );
+        } ).when( pageCache ).flushAndForce();
+        PageCacheFlusher flusher = new PageCacheFlusher( pageCache );
         flusher.start();
 
         // WHEN

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/TrackingResponseHandler.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/TrackingResponseHandler.java
@@ -35,10 +35,10 @@ import org.neo4j.causalclustering.core.state.snapshot.CoreSnapshot;
 @SuppressWarnings("unchecked")
 class TrackingResponseHandler implements CatchUpResponseHandler
 {
+    private CatchUpResponseCallback delegate;
+    private CompletableFuture<?> requestOutcomeSignal = new CompletableFuture<>();
     private final Clock clock;
-    private volatile CatchUpResponseCallback delegate;
-    private volatile CompletableFuture<?> requestOutcomeSignal = new CompletableFuture<>();
-    private volatile Long lastResponseTime;
+    private Long lastResponseTime;
 
     TrackingResponseHandler( CatchUpResponseCallback delegate, Clock clock )
     {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClient.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StoreCopyClient.java
@@ -20,15 +20,21 @@
 package org.neo4j.causalclustering.catchup.storecopy;
 
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.neo4j.causalclustering.catchup.CatchUpClient;
 import org.neo4j.causalclustering.catchup.CatchUpClientException;
 import org.neo4j.causalclustering.catchup.CatchUpResponseAdaptor;
+import org.neo4j.causalclustering.core.state.snapshot.TopologyLookupException;
+import org.neo4j.causalclustering.discovery.TopologyService;
+import org.neo4j.causalclustering.identity.MemberId;
 import org.neo4j.causalclustering.identity.StoreId;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
+
+import static java.lang.String.format;
 
 public class StoreCopyClient
 {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDisk.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/catchup/storecopy/StreamToDisk.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.causalclustering.catchup.storecopy;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -30,11 +29,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.neo4j.causalclustering.catchup.tx.FileCopyMonitor;
-import org.neo4j.io.IOUtils;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PagedFile;
-import org.neo4j.io.pagecache.impl.PageCacheFlusher;
 import org.neo4j.kernel.impl.store.StoreType;
 import org.neo4j.kernel.monitoring.Monitors;
 
@@ -44,20 +41,19 @@ class StreamToDisk implements StoreFileStreams
     private final FileSystemAbstraction fs;
     private final PageCache pageCache;
     private final FileCopyMonitor fileCopyMonitor;
-    private final PageCacheFlusher flusherThread;
-    private final Map<String,PageCacheDestination> channels;
-    private boolean closed;
+    private final Map<String,WritableByteChannel> channels;
+    private final Map<String,PagedFile> pagedFiles;
 
     StreamToDisk( File storeDir, FileSystemAbstraction fs, PageCache pageCache, Monitors monitors ) throws IOException
     {
         this.storeDir = storeDir;
         this.fs = fs;
         this.pageCache = pageCache;
-        this.flusherThread = new PageCacheFlusher( pageCache );
-        flusherThread.start();
         fs.mkdirs( storeDir );
         this.fileCopyMonitor = monitors.newMonitor( FileCopyMonitor.class );
         channels = new HashMap<>();
+        pagedFiles = new HashMap<>();
+
     }
 
     @Override
@@ -69,8 +65,21 @@ class StreamToDisk implements StoreFileStreams
         fileCopyMonitor.copyFile( fileName );
         if ( StoreType.shouldBeManagedByPageCache( destination ) )
         {
-            PageCacheDestination dest = getPageCacheDestination( destination, requiredAlignment, fileName );
-            dest.write( data );
+            WritableByteChannel channel = channels.get( destination );
+            if ( channel == null )
+            {
+                int filePageSize = pageCache.pageSize() - pageCache.pageSize() % requiredAlignment;
+                PagedFile pagedFile = pageCache.map( fileName, filePageSize, StandardOpenOption.CREATE );
+                channel = pagedFile.openWritableByteChannel();
+                pagedFiles.put( destination, pagedFile );
+                channels.put( destination, channel );
+            }
+
+            ByteBuffer buffer = ByteBuffer.wrap( data );
+            while ( buffer.hasRemaining() )
+            {
+                channel.write( buffer );
+            }
         }
         else
         {
@@ -81,86 +90,16 @@ class StreamToDisk implements StoreFileStreams
         }
     }
 
-    private synchronized PageCacheDestination getPageCacheDestination(
-            String destination, int requiredAlignment, File fileName ) throws IOException
-    {
-        if ( closed )
-        {
-            throw new IOException( "Destination has been closed: " + fileName );
-        }
-        PageCacheDestination dest = channels.get( destination );
-        if ( dest == null )
-        {
-            dest = new PageCacheDestination( pageCache, fileName, requiredAlignment );
-            channels.put( destination, dest );
-        }
-        return dest;
-    }
-
-    private static final class PageCacheDestination implements Closeable
-    {
-        private final PagedFile pagedFile;
-        private final WritableByteChannel channel;
-
-        PageCacheDestination( PageCache pageCache, File fileName, int requiredAlignment ) throws IOException
-        {
-            int filePageSize = pageCache.pageSize() - pageCache.pageSize() % requiredAlignment;
-            pagedFile = pageCache.map( fileName, filePageSize, StandardOpenOption.CREATE );
-            try
-            {
-                channel = pagedFile.openWritableByteChannel();
-            }
-            catch ( IOException channelException )
-            {
-                try
-                {
-                    pagedFile.close();
-                }
-                catch ( IOException pagedFileException )
-                {
-                    channelException.addSuppressed( pagedFileException );
-                }
-                channelException.printStackTrace();
-                throw channelException;
-            }
-        }
-
-        public synchronized void write( byte[] data ) throws IOException
-        {
-            ByteBuffer buf = ByteBuffer.wrap( data );
-            while ( buf.hasRemaining() )
-            {
-                channel.write( buf );
-            }
-        }
-
-        @Override
-        public synchronized void close() throws IOException
-        {
-            IOUtils.closeAll( channel, pagedFile );
-        }
-    }
-
     @Override
-    public synchronized void close() throws IOException
+    public void close() throws IOException
     {
-        closed = true;
-        try
+        for ( WritableByteChannel channel : channels.values() )
         {
-            flusherThread.halt();
+            channel.close();
         }
-        catch ( Exception haltException )
+        for ( PagedFile pagedFile : pagedFiles.values() )
         {
-            try
-            {
-                IOUtils.closeAll( channels.values() );
-            }
-            catch ( IOException channelsException )
-            {
-                haltException.addSuppressed( channelsException );
-            }
-            throw haltException;
+            pagedFile.close();
         }
-        IOUtils.closeAll( channels.values() );
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStoreTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/catchup/storecopy/RemoteStoreTest.java
@@ -60,7 +60,7 @@ public class RemoteStoreTest
         TransactionLogCatchUpWriter writer = mock( TransactionLogCatchUpWriter.class );
 
         RemoteStore remoteStore = new RemoteStore( NullLogProvider.getInstance(), mock( FileSystemAbstraction.class ),
-                mock( PageCache.class ), storeCopyClient, txPullClient, factory( writer ), new Monitors() );
+                null, storeCopyClient, txPullClient, factory( writer ), new Monitors() );
 
         // when
         AdvertisedSocketAddress localhost = new AdvertisedSocketAddress( "127.0.0.1", 1234 );
@@ -90,7 +90,7 @@ public class RemoteStoreTest
         TransactionLogCatchUpWriter writer = mock( TransactionLogCatchUpWriter.class );
 
         RemoteStore remoteStore = new RemoteStore( NullLogProvider.getInstance(), mock( FileSystemAbstraction.class ),
-                mock( PageCache.class ), storeCopyClient, txPullClient, factory( writer ), new Monitors() );
+                null, storeCopyClient, txPullClient, factory( writer ), new Monitors() );
 
         // when
         remoteStore.copy( localhost, wantedStoreId, new File( "destination" ) );
@@ -109,8 +109,8 @@ public class RemoteStoreTest
         TxPullClient txPullClient = mock( TxPullClient.class );
         TransactionLogCatchUpWriter writer = mock( TransactionLogCatchUpWriter.class );
 
-        RemoteStore remoteStore = new RemoteStore(
-                NullLogProvider.getInstance(), mock( FileSystemAbstraction.class ), mock( PageCache.class ),
+        RemoteStore remoteStore = new RemoteStore( NullLogProvider.getInstance(), mock( FileSystemAbstraction.class ),
+                null,
                 storeCopyClient, txPullClient, factory( writer ), new Monitors() );
 
         doThrow( StoreCopyFailedException.class ).when( txPullClient )

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToFileStoreWriter.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ToFileStoreWriter.java
@@ -31,7 +31,6 @@ import org.neo4j.io.fs.StoreChannel;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PagedFile;
 import org.neo4j.kernel.impl.store.StoreType;
-import org.neo4j.io.pagecache.impl.PageCacheFlusher;
 
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.WRITE;
@@ -44,7 +43,6 @@ public class ToFileStoreWriter implements StoreWriter
     private final StoreCopyClient.Monitor monitor;
     private final PageCache pageCache;
     private final List<FileMoveAction> fileMoveActions;
-    private final PageCacheFlusher flusherThread;
 
     public ToFileStoreWriter( File graphDbStoreDir, FileSystemAbstraction fs,
             StoreCopyClient.Monitor monitor, PageCache pageCache, List<FileMoveAction> fileMoveActions )
@@ -54,8 +52,6 @@ public class ToFileStoreWriter implements StoreWriter
         this.monitor = monitor;
         this.pageCache = pageCache;
         this.fileMoveActions = fileMoveActions;
-        this.flusherThread = new PageCacheFlusher( pageCache );
-        flusherThread.start();
     }
 
     @Override
@@ -162,6 +158,6 @@ public class ToFileStoreWriter implements StoreWriter
     @Override
     public void close()
     {
-        flusherThread.halt();
+        // Do nothing
     }
 }


### PR DESCRIPTION
Reverts neo4j/neo4j#10843