### PR TITLE
Native indexes recovery cleanup.

### DIFF
--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
@@ -37,7 +37,6 @@ import org.neo4j.consistency.statistics.VerboseStatistics;
 import org.neo4j.function.Suppliers;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
-import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
@@ -244,7 +243,7 @@ public class ConsistencyCheckService
 
             LabelScanStore labelScanStore =
                     new NativeLabelScanStore( pageCache, storeDir, FullStoreChangeStream.EMPTY, true, monitors,
-                            RecoveryCleanupWorkCollector.IMMEDIATE );
+                            RECOVERY_PREVENTING_COLLECTOR );
             life.add( labelScanStore );
 
             int numberOfThreads = defaultConsistencyCheckThreadsNumber();

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/ConsistencyCheckService.java
@@ -37,6 +37,7 @@ import org.neo4j.consistency.statistics.VerboseStatistics;
 import org.neo4j.function.Suppliers;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
+import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
 import org.neo4j.io.fs.DefaultFileSystemAbstraction;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
@@ -63,7 +64,6 @@ import org.neo4j.logging.Log;
 import org.neo4j.logging.LogProvider;
 
 import static java.lang.String.format;
-import static org.neo4j.consistency.internal.SchemaIndexExtensionLoader.RECOVERY_PREVENTING_COLLECTOR;
 import static org.neo4j.consistency.internal.SchemaIndexExtensionLoader.instantiateKernelExtensions;
 import static org.neo4j.consistency.internal.SchemaIndexExtensionLoader.loadSchemaIndexProviders;
 import static org.neo4j.io.file.Files.createOrOpenAsOuputStream;
@@ -230,7 +230,7 @@ public class ConsistencyCheckService
         LifeSupport life = new LifeSupport();
         KernelExtensions extensions = life.add( instantiateKernelExtensions( storeDir,
                 fileSystem, config, new SimpleLogService( logProvider, logProvider ), pageCache,
-                RECOVERY_PREVENTING_COLLECTOR,
+                RecoveryCleanupWorkCollector.IGNORE,
                 // May be enterprise edition, but in consistency checker we only care about the operational mode
                 COMMUNITY,
                 monitors ) );
@@ -243,7 +243,7 @@ public class ConsistencyCheckService
 
             LabelScanStore labelScanStore =
                     new NativeLabelScanStore( pageCache, storeDir, FullStoreChangeStream.EMPTY, true, monitors,
-                            RECOVERY_PREVENTING_COLLECTOR );
+                            RecoveryCleanupWorkCollector.IGNORE );
             life.add( labelScanStore );
 
             int numberOfThreads = defaultConsistencyCheckThreadsNumber();

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyCheckTasks.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/checking/full/ConsistencyCheckTasks.java
@@ -22,6 +22,7 @@ package org.neo4j.consistency.checking.full;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.neo4j.consistency.RecordType;
 import org.neo4j.consistency.checking.NodeRecordCheck;
 import org.neo4j.consistency.checking.PropertyChain;
 import org.neo4j.consistency.checking.RelationshipRecordCheck;
@@ -33,11 +34,15 @@ import org.neo4j.consistency.checking.index.IndexEntryProcessor;
 import org.neo4j.consistency.checking.index.IndexIterator;
 import org.neo4j.consistency.checking.labelscan.LabelScanCheck;
 import org.neo4j.consistency.checking.labelscan.LabelScanDocumentProcessor;
+import org.neo4j.consistency.report.ConsistencyReport;
 import org.neo4j.consistency.report.ConsistencyReporter;
 import org.neo4j.consistency.statistics.Statistics;
+import org.neo4j.consistency.store.synthetic.IndexRecord;
+import org.neo4j.consistency.store.synthetic.LabelScanIndex;
 import org.neo4j.helpers.collection.BoundedIterable;
 import org.neo4j.helpers.progress.ProgressMonitorFactory;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
+import org.neo4j.kernel.impl.index.labelscan.NativeLabelScanStore;
 import org.neo4j.kernel.impl.store.RecordStore;
 import org.neo4j.kernel.impl.store.Scanner;
 import org.neo4j.kernel.impl.store.SchemaStorage;
