### PR TITLE
Remove wrapping of proxies

### DIFF
--- a/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/valueHelper.scala
+++ b/community/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/valueHelper.scala
@@ -21,7 +21,8 @@ package org.neo4j.cypher.internal.compatibility
 
 import java.util.function.BiConsumer
 
-import org.neo4j.kernel.impl.util.{NodeProxyWrappingNodeValue, RelationshipProxyWrappingValue}
+import org.neo4j.graphdb.{Node, Relationship}
+import org.neo4j.kernel.impl.util.{CoreNodeWrappingNodeValue, CoreRelationshipWrappingValue}
 import org.neo4j.values.AnyValue
 import org.neo4j.values.storable._
 import org.neo4j.values.virtual.{ListValue, MapValue}
@@ -42,8 +43,10 @@ object valueHelper {
       })
       map.toMap
     }
-    case n: NodeProxyWrappingNodeValue => n.nodeProxy()
-    case n: RelationshipProxyWrappingValue => n.relationshipProxy()
+    case n: Node => n
+    case r: Relationship => r
+    case n: CoreNodeWrappingNodeValue => n.nodeProxy()
+    case r: CoreRelationshipWrappingValue => r.relationshipProxy()
     case a: ListValue => Vector(a.asArray().map(fromValue): _*)
     case Values.NO_VALUE => null
   }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/BeansAPIRelationshipIterator.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/BeansAPIRelationshipIterator.scala
@@ -19,19 +19,18 @@
  */
 package org.neo4j.cypher.internal.runtime.interpreted
 
-import org.neo4j.graphdb.Relationship
 import org.neo4j.kernel.impl.api.RelationshipVisitor
 import org.neo4j.kernel.impl.api.store.RelationshipIterator
