### PR TITLE
Improve CypherComparisonSupport

### DIFF
--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/BuiltInProcedureAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/BuiltInProcedureAcceptanceTest.scala
@@ -280,11 +280,8 @@ class BuiltInProcedureAcceptanceTest extends ProcedureCallAcceptanceTest with Cy
   }
 
   test("yield from void procedure should return correct error msg") {
-
-    val thrown = intercept[SyntaxException]{
-      executeWith(Configs.Procs, "CALL db.createLabel('Label') yield node")
-    }
-
-    thrown.getMessage should include("Cannot yield value from void procedure.")
+    failWithError(Configs.Procs + Configs.Version3_4 + Configs.Version3_3 - Configs.AllRulePlanners,
+      "CALL db.createLabel('Label') yield node",
+      List("Cannot yield value from void procedure."))
   }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeIndexAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeIndexAcceptanceTest.scala
@@ -34,8 +34,6 @@ import scala.collection.JavaConverters._
   */
 class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
 
-  val planFailConfig = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1
-
   test("should succeed in creating and deleting composite index") {
     // When
     graph.createIndex("Person", "firstname")
@@ -65,7 +63,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperators("NodeIndexSeek")
-      }, planFailConfig))
+      }, Configs.OldAndRule))
 
     // Then
     result.toComparableResult should equal(List(Map("n" -> n1)))
@@ -113,7 +111,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
         plan should useOperatorWithText("NodeIndexSeek", ":User(firstname,lastname)")
         plan should not(useOperatorWithText("NodeIndexSeek", ":User(firstname)"))
         plan should not(useOperatorWithText("NodeIndexSeek", ":User(lastname)"))
-      }, planFailConfig))
+      }, Configs.OldAndRule))
 
     // Then
     result.toComparableResult should equal(List(Map("n" -> n1)))
@@ -184,20 +182,20 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperators("NodeIndexSeek")
-      }, planFailConfig))
+      }, Configs.OldAndRule))
     result.toComparableResult should equal(List(Map("n" -> n)))
   }
 
   test("should plan a composite index seek for a multiple property predicate expression when index is created after data") {
-    executeWith(Configs.Interpreted - Configs.Cost2_3, "WITH RANGE(0,10) AS num CREATE (:Person {id:num})") // ensure label cardinality favors index
-    executeWith(Configs.Interpreted - Configs.Cost2_3, "CREATE (n:Person {firstname:'Joe', lastname:'Soap'})")
+    executeWith(Configs.UpdateConf, "WITH RANGE(0,10) AS num CREATE (:Person {id:num})") // ensure label cardinality favors index
+    executeWith(Configs.UpdateConf, "CREATE (n:Person {firstname:'Joe', lastname:'Soap'})")
     graph.createIndex("Person", "firstname")
     graph.createIndex("Person", "firstname", "lastname")
     executeWith(Configs.Interpreted, "MATCH (n:Person) WHERE n.firstname = 'Joe' AND n.lastname = 'Soap' RETURN n",
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperatorWithText("NodeIndexSeek", ":Person(firstname,lastname)")
-      }, planFailConfig))
+      }, Configs.OldAndRule))
   }
 
   test("should use composite index correctly given two IN predicates") {
@@ -219,7 +217,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperatorWithText("NodeIndexSeek", ":Foo(bar,baz)")
-      }, planFailConfig))
+      }, Configs.OldAndRule))
 
     // Then
     result.toComparableResult should equal((0 to 99).map(i => Map("x" -> i)).toList)
@@ -242,7 +240,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperatorWithText("NodeIndexSeek", ":Foo(bar,baz)")
-      }, planFailConfig))
+      }, Configs.OldAndRule))
 
     // Then
     result.toComparableResult should equal((0 to 9).map(i => Map("x" -> i)).toList)
@@ -265,7 +263,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperatorWithText("NodeIndexSeek", ":Foo(bar,baz)")
-      }, planFailConfig))
+      }, Configs.OldAndRule))
 
     // Then
     result.toComparableResult should equal(List(Map("x" -> 1), Map("x" -> 3), Map("x" -> 5), Map("x" -> 7), Map("x" -> 9)))
@@ -285,7 +283,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperatorWithText("NodeIndexSeek", ":L(foo,bar,baz")
-      }, planFailConfig))
+      }, Configs.OldAndRule))
     result.toComparableResult should equal(Seq(Map("count(n)" -> 1)))
   }
 
@@ -303,7 +301,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperatorWithText("NodeIndexSeek", ":L(foo,bar,baz)")
-      }, planFailConfig))
+      }, Configs.OldAndRule))
     result.toComparableResult should equal(Seq(Map("count(n)" -> 1)))
   }
 
