### PR TITLE
Reuse Kernel API cursors in InstanceCache

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/ThreadToStatementContextBridge.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/ThreadToStatementContextBridge.java
@@ -72,11 +72,11 @@ public class ThreadToStatementContextBridge extends LifecycleAdapter implements 
         {
             throw new BridgeNotInTransactionException();
         }
-        Optional<Status> terminationReason = transaction.getReasonIfTerminated();
-        terminationReason.ifPresent( status ->
+        if ( transaction.isTerminated() )
         {
-            throw new TransactionTerminatedException( status );
-        } );
+            Status terminationReason = transaction.getReasonIfTerminated().orElse( Status.Transaction.Terminated );
+            throw new TransactionTerminatedException( terminationReason );
+        }
     }
 
     public void assertInUnterminatedTransaction()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultCursors.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultCursors.java
@@ -59,7 +59,7 @@ public class DefaultCursors implements CursorFactory
             @Override
             protected DefaultRelationshipTraversalCursor create()
             {
-                return new DefaultRelationshipTraversalCursor( new DefaultRelationshipGroupCursor( null ), this );
+                return new DefaultRelationshipTraversalCursor( new DefaultRelationshipGroupCursor( cursor -> {} ), this );
             }
         };
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultCursors.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultCursors.java
@@ -20,60 +20,155 @@
 package org.neo4j.kernel.impl.newapi;
 
 import org.neo4j.internal.kernel.api.CursorFactory;