-import org.neo4j.kernel.impl.core.EmbeddedProxySPI
+import org.neo4j.kernel.impl.core.{EmbeddedProxySPI, RelationshipProxy}
 
 /**
   * Converts a RelationshipIterator coming from the Kernel API into an Iterator[Relationship] while
   * still sticking to the fact that each relationship record is only loaded once.
   */
 class BeansAPIRelationshipIterator(relationships: RelationshipIterator,
-                                   nodeManager: EmbeddedProxySPI) extends Iterator[Relationship] {
+                                   nodeManager: EmbeddedProxySPI) extends Iterator[RelationshipProxy] {
 
-  private var nextRelationship: Relationship = null
+  private var nextRelationship: RelationshipProxy = null
   private val visitor = new RelationshipVisitor[RuntimeException] {
     override def visit(relationshipId: Long, typeId: Int, startNodeId: Long, endNodeId: Long) {
       nextRelationship = nodeManager.newRelationshipProxy(relationshipId, startNodeId, typeId, endNodeId)
@@ -40,7 +39,7 @@ class BeansAPIRelationshipIterator(relationships: RelationshipIterator,
 
   override def hasNext: Boolean = relationships.hasNext
 
-  override def next(): Relationship = {
+  override def next(): RelationshipProxy = {
     if (hasNext) {
       val relationshipId = relationships.next()
       relationships.relationshipVisit(relationshipId, visitor)

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/CoreNodeWrappingNodeValue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/CoreNodeWrappingNodeValue.java
@@ -31,13 +31,17 @@ import org.neo4j.values.virtual.MapValue;
 import org.neo4j.values.virtual.NodeValue;
 import org.neo4j.values.virtual.VirtualValues;
 
-public class NodeProxyWrappingNodeValue extends NodeValue
+/**
+ * This NodeValue wraps a Core API Node and delegates method call to the
+ * Node instance.
+ */
+public class CoreNodeWrappingNodeValue extends NodeValue
 {
     private final Node node;
     private volatile TextArray labels;
     private volatile MapValue properties;
 
-    NodeProxyWrappingNodeValue( Node node )
+    CoreNodeWrappingNodeValue( Node node )
     {
         super( node.getId() );
         this.node = node;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/CoreRelationshipWrappingValue.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/CoreRelationshipWrappingValue.java
@@ -25,13 +25,17 @@ import org.neo4j.graphdb.Relationship;
 import org.neo4j.values.AnyValueWriter;
 import org.neo4j.values.storable.TextValue;
 import org.neo4j.values.storable.Values;
-import org.neo4j.values.virtual.RelationshipValue;
 import org.neo4j.values.virtual.MapValue;
 import org.neo4j.values.virtual.NodeValue;
+import org.neo4j.values.virtual.RelationshipValue;
 import org.neo4j.values.virtual.VirtualNodeValue;
 import org.neo4j.values.virtual.VirtualValues;
 
-public class RelationshipProxyWrappingValue extends RelationshipValue
+/**
+ * This RelationshipValue wraps a Core API Relationship and delegates method calls to the
+ * Relationship instance.
+ */
+public class CoreRelationshipWrappingValue extends RelationshipValue
 {
     private final Relationship relationship;
     private volatile TextValue type;
@@ -39,7 +43,7 @@ public class RelationshipProxyWrappingValue extends RelationshipValue
     private volatile NodeValue startNode;
     private volatile NodeValue endNode;
 
-    RelationshipProxyWrappingValue( Relationship relationship )
+    CoreRelationshipWrappingValue( Relationship relationship )
     {
         super( relationship.getId() );
         this.relationship = relationship;
@@ -111,9 +115,9 @@ public class RelationshipProxyWrappingValue extends RelationshipValue
     @Override
     public NodeValue otherNode( VirtualNodeValue node )
     {
-        if ( node instanceof NodeProxyWrappingNodeValue )
+        if ( node instanceof CoreNodeWrappingNodeValue )
         {
-            Node proxy = ((NodeProxyWrappingNodeValue) node).nodeProxy();
+            Node proxy = ((CoreNodeWrappingNodeValue) node).nodeProxy();
             return ValueUtils.fromNodeProxy( relationship.getOtherNode( proxy ) );
         }
         else

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ValueUtils.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/ValueUtils.java
@@ -42,11 +42,11 @@ import org.neo4j.values.storable.PointValue;
 import org.neo4j.values.storable.TextValue;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
-import org.neo4j.values.virtual.RelationshipValue;
 import org.neo4j.values.virtual.ListValue;
 import org.neo4j.values.virtual.MapValue;
 import org.neo4j.values.virtual.NodeValue;
 import org.neo4j.values.virtual.PathValue;
+import org.neo4j.values.virtual.RelationshipValue;
 import org.neo4j.values.virtual.VirtualValues;
 
 import static java.util.stream.StreamSupport.stream;
@@ -326,11 +326,25 @@ public final class ValueUtils
 
     public static NodeValue fromNodeProxy( Node node )
     {
-        return new NodeProxyWrappingNodeValue( node );
+        if ( node instanceof NodeValue )
+        {
+            return (NodeValue) node;
+        }
+        else
+        {
+            return new CoreNodeWrappingNodeValue( node );
+        }
     }
 
     public static RelationshipValue fromRelationshipProxy( Relationship relationship )
     {
-        return new RelationshipProxyWrappingValue( relationship );
+        if ( relationship instanceof RelationshipValue )
+        {
+            return (RelationshipValue) relationship;
+        }
+        else
+        {
+            return new CoreRelationshipWrappingValue( relationship );
+        }
     }
 }

--- a/community/values/src/main/java/org/neo4j/values/virtual/NodeValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/NodeValue.java
@@ -27,7 +27,7 @@ import static java.lang.String.format;
 
 public abstract class NodeValue extends VirtualNodeValue
 {
-    private final long id;
+    protected final long id;
 
     protected NodeValue( long id )
     {

--- a/community/values/src/main/java/org/neo4j/values/virtual/RelationshipValue.java
+++ b/community/values/src/main/java/org/neo4j/values/virtual/RelationshipValue.java
@@ -26,7 +26,7 @@ import static java.lang.String.format;
 
 public abstract class RelationshipValue extends VirtualRelationshipValue
 {
-    private final long id;
+    protected long id;
 
     protected RelationshipValue( long id )
     {


### PR DESCRIPTION
By instead letting `NodeProxy` and `RelationshipProxy` extend `NodeValue`
and `RelationshipValue` respectively we can remove a lot of wrapping in
the interpreted runtime. We cannot get rid of the wrapping altogether
since we must still support passing in `Node` and `Relationship` via
parameters.