### PR TITLE
Native memory allocation trackers

### DIFF
--- a/community/common/src/main/java/org/neo4j/memory/LocalMemoryTracker.java
+++ b/community/common/src/main/java/org/neo4j/memory/LocalMemoryTracker.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.memory;
+
+/**
+ * Memory allocation tracker that can be used in local context that required
+ * tracking of memory that is independent from global.
+ * All allocations/de-allocation reported to this trackers also will be reported to global tracker transparently.
+ */
+public class LocalMemoryTracker implements MemoryTracker, MemoryAllocationTracker
+{
+    private long allocatedBytes;
+    private GlobalMemoryTracker globalTracker = GlobalMemoryTracker.INSTANCE;
+
+    @Override
+    public void allocate( long allocatedBytes )
+    {
+        globalTracker.allocate( allocatedBytes );
+        this.allocatedBytes += allocatedBytes;
+    }
+
+    @Override
+    public void deallocate( long deallocatedBytes )
+    {
+        globalTracker.deallocate( deallocatedBytes );
+        this.allocatedBytes -= deallocatedBytes;
+    }
+
+    /**
+     * @return number of locally used bytes.
+     */
+    @Override
+    public long usedDirectMemory()
+    {
+        return allocatedBytes;
+    }
+}

--- a/community/common/src/main/java/org/neo4j/memory/MemoryAllocationTracker.java
+++ b/community/common/src/main/java/org/neo4j/memory/MemoryAllocationTracker.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.memory;
+
+/**
+ * Memory allocation tracker that tracks bytes allocation and de-allocation
+ */
+public interface MemoryAllocationTracker
+{
+    /**
+     * Record allocation of bytes
+     * @param allocatedBytes number of allocated bytes
+     */
+    void allocate( long allocatedBytes );
+
+    /**
+     * Record de-allocation of bytes
+     * @param deAllocatedBytes number of de0allocated bytes
+     */
+    void deallocate( long deAllocatedBytes );
+}

--- a/community/common/src/main/java/org/neo4j/memory/MemoryTracker.java
+++ b/community/common/src/main/java/org/neo4j/memory/MemoryTracker.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.memory;
+
+/**
+ * Tracker that capable to report number of allocated bytes.
+ * @see MemoryAllocationTracker
+ */
+public interface MemoryTracker
+{
+    /**
+     * @return number of bytes of direct memory that are used
+     */
+    long usedDirectMemory();
+}

--- a/community/common/src/test/java/org/neo4j/memory/GlobalMemoryTrackerTest.java
+++ b/community/common/src/test/java/org/neo4j/memory/GlobalMemoryTrackerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.memory;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class GlobalMemoryTrackerTest
+{
+
+    @Test
+    public void trackMemoryAllocations()
+    {
+        long initialUsedMemory = GlobalMemoryTracker.INSTANCE.usedDirectMemory();
+        GlobalMemoryTracker.INSTANCE.allocate( 10 );
+        GlobalMemoryTracker.INSTANCE.allocate( 20 );
+        GlobalMemoryTracker.INSTANCE.allocate( 40 );
+        assertEquals( 70, GlobalMemoryTracker.INSTANCE.usedDirectMemory() - initialUsedMemory );
+    }
+
+    @Test
+    public void trackMemoryDeallocations()
+    {
+        long initialUsedMemory = GlobalMemoryTracker.INSTANCE.usedDirectMemory();
+        GlobalMemoryTracker.INSTANCE.allocate( 100 );
+        assertEquals( 100, GlobalMemoryTracker.INSTANCE.usedDirectMemory() - initialUsedMemory );
+
+        GlobalMemoryTracker.INSTANCE.deallocate( 20 );
+        assertEquals( 80, GlobalMemoryTracker.INSTANCE.usedDirectMemory() - initialUsedMemory );
+
+        GlobalMemoryTracker.INSTANCE.deallocate( 40 );
+        assertEquals( 40, GlobalMemoryTracker.INSTANCE.usedDirectMemory() - initialUsedMemory );
+    }
+}

--- a/community/common/src/test/java/org/neo4j/memory/LocalMemoryTrackerTest.java
+++ b/community/common/src/test/java/org/neo4j/memory/LocalMemoryTrackerTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.memory;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class LocalMemoryTrackerTest
+{
+    @Test
+    public void trackMemoryAllocations()
+    {
+        LocalMemoryTracker memoryTracker = new LocalMemoryTracker();
+        memoryTracker.allocate( 10 );
+        memoryTracker.allocate( 20 );
+        memoryTracker.allocate( 40 );
+        assertEquals( 70, memoryTracker.usedDirectMemory());
+    }
+
+    @Test
+    public void trackMemoryDeallocations()
+    {
+        LocalMemoryTracker memoryTracker = new LocalMemoryTracker();
+        memoryTracker.allocate( 100 );
+        assertEquals( 100, memoryTracker.usedDirectMemory() );
+
+        memoryTracker.deallocate( 20 );
+        assertEquals( 80, memoryTracker.usedDirectMemory() );
+
+        memoryTracker.deallocate( 40 );
+        assertEquals( 40, memoryTracker.usedDirectMemory() );
+    }
+
+    @Test
+    public void localMemoryTrackerPropagatesAllocationsToGlobalTracker()
+    {
+        GlobalMemoryTracker globalMemoryTracker = GlobalMemoryTracker.INSTANCE;
+        long initialGlobalUsage = globalMemoryTracker.usedDirectMemory();
+        LocalMemoryTracker memoryTracker = new LocalMemoryTracker();
+
+        memoryTracker.allocate( 100 );
+        assertEquals( 100, memoryTracker.usedDirectMemory() );
+        assertEquals( 100, globalMemoryTracker.usedDirectMemory() - initialGlobalUsage );
+
+        memoryTracker.deallocate( 50 );
+        assertEquals( 50, memoryTracker.usedDirectMemory() );
+        assertEquals( 50, globalMemoryTracker.usedDirectMemory() - initialGlobalUsage );
+    }
+
+}

--- a/community/io/src/main/java/org/neo4j/io/mem/GrabAllocator.java
+++ b/community/io/src/main/java/org/neo4j/io/mem/GrabAllocator.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.io.mem;
 
+import org.neo4j.memory.MemoryAllocationTracker;
 import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
 import static org.neo4j.io.ByteUnit.kibiBytes;
@@ -39,6 +40,7 @@ public final class GrabAllocator implements MemoryAllocator
      * The amount of memory that this memory manager can still allocate.
      */
     private long memoryReserve;
+    private final MemoryAllocationTracker memoryTracker;
 
     private Grab grabs;
 
@@ -47,10 +49,12 @@ public final class GrabAllocator implements MemoryAllocator
      * given alignment size.
      * @param expectedMaxMemory The maximum amount of memory that this memory manager is expected to allocate. The
      * actual amount of memory used can end up greater than this value, if some of it gets wasted on alignment padding.
+     * @param memoryTracker memory usage tracker
      */
-    GrabAllocator( long expectedMaxMemory )
+    GrabAllocator( long expectedMaxMemory, MemoryAllocationTracker memoryTracker )
     {
         this.memoryReserve = expectedMaxMemory;
+        this.memoryTracker = memoryTracker;
     }
 
     @Override
@@ -93,12 +97,12 @@ public final class GrabAllocator implements MemoryAllocator
                 // This is a huge allocation. Put it in its own grab and keep any existing grab at the head.
                 grabSize = bytes;
                 Grab nextGrab = grabs == null ? null : grabs.next;
-                Grab allocationGrab = new Grab( nextGrab, grabSize );
+                Grab allocationGrab = new Grab( nextGrab, grabSize, memoryTracker );
                 if ( !allocationGrab.canAllocate( bytes ) )
                 {
                     allocationGrab.free();
                     grabSize = bytes + alignment;
-                    allocationGrab = new Grab( nextGrab, grabSize );
+                    allocationGrab = new Grab( nextGrab, grabSize, memoryTracker );
                 }
                 long allocation = allocationGrab.allocate( bytes, alignment );
                 grabs = grabs == null ? allocationGrab : grabs.setNext( allocationGrab );
@@ -111,7 +115,7 @@ public final class GrabAllocator implements MemoryAllocator
                 if ( grabSize < bytes )
                 {
                     grabSize = bytes;
-                    Grab grab = new Grab( grabs, grabSize );
+                    Grab grab = new Grab( grabs, grabSize, memoryTracker );
                     if ( grab.canAllocate( bytes ) )
                     {
                         memoryReserve -= grabSize;
@@ -121,7 +125,7 @@ public final class GrabAllocator implements MemoryAllocator
                     grab.free();
                     grabSize = bytes + alignment;
                 }
-                grabs = new Grab( grabs, grabSize );
+                grabs = new Grab( grabs, grabSize, memoryTracker );
                 memoryReserve -= grabSize;
             }
             return grabs.allocate( bytes, alignment );
@@ -162,8 +166,13 @@ public final class GrabAllocator implements MemoryAllocator
     protected synchronized void finalize() throws Throwable
     {
         super.finalize();
-        Grab current = grabs;
+        close();
+    }
 
