### PR TITLE
Fixes as issue with applying index updates to unique indexes

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexUpdateProcessor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexUpdateProcessor.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.api.index;
+
+import java.io.IOException;
+
+import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
+import org.neo4j.kernel.api.index.IndexEntryUpdate;
+import org.neo4j.kernel.api.schema.LabelSchemaSupplier;
+
+public interface IndexUpdateProcessor<INDEX_KEY extends LabelSchemaSupplier>
+{
+    void accept( IndexEntryUpdate<INDEX_KEY> update ) throws IOException, IndexEntryConflictException;
+
+    static <INDEX_KEY extends LabelSchemaSupplier> void applyIndexUpdatesByMode( Iterable<IndexEntryUpdate<INDEX_KEY>> updates,
+            IndexUpdateProcessor<INDEX_KEY> target )
+            throws IOException, IndexEntryConflictException
+    {
+        // deletes
+        for ( IndexEntryUpdate<INDEX_KEY> indexUpdate : updates )
+        {
+            if ( indexUpdate.updateMode() == UpdateMode.REMOVED )
+            {
+                target.accept( indexUpdate );
+            }
+            else if ( indexUpdate.updateMode() == UpdateMode.CHANGED )
+            {
+                target.accept( removalOfChange( indexUpdate ) );
+            }
+        }
+        // adds
+        for ( IndexEntryUpdate<INDEX_KEY> indexUpdate : updates )
+        {
+            if ( indexUpdate.updateMode() == UpdateMode.ADDED )
+            {
+                target.accept( indexUpdate );
+            }
+            else if ( indexUpdate.updateMode() == UpdateMode.CHANGED )
+            {
+                target.accept( additionOfChange( indexUpdate ) );
+            }
+        }
+    }
+
+    static <INDEX_KEY extends LabelSchemaSupplier> IndexEntryUpdate<INDEX_KEY> additionOfChange( IndexEntryUpdate<INDEX_KEY> indexUpdate )
+    {
+        return IndexEntryUpdate.add( indexUpdate.getEntityId(), indexUpdate.indexKey(), indexUpdate.values() );
+    }
+
+    static <INDEX_KEY extends LabelSchemaSupplier> IndexEntryUpdate<INDEX_KEY> removalOfChange( IndexEntryUpdate<INDEX_KEY> indexUpdate )
+    {
+        return IndexEntryUpdate.remove( indexUpdate.getEntityId(), indexUpdate.indexKey(), indexUpdate.beforeValues() );
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexingService.java
@@ -64,6 +64,7 @@ import org.neo4j.scheduler.JobScheduler;
 
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MINUTES;
+
 import static org.neo4j.helpers.Exceptions.launderedException;
 import static org.neo4j.helpers.collection.Iterables.asList;
 import static org.neo4j.kernel.api.index.InternalIndexState.FAILED;
@@ -424,10 +425,7 @@ public class IndexingService extends LifecycleAdapter implements IndexingUpdateS
     {
         try ( IndexUpdaterMap updaterMap = indexMapRef.createIndexUpdaterMap( updateMode ) )
         {
-            for ( IndexEntryUpdate<LabelSchemaDescriptor> indexUpdate : updates )
-            {
-                processUpdate( updaterMap, indexUpdate );
-            }
+            IndexUpdateProcessor.applyIndexUpdatesByMode( updates, update -> processUpdate( updaterMap, update ) );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/MultipleIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/MultipleIndexPopulator.java
@@ -33,6 +33,7 @@ import java.util.function.IntPredicate;
 import java.util.stream.IntStream;
 
 import org.neo4j.function.ThrowingConsumer;
+import org.neo4j.helpers.Exceptions;
 import org.neo4j.helpers.collection.Pair;
 import org.neo4j.helpers.collection.Visitor;
 import org.neo4j.kernel.api.exceptions.index.FlipFailedKernelException;
@@ -54,6 +55,7 @@ import org.neo4j.storageengine.api.schema.PopulationProgress;
 import org.neo4j.unsafe.impl.internal.dragons.FeatureToggles;
 
 import static java.lang.String.format;
+
 import static org.neo4j.collection.primitive.PrimitiveIntCollections.contains;
 import static org.neo4j.kernel.impl.api.index.IndexPopulationFailure.failure;
 
@@ -93,7 +95,7 @@ public class MultipleIndexPopulator implements IndexPopulator
 
     // Concurrency queue since multiple concurrent threads may enqueue updates into it. It is important for this queue
     // to have fast #size() method since it might be drained in batches
-    protected final Queue<IndexEntryUpdate<?>> queue = new LinkedBlockingQueue<>();
+    protected final Queue queue = new LinkedBlockingQueue<>();
 
     // Populators are added into this list. The same thread adding populators will later call #indexAllNodes.
     // Multiple concurrent threads might fail individual populations.
@@ -375,13 +377,19 @@ public class MultipleIndexPopulator implements IndexPopulator
         {
             try ( MultipleIndexUpdater updater = newPopulatingUpdater( storeView ) )
             {
-                do
+                // TODO the generics of IndexEntryUpdate in combination with that of IndexUpdater make the IndexUpdateProcessor
+                // generics hard to make fit for all scenarios. For that reason the queue holding updates cannot quite have the generics
+                // it would have liked to have. Also this specific scenario catches the exceptions seen below inside acceptUpdate method,
+                // but they are caught here to satisfy the compiler, even though knowing that they will never be thrown.
+                // Generifying IndexUpdateProcessor with exception type doesn't work due to multiple exception types thrown.
+                try
                 {
-                    // no need to check for null as nobody else is emptying this queue
-                    IndexEntryUpdate<?> update = queue.poll();
-                    storeScan.acceptUpdate( updater, update, currentlyIndexedNodeId );
+                    IndexUpdateProcessor.applyIndexUpdatesByMode( queue, update -> storeScan.acceptUpdate( updater, update, currentlyIndexedNodeId ) );
                 }
-                while ( !queue.isEmpty() );
+                catch ( IOException | IndexEntryConflictException e )
+                {
+                    throw Exceptions.launderedException( e );
+                }
             }
         }
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
@@ -492,7 +492,7 @@ public class IndexPopulationJobTest
                             added.add( Pair.of( update.getEntityId(), update.values()[0].asObjectCopy() ) );
                             break;
                         default:
-                            throw new IllegalArgumentException( update.updateMode().name() );
+                            // ignore removals
                     }
                 }
 

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/IndexPopulationJobTest.java
@@ -491,8 +491,11 @@ public class IndexPopulationJobTest
                         case CHANGED:
                             added.add( Pair.of( update.getEntityId(), update.values()[0].asObjectCopy() ) );
                             break;
-                        default:
+                        case REMOVED:
                             // ignore removals
+                            break;
+                        default:
+                            throw new IllegalArgumentException( update.updateMode().name() );
                     }
                 }
 

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/AccidentalUniquenessConstraintViolationIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/AccidentalUniquenessConstraintViolationIT.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.index;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Map;
+
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.NotFoundException;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.rule.DatabaseRule;
+import org.neo4j.test.rule.ImpermanentDatabaseRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class AccidentalUniquenessConstraintViolationIT
+{
+    private static final Label Foo = Label.label( "Foo" );
+    private static final String BAR = "bar";
+
+    @Rule
+    public final DatabaseRule db = new ImpermanentDatabaseRule();
+
+    @Test
+    public void shouldApplyChangesWithIntermediateConstraintViolations() throws Exception
+    {
+        // given
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.schema().constraintFor( Foo ).assertPropertyIsUnique( BAR ).create();
+            tx.success();
+        }
+        Node fourtyTwo;
+        Node fourtyOne;
+        try ( Transaction tx = db.beginTx() )
+        {
+            fourtyTwo = db.createNode( Foo );
+            fourtyTwo.setProperty( BAR, 42 );
+            fourtyOne = db.createNode( Foo );
+            fourtyOne.setProperty( BAR, 41 );
+            tx.success();
+        }
+
+        // when
+        try ( Transaction tx = db.beginTx() )
+        {
+            Map<String,Object> props = fourtyOne.getAllProperties();
+            fourtyOne.delete();
+            fourtyTwo.setProperty( BAR, props.get( BAR ) );
+            tx.success();
+        }
+
+        // then
+        try ( Transaction tx = db.beginTx() )
+        {
+            assertEquals( 41, fourtyTwo.getProperty( BAR ) );
+            try
+            {
+                fourtyOne.getProperty( BAR );
+                fail( "Should be deleted" );
+            }
+            catch ( NotFoundException e )
+            {
+                // good
+            }
+            tx.success();
+        }
+    }
+}


### PR DESCRIPTION
Given a uniqueness contraint on Foo:bar. If a transaction make changes
such that in the end, the constraint is not violated but some intermediate
individual step violates the constraint the index would still throw an
exception.

The reason this happens is that native index validates the uniqueness
constraint on every insert and can not defer this validation to later,
unlike Lucene.

We avoid this problem by first applying all removals and then adds. Also
changes are split up into a remove and an add and applied accordingly.