@@ -176,6 +181,7 @@ public class ConsistencyCheckTasks
         if ( checkLabelScanStore )
         {
             long highId = nativeStores.getNodeStore().getHighId();
+            tasks.add( new LabelIndexDirtyCheckTask() );
             tasks.add( recordScanner( "LabelScanStore",
                     new GapFreeAllEntriesLabelScanReader( labelScanStore.allNodeLabelRanges(), highId ),
                     new LabelScanDocumentProcessor( filteredReporter, new LabelScanCheck() ), Stage.SEQUENTIAL_FORWARD,
@@ -183,6 +189,7 @@ public class ConsistencyCheckTasks
         }
         if ( checkIndexes )
         {
+            tasks.add( new IndexDirtyCheckTask() );
             for ( IndexRule indexRule : indexes.onlineRules() )
             {
                 tasks.add( recordScanner( format( "Index_%d", indexRule.getId() ),
@@ -218,5 +225,48 @@ public class ConsistencyCheckTasks
     {
         return new StoreProcessorTask<>( name, statistics, numberOfThreads, input, nativeStores, name, progress,
                 cacheAccess, processor, distribution );
+    }
+
+    private class LabelIndexDirtyCheckTask extends ConsistencyCheckerTask
+    {
+        LabelIndexDirtyCheckTask()
+        {
+            super( "Label index dirty check", Statistics.NONE, 1 );
+        }
+
+        @Override
+        public void run()
+        {
+            if ( labelScanStore instanceof NativeLabelScanStore )
+            {
+                if ( ((NativeLabelScanStore)labelScanStore).isDirty() )
+                {
+                    reporter.report( new LabelScanIndex(), ConsistencyReport.LabelScanConsistencyReport.class,
+                            RecordType.LABEL_SCAN_DOCUMENT ).dirtyIndex();
+                }
+            }
+        }
+    }
+
+    private class IndexDirtyCheckTask extends ConsistencyCheckerTask
+    {
+        IndexDirtyCheckTask()
+        {
+            super( "Indexes dirty check", Statistics.NONE, 1 );
+        }
+
+        @Override
+        public void run()
+        {
+            for ( IndexRule indexRule : indexes.onlineRules() )
+            {
+                if ( indexes.accessorFor( indexRule ).isDirty() )
+                {
+                    reporter.report( new IndexRecord( indexRule ), ConsistencyReport.IndexConsistencyReport.class,
+                            RecordType.INDEX ).dirtyIndex();
+                }
+            }
+
+        }
     }
 }

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReport.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/report/ConsistencyReport.java
@@ -492,6 +492,10 @@ public interface ConsistencyReport
         @Override
         @Documented( "This node record has a label that is not found in the label scan store entry for this node" )
         void nodeLabelNotInIndex( NodeRecord referredNodeRecord, long missingLabelId );
+
+        @Warning
+        @Documented( "Label index was not properly shutdown and rebuild is required." )
+        void dirtyIndex();
     }
 
     interface IndexConsistencyReport extends NodeInUseWithCorrectLabelsReport
@@ -507,6 +511,10 @@ public interface ConsistencyReport
         @Override
         @Documented( "This node record has a label that is not found in the index for this node" )
         void nodeLabelNotInIndex( NodeRecord referredNodeRecord, long missingLabelId );
+
+        @Warning
+        @Documented( "Index was not properly shutdown and rebuild is required." )
+        void dirtyIndex();
     }
 
     interface CountsConsistencyReport extends ConsistencyReport

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/store/synthetic/IndexRecord.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/store/synthetic/IndexRecord.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.consistency.store.synthetic;
+
+import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
+import org.neo4j.kernel.impl.store.record.IndexRule;
+
+public class IndexRecord extends AbstractBaseRecord
+{
+    private final IndexRule indexRule;
+
+    public IndexRecord( IndexRule indexRule )
+    {
+        super( indexRule.getId() );
+        this.indexRule = indexRule;
+    }
+
+    @Override
+    public void clear()
+    {
+        initialize( false );
+    }
+
+    @Override
+    public String toString()
+    {
+        return "Index[ " + indexRule.toString() + " ]";
+    }
+}

--- a/community/consistency-check/src/main/java/org/neo4j/consistency/store/synthetic/LabelScanIndex.java
+++ b/community/consistency-check/src/main/java/org/neo4j/consistency/store/synthetic/LabelScanIndex.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.consistency.store.synthetic;
+
+import org.neo4j.kernel.impl.index.labelscan.NativeLabelScanStore;
+import org.neo4j.kernel.impl.store.record.AbstractBaseRecord;
+
+public class LabelScanIndex extends AbstractBaseRecord
+{
+    public LabelScanIndex()
+    {
+        super( NO_ID );
+    }
+
+    @Override
+    public String toString()
+    {
+        return "Label index: " + NativeLabelScanStore.FILE_NAME;
+    }
+}

--- a/community/consistency-check/src/test/java/org/neo4j/consistency/checking/GraphStoreFixture.java
+++ b/community/consistency-check/src/test/java/org/neo4j/consistency/checking/GraphStoreFixture.java
@@ -92,7 +92,6 @@ import org.neo4j.test.rule.TestDirectory;
 
 import static java.lang.System.currentTimeMillis;
 import static org.neo4j.consistency.ConsistencyCheckService.defaultConsistencyCheckThreadsNumber;
-import static org.neo4j.consistency.internal.SchemaIndexExtensionLoader.RECOVERY_PREVENTING_COLLECTOR;
 import static org.neo4j.consistency.internal.SchemaIndexExtensionLoader.instantiateKernelExtensions;
 import static org.neo4j.consistency.internal.SchemaIndexExtensionLoader.loadSchemaIndexProviders;
 
@@ -217,7 +216,7 @@ public abstract class GraphStoreFixture extends ConfigurablePageCacheRule implem
     {
         LogService logService = new SimpleLogService( logProvider, logProvider );
         KernelExtensions extensions = life.add( instantiateKernelExtensions( storeDir, fileSystem, config, logService,
-                pageCache, RECOVERY_PREVENTING_COLLECTOR, DatabaseInfo.COMMUNITY, monitors ) );
+                pageCache, RecoveryCleanupWorkCollector.IGNORE, DatabaseInfo.COMMUNITY, monitors ) );
         return loadSchemaIndexProviders( extensions );
     }
 

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
@@ -338,7 +338,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
     /**
      * True if initial tree state was dirty
      */
-    private boolean dirtyInitialState;
+    private boolean dirtyOnStartup;
 
     /**
      * State of cleanup job.
@@ -447,11 +447,11 @@ public class GBPTree<KEY,VALUE> implements Closeable
             this.monitor.startupState( clean );
 
             // Prepare tree for action
-            dirtyInitialState = !clean;
+            dirtyOnStartup = !clean;
             clean = false;
             bumpUnstableGeneration();
             forceState();
-            cleaning = createCleanupJob( dirtyInitialState );
+            cleaning = createCleanupJob( dirtyOnStartup );
             recoveryCleanupWorkCollector.add( cleaning );
             success = true;
         }
@@ -1302,8 +1302,8 @@ public class GBPTree<KEY,VALUE> implements Closeable
         }
     }
 
-    public boolean isDirty()
+    public boolean wasDirtyOnStartup()
     {
-        return dirtyInitialState;
+        return dirtyOnStartup;
     }
 }

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
@@ -43,7 +43,6 @@ import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.PagedFile;
 
 import static java.lang.String.format;
-
 import static org.neo4j.helpers.Exceptions.withMessage;
 import static org.neo4j.index.internal.gbptree.Generation.generation;
 import static org.neo4j.index.internal.gbptree.Generation.stableGeneration;
@@ -337,6 +336,11 @@ public class GBPTree<KEY,VALUE> implements Closeable
     private boolean clean;
 
     /**
+     * True if initial tree state was dirty
+     */
+    private boolean dirtyInitialState;
+
+    /**
      * State of cleanup job.
      */
     private final CleanupJob cleaning;
@@ -443,11 +447,11 @@ public class GBPTree<KEY,VALUE> implements Closeable
             this.monitor.startupState( clean );
 
             // Prepare tree for action
-            boolean needsCleaning = !clean;
+            dirtyInitialState = !clean;
             clean = false;
             bumpUnstableGeneration();
             forceState();
-            cleaning = createCleanupJob( needsCleaning );
+            cleaning = createCleanupJob( dirtyInitialState );
             recoveryCleanupWorkCollector.add( cleaning );
             success = true;
         }