+    @Override
+    public void close()
+    {
+        Grab current = grabs;
         while ( current != null )
         {
             current.free();
@@ -176,22 +185,25 @@ public final class GrabAllocator implements MemoryAllocator
         public final Grab next;
         private final long address;
         private final long limit;
+        private final MemoryAllocationTracker memoryTracker;
         private long nextPointer;
 
-        Grab( Grab next, long size )
+        Grab( Grab next, long size, MemoryAllocationTracker memoryTracker )
         {
             this.next = next;
-            this.address = UnsafeUtil.allocateMemory( size );
+            this.address = UnsafeUtil.allocateMemory( size, memoryTracker );
             this.limit = address + size;
+            this.memoryTracker = memoryTracker;
             nextPointer = address;
         }
 
-        Grab( Grab next, long address, long limit, long nextPointer )
+        Grab( Grab next, long address, long limit, long nextPointer, MemoryAllocationTracker memoryTracker )
         {
             this.next = next;
             this.address = address;
             this.limit = limit;
             this.nextPointer = nextPointer;
+            this.memoryTracker = memoryTracker;
         }
 
         private long nextAligned( long pointer, long alignment )
@@ -213,7 +225,7 @@ public final class GrabAllocator implements MemoryAllocator
 
         void free()
         {
-            UnsafeUtil.free( address );
+            UnsafeUtil.free( address, limit - address, memoryTracker );
         }
 
         boolean canAllocate( long bytes )
@@ -223,7 +235,7 @@ public final class GrabAllocator implements MemoryAllocator
 
         Grab setNext( Grab grab )
         {
-            return new Grab( grab, address, limit, nextPointer );
+            return new Grab( grab, address, limit, nextPointer, memoryTracker );
         }
 
         @Override

--- a/community/io/src/main/java/org/neo4j/io/mem/GrabAllocator.java
+++ b/community/io/src/main/java/org/neo4j/io/mem/GrabAllocator.java
@@ -166,13 +166,8 @@ public final class GrabAllocator implements MemoryAllocator
     protected synchronized void finalize() throws Throwable
     {
         super.finalize();
-        close();
-    }
-
-    @Override
-    public void close()
-    {
         Grab current = grabs;
+
         while ( current != null )
         {
             current.free();

--- a/community/io/src/main/java/org/neo4j/io/mem/MemoryAllocator.java
+++ b/community/io/src/main/java/org/neo4j/io/mem/MemoryAllocator.java
@@ -50,9 +50,4 @@ public interface MemoryAllocator
      * @throws OutOfMemoryError if the requested memory could not be allocated.
      */
     long allocateAligned( long bytes, long alignment );
-
-    /**
-     * Close allocator and release all allocated resources
-     */
-    void close();
 }

--- a/community/io/src/main/java/org/neo4j/io/mem/MemoryAllocator.java
+++ b/community/io/src/main/java/org/neo4j/io/mem/MemoryAllocator.java
@@ -20,15 +20,16 @@
 package org.neo4j.io.mem;
 
 import org.neo4j.io.ByteUnit;
+import org.neo4j.memory.MemoryAllocationTracker;
 
 /**
  * A MemoryAllocator is simple: it only allocates memory, until it itself is finalizable and frees it all in one go.
  */
 public interface MemoryAllocator
 {
-    static MemoryAllocator createAllocator( String expectedMemory )
+    static MemoryAllocator createAllocator( String expectedMemory, MemoryAllocationTracker memoryTracker )
     {
-        return new GrabAllocator( ByteUnit.parse( expectedMemory ) );
+        return new GrabAllocator( ByteUnit.parse( expectedMemory ), memoryTracker );
     }
 
     /**
@@ -49,4 +50,9 @@ public interface MemoryAllocator
      * @throws OutOfMemoryError if the requested memory could not be allocated.
      */
     long allocateAligned( long bytes, long alignment );
+
+    /**
+     * Close allocator and release all allocated resources
+     */
+    void close();
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/StandalonePageCacheFactory.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/StandalonePageCacheFactory.java
@@ -26,6 +26,7 @@ import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.impl.SingleFilePageSwapperFactory;
 import org.neo4j.io.pagecache.tracing.PageCacheTracer;
 import org.neo4j.io.pagecache.tracing.cursor.DefaultPageCursorTracerSupplier;
+import org.neo4j.memory.GlobalMemoryTracker;
 
 /*
  * This class is an helper to allow to construct properly a page cache in the few places we need it without all
@@ -47,7 +48,7 @@ public final class StandalonePageCacheFactory
 
         PageCacheTracer cacheTracer = PageCacheTracer.NULL;
         DefaultPageCursorTracerSupplier cursorTracerSupplier = DefaultPageCursorTracerSupplier.INSTANCE;
-        MemoryAllocator memoryAllocator = MemoryAllocator.createAllocator( "8 MiB" );
+        MemoryAllocator memoryAllocator = MemoryAllocator.createAllocator( "8 MiB", GlobalMemoryTracker.INSTANCE );
         return new MuninnPageCache( factory, memoryAllocator, cacheTracer, cursorTracerSupplier );
     }
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/VictimPageReference.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/VictimPageReference.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.io.pagecache.impl.muninn;
 
+import org.neo4j.memory.MemoryAllocationTracker;
 import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
 class VictimPageReference
@@ -31,14 +32,14 @@ class VictimPageReference
         // All state is static
     }
 
-    static synchronized long getVictimPage( int pageSize )
+    static synchronized long getVictimPage( int pageSize, MemoryAllocationTracker allocationTracker )
     {
         if ( victimPageSize < pageSize )
         {
             // Note that we NEVER free any old victim pages. This is important because we cannot tell
             // when we are done using them. Therefor, victim pages are allocated and stay allocated
             // until our process terminates.
-            victimPagePointer = UnsafeUtil.allocateMemory( pageSize );
+            victimPagePointer = UnsafeUtil.allocateMemory( pageSize, allocationTracker );
             victimPageSize = pageSize;
         }
         return victimPagePointer;

--- a/community/io/src/test/java/org/neo4j/io/mem/MemoryAllocatorTest.java
+++ b/community/io/src/test/java/org/neo4j/io/mem/MemoryAllocatorTest.java
@@ -119,10 +119,10 @@ public class MemoryAllocatorTest
     }
 
     @Test
-    public void trackMemoryAllocations()
+    public void trackMemoryAllocations() throws Throwable
     {
         LocalMemoryTracker memoryTracker = new LocalMemoryTracker();
-        MemoryAllocator allocator = MemoryAllocator.createAllocator( "2m", memoryTracker );
+        GrabAllocator allocator = (GrabAllocator) MemoryAllocator.createAllocator( "2m", memoryTracker );
 
         assertEquals( 0, memoryTracker.usedDirectMemory() );
 
@@ -130,7 +130,8 @@ public class MemoryAllocatorTest
 
         assertEquals( ByteUnit.mebiBytes( 1 ), memoryTracker.usedDirectMemory() );
 
-        allocator.close();
+        //noinspection FinalizeCalledExplicitly
+        allocator.finalize();
         assertEquals( 0, memoryTracker.usedDirectMemory() );
     }
 }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageSwapperTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageSwapperTest.java
@@ -43,6 +43,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.neo4j.io.mem.MemoryAllocator;
+import org.neo4j.memory.LocalMemoryTracker;
 import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
@@ -70,7 +71,7 @@ public abstract class PageSwapperTest
 
     private final ConcurrentLinkedQueue<PageSwapperFactory> openedFactories = new ConcurrentLinkedQueue<>();
     private final ConcurrentLinkedQueue<PageSwapper> openedSwappers = new ConcurrentLinkedQueue<>();
-    private final MemoryAllocator mman = MemoryAllocator.createAllocator( "32 KiB" );
+    private final MemoryAllocator mman = MemoryAllocator.createAllocator( "32 KiB", new LocalMemoryTracker() );
 
     protected abstract PageSwapperFactory swapperFactory() throws Exception;
 

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/LargePageListIT.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/LargePageListIT.java
@@ -25,6 +25,8 @@ import java.util.stream.IntStream;
 
 import org.neo4j.io.ByteUnit;
 import org.neo4j.io.mem.MemoryAllocator;
+import org.neo4j.memory.GlobalMemoryTracker;
+import org.neo4j.memory.LocalMemoryTracker;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -43,9 +45,9 @@ public class LargePageListIT
         long pageCacheSize = ByteUnit.gibiBytes( 513 ) + pageSize;
         int pages = Math.toIntExact( pageCacheSize / pageSize );
 
-        MemoryAllocator mman = MemoryAllocator.createAllocator( "2 GiB" );
+        MemoryAllocator mman = MemoryAllocator.createAllocator( "2 GiB", new LocalMemoryTracker() );
         SwapperSet swappers = new SwapperSet();
-        long victimPage = VictimPageReference.getVictimPage( pageSize );
+        long victimPage = VictimPageReference.getVictimPage( pageSize, GlobalMemoryTracker.INSTANCE );
 
         PageList pageList = new PageList( pages, pageSize, mman, swappers, victimPage, Long.BYTES );
 

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/LargePageListIT.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/LargePageListIT.java
@@ -26,7 +26,6 @@ import java.util.stream.IntStream;
 import org.neo4j.io.ByteUnit;
 import org.neo4j.io.mem.MemoryAllocator;
 import org.neo4j.memory.GlobalMemoryTracker;
-import org.neo4j.memory.LocalMemoryTracker;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -45,7 +44,7 @@ public class LargePageListIT
         long pageCacheSize = ByteUnit.gibiBytes( 513 ) + pageSize;
         int pages = Math.toIntExact( pageCacheSize / pageSize );
 
-        MemoryAllocator mman = MemoryAllocator.createAllocator( "2 GiB", new LocalMemoryTracker() );
+        MemoryAllocator mman = MemoryAllocator.createAllocator( "2 GiB", GlobalMemoryTracker.INSTANCE );
         SwapperSet swappers = new SwapperSet();
         long victimPage = VictimPageReference.getVictimPage( pageSize, GlobalMemoryTracker.INSTANCE );
 

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCacheFixture.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCacheFixture.java
@@ -27,6 +27,7 @@ import org.neo4j.io.pagecache.PageCacheTestSupport;
 import org.neo4j.io.pagecache.PageSwapperFactory;
 import org.neo4j.io.pagecache.tracing.PageCacheTracer;
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier;
+import org.neo4j.memory.LocalMemoryTracker;
 
 public class MuninnPageCacheFixture extends PageCacheTestSupport.Fixture<MuninnPageCache>
 {
@@ -37,7 +38,8 @@ public class MuninnPageCacheFixture extends PageCacheTestSupport.Fixture<MuninnP
                                             PageCacheTracer tracer, PageCursorTracerSupplier cursorTracerSupplier )
     {
         long memory = MuninnPageCache.memoryRequiredForPages( maxPages );
-        MemoryAllocator allocator = MemoryAllocator.createAllocator( String.valueOf( memory ) );
+        MemoryAllocator allocator = MemoryAllocator.createAllocator( String.valueOf( memory ),
+                new LocalMemoryTracker() );
         return new MuninnPageCache( swapperFactory, allocator, tracer, cursorTracerSupplier );
     }
 

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/PageListTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/PageListTest.java
@@ -51,7 +51,6 @@ import org.neo4j.io.pagecache.tracing.FlushEvent;
 import org.neo4j.io.pagecache.tracing.FlushEventOpportunity;
 import org.neo4j.io.pagecache.tracing.PageFaultEvent;
 import org.neo4j.memory.GlobalMemoryTracker;
-import org.neo4j.memory.LocalMemoryTracker;
 import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -89,7 +88,7 @@ public class PageListTest
     public static void setUpStatics()
     {
         executor = Executors.newCachedThreadPool( new DaemonThreadFactory() );
-        mman = MemoryAllocator.createAllocator( "1 MiB", new LocalMemoryTracker() );
+        mman = MemoryAllocator.createAllocator( "1 MiB", GlobalMemoryTracker.INSTANCE );
     }
 
     @AfterClass

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/SequenceLockStressIT.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/SequenceLockStressIT.java
@@ -35,7 +35,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.neo4j.memory.GlobalMemoryTracker;
 import org.neo4j.test.rule.RepeatRule;
 import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
@@ -57,7 +56,7 @@ public class SequenceLockStressIT
     @Before
     public void allocateLock()
     {
-        lockAddr = UnsafeUtil.allocateMemory( Long.BYTES, GlobalMemoryTracker.INSTANCE );
+        lockAddr = UnsafeUtil.allocateMemory( Long.BYTES );
         UnsafeUtil.putLong( lockAddr, 0 );
     }
 

--- a/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/SequenceLockStressIT.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/impl/muninn/SequenceLockStressIT.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.neo4j.memory.GlobalMemoryTracker;
 import org.neo4j.test.rule.RepeatRule;
 import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
@@ -56,7 +57,7 @@ public class SequenceLockStressIT
     @Before
     public void allocateLock()
     {
-        lockAddr = UnsafeUtil.allocateMemory( Long.BYTES );
+        lockAddr = UnsafeUtil.allocateMemory( Long.BYTES, GlobalMemoryTracker.INSTANCE );
         UnsafeUtil.putLong( lockAddr, 0 );
     }
 

--- a/community/io/src/test/java/org/neo4j/test/rule/PageCacheRule.java
+++ b/community/io/src/test/java/org/neo4j/test/rule/PageCacheRule.java
@@ -35,6 +35,7 @@ import org.neo4j.io.pagecache.impl.SingleFilePageSwapperFactory;
 import org.neo4j.io.pagecache.impl.muninn.MuninnPageCache;
 import org.neo4j.io.pagecache.tracing.PageCacheTracer;
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier;
+import org.neo4j.memory.LocalMemoryTracker;
 
 public class PageCacheRule extends ExternalResource
 {
@@ -193,7 +194,8 @@ public class PageCacheRule extends ExternalResource
         SingleFilePageSwapperFactory factory = new SingleFilePageSwapperFactory();
         factory.open( fs, Configuration.EMPTY );
 
-        MemoryAllocator mman = MemoryAllocator.createAllocator( selectConfig( baseConfig.memory, overriddenConfig.memory, "8 MiB" ) );
+        MemoryAllocator mman = MemoryAllocator.createAllocator( selectConfig( baseConfig.memory, overriddenConfig.memory, "8 MiB" ),
+                new LocalMemoryTracker() );
         if ( pageSize != null )
         {
             pageCache = new MuninnPageCache( factory, mman, pageSize, cacheTracer, cursorTracerSupplier );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfiguringPageCacheFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ConfiguringPageCacheFactory.java
@@ -23,6 +23,7 @@ import org.neo4j.helpers.Service;
 import org.neo4j.io.ByteUnit;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.mem.MemoryAllocator;
+import org.neo4j.io.os.OsBeanUtil;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.io.pagecache.PageSwapperFactory;
 import org.neo4j.io.pagecache.impl.SingleFilePageSwapperFactory;
@@ -30,8 +31,8 @@ import org.neo4j.io.pagecache.impl.muninn.MuninnPageCache;
 import org.neo4j.io.pagecache.tracing.PageCacheTracer;
 import org.neo4j.io.pagecache.tracing.cursor.PageCursorTracerSupplier;
 import org.neo4j.kernel.configuration.Config;
-import org.neo4j.io.os.OsBeanUtil;
 import org.neo4j.logging.Log;
+import org.neo4j.memory.GlobalMemoryTracker;
 
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.mapped_memory_page_size;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.pagecache_memory;
@@ -97,7 +98,7 @@ public class ConfiguringPageCacheFactory
             pageCacheMemorySetting = "" + heuristic;
         }
 
-        return MemoryAllocator.createAllocator( pageCacheMemorySetting );
+        return MemoryAllocator.createAllocator( pageCacheMemorySetting, GlobalMemoryTracker.INSTANCE );
     }
 
     public static long defaultHeuristicPageCacheMemory()

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/MemoryStatsVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/MemoryStatsVisitor.java
@@ -24,7 +24,8 @@ package org.neo4j.unsafe.impl.batchimport.cache;
  */
 public interface MemoryStatsVisitor
 {
-    Visitable NONE = visitor -> {   // report no memory
+    Visitable NONE = visitor ->
+    {   // report no memory
     };
 
     interface Visitable

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/MemoryStatsVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/MemoryStatsVisitor.java
@@ -24,12 +24,7 @@ package org.neo4j.unsafe.impl.batchimport.cache;
  */
 public interface MemoryStatsVisitor
 {
-    Visitable NONE = new Visitable()
-    {
-        @Override
-        public void acceptMemoryStatsVisitor( MemoryStatsVisitor visitor )
-        {   // report no memory
-        }
+    Visitable NONE = visitor -> {   // report no memory
     };
 
     interface Visitable

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/NumberArrayFactory.java
@@ -28,6 +28,7 @@ import java.util.function.Function;
 
 import org.neo4j.helpers.Exceptions;
 import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.memory.GlobalMemoryTracker;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -79,19 +80,19 @@ public interface NumberArrayFactory
         @Override
         public IntArray newIntArray( long length, int defaultValue, long base )
         {
-            return new OffHeapIntArray( length, defaultValue, base );
+            return new OffHeapIntArray( length, defaultValue, base, GlobalMemoryTracker.INSTANCE );
         }
 
         @Override
         public LongArray newLongArray( long length, long defaultValue, long base )
         {
-            return new OffHeapLongArray( length, defaultValue, base );
+            return new OffHeapLongArray( length, defaultValue, base, GlobalMemoryTracker.INSTANCE );
         }
 
         @Override
         public ByteArray newByteArray( long length, byte[] defaultValue, long base )
         {
-            return new OffHeapByteArray( length, defaultValue, base );
+            return new OffHeapByteArray( length, defaultValue, base, GlobalMemoryTracker.INSTANCE );
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapByteArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapByteArray.java
@@ -19,15 +19,16 @@
  */
 package org.neo4j.unsafe.impl.batchimport.cache;
 
+import org.neo4j.memory.MemoryAllocationTracker;
 import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
 public class OffHeapByteArray extends OffHeapNumberArray<ByteArray> implements ByteArray
 {
     private final byte[] defaultValue;
 
-    protected OffHeapByteArray( long length, byte[] defaultValue, long base )
+    protected OffHeapByteArray( long length, byte[] defaultValue, long base, MemoryAllocationTracker allocationTracker )
     {
-        super( length, defaultValue.length, base );
+        super( length, defaultValue.length, base, allocationTracker );
         this.defaultValue = defaultValue;
         clear();
     }
@@ -86,7 +87,7 @@ public class OffHeapByteArray extends OffHeapNumberArray<ByteArray> implements B
         }
         else
         {
-            long intermediary = UnsafeUtil.allocateMemory( itemSize );
+            long intermediary = UnsafeUtil.allocateMemory( itemSize, allocationTracker );
             for ( int i = 0; i < defaultValue.length; i++ )
             {
                 UnsafeUtil.putByte( intermediary + i, defaultValue[i] );
@@ -96,7 +97,7 @@ public class OffHeapByteArray extends OffHeapNumberArray<ByteArray> implements B
             {
                 UnsafeUtil.copyMemory( intermediary, adr, itemSize );
             }
-            UnsafeUtil.free( intermediary );
+            UnsafeUtil.free( intermediary, itemSize, allocationTracker );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapIntArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapIntArray.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.unsafe.impl.batchimport.cache;
 
+import org.neo4j.memory.MemoryAllocationTracker;
 import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
 /**
@@ -29,9 +30,9 @@ public class OffHeapIntArray extends OffHeapRegularNumberArray<IntArray> impleme
 {
     private final int defaultValue;
 
-    public OffHeapIntArray( long length, int defaultValue, long base )
+    public OffHeapIntArray( long length, int defaultValue, long base, MemoryAllocationTracker allocationTracker )
     {
-        super( length, 2, base );
+        super( length, 2, base, allocationTracker );
         this.defaultValue = defaultValue;
         clear();
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapLongArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapLongArray.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.unsafe.impl.batchimport.cache;
 
+import org.neo4j.memory.MemoryAllocationTracker;
 import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
 /**
@@ -29,9 +30,9 @@ public class OffHeapLongArray extends OffHeapRegularNumberArray<LongArray> imple
 {
     private final long defaultValue;
 
-    public OffHeapLongArray( long length, long defaultValue, long base )
+    public OffHeapLongArray( long length, long defaultValue, long base, MemoryAllocationTracker allocationTracker )
     {
-        super( length, 3, base );
+        super( length, 3, base, allocationTracker );
         this.defaultValue = defaultValue;
         clear();
     }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapNumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapNumberArray.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.unsafe.impl.batchimport.cache;
 
+import org.neo4j.memory.MemoryAllocationTracker;
 import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
 public abstract class OffHeapNumberArray<N extends NumberArray<N>> extends BaseNumberArray<N>
@@ -26,13 +27,16 @@ public abstract class OffHeapNumberArray<N extends NumberArray<N>> extends BaseN
     private final long allocatedAddress;
     protected final long address;
     protected final long length;
+    protected final MemoryAllocationTracker allocationTracker;
+    private final long allocatedBytes;
     private boolean closed;
 
-    protected OffHeapNumberArray( long length, int itemSize, long base )
+    protected OffHeapNumberArray( long length, int itemSize, long base, MemoryAllocationTracker allocationTracker )
     {
         super( itemSize, base );
         UnsafeUtil.assertHasUnsafe();
         this.length = length;
+        this.allocationTracker = allocationTracker;
 
         long dataSize = length * itemSize;
         boolean itemSizeIsPowerOfTwo = Integer.bitCount( itemSize ) == 1;
@@ -41,13 +45,15 @@ public abstract class OffHeapNumberArray<N extends NumberArray<N>> extends BaseN
             // we can end up here even if we require aligned memory access. Reason is that item size
             // isn't power of two anyway and so we have to fallback to safer means of accessing the memory,
             // i.e. byte for byte.
-            this.allocatedAddress = this.address = UnsafeUtil.allocateMemory( dataSize );
+            allocatedBytes = dataSize;
+            this.allocatedAddress = this.address = UnsafeUtil.allocateMemory( allocatedBytes, allocationTracker );
         }
         else
         {
             // the item size is a power of two and we're required to access memory aligned
             // so we can allocate a bit more to ensure we can get an aligned memory address to start from.
-            this.allocatedAddress = UnsafeUtil.allocateMemory( dataSize + itemSize - 1 );
+            allocatedBytes = dataSize + itemSize - 1;
+            this.allocatedAddress = UnsafeUtil.allocateMemory( allocatedBytes, allocationTracker );
             this.address = UnsafeUtil.alignedMemory( allocatedAddress, itemSize );
         }
     }
@@ -61,7 +67,7 @@ public abstract class OffHeapNumberArray<N extends NumberArray<N>> extends BaseN
     @Override
     public void acceptMemoryStatsVisitor( MemoryStatsVisitor visitor )
     {
-        visitor.offHeapUsage( length * itemSize );
+        visitor.offHeapUsage( allocatedBytes );
     }
 
     @Override
@@ -72,7 +78,7 @@ public abstract class OffHeapNumberArray<N extends NumberArray<N>> extends BaseN
             if ( length > 0 )
             {
                 // Allocating 0 bytes actually returns address 0
-                UnsafeUtil.free( allocatedAddress );
+                UnsafeUtil.free( allocatedAddress, allocatedBytes, allocationTracker );
             }
             closed = true;
         }

--- a/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapRegularNumberArray.java
+++ b/community/kernel/src/main/java/org/neo4j/unsafe/impl/batchimport/cache/OffHeapRegularNumberArray.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.unsafe.impl.batchimport.cache;
 
+import org.neo4j.memory.MemoryAllocationTracker;
+
 /**
  * Base class for common functionality for any {@link NumberArray} where the data lives off-heap.
  */
@@ -26,9 +28,9 @@ abstract class OffHeapRegularNumberArray<N extends NumberArray<N>> extends OffHe
 {
     protected final int shift;
 
-    protected OffHeapRegularNumberArray( long length, int shift, long base )
+    protected OffHeapRegularNumberArray( long length, int shift, long base, MemoryAllocationTracker allocationTracker )
     {
-        super( length, 1 << shift, base );
+        super( length, 1 << shift, base, allocationTracker );
         this.shift = shift;
     }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/ResourceTypesIT.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/locking/ResourceTypesIT.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveLongLongMap;
+import org.neo4j.memory.GlobalMemoryTracker;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -40,7 +41,7 @@ public class ResourceTypesIT
     public void indexEntryHashing()
     {
         int collisions = 0;
-        try ( PrimitiveLongLongMap map = Primitive.offHeapLongLongMap( 35_000_000 ) )
+        try ( PrimitiveLongLongMap map = Primitive.offHeapLongLongMap( 35_000_000, GlobalMemoryTracker.INSTANCE ) )
         {
 
             int labelIdCount = 50;

--- a/community/kernel/src/test/java/org/neo4j/test/FakeCpuClock.java
+++ b/community/kernel/src/test/java/org/neo4j/test/FakeCpuClock.java
@@ -19,14 +19,15 @@
  */
 package org.neo4j.test;
 
-import java.util.concurrent.TimeUnit;
-
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
+import java.util.concurrent.TimeUnit;
+
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveLongLongMap;
+import org.neo4j.memory.GlobalMemoryTracker;
 import org.neo4j.resources.CpuClock;
 
 public class FakeCpuClock extends CpuClock implements TestRule
@@ -39,7 +40,7 @@ public class FakeCpuClock extends CpuClock implements TestRule
             return -1;
         }
     };
-    private final PrimitiveLongLongMap cpuTimes = Primitive.offHeapLongLongMap();
+    private final PrimitiveLongLongMap cpuTimes = Primitive.offHeapLongLongMap( GlobalMemoryTracker.INSTANCE );
 
     @Override
     public long cpuTimeNanos( long threadId )

--- a/community/kernel/src/test/java/org/neo4j/test/FakeHeapAllocation.java
+++ b/community/kernel/src/test/java/org/neo4j/test/FakeHeapAllocation.java
@@ -24,6 +24,7 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 import org.neo4j.collection.primitive.PrimitiveLongLongMap;
+import org.neo4j.memory.GlobalMemoryTracker;
 import org.neo4j.resources.HeapAllocation;
 
 import static java.lang.Thread.currentThread;
@@ -31,7 +32,7 @@ import static org.neo4j.collection.primitive.Primitive.offHeapLongLongMap;
 
 public class FakeHeapAllocation extends HeapAllocation implements TestRule
 {
-    private final PrimitiveLongLongMap allocation = offHeapLongLongMap();
+    private final PrimitiveLongLongMap allocation = offHeapLongLongMap( GlobalMemoryTracker.INSTANCE );
 
     @Override
     public long allocatedBytes( long threadId )

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/Primitive.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/Primitive.java
@@ -36,6 +36,7 @@ import org.neo4j.collection.primitive.hopscotch.PrimitiveLongHashSet;
 import org.neo4j.collection.primitive.hopscotch.PrimitiveLongIntHashMap;
 import org.neo4j.collection.primitive.hopscotch.PrimitiveLongLongHashMap;
 import org.neo4j.collection.primitive.hopscotch.PrimitiveLongObjectHashMap;
+import org.neo4j.memory.MemoryAllocationTracker;
 
 import static org.neo4j.collection.primitive.hopscotch.HopScotchHashingAlgorithm.NO_MONITOR;
 
@@ -82,14 +83,14 @@ public class Primitive
                 VALUE_MARKER, NO_MONITOR );
     }
 
-    public static PrimitiveLongSet offHeapLongSet()
+    public static PrimitiveLongSet offHeapLongSet( MemoryAllocationTracker allocationTracker )
     {
-        return offHeapLongSet( DEFAULT_OFFHEAP_CAPACITY );
+        return offHeapLongSet( DEFAULT_OFFHEAP_CAPACITY, allocationTracker );
     }
 
-    public static PrimitiveLongSet offHeapLongSet( int initialCapacity )
+    public static PrimitiveLongSet offHeapLongSet( int initialCapacity, MemoryAllocationTracker allocationTracker )
     {
-        return new PrimitiveLongHashSet( new LongKeyUnsafeTable<>( initialCapacity, VALUE_MARKER ),
+        return new PrimitiveLongHashSet( new LongKeyUnsafeTable<>( initialCapacity, VALUE_MARKER, allocationTracker ),
                 VALUE_MARKER, NO_MONITOR );
     }
 
@@ -113,14 +114,14 @@ public class Primitive
         return new PrimitiveLongLongHashMap( new LongKeyLongValueTable( initialCapacity ), NO_MONITOR );
     }
 
-    public static PrimitiveLongLongMap offHeapLongLongMap()
+    public static PrimitiveLongLongMap offHeapLongLongMap( MemoryAllocationTracker allocationTracker )
     {
-        return offHeapLongLongMap( DEFAULT_OFFHEAP_CAPACITY );
+        return offHeapLongLongMap( DEFAULT_OFFHEAP_CAPACITY, allocationTracker );
     }
 
-    public static PrimitiveLongLongMap offHeapLongLongMap( int initialCapacity )
+    public static PrimitiveLongLongMap offHeapLongLongMap( int initialCapacity, MemoryAllocationTracker allocationTracker )
     {
-        return new PrimitiveLongLongHashMap( new LongKeyLongValueUnsafeTable( initialCapacity ), NO_MONITOR );
+        return new PrimitiveLongLongHashMap( new LongKeyLongValueUnsafeTable( initialCapacity, allocationTracker ), NO_MONITOR );
     }
 
     public static <VALUE> PrimitiveLongObjectMap<VALUE> longObjectMap()
@@ -144,15 +145,15 @@ public class Primitive
                 VALUE_MARKER, NO_MONITOR );
     }
 
-    public static PrimitiveIntSet offHeapIntSet()
+    public static PrimitiveIntSet offHeapIntSet( MemoryAllocationTracker allocationTracker )
     {
-        return new PrimitiveIntHashSet( new IntKeyUnsafeTable<>( 1 << 20, VALUE_MARKER ),
+        return new PrimitiveIntHashSet( new IntKeyUnsafeTable<>( 1 << 20, VALUE_MARKER, allocationTracker ),
                 VALUE_MARKER, NO_MONITOR );
     }
 
-    public static PrimitiveIntSet offHeapIntSet( int initialCapacity )
+    public static PrimitiveIntSet offHeapIntSet( int initialCapacity, MemoryAllocationTracker allocationTracker )
     {
-        return new PrimitiveIntHashSet( new IntKeyUnsafeTable<>( initialCapacity, VALUE_MARKER ),
+        return new PrimitiveIntHashSet( new IntKeyUnsafeTable<>( initialCapacity, VALUE_MARKER, allocationTracker ),
                 VALUE_MARKER, NO_MONITOR );
     }
 

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/Primitive.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/Primitive.java
@@ -147,7 +147,7 @@ public class Primitive
 
     public static PrimitiveIntSet offHeapIntSet( MemoryAllocationTracker allocationTracker )
     {
-        return new PrimitiveIntHashSet( new IntKeyUnsafeTable<>( 1 << 20, VALUE_MARKER, allocationTracker ),
+        return new PrimitiveIntHashSet( new IntKeyUnsafeTable<>( DEFAULT_OFFHEAP_CAPACITY, VALUE_MARKER, allocationTracker ),
                 VALUE_MARKER, NO_MONITOR );
     }
 
@@ -164,7 +164,7 @@ public class Primitive
 
     public static <VALUE> PrimitiveIntObjectMap<VALUE> intObjectMap( int initialCapacity )
     {
-        return new PrimitiveIntObjectHashMap<>( new IntKeyObjectValueTable<VALUE>( initialCapacity ), NO_MONITOR );
+        return new PrimitiveIntObjectHashMap<>( new IntKeyObjectValueTable<>( initialCapacity ), NO_MONITOR );
     }
 
     public static PrimitiveIntLongMap intLongMap()

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/Primitive.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/Primitive.java
@@ -36,6 +36,7 @@ import org.neo4j.collection.primitive.hopscotch.PrimitiveLongHashSet;
 import org.neo4j.collection.primitive.hopscotch.PrimitiveLongIntHashMap;
 import org.neo4j.collection.primitive.hopscotch.PrimitiveLongLongHashMap;
 import org.neo4j.collection.primitive.hopscotch.PrimitiveLongObjectHashMap;
+import org.neo4j.memory.GlobalMemoryTracker;
 import org.neo4j.memory.MemoryAllocationTracker;
 
 import static org.neo4j.collection.primitive.hopscotch.HopScotchHashingAlgorithm.NO_MONITOR;
@@ -83,6 +84,11 @@ public class Primitive
                 VALUE_MARKER, NO_MONITOR );
     }
 
+    public static PrimitiveLongSet offHeapLongSet()
+    {
+        return offHeapLongSet( GlobalMemoryTracker.INSTANCE );
+    }
+
     public static PrimitiveLongSet offHeapLongSet( MemoryAllocationTracker allocationTracker )
     {
         return offHeapLongSet( DEFAULT_OFFHEAP_CAPACITY, allocationTracker );
@@ -114,6 +120,11 @@ public class Primitive
         return new PrimitiveLongLongHashMap( new LongKeyLongValueTable( initialCapacity ), NO_MONITOR );
     }
 
+    public static PrimitiveLongLongMap offHeapLongLongMap()
+    {
+        return offHeapLongLongMap( GlobalMemoryTracker.INSTANCE );
+    }
+
     public static PrimitiveLongLongMap offHeapLongLongMap( MemoryAllocationTracker allocationTracker )
     {
         return offHeapLongLongMap( DEFAULT_OFFHEAP_CAPACITY, allocationTracker );
@@ -143,6 +154,11 @@ public class Primitive
     {
         return new PrimitiveIntHashSet( new IntKeyTable<>( initialCapacity, VALUE_MARKER ),
                 VALUE_MARKER, NO_MONITOR );
+    }
+
+    public static PrimitiveIntSet offHeapIntSet()
+    {
+        return offHeapIntSet( GlobalMemoryTracker.INSTANCE );
     }
 
     public static PrimitiveIntSet offHeapIntSet( MemoryAllocationTracker allocationTracker )

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/IntKeyUnsafeTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/IntKeyUnsafeTable.java
@@ -19,13 +19,14 @@
  */
 package org.neo4j.collection.primitive.hopscotch;
 
+import org.neo4j.memory.MemoryAllocationTracker;
 import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
 public class IntKeyUnsafeTable<VALUE> extends UnsafeTable<VALUE>
 {
-    public IntKeyUnsafeTable( int capacity, VALUE valueMarker )
+    public IntKeyUnsafeTable( int capacity, VALUE valueMarker, MemoryAllocationTracker allocationTracker )
     {
-        super( capacity, 4, valueMarker );
+        super( capacity, 4, valueMarker, allocationTracker );
     }
 
     @Override
@@ -46,6 +47,6 @@ public class IntKeyUnsafeTable<VALUE> extends UnsafeTable<VALUE>
     @Override
     protected Table<VALUE> newInstance( int newCapacity )
     {
-        return new IntKeyUnsafeTable<>( newCapacity, valueMarker );
+        return new IntKeyUnsafeTable<>( newCapacity, valueMarker, allocationTracker );
     }
 }

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyLongValueUnsafeTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/LongKeyLongValueUnsafeTable.java
@@ -19,11 +19,13 @@
  */
 package org.neo4j.collection.primitive.hopscotch;
 
+import org.neo4j.memory.MemoryAllocationTracker;
+
 public class LongKeyLongValueUnsafeTable extends UnsafeTable<long[]>
 {
-    public LongKeyLongValueUnsafeTable( int capacity )
+    public LongKeyLongValueUnsafeTable( int capacity, MemoryAllocationTracker allocationTracker )
     {
-        super( capacity, 16, new long[1] );
+        super( capacity, 16, new long[1], allocationTracker );
     }
 
     @Override
@@ -77,6 +79,6 @@ public class LongKeyLongValueUnsafeTable extends UnsafeTable<long[]>
     @Override
     protected Table<long[]> newInstance( int newCapacity )
     {
-        return new LongKeyLongValueUnsafeTable( newCapacity );
+        return new LongKeyLongValueUnsafeTable( newCapacity, allocationTracker );
     }
 }

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/UnsafeTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/UnsafeTable.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.collection.primitive.hopscotch;
 
+import org.neo4j.memory.MemoryAllocationTracker;
 import org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil;
 
 public abstract class UnsafeTable<VALUE> extends PowerOfTwoQuantizedTable<VALUE>
@@ -26,16 +27,19 @@ public abstract class UnsafeTable<VALUE> extends PowerOfTwoQuantizedTable<VALUE>
     private final int bytesPerKey;
     private final int bytesPerEntry;
     private final long dataSize;
+    private final long bytesToAllocate;
     // address which should be free when closing
     private final long allocatedAddress;
     // address which should be used to access the table, the address where the table actually starts at
     private final long address;
     protected final VALUE valueMarker;
+    protected final MemoryAllocationTracker allocationTracker;
 
-    protected UnsafeTable( int capacity, int bytesPerKey, VALUE valueMarker )
+    protected UnsafeTable( int capacity, int bytesPerKey, VALUE valueMarker, MemoryAllocationTracker allocationTracker )
     {
         super( capacity, 32 );
         UnsafeUtil.assertHasUnsafe();
+        this.allocationTracker = allocationTracker;
         this.bytesPerKey = bytesPerKey;
         this.bytesPerEntry = 4 + bytesPerKey;
         this.valueMarker = valueMarker;
@@ -54,7 +58,8 @@ public abstract class UnsafeTable<VALUE> extends PowerOfTwoQuantizedTable<VALUE>
 
         if ( UnsafeUtil.allowUnalignedMemoryAccess )
         {
-            this.allocatedAddress = this.address = UnsafeUtil.allocateMemory( dataSize );
+            bytesToAllocate = dataSize;
+            this.allocatedAddress = this.address = allocateMemory( bytesToAllocate );
         }
         else
         {
@@ -69,7 +74,8 @@ public abstract class UnsafeTable<VALUE> extends PowerOfTwoQuantizedTable<VALUE>
                         " yielding a bytesPerEntry:" + bytesPerEntry + ", which isn't 4-byte aligned." );
             }
 
-            this.allocatedAddress = UnsafeUtil.allocateMemory( dataSize + Integer.BYTES - 1 );
+            bytesToAllocate = dataSize + Integer.BYTES - 1;
+            this.allocatedAddress = allocateMemory( bytesToAllocate );
             this.address = UnsafeUtil.alignedMemory( allocatedAddress, Integer.BYTES );
         }
 
@@ -190,7 +196,7 @@ public abstract class UnsafeTable<VALUE> extends PowerOfTwoQuantizedTable<VALUE>
     @Override
     public void close()
     {
-        UnsafeUtil.free( allocatedAddress );
+        deallocateMemory();
     }
 
     protected static void alignmentSafePutLongAsTwoInts( long address, long value )
@@ -218,5 +224,18 @@ public abstract class UnsafeTable<VALUE> extends PowerOfTwoQuantizedTable<VALUE>
         long lsb = UnsafeUtil.getInt( address ) & 0xFFFFFFFFL;
         long msb = UnsafeUtil.getInt( address + Integer.BYTES ) & 0xFFFFFFFFL;
         return lsb | (msb << Integer.SIZE);
+    }
+
+    private long allocateMemory( long bytesToAllocate )
+    {
+        long address = UnsafeUtil.allocateMemory( bytesToAllocate );
+        allocationTracker.allocate( bytesToAllocate );
+        return address;
+    }
+
+    private void deallocateMemory()
+    {
+        UnsafeUtil.free( allocatedAddress );
+        allocationTracker.deallocate( bytesToAllocate );
     }
 }

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/UnsafeTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/UnsafeTable.java
@@ -59,7 +59,7 @@ public abstract class UnsafeTable<VALUE> extends PowerOfTwoQuantizedTable<VALUE>
         if ( UnsafeUtil.allowUnalignedMemoryAccess )
         {
             allocatedBytes = dataSize;
-            this.allocatedAddress = this.address = allocateMemory( allocatedBytes );
+            this.allocatedAddress = this.address = UnsafeUtil.allocateMemory( allocatedBytes, this.allocationTracker );
         }
         else
         {
@@ -75,7 +75,7 @@ public abstract class UnsafeTable<VALUE> extends PowerOfTwoQuantizedTable<VALUE>
             }
 
             allocatedBytes = dataSize + Integer.BYTES - 1;
-            this.allocatedAddress = allocateMemory( allocatedBytes );
+            this.allocatedAddress = UnsafeUtil.allocateMemory( allocatedBytes, this.allocationTracker );
             this.address = UnsafeUtil.alignedMemory( allocatedAddress, Integer.BYTES );
         }
 
@@ -196,7 +196,7 @@ public abstract class UnsafeTable<VALUE> extends PowerOfTwoQuantizedTable<VALUE>
     @Override
     public void close()
     {
-        deallocateMemory();
+        UnsafeUtil.free( allocatedAddress, allocatedBytes, allocationTracker );
     }
 
     protected static void alignmentSafePutLongAsTwoInts( long address, long value )
@@ -226,13 +226,4 @@ public abstract class UnsafeTable<VALUE> extends PowerOfTwoQuantizedTable<VALUE>
         return lsb | (msb << Integer.SIZE);
     }
 
-    private long allocateMemory( long bytesToAllocate )
-    {
-        return UnsafeUtil.allocateMemory( bytesToAllocate, allocationTracker );
-    }
-
-    private void deallocateMemory()
-    {
-        UnsafeUtil.free( allocatedAddress, allocatedBytes, allocationTracker );
-    }
 }

--- a/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/UnsafeTable.java
+++ b/community/primitive-collections/src/main/java/org/neo4j/collection/primitive/hopscotch/UnsafeTable.java
@@ -27,7 +27,7 @@ public abstract class UnsafeTable<VALUE> extends PowerOfTwoQuantizedTable<VALUE>
     private final int bytesPerKey;
     private final int bytesPerEntry;
     private final long dataSize;
-    private final long bytesToAllocate;
+    private final long allocatedBytes;
     // address which should be free when closing
     private final long allocatedAddress;
     // address which should be used to access the table, the address where the table actually starts at
@@ -58,8 +58,8 @@ public abstract class UnsafeTable<VALUE> extends PowerOfTwoQuantizedTable<VALUE>
 
         if ( UnsafeUtil.allowUnalignedMemoryAccess )
         {
-            bytesToAllocate = dataSize;
-            this.allocatedAddress = this.address = allocateMemory( bytesToAllocate );
+            allocatedBytes = dataSize;
+            this.allocatedAddress = this.address = allocateMemory( allocatedBytes );
         }
         else
         {
@@ -74,8 +74,8 @@ public abstract class UnsafeTable<VALUE> extends PowerOfTwoQuantizedTable<VALUE>
                         " yielding a bytesPerEntry:" + bytesPerEntry + ", which isn't 4-byte aligned." );
             }
 
-            bytesToAllocate = dataSize + Integer.BYTES - 1;
-            this.allocatedAddress = allocateMemory( bytesToAllocate );
+            allocatedBytes = dataSize + Integer.BYTES - 1;
+            this.allocatedAddress = allocateMemory( allocatedBytes );
             this.address = UnsafeUtil.alignedMemory( allocatedAddress, Integer.BYTES );
         }
 
@@ -228,14 +228,11 @@ public abstract class UnsafeTable<VALUE> extends PowerOfTwoQuantizedTable<VALUE>
 
     private long allocateMemory( long bytesToAllocate )
     {
-        long address = UnsafeUtil.allocateMemory( bytesToAllocate );
-        allocationTracker.allocate( bytesToAllocate );
-        return address;
+        return UnsafeUtil.allocateMemory( bytesToAllocate, allocationTracker );
     }
 
     private void deallocateMemory()
     {
-        UnsafeUtil.free( allocatedAddress );
-        allocationTracker.deallocate( bytesToAllocate );
+        UnsafeUtil.free( allocatedAddress, allocatedBytes, allocationTracker );
     }
 }

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveCollectionsAllocationsTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveCollectionsAllocationsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.collection.primitive;
+
+import org.junit.Test;
+
+import org.neo4j.memory.LocalMemoryTracker;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class PrimitiveCollectionsAllocationsTest
+{
+
+    @Test
+    public void trackPrimitiveMemoryAllocations()
+    {
+        LocalMemoryTracker memoryTracker = new LocalMemoryTracker();
+        PrimitiveIntSet offHeapIntSet = Primitive.offHeapIntSet( memoryTracker );
+        assertTrue( memoryTracker.usedDirectMemory() > 0 );
+
+        offHeapIntSet.close();
+        assertEquals( 0, memoryTracker.usedDirectMemory() );
+    }
+
+    @Test
+    public void trackPrimitiveMemoryOnResize()
+    {
+        LocalMemoryTracker memoryTracker = new LocalMemoryTracker();
+        PrimitiveIntSet offHeapIntSet = Primitive.offHeapIntSet( memoryTracker );
+        long originalSetMemory = memoryTracker.usedDirectMemory();
+
+        for ( int i = 0; i < Primitive.DEFAULT_OFFHEAP_CAPACITY + 1; i++ )
+        {
+            offHeapIntSet.add( i );
+        }
+
+        assertTrue( memoryTracker.usedDirectMemory() > originalSetMemory );
+
+        offHeapIntSet.close();
+        assertEquals( 0, memoryTracker.usedDirectMemory() );
+    }
+}

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveIntCollectionsTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/PrimitiveIntCollectionsTest.java
@@ -25,6 +25,8 @@ import java.util.Arrays;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.neo4j.memory.GlobalMemoryTracker;
+
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertArrayEquals;
@@ -54,7 +56,7 @@ public class PrimitiveIntCollectionsTest
     public void convertCollectionToLongArray()
     {
         PrimitiveIntSet heapSet = PrimitiveIntCollections.asSet( new int[]{1, 2, 3} );
-        PrimitiveIntSet offHeapIntSet = Primitive.offHeapIntSet();
+        PrimitiveIntSet offHeapIntSet = Primitive.offHeapIntSet( GlobalMemoryTracker.INSTANCE );
         offHeapIntSet.add( 7 );
         offHeapIntSet.add( 8 );
         assertArrayEquals( new long[]{1, 2, 3}, PrimitiveIntCollections.asLongArray( heapSet ) );

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/BasicTableTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/BasicTableTest.java
@@ -28,12 +28,11 @@ import java.util.Collection;
 import java.util.Random;
 
 import org.neo4j.collection.primitive.Primitive;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeTrue;
+import org.neo4j.memory.GlobalMemoryTracker;
 
 import static java.lang.System.currentTimeMillis;
-
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 import static org.neo4j.collection.primitive.Primitive.VALUE_MARKER;
 
 @RunWith( Parameterized.class )
@@ -93,7 +92,7 @@ public class BasicTableTest
             @Override
             public Table newTable( int capacity )
             {
-                return new IntKeyUnsafeTable( capacity, VALUE_MARKER );
+                return new IntKeyUnsafeTable( capacity, VALUE_MARKER, GlobalMemoryTracker.INSTANCE );
             }
 
             @Override
@@ -113,7 +112,7 @@ public class BasicTableTest
             @Override
             public Table newTable( int capacity )
             {
-                return new LongKeyUnsafeTable( capacity, VALUE_MARKER );
+                return new LongKeyUnsafeTable( capacity, VALUE_MARKER, GlobalMemoryTracker.INSTANCE );
             }
 
             @Override
@@ -193,7 +192,7 @@ public class BasicTableTest
             @Override
             public Table newTable( int capacity )
             {
-                return new LongKeyLongValueUnsafeTable( capacity );
+                return new LongKeyLongValueUnsafeTable( capacity, GlobalMemoryTracker.INSTANCE );
             }
 
             @Override

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveCollectionEqualityTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveCollectionEqualityTest.java
@@ -39,6 +39,7 @@ import org.neo4j.collection.primitive.PrimitiveLongLongMap;
 import org.neo4j.collection.primitive.PrimitiveLongObjectMap;
 import org.neo4j.collection.primitive.PrimitiveLongSet;
 import org.neo4j.function.Factory;
+import org.neo4j.memory.GlobalMemoryTracker;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -272,10 +273,12 @@ public class PrimitiveCollectionEqualityTest
     public static Factory<PrimitiveIntSet> intSetWithCapacity = () -> Primitive.intSet( randomCapacity() );
 
     @DataPoint
-    public static Factory<PrimitiveIntSet> offheapIntSet = Primitive::offHeapIntSet;
+    public static Factory<PrimitiveIntSet> offheapIntSet =
+            () -> Primitive.offHeapIntSet( GlobalMemoryTracker.INSTANCE );
 
     @DataPoint
-    public static Factory<PrimitiveIntSet> offheapIntSetWithCapacity = () -> Primitive.offHeapIntSet( randomCapacity() );
+    public static Factory<PrimitiveIntSet> offheapIntSetWithCapacity =
+            () -> Primitive.offHeapIntSet( randomCapacity(), GlobalMemoryTracker.INSTANCE );
 
     @DataPoint
     public static Factory<PrimitiveLongSet> longSet = Primitive::longSet;
@@ -284,10 +287,12 @@ public class PrimitiveCollectionEqualityTest
     public static Factory<PrimitiveLongSet> longSetWithCapacity = () -> Primitive.longSet( randomCapacity() );
 
     @DataPoint
-    public static Factory<PrimitiveLongSet> offheapLongSet = Primitive::offHeapLongSet;
+    public static Factory<PrimitiveLongSet> offheapLongSet =
+            () -> Primitive.offHeapLongSet( GlobalMemoryTracker.INSTANCE );
 
     @DataPoint
-    public static Factory<PrimitiveLongSet> offheapLongSetWithCapacity = () -> Primitive.offHeapLongSet( randomCapacity() );
+    public static Factory<PrimitiveLongSet> offheapLongSetWithCapacity =
+            () -> Primitive.offHeapLongSet( randomCapacity(), GlobalMemoryTracker.INSTANCE );
 
     @DataPoint
     public static Factory<PrimitiveIntLongMap> intLongMap = Primitive::intLongMap;
@@ -309,11 +314,12 @@ public class PrimitiveCollectionEqualityTest
             () -> Primitive.longLongMap( randomCapacity() );
 
     @DataPoint
-    public static Factory<PrimitiveLongLongMap> offheapLongLongMap = Primitive::offHeapLongLongMap;
+    public static Factory<PrimitiveLongLongMap> offheapLongLongMap =
+            () -> Primitive.offHeapLongLongMap( GlobalMemoryTracker.INSTANCE );
 
     @DataPoint
     public static Factory<PrimitiveLongLongMap> offheapLongLongMapWithCapacity =
-            () -> Primitive.offHeapLongLongMap( randomCapacity() );
+            () -> Primitive.offHeapLongLongMap( randomCapacity(), GlobalMemoryTracker.INSTANCE );
 
     @DataPoint
     public static Factory<PrimitiveIntObjectMap> intObjMap = Primitive::intObjectMap;

--- a/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongMapTest.java
+++ b/community/primitive-collections/src/test/java/org/neo4j/collection/primitive/hopscotch/PrimitiveLongMapTest.java
@@ -42,6 +42,7 @@ import org.neo4j.collection.primitive.PrimitiveLongLongVisitor;
 import org.neo4j.collection.primitive.PrimitiveLongObjectMap;
 import org.neo4j.collection.primitive.PrimitiveLongObjectVisitor;
 import org.neo4j.collection.primitive.PrimitiveLongVisitor;
+import org.neo4j.memory.GlobalMemoryTracker;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
@@ -984,7 +985,7 @@ public class PrimitiveLongMapTest
     {
         // GIVEN
         PrimitiveLongLongVisitor<RuntimeException> visitor;
-        try ( PrimitiveLongLongMap map = Primitive.offHeapLongLongMap() )
+        try ( PrimitiveLongLongMap map = Primitive.offHeapLongLongMap( GlobalMemoryTracker.INSTANCE ) )
         {
             map.put( 1, 100 );
             map.put( 2, 200 );
@@ -1007,7 +1008,7 @@ public class PrimitiveLongMapTest
     {
         // GIVEN
         AtomicInteger counter = new AtomicInteger();
-        try ( PrimitiveLongLongMap map = Primitive.offHeapLongLongMap() )
+        try ( PrimitiveLongLongMap map = Primitive.offHeapLongLongMap( GlobalMemoryTracker.INSTANCE ) )
         {
             map.put( 1, 100 );
             map.put( 2, 200 );
@@ -1188,7 +1189,7 @@ public class PrimitiveLongMapTest
     {
         // GIVEN
         PrimitiveLongVisitor<RuntimeException> visitor = mock( PrimitiveLongVisitor.class );
-        try ( PrimitiveLongLongMap map = Primitive.offHeapLongLongMap() )
+        try ( PrimitiveLongLongMap map = Primitive.offHeapLongLongMap( GlobalMemoryTracker.INSTANCE ) )
         {
             map.put( 1, 100 );
             map.put( 2, 200 );
@@ -1210,7 +1211,7 @@ public class PrimitiveLongMapTest
     {
         // GIVEN
         AtomicInteger counter = new AtomicInteger();
-        try ( PrimitiveLongLongMap map = Primitive.offHeapLongLongMap() )
+        try ( PrimitiveLongLongMap map = Primitive.offHeapLongLongMap( GlobalMemoryTracker.INSTANCE ) )
         {
             map.put( 1, 100 );
             map.put( 2, 200 );
@@ -1335,7 +1336,6 @@ public class PrimitiveLongMapTest
 
     @Test
     public void recursivePutGrowInterleavingShouldNotDropOriginalValuesEvenWhenFirstGrowAddsMoreValuesAfterSecondGrow()
-            throws Exception
     {
         // List of values that cause recursive growth like above, but this time the first grow wants to add more values
         // to the table *after* the second grow has occurred.

--- a/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtil.java
+++ b/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtil.java
@@ -38,6 +38,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
+import org.neo4j.memory.GlobalMemoryTracker;
 import org.neo4j.memory.MemoryAllocationTracker;
 
 import static java.lang.String.format;
@@ -344,6 +345,11 @@ public final class UnsafeUtil
         {
             return new String( chars );
         }
+    }
+
+    public static long allocateMemory( long sizeInBytes )
+    {
+        return allocateMemory( sizeInBytes, GlobalMemoryTracker.INSTANCE );
     }
 
     /**

--- a/community/unsafe/src/test/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtilTest.java
+++ b/community/unsafe/src/test/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtilTest.java
@@ -276,7 +276,7 @@ public class UnsafeUtilTest
     public void mustSupportReadingAndWritingOfPrimitivesToMemory()
     {
         int sizeInBytes = 8;
-        long address = allocateMemory( sizeInBytes, GlobalMemoryTracker.INSTANCE );
+        long address = allocateMemory( sizeInBytes );
         try
         {
             putByte( address, (byte) 1 );
@@ -483,7 +483,7 @@ public class UnsafeUtilTest
     public void directByteBufferCreationAndInitialisation() throws Exception
     {
         int sizeInBytes = 313;
-        long address = allocateMemory( sizeInBytes, GlobalMemoryTracker.INSTANCE );
+        long address = allocateMemory( sizeInBytes );
         try
         {
             setMemory( address, sizeInBytes, (byte) 0 );
@@ -504,7 +504,7 @@ public class UnsafeUtilTest
             a.limit( 202 );
 
             int sizeInBytes2 = 424;
-            long address2 = allocateMemory( sizeInBytes2, GlobalMemoryTracker.INSTANCE );
+            long address2 = allocateMemory( sizeInBytes2 );
             try
             {
                 setMemory( address2, sizeInBytes2, (byte) 0 );

--- a/community/unsafe/src/test/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtilTest.java
+++ b/community/unsafe/src/test/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtilTest.java
@@ -24,6 +24,8 @@ import org.junit.Test;
 import java.nio.ByteBuffer;
 import java.util.Objects;
 
+import org.neo4j.memory.GlobalMemoryTracker;
+
 import static java.lang.System.currentTimeMillis;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isOneOf;
@@ -131,13 +133,13 @@ public class UnsafeUtilTest
     }
 
     @Test
-    public void mustHaveUnsafe() throws Exception
+    public void mustHaveUnsafe()
     {
         assertHasUnsafe();
     }
 
     @Test
-    public void pageSizeIsPowerOfTwo() throws Exception
+    public void pageSizeIsPowerOfTwo()
     {
         assertThat( pageSize(), isOneOf(
                 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144,
@@ -146,7 +148,7 @@ public class UnsafeUtilTest
     }
 
     @Test
-    public void mustSupportReadingFromAndWritingToFields() throws Exception
+    public void mustSupportReadingFromAndWritingToFields()
     {
         Obj obj;
 
@@ -271,89 +273,90 @@ public class UnsafeUtilTest
     }
 
     @Test
-    public void mustSupportReadingAndWritingOfPrimitivesToMemory() throws Exception
+    public void mustSupportReadingAndWritingOfPrimitivesToMemory()
     {
-        long address = allocateMemory( 8 );
+        int sizeInBytes = 8;
+        long address = allocateMemory( sizeInBytes, GlobalMemoryTracker.INSTANCE );
         try
         {
             putByte( address, (byte) 1 );
             assertThat( getByte( address ), is( (byte) 1 ) );
-            setMemory( address, 8, (byte) 0 );
+            setMemory( address, sizeInBytes, (byte) 0 );
             assertThat( getByte( address ), is( (byte) 0 ) );
 
             putByteVolatile( address, (byte) 1 );
             assertThat( getByteVolatile( address ), is( (byte) 1 ) );
-            setMemory( address, 8, (byte) 0 );
+            setMemory( address, sizeInBytes, (byte) 0 );
             assertThat( getByteVolatile( address ), is( (byte) 0 ) );
 
             putShort( address, (short) 1 );
             assertThat( getShort( address ), is( (short) 1 ) );
-            setMemory( address, 8, (byte) 0 );
+            setMemory( address, sizeInBytes, (byte) 0 );
             assertThat( getShort( address ), is( (short) 0 ) );
 
             putShortVolatile( address, (short) 1 );
             assertThat( getShortVolatile( address ), is( (short) 1 ) );
-            setMemory( address, 8, (byte) 0 );
+            setMemory( address, sizeInBytes, (byte) 0 );
             assertThat( getShortVolatile( address ), is( (short) 0 ) );
 
             putFloat( address, 1 );
             assertThat( getFloat( address ), is( (float) 1 ) );
-            setMemory( address, 8, (byte) 0 );
+            setMemory( address, sizeInBytes, (byte) 0 );
             assertThat( getFloat( address ), is( (float) 0 ) );
 
             putFloatVolatile( address, 1 );
             assertThat( getFloatVolatile( address ), is( (float) 1 ) );
-            setMemory( address, 8, (byte) 0 );
+            setMemory( address, sizeInBytes, (byte) 0 );
             assertThat( getFloatVolatile( address ), is( (float) 0 ) );
 
             putChar( address, '1' );
             assertThat( getChar( address ), is( '1' ) );
-            setMemory( address, 8, (byte) 0 );
+            setMemory( address, sizeInBytes, (byte) 0 );
             assertThat( getChar( address ), is( (char) 0 ) );
 
             putCharVolatile( address, '1' );
             assertThat( getCharVolatile( address ), is( '1' ) );
-            setMemory( address, 8, (byte) 0 );
+            setMemory( address, sizeInBytes, (byte) 0 );
             assertThat( getCharVolatile( address ), is( (char) 0 ) );
 
             putInt( address, 1 );
             assertThat( getInt( address ), is( 1 ) );
-            setMemory( address, 8, (byte) 0 );
+            setMemory( address, sizeInBytes, (byte) 0 );
             assertThat( getInt( address ), is( 0 ) );
 
             putIntVolatile( address, 1 );
             assertThat( getIntVolatile( address ), is( 1 ) );
-            setMemory( address, 8, (byte) 0 );
+            setMemory( address, sizeInBytes, (byte) 0 );
             assertThat( getIntVolatile( address ), is( 0 ) );
 
             putLong( address, 1 );
             assertThat( getLong( address ), is( 1L ) );
-            setMemory( address, 8, (byte) 0 );
+            setMemory( address, sizeInBytes, (byte) 0 );
             assertThat( getLong( address ), is( 0L ) );
 
             putLongVolatile( address, 1 );
             assertThat( getLongVolatile( address ), is( 1L ) );
-            setMemory( address, 8, (byte) 0 );
+            setMemory( address, sizeInBytes, (byte) 0 );
             assertThat( getLongVolatile( address ), is( 0L ) );
 
             putDouble( address, 1 );
             assertThat( getDouble( address ), is( (double) 1 ) );
-            setMemory( address, 8, (byte) 0 );
+            setMemory( address, sizeInBytes, (byte) 0 );
             assertThat( getDouble( address ), is( (double) 0 ) );
 
             putDoubleVolatile( address, 1 );
             assertThat( getDoubleVolatile( address ), is( (double) 1 ) );
-            setMemory( address, 8, (byte) 0 );
+            setMemory( address, sizeInBytes, (byte) 0 );
             assertThat( getDoubleVolatile( address ), is( (double) 0 ) );
         }
         finally
         {
-            free( address );
+            free( address, sizeInBytes, GlobalMemoryTracker.INSTANCE );
         }
     }
 
     @Test
-    public void getAndAddIntOfField() throws Exception
+    public void getAndAddIntOfField()
     {
         Obj obj = new Obj();
         long anIntOffset = getFieldOffset( Obj.class, "anInt" );
@@ -365,7 +368,7 @@ public class UnsafeUtilTest
     }
 
     @Test
-    public void compareAndSwapLongField() throws Exception
+    public void compareAndSwapLongField()
     {
         Obj obj = new Obj();
         long aLongOffset = getFieldOffset( Obj.class, "aLong" );
@@ -376,7 +379,7 @@ public class UnsafeUtilTest
     }
 
     @Test
-    public void compareAndSwapObjectField() throws Exception
+    public void compareAndSwapObjectField()
     {
         Obj obj = new Obj();
         long objectOffset = getFieldOffset( Obj.class, "object" );
@@ -387,7 +390,7 @@ public class UnsafeUtilTest
     }
 
     @Test
-    public void getAndSetObjectField() throws Exception
+    public void getAndSetObjectField()
     {
         Obj obj = new Obj();
         long objectOffset = getFieldOffset( Obj.class, "object" );
@@ -397,7 +400,7 @@ public class UnsafeUtilTest
     }
 
     @Test
-    public void unsafeArrayElementAccess() throws Exception
+    public void unsafeArrayElementAccess()
     {
         int len = 3;
         int scale;
@@ -479,18 +482,19 @@ public class UnsafeUtilTest
     @Test
     public void directByteBufferCreationAndInitialisation() throws Exception
     {
-        long address = allocateMemory( 313 );
+        int sizeInBytes = 313;
+        long address = allocateMemory( sizeInBytes, GlobalMemoryTracker.INSTANCE );
         try
         {
-            setMemory( address, 313, (byte) 0 );
-            ByteBuffer a = newDirectByteBuffer( address, 313 );
-            assertThat( a, is( not( sameInstance( newDirectByteBuffer( address, 313 ) ) ) ) );
+            setMemory( address, sizeInBytes, (byte) 0 );
+            ByteBuffer a = newDirectByteBuffer( address, sizeInBytes );
+            assertThat( a, is( not( sameInstance( newDirectByteBuffer( address, sizeInBytes ) ) ) ) );
             assertThat( a.hasArray(), is( false ) );
             assertThat( a.isDirect(), is( true ) );
-            assertThat( a.capacity(), is( 313 ) );
-            assertThat( a.limit(), is( 313 ) );
+            assertThat( a.capacity(), is( sizeInBytes ) );
+            assertThat( a.limit(), is( sizeInBytes ) );
             assertThat( a.position(), is( 0 ) );
-            assertThat( a.remaining(), is( 313 ) );
+            assertThat( a.remaining(), is( sizeInBytes ) );
             assertThat( getByte( address ), is( (byte) 0 ) );
             a.put( (byte) -1 );
             assertThat( getByte( address ), is( (byte) -1 ) );
@@ -499,34 +503,35 @@ public class UnsafeUtilTest
             a.mark();
             a.limit( 202 );
 
-            long address2 = allocateMemory( 424 );
+            int sizeInBytes2 = 424;
+            long address2 = allocateMemory( sizeInBytes2, GlobalMemoryTracker.INSTANCE );
             try
             {
-                setMemory( address2, 424, (byte) 0 );
-                initDirectByteBuffer( a, address2, 424 );
+                setMemory( address2, sizeInBytes2, (byte) 0 );
+                initDirectByteBuffer( a, address2, sizeInBytes2 );
                 assertThat( a.hasArray(), is( false ) );
                 assertThat( a.isDirect(), is( true ) );
-                assertThat( a.capacity(), is( 424 ) );
-                assertThat( a.limit(), is( 424 ) );
+                assertThat( a.capacity(), is( sizeInBytes2 ) );
+                assertThat( a.limit(), is( sizeInBytes2 ) );
                 assertThat( a.position(), is( 0 ) );
-                assertThat( a.remaining(), is( 424 ) );
+                assertThat( a.remaining(), is( sizeInBytes2 ) );
                 assertThat( getByte( address2 ), is( (byte) 0 ) );
                 a.put( (byte) -1 );
                 assertThat( getByte( address2 ), is( (byte) -1 ) );
             }
             finally
             {
-                free( address2 );
+                free( address2, sizeInBytes2, GlobalMemoryTracker.INSTANCE );
             }
         }
         finally
         {
-            free( address );
+            free( address, sizeInBytes, GlobalMemoryTracker.INSTANCE );
         }
     }
 
     @Test
-    public void shouldAlignMemoryTo4ByteBoundary() throws Exception
+    public void shouldAlignMemoryTo4ByteBoundary()
     {
         // GIVEN
         long allocatedMemory = currentTimeMillis();
@@ -545,10 +550,12 @@ public class UnsafeUtilTest
     }
 
     @Test
-    public void shouldPutAndGetByteWiseLittleEndianShort() throws Exception
+    public void shouldPutAndGetByteWiseLittleEndianShort()
     {
         // GIVEN
-        long p = allocateMemory( 2 );
+        int sizeInBytes = 2;
+        GlobalMemoryTracker tracker = GlobalMemoryTracker.INSTANCE;
+        long p = allocateMemory( sizeInBytes, tracker );
         short value = (short) 0b11001100_10101010;
 
         // WHEN
@@ -556,15 +563,17 @@ public class UnsafeUtilTest
         short readValue = UnsafeUtil.getShortByteWiseLittleEndian( p );
 
         // THEN
-        free( p );
+        free( p, sizeInBytes, tracker );
         assertEquals( value, readValue );
     }
 
     @Test
-    public void shouldPutAndGetByteWiseLittleEndianInt() throws Exception
+    public void shouldPutAndGetByteWiseLittleEndianInt()
     {
         // GIVEN
-        long p = allocateMemory( 4 );
+        int sizeInBytes = 4;
+        GlobalMemoryTracker tracker = GlobalMemoryTracker.INSTANCE;
+        long p = allocateMemory( sizeInBytes, tracker );
         int value = 0b11001100_10101010_10011001_01100110;
 
         // WHEN
@@ -572,15 +581,17 @@ public class UnsafeUtilTest
         int readValue = UnsafeUtil.getIntByteWiseLittleEndian( p );
 
         // THEN
-        free( p );
+        free( p, sizeInBytes, tracker );
         assertEquals( value, readValue );
     }
 
     @Test
-    public void shouldPutAndGetByteWiseLittleEndianLong() throws Exception
+    public void shouldPutAndGetByteWiseLittleEndianLong()
     {
         // GIVEN
-        long p = allocateMemory( 8 );
+        int sizeInBytes = 8;
+        GlobalMemoryTracker tracker = GlobalMemoryTracker.INSTANCE;
+        long p = allocateMemory( sizeInBytes, tracker );
         long value = 0b11001100_10101010_10011001_01100110__10001000_01000100_00100010_00010001L;
 
         // WHEN
@@ -588,7 +599,7 @@ public class UnsafeUtilTest
         long readValue = UnsafeUtil.getLongByteWiseLittleEndian( p );
 
         // THEN
-        free( p );
+        free( p, sizeInBytes, tracker );
         assertEquals( value, readValue );
     }
 }

--- a/tools/src/main/java/org/neo4j/tools/txlog/CheckTxLogs.java
+++ b/tools/src/main/java/org/neo4j/tools/txlog/CheckTxLogs.java
@@ -43,6 +43,7 @@ import org.neo4j.kernel.impl.transaction.log.entry.LogEntryCommand;
 import org.neo4j.kernel.impl.transaction.log.entry.LogEntryCommit;
 import org.neo4j.kernel.impl.transaction.log.files.LogFiles;
 import org.neo4j.kernel.impl.transaction.log.files.LogFilesBuilder;
+import org.neo4j.memory.GlobalMemoryTracker;
 import org.neo4j.storageengine.api.StorageCommand;
 import org.neo4j.tools.txlog.checktypes.CheckType;
 import org.neo4j.tools.txlog.checktypes.CheckTypes;
@@ -127,7 +128,7 @@ public class CheckTxLogs
         final long lowestLogVersion = logFiles.getLowestLogVersion();
         final long highestLogVersion = logFiles.getHighestLogVersion();
         boolean success = true;
-        try ( PrimitiveLongLongMap logFileSizes = Primitive.offHeapLongLongMap() )
+        try ( PrimitiveLongLongMap logFileSizes = Primitive.offHeapLongLongMap( GlobalMemoryTracker.INSTANCE ) )
         {
             for ( long i = lowestLogVersion; i <= highestLogVersion; i++ )
             {


### PR DESCRIPTION
Introduce possibility to track native memory that we allocate.
allow track allocations in global and local contexts, where local contexts
can be the context of any granularity.
Update primitive off-heap collections to report memory allocation and
de-allocations.

Force all native allocations and deallocation to track 
requested and freed bytes
