### PR TITLE
Reactivate scala tests in enterprise-kernel

### DIFF
--- a/enterprise/kernel/pom.xml
+++ b/enterprise/kernel/pom.xml
@@ -49,6 +49,10 @@
         <groupId>org.revapi</groupId>
         <artifactId>revapi-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 
@@ -175,6 +179,10 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_2.11</artifactId>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
They were accidentally disabled in the parent pom refactoring.