@@ -357,7 +355,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
               planComparisonStrategy = ComparePlansWithAssertion((plan) => {
                 //THEN
                 plan should useOperatorWithText("NodeIndexSeek", ":User(name,surname,age,active)")
-              }, planFailConfig))
+              }, Configs.OldAndRule))
           else
             executeWith(testConfig, query,
               planComparisonStrategy = ComparePlansWithAssertion((plan) => {
@@ -396,7 +394,7 @@ class CompositeIndexAcceptanceTest extends ExecutionEngineFunSuite with CypherCo
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperatorWithText("NodeIndexSeek", ":X(p1,p2)")
-      }, planFailConfig), params = Map("id" -> a.getId))
+      }, Configs.OldAndRule), params = Map("id" -> a.getId))
 
     result.toComparableResult should equal(Seq(Map("b" -> b)))
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeUniquenessConstraintAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CompositeUniquenessConstraintAcceptanceTest.scala
@@ -57,7 +57,7 @@ class CompositeUniquenessConstraintAcceptanceTest extends ExecutionEngineFunSuit
 
   test("should fail to to drop composite uniqueness constraints") {
     // When
-    failWithError(singlePropertyUniquenessFailConf + Configs.Morsel + TestScenario(Versions.Default, Planners.Default, Runtimes.ProcedureOrSchema),
+    failWithError(singlePropertyUniquenessFailConf + Configs.Morsel + Configs.Procs,
       "DROP CONSTRAINT ON (n:Person) ASSERT (n.firstname,n.lastname) IS UNIQUE",
       List("Only single property uniqueness constraints are supported"))
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CreateAcceptanceTest.scala
@@ -27,12 +27,12 @@ class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
   with CreateTempFileTestSupport {
 
   //Rule planners will start working after next patch relese
-  val conf: TestConfiguration = Configs.Interpreted - Configs.AllRulePlanners - Configs.Version2_3
+  val tmpConf: TestConfiguration = Configs.AllRulePlanners
 
   test("handle null value in property map from parameter for create node") {
     val query = "CREATE (a {props}) RETURN a.foo, a.bar"
 
-    val result = executeWith(conf, query, params = Map("props" -> Map("foo" -> null, "bar" -> "baz")))
+    val result = executeWith(Configs.UpdateConf - tmpConf, query, params = Map("props" -> Map("foo" -> null, "bar" -> "baz")))
 
     result.toSet should equal(Set(Map("a.foo" -> null, "a.bar" -> "baz")))
     assertStats(result, nodesCreated = 1, propertiesWritten = 1)
@@ -42,7 +42,7 @@ class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
     createNode(("foo", 42), ("bar", "fu"))
     val query = "MATCH (a) SET a = {props} RETURN a.foo, a.bar"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query, params = Map("props" -> Map("foo" -> null, "bar" -> "baz")))
+    val result = executeWith(Configs.UpdateConf, query, params = Map("props" -> Map("foo" -> null, "bar" -> "baz")))
 
     result.toSet should equal(Set(Map("a.foo" -> null, "a.bar" -> "baz")))
     assertStats(result, propertiesWritten = 2)
@@ -51,7 +51,7 @@ class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
   test("handle null value in property map from parameter for create relationship") {
     val query = "CREATE (a)-[r:REL {props}]->() RETURN r.foo, r.bar"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query, params = Map("props" -> Map("foo" -> null, "bar" -> "baz")))
+    val result = executeWith(Configs.UpdateConf, query, params = Map("props" -> Map("foo" -> null, "bar" -> "baz")))
 
     result.toSet should equal(Set(Map("r.foo" -> null, "r.bar" -> "baz")))
     assertStats(result, nodesCreated = 2, relationshipsCreated = 1, propertiesWritten = 1)
@@ -60,7 +60,7 @@ class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
   test("handle null value in property map from parameter") {
     val query = "CREATE (a {props})-[r:REL {props}]->() RETURN a.foo, a.bar, r.foo, r.bar"
 
-    val result = executeWith(conf, query, params = Map("props" -> Map("foo" -> null, "bar" -> "baz")))
+    val result = executeWith(Configs.UpdateConf - tmpConf, query, params = Map("props" -> Map("foo" -> null, "bar" -> "baz")))
 
     result.toSet should equal(Set(Map("a.foo" -> null, "a.bar" -> "baz", "r.foo" -> null, "r.bar" -> "baz")))
     assertStats(result, nodesCreated = 2, relationshipsCreated = 1, propertiesWritten = 2)
@@ -72,7 +72,7 @@ class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
 
     val query = s"CREATE (a) WITH a LOAD CSV FROM '$url' AS line CREATE (b) CREATE (a)<-[:T]-(b)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query)
+    val result = executeWith(Configs.UpdateConf, query)
 
     assertStats(result, nodesCreated = 2, relationshipsCreated = 1)
   }
@@ -81,7 +81,7 @@ class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
   test("should have bound node recognized after projection with WITH + CALL") {
     val query = "CREATE (a:L) WITH a CALL db.labels() YIELD label CREATE (b) CREATE (a)<-[:T]-(b)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Version2_3 - Configs.AllRulePlanners, query)
+    val result = executeWith(Configs.UpdateConf - Configs.AllRulePlanners, query)
 
     assertStats(result, nodesCreated = 2, relationshipsCreated = 1, labelsAdded = 1)
   }
@@ -90,7 +90,7 @@ class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
   test("should have bound node recognized after projection with WITH + FOREACH") {
     val query = "CREATE (a) WITH a FOREACH (i in [] | SET a.prop = 1) CREATE (b) CREATE (a)<-[:T]-(b)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query)
+    val result = executeWith(Configs.UpdateConf, query)
 
     assertStats(result, nodesCreated = 2, relationshipsCreated = 1)
   }
@@ -102,7 +102,7 @@ class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
 
     val query = "CREATE" + List.fill(amount)("(:Bar)-[:FOO]->(:Baz)").mkString(", ")
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query)
+    val result = executeWith(Configs.UpdateConf, query)
 
     assertStats(result, nodesCreated = 2 * amount, relationshipsCreated = amount, labelsAdded = 2 * amount)
 
@@ -113,7 +113,7 @@ class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
   test("should allow create, delete and return in one go (relationship)") {
     val typ = "ThisIsTheRelationshipType"
     val query = s"CREATE ()-[r:$typ]->() DELETE r RETURN type(r)"
-    val result = executeWith(Configs.CommunityInterpreted - Configs.Cost2_3, query)
+    val result = executeWith(Configs.UpdateConf - Configs.SlottedInterpreted, query)
     result.toList should equal(List(Map("type(r)" -> typ)))
   }
 
@@ -123,7 +123,7 @@ class CreateAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
 
     val query = "CREATE" + List.fill(createdNumber)("(:Bar{prop: 1})").mkString(", ")
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query)
+    val result = executeWith(Configs.UpdateConf, query)
 
     assertStats(result, nodesCreated = createdNumber, labelsAdded = createdNumber, propertiesWritten = createdNumber)
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
@@ -145,44 +145,59 @@ trait CypherComparisonSupport extends CypherTestSupport {
                             params: Map[String, Any] = Map.empty): InternalExecutionResult = {
     // Never consider Morsel even if test requests it
     val expectSucceedEffective = expectSucceed - Configs.Morsel
-    val expectedDifferentResultsEffective = expectedDifferentResults - Configs.Morsel
 
-    val compareResults = expectSucceedEffective - expectedDifferentResultsEffective
-    val baseScenario =
-      if (expectSucceedEffective.scenarios.nonEmpty) extractBaseScenario(expectSucceedEffective, compareResults)
-      else TestScenario(Versions.Default, Planners.Default, Runtimes.Interpreted)
+    if (expectSucceedEffective.scenarios.nonEmpty) {
+      val expectedDifferentResultsEffective = expectedDifferentResults - Configs.Morsel
+      val compareResults = expectSucceedEffective - expectedDifferentResultsEffective
+      val baseScenario = extractBaseScenario(expectSucceedEffective, compareResults)
+      val explicitlyRequestedExperimentalScenarios = expectSucceedEffective.scenarios intersect Configs.Experimental.scenarios
 
-    val explicitlyRequestedExperimentalScenarios = expectSucceedEffective.scenarios intersect Configs.Experimental.scenarios
-    val positiveResults = ((Configs.AbsolutelyAll.scenarios ++ explicitlyRequestedExperimentalScenarios) - baseScenario).flatMap {
-      thisScenario =>
-        executeScenario(thisScenario, query, expectSucceedEffective.containsScenario(thisScenario), executeBefore, params, resultAssertionInTx)
+      val positiveResults = ((Configs.AbsolutelyAll.scenarios ++ explicitlyRequestedExperimentalScenarios) - baseScenario).flatMap {
+        thisScenario =>
+          executeScenario(thisScenario, query, expectSucceedEffective.containsScenario(thisScenario), executeBefore, params, resultAssertionInTx)
+      }
+
+      //Must be run last and have no rollback to be able to do certain result assertions
+      val baseOption = executeScenario(baseScenario, query, expectedToSucceed = true, executeBefore, params, resultAssertionInTx = None, rollback = false)
+
+      // Assumption: baseOption.get is safe because the baseScenario is expected to succeed
+      val baseResult = baseOption.get._2
+
+      positiveResults.foreach {
+        case (scenario, result) =>
+          planComparisonStrategy.compare(expectSucceedEffective, scenario, result)
+
+          if (compareResults.containsScenario(scenario)) {
+            assertResultsSame(result, baseResult, query, s"${scenario.name} returned different results than ${baseScenario.name}")
+          } else {
+            assertResultsNotSame(result, baseResult, query, s"Unexpectedly (but correctly!)\n${scenario.name} returned same results as ${baseScenario.name}")
+          }
+      }
+      baseResult
+    } else {
+      /**
+        * If we are ending up here we don't expect any config to succeed i.e. Configs.Empty was used.
+        * Currently this only happens when we use a[xxxException] should be thrownBy...
+        * Consider to not allow this, but always use failWithError instead.
+        * For now, don't support plan comparisons and only run som default config without a transaction to get a result.
+        */
+      if (planComparisonStrategy != DoNotComparePlans) {
+        fail("At least one scenario must be expected to succeed to be able to compare plans")
+      }
+
+      val baseScenario = TestScenario(Versions.Default, Planners.Default, Runtimes.Interpreted)
+      baseScenario.prepare()
+      executeBefore()
+      val baseResult = innerExecute(s"CYPHER ${baseScenario.preparserOptions} $query", params)
+      baseResult
     }
-
-    baseScenario.prepare()
-    executeBefore()
-    val baseResult = innerExecute(s"CYPHER ${baseScenario.preparserOptions} $query", params)
-    baseScenario.checkResultForSuccess(query, baseResult)
-    planComparisonStrategy.compare(expectSucceedEffective, baseScenario, baseResult)
-
-    positiveResults.foreach {
-      case (scenario, result) =>
-        planComparisonStrategy.compare(expectSucceedEffective, scenario, result)
-
-        if (compareResults.containsScenario(scenario)) {
-          assertResultsSame(result, baseResult, query, s"${scenario.name} returned different results than ${baseScenario.name}")
-        } else {
-          assertResultsNotSame(result, baseResult, query, s"Unexpectedly (but correctly!)\n${scenario.name} returned same results as ${baseScenario.name}")
-        }
-    }
-
-    baseResult
   }
 
   private def extractBaseScenario(expectSucceed: TestConfiguration, compareResults: TestConfiguration): TestScenario = {
     val scenariosToChooseFrom = if (compareResults.scenarios.isEmpty) expectSucceed else compareResults
 
     if (scenariosToChooseFrom.scenarios.isEmpty) {
-      fail("At least one scenario must be expected to succeed, be comparable with plan and result")
+      fail("At least one scenario must be expected to succeed, to be comparable with plan and result")
     }
     val preferredScenario = TestScenario(Versions.Default, Planners.Default, Runtimes.Interpreted)
     if (scenariosToChooseFrom.containsScenario(preferredScenario))
@@ -196,25 +211,27 @@ trait CypherComparisonSupport extends CypherTestSupport {
                               expectedToSucceed: Boolean,
                               executeBefore: () => Unit,
                               params: Map[String, Any],
-                              resultAssertionInTx: Option[(InternalExecutionResult) => Unit]) = {
+                              resultAssertionInTx: Option[(InternalExecutionResult) => Unit],
+                              rollback: Boolean = true) = {
     scenario.prepare()
-    val tryResult =
-      graph.rollback(
-        {
-          executeBefore()
-          val tryRes = Try(innerExecute(s"CYPHER ${scenario.preparserOptions} $query", params))
-          if (expectedToSucceed && resultAssertionInTx.isDefined) {
-            tryRes match {
-              case Success(thisResult) =>
-                withClue(s"result in transaction for ${scenario.name}\n") {
-                  resultAssertionInTx.get.apply(thisResult)
-                }
-              case Failure(_) =>
-              // No need to do anything: will be handled by match below
+
+    def execute = {
+      executeBefore()
+      val tryRes = Try(innerExecute(s"CYPHER ${scenario.preparserOptions} $query", params))
+      if (expectedToSucceed && resultAssertionInTx.isDefined) {
+        tryRes match {
+          case Success(thisResult) =>
+            withClue(s"result in transaction for ${scenario.name}\n") {
+              resultAssertionInTx.get.apply(thisResult)
             }
-          }
-          tryRes
-        })
+          case Failure(_) =>
+          // No need to do anything: will be handled by match below
+        }
+      }
+      tryRes
+    }
+
+    val tryResult = if (rollback) graph.rollback(execute) else execute
 
     if (expectedToSucceed) {
       tryResult match {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
@@ -636,19 +636,9 @@ object CypherComparisonSupport {
     If you are unsure what you need, this is a good start. It's not really all scenarios, but this is testing all
     interesting scenarios.
      */
-    def All: TestConfiguration =
-      TestConfiguration(Versions.V3_4, Planners.Cost, Runtimes(Runtimes.CompiledSource, Runtimes.CompiledBytecode)) +
-        TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Slotted)) +
-        TestConfiguration(Versions.V2_3 -> Versions.V3_1, Planners.all, Runtimes.Default) +
-        TestScenario(Versions.Default, Planners.Rule, Runtimes.Default) +
-        TestScenario(Versions.V3_3, Planners.Cost, Runtimes.Default)
+    def All: TestConfiguration = AbsolutelyAll - Procs
 
-    def AllExceptSlotted: TestConfiguration =
-      TestConfiguration(Versions.V3_4, Planners.Cost, Runtimes(Runtimes.CompiledSource, Runtimes.CompiledBytecode)) +
-        TestConfiguration(Versions.Default, Planners.Default, Runtimes.Interpreted) +
-        TestConfiguration(Versions.V2_3 -> Versions.V3_1, Planners.all, Runtimes.Default) +
-        TestScenario(Versions.Default, Planners.Rule, Runtimes.Default) +
-        TestScenario(Versions.V3_3, Planners.Cost, Runtimes.Default)
+    def AllExceptSlotted: TestConfiguration = All - SlottedInterpreted
 
     /**
       * These are all configurations that will be executed even if not explicitly expected to succeed or fail.

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/CypherComparisonSupport.scala
@@ -632,6 +632,16 @@ object CypherComparisonSupport {
 
     def Procs: TestConfiguration = TestScenario(Versions.Default, Planners.Default, Runtimes.ProcedureOrSchema)
 
+    /**
+      * Handy configs for things only supported from 3.3 (not rule) and for checking plans
+      */
+    def OldAndRule: TestConfiguration = Cost2_3 + Cost3_1 + AllRulePlanners
+
+    /**
+      * Configs which support CREATE, DELETE, SET, REMOVE, MERGE etc.
+      */
+    def UpdateConf: TestConfiguration = Interpreted - Cost2_3
+
     /*
     If you are unsure what you need, this is a good start. It's not really all scenarios, but this is testing all
     interesting scenarios.

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/EagerizationAcceptanceTest.scala
@@ -61,7 +61,7 @@ class EagerizationAcceptanceTest
         |RETURN n.val AS nv, m.val AS mv
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Cost2_3 + Configs.Rule2_3))
 
     result.toList should equal(List(Map("nv" -> 2, "mv" -> 2),
@@ -81,7 +81,7 @@ class EagerizationAcceptanceTest
         |RETURN n.val AS nv, m.val AS mv
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
+    val result = executeWith(Configs.UpdateConf, query, expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
 
     result.toList should equal(List(Map("nv" -> 2, "mv" -> 2),
@@ -104,7 +104,7 @@ class EagerizationAcceptanceTest
       """.stripMargin
 
     val result = executeWith(
-      Configs.Interpreted - Configs.Cost2_3, query,
+      Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
 
     result.toList should equal(List(Map("nv" -> 2, "mv" -> 2),
@@ -124,7 +124,7 @@ class EagerizationAcceptanceTest
       """.stripMargin
 
     val result = executeWith(
-      Configs.Interpreted - Configs.Cost2_3,
+      Configs.UpdateConf,
       expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3),
       query = query)
@@ -146,7 +146,7 @@ class EagerizationAcceptanceTest
       """.stripMargin
 
     val result = executeWith(
-      Configs.Interpreted - Configs.Cost2_3,
+      Configs.UpdateConf,
       expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1),
       query = query)
@@ -167,7 +167,7 @@ class EagerizationAcceptanceTest
         |RETURN count(*)
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query = query,
+    val result = executeWith(Configs.UpdateConf, query = query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
 
     result.columnAs[Long]("count(*)").next should equal(2)
@@ -180,7 +180,7 @@ class EagerizationAcceptanceTest
     relate(a, b, "T")
     val query = "MATCH (a)-[t:T]-(b) DELETE t RETURN count(*) as count"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query = query,
+    val result = executeWith(Configs.UpdateConf, query = query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsDeleted = 1)
@@ -220,7 +220,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (a), (b) CALL user.mkRel(a, b) YIELD relId WITH * MATCH ()-[rel]->() WHERE id(rel) = relId RETURN rel.foo"
 
     // Correct! Eagerization happens as part of query context operation
-    val result = executeWith(Configs.Interpreted - Configs.AllRulePlanners - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf - Configs.AllRulePlanners, query,
       executeBefore = () => counter.reset(),
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
 
@@ -261,7 +261,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (a), (b) CALL user.mkRel(a, b) MATCH (a)-[rel]->(b) RETURN rel.foo"
 
     // Correct! Eagerization happens as part of query context operation
-    val result = executeWith(Configs.Interpreted - Configs.AllRulePlanners - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf - Configs.AllRulePlanners, query,
       executeBefore = () => counter.reset(),
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
 
@@ -310,7 +310,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (x), (y) CALL user.expand(x, y) YIELD relId RETURN x, y, relId"
 
     // Correct! No eagerization necessary
-    val result = executeWith(Configs.Interpreted - Configs.AllRulePlanners - Configs.Version2_3, query,
+    val result = executeWith(Configs.UpdateConf - Configs.AllRulePlanners, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
 
     result.size should equal(2)
@@ -358,7 +358,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH (x), (y) CALL user.expand(x, y) WITH * MATCH (x)-[rel]->(y) RETURN *"
 
     // Correct! No eagerization necessary
-    val result = executeWith(Configs.Interpreted - Configs.AllRulePlanners - Configs.Version2_3, query,
+    val result = executeWith(Configs.UpdateConf - Configs.AllRulePlanners, query,
       executeBefore = () => counter.reset(),
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
 
@@ -372,7 +372,7 @@ class EagerizationAcceptanceTest
     relate(a, b, "T")
     val query = "MATCH (a)-[t:T]-(b) CREATE (a)-[:T]->(b) RETURN count(*) as count"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsCreated = 2)
@@ -384,7 +384,7 @@ class EagerizationAcceptanceTest
     relate(a, b, "T", Map("prop1" -> "foo"))
     val query = "MATCH (a)-[t:T {prop1: 'foo'}]-(b) CREATE (a)-[:T {prop2: 'bar'}]->(b) RETURN count(*) as count"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.AllRulePlanners))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsCreated = 2, propertiesWritten = 2)
@@ -396,7 +396,7 @@ class EagerizationAcceptanceTest
     relate(a, b, "T", Map("prop1" -> "foo"))
     val query = "MATCH (a)-[t:T {prop1: 'foo'}]-(b) CREATE (a)-[:T {prop1: 'foo'}]->(b) RETURN count(*) as count"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsCreated = 2, propertiesWritten = 2)
@@ -409,7 +409,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH p=(:L)-[*]-() DELETE p RETURN count(*) as count"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsDeleted = 1, nodesDeleted = 2)
@@ -422,7 +422,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH p=(:L)-[*]-() DETACH DELETE p RETURN count(*) as count"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsDeleted = 1, nodesDeleted = 2)
@@ -432,7 +432,7 @@ class EagerizationAcceptanceTest
     graph.execute("CREATE (a:Person {id: 42})-[:FRIEND_OF]->(b:Person {id:42}), (b)-[:FRIEND_OF]->(a), (:Person)-[:FRIEND_OF]->(b)")
 
     val query = "MATCH (p1:Person {id: 42})-[r:FRIEND_OF]->(p2:Person {id:42}) DETACH DELETE r, p1, p2 RETURN count(*) AS count"
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsDeleted = 3, nodesDeleted = 2)
@@ -442,7 +442,7 @@ class EagerizationAcceptanceTest
     graph.execute("CREATE (a:Person {id: 42})-[:FRIEND_OF]->(b:Person {id:42}), (b)-[:FRIEND_OF]->(a), (:Person)-[:FRIEND_OF]->(b)")
 
     val query = "MATCH p = (p1:Person {id: 42})-[r:FRIEND_OF]->(p2:Person {id:42}) DETACH DELETE p RETURN count(*) AS count"
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsDeleted = 3, nodesDeleted = 2)
@@ -454,7 +454,7 @@ class EagerizationAcceptanceTest
     relate(a, b, "T")
     val query = "MATCH (a)-[t:T]->(b) CREATE (a)-[:T]->(b) RETURN count(*) as count"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, optimalEagerCount = 0))
     result.columnAs[Int]("count").next should equal(1)
     assertStats(result, relationshipsCreated = 1)
@@ -466,7 +466,7 @@ class EagerizationAcceptanceTest
     relate(a, b, "T")
     val query = "MATCH (a)-[t:T]-(b) CREATE (a)-[:T2]->(b) RETURN count(*) as count"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsCreated = 2)
@@ -480,7 +480,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (n) DELETE n MERGE (m {p: 0}) ON CREATE SET m.p = 1 RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
 
     assertStats(result, nodesCreated = 2, propertiesWritten = 4, nodesDeleted = 2)
@@ -501,7 +501,7 @@ class EagerizationAcceptanceTest
         |RETURN count(*)
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
     assertStats(result, nodesCreated = 1, nodesDeleted = 2, propertiesWritten = 1, labelsAdded = 1)
     result.columnAs[Long]("count(*)").next shouldBe 2
@@ -520,7 +520,7 @@ class EagerizationAcceptanceTest
         |RETURN b2.deleted
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
     assertStats(result, nodesCreated = 1, nodesDeleted = 3, propertiesWritten = 1, labelsAdded = 1)
     result.columnAs[Node]("b2.deleted").toList should equal(List(null, null, null))
@@ -540,7 +540,7 @@ class EagerizationAcceptanceTest
         |RETURN b2.deleted
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, optimalEagerCount = 1, expectPlansToFailPredicate = Configs.AllRulePlanners - Configs.Rule2_3))
     assertStats(result, nodesCreated = 2, nodesDeleted = 2, propertiesWritten = 2, labelsAdded = 2)
     result.columnAs[Node]("b2.deleted").toList should equal(List(null, null))
@@ -558,7 +558,7 @@ class EagerizationAcceptanceTest
         |RETURN count(*)
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query)
+    val result = executeWith(Configs.UpdateConf, query)
     result.toList should equal(List(Map("count(*)" -> 2)))
     assertStats(result, nodesCreated = 1, nodesDeleted = 2)
   }
@@ -579,7 +579,7 @@ class EagerizationAcceptanceTest
         |RETURN count(*)
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     assertStats(result, nodesCreated = 0, nodesDeleted = 2)
     result.columnAs[Long]("count(*)").next shouldBe 8
@@ -598,7 +598,7 @@ class EagerizationAcceptanceTest
         |RETURN exists(t2.id)
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, optimalEagerCount = 1))
     assertStats(result, relationshipsDeleted = 2, relationshipsCreated = 1)
 
@@ -618,7 +618,7 @@ class EagerizationAcceptanceTest
         |RETURN count(*)
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2))
     assertStats(result, relationshipsDeleted = 1, relationshipsCreated = 1)
     result.columnAs[Long]("count(*)").next shouldBe 1
@@ -637,7 +637,7 @@ class EagerizationAcceptanceTest
         |RETURN exists(t2.id)
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, optimalEagerCount = 1))
     assertStats(result, relationshipsDeleted = 2, relationshipsCreated = 1)
     result.toList should equal(List(Map("exists(t2.id)" -> false), Map("exists(t2.id)" -> false)))
@@ -656,7 +656,7 @@ class EagerizationAcceptanceTest
         |RETURN exists(t2.id)
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, optimalEagerCount = 1))
     assertStats(result, relationshipsDeleted = 2, relationshipsCreated = 1)
     result.toList should equal(List(Map("exists(t2.id)" -> false), Map("exists(t2.id)" -> false)))
@@ -675,7 +675,7 @@ class EagerizationAcceptanceTest
         |RETURN count(*)
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2))
     assertStats(result, relationshipsDeleted = 2, relationshipsCreated = 1)
     result.columnAs[Long]("count(*)").next shouldBe 2
@@ -688,7 +688,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (a), (b) CREATE (a)-[:KNOWS]->(b) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     assertStats(result, relationshipsCreated = 4)
     result.columnAs[Long]("count(*)").next shouldBe 4
@@ -700,7 +700,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH () CREATE () WITH * MATCH (n) RETURN count(*) AS count"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
+    val result = executeWith(Configs.UpdateConf, query, expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
 
     assertStats(result, nodesCreated = 2)
@@ -713,7 +713,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (k) CREATE (l {prop: 44}) WITH * MATCH (m) CREATE (n {prop:45}) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2))
 
@@ -735,7 +735,7 @@ class EagerizationAcceptanceTest
     val query = "MATCH () CREATE () RETURN count(*)"
 
     val result = executeWith(
-      Configs.Interpreted - Configs.Cost2_3,
+      Configs.UpdateConf,
       query = query,
       executeBefore = executeBefore,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
@@ -745,7 +745,7 @@ class EagerizationAcceptanceTest
 
   test("should not introduce eagerness for leaf create match") {
     val query = "CREATE () WITH * MATCH () RETURN count(*)"
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         plan should not(useOperators("ReadOnly"))
         assertNumberOfEagerness(plan, 0) should be(true)
@@ -758,7 +758,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("L")
     val query = "MATCH (:L) CREATE (:L) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 1, labelsAdded = 1)
@@ -770,7 +770,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (n:L {id: 0}) USING INDEX n:L(id) CREATE (:L {id:0}) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesWritten = 1)
@@ -781,7 +781,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (), () CREATE () RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, nodesCreated = 4)
@@ -792,7 +792,7 @@ class EagerizationAcceptanceTest
     createNode("prop1" -> 42, "prop2" -> 42)
     val query = "MATCH (a {prop1: 42}), (n {prop2: 42}) CREATE ({prop3: 42}) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.AllRulePlanners))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, nodesCreated = 4, propertiesWritten = 4)
@@ -803,7 +803,7 @@ class EagerizationAcceptanceTest
     createNode("prop1" -> 42, "prop2" -> 42)
     val query = "MATCH (a {prop1: 42}), (n {prop2: 42}) CREATE ({prop1: 42, prop2: 42}) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, nodesCreated = 4, propertiesWritten = 8)
@@ -814,7 +814,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (a), (b) CREATE (a)-[r:KNOWS]->(b) SET r = { key: 42 } RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 4, propertiesWritten = 4)
@@ -824,7 +824,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode())
     val query = "MATCH (n) WHERE (n)-->() CREATE (n)-[:T]->() RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 1, relationshipsCreated = 1)
@@ -835,7 +835,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode())
     val query = "MATCH ()--() CREATE () RETURN count(*) AS count"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count").next shouldBe 4
     assertStats(result, nodesCreated = 4)
@@ -852,7 +852,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH () CREATE () RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 1)
@@ -863,7 +863,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (a), (b) CREATE (a)-[:TYPE]->(b) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 4)
@@ -874,7 +874,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (a), (b) WITH a, b ORDER BY id(a) CREATE (a)-[:TYPE]->(b) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 4)
@@ -885,7 +885,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (a) CREATE (a)-[:TYPE]->() RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, nodesCreated = 2, relationshipsCreated = 2)
@@ -896,7 +896,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (), (a) CREATE (a)-[:TYPE]->() RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, nodesCreated = 4, relationshipsCreated = 4)
@@ -907,7 +907,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode(), "TYPE")
     val query = "MATCH (a)-[:TYPE]->(b) CREATE (a)-[:TYPE]->(b) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, optimalEagerCount = 0))
     assertStats(result, relationshipsCreated = 2)
     result.columnAs[Int]("count(*)").next should equal(2)
@@ -919,7 +919,7 @@ class EagerizationAcceptanceTest
     relate(a, b, "TYPE") // NOTE: The order the nodes are related should not affect the result (opposite from the test below)
     val query = "MATCH (a)-[:TYPE]->(b) CREATE (a)<-[:TYPE]-(b) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, relationshipsCreated = 1)
     result.columnAs[Int]("count(*)").next should equal(1)
@@ -931,7 +931,7 @@ class EagerizationAcceptanceTest
     relate(b, a, "TYPE") // NOTE: The order the nodes are related should not affect the result (opposite from the test above)
     val query = "MATCH (a)-[:TYPE]->(b) CREATE (a)<-[:TYPE]-(b) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, relationshipsCreated = 1)
     result.columnAs[Int]("count(*)").next should equal(1)
@@ -942,7 +942,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode(), "TYPE")
     val query = "MATCH (a)-[:TYPE]-(b) CREATE (a)-[:TYPE]->(b) RETURN count(*) as count"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, relationshipsCreated = 4)
     result.columnAs[Int]("count").next should equal(4)
@@ -953,7 +953,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode(), "TYPE")
     val query = "MATCH (a)-[:TYPE]-(b) MERGE (a)-[:TYPE]->(b) RETURN count(*) as count"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, relationshipsCreated = 2)
     result.columnAs[Int]("count").next should equal(4)
@@ -965,7 +965,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode(), "TYPE")
     val query = "MATCH ()-[:TYPE]->(), (a)-[:TYPE]->(b) CREATE (a)-[:TYPE]->(b) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, relationshipsCreated = 2)
@@ -976,7 +976,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode(), "TYPE")
     val query = "MATCH ()-[:TYPE]->() MATCH (a)-[:TYPE]->(b) CREATE (a)-[:TYPE]->(b) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 4)
@@ -987,7 +987,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode(), "TYPE")
     val query = "MATCH ()-[:TYPE]->() CREATE (a)-[:TYPE]->(b) WITH * MATCH ()-[:TYPE]->() CREATE (c)-[:TYPE]->(d) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
+    val result = executeWith(Configs.UpdateConf, query, expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(3, optimalEagerCount = 2, expectPlansToFailPredicate = Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 8
     assertStats(result, nodesCreated = 20, relationshipsCreated = 10)
@@ -998,7 +998,7 @@ class EagerizationAcceptanceTest
     relate(createLabeledNode("LabelOne"), createLabeledNode("LabelTwo"), "TYPE")
     val query = "MATCH ()-[:TYPE]->() MATCH (a:LabelOne)-[:TYPE]->(b:LabelTwo) CREATE (a)-[:TYPE]->(b) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 4)
@@ -1009,7 +1009,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode(), "T1")
     val query = "MATCH ()-[:T1]->() CREATE ()-[:T2]->() RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, nodesCreated = 4, relationshipsCreated = 2)
@@ -1026,7 +1026,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Person), (m:Movie) DELETE a, m RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, nodesDeleted = 4)
@@ -1039,7 +1039,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Person) DELETE a RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, nodesDeleted = 2)
@@ -1050,7 +1050,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r]-(b) DELETE r,a,b RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, nodesDeleted = 2, relationshipsDeleted = 1)
@@ -1063,7 +1063,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r]-(b) DELETE r, a, b RETURN count(*) as count"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.toList should equal(List(Map("count" -> 2)))
     assertStats(result, nodesDeleted = 2, relationshipsDeleted = 1)
@@ -1076,7 +1076,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r {prop : 3}]-(b) DELETE r, a, b RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, nodesDeleted = 2, relationshipsDeleted = 1)
@@ -1090,7 +1090,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r]->(b) DETACH DELETE a, b RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
 
     result.toList should equal(List(Map("count(*)" -> 2)))
@@ -1105,7 +1105,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r]->(b) DELETE r RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, optimalEagerCount = 0))
 
     result.toList should equal(List(Map("count(*)" -> 2)))
@@ -1118,7 +1118,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:A)-[r]->(b:B) DELETE r, a, b RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, optimalEagerCount = 0))
     result.toList should equal(List(Map("count(*)" -> 2)))
     assertStats(result, nodesDeleted = 4, relationshipsDeleted = 2)
@@ -1130,7 +1130,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (b:B)<-[r]-(a:A) DELETE r, a, b RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, optimalEagerCount = 0))
     result.toList should equal(List(Map("count(*)" -> 2)))
     assertStats(result, nodesDeleted = 4, relationshipsDeleted = 2)
@@ -1144,7 +1144,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r {prop : 3}]->(b) DELETE r, a, b RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, optimalEagerCount = 0))
     result.toList should equal(List(Map("count(*)" -> 4)))
     assertStats(result, nodesDeleted = 8, relationshipsDeleted = 4)
@@ -1160,7 +1160,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r]-(b) DELETE r, a, b RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.toList should equal(List(Map("count(*)" -> 12)))
     assertStats(result, nodesDeleted = 12, relationshipsDeleted = 6)
@@ -1173,7 +1173,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:A)-[r]-(b) DELETE r, a, b RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.toList should equal(List(Map("count(*)" -> 4)))
     assertStats(result, nodesDeleted = 6, relationshipsDeleted = 3)
@@ -1187,7 +1187,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r {prop : 3}]-(b) DELETE r, a, b RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.toList should equal(List(Map("count(*)" -> 8)))
     assertStats(result, nodesDeleted = 8, relationshipsDeleted = 4)
@@ -1202,7 +1202,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r1]->(b)-[r2]->(c) DELETE r1, r2, a, b, c RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.toList should equal(List(Map("count(*)" -> 4)))
     assertStats(result, nodesDeleted = 5, relationshipsDeleted = 4)
@@ -1217,7 +1217,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a)-[r*]->(b) DETACH DELETE a, b RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.toList should equal(List(Map("count(*)" -> 8)))
     assertStats(result, nodesDeleted = 5, relationshipsDeleted = 4)
@@ -1227,7 +1227,7 @@ class EagerizationAcceptanceTest
   test("create directional relationship with property, match and delete relationship and nodes within same query should be eager and work") {
     val query = "CREATE ()-[:T {prop: 3}]->() WITH * MATCH (a)-[r {prop : 3}]->(b) DELETE r, a, b RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 2, relationshipsCreated = 1, propertiesWritten = 1, nodesDeleted = 2, relationshipsDeleted = 1)
@@ -1241,7 +1241,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("A")
     val query = "MATCH (a:A) OPTIONAL MATCH (b:B) CREATE (:B) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 6
     assertStats(result, nodesCreated = 6, labelsAdded = 6)
@@ -1253,7 +1253,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("A")
     val query = "MATCH (a:A) OPTIONAL MATCH (b:B) CREATE (:A) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 6
     assertStats(result, nodesCreated = 6, labelsAdded = 6)
@@ -1274,7 +1274,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Person) OPTIONAL MATCH (a)-[r1]-() DELETE a, r1 RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 7
     assertStats(result, nodesDeleted = 2, relationshipsDeleted = 7)
@@ -1288,7 +1288,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Person) MERGE (b) WITH * OPTIONAL MATCH (a)-[r1]-(b) DELETE r1 RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, optimalEagerCount = 1, expectPlansToFailPredicate = Configs.AllRulePlanners - Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 3
     assertStats(result, relationshipsDeleted = 2)
@@ -1307,7 +1307,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Person) OPTIONAL MATCH (a)-[r1]-(), (m:Movie)-[r2]-() DELETE a, r1, m, r2 RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 6
     assertStats(result, nodesDeleted = 3, relationshipsDeleted = 4)
@@ -1318,7 +1318,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Movie")
     val query = "MATCH (a:Person), (m:Movie) CREATE (a)-[:T]->(m) WITH a OPTIONAL MATCH (a) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, relationshipsCreated = 1)
@@ -1332,7 +1332,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (m1:Two), (m2:Two), (n) MERGE (q) ON MATCH SET q:Two RETURN count(*) AS c"
 
-    val result: InternalExecutionResult = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result: InternalExecutionResult = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, labelsAdded = 1)
     result.toList should equal(List(Map("c" -> 36)))
@@ -1344,7 +1344,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (m1:Two), (m2:Two), (n) MERGE (q:Three) ON MATCH SET q:Two RETURN count(*) AS c"
 
-    val result: InternalExecutionResult = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result: InternalExecutionResult = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, labelsAdded = 2, nodesCreated = 1)
     result.toList should equal(List(Map("c" -> 12)))
@@ -1356,7 +1356,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (a:Two), (b) MERGE (q {p: 1}) RETURN count(*) AS c"
 
-    val result: InternalExecutionResult = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result: InternalExecutionResult = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, nodesCreated = 1, propertiesWritten = 1)
     result.toList should equal(List(Map("c" -> 6)))
@@ -1368,7 +1368,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (m1:Two), (m2:Two) MERGE (q) ON MATCH SET q:One RETURN count(*) AS c"
 
-    val result: InternalExecutionResult = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result: InternalExecutionResult = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     assertStats(result, labelsAdded = 3)
     result.toList should equal(List(Map("c" -> 12)))
@@ -1380,7 +1380,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (m1:Two), (m2:Two), (n) MERGE (q) ON CREATE SET q:Two RETURN count(*) AS c"
 
-    val result: InternalExecutionResult = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result: InternalExecutionResult = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, labelsAdded = 0)
     result.toList should equal(List(Map("c" -> 36)))
@@ -1392,7 +1392,7 @@ class EagerizationAcceptanceTest
     createNode(Map("id" -> 0))
     val query = "MATCH (b {id: 0}), (c {id: 0}), (a) MERGE () ON MATCH SET a.id = 0 RETURN count(*) AS c"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.toList should equal(List(Map("c" -> 36)))
     assertStats(result, propertiesWritten = 36)
@@ -1404,7 +1404,7 @@ class EagerizationAcceptanceTest
     createNode(Map("id" -> 0))
     val query = "MATCH (b {id: 0}), (c {id: 0}) MERGE (a) ON MATCH SET a.id2 = 0 RETURN count(*) AS c"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.AllRulePlanners))
     result.toList should equal(List(Map("c" -> 12)))
     assertStats(result, propertiesWritten = 12)
@@ -1416,7 +1416,7 @@ class EagerizationAcceptanceTest
     createNode(Map("id" -> 0))
     val query = "MATCH (b {id: 0}), (c {id: 0}), (a) MERGE () ON CREATE SET a = {id: 0} RETURN count(*) AS c"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.toList should equal(List(Map("c" -> 36)))
     assertStats(result, propertiesWritten = 0)
@@ -1428,7 +1428,7 @@ class EagerizationAcceptanceTest
     createNode(Map("id" -> 0))
     val query = "MATCH (b {id: 0}), (c {id: 0}), (a) MERGE () ON CREATE SET a += {id: 0} RETURN count(*) AS c"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.toList should equal(List(Map("c" -> 36)))
     assertStats(result, propertiesWritten = 0)
@@ -1440,7 +1440,7 @@ class EagerizationAcceptanceTest
     createNode(Map("id" -> 0))
     val query = "MATCH (b {id: 0}), (c {id: 0}), (a) MERGE () ON MATCH SET a = {map} RETURN count(*) AS c"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1),
       params = Map("map" -> Map("id" -> 0)))
     result.toList should equal(List(Map("c" -> 36)))
@@ -1459,7 +1459,7 @@ class EagerizationAcceptanceTest
         |RETURN count(*)
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, nodesDeleted = 2, relationshipsDeleted = 2)
     result.columnAs[Long]("count(*)").next shouldBe 2
@@ -1479,7 +1479,7 @@ class EagerizationAcceptanceTest
         |RETURN count(*)
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, nodesDeleted = 2, relationshipsDeleted = 2)
     result.columnAs[Long]("count(*)").next shouldBe 2
@@ -1490,7 +1490,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (a), (b) MERGE (a)-[r:KNOWS]->(b) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 4)
@@ -1503,7 +1503,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON MATCH SET a.prop = 42 RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
@@ -1518,7 +1518,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON MATCH SET b:Foo RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, optimalEagerCount = 0, expectPlansToFailPredicate = Configs.AllRulePlanners - Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 3, labelsAdded = 1)
@@ -1535,7 +1535,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON MATCH SET a:Bar RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, relationshipsCreated = 3, labelsAdded = 1)
@@ -1550,7 +1550,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON CREATE SET b:Foo RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, optimalEagerCount = 0, expectPlansToFailPredicate = Configs.AllRulePlanners - Configs.Rule2_3))
 
     result.columnAs[Long]("count(*)").next shouldBe 4
@@ -1567,7 +1567,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:Foo), (b:Bar) MERGE (a)-[r:KNOWS]->(b) ON CREATE SET a:Bar RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
 
     result.columnAs[Long]("count(*)").next shouldBe 4
@@ -1578,7 +1578,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("A")
     val query = "MATCH (a:A) MERGE (a)-[:BAR]->(b:B) WITH a MATCH (a) WHERE (a)-[:FOO]->() RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 0
     assertStats(result, relationshipsCreated = 1, nodesCreated = 1, labelsAdded = 1)
@@ -1592,7 +1592,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a:A) MERGE (a)-[:BAR]->(b:A) WITH a MATCH (a2) RETURN count (a2) AS nodes"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
+    val result = executeWith(Configs.UpdateConf, query, expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
 
     assertStats(result, nodesCreated = 2, relationshipsCreated = 2, labelsAdded = 2)
@@ -1604,7 +1604,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("B")
     val query = "MATCH (a:A), (b:B) MERGE (a)-[:BAR]->(b) WITH a MATCH (a) WHERE (a)-[:FOO]->() RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 0
     assertStats(result, relationshipsCreated = 1)
@@ -1613,7 +1613,7 @@ class EagerizationAcceptanceTest
   test("never ending query should end - this is the query that prompted Eagerness in the first place") {
     createNode()
     val query = "MATCH (a) CREATE ()"
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     assertStats(result, nodesCreated = 1)
   }
@@ -1624,7 +1624,7 @@ class EagerizationAcceptanceTest
 
     val query = "UNWIND range(0, 9) AS i MATCH (x) MERGE (m {v: i % 2}) ON CREATE SET m:Merged CREATE ({v: (i + 1) % 2}) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2))
 
     result.columnAs[Long]("count(*)").next shouldBe 20
@@ -1637,7 +1637,7 @@ class EagerizationAcceptanceTest
 
     val query = "UNWIND range(0, 9) AS i MATCH (x) MATCH (m {v: i % 2}) CREATE ({v: (i + 1) % 2}) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
 
     result.columnAs[Long]("count(*)").next shouldBe 10
@@ -1650,7 +1650,7 @@ class EagerizationAcceptanceTest
 
     val query = "UNWIND range(0, 9) AS i MATCH (x) WITH * CREATE ({v: i % 2}) MERGE (m {v: (i + 1) % 2}) ON CREATE SET m:Merged RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2))
 
     result.columnAs[Long]("count(*)").next shouldBe 200
@@ -1662,7 +1662,7 @@ class EagerizationAcceptanceTest
   test("should not be eager when merging on two different labels") {
     val query = "MERGE(:L1) MERGE(p:L2) ON CREATE SET p.name = 'Blaine' RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 2, propertiesWritten = 1, labelsAdded = 2)
@@ -1673,7 +1673,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("L1")
     val query = "MERGE(:L1) MERGE(p:L1) ON CREATE SET p.name = 'Blaine' RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result)
@@ -1683,7 +1683,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MERGE(:L1) MERGE(p:L1) ON CREATE SET p.name = 'Blaine' RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 1, labelsAdded = 1)
@@ -1694,7 +1694,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Person")
     val query = "MERGE() MERGE(p: Person) ON CREATE SET p.name = 'Blaine' RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result)
@@ -1705,7 +1705,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MERGE() MERGE(p: Person) ON CREATE SET p.name = 'Blaine' RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, nodesCreated = 1, labelsAdded = 1, propertiesWritten = 1)
@@ -1715,7 +1715,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MERGE() MERGE(p) ON CREATE SET p.name = 'Blaine' RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result)
@@ -1724,7 +1724,7 @@ class EagerizationAcceptanceTest
   ignore("does not need to be eager when no merge has labels, merges create") {
     val query = "MERGE() MERGE(p) ON CREATE SET p.name = 'Blaine' RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 1)
@@ -1733,7 +1733,7 @@ class EagerizationAcceptanceTest
   test("Multiple single node merges building on each other through property values should be eager") {
     val query = "MERGE(a {p: 1}) MERGE(b {p: a.p}) MERGE(c {p: b.p}) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, Configs.AllRulePlanners - Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, nodesCreated = 1, propertiesWritten = 1)
@@ -1742,7 +1742,7 @@ class EagerizationAcceptanceTest
   test("Multiple single node merges should be eager") {
     val query = "UNWIND [0, 1] AS i MERGE (a {p: i % 2}) MERGE (b {p: (i + 1) % 2}) ON CREATE SET b:ShouldNotBeSet RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
 
     result.columnAs[Long]("count(*)").next shouldBe 2
@@ -1752,7 +1752,7 @@ class EagerizationAcceptanceTest
   test("should not be eager when merging on already bound variables") {
     val query = "MERGE (city:City) MERGE (country:Country) MERGE (city)-[:IN]->(country) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
 
     result.columnAs[Long]("count(*)").next shouldBe 1
@@ -1766,7 +1766,7 @@ class EagerizationAcceptanceTest
       """MATCH (src:LeftLabel), (dst:RightLabel)
         |MERGE (src)-[r:IS_RELATED_TO ]->(dst)
         |ON CREATE SET r.p3 = 42""".stripMargin
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
 
     assertStats(result, relationshipsCreated = 1, propertiesWritten = 1)
@@ -1778,7 +1778,7 @@ class EagerizationAcceptanceTest
     createLabeledNode(Map("prop" -> 5), "Node")
     val query = "MATCH (n:Node {prop:5}) SET n.value = 10 RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
@@ -1788,7 +1788,7 @@ class EagerizationAcceptanceTest
     createLabeledNode(Map("prop" -> 5), "Node")
     val query = "MATCH (n:Node) SET n:Lol RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, labelsAdded = 1)
@@ -1798,7 +1798,7 @@ class EagerizationAcceptanceTest
     createLabeledNode(Map("prop" -> 5), "Lol")
     val query = "MATCH (n:Lol) SET n:Lol RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, labelsAdded = 0)
@@ -1810,7 +1810,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (m1:Two), (m2:Two), (n) SET n:Two RETURN count(*) AS c"
 
-    val result: InternalExecutionResult = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result: InternalExecutionResult = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, labelsAdded = 1)
     result.toList should equal(List(Map("c" -> 12)))
@@ -1821,7 +1821,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (n), (m1:Lol), (m2:Lol) SET n:Rofl RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, labelsAdded = 2)
@@ -1834,7 +1834,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Foo")
     val query = "MATCH (n) CREATE (m) WITH * MATCH (o:Foo) SET n:Foo RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 8
     assertStats(result, labelsAdded = 2, nodesCreated = 4)
@@ -1847,7 +1847,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("B")
     val query = "MATCH (n:A) CREATE (m:C) WITH * MATCH (o:B), (p:C) SET p:B RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
+    val result = executeWith(Configs.UpdateConf, query, expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, Configs.AllRulePlanners))
     result.columnAs[Long]("count(*)").next shouldBe 8
     assertStats(result, labelsAdded = 4, nodesCreated = 2)
@@ -1860,7 +1860,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Bar")
     val query = "MATCH (n) CREATE (m) WITH * MATCH (o:Bar) SET n:Foo RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 8
     assertStats(result, labelsAdded = 2, nodesCreated = 4)
@@ -1870,7 +1870,7 @@ class EagerizationAcceptanceTest
     createNode(Map("name" -> "thing"))
     val query = "MATCH (n {name : 'thing'}) SET n:Lol RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, labelsAdded = 1)
@@ -1880,7 +1880,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (n) SET n.prop = 5 RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
@@ -1890,7 +1890,7 @@ class EagerizationAcceptanceTest
     createNode(Map("prop" -> 20))
     val query = "MATCH (n { prop: 20 }) SET n.prop = 10 RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
@@ -1900,7 +1900,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Node")
     val query = "MATCH (n:Node) SET n.prop = 10 RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
@@ -1909,7 +1909,7 @@ class EagerizationAcceptanceTest
   test("single label+property match followed by set property should not be eager") {
     val query = "MATCH (n:Node {prop:5}) SET n.prop = 10 RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 0
   }
@@ -1920,7 +1920,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (b :Book {isbn : '123'}) SET b.isbn = '456' RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
 
     result.columnAs[Long]("count(*)").next shouldBe 1
@@ -1932,7 +1932,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (a), (b :Book {isbn : '123'}) SET a.isbn = '456' RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
 
     result.columnAs[Long]("count(*)").next shouldBe 1
@@ -1944,7 +1944,7 @@ class EagerizationAcceptanceTest
     createNode(Map("id" -> 0))
     val query = "MATCH (a),(b {id: 0}),(c {id: 0}) SET a.id = 0 RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, propertiesWritten = 2)
@@ -1955,7 +1955,7 @@ class EagerizationAcceptanceTest
     createNode(Map("id" -> 0))
     val query = "MATCH (a),(b {id: 0}),(c {id: 0}) SET c.id = 1 RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, propertiesWritten = 2)
@@ -1967,7 +1967,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (b {id: 0}) SET b.id = 1 RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, propertiesWritten = 1)
@@ -1978,7 +1978,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (n {prop : 5})-[r]-() SET r.prop = 6 RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
 
     result.columnAs[Long]("count(*)").next shouldBe 1
@@ -1990,7 +1990,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (n {prop : 5})-[r]-(m) SET m.prop = 5 RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, propertiesWritten = 1)
     result.toList should equal(List(Map("count(*)" -> 1)))
@@ -2000,7 +2000,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode(), "prop" -> 3)
     val query = "MATCH ()-[r {prop : 3}]-() SET r.prop = 6 RETURN count(*) AS c"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
 
     assertStats(result, propertiesWritten = 2)
@@ -2013,7 +2013,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH ()-[r {prop1 : 3}]-() SET r.prop2 = 6 RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
 
     result.columnAs[Long]("count(*)").next shouldBe 2
@@ -2024,7 +2024,7 @@ class EagerizationAcceptanceTest
     relate(createNode(), createNode(), "prop" -> 3)
     val query = "MATCH (n)-[r {prop : 3}]-() SET n.prop = 6 RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 2
     assertStats(result, propertiesWritten = 2)
@@ -2036,7 +2036,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH ()-[r]-() WHERE exists(r.prop) SET r.prop = 'foo' RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
 
     result.columnAs[Long]("count(*)").next shouldBe 2
@@ -2049,7 +2049,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH ()-[r]-() WHERE exists(r.prop1) SET r.prop2 = 'foo'"
 
-    assertStats(executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    assertStats(executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0)), propertiesWritten = 2)
   }
 
@@ -2061,7 +2061,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH ()-[r {prop: 42}]-(), (:L)-[r2]-() SET r2.prop = 42"
 
-    assertStats(executeWith(Configs.Interpreted - Configs.Cost2_3, query, planComparisonStrategy = testEagerPlanComparisonStrategy(1)), propertiesWritten = 2)
+    assertStats(executeWith(Configs.UpdateConf, query, planComparisonStrategy = testEagerPlanComparisonStrategy(1)), propertiesWritten = 2)
 
   }
 
@@ -2072,7 +2072,7 @@ class EagerizationAcceptanceTest
     createNode("prop" -> 42)
     val query = "MATCH (n) CREATE (m) WITH * MATCH (o {prop:42}) SET n.prop = 42 RETURN count(*) as count"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.AllRulePlanners))
     result.columnAs[Int]("count").next should equal(8)
     assertStats(result, propertiesWritten = 8, nodesCreated = 4)
@@ -2085,7 +2085,7 @@ class EagerizationAcceptanceTest
     createNode("prop" -> 42)
     val query = "MATCH (n {prop: 42}) CREATE (m) WITH * MATCH (o) SET n.prop = 42 RETURN count(*) as count"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
+    val result = executeWith(Configs.UpdateConf, query, expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Int]("count").next should equal(12)
     assertStats(result, propertiesWritten = 12, nodesCreated = 2)
@@ -2106,7 +2106,7 @@ class EagerizationAcceptanceTest
         |SET m.prop = 42
         |RETURN count(*) as count""".stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
+    val result = executeWith(Configs.UpdateConf, query, expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.AllRulePlanners - Configs.Rule2_3))
     result.columnAs[Int]("count").next should equal(14)
     assertStats(result, propertiesWritten = 14, nodesCreated = 3)
@@ -2119,7 +2119,7 @@ class EagerizationAcceptanceTest
     createNode("prop" -> 42)
     val query = "MATCH (n) CREATE (m) WITH * MATCH (o {prop:42}) SET n.prop2 = 42 RETURN count(*) as count"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.AllRulePlanners))
     result.columnAs[Int]("count").next should equal(8)
     assertStats(result, propertiesWritten = 8, nodesCreated = 4)
@@ -2128,7 +2128,7 @@ class EagerizationAcceptanceTest
   test("matching node property, writing with += should be eager") {
     relate(createNode(Map("prop" -> 5)), createNode())
     val query = "MATCH (n {prop : 5})-[r]-(m) SET m += {prop: 5} RETURN count(*)"
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, propertiesWritten = 1)
     result.toList should equal(List(Map("count(*)" -> 1)))
@@ -2137,7 +2137,7 @@ class EagerizationAcceptanceTest
   test("matching node property, writing with += should not be eager when we can avoid it") {
     relate(createNode(Map("prop" -> 5)), createNode())
     val query = "MATCH (n {prop : 5})-[r]-(m) SET m += {prop2: 5} RETURN count(*)"
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.AllRulePlanners))
     assertStats(result, propertiesWritten = 1)
     result.toList should equal(List(Map("count(*)" -> 1)))
@@ -2151,7 +2151,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (n {prop : 5})-[r]->(m) SET m += {props} RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1), params = Map("props" -> Map("prop" -> 5)))
     assertStats(result, propertiesWritten = 1)
     result.toList should equal(List(Map("count(*)" -> 1)))
@@ -2160,7 +2160,7 @@ class EagerizationAcceptanceTest
   test("matching rel property, writing with += should not be eager when we can avoid it") {
     relate(createNode(Map("prop" -> 5)), createNode())
     val query = "MATCH (n {prop : 5})-[r]-(m) SET m += {prop2: 5} RETURN count(*)"
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.AllRulePlanners))
     assertStats(result, propertiesWritten = 1)
     result.toList should equal(List(Map("count(*)" -> 1)))
@@ -2171,7 +2171,7 @@ class EagerizationAcceptanceTest
     createLabeledNode(Map("prop" -> 5), "Node", "Lol")
     val query = "MATCH (n:Node) REMOVE n:Lol"
 
-    assertStats(executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    assertStats(executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0)), labelsRemoved = 1)
   }
 
@@ -2179,7 +2179,7 @@ class EagerizationAcceptanceTest
     createLabeledNode(Map("prop" -> 5), "Node")
     val query = "MATCH (n:Node) REMOVE n:Node"
 
-    assertStats(executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    assertStats(executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3)), labelsRemoved = 1)
   }
 
@@ -2188,7 +2188,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (m:Lol), (n) REMOVE n:Lol RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
 
     assertStats(result, labelsRemoved = 1)
@@ -2200,7 +2200,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Lol")
     val query = "MATCH (m:Lol), (n:Lol) REMOVE m:Lol RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
 
     assertStats(result, labelsRemoved = 2)
@@ -2213,7 +2213,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("C")
     val query = "MATCH  (m1:A), (m2:B), (n:C) REMOVE n:C RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.AllRulePlanners))
     result.columnAs[Long]("count(*)").next shouldBe 1
     assertStats(result, labelsRemoved = 1)
@@ -2225,7 +2225,7 @@ class EagerizationAcceptanceTest
     createNode()
     val query = "MATCH (m1:Two), (m2:Two), (n) REMOVE n:Two RETURN count(*) AS c"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     assertStats(result, labelsRemoved = 2)
     result.toList should equal(List(Map("c" -> 12)))
@@ -2237,7 +2237,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("B")
     val query = "MATCH (n), (m1:A), (m2:A) REMOVE n:B RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 12
     assertStats(result, labelsRemoved = 3)
@@ -2248,7 +2248,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Foo")
     val query = "MATCH (n) CREATE (m) WITH * MATCH (o:Foo) REMOVE n:Foo RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, labelsRemoved = 2, nodesCreated = 2)
@@ -2259,7 +2259,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Foo")
     val query = "MATCH (n) CREATE (m:Foo) WITH * MATCH (o:Foo) REMOVE n:Foo RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
+    val result = executeWith(Configs.UpdateConf, query, expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 8
     assertStats(result, labelsAdded = 2, labelsRemoved = 2, nodesCreated = 2)
@@ -2272,7 +2272,7 @@ class EagerizationAcceptanceTest
     createLabeledNode("Bar")
     val query = "MATCH (n) CREATE (m) WITH * MATCH (o:Bar) REMOVE n:Foo RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next shouldBe 8
     assertStats(result, labelsRemoved = 2, nodesCreated = 4)
@@ -2284,7 +2284,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (n:Foo)--(m) REMOVE m:Foo RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next shouldBe 4
     assertStats(result, labelsRemoved = 4)
@@ -2300,7 +2300,7 @@ class EagerizationAcceptanceTest
     // Relationship match is non-directional, so should give 2 rows
     val query = "MATCH (a)-[t:T]-(b) UNWIND [1] as i DELETE t RETURN count(*) as count"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsDeleted = 1)
@@ -2315,7 +2315,7 @@ class EagerizationAcceptanceTest
     // Relationship match is non-directional, so should give 2 rows
     val query = "CREATE () WITH * MATCH (a)-[t:T]-(b) UNWIND [1] as i DELETE t RETURN count(*) as count"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, nodesCreated = 1, relationshipsDeleted = 1)
@@ -2330,7 +2330,7 @@ class EagerizationAcceptanceTest
     // Relationship match is non-directional, so should give 2 rows
     val query = "CREATE () WITH * CREATE () WITH * MATCH (a)-[t:T]-(b) UNWIND [1] as i DELETE t RETURN count(*) as count"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, optimalEagerCount = 1, expectPlansToFailPredicate = Configs.Rule2_3))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, nodesCreated = 2, relationshipsDeleted = 1)
@@ -2343,7 +2343,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (), () UNWIND [] AS i CREATE () RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next() should equal(0)
     assertStats(result, nodesCreated = 0)
@@ -2355,7 +2355,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (), () UNWIND [0] AS i CREATE () RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next() should equal(4)
     assertStats(result, nodesCreated = 4)
@@ -2367,7 +2367,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (), () UNWIND [0, 0] AS i CREATE () RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next() should equal(8)
     assertStats(result, nodesCreated = 8)
@@ -2379,7 +2379,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH () UNWIND [0] as i MATCH () CREATE () RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next() should equal(4)
     assertStats(result, nodesCreated = 4)
@@ -2391,7 +2391,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH () UNWIND [0] as i MATCH () UNWIND [0] as j CREATE () RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next() should equal(4)
     assertStats(result, nodesCreated = 4)
@@ -2403,7 +2403,7 @@ class EagerizationAcceptanceTest
 
     val query = "MERGE () WITH * UNWIND [0] as i MATCH () UNWIND [0] as j CREATE () RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, optimalEagerCount = 1, expectPlansToFailPredicate = Configs.AllRulePlanners))
     result.columnAs[Long]("count(*)").next() should equal(4)
     assertStats(result, nodesCreated = 4)
@@ -2417,7 +2417,7 @@ class EagerizationAcceptanceTest
     //val query = "UNWIND [0] as u MATCH (a), (b) FOREACH(i in range(0, 1) | DELETE a) RETURN count(*)"
     val query = "MATCH (a), (b) FOREACH(i in range(0, 1) | DELETE a) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next() should equal(4)
     assertStats(result, nodesDeleted = 2)
@@ -2436,7 +2436,7 @@ class EagerizationAcceptanceTest
         |)
         |RETURN count(*)""".stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next() should equal(2)
     assertStats(result, nodesCreated = 2, labelsAdded = 2, propertiesWritten = 8)
@@ -2460,7 +2460,7 @@ class EagerizationAcceptanceTest
         |RETURN count(*)
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
     assertStats(result, nodesCreated = 2, nodesDeleted = 2, propertiesWritten = 6, labelsAdded = 2)
     result.columnAs[Long]("count(*)").next shouldBe 2
@@ -2481,7 +2481,7 @@ class EagerizationAcceptanceTest
         |)
         |RETURN count(*)""".stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0, Configs.Rule2_3))
     result.columnAs[Long]("count(*)").next() should equal(2)
     assertStats(result, nodesCreated = 2, labelsAdded = 2, propertiesWritten = 6)
@@ -2503,7 +2503,7 @@ class EagerizationAcceptanceTest
         |)
         |RETURN count(*)""".stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, Configs.AllRulePlanners))
     result.columnAs[Long]("count(*)").next() should equal(2)
     assertStats(result, nodesCreated = 4, labelsAdded = 4, propertiesWritten = 24)
@@ -2523,7 +2523,7 @@ class EagerizationAcceptanceTest
         |)
         |RETURN count(*)""".stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(0))
     result.columnAs[Long]("count(*)").next() should equal(1)
     assertStats(result, nodesCreated = 4, labelsAdded = 4)
@@ -2532,13 +2532,7 @@ class EagerizationAcceptanceTest
   // LOAD CSV
   test("should not be eager for LOAD CSV followed by MERGE") {
     val query = "LOAD CSV FROM 'file:///something' AS line MERGE (b:B {p:line[0]}) RETURN b"
-    val config =
-      TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.Interpreted, Runtimes.Slotted, Runtimes.Default)) +
-      TestConfiguration(Versions.Default, Planners.Rule, Runtimes(Runtimes.Interpreted, Runtimes.Default)) +
-      TestConfiguration(Versions.V2_3 -> Versions.V3_1, Planners.Rule, Runtimes.Default) +
-      Configs.Cost3_1 + Configs.Version3_3
-
-    executeWith(config, "EXPLAIN " + query, planComparisonStrategy = testEagerPlanComparisonStrategy(0))
+    executeWith(Configs.UpdateConf, "EXPLAIN " + query, planComparisonStrategy = testEagerPlanComparisonStrategy(0))
   }
 
   test("eagerness should work with match - load csv - delete") {
@@ -2553,7 +2547,7 @@ class EagerizationAcceptanceTest
 
     val query = s"MATCH (a)-[t:T]-(b) LOAD CSV FROM '$url' AS line DELETE t RETURN count(*) as count"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, relationshipsDeleted = 1)
@@ -2572,7 +2566,7 @@ class EagerizationAcceptanceTest
 
     val query = s"CREATE () WITH * MATCH (a)-[t:T]-(b) LOAD CSV FROM '$url' AS line DELETE t RETURN count(*) as count"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Int]("count").next should equal(2)
     assertStats(result, nodesCreated = 1, relationshipsDeleted = 1)
@@ -2590,7 +2584,7 @@ class EagerizationAcceptanceTest
 
     val query = s"MATCH () LOAD CSV FROM '$url' AS i MATCH () UNWIND [0] as j CREATE () RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1))
     result.columnAs[Long]("count(*)").next() should equal(4)
     assertStats(result, nodesCreated = 4)
@@ -2607,7 +2601,7 @@ class EagerizationAcceptanceTest
 
     val query = s"MERGE () WITH * LOAD CSV FROM '$url' AS line MATCH () LOAD CSV FROM '$url' AS line2 CREATE () RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, optimalEagerCount = 1, expectPlansToFailPredicate = Configs.AllRulePlanners))
     result.columnAs[Long]("count(*)").next() should equal(4)
     assertStats(result, nodesCreated = 4)
@@ -2634,7 +2628,7 @@ class EagerizationAcceptanceTest
         |RETURN d, c2""".stripMargin
 
     cookies.foreach { case (name, node) =>
-      val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+      val result = executeWith(Configs.UpdateConf, query,
         planComparisonStrategy = testEagerPlanComparisonStrategy(2),
         params = Map("cookie" -> name))
       assertStats(result, nodesDeleted = 1, relationshipsDeleted = 2)
@@ -2650,7 +2644,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH (c:Cookie) DELETE c WITH 1 as t MATCH (x:Cookie) RETURN count(*) as count"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
 
     result.columnAs[Int]("count").next should equal(0)
@@ -2666,7 +2660,7 @@ class EagerizationAcceptanceTest
 
     val query = "MATCH p=(:Cookie) DELETE p WITH 1 as t MATCH (x:Cookie) RETURN count(*) as count"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
 
     result.columnAs[Int]("count").next should equal(0)
@@ -2685,7 +2679,7 @@ class EagerizationAcceptanceTest
         |RETURN labels
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
+    val result = executeWith(Configs.UpdateConf, query, expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
     result.toList should equal(List(Map("labels" -> List()), Map("labels" -> List())))
     assertStats(result, labelsAdded = 2)
@@ -2703,7 +2697,7 @@ class EagerizationAcceptanceTest
         |RETURN labels
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
+    val result = executeWith(Configs.UpdateConf, query, expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
     result.toList should equal(List(Map("labels" -> List("Foo")), Map("labels" -> List("Foo"))))
     assertStats(result, labelsRemoved = 2)
@@ -2720,7 +2714,7 @@ class EagerizationAcceptanceTest
         |RETURN labels(n), labels(m)
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query, expectedDifferentResults = Configs.Rule2_3,
+    val result = executeWith(Configs.UpdateConf, query, expectedDifferentResults = Configs.Rule2_3,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
     result.toList should equal(List(Map("labels(n)" -> List("Foo"), "labels(m)" -> List("Foo")),
       Map("labels(n)" -> List("Foo"), "labels(m)" -> List("Foo"))))
@@ -2739,7 +2733,7 @@ class EagerizationAcceptanceTest
         |RETURN labels(n), labels(m)
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
     result.toList should equal(List(Map("labels(n)" -> List("Foo"), "labels(m)" -> List("Foo")),
       Map("labels(n)" -> List("Foo"), "labels(m)" -> List("Foo"))))
@@ -2757,7 +2751,7 @@ class EagerizationAcceptanceTest
         |RETURN labels(n), labels(m)
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, expectedDifferentResults = Configs.Rule2_3, query = query,
+    val result = executeWith(Configs.UpdateConf, expectedDifferentResults = Configs.Rule2_3, query = query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, Configs.Rule2_3))
     result.toList should equal(List(Map("labels(n)" -> List(), "labels(m)" -> List()),
       Map("labels(n)" -> List(), "labels(m)" -> List())))
@@ -2780,7 +2774,7 @@ class EagerizationAcceptanceTest
     // Fixed in 3.3.3
     val nonBugFixedConfig = Configs.Version3_3 + Configs.Cost3_1
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3 - Configs.AllRulePlanners, query,
+    val result = executeWith(Configs.UpdateConf - Configs.AllRulePlanners, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(1, nonBugFixedConfig),
       expectedDifferentResults = nonBugFixedConfig)
 
@@ -2803,7 +2797,7 @@ class EagerizationAcceptanceTest
     // Fixed in 3.3.3
     val nonBugFixedConfig = Configs.Version3_3 + Configs.Cost3_1 + Configs.AllRulePlanners
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = testEagerPlanComparisonStrategy(2, nonBugFixedConfig),
       expectedDifferentResults = nonBugFixedConfig)
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionEngineTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ExecutionEngineTest.scala
@@ -47,9 +47,7 @@ import scala.collection.mutable
 
 class ExecutionEngineTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with CreateTempFileTestSupport with CypherComparisonSupport {
 
-  val createConf = Configs.Interpreted - Configs.Cost2_3
-  val startConf = TestConfiguration(Versions(V3_4, Versions.Default), Planners(Planners.Rule, Planners.Default), Runtimes(Runtimes.Interpreted, Runtimes.Default)) +
-                  TestConfiguration(Versions(V2_3, V3_1), Planners.all, Runtimes.Default)
+  val startConf = Configs.CommunityInterpreted - Configs.Version3_3
 
   test("shouldGetRelationshipById") {
     val n = createNode()
@@ -533,7 +531,7 @@ order by a.COL1""".format(a, b))
   }
 
   test("with should not forget original type") {
-    val result = executeWith(createConf, "create (a{x:8}) with a.x as foo return sum(foo)")
+    val result = executeWith(Configs.UpdateConf, "create (a{x:8}) with a.x as foo return sum(foo)")
 
     result.toList should equal(List(Map("sum(foo)" -> 8)))
   }
@@ -550,7 +548,7 @@ order by a.COL1""".format(a, b))
 
   test("with should not forget parameters2") {
     val id = createNode().getId
-    val result = executeWith(createConf, "match (n) where id(n) = {id} with n set n.foo={id} return n", params = Map("id" -> id)).toList
+    val result = executeWith(Configs.UpdateConf, "match (n) where id(n) = {id} with n set n.foo={id} return n", params = Map("id" -> id)).toList
 
     result should have size 1
     graph.inTx {
@@ -596,7 +594,7 @@ order by a.COL1""".format(a, b))
 
   test("can use variables created inside the foreach") {
     createNode()
-    val result = executeWith(createConf, "match (n) where id(n) = 0 foreach (x in [1,2,3] | create (a { name: 'foo'})  set a.id = x)")
+    val result = executeWith(Configs.UpdateConf, "match (n) where id(n) = 0 foreach (x in [1,2,3] | create (a { name: 'foo'})  set a.id = x)")
 
     result.toList shouldBe empty
   }
@@ -654,28 +652,28 @@ order by a.COL1""".format(a, b))
 
   test("should add label to node") {
     val a = createNode()
-    val result = executeWith(createConf, "match (a) where id(a) = 0 SET a :foo RETURN a")
+    val result = executeWith(Configs.UpdateConf, "match (a) where id(a) = 0 SET a :foo RETURN a")
 
     result.toList should equal(List(Map("a" -> a)))
   }
 
   test("should add multiple labels to node") {
     val a = createNode()
-    val result = executeWith(createConf, "match (a) where id(a) = 0 SET a :foo:bar RETURN a")
+    val result = executeWith(Configs.UpdateConf, "match (a) where id(a) = 0 SET a :foo:bar RETURN a")
 
     result.toList should equal(List(Map("a" -> a)))
   }
 
   test("should set label on node") {
     val a = createNode()
-    val result = executeWith(createConf, "match (a) SET a:foo RETURN a")
+    val result = executeWith(Configs.UpdateConf, "match (a) SET a:foo RETURN a")
 
     result.toList should equal(List(Map("a" -> a)))
   }
 
   test("should set multiple labels on node") {
     val a = createNode()
-    val result = executeWith(createConf, "match (a) where id(a) = 0 SET a:foo:bar RETURN a")
+    val result = executeWith(Configs.UpdateConf, "match (a) where id(a) = 0 SET a:foo:bar RETURN a")
 
     result.toList should equal(List(Map("a" -> a)))
   }
@@ -801,7 +799,7 @@ order by a.COL1""".format(a, b))
     relate(a,b,"FOO")
 
     //WHEN
-    val result = executeWith(createConf,
+    val result = executeWith(Configs.UpdateConf,
       """MATCH (a), (b)
          WHERE id(a) = 0 AND id(b) = 1
          AND not (a)-[:FOO]->(b)
@@ -859,10 +857,10 @@ order by a.COL1""".format(a, b))
 
   test("doctest gone wild") {
     // given
-    executeWith(createConf, "CREATE (n:Actor {name:'Tom Hanks'})")
+    executeWith(Configs.UpdateConf, "CREATE (n:Actor {name:'Tom Hanks'})")
 
     // when
-    val result = executeWith(createConf, """MATCH (actor:Actor)
+    val result = executeWith(Configs.UpdateConf, """MATCH (actor:Actor)
                                WHERE actor.name = "Tom Hanks"
                                CREATE (movie:Movie {title:'Sleepless in Seattle'})
                                CREATE (actor)-[:ACTED_IN]->(movie)""")
@@ -890,7 +888,7 @@ order by a.COL1""".format(a, b))
 
   test("merge should support single parameter") {
     //WHEN
-    val result = executeWith(createConf, "MERGE (n:User {foo: {single_param}})", params = Map("single_param" -> 42))
+    val result = executeWith(Configs.UpdateConf, "MERGE (n:User {foo: {single_param}})", params = Map("single_param" -> 42))
 
     //THEN DOESN'T THROW EXCEPTION
     result.toList shouldBe empty
@@ -947,7 +945,7 @@ order by a.COL1""".format(a, b))
   }
 
   test("should not mind rewriting NOT queries") {
-    val result = executeWith(createConf, " create (a {x: 1}) return a.x is not null as A, a.y is null as B, a.x is not null as C, a.y is not null as D")
+    val result = executeWith(Configs.UpdateConf, " create (a {x: 1}) return a.x is not null as A, a.y is null as B, a.x is not null as C, a.y is not null as D")
     result.toList should equal(List(Map("A" -> true, "B" -> true, "C" -> true, "D" -> false)))
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/HelpfulErrorMessagesTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/HelpfulErrorMessagesTest.scala
@@ -24,11 +24,9 @@ import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
 
 class HelpfulErrorMessagesTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
 
-  private val configuration = Configs.AbsolutelyAll - Configs.AllRulePlanners - Configs.Version3_1 - Configs.Version2_3
-
   test("should provide sensible error message when omitting colon before relationship type on create") {
 
-    failWithError(configuration,
+    failWithError(Configs.AbsolutelyAll - Configs.OldAndRule,
 
       "CREATE (a)-[ASSOCIATED_WITH]->(b)",
       Seq("Exactly one relationship type must be specified for CREATE. Did you forget to prefix your relationship type with a ':'?"))
@@ -42,7 +40,7 @@ class HelpfulErrorMessagesTest extends ExecutionEngineFunSuite with CypherCompar
   }
 
   test("should provide sensible error message when omitting colon before relationship type on merge") {
-    failWithError(configuration,
+    failWithError(Configs.AbsolutelyAll - Configs.OldAndRule,
       "MERGE (a)-[ASSOCIATED_WITH]->(b)",
       Seq("Exactly one relationship type must be specified for MERGE. Did you forget to prefix your relationship type with a ':'?"))
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/IndexNestedLoopJoinAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/IndexNestedLoopJoinAcceptanceTest.scala
@@ -42,7 +42,7 @@ class IndexNestedLoopJoinAcceptanceTest extends ExecutionEngineFunSuite with Cyp
 
     // when
     val result = executeWith(
-      Configs.All - Configs.Compiled,
+      Configs.Interpreted,
       "MATCH (a:A)-->(b), (c:C) WHERE b.id = c.id AND a.id = 42 RETURN count(*)",
       planComparisonStrategy = ComparePlansWithAssertion(planDescription => {
         planDescription should useOperators("Apply", "NodeIndexSeek")
@@ -68,7 +68,7 @@ class IndexNestedLoopJoinAcceptanceTest extends ExecutionEngineFunSuite with Cyp
     graph.createIndex("C", "id")
 
     // when
-    val result = executeWith(Configs.All - Configs.Compiled,
+    val result = executeWith(Configs.Interpreted,
       "MATCH (a:A)-->(b), (c:C) WHERE b.id = c.id AND a.id = 42 OPTIONAL MATCH (a)-[:T]->() RETURN count(*)",
       planComparisonStrategy = ComparePlansWithAssertion(planDescription => {
         planDescription should useOperators("Apply", "NodeIndexSeek")
@@ -91,7 +91,7 @@ class IndexNestedLoopJoinAcceptanceTest extends ExecutionEngineFunSuite with Cyp
         | RETURN f
       """.stripMargin
 
-    val result = executeWith(Configs.All - Configs.Compiled - Configs.Version2_3, query,
+    val result = executeWith(Configs.Interpreted - Configs.Version2_3, query,
       planComparisonStrategy = ComparePlansWithAssertion( _ should includeAtLeastOne(classOf[NodeIndexSeek], withVariable = "f"), expectPlansToFail = Configs.AllRulePlanners ))
 
     result.columnAs[Node]("f").toSet should equal(Set(nodes(122),nodes(123)))
@@ -108,7 +108,7 @@ class IndexNestedLoopJoinAcceptanceTest extends ExecutionEngineFunSuite with Cyp
         | MATCH (f:Foo) WHERE f.id = b.id
         | RETURN f
       """.stripMargin
-    val result = executeWith(Configs.All - Configs.Compiled, query,
+    val result = executeWith(Configs.Interpreted, query,
       planComparisonStrategy = ComparePlansWithAssertion( _ should includeAtLeastOne(classOf[NodeIndexSeek], withVariable = "f"), expectPlansToFail = Configs.AllRulePlanners + Configs.Cost2_3))
     result.columnAs[Node]("f").toList should equal(List(nodes(123)))
   }
@@ -126,7 +126,7 @@ class IndexNestedLoopJoinAcceptanceTest extends ExecutionEngineFunSuite with Cyp
         | MATCH (f:Foo) WHERE f.id = b.id
         | RETURN f
       """.stripMargin
-    val result = executeWith(Configs.All - Configs.Compiled, query,
+    val result = executeWith(Configs.Interpreted, query,
       planComparisonStrategy = ComparePlansWithAssertion( _ should includeAtLeastOne(classOf[NodeIndexSeek], withVariable = "f"), expectPlansToFail = Configs.AllRulePlanners + Configs.Cost2_3))
     result.columnAs[Node]("f").toSet should equal(Set(nodes(122), nodes(123)))
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceTest.scala
@@ -42,9 +42,7 @@ class LoadCsvAcceptanceTest
   extends ExecutionEngineFunSuite with BeforeAndAfterAll
   with QueryStatisticsTestSupport with CreateTempFileTestSupport with CypherComparisonSupport{
 
-  val expectedToSucceed = Configs.Interpreted - Configs.Cost2_3
-  val expectedToFail = Configs.Interpreted - Configs.Cost2_3 + TestConfiguration(Versions.Default, Planners.Default,
-    Runtimes(Runtimes.Default, Runtimes.ProcedureOrSchema, Runtimes.CompiledSource, Runtimes.CompiledBytecode))
+  val expectedToFail = Configs.AbsolutelyAll - Configs.Compiled - Configs.Cost2_3
 
   def csvUrls(f: PrintWriter => Unit) = Seq(
     createCSVTempFileURL(f),
@@ -100,7 +98,7 @@ class LoadCsvAcceptanceTest
         writer.println("6,bye")
     })
 
-    val result = executeWith(expectedToSucceed,
+    val result = executeWith(Configs.UpdateConf,
       s"""LOAD CSV WITH HEADERS FROM '${urls.head}' AS row
          | WITH row.field1 as field, row.OrderId as order
          | MATCH (o) WHERE o.OrderId = order
@@ -119,7 +117,7 @@ class LoadCsvAcceptanceTest
     })
 
     for (url <- urls) {
-      val result = executeWith(expectedToSucceed, s"LOAD CSV FROM '$url' AS line CREATE (a {name: line[0]}) RETURN a.name")
+      val result = executeWith(Configs.UpdateConf, s"LOAD CSV FROM '$url' AS line CREATE (a {name: line[0]}) RETURN a.name")
       assertStats(result, nodesCreated = 3, propertiesWritten = 3)
     }
   }
@@ -147,7 +145,7 @@ class LoadCsvAcceptanceTest
         writer.println("3")
     })
     for (url <- urls) {
-      val result = executeWith(expectedToSucceed, s"LOAD CSV FROM '$url' AS line CREATE (a {number: line[0]}) RETURN a.number")
+      val result = executeWith(Configs.UpdateConf, s"LOAD CSV FROM '$url' AS line CREATE (a {number: line[0]}) RETURN a.number")
       assertStats(result, nodesCreated = 3, propertiesWritten = 3)
 
       result.columnAs[Long]("a.number").toList === List("")
@@ -162,7 +160,7 @@ class LoadCsvAcceptanceTest
         writer.println("3, 'Cash'")
     })
     for (url <- urls) {
-      val result = executeWith(expectedToSucceed, s"LOAD CSV FROM '$url' AS line CREATE (a {name: line[0]}) RETURN a.name")
+      val result = executeWith(Configs.UpdateConf, s"LOAD CSV FROM '$url' AS line CREATE (a {name: line[0]}) RETURN a.name")
       assertStats(result, nodesCreated = 3, propertiesWritten = 3)
     }
   }
@@ -176,7 +174,7 @@ class LoadCsvAcceptanceTest
         writer.println("3, 'Cash'")
     })
     for (url <- urls) {
-      val result = executeWith(expectedToSucceed,
+      val result = executeWith(Configs.UpdateConf,
         s"LOAD CSV WITH HEADERS FROM '$url' AS line CREATE (a {id: line.id, name: line.name}) RETURN a.name"
       )
 
@@ -196,7 +194,7 @@ class LoadCsvAcceptanceTest
         writer.println("5,'Emerald',")
     })
     for (url <- urls) {
-      val result =executeWith(expectedToSucceed, s"LOAD CSV WITH HEADERS FROM '$url' AS line RETURN line.x")
+      val result =executeWith(Configs.UpdateConf, s"LOAD CSV WITH HEADERS FROM '$url' AS line RETURN line.x")
       assert(result.toList === List(
         Map("line.x" -> "0"),
         Map("line.x" -> null),
@@ -218,7 +216,7 @@ class LoadCsvAcceptanceTest
         writer.println("5,'Emerald',")
     })
     for (url <- urls) {
-      val result = executeWith(expectedToSucceed + Configs.SlottedInterpreted, s"LOAD CSV WITH HEADERS FROM '$url' AS line WITH line WHERE line.x IS NOT NULL RETURN line.name")
+      val result = executeWith(Configs.UpdateConf + Configs.SlottedInterpreted, s"LOAD CSV WITH HEADERS FROM '$url' AS line WITH line WHERE line.x IS NOT NULL RETURN line.name")
       assert(result.toList === List(
         Map("line.name" -> "'Aardvark'"),
         Map("line.name" -> "'Cash'"),
@@ -236,7 +234,7 @@ class LoadCsvAcceptanceTest
         writer.println( """"String with ""quotes"" in it"""")
     })
     for (url <- urls) {
-      val result = executeWith(expectedToSucceed, s"LOAD CSV FROM '$url' AS line RETURN line as string").toList
+      val result = executeWith(Configs.UpdateConf, s"LOAD CSV FROM '$url' AS line RETURN line as string").toList
       assert(result === List(
         Map("string" -> Seq("String without quotes")),
         Map("string" -> Seq("'String", " with single quotes'")),
@@ -254,7 +252,7 @@ class LoadCsvAcceptanceTest
     })
 
     for (url <- urls) {
-      val result = executeWith(expectedToSucceed, s"LOAD CSV FROM '$url' AS line RETURN line")
+      val result = executeWith(Configs.UpdateConf, s"LOAD CSV FROM '$url' AS line RETURN line")
       assert(result.toList === List(Map("line" -> Seq("1", "'Aadvark'", "0")), Map("line" -> Seq("2", "'Babs'")),
         Map("line" -> Seq("3", "'Cash'", "1"))))
     }
@@ -268,7 +266,7 @@ class LoadCsvAcceptanceTest
         writer.print("3,'Cash',1\n")
     })
     for (url <- urls) {
-      val result = executeWith(expectedToSucceed, s"LOAD CSV FROM '$url' AS line RETURN line")
+      val result = executeWith(Configs.UpdateConf, s"LOAD CSV FROM '$url' AS line RETURN line")
       assert(result.toList === List(Map("line" -> Seq("1", "'Aadvark'", "0")), Map("line" -> Seq("2", "'Babs'")),
         Map("line" -> Seq("3", "'Cash'", "1"))))
     }
@@ -282,7 +280,7 @@ class LoadCsvAcceptanceTest
         writer.print("3,'Cash',1\r")
     })
     for (url <- urls) {
-      val result = executeWith(expectedToSucceed, s"LOAD CSV FROM '$url' AS line RETURN line")
+      val result = executeWith(Configs.UpdateConf, s"LOAD CSV FROM '$url' AS line RETURN line")
       assert(result.toList === List(Map("line" -> Seq("1", "'Aadvark'", "0")), Map("line" -> Seq("2", "'Babs'")),
         Map("line" -> Seq("3", "'Cash'", "1"))))
     }
@@ -296,7 +294,7 @@ class LoadCsvAcceptanceTest
         writer.println("3;'Cash';1")
     })
     for (url <- urls) {
-      val result = executeWith(expectedToSucceed, s"LOAD CSV FROM '$url' AS line FIELDTERMINATOR ';' RETURN line")
+      val result = executeWith(Configs.UpdateConf, s"LOAD CSV FROM '$url' AS line FIELDTERMINATOR ';' RETURN line")
       assert(result.toList === List(Map("line" -> Seq("1", "'Aadvark'", "0")), Map("line" -> Seq("2", "'Babs'")),
         Map("line" -> Seq("3", "'Cash'", "1"))))
     }
@@ -309,7 +307,7 @@ class LoadCsvAcceptanceTest
         writer.println("something")
     })
 
-    val result = executeWith(expectedToSucceed, "LOAD CSV FROM \"" + url + "\" AS line RETURN line as string").toList
+    val result = executeWith(Configs.UpdateConf, "LOAD CSV FROM \"" + url + "\" AS line RETURN line as string").toList
     assert(result === List(Map("string" -> Seq("something"))))
   }
 
@@ -320,14 +318,14 @@ class LoadCsvAcceptanceTest
         writer.println("something")
     })
 
-    val result = executeWith(expectedToSucceed, s"LOAD CSV FROM '$url' AS line RETURN line as string").toList
+    val result = executeWith(Configs.UpdateConf, s"LOAD CSV FROM '$url' AS line RETURN line as string").toList
     assert(result === List(Map("string" -> Seq("something"))))
   }
 
   test("empty file does not create anything") {
     val urls = csvUrls(writer => {})
     for (url <- urls) {
-      val result = executeWith(expectedToSucceed, s"LOAD CSV FROM '$url' AS line CREATE (a {name: line[0]}) RETURN a.name")
+      val result = executeWith(Configs.UpdateConf, s"LOAD CSV FROM '$url' AS line CREATE (a {name: line[0]}) RETURN a.name")
       assertStats(result, nodesCreated = 0)
     }
   }
@@ -338,7 +336,7 @@ class LoadCsvAcceptanceTest
             writer.println("something")
     ).cypherEscape
 
-    val result = executeWith(expectedToSucceed, s"LOAD CSV FROM '$url' AS line CREATE (a {name: line[0]}) RETURN a.name")
+    val result = executeWith(Configs.UpdateConf, s"LOAD CSV FROM '$url' AS line CREATE (a {name: line[0]}) RETURN a.name")
     assertStats(result, nodesCreated = 1, propertiesWritten = 1)
   }
 
@@ -348,7 +346,7 @@ class LoadCsvAcceptanceTest
             writer.println("something")
     ).cypherEscape
 
-    val result = executeWith(expectedToSucceed, s"LOAD CSV FROM '$url' AS line CREATE (a {name: line[0]}) RETURN a.name")
+    val result = executeWith(Configs.UpdateConf, s"LOAD CSV FROM '$url' AS line CREATE (a {name: line[0]}) RETURN a.name")
     assertStats(result, nodesCreated = 1, propertiesWritten = 1)
   }
 
@@ -361,7 +359,7 @@ class LoadCsvAcceptanceTest
         writer.println("010-1015;MFG - Engineering HQ;")
     })
     for (url <- urls) {
-      val result = executeWith(expectedToSucceed, s"LOAD CSV WITH HEADERS FROM '$url' AS line FIELDTERMINATOR ';' RETURN *").toList
+      val result = executeWith(Configs.UpdateConf, s"LOAD CSV WITH HEADERS FROM '$url' AS line FIELDTERMINATOR ';' RETURN *").toList
       assert(result === List(
         Map("line" -> Map("DEPARTMENT ID" -> "010-1010", "DEPARTMENT NAME" -> "MFG Supplies",
           null.asInstanceOf[String] -> null)),
@@ -382,7 +380,7 @@ class LoadCsvAcceptanceTest
     val url = s"http://127.0.0.1:$port/test.csv".cypherEscape
 
     //val result = executeScalarWithAllPlannersAndCompatibilityMode[Long](s"LOAD CSV FROM '$url' AS line RETURN count(line)")
-    val result = executeWith(expectedToSucceed, s"LOAD CSV FROM '$url' AS line RETURN count(line)")
+    val result = executeWith(Configs.UpdateConf, s"LOAD CSV FROM '$url' AS line RETURN count(line)")
     result.columnAs[Long]("count(line)").toList should equal(List(3))
   }
 
@@ -390,7 +388,7 @@ class LoadCsvAcceptanceTest
     val url = s"http://127.0.0.1:$port/redirect_test.csv".cypherEscape
 
 //    val result = executeScalarWithAllPlannersAndCompatibilityMode[Long](s"LOAD CSV FROM '$url' AS line RETURN count(line)")
-    val result = executeWith(expectedToSucceed, s"LOAD CSV FROM '$url' AS line RETURN count(line)")
+    val result = executeWith(Configs.UpdateConf, s"LOAD CSV FROM '$url' AS line RETURN count(line)")
     result.columnAs[Long]("count(line)").toList should equal(List(3))
   }
 
@@ -566,7 +564,7 @@ class LoadCsvAcceptanceTest
     val second = url.substring(url.length / 2)
     createNode(Map("prop" -> second))
 
-    val result = executeWith(expectedToSucceed, s"MATCH (n) WITH n, '$first' as prefix  LOAD CSV FROM prefix + n.prop AS line CREATE (a {name: line[0]}) RETURN a.name")
+    val result = executeWith(Configs.UpdateConf, s"MATCH (n) WITH n, '$first' as prefix  LOAD CSV FROM prefix + n.prop AS line CREATE (a {name: line[0]}) RETURN a.name")
     assertStats(result, nodesCreated = 3, propertiesWritten = 3)
   }
 
@@ -581,7 +579,7 @@ class LoadCsvAcceptanceTest
                    |MERGE (c:City {data:data})
                    |RETURN count(*) as c""".stripMargin
 
-    val result = executeWith(expectedToSucceed, query)
+    val result = executeWith(Configs.UpdateConf, query)
     result.columnAs("c").toList should equal(List(0))
     result.close()
   }
@@ -589,7 +587,7 @@ class LoadCsvAcceptanceTest
   test("empty headers file should not throw") {
     val urls = csvUrls({ _ => {} })
     for (url <- urls) {
-      val result = executeWith(expectedToSucceed,
+      val result = executeWith(Configs.UpdateConf,
         s"LOAD CSV WITH HEADERS FROM '$url' AS line RETURN count(*)"
       )
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceUserAgentTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/LoadCsvAcceptanceUserAgentTest.scala
@@ -22,26 +22,24 @@ package org.neo4j.internal.cypher.acceptance
 import org.neo4j.cypher._
 import org.neo4j.cypher.internal.frontend.v3_4.helpers.StringHelper.RichString
 import org.neo4j.cypher.internal.runtime.interpreted.CSVResources
-import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.{Configs, TestConfiguration}
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
 import org.scalatest.BeforeAndAfterAll
 import sun.net.www.protocol.http.HttpURLConnection
 
 class LoadCsvAcceptanceUserAgentTest
   extends ExecutionEngineFunSuite with BeforeAndAfterAll with CypherComparisonSupport {
 
-  val expectedToSucceed: TestConfiguration = Configs.Interpreted - Configs.Version2_3
-
   test("should be able to download data from the web") {
     val url = s"http://127.0.0.1:$port/test.csv".cypherEscape
 
-    val result = executeWith(expectedToSucceed, s"LOAD CSV FROM '$url' AS line RETURN count(line)")
+    val result = executeWith(Configs.Interpreted - Configs.Version2_3, s"LOAD CSV FROM '$url' AS line RETURN count(line)")
     result.columnAs[Long]("count(line)").toList should equal(List(3))
   }
 
   test("should be able to download from a website when redirected and cookies are set") {
     val url = s"http://127.0.0.1:$port/redirect_test.csv".cypherEscape
 
-    val result = executeWith(expectedToSucceed, s"LOAD CSV FROM '$url' AS line RETURN count(line)")
+    val result = executeWith(Configs.Interpreted - Configs.Version2_3, s"LOAD CSV FROM '$url' AS line RETURN count(line)")
     result.columnAs[Long]("count(line)").toList should equal(List(3))
   }
   private val CSV_DATA_CONTENT = "1,1,1\n2,2,2\n3,3,3\n".getBytes

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAcceptanceTest.scala
@@ -106,7 +106,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
   test("OPTIONAL MATCH, DISTINCT and DELETE in an unfortunate combination") {
     val start = createLabeledNode("Start")
     createLabeledNode("End")
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3,
+    val result = executeWith(Configs.UpdateConf,
       """
         |MATCH (start:Start),(end:End)
         |OPTIONAL MATCH (start)-[rel]->(end)
@@ -365,7 +365,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
     val r1 = relate(node1, node2, "prop" -> 10)
     val r2 = relate(node1, node2, "prop" -> 0)
 
-    val result = executeWith(Configs.All - Configs.Compiled + Configs.Morsel, query)
+    val result = executeWith(Configs.Interpreted + Configs.Morsel, query)
 
     result.toList should equal(List(Map("r" -> r1)))
   }
@@ -388,8 +388,8 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
   test("should be able to set properties with a literal map twice in the same transaction") {
     val node = createLabeledNode("FOO")
 
-    executeWith(Configs.Interpreted - Configs.Cost2_3, "MATCH (n:FOO) SET n = { first: 'value' }")
-    executeWith(Configs.Interpreted - Configs.Cost2_3, "MATCH (n:FOO) SET n = { second: 'value' }")
+    executeWith(Configs.UpdateConf, "MATCH (n:FOO) SET n = { first: 'value' }")
+    executeWith(Configs.UpdateConf, "MATCH (n:FOO) SET n = { second: 'value' }")
 
     graph.inTx {
       node.getProperty("first", null) should equal(null)
@@ -572,8 +572,8 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
         |RETURN project.p""".stripMargin
 
     //WHEN
-    val first = executeWith(Configs.Interpreted - Configs.Cost2_3, query).length
-    val second = executeWith(Configs.Interpreted - Configs.Cost2_3, query).length
+    val first = executeWith(Configs.UpdateConf, query).length
+    val second = executeWith(Configs.UpdateConf, query).length
     val check = executeWith(Configs.All, "MATCH (f:Folder) RETURN f.name").toSet
 
     //THEN
@@ -607,8 +607,8 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
 
     //WHEN
 
-    val first = executeWith(Configs.Interpreted - Configs.Cost2_3, query).length
-    val second = executeWith(Configs.Interpreted - Configs.Cost2_3, query).length
+    val first = executeWith(Configs.UpdateConf, query).length
+    val second = executeWith(Configs.UpdateConf, query).length
     val check = executeWith(Configs.All, "MATCH (f:Folder) RETURN f.name").toSet
 
     //THEN
@@ -654,7 +654,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
 
     val query = "MATCH (a) MERGE (b) WITH * OPTIONAL MATCH (a)--(b) RETURN count(*)"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query)
+    val result = executeWith(Configs.UpdateConf, query)
 
     result.columnAs[Long]("count(*)").next shouldBe 6
   }
@@ -755,7 +755,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
         |         RETURN candidate
       """.stripMargin
 
-    val res = executeWith(Configs.All + Configs.Morsel - Configs.Compiled, query)
+    val res = executeWith(Configs.Interpreted + Configs.Morsel, query)
 
     //Then
     res.toList should equal(List(Map("candidate" -> "John"), Map("candidate" -> "Jonathan")))
@@ -772,7 +772,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
         |         RETURN candidate
       """.stripMargin
 
-    val res = executeWith(Configs.All + Configs.Morsel - Configs.Compiled, query)
+    val res = executeWith(Configs.Interpreted + Configs.Morsel, query)
 
     //Then
     res.toList should equal(List(Map("candidate" -> "John"), Map("candidate" -> "Jonathan")))
@@ -942,9 +942,7 @@ class MatchAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTe
         |    ))
       """.stripMargin
 
-
-    val configuration = Configs.Interpreted - Configs.Version2_3
-    val result = executeWith(configuration, query, params = Map("position" -> "2", "folderId" -> 0, "videoId" -> 0))
+    val result = executeWith(Configs.Interpreted - Configs.Version2_3, query, params = Map("position" -> "2", "folderId" -> 0, "videoId" -> 0))
 
     result.toList should equal(List.empty)
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAggregationsBackedByCountStoreAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MatchAggregationsBackedByCountStoreAcceptanceTest.scala
@@ -93,8 +93,8 @@ class MatchAggregationsBackedByCountStoreAcceptanceTest
     val query = "MATCH (n:User) RETURN count(n) > 0"
 
     // Then
-    compareCount(query, false, Configs.All - Configs.Compiled)
-    compareCount(query, true, Configs.All - Configs.Compiled, executeBefore = executeBefore)
+    compareCount(query, false, Configs.Interpreted)
+    compareCount(query, true, Configs.Interpreted, executeBefore = executeBefore)
   }
 
   test("counts nodes using count store and projection expression with variable") {
@@ -103,8 +103,8 @@ class MatchAggregationsBackedByCountStoreAcceptanceTest
     val query = "MATCH (n) RETURN count(n)/2.0*5 as someNum"
 
     // Then
-    compareCount(query, 0, Configs.All - Configs.Compiled)
-    compareCount(query, 7.5, Configs.All - Configs.Compiled, executeBefore = executeBefore)
+    compareCount(query, 0, Configs.Interpreted)
+    compareCount(query, 7.5, Configs.Interpreted, executeBefore = executeBefore)
   }
 
   test("counts relationships with unspecified type using count store") {
@@ -319,9 +319,9 @@ class MatchAggregationsBackedByCountStoreAcceptanceTest
     val query = "MATCH (n:User) RETURN count(n) > 1"
 
     // Then
-    compareCount(query, false, Configs.All - Configs.Compiled)
+    compareCount(query, false, Configs.Interpreted)
     setupBigModel(label1 = "Admin")
-    compareCount(query, true, Configs.All - Configs.Compiled, assertCountInTransaction = true, executeBefore = executeBefore)
+    compareCount(query, true, Configs.Interpreted, assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts nodes using count store and projection expression with variable considering transaction state") {
@@ -330,9 +330,9 @@ class MatchAggregationsBackedByCountStoreAcceptanceTest
     val query = "MATCH (n) RETURN count(n)/3*5 as someNum"
 
     // Then
-    compareCount(query, 0, Configs.All - Configs.Compiled)
+    compareCount(query, 0, Configs.Interpreted)
     setupBigModel()
-    compareCount(query, 5, Configs.All - Configs.Compiled, assertCountInTransaction = true, executeBefore = executeBefore)
+    compareCount(query, 5, Configs.Interpreted, assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts relationships using count store considering transaction state") {
@@ -374,9 +374,9 @@ class MatchAggregationsBackedByCountStoreAcceptanceTest
     val query = "MATCH ()-[r]->() RETURN count(r) > 2"
 
     // Then
-    compareCount(query, false, Configs.All - Configs.Compiled, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    compareCount(query, false, Configs.Interpreted, expectedLogicalPlan = "RelationshipCountFromCountStore")
     setupBigModel()
-    compareCount(query, true, Configs.All - Configs.Compiled, expectedLogicalPlan = "RelationshipCountFromCountStore", assertCountInTransaction = true, executeBefore = executeBefore)
+    compareCount(query, true, Configs.Interpreted, expectedLogicalPlan = "RelationshipCountFromCountStore", assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts relationships using count store and projection with expression and variable considering transaction state") {
@@ -385,9 +385,9 @@ class MatchAggregationsBackedByCountStoreAcceptanceTest
     val query = "MATCH ()-[r]->() RETURN count(r)/3*5 as someNum"
 
     // Then
-    compareCount(query, 0, Configs.All - Configs.Compiled, expectedLogicalPlan = "RelationshipCountFromCountStore")
+    compareCount(query, 0, Configs.Interpreted, expectedLogicalPlan = "RelationshipCountFromCountStore")
     setupBigModel()
-    compareCount(query, 5, Configs.All - Configs.Compiled, expectedLogicalPlan = "RelationshipCountFromCountStore", assertCountInTransaction = true, executeBefore = executeBefore)
+    compareCount(query, 5, Configs.Interpreted, expectedLogicalPlan = "RelationshipCountFromCountStore", assertCountInTransaction = true, executeBefore = executeBefore)
   }
 
   test("counts relationships using count store and horizon with further query") {
@@ -398,7 +398,7 @@ class MatchAggregationsBackedByCountStoreAcceptanceTest
                   |MATCH (n)-[r:KNOWS]->() WITH count(r) as otherKnows, n, userKnows WHERE otherKnows <> userKnows
                   |RETURN userKnows, otherKnows
                 """.stripMargin
-    val expectSucceed = Configs.All - Configs.Compiled
+    val expectSucceed = Configs.Interpreted
 
     // Then
     val resultOnEmpty = executeWith(

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MemoryPerformanceAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MemoryPerformanceAcceptanceTest.scala
@@ -65,14 +65,14 @@ class MemoryPerformanceAcceptanceTest extends ExecutionEngineFunSuite with Cyphe
                   |RETURN ID(a), ID(b), type(r)""".stripMargin
 
     // when
-    executeWith(Configs.All + Configs.Morsel - Configs.Compiled, query)
+    executeWith(Configs.Interpreted + Configs.Morsel, query)
     // then it should not fail or run out of memory
   }
 
   test("should unwind a long range without going OOM") {
     val expectedResult = 20000000
 
-    val result = executeWith(Configs.All - Configs.Compiled, s"UNWIND range(1, $expectedResult) AS i RETURN count(*) AS c")
+    val result = executeWith(Configs.Interpreted, s"UNWIND range(1, $expectedResult) AS i RETURN count(*) AS c")
     result.columnAs[Long]("c").toList should equal(List(expectedResult))
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeAcceptanceTest.scala
@@ -29,7 +29,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
   // TODO: Reflect something like this in the TCK
   test("multiple merges after each other") {
     1 to 100 foreach { prop =>
-      val result = executeWith(Configs.Interpreted - Configs.Cost2_3, s"merge (a:Label {prop: $prop}) return a.prop")
+      val result = executeWith(Configs.UpdateConf, s"merge (a:Label {prop: $prop}) return a.prop")
       assertStats(result, nodesCreated = 1, propertiesWritten = 1, labelsAdded = 1)
     }
   }
@@ -61,26 +61,25 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     }
   }
 
-  private val supportMerge = Configs.Interpreted - Configs.Cost2_3
   // TODO: Change this setting when the bugfix #10771 merged to earlier 3.x versions is included as a dependency
   private val doNotYetHaveBugFix = Configs.Cost3_1
 
   test("Merging with self loop and relationship uniqueness") {
     graph.execute("CREATE (a) CREATE (a)-[:X]->(a)")
-    val result = executeWith(supportMerge, "MERGE (a)-[:X]->(b)-[:X]->(c) RETURN 42")
+    val result = executeWith(Configs.UpdateConf, "MERGE (a)-[:X]->(b)-[:X]->(c) RETURN 42")
     assertStats(result, relationshipsCreated = 2, nodesCreated = 3)
   }
 
   test("Merging with self loop and relationship uniqueness - no stats") {
     graph.execute("CREATE (a) CREATE (a)-[:X]->(a)")
-    val result = executeWith(supportMerge, "MERGE (a)-[r1:X]->(b)-[r2:X]->(c) RETURN id(r1) = id(r2) as sameEdge",
+    val result = executeWith(Configs.UpdateConf, "MERGE (a)-[r1:X]->(b)-[r2:X]->(c) RETURN id(r1) = id(r2) as sameEdge",
       expectedDifferentResults = doNotYetHaveBugFix)
     result.columnAs[Boolean]("sameEdge").toList should equal(List(false))
   }
 
   test("Merging with self loop and relationship uniqueness - no stats - reverse direction") {
     graph.execute("CREATE (a) CREATE (a)-[:X]->(a)")
-    val result = executeWith(supportMerge, "MERGE (a)-[r1:X]->(b)<-[r2:X]-(c) RETURN id(r1) = id(r2) as sameEdge",
+    val result = executeWith(Configs.UpdateConf, "MERGE (a)-[r1:X]->(b)<-[r2:X]-(c) RETURN id(r1) = id(r2) as sameEdge",
       expectedDifferentResults = doNotYetHaveBugFix)
     result.columnAs[Boolean]("sameEdge").toList should equal(List(false))
   }
@@ -89,7 +88,7 @@ class MergeNodeAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisti
     val a = createLabeledNode(Map("name" -> "a"), "A")
     val b = createLabeledNode(Map("name" -> "b"), "B")
     relate(a, b, "X")
-    val result = executeWith(supportMerge, "MERGE (a)-[r1:X]->(b)<-[r2:X]-(c) RETURN id(r1) = id(r2) as sameEdge, c.name as name",
+    val result = executeWith(Configs.UpdateConf, "MERGE (a)-[r1:X]->(b)<-[r2:X]-(c) RETURN id(r1) = id(r2) as sameEdge, c.name as name",
       expectedDifferentResults = doNotYetHaveBugFix)
     result.toList should equal(List(Map("sameEdge" -> false, "name" -> null)))
   }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeCompatibilityAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MergeNodeCompatibilityAcceptanceTest.scala
@@ -22,14 +22,12 @@ package org.neo4j.internal.cypher.acceptance
 import org.neo4j.cypher.internal.helpers.{NodeKeyConstraintCreator, UniquenessConstraintCreator}
 import org.neo4j.cypher.{ExecutionEngineFunSuite, MergeConstraintConflictException, QueryStatisticsTestSupport}
 import org.neo4j.graphdb.Node
-import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.{Configs, TestConfiguration}
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
 
 import scala.collection.Map
 
 class MergeNodeCompatibilityAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport
   with CypherComparisonSupport {
-
-  val expectedSucceed: TestConfiguration = Configs.Interpreted - Configs.Cost2_3
 
   Seq(UniquenessConstraintCreator, NodeKeyConstraintCreator).foreach { constraintCreator =>
 
@@ -42,7 +40,7 @@ class MergeNodeCompatibilityAcceptanceTest extends ExecutionEngineFunSuite with 
 
       // when
       val results =
-        executeWith(expectedSucceed, "merge (a:Person {id: 23, mail: 'emil@neo.com'}) on match set a.country='Sweden' return a")
+        executeWith(Configs.UpdateConf, "merge (a:Person {id: 23, mail: 'emil@neo.com'}) on match set a.country='Sweden' return a")
       val result = results.columnAs("a").next().asInstanceOf[Node]
 
       // then
@@ -63,7 +61,7 @@ class MergeNodeCompatibilityAcceptanceTest extends ExecutionEngineFunSuite with 
 
       // when
       val results =
-        executeWith(expectedSucceed, "merge (a:Person:User {id: 23, mail: 'emil@neo.com'}) on match set a.country='Sweden' return a")
+        executeWith(Configs.UpdateConf, "merge (a:Person:User {id: 23, mail: 'emil@neo.com'}) on match set a.country='Sweden' return a")
       val result = results.columnAs("a").next().asInstanceOf[Node]
 
       // then
@@ -84,7 +82,7 @@ class MergeNodeCompatibilityAcceptanceTest extends ExecutionEngineFunSuite with 
 
       // when
       val results =
-        executeWith(expectedSucceed, "merge (a:Person:User {id: 23}) on match set a.country='Sweden' return a")
+        executeWith(Configs.UpdateConf, "merge (a:Person:User {id: 23}) on match set a.country='Sweden' return a")
       val result = results.columnAs("a").next().asInstanceOf[Node]
 
       // then
@@ -104,7 +102,7 @@ class MergeNodeCompatibilityAcceptanceTest extends ExecutionEngineFunSuite with 
       createLabeledNode(Map("id" -> 23), "User")
 
       // when + then
-      failWithError(expectedSucceed + Configs.Procs, "merge (a:Person:User {id: 23}) return a",
+      failWithError(Configs.UpdateConf + Configs.Procs, "merge (a:Person:User {id: 23}) return a",
         List("can not create a new node due to conflicts with existing unique nodes"))
       countNodes() should equal(2)
     }
@@ -116,7 +114,7 @@ class MergeNodeCompatibilityAcceptanceTest extends ExecutionEngineFunSuite with 
 
       // when
       val results =
-        executeWith(expectedSucceed, "merge (a:Person {id: 23, mail: 'emil@neo.com'}) on create set a.country='Sweden' return a.id, a.mail, a.country, labels(a)")
+        executeWith(Configs.UpdateConf, "merge (a:Person {id: 23, mail: 'emil@neo.com'}) on create set a.country='Sweden' return a.id, a.mail, a.country, labels(a)")
 
       // then
       results.toSet should equal(Set(Map("a.id" -> 23, "a.mail" -> "emil@neo.com", "a.country" -> "Sweden", "labels(a)" -> List("Person"))))
@@ -129,7 +127,7 @@ class MergeNodeCompatibilityAcceptanceTest extends ExecutionEngineFunSuite with 
 
       // when
       val results =
-        executeWith(expectedSucceed, "merge (a:Person:User {id: 23, mail: 'emil@neo.com'}) on create set a.country='Sweden' return a.id, a.mail, a.country, labels(a)")
+        executeWith(Configs.UpdateConf, "merge (a:Person:User {id: 23, mail: 'emil@neo.com'}) on create set a.country='Sweden' return a.id, a.mail, a.country, labels(a)")
 
       // then
       results.toSet should equal(Set(Map("a.id" -> 23, "a.mail" -> "emil@neo.com", "a.country" -> "Sweden", "labels(a)" -> List("Person", "User"))))

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MiscAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MiscAcceptanceTest.scala
@@ -33,7 +33,7 @@ class MiscAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSu
       WHERE i <> j
       RETURN i, j"""
 
-    val result = executeWith(Configs.All + Configs.Morsel - Configs.Compiled, query)
+    val result = executeWith(Configs.Interpreted + Configs.Morsel, query)
     result.toList should equal(List(Map("j" -> 1, "i" -> 0), Map("j" -> 0, "i" -> 1)))
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MultipleGraphsAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MultipleGraphsAcceptanceTest.scala
@@ -25,8 +25,7 @@ import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
 import scala.language.postfixOps
 
 class MultipleGraphsAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
-  val configs = TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.ProcedureOrSchema, Runtimes.Interpreted, Runtimes.Slotted)) +
-    TestConfiguration(Versions.V3_4, Planners.Cost, Runtimes(Runtimes.CompiledBytecode, Runtimes.CompiledSource)) + Configs.Version3_3
+  val configs = Configs.Version3_4 + Configs.Version3_3 + Configs.Procs - Configs.AllRulePlanners
   val expectedException = "Projecting and returning graphs is not available in this implementation of Cypher due to lack of support for multiple graphs."
 
   test("from graph") {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MutatingIntegrationTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/MutatingIntegrationTest.scala
@@ -30,13 +30,10 @@ import scala.collection.JavaConverters._
 
 class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with CypherComparisonSupport {
 
-  val createConf = Configs.Interpreted - Configs.Cost2_3
-  val deleteConf = Configs.Interpreted - Configs.Cost2_3
-
   test("create a single node") {
     val before = graph.inTx(graph.getAllNodes.asScala.size)
 
-    val result = executeWith(createConf, "create (a)")
+    val result = executeWith(Configs.UpdateConf, "create (a)")
 
     assertStats(result, nodesCreated = 1)
     graph.inTx {
@@ -47,7 +44,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
   test("create a single node with props and return it") {
     val before = graph.inTx(graph.getAllNodes.asScala.size)
 
-    val result = executeWith(createConf, "create (a {name : 'Andres'}) return a.name")
+    val result = executeWith(Configs.UpdateConf, "create (a {name : 'Andres'}) return a.name")
 
     assertStats(result, nodesCreated = 1, propertiesWritten = 1)
     graph.inTx {
@@ -60,7 +57,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
   test("start with a node and create a new node with the same properties") {
     createNode("age" -> 15)
 
-    val result = executeWith(createConf, "match (a) where id(a) = 0 with a create (b {age : a.age * 2}) return b.age")
+    val result = executeWith(Configs.UpdateConf, "match (a) where id(a) = 0 with a create (b {age : a.age * 2}) return b.age")
 
     assertStats(result, nodesCreated = 1, propertiesWritten = 1)
 
@@ -68,13 +65,13 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
   }
 
   test("create two nodes and a relationship between them") {
-    val result = executeWith(createConf - Configs.Cost2_3, "create (a), (b), (a)-[r:REL]->(b)")
+    val result = executeWith(Configs.UpdateConf - Configs.Cost2_3, "create (a), (b), (a)-[r:REL]->(b)")
 
     assertStats(result, nodesCreated = 2, relationshipsCreated = 1)
   }
 
   test("create one node and dumpToString") {
-    val result = executeWith(createConf, "create (a {name:'Cypher'})")
+    val result = executeWith(Configs.UpdateConf, "create (a {name:'Cypher'})")
 
     assertStats(result,
       nodesCreated = 1,
@@ -85,7 +82,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
   test("deletes single node") {
     val a = createNode().getId
 
-    val result = executeWith(deleteConf, "match (a) where id(a) = 0 delete a")
+    val result = executeWith(Configs.UpdateConf, "match (a) where id(a) = 0 delete a")
     assertStats(result, nodesDeleted = 1)
 
     result.toList shouldBe empty
@@ -95,7 +92,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
   test("multiple deletes should not break anything") {
     (1 to 4).foreach(i => createNode())
 
-    val result = executeWith(deleteConf, "match (a), (b) where id(a) = 0 AND id(b) IN [1, 2, 3] delete a")
+    val result = executeWith(Configs.UpdateConf, "match (a), (b) where id(a) = 0 AND id(b) IN [1, 2, 3] delete a")
     assertStats(result, nodesDeleted = 1)
 
     result.toList shouldBe empty
@@ -111,7 +108,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
     relate(a, c)
     relate(a, d)
 
-    val result = executeWith(deleteConf, "match (a) where id(a) = 0 match (a)-[r]->() delete r")
+    val result = executeWith(Configs.UpdateConf, "match (a) where id(a) = 0 match (a)-[r]->() delete r")
     assertStats( result, relationshipsDeleted = 3  )
 
     graph.inTx {
@@ -124,7 +121,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
     val b = createNode()
     val c = createNode()
 
-    val result = executeWith(createConf, "create (n) with n MATCH (x) WHERE id(x) IN [0, 1, 2] create (n)-[:REL]->(x)")
+    val result = executeWith(Configs.UpdateConf, "create (n) with n MATCH (x) WHERE id(x) IN [0, 1, 2] create (n)-[:REL]->(x)")
     assertStats(result,
       nodesCreated = 1,
       relationshipsCreated = 3
@@ -142,7 +139,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
     createNode("Michael")
     createNode("Peter")
 
-    val result = executeWith(createConf, "MATCH (n) with collect(n.name) as names create (m {name : names}) RETURN m.name")
+    val result = executeWith(Configs.UpdateConf, "MATCH (n) with collect(n.name) as names create (m {name : names}) RETURN m.name")
     assertStats(result,
       propertiesWritten = 1,
       nodesCreated = 1
@@ -152,7 +149,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
   }
 
   test("set a property to an empty collection") {
-    val result = executeWith(createConf, "create (n {x : []}) return n.x")
+    val result = executeWith(Configs.UpdateConf, "create (n {x : []}) return n.x")
     assertStats(result,
       propertiesWritten = 1,
       nodesCreated = 1
@@ -161,7 +158,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
   }
 
   test("create node from map values") {
-    val result = executeWith(createConf, "create (n {a}) return n.age, n.name", params = Map("a" -> Map("name" -> "Andres", "age" -> 66)))
+    val result = executeWith(Configs.UpdateConf, "create (n {a}) return n.age, n.name", params = Map("a" -> Map("name" -> "Andres", "age" -> 66)))
 
     result.toList should equal(List(Map("n.age" -> 66, "n.name" -> "Andres")))
   }
@@ -171,7 +168,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
     createNode()
 
 
-    val result = executeWith(createConf, "match (a), (b) where id(a) = 0 AND id(b) = 1 create (a)-[r:REL {param}]->(b) return r.name, r.age", params = Map("param" -> Map("name" -> "Andres", "age" -> 66)))
+    val result = executeWith(Configs.UpdateConf, "match (a), (b) where id(a) = 0 AND id(b) = 1 create (a)-[r:REL {param}]->(b) return r.name, r.age", params = Map("param" -> Map("name" -> "Andres", "age" -> 66)))
 
     result.toList should equal(List(Map("r.name" -> "Andres", "r.age" -> 66)))
   }
@@ -184,13 +181,13 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
     relate(a, b, "LOVES")
 
     val msg = "Cannot delete node<0>, because it still has relationships. To delete this node, you must first delete its relationships."
-    failWithError(deleteConf + Configs.Procs, "match (n) where id(n) = 0 match (n)-[r:HATES]->() delete n,r", List(msg))
+    failWithError(Configs.UpdateConf + Configs.Procs, "match (n) where id(n) = 0 match (n)-[r:HATES]->() delete n,r", List(msg))
   }
 
   test("delete and return") {
     val a = createNode()
 
-    val result = executeWith(deleteConf, "match (n) where id(n) = 0 delete n return n")
+    val result = executeWith(Configs.UpdateConf, "match (n) where id(n) = 0 delete n return n")
 
     result.toList should equal(List(Map("n" -> a)))
   }
@@ -201,7 +198,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
       Map("name" -> "Michael", "prefers" -> "Java"),
       Map("name" -> "Peter", "prefers" -> "Java"))
 
-    val result = executeWith(createConf, "unwind {params} as m create (x) set x = m ", params = Map("params" -> maps))
+    val result = executeWith(Configs.UpdateConf, "unwind {params} as m create (x) set x = m ", params = Map("params" -> maps))
 
     assertStats(result,
       nodesCreated = 3,
@@ -216,7 +213,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
       Map("name" -> "Peter", "prefers" -> "Java"))
 
     val errorMessages = List("If you want to create multiple nodes, please use UNWIND.", "Parameter provided for node creation is not a Map")
-    failWithError(createConf - Configs.Rule2_3 + Configs.Procs, "create ({params})", params = "params" -> maps, message = errorMessages)
+    failWithError(Configs.UpdateConf - Configs.Rule2_3 + Configs.Procs, "create ({params})", params = "params" -> maps, message = errorMessages)
   }
 
   test("fail to create from two iterables") {
@@ -230,7 +227,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
       Map("name" -> "Peter"))
     val query = "create (a {params1}), (b {params2})"
     val errorMessages = List("If you want to create multiple nodes, please use UNWIND.", "Parameter provided for node creation is not a Map", "If you create multiple elements, you can only create one of each.")
-    failWithError(createConf + Configs.Procs, query, message = errorMessages, params = "params1" -> maps1, "params2" -> maps2)
+    failWithError(Configs.UpdateConf + Configs.Procs, query, message = errorMessages, params = "params1" -> maps1, "params2" -> maps2)
   }
 
   test("first read then write") {
@@ -243,14 +240,14 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
     relate(root, b)
     relate(root, c)
 
-    executeWith(createConf, "match (root) where id(root) = 0 match (root)-->(other) create (new {name:other.name}), (root)-[:REL]->(new)")
+    executeWith(Configs.UpdateConf, "match (root) where id(root) = 0 match (root)-->(other) create (new {name:other.name}), (root)-[:REL]->(new)")
 
     val result = executeWith(Configs.All, "match (root) where id(root) = 0 match (root)-->(other) return other.name order by other.name").columnAs[String]("other.name").toList
     result should equal(List("Alfa", "Alfa", "Beta", "Beta", "Gamma", "Gamma"))
   }
 
   test("create node and rel in foreach") {
-    executeWith(createConf, """
+    executeWith(Configs.UpdateConf, """
       |create (center {name: "center"})
       |foreach(x in range(1,10) |
       |  create (leaf1 {number : x}) , (center)-[:X]->(leaf1)
@@ -264,7 +261,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
     val b = createNode()
     relate(a,b)
 
-    executeWith(deleteConf, """match (n) optional match (n)-[r]-() delete n,r""")
+    executeWith(Configs.UpdateConf, """match (n) optional match (n)-[r]-() delete n,r""")
 
     graph.inTx {
       graph.getAllNodes.asScala shouldBe empty
@@ -276,7 +273,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
     val b = createNode()
     relate(a,b)
 
-    executeWith(deleteConf, """match (n) where id(n) = 0 match p=(n)-->() delete p""")
+    executeWith(Configs.UpdateConf, """match (n) where id(n) = 0 match p=(n)-->() delete p""")
 
     graph.inTx {
       graph.getAllNodes().asScala shouldBe empty
@@ -285,7 +282,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
 
   test("string literals should not be mistaken for variables") {
     //https://github.com/neo4j/community/issues/523
-    executeWith(createConf, "EXPLAIN create (tag1 {name:'tag2'}), (tag2 {name:'tag1'}) return [tag1,tag2] as tags")
+    executeWith(Configs.UpdateConf, "EXPLAIN create (tag1 {name:'tag2'}), (tag2 {name:'tag1'}) return [tag1,tag2] as tags")
     val result = executeScalar[Seq[Node]]("create (tag1 {name:'tag2'}), (tag2 {name:'tag1'}) return [tag1,tag2] as tags")
     result should have size 2
   }
@@ -301,7 +298,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
     val q = "create (a{param}) return a.arrayProp"
     val result =  executeScalar[Array[String]](q, "param" -> map)
 
-    assertStats(executeWith(createConf, q, params = Map("param"->map)), nodesCreated = 1, propertiesWritten = 1)
+    assertStats(executeWith(Configs.UpdateConf, q, params = Map("param"->map)), nodesCreated = 1, propertiesWritten = 1)
     result.toList should equal(List("foo","bar"))
   }
 
@@ -315,14 +312,14 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
   test("full path in one create") {
     createNode()
     createNode()
-    val result = executeWith(createConf, "match (a), (b) where id(a) = 0 AND id(b) = 1 create (a)-[:KNOWS]->()-[:LOVES]->(b)")
+    val result = executeWith(Configs.UpdateConf, "match (a), (b) where id(a) = 0 AND id(b) = 1 create (a)-[:KNOWS]->()-[:LOVES]->(b)")
 
     assertStats(result, nodesCreated = 1, relationshipsCreated = 2)
   }
 
   test("delete and delete again") {
     createNode()
-    val result = executeWith(deleteConf, "match (a) where id(a) = 0 delete a foreach( x in [1] | delete a)")
+    val result = executeWith(Configs.UpdateConf, "match (a) where id(a) = 0 delete a foreach( x in [1] | delete a)")
 
     assertStats(result, nodesDeleted = 1)
   }
@@ -332,7 +329,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
     val b = createNode(Map("prop" -> "end"))
 
     val query = "match (a), (b) where a.prop = 'start' AND b.prop = 'end' create p = (a)<-[:X]-(b) with p unwind nodes(p) as x return x.prop"
-    val result = executeWith(createConf, query)
+    val result = executeWith(Configs.UpdateConf, query)
 
     result.toList should equal(List(Map("x.prop" -> "start"), Map("x.prop" -> "end")))
   }
@@ -345,7 +342,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
   test("failure_only_fails_inner_transaction") {
     val tx = graph.beginTransaction( Type.explicit, AnonymousContext.write() )
     try {
-      executeWith(createConf, "match (a) where id(a) = {id} set a.foo = 'bar' return a", params = Map("id"->"0"))
+      executeWith(Configs.UpdateConf, "match (a) where id(a) = {id} set a.foo = 'bar' return a", params = Map("id"->"0"))
     } catch {
       case _: Throwable => tx.failure()
     }
@@ -353,7 +350,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
   }
 
   test("create two rels in one command should work") {
-    val result = executeWith(createConf, "create (a{name:'a'})-[:test]->(b), (a)-[:test2]->(c)")
+    val result = executeWith(Configs.UpdateConf, "create (a{name:'a'})-[:test]->(b), (a)-[:test2]->(c)")
 
     assertStats(result, nodesCreated = 3, relationshipsCreated = 2, propertiesWritten = 1)
   }
@@ -365,20 +362,20 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
 
   test("can create anonymous nodes inside foreach") {
     createNode()
-    val result = executeWith(createConf, "match (me) where id(me) = 0 foreach (i in range(1,10) | create (me)-[:FRIEND]->())")
+    val result = executeWith(Configs.UpdateConf, "match (me) where id(me) = 0 foreach (i in range(1,10) | create (me)-[:FRIEND]->())")
 
     result.toList shouldBe empty
   }
 
   test("should be able to use external variables inside foreach") {
     createNode()
-    val result = executeWith(createConf, "match (a), (b) where id(a) = 0 AND id(b) = 0 foreach(x in [b] | create (x)-[:FOO]->(a)) ")
+    val result = executeWith(Configs.UpdateConf, "match (a), (b) where id(a) = 0 AND id(b) = 0 foreach(x in [b] | create (x)-[:FOO]->(a)) ")
 
     result.toList shouldBe empty
   }
 
   test("should be able to create node with labels") {
-    val result = executeWith(createConf, "create (n:FOO:BAR) return labels(n) as l")
+    val result = executeWith(Configs.UpdateConf, "create (n:FOO:BAR) return labels(n) as l")
 
     assertStats(result, nodesCreated = 1, labelsAdded = 2)
     result.toList should equal(List(Map("l" -> List("FOO", "BAR"))))
@@ -386,7 +383,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
 
   test("complete graph") {
     val result =
-      executeWith(createConf, """CREATE (center { count:0 })
+      executeWith(Configs.UpdateConf, """CREATE (center { count:0 })
                  FOREACH (x IN range(1,6) | CREATE (leaf { count : x }),(center)-[:X]->(leaf))
                  WITH center
                  MATCH (leaf1)<--(center)-->(leaf2)
@@ -400,19 +397,19 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
   }
 
   test("for each applied to null should never execute") {
-    val result = executeWith(createConf, "foreach(x in null| create ())")
+    val result = executeWith(Configs.UpdateConf, "foreach(x in null| create ())")
 
     assertStats(result, nodesCreated = 0)
   }
 
   test("should execute when null is contained in a collection") {
-    val result = executeWith(createConf, "foreach(x in [null]| create ())")
+    val result = executeWith(Configs.UpdateConf, "foreach(x in [null]| create ())")
 
     assertStats(result, nodesCreated = 1)
   }
 
   test("should be possible to remove nodes created in the same query") {
-    val result = executeWith(deleteConf,
+    val result = executeWith(Configs.UpdateConf,
       """CREATE (a)-[:FOO]->(b)
          WITH *
          MATCH (x)-[r]-(y)
@@ -428,7 +425,7 @@ class MutatingIntegrationTest extends ExecutionEngineFunSuite with QueryStatisti
     createNode("prop" -> 42)
     val query = "UNWIND range(0, 1) as i MATCH (n) CREATE (m) WITH * MATCH (o) RETURN count(*) as count"
 
-    val result = executeWith(createConf, query, expectedDifferentResults = Configs.Rule2_3)
+    val result = executeWith(Configs.UpdateConf, query, expectedDifferentResults = Configs.Rule2_3)
 
     assertStats(result, nodesCreated = 8)
     val unwind = 2

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexEndsWithScanAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexEndsWithScanAcceptanceTest.scala
@@ -20,6 +20,7 @@
 package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.ExecutionEngineFunSuite
+import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Versions.V3_1
 import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
 
 /**
@@ -182,12 +183,10 @@ class NodeIndexEndsWithScanAcceptanceTest extends ExecutionEngineFunSuite with C
 
     graph.createConstraint("Location", "name")
 
+    val config = Configs.AbsolutelyAll - Configs.Compiled - TestConfiguration(Versions(V3_1, Versions.Default), Planners.Rule, Runtimes.Default)
     val query = "MATCH (l:Location) WHERE l.name ENDS WITH {param} RETURN l"
+    val message = List("Expected a string value, but got 42","Expected a string value, but got Long(42)","Expected two strings, but got London and 42")
 
-    failWithError(TestConfiguration(Versions.Default, Planners.Default, Runtimes(Runtimes.ProcedureOrSchema, Runtimes.Interpreted, Runtimes.Slotted)) +
-      TestConfiguration(Versions.all, Planners.Cost, Runtimes(Runtimes.Interpreted, Runtimes.Default)) +
-      TestConfiguration(Versions.V2_3, Planners.Rule, Runtimes(Runtimes.Interpreted, Runtimes.Default)),
-      query, message = List("Expected a string value, but got 42","Expected a string value, but got Long(42)","Expected two strings, but got London and 42"),
-      params = "param" -> 42)
+    failWithError(config, query, message, params = "param" -> 42)
   }
 }

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekAcceptanceTest.scala
@@ -29,6 +29,8 @@ import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.{ComparePlan
  */
 class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport{
 
+  private val expectPlansToFailConfig1 =  Configs.Cost2_3 + Configs.AllRulePlanners
+
   test("should handle OR when using index") {
     // Given
     graph.createIndex("L", "prop")
@@ -38,7 +40,7 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with CypherCom
 
     // When
     val result = executeWith(Configs.All, "MATCH (n:L) WHERE n.prop = 1 OR n.prop = 2 RETURN n",
-      planComparisonStrategy = ComparePlansWithAssertion(_ should useOperatorTimes("NodeIndexSeek", 1), expectPlansToFail = Configs.AllRulePlanners + Configs.Cost2_3))
+      planComparisonStrategy = ComparePlansWithAssertion(_ should useOperatorTimes("NodeIndexSeek", 1), expectPlansToFail = expectPlansToFailConfig1))
 
     // Then
     result.toList should equal(List(Map("n" -> node1), Map("n" -> node2)))
@@ -53,7 +55,7 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with CypherCom
 
     // When
     val result = executeWith(Configs.All, "MATCH (n:L) WHERE n.prop = 1 AND n.prop = 2 RETURN n",
-      planComparisonStrategy = ComparePlansWithAssertion(_ should useOperatorTimes("NodeIndexSeek", 1), expectPlansToFail = Configs.AllRulePlanners + Configs.Cost2_3))
+      planComparisonStrategy = ComparePlansWithAssertion(_ should useOperatorTimes("NodeIndexSeek", 1), expectPlansToFail = expectPlansToFailConfig1))
 
     // Then
     result.toList shouldBe empty
@@ -74,7 +76,7 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with CypherCom
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         plan should useOperatorTimes("NodeIndexSeek", 2)
         plan should useOperators("Union")
-    }, expectPlansToFail = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1))
+    }, expectPlansToFail = Configs.OldAndRule))
 
     result.columnAs("c").toSet should be(Set(nodes(1), nodes(11)))
   }