@@ -1296,5 +1300,10 @@ public class GBPTree<KEY,VALUE> implements Closeable
                 cursor = null;
             }
         }
+    }
+
+    public boolean isDirty()
+    {
+        return dirtyInitialState;
     }
 }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/GBPTreeTest.java
@@ -973,7 +973,7 @@ public class GBPTreeTest
 
         try ( GBPTree<MutableLong, MutableLong> index = index().with( RecoveryCleanupWorkCollector.IGNORE ).build() )
         {
-            assertTrue( index.isDirty() );
+            assertTrue( index.wasDirtyOnStartup() );
         }
     }
 
@@ -990,7 +990,7 @@ public class GBPTreeTest
         }
         try ( GBPTree<MutableLong,MutableLong> index = index().build() )
         {
-            assertFalse( index.isDirty() );
+            assertFalse( index.wasDirtyOnStartup() );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/index/IndexAccessor.java
@@ -111,6 +111,11 @@ public interface IndexAccessor extends Closeable
      */
     void verifyDeferredConstraints( PropertyAccessor propertyAccessor ) throws IndexEntryConflictException, IOException;
 
+    /**
+     * @return true if index was not shutdown properly and its internal state is dirty, false otherwise
+     */
+    boolean isDirty();
+
     class Adapter implements IndexAccessor
     {
         @Override
@@ -179,6 +184,12 @@ public interface IndexAccessor extends Closeable
         public void verifyDeferredConstraints( PropertyAccessor propertyAccessor )
                 throws IndexEntryConflictException, IOException
         {
+        }
+
+        @Override
+        public boolean isDirty()
+        {
+            return false;
         }
     }
 
@@ -250,6 +261,12 @@ public interface IndexAccessor extends Closeable
                 throws IndexEntryConflictException, IOException
         {
             delegate.verifyDeferredConstraints( propertyAccessor );
+        }
+
+        @Override
+        public boolean isDirty()
+        {
+            return delegate.isDirty();
         }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
@@ -339,8 +339,11 @@ public class NativeLabelScanStore implements LabelScanStore
         if ( isDirty )
         {
             monitor.notValidIndex();
-            dropStrict();
-            instantiateTree();
+            if ( !readOnly )
+            {
+                dropStrict();
+                instantiateTree();
+            }
             needsRebuild = true;
         }
     }
