### PR TITLE
More usage of Kernel API in compiled runtime

### DIFF
--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/DelegatingQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/DelegatingQueryContext.scala
@@ -27,7 +27,7 @@ import org.neo4j.cypher.internal.runtime._
 import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection
 import org.neo4j.cypher.internal.v3_4.logical.plans.QualifiedName
 import org.neo4j.graphdb.{Node, Path, PropertyContainer}
-import org.neo4j.internal.kernel.api.{CursorFactory, IndexReference, Read, Write}
+import org.neo4j.internal.kernel.api._
 import org.neo4j.kernel.api.ReadOperations
 import org.neo4j.kernel.api.dbms.DbmsOperations
 import org.neo4j.kernel.impl.api.store.RelationshipIterator
@@ -35,7 +35,7 @@ import org.neo4j.kernel.impl.core.EmbeddedProxySPI
 import org.neo4j.kernel.impl.factory.DatabaseInfo
 import org.neo4j.values.AnyValue
 import org.neo4j.values.storable.Value
-import org.neo4j.values.virtual.{RelationshipValue, ListValue, NodeValue}
+import org.neo4j.values.virtual.{ListValue, NodeValue, RelationshipValue}
 
 import scala.collection.Iterator
 
@@ -297,6 +297,8 @@ class DelegatingQueryTransactionalContext(val inner: QueryTransactionalContext) 
   override def cursors: CursorFactory = inner.cursors
 
   override def dataRead: Read = inner.dataRead
+
+  override def tokenRead: TokenRead = inner.tokenRead
 
   override def dataWrite: Write = inner.dataWrite
 }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/DelegatingQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/DelegatingQueryContext.scala
@@ -300,5 +300,7 @@ class DelegatingQueryTransactionalContext(val inner: QueryTransactionalContext) 
 
   override def tokenRead: TokenRead = inner.tokenRead
 