@@ -94,7 +96,7 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with CypherCom
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         plan should useOperatorTimes("NodeIndexScan", 2)
         plan should useOperators("Union")
-      }, expectPlansToFail = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1))
+      }, expectPlansToFail = Configs.OldAndRule))
 
     result.columnAs("c").toSet should be(Set(nodes(1), nodes(11)))
   }
@@ -114,7 +116,7 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with CypherCom
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         plan should useOperatorTimes("NodeIndexSeekByRange", 2)
         plan should useOperators("Union")
-      }, expectPlansToFail = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1))
+      }, expectPlansToFail = Configs.OldAndRule))
 
     result.columnAs("c").toSet should be(Set(nodes(1), nodes(11)))
   }
@@ -134,7 +136,7 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with CypherCom
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         plan should useOperatorTimes("NodeIndexScan", 2)
         plan should useOperators("Union")
-      }, expectPlansToFail = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1))
+      }, expectPlansToFail = Configs.OldAndRule))
 
     result.columnAs("c").toSet should be(Set(nodes(1), nodes(11)))
   }
@@ -152,7 +154,7 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with CypherCom
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         plan should useOperatorTimes("NodeIndexScan", 2)
         plan should useOperators("Union")
-      }, expectPlansToFail = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1))
+      }, expectPlansToFail = Configs.OldAndRule))
 
     result.columnAs("c").toSet should be(Set(nodes(1), nodes(11)))
   }