@@ -420,7 +423,7 @@ public class NativeLabelScanStore implements LabelScanStore
     @Override
     public void start() throws IOException
     {
-        if ( needsRebuild )
+        if ( needsRebuild && !readOnly )
         {
             monitor.rebuilding();
             long numberOfNodes;

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
@@ -467,7 +467,10 @@ public class NativeLabelScanStore implements LabelScanStore
     @Override
     public void shutdown() throws IOException
     {
-        index.close();
+        if ( index != null )
+        {
+            index.close();
+        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
@@ -481,4 +481,9 @@ public class NativeLabelScanStore implements LabelScanStore
     {
         return readOnly;
     }
+
+    public boolean isDirty()
+    {
+        return index == null || index.isDirty();
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStore.java
@@ -473,6 +473,7 @@ public class NativeLabelScanStore implements LabelScanStore
         if ( index != null )
         {
             index.close();
+            index = null;
         }
     }
 
@@ -484,6 +485,6 @@ public class NativeLabelScanStore implements LabelScanStore
 
     public boolean isDirty()
     {
-        return index == null || index.isDirty();
+        return index == null || index.wasDirtyOnStartup();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexAccessor.java
@@ -135,6 +135,6 @@ public class NativeSchemaNumberIndexAccessor<KEY extends SchemaNumberKey, VALUE 
     @Override
     public boolean isDirty()
     {
-        return tree.isDirty();
+        return tree.wasDirtyOnStartup();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexAccessor.java
@@ -131,4 +131,10 @@ public class NativeSchemaNumberIndexAccessor<KEY extends SchemaNumberKey, VALUE 
             throws IndexEntryConflictException, IOException
     {   // Not needed since uniqueness is verified automatically w/o cost for every update.
     }
+
+    @Override
+    public boolean isDirty()
+    {
+        return tree.isDirty();
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexAccessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexAccessor.java
@@ -160,4 +160,10 @@ class FusionIndexAccessor implements IndexAccessor
         nativeAccessor.verifyDeferredConstraints( propertyAccessor );
         luceneAccessor.verifyDeferredConstraints( propertyAccessor );
     }
+
+    @Override
+    public boolean isDirty()
+    {
+        return nativeAccessor.isDirty();
+    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/recovery/RecoveryRequiredChecker.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/recovery/RecoveryRequiredChecker.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
-import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.NeoStores;
 import org.neo4j.kernel.impl.transaction.log.LogPosition;
 import org.neo4j.kernel.impl.transaction.log.LogTailScanner;
@@ -52,13 +51,9 @@ public class RecoveryRequiredChecker
 
     public boolean isRecoveryRequiredAt( File dataDir ) throws IOException
     {
-        File neoStore = new File( dataDir, MetaDataStore.DEFAULT_NAME );
         boolean noStoreFound = !NeoStores.isStorePresent( pageCache, dataDir );
-
-        // We need config to determine where the logical log files are
         if ( noStoreFound )
         {
-            // No database in the specified directory.
             return false;
         }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/IndexRule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/store/record/IndexRule.java
@@ -156,7 +156,7 @@ public class IndexRule extends SchemaRule implements IndexDescriptor.Supplier
     @Override
     public boolean equals( Object o )
     {
-        if ( o != null && o instanceof IndexRule )
+        if ( o instanceof IndexRule )
         {
             IndexRule that = (IndexRule) o;
             return this.descriptor.equals( that.descriptor );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/InMemoryIndex.java
@@ -234,6 +234,12 @@ class InMemoryIndex
         {
             InMemoryIndex.this.verifyDeferredConstraints( propertyAccessor );
         }
+
+        @Override
+        public boolean isDirty()
+        {
+            return false;
+        }
     }
 
     protected IndexUpdater newUpdater( IndexUpdateMode mode, boolean populating )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UpdateCapturingIndexAccessor.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/UpdateCapturingIndexAccessor.java
@@ -107,6 +107,12 @@ public class UpdateCapturingIndexAccessor implements IndexAccessor
         actual.verifyDeferredConstraints( propertyAccessor );
     }
 
+    @Override
+    public boolean isDirty()
+    {
+        return actual.isDirty();
+    }
+
     public Collection<IndexEntryUpdate<?>> snapshot()
     {
         return new ArrayList<>( updates );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreRebuildTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreRebuildTest.java
@@ -26,10 +26,12 @@ import org.junit.Test;
 import org.junit.rules.RuleChain;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.index.internal.gbptree.RecoveryCleanupWorkCollector;
 import org.neo4j.io.pagecache.PageCache;
 import org.neo4j.kernel.api.labelscan.LabelScanStore;
 import org.neo4j.kernel.api.labelscan.NodeLabelUpdate;
@@ -40,6 +42,7 @@ import org.neo4j.test.rule.TestDirectory;
 import org.neo4j.test.rule.fs.DefaultFileSystemRule;
 import org.neo4j.test.rule.fs.FileSystemRule;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -73,30 +76,14 @@ public class NativeLabelScanStoreRebuildTest
     {
         // given
         PageCache pageCache = pageCacheRule.getPageCache( fileSystemRule.get() );
-        NativeLabelScanStore nativeLabelScanStore = null;
-        try
-        {
-            nativeLabelScanStore =
-                    new NativeLabelScanStore( pageCache, storeDir, THROWING_STREAM, false, new Monitors(),
-                            IMMEDIATE );
-
-            nativeLabelScanStore.init();
-            nativeLabelScanStore.start();
-        }
-        catch ( IllegalArgumentException e )
-        {
-            if ( nativeLabelScanStore != null )
-            {
-                nativeLabelScanStore.shutdown();
-            }
-        }
+        createDirtyIndex( pageCache );
 
         // when
         RecordingMonitor monitor = new RecordingMonitor();
         Monitors monitors = new Monitors();
         monitors.addMonitorListener( monitor );
 
-        nativeLabelScanStore =
+        NativeLabelScanStore nativeLabelScanStore =
                 new NativeLabelScanStore( pageCache, storeDir, EMPTY, false, monitors, IMMEDIATE );
         nativeLabelScanStore.init();
         nativeLabelScanStore.start();
@@ -105,6 +92,27 @@ public class NativeLabelScanStoreRebuildTest
         assertTrue( monitor.notValid );
         assertTrue( monitor.rebuilding );
         assertTrue( monitor.rebuilt );
+        nativeLabelScanStore.shutdown();
+    }
+
+    @Test
+    public void doNotRebuildIfOpenedInReadOnlyModeAndIndexIsNotClean() throws IOException
+    {
+        PageCache pageCache = pageCacheRule.getPageCache( fileSystemRule.get() );
+        createDirtyIndex( pageCache );
+
+        Monitors monitors = new Monitors();
+        RecordingMonitor monitor = new RecordingMonitor();
+        monitors.addMonitorListener( monitor );
+
+        NativeLabelScanStore nativeLabelScanStore =
+                new NativeLabelScanStore( pageCache, storeDir, EMPTY, true, monitors, RecoveryCleanupWorkCollector.IGNORE );
+        nativeLabelScanStore.init();
+        nativeLabelScanStore.start();
+
+        assertTrue( monitor.notValid );
+        assertFalse( monitor.rebuilt );
+        assertFalse( monitor.rebuilding );
         nativeLabelScanStore.shutdown();
     }
 
@@ -134,6 +142,26 @@ public class NativeLabelScanStoreRebuildTest
             assertThat( e.getMessage(), Matchers.stringContainsInOrder( Iterables.asIterable( "2", "1" ) ) );
         }
         finally
+        {
+            if ( nativeLabelScanStore != null )
+            {
+                nativeLabelScanStore.shutdown();
+            }
+        }
+    }
+
+    private void createDirtyIndex( PageCache pageCache ) throws IOException
+    {
+        NativeLabelScanStore nativeLabelScanStore = null;
+        try
+        {
+            nativeLabelScanStore = new NativeLabelScanStore( pageCache, storeDir, THROWING_STREAM, false,
+                    new Monitors(), IMMEDIATE );
+
+            nativeLabelScanStore.init();
+            nativeLabelScanStore.start();
+        }
+        catch ( IllegalArgumentException e )
         {
             if ( nativeLabelScanStore != null )
             {

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreRebuildTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreRebuildTest.java
@@ -117,6 +117,25 @@ public class NativeLabelScanStoreRebuildTest
     }
 
     @Test
+    public void labelScanStoreIdDirtyWhenIndexIsNotClean() throws IOException
+    {
+        PageCache pageCache = pageCacheRule.getPageCache( fileSystemRule.get() );
+        createDirtyIndex( pageCache );
+
+        Monitors monitors = new Monitors();
+        RecordingMonitor monitor = new RecordingMonitor();
+        monitors.addMonitorListener( monitor );
+
+        NativeLabelScanStore nativeLabelScanStore =
+                new NativeLabelScanStore( pageCache, storeDir, EMPTY, true, monitors, RecoveryCleanupWorkCollector.IGNORE );
+        nativeLabelScanStore.init();
+        nativeLabelScanStore.start();
+
+        assertTrue( nativeLabelScanStore.isDirty() );
+        nativeLabelScanStore.shutdown();
+    }
+
+    @Test
     public void shouldFailOnUnsortedLabelsFromFullStoreChangeStream() throws Exception
     {
         // given

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreRebuildTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreRebuildTest.java
@@ -117,7 +117,7 @@ public class NativeLabelScanStoreRebuildTest
     }
 
     @Test
-    public void labelScanStoreIdDirtyWhenIndexIsNotClean() throws IOException
+    public void labelScanStoreIsDirtyWhenIndexIsNotClean() throws IOException
     {
         PageCache pageCache = pageCacheRule.getPageCache( fileSystemRule.get() );
         createDirtyIndex( pageCache );

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/labelscan/NativeLabelScanStoreTest.java
@@ -37,7 +37,13 @@ import org.neo4j.kernel.lifecycle.LifeSupport;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.test.rule.PageCacheRule;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.neo4j.kernel.impl.api.scan.FullStoreChangeStream.EMPTY;
 
 public class NativeLabelScanStoreTest extends LabelScanStoreTest
@@ -52,6 +58,12 @@ public class NativeLabelScanStoreTest extends LabelScanStoreTest
     {
         Monitors monitors = new Monitors();
         monitors.addMonitorListener( monitor );
+        return getLabelScanStore( fileSystemAbstraction, rootFolder, fullStoreChangeStream, readOnly, monitors );
+    }
+
+    private LabelScanStore getLabelScanStore( FileSystemAbstraction fileSystemAbstraction, File rootFolder,
+            FullStoreChangeStream fullStoreChangeStream, boolean readOnly, Monitors monitors )
+    {
         PageCache pageCache = pageCacheRule.getPageCache( fileSystemAbstraction );
         return new NativeLabelScanStore( pageCache, rootFolder,
                 fullStoreChangeStream, readOnly, monitors, RecoveryCleanupWorkCollector.IMMEDIATE );
@@ -68,6 +80,28 @@ public class NativeLabelScanStoreTest extends LabelScanStoreTest
     {
         File lssFile = new File( rootFolder, NativeLabelScanStore.FILE_NAME );
         scrambleFile( lssFile );
+    }
+
+    @Test
+    public void shutdownNonInitialisedNativeScanStoreWithoutException() throws IOException
+    {
+        String expectedMessage = "Expected exception message";
+        Monitors monitors = mock( Monitors.class );
+        when( monitors.newMonitor( LabelScanStore.Monitor.class ) ).thenReturn( LabelScanStore.Monitor.EMPTY );
+        doThrow( new RuntimeException( expectedMessage ) ).when( monitors ).addMonitorListener( any() );
+
+        LabelScanStore scanStore = getLabelScanStore( fileSystemRule.get(), dir, EMPTY, true, monitors );
+        try
+        {
+            scanStore.init();
+            fail( "Initialisation of store should fail." );
+        }
+        catch ( RuntimeException e )
+        {
+            assertEquals( expectedMessage, e.getMessage() );
+        }
+
+        scanStore.shutdown();
     }
 
     @Test

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexAccessorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/fusion/FusionIndexAccessorTest.java
@@ -35,6 +35,7 @@ import org.neo4j.kernel.impl.index.schema.fusion.FusionSchemaIndexProvider.DropA
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.core.AnyOf.anyOf;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -44,7 +45,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
-
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexTestHelp.verifyFusionCloseThrowIfBothThrow;
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexTestHelp.verifyFusionCloseThrowOnSingleCloseThrow;
 import static org.neo4j.kernel.impl.index.schema.fusion.FusionIndexTestHelp.verifyOtherIsClosedOnSingleThrow;
@@ -84,6 +84,15 @@ public class FusionIndexAccessorTest
     {
         // when
         verifyFailOnSingleDropFailure( nativeAccessor, fusionIndexAccessor );
+    }
+
+    @Test
+    public void fusionIndexIsDirtyWhenNativeIndexIsDirty()
+    {
+        when( nativeAccessor.isDirty() ).thenReturn( true ).thenReturn( false );
+
+        assertTrue( fusionIndexAccessor.isDirty() );
+        assertFalse( fusionIndexAccessor.isDirty() );
     }
 
     @Test

--- a/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexAccessor.java
+++ b/community/lucene-index/src/main/java/org/neo4j/kernel/api/impl/schema/LuceneIndexAccessor.java
@@ -120,6 +120,12 @@ public class LuceneIndexAccessor implements IndexAccessor
         luceneIndex.verifyUniqueness( propertyAccessor, descriptor.schema().getPropertyIds() );
     }
 
+    @Override
+    public boolean isDirty()
+    {
+        return luceneIndex.isValid();
+    }
+
     private class LuceneIndexUpdater implements IndexUpdater
     {
         private final boolean idempotent;


### PR DESCRIPTION
Do not try to recover native label scan store on CC.
Allow native scan store to shutdown even if init failed.
Cleanup in RecoverRequiredChecker.