+import org.neo4j.kernel.impl.util.InstanceCache;
 
 public class DefaultCursors implements CursorFactory
 {
+    private final InstanceCache<DefaultNodeCursor> nodeCursor;
+    private final InstanceCache<DefaultRelationshipScanCursor> relationshipScanCursor;
+    private final InstanceCache<DefaultRelationshipTraversalCursor> relationshipTraversalCursor;
+    private final InstanceCache<DefaultPropertyCursor> propertyCursor;
+    private final InstanceCache<DefaultRelationshipGroupCursor> relationshipGroupCursor;
+    private final InstanceCache<DefaultNodeValueIndexCursor> nodeValueIndexCursor;
+    private final InstanceCache<DefaultNodeLabelIndexCursor> nodeLabelIndexCursor;
+    private final InstanceCache<DefaultNodeExplicitIndexCursor> nodeExplicitIndexCursor;
+    private final InstanceCache<DefaultRelationshipExplicitIndexCursor> relationshipExplicitIndexCursor;
+
+    public DefaultCursors()
+    {
+        nodeCursor = new InstanceCache<DefaultNodeCursor>()
+        {
+            @Override
+            protected DefaultNodeCursor create()
+            {
+                return new DefaultNodeCursor( this );
+            }
+        };
+
+        relationshipScanCursor = new InstanceCache<DefaultRelationshipScanCursor>()
+        {
+            @Override
+            protected DefaultRelationshipScanCursor create()
+            {
+                return new DefaultRelationshipScanCursor( this );
+            }
+        };
+
+        relationshipTraversalCursor = new InstanceCache<DefaultRelationshipTraversalCursor>()
+        {
+            @Override
+            protected DefaultRelationshipTraversalCursor create()
+            {
+                return new DefaultRelationshipTraversalCursor( new DefaultRelationshipGroupCursor( null ), this );
+            }
+        };
+
+        propertyCursor = new InstanceCache<DefaultPropertyCursor>()
+        {
+            @Override
+            protected DefaultPropertyCursor create()
+            {
+                return new DefaultPropertyCursor( this );
+            }
+        };
+
+        relationshipGroupCursor = new InstanceCache<DefaultRelationshipGroupCursor>()
+        {
+            @Override
+            protected DefaultRelationshipGroupCursor create()
+            {
+                return new DefaultRelationshipGroupCursor( this );
+            }
+        };
+
+        nodeValueIndexCursor = new InstanceCache<DefaultNodeValueIndexCursor>()
+        {
+            @Override
+            protected DefaultNodeValueIndexCursor create()
+            {
+                return new DefaultNodeValueIndexCursor( this );
+            }
+        };
+
+        nodeLabelIndexCursor = new InstanceCache<DefaultNodeLabelIndexCursor>()
+        {
+            @Override
+            protected DefaultNodeLabelIndexCursor create()
+            {
+                return new DefaultNodeLabelIndexCursor( this );
+            }
+        };
+
+        nodeExplicitIndexCursor = new InstanceCache<DefaultNodeExplicitIndexCursor>()
+        {
+            @Override
+            protected DefaultNodeExplicitIndexCursor create()
+            {
+                return new DefaultNodeExplicitIndexCursor( this );
+            }
+        };
+
+        relationshipExplicitIndexCursor = new InstanceCache<DefaultRelationshipExplicitIndexCursor>()
+        {
+            @Override
+            protected DefaultRelationshipExplicitIndexCursor create()
+            {
+                return new DefaultRelationshipExplicitIndexCursor( this );
+            }
+        };
+    }
+
     @Override
     public DefaultNodeCursor allocateNodeCursor()
     {
-        return new DefaultNodeCursor( );
+        return nodeCursor.get();
     }
 
     @Override
     public DefaultRelationshipScanCursor allocateRelationshipScanCursor()
     {
-        return new DefaultRelationshipScanCursor( );
+        return relationshipScanCursor.get( );
     }
 
     @Override
     public DefaultRelationshipTraversalCursor allocateRelationshipTraversalCursor()
     {
-        return new DefaultRelationshipTraversalCursor( allocateRelationshipGroupCursor() );
+        return relationshipTraversalCursor.get();
     }
 
     @Override
     public DefaultPropertyCursor allocatePropertyCursor()
     {
-        return new DefaultPropertyCursor( );
+        return propertyCursor.get();
     }
 
     @Override
     public DefaultRelationshipGroupCursor allocateRelationshipGroupCursor()
     {
-        return new DefaultRelationshipGroupCursor( );
+        return relationshipGroupCursor.get();
     }
 
     @Override
     public DefaultNodeValueIndexCursor allocateNodeValueIndexCursor()
     {
-        return new DefaultNodeValueIndexCursor( );
+        return nodeValueIndexCursor.get();
     }
 
     @Override
     public DefaultNodeLabelIndexCursor allocateNodeLabelIndexCursor()
     {
-        return new DefaultNodeLabelIndexCursor( );
+        return nodeLabelIndexCursor.get();
     }
 
     @Override
     public DefaultNodeExplicitIndexCursor allocateNodeExplicitIndexCursor()
     {
-        return new DefaultNodeExplicitIndexCursor( );
+        return nodeExplicitIndexCursor.get();
     }
 
     @Override
     public DefaultRelationshipExplicitIndexCursor allocateRelationshipExplicitIndexCursor()
     {
-        return new DefaultRelationshipExplicitIndexCursor( );
+        return relationshipExplicitIndexCursor.get();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeCursor.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.newapi;
 
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveIntSet;
@@ -47,9 +48,12 @@ class DefaultNodeCursor extends NodeRecord implements NodeCursor
     private HasChanges hasChanges = HasChanges.MAYBE;
     private Set<Long> addedNodes;
 
-    DefaultNodeCursor()
+    private final Consumer<DefaultNodeCursor> pool;
+
+    DefaultNodeCursor( Consumer<DefaultNodeCursor> pool )
     {
         super( NO_ID );
+        this.pool = pool;
     }
 
     void scan( Read read )
@@ -242,21 +246,27 @@ class DefaultNodeCursor extends NodeRecord implements NodeCursor
     @Override
     public void close()
     {
-        if ( pageCursor != null )
-        {
-            pageCursor.close();
-            pageCursor = null;
-        }
         read = null;
+        hasChanges = HasChanges.MAYBE;
+        addedNodes = emptySet();
+        reset();
 
         if ( labelCursor != null )
         {
             labelCursor.close();
             labelCursor = null;
         }
-        hasChanges = HasChanges.MAYBE;
-        addedNodes = emptySet();
-        reset();
+
+        if ( pageCursor != null )
+        {
+            pageCursor.close();
+            pageCursor = null;
+
+            if ( pool != null )
+            {
+                pool.accept( this );
+            }
+        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeCursor.java
@@ -262,10 +262,7 @@ class DefaultNodeCursor extends NodeRecord implements NodeCursor
             pageCursor.close();
             pageCursor = null;
 
-            if ( pool != null )
-            {
-                pool.accept( this );
-            }
+            pool.accept( this );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeExplicitIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeExplicitIndexCursor.java
@@ -103,10 +103,7 @@ class DefaultNodeExplicitIndexCursor extends IndexCursor<ExplicitIndexProgressor
             expectedSize = 0;
             read = null;
 
-            if ( pool != null )
-            {
-                pool.accept( this );
-            }
+            pool.accept( this );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeLabelIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeLabelIndexCursor.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.newapi;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
@@ -43,8 +44,11 @@ class DefaultNodeLabelIndexCursor extends IndexCursor<LabelScanValueIndexProgres
     private PrimitiveLongIterator added;
     private Set<Long> removed;
 
-    DefaultNodeLabelIndexCursor()
+    private final Consumer<DefaultNodeLabelIndexCursor> pool;
+
+    DefaultNodeLabelIndexCursor( Consumer<DefaultNodeLabelIndexCursor> pool )
     {
+        this.pool = pool;
         node = NO_ID;
     }
 
@@ -140,11 +144,19 @@ class DefaultNodeLabelIndexCursor extends IndexCursor<LabelScanValueIndexProgres
     @Override
     public void close()
     {
-        super.close();
-        node = NO_ID;
-        labels = null;
-        read = null;
-        removed = null;
+        if ( !isClosed() )
+        {
+            super.close();
+            node = NO_ID;
+            labels = null;
+            read = null;
+            removed = null;
+
+            if ( pool != null )
+            {
+                pool.accept( this );
+            }
+        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeLabelIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeLabelIndexCursor.java
@@ -152,10 +152,7 @@ class DefaultNodeLabelIndexCursor extends IndexCursor<LabelScanValueIndexProgres
             read = null;
             removed = null;
 
-            if ( pool != null )
-            {
-                pool.accept( this );
-            }
+            pool.accept( this );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeValueIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeValueIndexCursor.java
@@ -200,10 +200,7 @@ final class DefaultNodeValueIndexCursor extends IndexCursor<IndexProgressor>
             this.added = emptyIterator();
             this.removed = PrimitiveLongCollections.emptySet();
 
-            if ( pool != null )
-            {
-                pool.accept( this );
-            }
+            pool.accept( this );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeValueIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeValueIndexCursor.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.newapi;
 
 import java.util.Arrays;
+import java.util.function.Consumer;
 
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
@@ -51,9 +52,11 @@ final class DefaultNodeValueIndexCursor extends IndexCursor<IndexProgressor>
     private PrimitiveLongIterator added = emptyIterator();
     private PrimitiveLongSet removed = emptySet();
     private boolean needsValues;
+    private final Consumer<DefaultNodeValueIndexCursor> pool;
 
-    DefaultNodeValueIndexCursor()
+    DefaultNodeValueIndexCursor( Consumer<DefaultNodeValueIndexCursor> pool )
     {
+        this.pool = pool;
         node = NO_ID;
     }
 
@@ -187,13 +190,21 @@ final class DefaultNodeValueIndexCursor extends IndexCursor<IndexProgressor>
     @Override
     public void close()
     {
-        super.close();
-        this.node = NO_ID;
-        this.query = null;
-        this.values = null;
-        this.read = null;
-        this.added = emptyIterator();
-        this.removed = PrimitiveLongCollections.emptySet();
+        if ( !isClosed() )
+        {
+            super.close();
+            this.node = NO_ID;
+            this.query = null;
+            this.values = null;
+            this.read = null;
+            this.added = emptyIterator();
+            this.removed = PrimitiveLongCollections.emptySet();
+
+            if ( pool != null )
+            {
+                pool.accept( this );
+            }
+        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultPropertyCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultPropertyCursor.java
@@ -254,10 +254,7 @@ public class DefaultPropertyCursor extends PropertyRecord implements PropertyCur
             page.close();
             page = null;
 
-            if ( pool != null )
-            {
-                pool.accept( this );
-            }
+            pool.accept( this );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipExplicitIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipExplicitIndexCursor.java
@@ -134,10 +134,7 @@ class DefaultRelationshipExplicitIndexCursor extends IndexCursor<ExplicitIndexPr
             expectedSize = 0;
             read = null;
 
-            if ( pool != null )
-            {
-                pool.accept( this );
-            }
+            pool.accept( this );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipExplicitIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipExplicitIndexCursor.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.impl.newapi;
 
+import java.util.function.Consumer;
+
 import org.neo4j.internal.kernel.api.NodeCursor;
 import org.neo4j.internal.kernel.api.RelationshipExplicitIndexCursor;
 import org.neo4j.internal.kernel.api.RelationshipScanCursor;
@@ -33,6 +35,13 @@ class DefaultRelationshipExplicitIndexCursor extends IndexCursor<ExplicitIndexPr
     private int expectedSize;
     private long relationship;
     private float score;
+
+    private final Consumer<DefaultRelationshipExplicitIndexCursor> pool;
+
+    DefaultRelationshipExplicitIndexCursor( Consumer<DefaultRelationshipExplicitIndexCursor> pool )
+    {
+        this.pool = pool;
+    }
 
     @Override
     public void initialize( ExplicitIndexProgressor progressor, int expectedSize )
@@ -117,11 +126,19 @@ class DefaultRelationshipExplicitIndexCursor extends IndexCursor<ExplicitIndexPr
     @Override
     public void close()
     {
-        super.close();
-        relationship = NO_ID;
-        score = 0;
-        expectedSize = 0;
-        read = null;
+        if ( !isClosed() )
+        {
+            super.close();
+            relationship = NO_ID;
+            score = 0;
+            expectedSize = 0;
+            read = null;
+
+            if ( pool != null )
+            {
+                pool.accept( this );
+            }
+        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipGroupCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipGroupCursor.java
@@ -178,10 +178,7 @@ class DefaultRelationshipGroupCursor extends RelationshipGroupRecord implements 
             page.close();
             page = null;
 
-            if ( pool != null )
-            {
-                pool.accept( this );
-            }
+            pool.accept( this );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipScanCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipScanCursor.java
@@ -157,10 +157,7 @@ class DefaultRelationshipScanCursor extends RelationshipCursor implements Relati
             pageCursor.close();
             pageCursor = null;
 
-            if ( pool != null )
-            {
-                pool.accept( this );
-            }
+            pool.accept( this );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipScanCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipScanCursor.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.newapi;
 
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.neo4j.internal.kernel.api.RelationshipScanCursor;
 import org.neo4j.io.pagecache.PageCursor;
@@ -33,7 +34,14 @@ class DefaultRelationshipScanCursor extends RelationshipCursor implements Relati
     private long next;
     private long highMark;
     private PageCursor pageCursor;
-    Set<Long> addedRelationships;
+    private Set<Long> addedRelationships;
+
+    private final Consumer<DefaultRelationshipScanCursor> pool;
+
+    DefaultRelationshipScanCursor( Consumer<DefaultRelationshipScanCursor> pool )
+    {
+        this.pool = pool;
+    }
 
     void scan( int label, Read read )
     {
@@ -141,13 +149,19 @@ class DefaultRelationshipScanCursor extends RelationshipCursor implements Relati
     @Override
     public void close()
     {
+        read = null;
+        reset();
+
         if ( pageCursor != null )
         {
             pageCursor.close();
             pageCursor = null;
+
+            if ( pool != null )
+            {
+                pool.accept( this );
+            }
         }
-        read = null;
-        reset();
     }
 
     private void reset()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.impl.newapi;
 
+import java.util.function.Consumer;
+
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.internal.kernel.api.NodeCursor;
@@ -117,6 +119,7 @@ class DefaultRelationshipTraversalCursor extends RelationshipCursor
     private Record buffer;
     private PageCursor pageCursor;
     private final DefaultRelationshipGroupCursor group;
+    private final Consumer<DefaultRelationshipTraversalCursor> pool;
     private GroupState groupState;
     private FilterState filterState;
     private boolean filterStore;
@@ -124,9 +127,10 @@ class DefaultRelationshipTraversalCursor extends RelationshipCursor
 
     private PrimitiveLongIterator addedRelationships;
 
-    DefaultRelationshipTraversalCursor( DefaultRelationshipGroupCursor group )
+    DefaultRelationshipTraversalCursor( DefaultRelationshipGroupCursor group, Consumer<DefaultRelationshipTraversalCursor> pool )
     {
         this.group = group;
+        this.pool = pool;
     }
 
     /*
@@ -478,13 +482,19 @@ class DefaultRelationshipTraversalCursor extends RelationshipCursor
     @Override
     public void close()
     {
+        read = null;
+        reset();
+
         if ( pageCursor != null )
         {
             pageCursor.close();
             pageCursor = null;
+
+            if ( pool != null )
+            {
+                pool.accept( this );
+            }
         }
-        read = null;
-        reset();
     }
 
     private void reset()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
@@ -490,10 +490,7 @@ class DefaultRelationshipTraversalCursor extends RelationshipCursor
             pageCursor.close();
             pageCursor = null;
 
-            if ( pool != null )
-            {
-                pool.accept( this );
-            }
+            pool.accept( this );
         }
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.newapi;
 
-import java.util.Set;
-
 import org.neo4j.internal.kernel.api.NodeCursor;
 import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.RelationshipDataAccessor;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueClientFilterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueClientFilterTest.java
@@ -48,6 +48,7 @@ public class NodeValueClientFilterTest implements IndexProgressor, NodeValueClie
     @Rule
     public final MockStore store = new MockStore( new DefaultCursors() );
     private final List<Event> events = new ArrayList<>();
+    private final DefaultCursors cursors = new DefaultCursors();
 
     @Test
     public void shouldAcceptAllNodesOnNoFilters()
@@ -135,7 +136,7 @@ public class NodeValueClientFilterTest implements IndexProgressor, NodeValueClie
     private NodeValueClientFilter initializeFilter( IndexQuery... filters )
     {
         NodeValueClientFilter filter = new NodeValueClientFilter(
-                this, new DefaultNodeCursor( null ), new DefaultPropertyCursor( null ), store, filters );
+                this, cursors.allocateNodeCursor(), cursors.allocatePropertyCursor(), store, filters );
         filter.initialize( IndexDescriptorFactory.forLabel( 11), this, null );
         return filter;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueClientFilterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueClientFilterTest.java
@@ -135,7 +135,7 @@ public class NodeValueClientFilterTest implements IndexProgressor, NodeValueClie
     private NodeValueClientFilter initializeFilter( IndexQuery... filters )
     {
         NodeValueClientFilter filter = new NodeValueClientFilter(
-                this, new DefaultNodeCursor(), new DefaultPropertyCursor(), store, filters );
+                this, new DefaultNodeCursor( null ), new DefaultPropertyCursor( null ), store, filters );
         filter.initialize( IndexDescriptorFactory.forLabel( 11), this, null );
         return filter;
     }


### PR DESCRIPTION
This is done to reduce GC pressure during heavy Core API loads, where we would allocate
new cursors for every iterator. This is extremely expensive for eg NodeProxy.singleRelationship(),
so now we are instead reusing the object if no-one else has handed back their cursor in between.