### PR TITLE
Fix bug in bytecode generation for multiple ands and ors

### DIFF
--- a/community/codegen/src/main/java/org/neo4j/codegen/Expression.java
+++ b/community/codegen/src/main/java/org/neo4j/codegen/Expression.java
@@ -259,7 +259,7 @@ public abstract class Expression extends ExpressionTemplate
 
     private static Expression[] expressions( Expression first, Expression[] more )
     {
-        Expression[] result = new Expression[more.length];
+        Expression[] result = new Expression[more.length + 1];
         result[0] = first;
         System.arraycopy( more, 0, result, 1, more.length );
         return result;

--- a/community/codegen/src/test/java/org/neo4j/codegen/CodeGenerationTest.java
+++ b/community/codegen/src/test/java/org/neo4j/codegen/CodeGenerationTest.java
@@ -1057,6 +1057,150 @@ public class CodeGenerationTest
     }
 
     @Test
+    public void shouldGenerateMethodUsingMultipleAnds() throws Throwable
+    {
+        // given
+        ClassHandle handle;
+        try ( ClassGenerator simple = generateClass( "SimpleClass" ) )
+        {
+            try ( CodeBlock conditional = simple.generateMethod( boolean.class, "conditional",
+                    param( boolean.class, "test1" ),
+                    param( boolean.class, "test2" ),
+                    param( boolean.class, "test3" ) ) )
+            {
+                conditional.returns( and(
+                        conditional.load( "test1" ),
+                        and( conditional.load( "test2" ),
+                                conditional.load( "test3" ) ) ) );
+            }
+
+            handle = simple.handle();
+        }
+
+        // when
+        MethodHandle conditional =
+                instanceMethod( handle.newInstance(), "conditional", boolean.class, boolean.class, boolean.class );
+
+        // then
+        assertThat( conditional.invoke( true, true, true ), equalTo( true ) );
+        assertThat( conditional.invoke( true, false, true ), equalTo( false ) );
+        assertThat( conditional.invoke( false, true, true ), equalTo( false ) );
+        assertThat( conditional.invoke( false, false, true ), equalTo( false ) );
+        assertThat( conditional.invoke( true, true, false ), equalTo( false ) );
+        assertThat( conditional.invoke( true, false, false ), equalTo( false ) );
+        assertThat( conditional.invoke( false, true, false ), equalTo( false ) );
+        assertThat( conditional.invoke( false, false, false ), equalTo( false ) );
+    }
+
+    @Test
+    public void shouldGenerateMethodUsingMultipleAnds2() throws Throwable
+    {
+        // given
+        ClassHandle handle;
+        try ( ClassGenerator simple = generateClass( "SimpleClass" ) )
+        {
+            try ( CodeBlock conditional = simple.generateMethod( boolean.class, "conditional",
+                    param( boolean.class, "test1" ),
+                    param( boolean.class, "test2" ),
+                    param( boolean.class, "test3" ) ) )
+            {
+                conditional.returns( and(
+                        and( conditional.load( "test1" ),
+                                conditional.load( "test2" ) ),
+                        conditional.load( "test3" ) ) );
+            }
+
+            handle = simple.handle();
+        }
+
+        // when
+        MethodHandle conditional =
+                instanceMethod( handle.newInstance(), "conditional", boolean.class, boolean.class, boolean.class );
+
+        // then
+        assertThat( conditional.invoke( true, true, true ), equalTo( true ) );
+        assertThat( conditional.invoke( true, false, true ), equalTo( false ) );
+        assertThat( conditional.invoke( false, true, true ), equalTo( false ) );
+        assertThat( conditional.invoke( false, false, true ), equalTo( false ) );
+        assertThat( conditional.invoke( true, true, false ), equalTo( false ) );
+        assertThat( conditional.invoke( true, false, false ), equalTo( false ) );
+        assertThat( conditional.invoke( false, true, false ), equalTo( false ) );
+        assertThat( conditional.invoke( false, false, false ), equalTo( false ) );
+    }
+
+    @Test
+    public void shouldGenerateMethodUsingMultipleOrs() throws Throwable
+    {
+        // given
+        ClassHandle handle;
+        try ( ClassGenerator simple = generateClass( "SimpleClass" ) )
+        {
+            try ( CodeBlock conditional = simple.generateMethod( boolean.class, "conditional",
+                    param( boolean.class, "test1" ),
+                    param( boolean.class, "test2" ),
+                    param( boolean.class, "test3" ) ) )
+            {
+                conditional.returns( or(
+                        conditional.load( "test1" ),
+                        or( conditional.load( "test2" ),
+                                conditional.load( "test3" ) ) ) );
+            }
+
+            handle = simple.handle();
+        }
+
+        // when
+        MethodHandle conditional =
+                instanceMethod( handle.newInstance(), "conditional", boolean.class, boolean.class, boolean.class );
+
+        // then
+        assertThat( conditional.invoke( true, true, true ), equalTo( true ) );
+        assertThat( conditional.invoke( true, false, true ), equalTo( true ) );
+        assertThat( conditional.invoke( false, true, true ), equalTo( true ) );
+        assertThat( conditional.invoke( false, false, true ), equalTo( true ) );
+        assertThat( conditional.invoke( true, true, false ), equalTo( true ) );
+        assertThat( conditional.invoke( true, false, false ), equalTo( true ) );
+        assertThat( conditional.invoke( false, true, false ), equalTo( true ) );
+        assertThat( conditional.invoke( false, false, false ), equalTo( false ) );
+    }
+
+    @Test
+    public void shouldGenerateMethodUsingMultipleOrs2() throws Throwable
+    {
+        // given
+        ClassHandle handle;
+        try ( ClassGenerator simple = generateClass( "SimpleClass" ) )
+        {
+            try ( CodeBlock conditional = simple.generateMethod( boolean.class, "conditional",
+                    param( boolean.class, "test1" ),
+                    param( boolean.class, "test2" ),
+                    param( boolean.class, "test3" ) ) )
+            {
+                conditional.returns( or(
+                        or( conditional.load( "test1" ),
+                                conditional.load( "test2" ) ),
+                        conditional.load( "test3" ) ) );
+            }
+
+            handle = simple.handle();
+        }
+
+        // when
+        MethodHandle conditional =
+                instanceMethod( handle.newInstance(), "conditional", boolean.class, boolean.class, boolean.class );
+
+        // then
+        assertThat( conditional.invoke( true, true, true ), equalTo( true ) );
+        assertThat( conditional.invoke( true, false, true ), equalTo( true ) );
+        assertThat( conditional.invoke( false, true, true ), equalTo( true ) );
+        assertThat( conditional.invoke( false, false, true ), equalTo( true ) );
+        assertThat( conditional.invoke( true, true, false ), equalTo( true ) );
+        assertThat( conditional.invoke( true, false, false ), equalTo( true ) );
+        assertThat( conditional.invoke( false, true, false ), equalTo( true ) );
+        assertThat( conditional.invoke( false, false, false ), equalTo( false ) );
+    }
+
+    @Test
     public void shouldHandleNot() throws Throwable
     {
         // given

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/AggregationAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/AggregationAcceptance.feature
@@ -64,3 +64,36 @@ Feature: AggregationAcceptance
       | 'The Autograph Man' | 1        | 1                 |
       | 'White teeth'       | 1        | 1                 |
     And no side effects
+
+  Scenario: Distinct should work with multiple equal grouping keys and only one different
+    And having executed:
+      """
+      UNWIND range(1,9) as i
+      CREATE ({prop1:'prop1',prop2:'prop2',prop3:'prop3',prop4:'prop4',prop5:'prop5',prop6:toString(i),prop7:'prop7',prop8:'prop8',prop9:'prop9'})
+      """
+    When executing query:
+      """
+      MATCH (node)
+      RETURN DISTINCT
+        node.prop1 as p1,
+        node.prop2 as p2,
+        node.prop3 as p3,
+        node.prop4 as p4,
+        node.prop5 as p5,
+        node.prop6 as p6,
+        node.prop7 as p7,
+        node.prop8 as p8,
+        node.prop9 as p9
+      """
+    Then the result should be:
+      | p1      | p2      | p3      | p4      | p5      | p6  | p7      | p8      | p9      |
+      | 'prop1' | 'prop2' | 'prop3' | 'prop4' | 'prop5' | '1' | 'prop7' | 'prop8' | 'prop9' |
+      | 'prop1' | 'prop2' | 'prop3' | 'prop4' | 'prop5' | '2' | 'prop7' | 'prop8' | 'prop9' |
+      | 'prop1' | 'prop2' | 'prop3' | 'prop4' | 'prop5' | '3' | 'prop7' | 'prop8' | 'prop9' |
+      | 'prop1' | 'prop2' | 'prop3' | 'prop4' | 'prop5' | '4' | 'prop7' | 'prop8' | 'prop9' |
+      | 'prop1' | 'prop2' | 'prop3' | 'prop4' | 'prop5' | '5' | 'prop7' | 'prop8' | 'prop9' |
+      | 'prop1' | 'prop2' | 'prop3' | 'prop4' | 'prop5' | '6' | 'prop7' | 'prop8' | 'prop9' |
+      | 'prop1' | 'prop2' | 'prop3' | 'prop4' | 'prop5' | '7' | 'prop7' | 'prop8' | 'prop9' |
+      | 'prop1' | 'prop2' | 'prop3' | 'prop4' | 'prop5' | '8' | 'prop7' | 'prop8' | 'prop9' |
+      | 'prop1' | 'prop2' | 'prop3' | 'prop4' | 'prop5' | '9' | 'prop7' | 'prop8' | 'prop9' |
+    And no side effects


### PR DESCRIPTION
This affected e.g. the generated equals-methods used by grouping keys
for distinct and aggregation, so that only the first two keys (in a
compile-time determined accidental ordering) were compared.