@@ -178,7 +180,7 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with CypherCom
     for (i <- 4 to 30) createLabeledNode(Map("id" -> i), "Prop")
 
     // When
-    val result = executeWith(Configs.All - Configs.Compiled, "unwind [1,2,3] as x match (n:Prop) where n.id = x return n;",
+    val result = executeWith(Configs.Interpreted, "unwind [1,2,3] as x match (n:Prop) where n.id = x return n;",
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         plan should useOperators("NodeIndexSeek")
       }, Configs.AllRulePlanners))
@@ -225,7 +227,7 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with CypherCom
    graph.createIndex("Place", "name")
 
     // When
-    val result = executeWith(Configs.All - Configs.Compiled,
+    val result = executeWith(Configs.Interpreted,
       """
         |MATCH ()-[f:FRIEND_OF]->()
         |WITH f.placeName AS placeName
@@ -254,7 +256,7 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with CypherCom
         |RETURN m""".stripMargin
 
     // When
-    val result = executeWith(Configs.All - Configs.Compiled, query,
+    val result = executeWith(Configs.Interpreted, query,
       planComparisonStrategy = ComparePlansWithAssertion((planDescription) => {
         planDescription.toString() shouldNot include("index")
       }))
@@ -281,7 +283,7 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with CypherCom
         |RETURN m""".stripMargin
 
     // When
-    val result = executeWith(Configs.All - Configs.Compiled, query,
+    val result = executeWith(Configs.Interpreted, query,
       planComparisonStrategy = ComparePlansWithAssertion((planDescription) => {
         planDescription.toString() shouldNot include("index")
       }))
@@ -304,7 +306,7 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with CypherCom
     // When
     val result = executeWith(Configs.All,
       "MATCH (root:Company) WHERE root.uuid IN {uuids} RETURN DISTINCT root",
-      planComparisonStrategy = ComparePlansWithAssertion(_ should useOperatorTimes("NodeIndexSeek", 1), expectPlansToFail = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1),
+      planComparisonStrategy = ComparePlansWithAssertion(_ should useOperatorTimes("NodeIndexSeek", 1), expectPlansToFail = Configs.OldAndRule),
       params = Map("uuids" -> Array("a", "b", "c")))
 
     //Then
@@ -322,7 +324,7 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with CypherCom
     // When
     val result = executeWith(Configs.All,
       "MATCH (root:Company) WHERE root.uuid IN {uuids} RETURN DISTINCT root",
-      planComparisonStrategy = ComparePlansWithAssertion(_ should useOperatorTimes("NodeIndexSeek", 1), expectPlansToFail = Configs.AllRulePlanners + Configs.Cost2_3 + Configs.Cost3_1),
+      planComparisonStrategy = ComparePlansWithAssertion(_ should useOperatorTimes("NodeIndexSeek", 1), expectPlansToFail = Configs.OldAndRule),
       params = Map("uuids" -> Array(1, 2, 3)))
 
     //Then
@@ -337,7 +339,7 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with CypherCom
 
     // When
     val result = executeWith(Configs.All, "MATCH (n:L) WHERE n.prop = [1,2,3] RETURN n",
-      planComparisonStrategy = ComparePlansWithAssertion(_ should useOperatorTimes("NodeIndexSeek", 1), expectPlansToFail = Configs.AllRulePlanners + Configs.Cost2_3))
+      planComparisonStrategy = ComparePlansWithAssertion(_ should useOperatorTimes("NodeIndexSeek", 1), expectPlansToFail = expectPlansToFailConfig1))
 
     // Then
     result.toList should equal(List(Map("n" -> node1)))
@@ -351,14 +353,14 @@ class NodeIndexSeekAcceptanceTest extends ExecutionEngineFunSuite with CypherCom
 
     // When
     val result = executeWith(Configs.All, "MATCH (n:L) WHERE n.prop = [1,2,3] RETURN n",
-      planComparisonStrategy = ComparePlansWithAssertion(_ should useOperatorTimes("NodeUniqueIndexSeek", 1), expectPlansToFail = Configs.AllRulePlanners + Configs.Cost2_3))
+      planComparisonStrategy = ComparePlansWithAssertion(_ should useOperatorTimes("NodeUniqueIndexSeek", 1), expectPlansToFail = expectPlansToFailConfig1))
 
     // Then
     result.toList should equal(List(Map("n" -> node1)))
   }
 
   private def setUpDatabaseForTests() {
-    executeWith(Configs.All - Configs.Compiled - Configs.Cost2_3,
+    executeWith(Configs.Interpreted - Configs.Cost2_3,
       """CREATE (architect:Matrix { name:'The Architect' }),
         |       (smith:Matrix { name:'Agent Smith' }),
         |       (cypher:Matrix:Crew { name:'Cypher' }),

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekByRangeAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NodeIndexSeekByRangeAcceptanceTest.scala
@@ -102,7 +102,7 @@ class NodeIndexSeekByRangeAcceptanceTest extends ExecutionEngineFunSuite with Cy
         |CREATE (L:Location {name: toUpper(l.name)})
         |RETURN L.name AS NAME""".stripMargin
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query)
+    val result = executeWith(Configs.UpdateConf, query)
 
     result.toList should equal(List(Map("NAME" -> "LONDON")))
   }
@@ -1134,7 +1134,7 @@ class NodeIndexSeekByRangeAcceptanceTest extends ExecutionEngineFunSuite with Cy
 
     val query = "MATCH (n:Label) WHERE n.prop < 10 CREATE () RETURN n.prop"
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, query,
+    val result = executeWith(Configs.UpdateConf, query,
       planComparisonStrategy = ComparePlansWithAssertion((plan) => {
         //THEN
         plan should useOperators(IndexSeekByRange.name)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NullListAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/NullListAcceptanceTest.scala
@@ -20,13 +20,12 @@
 package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher._
-import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Versions.{V2_3, V3_1}
 import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
 
 class NullListAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
 
   // Changed behaviour to comply with opencypher in 3.3
-  val nullInListConfigOld: TestConfiguration = TestConfiguration(V2_3 -> V3_1, Planners.all, Runtimes.all) + Configs.AllRulePlanners
+  val nullInListConfigOld = Configs.OldAndRule
 
   // Comparison between lists and non-lists
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
@@ -21,17 +21,12 @@ package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.ExecutionEngineFunSuite
 import org.neo4j.cypher.internal.runtime.PathImpl
-import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Versions.V3_1
 import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
 import org.neo4j.kernel.impl.proc.Procedures
 
 class PatternComprehensionAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
   val expectedToSucceed = Configs.Interpreted - Configs.Version2_3
-  val expectedToSucceedRestricted =
-    TestConfiguration(
-      Versions(V3_1, Versions.Default, Versions.V3_3),
-      Planners(Planners.Cost, Planners.Default),
-      Runtimes(Runtimes.Interpreted, Runtimes.Default)) + Configs.SlottedInterpreted
+  val expectedToSucceedRestricted = expectedToSucceed - Configs.AllRulePlanners
 
   test("pattern comprehension nested in pattern comprehension") {
     graph.getDependencyResolver.resolveDependency(classOf[Procedures]).registerFunction(classOf[TestFunction])

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/QueryPlanCompactionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/QueryPlanCompactionAcceptanceTest.scala
@@ -21,7 +21,6 @@ package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.internal.util.v3_4.test_helpers.WindowsStringSafe
 import org.neo4j.cypher.{ExecutionEngineFunSuite, QueryStatisticsTestSupport}
-import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Versions.{V2_3, V3_1}
 import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport._
 
 class QueryPlanCompactionAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport
@@ -826,7 +825,7 @@ class QueryPlanCompactionAcceptanceTest extends ExecutionEngineFunSuite with Que
         || +NodeByLabelScan |              5 | n                                    | :Actor                      |
         |+------------------+----------------+--------------------------------------+-----------------------------+
         |""".stripMargin
-    val ignoreConfiguration = TestConfiguration(V2_3 -> V3_1, Planners.all, Runtimes.all ) + Configs.AllRulePlanners + Configs.SlottedInterpreted
+    val ignoreConfiguration = Configs.Version2_3 + Configs.Version3_1 + Configs.AllRulePlanners + Configs.SlottedInterpreted
     executeWith(Configs.All, query, planComparisonStrategy = ComparePlansWithAssertion(_ should matchPlan(expectedPlan), expectPlansToFail = ignoreConfiguration))
   }
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/RemoveAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/RemoveAcceptanceTest.scala
@@ -35,7 +35,7 @@ class RemoveAcceptanceTest extends ExecutionEngineFunSuite with QueryStatisticsT
         |RETURN a.age, b.age""".stripMargin
 
     // Fixed in 3.3.3
-    val result = executeWith(Configs.Interpreted - Configs.Version3_3 - Configs.Cost3_1 - Configs.Cost2_3, query)
+    val result = executeWith(Configs.UpdateConf - Configs.Version3_3 - Configs.Cost3_1, query)
 
     // then
     result.toList should equal(List(Map("a.age" -> 23, "b.age" -> null)))

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathExhaustiveForbiddenAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathExhaustiveForbiddenAcceptanceTest.scala
@@ -20,7 +20,7 @@
 package org.neo4j.internal.cypher.acceptance
 
 import org.neo4j.cypher.internal.util.v3_4.{ExhaustiveShortestPathForbiddenException => InternalExhaustiveShortestPathForbiddenException}
-import org.neo4j.cypher.{ExecutionEngineFunSuite, ExhaustiveShortestPathForbiddenException}
+import org.neo4j.cypher.ExecutionEngineFunSuite
 import org.neo4j.graphdb.Node
 import org.neo4j.graphdb.config.Setting
 import org.neo4j.graphdb.factory.GraphDatabaseSettings
@@ -34,13 +34,9 @@ class ShortestPathExhaustiveForbiddenAcceptanceTest extends ExecutionEngineFunSu
   override def databaseConfig(): Map[Setting[_], String] =
     Map(GraphDatabaseSettings.forbid_exhaustive_shortestpath -> "true")
 
-  val allPossibleConfigs = Configs.All + TestConfiguration(Versions.Default, Planners.Default,
-    Runtimes(Runtimes.Default, Runtimes.ProcedureOrSchema, Runtimes.CompiledSource, Runtimes.CompiledBytecode))
-
   test("should fail at run time when using the shortest path fallback") {
     // when
-
-    failWithError(allPossibleConfigs - Configs.AllRulePlanners - Configs.Cost2_3,
+    failWithError(Configs.AbsolutelyAll - Configs.AllRulePlanners - Configs.Cost2_3,
       s"""MATCH p = shortestPath((src:$topLeft)-[*0..]-(dst:$topLeft))
          |WHERE ANY(n in nodes(p) WHERE n:$topRight)
          |RETURN nodes(p) AS nodes""".stripMargin,

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StoreIntegrationAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/StoreIntegrationAcceptanceTest.scala
@@ -29,7 +29,7 @@ class StoreIntegrationAcceptanceTest extends ExecutionEngineFunSuite with QueryS
   test("should not create labels id when trying to delete non-existing labels") {
     createNode()
 
-    val result = executeWith(Configs.Interpreted - Configs.Cost2_3, "MATCH (n) REMOVE n:BAR RETURN id(n) AS id")
+    val result = executeWith(Configs.UpdateConf, "MATCH (n) REMOVE n:BAR RETURN id(n) AS id")
 
     assertStats(result, labelsRemoved = 0)
     result.toList should equal(List(Map("id" -> 0)))

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UnionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UnionAcceptanceTest.scala
@@ -123,8 +123,7 @@ class UnionAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonS
         |M, N
       """.stripMargin
 
-    val result = executeWith(Configs.Interpreted + Configs.Rule3_1 - Configs.Cost3_1 +
-                              Configs.Rule2_3 - Configs.Cost2_3, query)
+    val result = executeWith(Configs.Interpreted - Configs.Cost3_1 - Configs.Cost2_3, query)
     val expected = List(Map("M" -> b, "N" -> a), Map("M" -> a, "N" -> b))
 
     result.toList should equal(expected)
@@ -146,8 +145,7 @@ class UnionAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonS
         |M.a as B
       """.stripMargin
 
-    val expectedToWorkIn = Configs.Interpreted -
-      TestConfiguration(Versions.V2_3 -> Versions.V3_1, Planners.Cost, Runtimes.Default)
+    val expectedToWorkIn = Configs.Interpreted - Configs.Cost3_1 - Configs.Cost2_3
     val result = executeWith(expectedToWorkIn, query)
     val expected = List(Map("A" -> "b", "B" -> "a"), Map("A" -> "a", "B" -> "b"))
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueIndexUsageAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UniqueIndexUsageAcceptanceTest.scala
@@ -78,7 +78,7 @@ class UniqueIndexUsageAcceptanceTest extends ExecutionEngineFunSuite with Cypher
     for (i <- 4 to 30) createLabeledNode(Map("id" -> i), "Prop")
 
     // When
-    val result = executeWith(Configs.All - Configs.Compiled, "unwind [1,2,3] as x match (n:Prop) where n.id = x return n;",
+    val result = executeWith(Configs.Interpreted, "unwind [1,2,3] as x match (n:Prop) where n.id = x return n;",
       planComparisonStrategy = ComparePlansWithAssertion((planDescription) => {
         planDescription.toString should include("NodeUniqueIndexSeek")
       }, expectPlansToFail))

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UpdateReportingAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UpdateReportingAcceptanceTest.scala
@@ -24,7 +24,7 @@ import org.neo4j.internal.cypher.acceptance.CypherComparisonSupport.Configs
 
 class UpdateReportingAcceptanceTest extends ExecutionEngineFunSuite with CypherComparisonSupport {
   test("creating a node gets reported as such") {
-    val output = executeWith(Configs.Interpreted - Configs.Cost2_3, "create (:A)").dumpToString()
+    val output = executeWith(Configs.UpdateConf, "create (:A)").dumpToString()
 
     output should include("Nodes created: 1")
     output should include("Labels added: 1")

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UsingAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/UsingAcceptanceTest.scala
@@ -30,10 +30,6 @@ import org.neo4j.kernel.api.exceptions.Status
 class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTestSupport with CypherComparisonSupport {
   override def databaseConfig(): Map[Setting[_], String] = Map(GraphDatabaseSettings.cypher_hints_error -> "true")
 
-  val expectedToSucceed = Configs.All
-  val allPossibleConfigs = Configs.All + TestConfiguration(Versions.Default, Planners.Default,
-    Runtimes(Runtimes.Default, Runtimes.ProcedureOrSchema, Runtimes.CompiledSource, Runtimes.CompiledBytecode))
-
   test("should use index on literal value") {
     val node = createLabeledNode(Map("id" -> 123), "Foo")
     graph.createIndex("Foo", "id")
@@ -46,7 +42,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
         | RETURN f
       """.stripMargin
 
-    val result = executeWith(expectedToSucceed, query,
+    val result = executeWith(Configs.All, query,
       planComparisonStrategy = ComparePlansWithAssertion(_ should includeAtLeastOne(classOf[NodeIndexSeek], withVariable = "f"),
         expectPlansToFail = Configs.AllRulePlanners))
 
@@ -97,7 +93,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
     graph.createIndex("Person", "name")
 
     // WHEN & THEN
-    failWithError(allPossibleConfigs + Configs.Morsel, "start n=node(*) using index n:Person(name) where n:Person and n.name = 'kabam' return n", List("Invalid input"))
+    failWithError(Configs.AbsolutelyAll + Configs.Morsel, "start n=node(*) using index n:Person(name) where n:Person and n.name = 'kabam' return n", List("Invalid input"))
   }
 
   test("fail if using a variable with label not used in match") {
@@ -105,7 +101,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
     graph.createIndex("Person", "name")
 
     // WHEN
-    failWithError(allPossibleConfigs + Configs.Morsel - Configs.Version2_3, "match n-->() using index n:Person(name) where n.name = 'kabam' return n",
+    failWithError(Configs.AbsolutelyAll + Configs.Morsel - Configs.Version2_3, "match n-->() using index n:Person(name) where n.name = 'kabam' return n",
       List("Unknown variable `n`.", "Parentheses are required to identify nodes in patterns, i.e. (n)"))
   }
 
@@ -113,7 +109,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
     // GIVEN: NO INDEX
 
     // WHEN
-    failWithError(allPossibleConfigs + Configs.Morsel, "match (n:Person)-->() using index n:Person(name) where n.name = 'kabam' return n", List("No such index"))
+    failWithError(Configs.AbsolutelyAll + Configs.Morsel, "match (n:Person)-->() using index n:Person(name) where n.name = 'kabam' return n", List("No such index"))
   }
 
   test("fail if using hints with unusable equality predicate") {
@@ -121,7 +117,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
     graph.createIndex("Person", "name")
 
     // WHEN
-    failWithError(allPossibleConfigs + Configs.Morsel, "match (n:Person)-->() using index n:Person(name) where n.name <> 'kabam' return n", List("Cannot use index hint in this context"))
+    failWithError(Configs.AbsolutelyAll + Configs.Morsel, "match (n:Person)-->() using index n:Person(name) where n.name <> 'kabam' return n", List("Cannot use index hint in this context"))
   }
 
   test("fail if joining index hints in equality predicates") {
@@ -130,7 +126,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
     graph.createIndex("Food", "name")
 
     // WHEN
-    failWithError(allPossibleConfigs + Configs.Morsel,
+    failWithError(Configs.AbsolutelyAll + Configs.Morsel,
       "match (n:Person)-->(m:Food) using index n:Person(name) using index m:Food(name) where n.name = m.name return n",
       List("Failed to fulfil the hints of the query.",
         "Unknown variable",
@@ -139,7 +135,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
   }
 
   test("scan hints are handled by ronja") {
-    executeWith(expectedToSucceed, "match (n:Person) using scan n:Person return n").toList
+    executeWith(Configs.All, "match (n:Person) using scan n:Person return n").toList
   }
 
   test("fail when equality checks are done with OR") {
@@ -147,7 +143,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
     graph.createIndex("Person", "name")
 
     // WHEN
-    failWithError(allPossibleConfigs + Configs.Morsel - Configs.Version2_3, "match n-->() using index n:Person(name) where n.name = 'kabam' OR n.name = 'kaboom' return n",
+    failWithError(Configs.AbsolutelyAll + Configs.Morsel - Configs.Version2_3, "match n-->() using index n:Person(name) where n.name = 'kabam' OR n.name = 'kaboom' return n",
       List("Parentheses are required to identify nodes in patterns, i.e. (n)"))
   }
 
@@ -161,7 +157,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
         |RETURN n""".stripMargin
 
     // WHEN
-    failWithError(allPossibleConfigs + Configs.Morsel, query, List("No such index"), params = "foo" -> 42)
+    failWithError(Configs.AbsolutelyAll + Configs.Morsel, query, List("No such index"), params = "foo" -> 42)
   }
 
   test("should succeed (i.e. no warnings or errors) if executing a query using a 'USING INDEX' which can be fulfilled") {
@@ -237,7 +233,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
     graph.createIndex("Person", "name")
 
     //WHEN
-    val result = executeWith(expectedToSucceed, "MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name IN ['Jacob'] RETURN n")
+    val result = executeWith(Configs.All, "MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name IN ['Jacob'] RETURN n")
 
     //THEN
     result.toList should equal(List(Map("n" -> jake)))
@@ -253,7 +249,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
     graph.createIndex("Person", "name")
 
     //WHEN
-    val result = executeWith(expectedToSucceed, "MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name IN ['Jacob','Jacob'] RETURN n")
+    val result = executeWith(Configs.All, "MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name IN ['Jacob','Jacob'] RETURN n")
 
     //THEN
     result.toList should equal(List(Map("n" -> jake)))
@@ -269,7 +265,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
     graph.createIndex("Person", "name")
 
     //WHEN
-    val result = executeWith(expectedToSucceed, "MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name IN null RETURN n")
+    val result = executeWith(Configs.All, "MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name IN null RETURN n")
 
     //THEN
     result.toList should equal(List())
@@ -285,7 +281,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
     graph.createIndex("Person", "name")
 
     //WHEN
-    val result = executeWith(expectedToSucceed, "MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name IN {coll} RETURN n",
+    val result = executeWith(Configs.All, "MATCH (n:Person)-->() USING INDEX n:Person(name) WHERE n.name IN {coll} RETURN n",
       params = Map("coll" -> List("Jacob")))
 
     //THEN
@@ -301,7 +297,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
 
     // WHEN THEN
 
-    failWithError(allPossibleConfigs + Configs.Morsel,
+    failWithError(Configs.AbsolutelyAll + Configs.Morsel,
       "MATCH (n:Entity:Person) " +
         "USING INDEX n:Person(first_name) " +
         "USING INDEX n:Entity(source) " +
@@ -311,7 +307,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
   }
 
   test("does not accept multiple scan hints for the same variable") {
-    failWithError(allPossibleConfigs + Configs.Morsel,
+    failWithError(Configs.AbsolutelyAll + Configs.Morsel,
       "MATCH (n:Entity:Person) " +
         "USING SCAN n:Person " +
         "USING SCAN n:Entity " +
@@ -322,7 +318,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
   }
 
   test("does not accept multiple mixed hints for the same variable") {
-    failWithError(allPossibleConfigs + Configs.Morsel,
+    failWithError(Configs.AbsolutelyAll + Configs.Morsel,
       "MATCH (n:Entity:Person) " +
         "USING SCAN n:Person " +
         "USING INDEX n:Entity(first_name) " +
@@ -335,14 +331,14 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
     // GIVEN
 
     // WHEN
-    failWithError(allPossibleConfigs + Configs.Morsel, "MATCH (n:Person)-->() USING SCAN x:Person return n", List("Variable `x` not defined", "x not defined"))
+    failWithError(Configs.AbsolutelyAll + Configs.Morsel, "MATCH (n:Person)-->() USING SCAN x:Person return n", List("Variable `x` not defined", "x not defined"))
   }
 
   test("scan hint must fail if using label not used in the query") {
     // GIVEN
 
     // WHEN
-   failWithError(allPossibleConfigs + Configs.Morsel, "MATCH n-->() USING SCAN n:Person return n",
+   failWithError(Configs.AbsolutelyAll + Configs.Morsel, "MATCH n-->() USING SCAN n:Person return n",
      List("Cannot use label scan hint in this context.", "Parentheses are required to identify nodes in patterns, i.e. (n)"))
   }
 
@@ -411,7 +407,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
   }
 
   test("should fail when join hint is applied to an undefined node") {
-    failWithError(allPossibleConfigs + Configs.Morsel,
+    failWithError(Configs.AbsolutelyAll + Configs.Morsel,
       s"""
          |MATCH (a:A)-->(b:B)<--(c:C)
          |USING JOIN ON d
@@ -420,7 +416,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
   }
 
   test("should fail when join hint is applied to a single node") {
-    failWithError(allPossibleConfigs + Configs.Morsel,
+    failWithError(Configs.AbsolutelyAll + Configs.Morsel,
       s"""
          |MATCH (a:A)
          |USING JOIN ON a
@@ -429,7 +425,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
     }
 
   test("should fail when join hint is applied to a relationship") {
-      failWithError(allPossibleConfigs + Configs.Morsel,
+      failWithError(Configs.AbsolutelyAll + Configs.Morsel,
         s"""
            |MATCH (a:A)-[r1]->(b:B)-[r2]->(c:C)
            |USING JOIN ON r1
@@ -438,7 +434,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
     }
 
   test("should fail when join hint is applied to a path") {
-      failWithError(allPossibleConfigs + Configs.Morsel,
+      failWithError(Configs.AbsolutelyAll + Configs.Morsel,
         s"""
            |MATCH p=(a:A)-->(b:B)-->(c:C)
            |USING JOIN ON p
@@ -742,7 +738,7 @@ class UsingAcceptanceTest extends ExecutionEngineFunSuite with RunWithConfigTest
   test("USING INDEX hint should not clash with used variables") {
     graph.createIndex("PERSON", "id")
 
-    val result = executeWith(expectedToSucceed,
+    val result = executeWith(Configs.All,
       """MATCH (actor:PERSON {id: 1})
         |USING INDEX actor:PERSON(id)
         |WITH 14 as id

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/VarLengthPlanningTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/VarLengthPlanningTest.scala
@@ -33,11 +33,13 @@ import scala.collection.mutable
 
 class VarLengthPlanningTest extends ExecutionEngineFunSuite with QueryStatisticsTestSupport with CypherComparisonSupport {
 
+  private val expectedToSucceed = Configs.Interpreted
+
   test("should handle LIKES*0.LIKES") {
     //Given
     makeTreeModel(maxNodeDepth = 4)
     //When
-    val result = executeWith(Configs.Interpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES*0]->()-[r:LIKES]->(c) RETURN c")
+    val result = executeWith(expectedToSucceed, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES*0]->()-[r:LIKES]->(c) RETURN c")
     //Then
     result should haveNoneRelFilter
   }
@@ -46,7 +48,7 @@ class VarLengthPlanningTest extends ExecutionEngineFunSuite with QueryStatistics
     //Given
     makeTreeModel(maxNodeDepth = 4)
     //When
-    val result = executeWith(Configs.Interpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()-[r:LIKES*0]->(c) RETURN c")
+    val result = executeWith(expectedToSucceed, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()-[r:LIKES*0]->(c) RETURN c")
     //Then
     result should haveNoneRelFilter
   }
@@ -55,7 +57,7 @@ class VarLengthPlanningTest extends ExecutionEngineFunSuite with QueryStatistics
     //Given
     makeTreeModel(maxNodeDepth = 4)
     //When
-    val result = executeWith(Configs.Interpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES*1]->()-[r:LIKES]->(c) RETURN c")
+    val result = executeWith(expectedToSucceed, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES*1]->()-[r:LIKES]->(c) RETURN c")
     //Then
     result should haveNoneRelFilter
   }
@@ -64,7 +66,7 @@ class VarLengthPlanningTest extends ExecutionEngineFunSuite with QueryStatistics
     //Given
     makeTreeModel(maxNodeDepth = 4)
     //When
-    val result = executeWith(Configs.Interpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()-[r:LIKES*1]->(c) RETURN c")
+    val result = executeWith(expectedToSucceed, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()-[r:LIKES*1]->(c) RETURN c")
     //Then
     result should haveNoneRelFilter
   }
@@ -73,7 +75,7 @@ class VarLengthPlanningTest extends ExecutionEngineFunSuite with QueryStatistics
     //Given
     makeTreeModel(maxNodeDepth = 4)
     //When
-    val result = executeWith(Configs.Interpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES*2]->()-[r:LIKES]->(c) RETURN c")
+    val result = executeWith(expectedToSucceed, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES*2]->()-[r:LIKES]->(c) RETURN c")
     //Then
     result should haveNoneRelFilter
   }
@@ -82,7 +84,7 @@ class VarLengthPlanningTest extends ExecutionEngineFunSuite with QueryStatistics
     //Given
     makeTreeModel(maxNodeDepth = 4)
     //When
-    val result = executeWith(Configs.Interpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()-[r:LIKES*2]->(c) RETURN c")
+    val result = executeWith(expectedToSucceed, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()-[r:LIKES*2]->(c) RETURN c")
     //Then
     result should haveNoneRelFilter
   }
@@ -91,7 +93,7 @@ class VarLengthPlanningTest extends ExecutionEngineFunSuite with QueryStatistics
     //Given
     makeTreeModel(maxNodeDepth = 5)
     //When
-    val result = executeWith(Configs.Interpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()-[r:LIKES*3]->(c) RETURN c")
+    val result = executeWith(expectedToSucceed, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()-[r:LIKES*3]->(c) RETURN c")
     //Then
     result should haveNoneRelFilter
   }
@@ -100,7 +102,7 @@ class VarLengthPlanningTest extends ExecutionEngineFunSuite with QueryStatistics
     //Given
     makeTreeModel(maxNodeDepth = 5, directions = Seq(INCOMING))
     //When
-    val result = executeWith(Configs.Interpreted, "MATCH (p { id:'n0' }) MATCH (p)<-[:LIKES]-()-[r:LIKES*3]->(c) RETURN c")
+    val result = executeWith(expectedToSucceed, "MATCH (p { id:'n0' }) MATCH (p)<-[:LIKES]-()-[r:LIKES*3]->(c) RETURN c")
     //Then
     result should haveNoneRelFilter
   }
@@ -109,7 +111,7 @@ class VarLengthPlanningTest extends ExecutionEngineFunSuite with QueryStatistics
     //Given
     makeTreeModel(maxNodeDepth = 5, directions = Seq(OUTGOING, INCOMING, INCOMING, INCOMING))
     //When
-    val result = executeWith(Configs.Interpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()<-[r:LIKES*3]->(c) RETURN c")
+    val result = executeWith(expectedToSucceed, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()<-[r:LIKES*3]->(c) RETURN c")
     //Then
     result should haveNoneRelFilter
   }
@@ -118,7 +120,7 @@ class VarLengthPlanningTest extends ExecutionEngineFunSuite with QueryStatistics
     //Given
     makeTreeModel(maxNodeDepth = 5)
     //When
-    val result = executeWith(Configs.Interpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES*1]->()-[:LIKES]->()-[r:LIKES*2]->(c) RETURN c")
+    val result = executeWith(expectedToSucceed, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES*1]->()-[:LIKES]->()-[r:LIKES*2]->(c) RETURN c")
     //Then
     result should haveNoneRelFilter
   }
@@ -127,7 +129,7 @@ class VarLengthPlanningTest extends ExecutionEngineFunSuite with QueryStatistics
     //Given
     makeTreeModel(maxNodeDepth = 5)
     //When
-    val result = executeWith(Configs.Interpreted, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()-[:LIKES*2]->()-[r:LIKES]->(c) RETURN c")
+    val result = executeWith(expectedToSucceed, "MATCH (p { id:'n0' }) MATCH (p)-[:LIKES]->()-[:LIKES*2]->()-[r:LIKES]->(c) RETURN c")
     //Then
     result should haveNoneRelFilter
   }


### PR DESCRIPTION
Includes:
- Create 2 new handy short TestConfigs
- Simplify a lot of configuration code

Note:
`resultAssertionInTx = None` was required to make the tests work, but maybe the base scenario should be able to use the same resultAssertionInTx function as the other scenarios does? Or is it running in a transaction anyway?