+  override def schemaRead: SchemaRead = inner.schemaRead
+
   override def dataWrite: Write = inner.dataWrite
 }

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionBoundQueryContext.scala
@@ -107,7 +107,6 @@ final class TransactionBoundQueryContext(val transactionalContext: Transactional
   private def reads() = transactionalContext.dataRead
   private val nodeCursor = allocateAndTraceNodeCursor()
   private val propertyCursor = allocateAndTracePropertyCursor()
-  private lazy val nodeValueIndexCursor = allocateAndTraceNodeValueIndexCursor()
   private def tokenRead = transactionalContext.kernelTransaction.tokenRead()
   private def tokenWrite = transactionalContext.kernelTransaction.tokenWrite()
 

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionalContextWrapper.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionalContextWrapper.scala
@@ -23,7 +23,7 @@ import org.neo4j.cypher.internal.planner.v3_4.spi.KernelStatisticProvider
 import org.neo4j.cypher.internal.runtime.QueryTransactionalContext
 import org.neo4j.graphdb.{Lock, PropertyContainer}
 import org.neo4j.internal.kernel.api.security.SecurityContext
-import org.neo4j.internal.kernel.api.{CursorFactory, Read, Write}
+import org.neo4j.internal.kernel.api.{CursorFactory, Read, TokenRead, Write}
 import org.neo4j.kernel.GraphDatabaseQueryService
 import org.neo4j.kernel.api.KernelTransaction.Revertable
 import org.neo4j.kernel.api.dbms.DbmsOperations
@@ -56,6 +56,8 @@ case class TransactionalContextWrapper(tc: TransactionalContext) extends QueryTr
   override def cursors: CursorFactory = tc.kernelTransaction.cursors()
 
   override def dataRead: Read = tc.kernelTransaction().dataRead()
+
+  override def tokenRead: TokenRead = tc.kernelTransaction().tokenRead()
 
   override def dataWrite: Write = tc.kernelTransaction().dataWrite()
 

--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionalContextWrapper.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/TransactionalContextWrapper.scala
@@ -22,8 +22,8 @@ package org.neo4j.cypher.internal.runtime.interpreted
 import org.neo4j.cypher.internal.planner.v3_4.spi.KernelStatisticProvider
 import org.neo4j.cypher.internal.runtime.QueryTransactionalContext
 import org.neo4j.graphdb.{Lock, PropertyContainer}
+import org.neo4j.internal.kernel.api._
 import org.neo4j.internal.kernel.api.security.SecurityContext
-import org.neo4j.internal.kernel.api.{CursorFactory, Read, TokenRead, Write}
 import org.neo4j.kernel.GraphDatabaseQueryService
 import org.neo4j.kernel.api.KernelTransaction.Revertable
 import org.neo4j.kernel.api.dbms.DbmsOperations
@@ -58,6 +58,8 @@ case class TransactionalContextWrapper(tc: TransactionalContext) extends QueryTr
   override def dataRead: Read = tc.kernelTransaction().dataRead()
 
   override def tokenRead: TokenRead = tc.kernelTransaction().tokenRead()
+
+  override def schemaRead: SchemaRead = tc.kernelTransaction().schemaRead()
 
   override def dataWrite: Write = tc.kernelTransaction().dataWrite()
 

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryContext.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryContext.scala
@@ -26,7 +26,7 @@ import org.neo4j.cypher.internal.planner.v3_4.spi.{IdempotentResult, IndexDescri
 import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection
 import org.neo4j.cypher.internal.v3_4.logical.plans.QualifiedName
 import org.neo4j.graphdb.{Node, Path, PropertyContainer}
-import org.neo4j.internal.kernel.api.{CursorFactory, IndexReference, Read, Write}
+import org.neo4j.internal.kernel.api._
 import org.neo4j.kernel.api.ReadOperations
 import org.neo4j.kernel.api.dbms.DbmsOperations
 import org.neo4j.kernel.impl.api.store.RelationshipIterator
@@ -34,7 +34,7 @@ import org.neo4j.kernel.impl.core.EmbeddedProxySPI
 import org.neo4j.kernel.impl.factory.DatabaseInfo
 import org.neo4j.values.AnyValue
 import org.neo4j.values.storable.Value
-import org.neo4j.values.virtual.{RelationshipValue, ListValue, NodeValue}
+import org.neo4j.values.virtual.{ListValue, NodeValue, RelationshipValue}
 
 import scala.collection.Iterator
 
@@ -243,6 +243,8 @@ trait QueryTransactionalContext extends CloseableResource {
   def cursors : CursorFactory
 
   def dataRead: Read
+
+  def tokenRead: TokenRead
 
   def dataWrite: Write
 

--- a/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryContext.scala
+++ b/community/cypher/runtime-util/src/main/scala/org/neo4j/cypher/internal/runtime/QueryContext.scala
@@ -246,6 +246,8 @@ trait QueryTransactionalContext extends CloseableResource {
 
   def tokenRead: TokenRead
 
+  def schemaRead: SchemaRead
+
   def dataWrite: Write
 
   def readOperations: ReadOperations

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/NodeValueIndexCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/NodeValueIndexCursor.java
@@ -21,6 +21,8 @@ package org.neo4j.internal.kernel.api;
 
 import org.neo4j.values.storable.Value;
 
+import static org.neo4j.values.storable.Values.NO_VALUE;
+
 /**
  * Cursor for scanning the property values of nodes in a schema index.
  * <p>
@@ -65,4 +67,70 @@ public interface NodeValueIndexCursor extends NodeIndexCursor
     boolean hasValue();
 
     Value propertyValue( int offset );
+
+    class Empty implements NodeValueIndexCursor
+    {
+
+        @Override
+        public void node( NodeCursor cursor )
+        {
+
+        }
+
+        @Override
+        public long nodeReference()
+        {
+            return -1L;
+        }
+
+        @Override
+        public boolean next()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean shouldRetry()
+        {
+            return false;
+        }
+
+        @Override
+        public void close()
+        {
+
+        }
+
+        @Override
+        public boolean isClosed()
+        {
+            return false;
+        }
+
+        @Override
+        public int numberOfProperties()
+        {
+            return 0;
+        }
+
+        @Override
+        public int propertyKey( int offset )
+        {
+            return -1;
+        }
+
+        @Override
+        public boolean hasValue()
+        {
+            return false;
+        }
+
+        @Override
+        public Value propertyValue( int offset )
+        {
+            return NO_VALUE;
+        }
+    }
+
+    NodeValueIndexCursor EMPTY = new Empty();
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ExpandAllLoopDataGenerator.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ExpandAllLoopDataGenerator.scala
@@ -33,7 +33,7 @@ case class ExpandAllLoopDataGenerator(opName: String, fromVar: Variable, dir: Se
     }
   }
 
-  override def produceIterator[E](iterVar: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
+  override def produceLoopData[E](iterVar: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
     if(types.isEmpty)
       generator.nodeGetRelationshipsWithDirection(iterVar, fromVar.name, fromVar.codeGenType, dir)
     else
@@ -41,11 +41,11 @@ case class ExpandAllLoopDataGenerator(opName: String, fromVar: Variable, dir: Se
     generator.incrementDbHits()
   }
 
-  override def produceNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
-                             (implicit context: CodeGenContext) = {
+  override def getNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
+                         (implicit context: CodeGenContext) = {
     generator.incrementDbHits()
     generator.nextRelationshipAndNode(toVar.name, iterVar, dir, fromVar.name, relVar.name)
   }
 
-  override def hasNext[E](generator: MethodStructure[E], iterVar: String): E = generator.advanceRelationshipSelectionCursor(iterVar)
+  override def checkNext[E](generator: MethodStructure[E], iterVar: String): E =  generator.advanceRelationshipSelectionCursor(iterVar)
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ExpandIntoLoopDataGenerator.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ExpandIntoLoopDataGenerator.scala
@@ -33,7 +33,7 @@ case class ExpandIntoLoopDataGenerator(opName: String, fromVar: Variable, dir: S
     }
   }
 
-  override def produceIterator[E](iterVar: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
+  override def produceLoopData[E](iterVar: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
     if(types.isEmpty)
       generator.connectingRelationships(iterVar, fromVar.name, fromVar.codeGenType, dir, toVar.name, toVar.codeGenType)
     else
@@ -41,11 +41,11 @@ case class ExpandIntoLoopDataGenerator(opName: String, fromVar: Variable, dir: S
     generator.incrementDbHits()
   }
 
-  override def produceNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
-                             (implicit context: CodeGenContext) = {
+  override def getNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
+                         (implicit context: CodeGenContext) = {
     generator.incrementDbHits()
     generator.nextRelationship(iterVar, dir, relVar.name)
   }
 
-  override def hasNext[E](generator: MethodStructure[E], iterVar: String): E = generator.advanceRelationshipSelectionCursor(iterVar)
+  override def checkNext[E](generator: MethodStructure[E], iterVar: String): E = generator.advanceRelationshipSelectionCursor(iterVar)
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/IndexSeek.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/IndexSeek.scala
@@ -33,7 +33,7 @@ case class IndexSeek(opName: String, labelName: String, propNames: Seq[String], 
     val propKeyVar = context.namer.newVarName()
     generator.lookupLabelId(labelVar, labelName)
     generator.lookupPropertyKey(propNames.head, propKeyVar)
-    generator.newIndexDescriptor(descriptorVar, labelVar, propKeyVar)
+    generator.newIndexReference(descriptorVar, labelVar, propKeyVar)
   }
 
   override def produceIterator[E](iterVar: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
@@ -44,8 +44,8 @@ case class IndexSeek(opName: String, labelName: String, propNames: Seq[String], 
   override def produceNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
                              (implicit context: CodeGenContext) = {
     generator.incrementDbHits()
-    generator.nextNode(nextVar.name, iterVar)
+    generator.nodeFromNodeValueIndexCursor(nextVar.name, iterVar)
   }
 
-  override def hasNext[E](generator: MethodStructure[E], iterVar: String): E = generator.hasNextNode(iterVar)
+  override def hasNext[E](generator: MethodStructure[E], iterVar: String): E = generator.advanceNodeValueIndexCursor(iterVar)
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/IndexSeek.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/IndexSeek.scala
@@ -36,16 +36,16 @@ case class IndexSeek(opName: String, labelName: String, propNames: Seq[String], 
     generator.newIndexReference(descriptorVar, labelVar, propKeyVar)
   }
 
-  override def produceIterator[E](iterVar: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
+  override def produceLoopData[E](iterVar: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
       generator.indexSeek(iterVar, descriptorVar, expression.generateExpression(generator), expression.codeGenType)
       generator.incrementDbHits()
   }
 
-  override def produceNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
-                             (implicit context: CodeGenContext) = {
+  override def getNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
+                         (implicit context: CodeGenContext) = {
     generator.incrementDbHits()
     generator.nodeFromNodeValueIndexCursor(nextVar.name, iterVar)
   }
 
-  override def hasNext[E](generator: MethodStructure[E], iterVar: String): E = generator.advanceNodeValueIndexCursor(iterVar)
+  override def checkNext[E](generator: MethodStructure[E], iterVar: String): E = generator.advanceNodeValueIndexCursor(iterVar)
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/LoopDataGenerator.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/LoopDataGenerator.scala
@@ -22,16 +22,16 @@ package org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.codegen.ir
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.codegen.spi.MethodStructure
 import org.neo4j.cypher.internal.compatibility.v3_4.runtime.compiled.codegen.{CodeGenContext, Variable}
 
-// Generates the code that moves data into local variables from the iterator being consumed
+// Generates the code that moves data into local variables from the iterator or cursor being consumed.
 trait LoopDataGenerator {
 
-  def hasNext[E](generator: MethodStructure[E], iterVar: String): E
+  def checkNext[E](generator: MethodStructure[E], iterVar: String): E
 
   def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext): Unit
 
-  def produceNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])(implicit context: CodeGenContext): Unit
+  def getNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])(implicit context: CodeGenContext): Unit
 
-  def produceIterator[E](iterVarName: String, generator: MethodStructure[E])(implicit context: CodeGenContext): Unit
+  def produceLoopData[E](iterVarName: String, generator: MethodStructure[E])(implicit context: CodeGenContext): Unit
 
   def opName: String
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ScanAllNodes.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ScanAllNodes.scala
@@ -26,16 +26,16 @@ case class ScanAllNodes(opName: String) extends LoopDataGenerator {
 
   override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {}
 
-  override def produceIterator[E](iterVar: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
+  override def produceLoopData[E](iterVar: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
     generator.allNodesScan(iterVar)
     generator.incrementDbHits()
   }
 
-  override def produceNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
-                             (implicit context: CodeGenContext) = {
+  override def getNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
+                         (implicit context: CodeGenContext) = {
     generator.incrementDbHits()
     generator.nodeFromNodeCursor(nextVar.name, iterVar)
   }
 
-  override def hasNext[E](generator: MethodStructure[E], iterVar: String): E = generator.advanceNodeCursor(iterVar)
+  override def checkNext[E](generator: MethodStructure[E], iterVar: String): E = generator.advanceNodeCursor(iterVar)
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ScanForLabel.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/ScanForLabel.scala
@@ -27,17 +27,17 @@ case class ScanForLabel(opName: String, labelName: String, labelVar: String) ext
   override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext) =
     generator.lookupLabelId(labelVar, labelName)
 
-  override def produceIterator[E](iterVar: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
+  override def produceLoopData[E](iterVar: String, generator: MethodStructure[E])(implicit context: CodeGenContext) = {
     generator.labelScan(iterVar, labelVar)
     generator.incrementDbHits()
   }
 
-  override def produceNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
-                             (implicit context: CodeGenContext) = {
+  override def getNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
+                         (implicit context: CodeGenContext) = {
     generator.incrementDbHits()
     generator.nodeFromNodeLabelIndexCursor(nextVar.name, iterVar)
   }
 
-  override def hasNext[E](generator: MethodStructure[E], iterVar: String): E =
+  override def checkNext[E](generator: MethodStructure[E], iterVar: String): E =
     generator.advanceNodeLabelIndexCursor(iterVar)
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/UnwindCollection.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/UnwindCollection.scala
@@ -27,19 +27,19 @@ case class UnwindCollection(opName: String, collection: CodeGenExpression) exten
   override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext): Unit =
     collection.init(generator)
 
-  override def produceIterator[E](iterVar: String, generator: MethodStructure[E])
+  override def produceLoopData[E](iterVar: String, generator: MethodStructure[E])
                                  (implicit context: CodeGenContext): Unit = {
     generator.declareIterator(iterVar)
     val iterator = generator.iteratorFrom(collection.generateExpression(generator))
     generator.assign(iterVar, CodeGenType.Any, iterator)
   }
 
-  override def produceNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
-                             (implicit context: CodeGenContext): Unit = {
+  override def getNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
+                         (implicit context: CodeGenContext): Unit = {
     val next = generator.iteratorNext(generator.loadVariable(iterVar))
     generator.assign(nextVar.name, CodeGenType.Any, next)
   }
 
-  override def hasNext[E](generator: MethodStructure[E], iterVar: String): E =
+  override def checkNext[E](generator: MethodStructure[E], iterVar: String): E =
     generator.iteratorHasNext(generator.loadVariable(iterVar))
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/UnwindPrimitiveCollection.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/UnwindPrimitiveCollection.scala
@@ -28,15 +28,15 @@ case class UnwindPrimitiveCollection(opName: String, collection: CodeGenExpressi
   override def init[E](generator: MethodStructure[E])(implicit context: CodeGenContext): Unit =
     collection.init(generator)
 
-  override def produceIterator[E](iterVar: String, generator: MethodStructure[E])
+  override def produceLoopData[E](iterVar: String, generator: MethodStructure[E])
                                  (implicit context: CodeGenContext): Unit = {
     generator.declarePrimitiveIterator(iterVar, collection.codeGenType)
     val iterator = generator.primitiveIteratorFrom(collection.generateExpression(generator), collection.codeGenType)
     generator.assign(iterVar, CodeGenType.Any, iterator)
   }
 
-  override def produceNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
-                             (implicit context: CodeGenContext): Unit = {
+  override def getNext[E](nextVar: Variable, iterVar: String, generator: MethodStructure[E])
+                         (implicit context: CodeGenContext): Unit = {
     val elementType = collection.codeGenType match {
       case CypherCodeGenType(symbols.ListType(innerCt), ListReferenceType(innerRepr)) => CypherCodeGenType(innerCt, innerRepr)
       case _ => throw new IllegalArgumentException(s"CodeGenType $collection.codeGenType not supported as primitive iterator")
@@ -45,6 +45,6 @@ case class UnwindPrimitiveCollection(opName: String, collection: CodeGenExpressi
     generator.assign(nextVar.name, elementType, next)
   }
 
-  override def hasNext[E](generator: MethodStructure[E], iterVar: String): E =
+  override def checkNext[E](generator: MethodStructure[E], iterVar: String): E =
     generator.iteratorHasNext(generator.loadVariable(iterVar))
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/WhileLoop.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/ir/WhileLoop.scala
@@ -27,10 +27,10 @@ case class WhileLoop(variable: Variable, producer: LoopDataGenerator, action: In
   override def body[E](generator: MethodStructure[E])(implicit context: CodeGenContext) = {
     val iterator = s"${variable.name}Iter"
     generator.trace(producer.opName) { body =>
-      producer.produceIterator(iterator, body)
-      body.whileLoop(producer.hasNext(body, iterator)) { loopBody =>
+      producer.produceLoopData(iterator, body)
+      body.whileLoop(producer.checkNext(body, iterator)) { loopBody =>
         loopBody.incrementRows()
-        producer.produceNext(variable, iterator, loopBody)
+        producer.getNext(variable, iterator, loopBody)
         action.body(loopBody)
       }
     }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/spi/MethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/spi/MethodStructure.scala
@@ -163,12 +163,12 @@ trait MethodStructure[E] {
   def nodeFromNodeLabelIndexCursor(targetVar: String, iterVar: String): Unit
   def nextRelationshipAndNode(toNodeVar: String, iterVar: String, direction: SemanticDirection, fromNodeVar: String, relVar: String): Unit
   def nextRelationship(iterVar: String, direction: SemanticDirection, relVar: String): Unit
-  def hasNextNode(iterVar: String): E
+
   def advanceNodeCursor(iterVar: String): E
   def advanceNodeLabelIndexCursor(iterVar: String): E
   def advanceRelationshipSelectionCursor(iterVar: String): E
   def advanceNodeValueIndexCursor(iterVar: String): E
-  def hasNextRelationship(iterVar: String): E
+
   def nodeGetPropertyById(nodeVar: String, nodeVarType: CodeGenType, propId: Int, propValueVar: String): Unit
   def nodeGetPropertyForVar(nodeVar: String, nodeVarType: CodeGenType, propIdVar: String, propValueVar: String): Unit
   def nodeIdSeek(nodeIdVar: String, expression: E, codeGenType: CodeGenType)(block: MethodStructure[E] => Unit): Unit
@@ -178,7 +178,6 @@ trait MethodStructure[E] {
   def indexSeek(iterVar: String, descriptorVar: String, value: E, codeGenType: CodeGenType): Unit
   def relType(relIdVar: String, typeVar: String): Unit
   def newIndexReference(descriptorVar: String, labelVar: String, propKeyVar: String): Unit
-  def createRelExtractor(extractorName: String): Unit
   def nodeCountFromCountStore(expression: E): E
   def relCountFromCountStore(start: E, end: E, types: E*): E
   def token(t: Int): E

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/spi/MethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/compatibility/v3_4/runtime/compiled/codegen/spi/MethodStructure.scala
@@ -158,7 +158,7 @@ trait MethodStructure[E] {
   def nodeGetRelationshipsWithDirectionAndTypes(iterVar: String, nodeVar: String, nodeVarType: CodeGenType, direction: SemanticDirection, typeVars: Seq[String]): Unit
   def connectingRelationships(iterVar: String, fromNode: String, fromNodeType: CodeGenType, dir: SemanticDirection, toNode:String, toNodeType: CodeGenType)
   def connectingRelationships(iterVar: String, fromNode: String, fromNodeType: CodeGenType, dir: SemanticDirection, types: Seq[String], toNode: String, toNodeType: CodeGenType)
-  def nextNode(targetVar: String, iterVar: String): Unit
+  def nodeFromNodeValueIndexCursor(targetVar: String, iterVar: String): Unit
   def nodeFromNodeCursor(targetVar: String, iterVar: String): Unit
   def nodeFromNodeLabelIndexCursor(targetVar: String, iterVar: String): Unit
   def nextRelationshipAndNode(toNodeVar: String, iterVar: String, direction: SemanticDirection, fromNodeVar: String, relVar: String): Unit
@@ -167,6 +167,8 @@ trait MethodStructure[E] {
   def advanceNodeCursor(iterVar: String): E
   def advanceNodeLabelIndexCursor(iterVar: String): E
   def advanceRelationshipSelectionCursor(iterVar: String): E
+  def advanceNodeValueIndexCursor(iterVar: String): E
+  def hasNextRelationship(iterVar: String): E
   def nodeGetPropertyById(nodeVar: String, nodeVarType: CodeGenType, propId: Int, propValueVar: String): Unit
   def nodeGetPropertyForVar(nodeVar: String, nodeVarType: CodeGenType, propIdVar: String, propValueVar: String): Unit
   def nodeIdSeek(nodeIdVar: String, expression: E, codeGenType: CodeGenType)(block: MethodStructure[E] => Unit): Unit
@@ -175,7 +177,8 @@ trait MethodStructure[E] {
   def lookupPropertyKey(propName: String, propVar: String)
   def indexSeek(iterVar: String, descriptorVar: String, value: E, codeGenType: CodeGenType): Unit
   def relType(relIdVar: String, typeVar: String): Unit
-  def newIndexDescriptor(descriptorVar: String, labelVar: String, propKeyVar: String): Unit
+  def newIndexReference(descriptorVar: String, labelVar: String, propKeyVar: String): Unit
+  def createRelExtractor(extractorName: String): Unit
   def nodeCountFromCountStore(expression: E): E
   def relCountFromCountStore(start: E, end: E, types: E*): E
   def token(t: Int): E

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Fields.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Fields.scala
@@ -35,5 +35,6 @@ case class Fields(closer: FieldReference,
                   nodeCursor: FieldReference,
                   propertyCursor: FieldReference,
                   dataRead: FieldReference,
-                  tokenRead: FieldReference
+                  tokenRead: FieldReference,
+                  schemaRead: FieldReference
                  )

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Fields.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Fields.scala
@@ -34,4 +34,6 @@ case class Fields(closer: FieldReference,
                   cursors: FieldReference,
                   nodeCursor: FieldReference,
                   propertyCursor: FieldReference,
-                  dataRead: FieldReference)
+                  dataRead: FieldReference,
+                  tokenRead: FieldReference
+                 )

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedMethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedMethodStructure.scala
@@ -1449,7 +1449,7 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
     }
     using(generator.ifStatement(and(
       gt(generator.load(nodeIdVar), constant(-1L)),
-      invoke(readOperations, nodeExists, generator.load(nodeIdVar))
+      invoke(dataRead, nodeExists, generator.load(nodeIdVar))
     ))) { ifBody =>
       block(copy(generator = ifBody))
     }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedMethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedMethodStructure.scala
@@ -157,16 +157,16 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
 
   override def lookupLabelId(labelIdVar: String, labelName: String) =
     generator.assign(typeRef[Int], labelIdVar,
-                     invoke(readOperations, labelGetForName, constant(labelName)))
+                     invoke(tokenRead, labelGetForName, constant(labelName)))
 
   override def lookupLabelIdE(labelName: String): Expression =
-    invoke(readOperations, labelGetForName, constant(labelName))
+    invoke(tokenRead, labelGetForName, constant(labelName))
 
   override def lookupRelationshipTypeId(typeIdVar: String, typeName: String) =
-    generator.assign(typeRef[Int], typeIdVar, invoke(readOperations, relationshipTypeGetForName, constant(typeName)))
+    generator.assign(typeRef[Int], typeIdVar, invoke(tokenRead, relationshipTypeGetForName, constant(typeName)))
 
   override def lookupRelationshipTypeIdE(typeName: String) =
-    invoke(readOperations, relationshipTypeGetForName, constant(typeName))
+    invoke(tokenRead, relationshipTypeGetForName, constant(typeName))
 
   override def hasNextNode(iterVar: String) =
     invoke(generator.load(iterVar), hasNextLong)
@@ -550,6 +550,9 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
 
   private def dataRead: Expression =
     invoke(generator.self(), methodReference(generator.owner(), typeRef[Read], "getOrLoadDataRead"))
+
+  private def tokenRead: Expression =
+    invoke(generator.self(), methodReference(generator.owner(), typeRef[TokenRead], "getOrLoadTokenRead"))
 
   private def cursors: Expression =
     invoke(generator.self(), methodReference(generator.owner(), typeRef[CursorFactory], "getOrLoadCursors"))
@@ -1364,7 +1367,7 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
     val variable = locals(typeVar)
     val typeOfRel = invoke(generator.load(relCursor(relVar)),  method[RelationshipSelectionCursor, Int]("type"))
     handleKernelExceptions(generator, fields, _finalizers) { inner =>
-      val res = invoke(readOperations, relationshipTypeGetName, typeOfRel)
+      val res = invoke(tokenRead, relationshipTypeGetName, typeOfRel)
       inner.assign(variable, res)
       generator.load(variable.name())
     }
@@ -1469,7 +1472,7 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
   }
 
   override def lookupPropertyKey(propName: String, propIdVar: String) =
-    generator.assign(typeRef[Int], propIdVar, invoke(readOperations, propertyKeyGetForName, constant(propName)))
+    generator.assign(typeRef[Int], propIdVar, invoke(tokenRead, propertyKeyGetForName, constant(propName)))
 
   override def newIndexDescriptor(descriptorVar: String, labelVar: String, propKeyVar: String) = {
     val getIndexDescriptor = method[IndexDescriptorFactory, IndexDescriptor]("forLabel", typeRef[Int], typeRef[Array[Int]])

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedMethodStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedMethodStructure.scala
@@ -128,8 +128,6 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
     generator.assign(typeRef[Long], relVar, invoke(generator.load(cursor),
                                                    method[RelationshipSelectionCursor, Long]("relationshipReference")))
   }
-
-  private def relExtractor(relVar: String) = s"${relVar}Extractor"
   private def relCursor(relVar: String) = s"${relVar}Iter"
 
   override def nextRelationship(iterVar: String, ignored: SemanticDirection, relVar: String) = {
@@ -167,26 +165,17 @@ class GeneratedMethodStructure(val fields: Fields, val generator: CodeBlock, aux
   override def lookupRelationshipTypeIdE(typeName: String) =
     invoke(tokenRead, relationshipTypeGetForName, constant(typeName))
 
-  override def hasNextNode(iterVar: String) =
-    invoke(generator.load(iterVar), hasNextLong)
-
   override def advanceNodeCursor(iterVar: String) =
     invoke(generator.load(iterVar), method[NodeCursor, Boolean]("next"))
 
   override def advanceNodeLabelIndexCursor(iterVar: String) =
     invoke(generator.load(iterVar), method[NodeLabelIndexCursor, Boolean]("next"))
 
-<<<<<<< HEAD
   override def advanceRelationshipSelectionCursor(iterVar: String) =
     invoke(generator.load(iterVar), method[RelationshipSelectionCursor, Boolean]("next"))
 
-=======
   override def advanceNodeValueIndexCursor(iterVar: String) =
     invoke(generator.load(iterVar), method[NodeValueIndexCursor, Boolean]("next"))
-
-  override def hasNextRelationship(iterVar: String) =
-    invoke(generator.load(iterVar), hasMoreRelationship)
->>>>>>> Use Kernel API for index seek in compiled runtime
 
   override def whileLoop(test: Expression)(block: MethodStructure[Expression] => Unit) =
     using(generator.whileLoop(test)) { body =>

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedQueryStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedQueryStructure.scala
@@ -181,6 +181,7 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
     Templates.getOrLoadReadOperations(clazz, fields)
     Templates.getOrLoadDataRead(clazz, fields)
     Templates.getOrLoadTokenRead(clazz, fields)
+    Templates.getOrLoadSchemaRead(clazz, fields)
     Templates.getOrLoadCursors(clazz, fields)
     Templates.nodeCursor(clazz, fields)
     Templates.propertyCursor(clazz, fields)
@@ -216,7 +217,8 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
       nodeCursor = clazz.field(typeRef[NodeCursor], "nodeCursor"),
       propertyCursor = clazz.field(typeRef[PropertyCursor], "propertyCursor"),
       dataRead =  clazz.field(typeRef[Read], "dataRead"),
-      tokenRead =  clazz.field(typeRef[TokenRead], "tokenRead")
+      tokenRead =  clazz.field(typeRef[TokenRead], "tokenRead"),
+      schemaRead =  clazz.field(typeRef[SchemaRead], "schemaRead")
       )
   }
 

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedQueryStructure.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/GeneratedQueryStructure.scala
@@ -43,7 +43,7 @@ import org.neo4j.cypher.internal.util.v3_4.{TaskCloser, symbols}
 import org.neo4j.cypher.internal.v3_4.codegen.QueryExecutionTracer
 import org.neo4j.cypher.internal.v3_4.executionplan.{GeneratedQuery, GeneratedQueryExecution}
 import org.neo4j.cypher.result.QueryResult.QueryResultVisitor
-import org.neo4j.internal.kernel.api.{CursorFactory, NodeCursor, PropertyCursor, Read}
+import org.neo4j.internal.kernel.api._
 import org.neo4j.kernel.api.ReadOperations
 import org.neo4j.kernel.impl.core.EmbeddedProxySPI
 import org.neo4j.values.virtual.MapValue
@@ -180,6 +180,7 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
     clazz.generate(Templates.constructor(clazz.handle()))
     Templates.getOrLoadReadOperations(clazz, fields)
     Templates.getOrLoadDataRead(clazz, fields)
+    Templates.getOrLoadTokenRead(clazz, fields)
     Templates.getOrLoadCursors(clazz, fields)
     Templates.nodeCursor(clazz, fields)
     Templates.propertyCursor(clazz, fields)
@@ -214,7 +215,9 @@ object GeneratedQueryStructure extends CodeStructure[GeneratedQuery] {
       cursors = clazz.field(typeRef[CursorFactory], "cursors"),
       nodeCursor = clazz.field(typeRef[NodeCursor], "nodeCursor"),
       propertyCursor = clazz.field(typeRef[PropertyCursor], "propertyCursor"),
-      dataRead =  clazz.field(typeRef[Read], "dataRead"))
+      dataRead =  clazz.field(typeRef[Read], "dataRead"),
+      tokenRead =  clazz.field(typeRef[TokenRead], "tokenRead")
+      )
   }
 
   def method[O <: AnyRef, R](name: String, params: TypeReference*)

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Methods.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Methods.scala
@@ -35,7 +35,6 @@ import org.neo4j.graphdb.Direction
 import org.neo4j.helpers.collection.MapUtil
 import org.neo4j.internal.kernel.api.helpers.RelationshipSelectionCursor
 import org.neo4j.internal.kernel.api._
-import org.neo4j.internal.kernel.api.{IndexQuery, Read, TokenRead}
 import org.neo4j.internal.kernel.api.{Read, TokenRead}
 import org.neo4j.kernel.api.ReadOperations
 import org.neo4j.kernel.impl.api.store.RelationshipIterator

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Methods.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Methods.scala
@@ -21,6 +21,7 @@ package org.neo4j.cypher.internal.spi.v3_4.codegen
 
 import java.util
 
+import org.neo4j.codegen.MethodReference
 import org.neo4j.collection.primitive.{PrimitiveLongIntMap, PrimitiveLongIterator, PrimitiveLongResourceIterator}
 import org.neo4j.cypher.internal.codegen.CompiledConversionUtils.CompositeKey
 import org.neo4j.cypher.internal.codegen._
@@ -35,8 +36,8 @@ import org.neo4j.helpers.collection.MapUtil
 import org.neo4j.internal.kernel.api.helpers.RelationshipSelectionCursor
 import org.neo4j.internal.kernel.api._
 import org.neo4j.internal.kernel.api.{IndexQuery, Read, TokenRead}
+import org.neo4j.internal.kernel.api.{Read, TokenRead}
 import org.neo4j.kernel.api.ReadOperations
-import org.neo4j.kernel.api.schema.index.IndexDescriptor
 import org.neo4j.kernel.impl.api.store.RelationshipIterator
 import org.neo4j.kernel.impl.api.{RelationshipDataExtractor, RelationshipVisitor}
 import org.neo4j.kernel.impl.core.{EmbeddedProxySPI, NodeProxy, RelationshipProxy}
@@ -46,88 +47,85 @@ import org.neo4j.values.storable.{Value, Values}
 object Methods {
 
   import GeneratedQueryStructure.{method, typeRef}
+  val countingTablePut: MethodReference = method[PrimitiveLongIntMap, Int]("put", typeRef[Long], typeRef[Int])
+  val countingTableCompositeKeyPut: MethodReference = method[util.HashMap[CompositeKey, Integer], Object]("put", typeRef[Object], typeRef[Object])
+  val countingTableGet: MethodReference = method[PrimitiveLongIntMap, Int]("get", typeRef[Long])
+  val countingTableCompositeKeyGet: MethodReference = method[util.HashMap[CompositeKey, Integer], Object]("get", typeRef[Object])
+  val compositeKey: MethodReference = method[CompiledConversionUtils, CompositeKey]("compositeKey", typeRef[Array[Long]])
+  val hasNextLong: MethodReference = method[PrimitiveLongIterator, Boolean]("hasNext")
+  val hasMoreRelationship: MethodReference = method[RelationshipIterator, Boolean]("hasNext")
+  val createMap: MethodReference = method[MapUtil, util.Map[String, Object]]("map", typeRef[Array[Object]])
+  val format: MethodReference = method[String, String]("format", typeRef[String], typeRef[Array[Object]])
+  val relationshipVisit: MethodReference = method[RelationshipIterator, Boolean]("relationshipVisit", typeRef[Long], typeRef[RelationshipVisitor[RuntimeException]])
+  val getRelationship: MethodReference = method[RelationshipDataExtractor, Long]("relationship")
+  val startNode: MethodReference = method[RelationshipDataExtractor, Long]("startNode")
+  val endNode: MethodReference = method[RelationshipDataExtractor, Long]("endNode")
+  val typeOf: MethodReference = method[RelationshipDataExtractor, Int]("type")
+  val nodeGetRelationshipsWithDirection: MethodReference = method[ReadOperations, RelationshipIterator]("nodeGetRelationships", typeRef[Long], typeRef[Direction])
+  val nodeGetRelationshipsWithDirectionAndTypes: MethodReference = method[ReadOperations, RelationshipIterator]("nodeGetRelationships", typeRef[Long], typeRef[Direction], typeRef[Array[Int]])
+  val allConnectingRelationships: MethodReference = method[CompiledExpandUtils, RelationshipSelectionCursor]("connectingRelationships",
+                                                                                                             typeRef[ReadOperations],
+                                                                                                             typeRef[Read],
+                                                                                                             typeRef[CursorFactory],
+                                                                                                             typeRef[NodeCursor],
+                                                                                                             typeRef[Long],
+                                                                                                             typeRef[Direction],
+                                                                                                             typeRef[Long])
+  val connectingRelationships: MethodReference = method[CompiledExpandUtils, RelationshipSelectionCursor]("connectingRelationships",
+                                                                                                          typeRef[ReadOperations],
+                                                                                                          typeRef[Read],
+                                                                                                          typeRef[CursorFactory],
+                                                                                                          typeRef[NodeCursor],
+                                                                                                          typeRef[Long],
+                                                                                                          typeRef[Direction],
+                                                                                                          typeRef[Long],
+                                                                                                          typeRef[Array[Int]])
 
-  val countingTablePut = method[PrimitiveLongIntMap, Int]("put", typeRef[Long], typeRef[Int])
-  val countingTableCompositeKeyPut = method[util.HashMap[CompositeKey, Integer], Object]("put", typeRef[Object], typeRef[Object])
-  val countingTableGet = method[PrimitiveLongIntMap, Int]("get", typeRef[Long])
-  val countingTableCompositeKeyGet = method[util.HashMap[CompositeKey, Integer], Object]("get", typeRef[Object])
-  val compositeKey = method[CompiledConversionUtils, CompositeKey]("compositeKey", typeRef[Array[Long]])
-  val hasNextLong = method[PrimitiveLongIterator, Boolean]("hasNext")
-  val hasMoreRelationship = method[RelationshipIterator, Boolean]("hasNext")
-  val createMap = method[MapUtil, util.Map[String, Object]]("map", typeRef[Array[Object]])
-  val format = method[String, String]("format", typeRef[String], typeRef[Array[Object]])
-  val relationshipVisit = method[RelationshipIterator, Boolean]("relationshipVisit", typeRef[Long], typeRef[RelationshipVisitor[RuntimeException]])
-  val getRelationship = method[RelationshipDataExtractor, Long]("relationship")
-  val startNode = method[RelationshipDataExtractor, Long]("startNode")
-  val endNode = method[RelationshipDataExtractor, Long]("endNode")
-  val typeOf = method[RelationshipDataExtractor, Int]("type")
-  val nodeGetRelationshipsWithDirection = method[ReadOperations, RelationshipIterator]("nodeGetRelationships", typeRef[Long], typeRef[Direction])
-  val nodeGetRelationshipsWithDirectionAndTypes = method[ReadOperations, RelationshipIterator]("nodeGetRelationships", typeRef[Long], typeRef[Direction], typeRef[Array[Int]])
-  val allConnectingRelationships = method[CompiledExpandUtils, RelationshipSelectionCursor]("connectingRelationships",
-                                                                                            typeRef[ReadOperations],
-                                                                                            typeRef[Read],
-                                                                                            typeRef[CursorFactory],
-                                                                                            typeRef[NodeCursor],
-                                                                                            typeRef[Long],
-                                                                                            typeRef[Direction],
-                                                                                            typeRef[Long])
-  val connectingRelationships = method[CompiledExpandUtils, RelationshipSelectionCursor]("connectingRelationships",
-                                                                                  typeRef[ReadOperations],
-                                                                                  typeRef[Read],
-                                                                                  typeRef[CursorFactory],
-                                                                                  typeRef[NodeCursor],
-                                                                                  typeRef[Long],
-                                                                                  typeRef[Direction],
-                                                                                  typeRef[Long],
-                                                                                  typeRef[Array[Int]])
-  val mathAdd = method[CompiledMathHelper, Object]("add", typeRef[Object], typeRef[Object])
-  val mathSub = method[CompiledMathHelper, Object]("subtract", typeRef[Object], typeRef[Object])
-  val mathMul = method[CompiledMathHelper, Object]("multiply", typeRef[Object], typeRef[Object])
-  val mathDiv = method[CompiledMathHelper, Object]("divide", typeRef[Object], typeRef[Object])
-  val mathMod = method[CompiledMathHelper, Object]("modulo", typeRef[Object], typeRef[Object])
-  val mathCastToInt = method[CompiledMathHelper, Int]("transformToInt", typeRef[Object])
-  val mathCastToLong = method[CompiledMathHelper, Long]("transformToLong", typeRef[Object])
-  val mapGet = method[util.Map[String, Object], Object]("get", typeRef[Object])
-  val mapContains = method[util.Map[String, Object], Boolean]("containsKey", typeRef[Object])
-  val setContains = method[util.Set[Object], Boolean]("contains", typeRef[Object])
-  val setAdd = method[util.Set[Object], Boolean]("add", typeRef[Object])
-  val labelGetForName = method[TokenRead, Int]("nodeLabel", typeRef[String])
-  val propertyKeyGetForName = method[TokenRead, Int]("propertyKey", typeRef[String])
-  val coerceToPredicate = method[CompiledConversionUtils, Boolean]("coerceToPredicate", typeRef[Object])
-  val toCollection = method[CompiledConversionUtils, java.util.Collection[Object]]("toCollection", typeRef[Object])
-  val ternaryEquals = method[CompiledConversionUtils, java.lang.Boolean]("equals", typeRef[Object], typeRef[Object])
-  val equals = method[Object, Boolean]("equals", typeRef[Object])
-  val or = method[CompiledConversionUtils, java.lang.Boolean]("or", typeRef[Object], typeRef[Object])
-  val not = method[CompiledConversionUtils, java.lang.Boolean]("not", typeRef[Object])
-  val loadParameter = method[CompiledConversionUtils, Object]("loadParameter", typeRef[AnyValue], typeRef[EmbeddedProxySPI])
-  val relationshipTypeGetForName = method[TokenRead, Int]("relationshipType", typeRef[String])
-  val relationshipTypeGetName = method[TokenRead, String]("relationshipTypeName", typeRef[Int])
-  val nodeExists = method[Read, Boolean]("nodeExists", typeRef[Long])
-  val indexQuery = method[ReadOperations, PrimitiveLongResourceIterator]("indexQuery", typeRef[IndexDescriptor], typeRef[Array[IndexQuery]])
-  val indexQueryExact = method[IndexQuery, IndexQuery.ExactPredicate]("exact", typeRef[Int], typeRef[Object])
-  val nodeGetUniqueFromIndexLookup = method[ReadOperations, Long]("nodeGetFromUniqueIndexSeek", typeRef[IndexDescriptor], typeRef[Array[IndexQuery.ExactPredicate]])
-  val countsForNode = method[ReadOperations, Long]("countsForNode", typeRef[Int])
-  val countsForRel = method[ReadOperations, Long]("countsForRelationship", typeRef[Int], typeRef[Int], typeRef[Int])
-  val relationshipGetProperty = method[ReadOperations, Value]("relationshipGetProperty", typeRef[Long], typeRef[Int])
-  val nodesGetForLabel = method[ReadOperations, PrimitiveLongResourceIterator]("nodesGetForLabel", typeRef[Int])
-  val nodeHasLabel = method[ReadOperations, Boolean]("nodeHasLabel", typeRef[Long], typeRef[Int])
-  val nextLong = method[PrimitiveLongIterator, Long]("next")
-  val fetchNextRelationship = method[RelationshipIterator, Long]("next")
-  val newNodeProxyById = method[EmbeddedProxySPI, NodeProxy]("newNodeProxy", typeRef[Long])
-  val newRelationshipProxyById = method[EmbeddedProxySPI, RelationshipProxy]("newRelationshipProxy", typeRef[Long])
-  val materializeAnyResult = method[CompiledConversionUtils, Object]("materializeAnyResult", typeRef[EmbeddedProxySPI], typeRef[Object])
-  val nodeId = method[NodeIdWrapper, Long]("id")
-  val relId = method[RelationshipIdWrapper, Long]("id")
-  val set = method[ResultRecord, Unit]("set", typeRef[Int], typeRef[AnyValue])
-  val visit = method[QueryResultVisitor[_], Boolean]("visit", typeRef[Record])
-  val executeOperator = method[QueryExecutionTracer, QueryExecutionEvent]("executeOperator", typeRef[Id])
-  val dbHit = method[QueryExecutionEvent, Unit]("dbHit")
-  val row = method[QueryExecutionEvent, Unit]("row")
-  val unboxInteger = method[java.lang.Integer, Int]("intValue")
-  val unboxBoolean = method[java.lang.Boolean, Boolean]("booleanValue")
-  val unboxLong = method[java.lang.Long, Long]("longValue")
-  val unboxDouble = method[java.lang.Double, Double]("doubleValue")
-  val unboxNode = method[CompiledConversionUtils, Long]("unboxNodeOrNull", typeRef[NodeIdWrapper])
-  val unboxRel = method[CompiledConversionUtils, Long]("unboxRelationshipOrNull", typeRef[RelationshipIdWrapper])
-  val reboxValue = method[Values, Object]("asObject", typeRef[Value])
+  val mathAdd: MethodReference = method[CompiledMathHelper, Object]("add", typeRef[Object], typeRef[Object])
+  val mathSub: MethodReference = method[CompiledMathHelper, Object]("subtract", typeRef[Object], typeRef[Object])
+  val mathMul: MethodReference = method[CompiledMathHelper, Object]("multiply", typeRef[Object], typeRef[Object])
+  val mathDiv: MethodReference = method[CompiledMathHelper, Object]("divide", typeRef[Object], typeRef[Object])
+  val mathMod: MethodReference = method[CompiledMathHelper, Object]("modulo", typeRef[Object], typeRef[Object])
+  val mathCastToInt: MethodReference = method[CompiledMathHelper, Int]("transformToInt", typeRef[Object])
+  val mathCastToLong: MethodReference = method[CompiledMathHelper, Long]("transformToLong", typeRef[Object])
+  val mapGet: MethodReference = method[util.Map[String, Object], Object]("get", typeRef[Object])
+  val mapContains: MethodReference = method[util.Map[String, Object], Boolean]("containsKey", typeRef[Object])
+  val setContains: MethodReference = method[util.Set[Object], Boolean]("contains", typeRef[Object])
+  val setAdd: MethodReference = method[util.Set[Object], Boolean]("add", typeRef[Object])
+  val labelGetForName: MethodReference = method[TokenRead, Int]("nodeLabel", typeRef[String])
+  val propertyKeyGetForName: MethodReference = method[TokenRead, Int]("propertyKey", typeRef[String])
+  val coerceToPredicate: MethodReference = method[CompiledConversionUtils, Boolean]("coerceToPredicate", typeRef[Object])
+  val toCollection: MethodReference = method[CompiledConversionUtils, java.util.Collection[Object]]("toCollection", typeRef[Object])
+  val ternaryEquals: MethodReference = method[CompiledConversionUtils, java.lang.Boolean]("equals", typeRef[Object], typeRef[Object])
+  val equals: MethodReference = method[Object, Boolean]("equals", typeRef[Object])
+  val or: MethodReference = method[CompiledConversionUtils, java.lang.Boolean]("or", typeRef[Object], typeRef[Object])
+  val not: MethodReference = method[CompiledConversionUtils, java.lang.Boolean]("not", typeRef[Object])
+  val loadParameter: MethodReference = method[CompiledConversionUtils, Object]("loadParameter", typeRef[AnyValue], typeRef[EmbeddedProxySPI])
+  val relationshipTypeGetForName: MethodReference = method[TokenRead, Int]("relationshipType", typeRef[String])
+  val relationshipTypeGetName: MethodReference = method[TokenRead, String]("relationshipTypeName", typeRef[Int])
+  val nodeExists: MethodReference = method[Read, Boolean]("nodeExists", typeRef[Long])
+  val countsForNode: MethodReference = method[ReadOperations, Long]("countsForNode", typeRef[Int])
+  val countsForRel: MethodReference = method[ReadOperations, Long]("countsForRelationship", typeRef[Int], typeRef[Int], typeRef[Int])
+  val relationshipGetProperty: MethodReference = method[ReadOperations, Value]("relationshipGetProperty", typeRef[Long], typeRef[Int])
+  val nodesGetForLabel: MethodReference = method[ReadOperations, PrimitiveLongResourceIterator]("nodesGetForLabel", typeRef[Int])
+  val nodeHasLabel: MethodReference = method[ReadOperations, Boolean]("nodeHasLabel", typeRef[Long], typeRef[Int])
+  val nextLong: MethodReference = method[PrimitiveLongIterator, Long]("next")
+  val fetchNextRelationship: MethodReference = method[RelationshipIterator, Long]("next")
+  val newNodeProxyById: MethodReference = method[EmbeddedProxySPI, NodeProxy]("newNodeProxy", typeRef[Long])
+  val newRelationshipProxyById: MethodReference = method[EmbeddedProxySPI, RelationshipProxy]("newRelationshipProxy", typeRef[Long])
+  val materializeAnyResult: MethodReference = method[CompiledConversionUtils, Object]("materializeAnyResult", typeRef[EmbeddedProxySPI], typeRef[Object])
+  val nodeId: MethodReference = method[NodeIdWrapper, Long]("id")
+  val relId: MethodReference = method[RelationshipIdWrapper, Long]("id")
+  val set: MethodReference = method[ResultRecord, Unit]("set", typeRef[Int], typeRef[AnyValue])
+  val visit: MethodReference = method[QueryResultVisitor[_], Boolean]("visit", typeRef[Record])
+  val executeOperator: MethodReference = method[QueryExecutionTracer, QueryExecutionEvent]("executeOperator", typeRef[Id])
+  val dbHit: MethodReference = method[QueryExecutionEvent, Unit]("dbHit")
+  val row: MethodReference = method[QueryExecutionEvent, Unit]("row")
+  val unboxInteger: MethodReference = method[java.lang.Integer, Int]("intValue")
+  val unboxBoolean: MethodReference = method[java.lang.Boolean, Boolean]("booleanValue")
+  val unboxLong: MethodReference = method[java.lang.Long, Long]("longValue")
+  val unboxDouble: MethodReference = method[java.lang.Double, Double]("doubleValue")
+  val unboxNode: MethodReference = method[CompiledConversionUtils, Long]("unboxNodeOrNull", typeRef[NodeIdWrapper])
+  val unboxRel: MethodReference = method[CompiledConversionUtils, Long]("unboxRelationshipOrNull", typeRef[RelationshipIdWrapper])
+  val reboxValue: MethodReference = method[Values, Object]("asObject", typeRef[Value])
 }

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Methods.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Methods.scala
@@ -33,7 +33,7 @@ import org.neo4j.cypher.result.QueryResult.{QueryResultVisitor, Record}
 import org.neo4j.graphdb.Direction
 import org.neo4j.helpers.collection.MapUtil
 import org.neo4j.internal.kernel.api.helpers.RelationshipSelectionCursor
-import org.neo4j.internal.kernel.api.{CursorFactory, IndexQuery, NodeCursor, Read}
+import org.neo4j.internal.kernel.api._
 import org.neo4j.kernel.api.ReadOperations
 import org.neo4j.kernel.api.schema.index.IndexDescriptor
 import org.neo4j.kernel.impl.api.store.RelationshipIterator
@@ -90,8 +90,8 @@ object Methods {
   val mapContains = method[util.Map[String, Object], Boolean]("containsKey", typeRef[Object])
   val setContains = method[util.Set[Object], Boolean]("contains", typeRef[Object])
   val setAdd = method[util.Set[Object], Boolean]("add", typeRef[Object])
-  val labelGetForName = method[ReadOperations, Int]("labelGetForName", typeRef[String])
-  val propertyKeyGetForName = method[ReadOperations, Int]("propertyKeyGetForName", typeRef[String])
+  val labelGetForName = method[TokenRead, Int]("nodeLabel", typeRef[String])
+  val propertyKeyGetForName = method[TokenRead, Int]("propertyKey", typeRef[String])
   val coerceToPredicate = method[CompiledConversionUtils, Boolean]("coerceToPredicate", typeRef[Object])
   val toCollection = method[CompiledConversionUtils, java.util.Collection[Object]]("toCollection", typeRef[Object])
   val ternaryEquals = method[CompiledConversionUtils, java.lang.Boolean]("equals", typeRef[Object], typeRef[Object])
@@ -99,11 +99,9 @@ object Methods {
   val or = method[CompiledConversionUtils, java.lang.Boolean]("or", typeRef[Object], typeRef[Object])
   val not = method[CompiledConversionUtils, java.lang.Boolean]("not", typeRef[Object])
   val loadParameter = method[CompiledConversionUtils, Object]("loadParameter", typeRef[AnyValue], typeRef[EmbeddedProxySPI])
-  val relationshipTypeGetForName = method[ReadOperations, Int]("relationshipTypeGetForName", typeRef[String])
-  val relationshipTypeGetName = method[ReadOperations, String]("relationshipTypeGetName", typeRef[Int])
+  val relationshipTypeGetForName = method[TokenRead, Int]("relationshipType", typeRef[String])
+  val relationshipTypeGetName = method[TokenRead, String]("relationshipTypeName", typeRef[Int])
   val nodeExists = method[ReadOperations, Boolean]("nodeExists", typeRef[Long])
-  val nodesGetAll = method[ReadOperations, PrimitiveLongIterator]("nodesGetAll")
-  val nodeGetProperty = method[ReadOperations, Value]("nodeGetProperty", typeRef[Long], typeRef[Int])
   val indexQuery = method[ReadOperations, PrimitiveLongResourceIterator]("indexQuery", typeRef[IndexDescriptor], typeRef[Array[IndexQuery]])
   val indexQueryExact = method[IndexQuery, IndexQuery.ExactPredicate]("exact", typeRef[Int], typeRef[Object])
   val nodeGetUniqueFromIndexLookup = method[ReadOperations, Long]("nodeGetFromUniqueIndexSeek", typeRef[IndexDescriptor], typeRef[Array[IndexQuery.ExactPredicate]])

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Methods.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Methods.scala
@@ -34,6 +34,7 @@ import org.neo4j.graphdb.Direction
 import org.neo4j.helpers.collection.MapUtil
 import org.neo4j.internal.kernel.api.helpers.RelationshipSelectionCursor
 import org.neo4j.internal.kernel.api._
+import org.neo4j.internal.kernel.api.{IndexQuery, Read, TokenRead}
 import org.neo4j.kernel.api.ReadOperations
 import org.neo4j.kernel.api.schema.index.IndexDescriptor
 import org.neo4j.kernel.impl.api.store.RelationshipIterator
@@ -101,7 +102,7 @@ object Methods {
   val loadParameter = method[CompiledConversionUtils, Object]("loadParameter", typeRef[AnyValue], typeRef[EmbeddedProxySPI])
   val relationshipTypeGetForName = method[TokenRead, Int]("relationshipType", typeRef[String])
   val relationshipTypeGetName = method[TokenRead, String]("relationshipTypeName", typeRef[Int])
-  val nodeExists = method[ReadOperations, Boolean]("nodeExists", typeRef[Long])
+  val nodeExists = method[Read, Boolean]("nodeExists", typeRef[Long])
   val indexQuery = method[ReadOperations, PrimitiveLongResourceIterator]("indexQuery", typeRef[IndexDescriptor], typeRef[Array[IndexQuery]])
   val indexQueryExact = method[IndexQuery, IndexQuery.ExactPredicate]("exact", typeRef[Int], typeRef[Object])
   val nodeGetUniqueFromIndexLookup = method[ReadOperations, Long]("nodeGetFromUniqueIndexSeek", typeRef[IndexDescriptor], typeRef[Array[IndexQuery.ExactPredicate]])

--- a/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Templates.scala
+++ b/enterprise/cypher/cypher/src/main/scala/org/neo4j/cypher/internal/spi/v3_4/codegen/Templates.scala
@@ -231,6 +231,7 @@ object Templates {
       generate.returns(cursors)
     }
   }
+
   def getOrLoadDataRead(clazz: ClassGenerator, fields: Fields) = {
     val methodBuilder: Builder = MethodDeclaration.method(typeRef[Read], "getOrLoadDataRead")
     using(clazz.generate(methodBuilder)) { generate =>
@@ -243,6 +244,21 @@ object Templates {
                   Expression.invoke(Expression.invoke(queryContext, transactionalContext), dataRead))
       }
       generate.returns(dataRead)
+    }
+  }
+
+  def getOrLoadTokenRead(clazz: ClassGenerator, fields: Fields) = {
+    val methodBuilder: Builder = MethodDeclaration.method(typeRef[TokenRead], "getOrLoadTokenRead")
+    using(clazz.generate(methodBuilder)) { generate =>
+      val tokenRead = Expression.get(generate.self(), fields.tokenRead)
+      using(generate.ifStatement(Expression.isNull(tokenRead))) { block =>
+        val transactionalContext: MethodReference = method[QueryContext, QueryTransactionalContext]("transactionalContext")
+        val tokenRead: MethodReference = method[QueryTransactionalContext, TokenRead]("tokenRead")
+        val queryContext = Expression.get(block.self(), fields.queryContext)
+        block.put(block.self(), fields.tokenRead,
+                  Expression.invoke(Expression.invoke(queryContext, transactionalContext), tokenRead))
+      }
+      generate.returns(tokenRead)
     }
   }
 

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_4/GeneratedMethodStructureTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_4/GeneratedMethodStructureTest.scala
@@ -40,6 +40,7 @@ import org.neo4j.cypher.internal.v3_4.codegen.QueryExecutionTracer
 import org.neo4j.cypher.internal.v3_4.expressions.SemanticDirection
 import org.neo4j.internal.kernel.api.helpers.RelationshipSelectionCursor
 import org.neo4j.internal.kernel.api.{CursorFactory, NodeCursor, PropertyCursor, Read}
+import org.neo4j.internal.kernel.api._
 import org.neo4j.kernel.api.ReadOperations
 import org.neo4j.kernel.impl.core.EmbeddedProxySPI
 
@@ -244,7 +245,8 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
         cursors = body.field(typeRef[CursorFactory], "cursors"),
         nodeCursor = body.field(typeRef[NodeCursor], "nodeCursor"),
         propertyCursor = body.field(typeRef[PropertyCursor], "propertyCursor"),
-        dataRead = body.field(typeRef[Read], "dataRead")
+        dataRead = body.field(typeRef[Read], "dataRead"),
+        tokenRead = body.field(typeRef[TokenRead], "tokenRead")
       )
       // the "COLUMNS" static field
       body.staticField(typeRef[util.List[String]], "COLUMNS", Templates.asList[String](Seq.empty))
@@ -254,6 +256,7 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
       Templates.getOrLoadDataRead(body, fields)
       Templates.getOrLoadReadOperations(body, fields)
       Templates.getOrLoadCursors(body, fields)
+      Templates.getOrLoadTokenRead(body, fields)
       Templates.nodeCursor(body, fields)
       Templates.propertyCursor(body, fields)
       body.handle()

--- a/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_4/GeneratedMethodStructureTest.scala
+++ b/enterprise/cypher/cypher/src/test/scala/org/neo4j/cypher/internal/compiled_runtime/spi/v3_4/GeneratedMethodStructureTest.scala
@@ -246,7 +246,8 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
         nodeCursor = body.field(typeRef[NodeCursor], "nodeCursor"),
         propertyCursor = body.field(typeRef[PropertyCursor], "propertyCursor"),
         dataRead = body.field(typeRef[Read], "dataRead"),
-        tokenRead = body.field(typeRef[TokenRead], "tokenRead")
+        tokenRead = body.field(typeRef[TokenRead], "tokenRead"),
+        schemaRead = body.field(typeRef[SchemaRead], "schemaRead")
       )
       // the "COLUMNS" static field
       body.staticField(typeRef[util.List[String]], "COLUMNS", Templates.asList[String](Seq.empty))
@@ -257,6 +258,7 @@ class GeneratedMethodStructureTest extends CypherFunSuite {
       Templates.getOrLoadReadOperations(body, fields)
       Templates.getOrLoadCursors(body, fields)
       Templates.getOrLoadTokenRead(body, fields)
+      Templates.getOrLoadSchemaRead(body, fields)
       Templates.nodeCursor(body, fields)
       Templates.propertyCursor(body, fields)
       body.handle()


### PR DESCRIPTION
Ports the following to use Kernel API instead:
- all token operations
- node index seek
- node by id