### PR TITLE
Active page cache warmup

### DIFF
--- a/community/common/src/main/java/org/neo4j/scheduler/JobScheduler.java
+++ b/community/common/src/main/java/org/neo4j/scheduler/JobScheduler.java
@@ -202,6 +202,8 @@ public interface JobScheduler extends Lifecycle
          */
         public static Group vmPauseMonitor = new Group( "VmPauseMonitor" );
 
+        public static Group pageCacheIOHelper = new Group( "PageCacheIOHelper" );
+
         private Groups()
         {
         }
@@ -235,7 +237,9 @@ public interface JobScheduler extends Lifecycle
     /** Expose a group scheduler as an {@link Executor} */
     Executor executor( Group group );
 
-    /** Creates an {@link ExecutorService} that does works-stealing - read more about this in {@link ForkJoinPool}*/
+    /**
+     * Creates an {@link ExecutorService} that does works-stealing - read more about this in {@link ForkJoinPool}
+     */
     ExecutorService workStealingExecutor( Group group, int parallelism );
 
     /**

--- a/community/common/src/main/java/org/neo4j/scheduler/JobScheduler.java
+++ b/community/common/src/main/java/org/neo4j/scheduler/JobScheduler.java
@@ -160,49 +160,52 @@ public interface JobScheduler extends Lifecycle
         /**
          * UDC timed events.
          */
-        public static Group udc  = new Group( "UsageDataCollection" );
+        public static final Group udc  = new Group( "UsageDataCollection" );
 
         /**
          * Storage maintenance.
          */
-        public static Group storageMaintenance = new Group( "StorageMaintenance" );
+        public static final Group storageMaintenance = new Group( "StorageMaintenance" );
 
         /**
          * Raft timers.
          */
-        public static Group raft = new Group( "RaftTimer" );
+        public static final Group raft = new Group( "RaftTimer" );
 
         /**
          * Native security.
          */
-        public static Group nativeSecurity = new Group( "NativeSecurity" );
+        public static final Group nativeSecurity = new Group( "NativeSecurity" );
 
         /**
          * File watch service group
          */
-        public static Group fileWatch = new Group( "FileWatcher" );
+        public static final Group fileWatch = new Group( "FileWatcher" );
 
         /**
          * Recovery cleanup.
          */
-        public static Group recoveryCleanup = new Group( "RecoveryCleanup" );
+        public static final Group recoveryCleanup = new Group( "RecoveryCleanup" );
 
         /**
          * Kernel transaction timeout monitor.
          */
-        public static Group transactionTimeoutMonitor = new Group( "TransactionTimeoutMonitor" );
+        public static final Group transactionTimeoutMonitor = new Group( "TransactionTimeoutMonitor" );
 
         /**
          * Kernel transaction timeout monitor.
          */
-        public static Group cypherWorker = new Group( "CypherWorker" );
+        public static final Group cypherWorker = new Group( "CypherWorker" );
 
         /**
          * VM pause monitor
          */
-        public static Group vmPauseMonitor = new Group( "VmPauseMonitor" );
+        public static final Group vmPauseMonitor = new Group( "VmPauseMonitor" );
 
-        public static Group pageCacheIOHelper = new Group( "PageCacheIOHelper" );
+        /**
+         * IO helper threads for page cache and IO related stuff.
+         */
+        public static final Group pageCacheIOHelper = new Group( "PageCacheIOHelper" );
 
         private Groups()
         {

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
@@ -138,4 +138,10 @@ public interface PageCache extends AutoCloseable
      * @return the filesystem that the page cache is using.
      */
     FileSystemAbstraction getCachedFileSystem();
+
+    /**
+     * Report any thread-local events to the global page cache tracer, as if acquiring a thread-specific page cursor
+     * tracer, and reporting the events collected within it.
+     */
+    void reportEvents();
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageCache.java
@@ -134,6 +134,7 @@ public interface PageCache extends AutoCloseable
 
     /**
      * Get the {@link FileSystemAbstraction} that represents the filesystem where the paged files reside.
+     *
      * @return the filesystem that the page cache is using.
      */
     FileSystemAbstraction getCachedFileSystem();

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PagedFile.java
@@ -150,6 +150,11 @@ public interface PagedFile extends AutoCloseable
     long fileSize() throws IOException;
 
     /**
+     * Get the filename that is mapped by this {@code PagedFile}.
+     */
+    File file();
+
+    /**
      * Flush all dirty pages into the file channel, and force the file channel to disk.
      */
     void flushAndForce() throws IOException;

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -690,6 +690,12 @@ public class MuninnPageCache implements PageCache
         return swapperFactory.getFileSystemAbstraction();
     }
 
+    @Override
+    public void reportEvents()
+    {
+        pageCursorTracerSupplier.get().reportEvents();
+    }
+
     int getPageCacheId()
     {
         return pageCacheId;

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -999,7 +999,7 @@ public class MuninnPageCache implements PageCache
 
     void vacuum( SwapperSet swappers )
     {
-        if ( getFreelistHead() instanceof AtomicInteger  && swappers.countAvailableIds() > 200 )
+        if ( getFreelistHead() instanceof AtomicInteger && swappers.countAvailableIds() > 200 )
         {
             return; // We probably still have plenty of free pages left. Don't bother vacuuming just yet.
         }
@@ -1025,6 +1025,6 @@ public class MuninnPageCache implements PageCache
             {
                 throw new UncheckedIOException( e );
             }
-        });
+        } );
     }
 }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPagedFile.java
@@ -214,7 +214,8 @@ final class MuninnPagedFile extends PageList implements PagedFile, Flushable
         return (lastPageId + 1) * pageSize();
     }
 
-    File file()
+    @Override
+    public File file()
     {
         return swapper.file();
     }

--- a/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialPageCache.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialPageCache.java
@@ -128,4 +128,10 @@ public class AdversarialPageCache implements PageCache
     {
         return delegate.getCachedFileSystem();
     }
+
+    @Override
+    public void reportEvents()
+    {
+        delegate.reportEvents();
+    }
 }

--- a/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialPagedFile.java
+++ b/community/io/src/test/java/org/neo4j/adversaries/pagecache/AdversarialPagedFile.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.adversaries.pagecache;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.channels.ReadableByteChannel;
@@ -74,6 +75,12 @@ public class AdversarialPagedFile implements PagedFile
     {
         adversary.injectFailure( IllegalStateException.class );
         return delegate.fileSize();
+    }
+
+    @Override
+    public File file()
+    {
+        return delegate.file();
     }
 
     @Override

--- a/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPageCache.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPageCache.java
@@ -79,6 +79,12 @@ public class DelegatingPageCache implements PageCache
     }
 
     @Override
+    public void reportEvents()
+    {
+        delegate.reportEvents();
+    }
+
+    @Override
     public void flushAndForce( IOLimiter limiter ) throws IOException
     {
         delegate.flushAndForce( limiter );

--- a/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPagedFile.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/DelegatingPagedFile.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.io.pagecache;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
@@ -60,6 +61,12 @@ public class DelegatingPagedFile implements PagedFile
     public long fileSize() throws IOException
     {
         return delegate.fileSize();
+    }
+
+    @Override
+    public File file()
+    {
+        return delegate.file();
     }
 
     @Override

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -2180,7 +2180,7 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
             }
         }
 
-        cursorTracerSupplier.get().reportEvents();
+        pageCache.reportEvents();
 
         assertThat( "wrong count of pins", tracer.pins(), is( countedPages ) );
         assertThat( "wrong count of unpins", tracer.unpins(), is( countedPages ) );
@@ -2228,7 +2228,7 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
             assertTrue( cursor.next( 0 ) );
             assertTrue( cursor.next( 0 ) );
         }
-        tracerSupplier.get().reportEvents();
+        pageCache.reportEvents();
 
         assertThat( "wrong count of pins", tracer.pins(), is( pagesToGenerate + 1 ) );
         assertThat( "wrong count of unpins", tracer.unpins(), is( pagesToGenerate + 1 ) );
@@ -2300,7 +2300,7 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
             dirtyManyPages( pagedFile, pinsForWrite );
         }
 
-        cursorTracerSupplier.get().reportEvents(); // Reset thread-local event counters.
+        pageCache.reportEvents(); // Reset thread-local event counters.
         assertThat( "wrong read pin count", readCount.get(), is( pinsForRead ) );
         assertThat( "wrong write pin count", writeCount.get(), is( pinsForWrite ) );
     }

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -80,6 +80,7 @@ import static java.nio.file.StandardOpenOption.DELETE_ON_CLOSE;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
@@ -130,6 +131,17 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
     public void mustAcceptTwoPagesAsMinimumConfiguration()
     {
         getPageCache( fs, 2, PageCacheTracer.NULL, PageCursorTracerSupplier.NULL );
+    }
+
+    @Test
+    public void gettingNameFromMappedFileMustMatchMappedFileName() throws Exception
+    {
+        configureStandardPageCache();
+        File file = file( "a" );
+        try ( PagedFile pf = pageCache.map( file, filePageSize ) )
+        {
+            assertThat( pf.file(), equalTo( file ) );
+        }
     }
 
     @Test

--- a/community/io/src/test/java/org/neo4j/io/pagecache/StubPagedFile.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/StubPagedFile.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.io.pagecache;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
@@ -62,6 +63,12 @@ public class StubPagedFile implements PagedFile
             return 0L;
         }
         return (lastPageId + 1) * pageSize();
+    }
+
+    @Override
+    public File file()
+    {
+        return new File( "stub" );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -570,7 +570,7 @@ public class GraphDatabaseSettings implements LoadableConfig
     @Internal
     @Description( "The profiling frequency for the page cache. Accurate profiles allow the page cache to do active " +
                   "warmup after a restart, reducing the mean time to performance." )
-    public static Setting<Duration> pagecache_warmup_profiling_interval =
+    public static final Setting<Duration> pagecache_warmup_profiling_interval =
             setting( "unsupported.dbms.memory.pagecache.warmup.profile.interval", DURATION, "1m" );
 
     /**

--- a/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
+++ b/community/kernel/src/main/java/org/neo4j/graphdb/factory/GraphDatabaseSettings.java
@@ -567,6 +567,12 @@ public class GraphDatabaseSettings implements LoadableConfig
     public static final Setting<String> pagecache_swapper =
             setting( "dbms.memory.pagecache.swapper", STRING, null );
 
+    @Internal
+    @Description( "The profiling frequency for the page cache. Accurate profiles allow the page cache to do active " +
+                  "warmup after a restart, reducing the mean time to performance." )
+    public static Setting<Duration> pagecache_warmup_profiling_interval =
+            setting( "unsupported.dbms.memory.pagecache.warmup.profile.interval", DURATION, "1m" );
+
     /**
      * Block size properties values depends from selected record format.
      * We can't figured out record format until it will be selected by corresponding edition.

--- a/community/kernel/src/main/java/org/neo4j/helpers/Format.java
+++ b/community/kernel/src/main/java/org/neo4j/helpers/Format.java
@@ -159,6 +159,13 @@ public class Format
             }
         }
 
+        if ( builder.length() == 0 )
+        {
+            // The value is too low to extract any meaningful numbers with the given unit brackets.
+            // So we append a zero of the lowest unit.
+            builder.append( "0" ).append( shortName( lowestGranularity ) );
+        }
+
         return builder.toString();
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/factory/CommunityEditionModule.java
@@ -143,7 +143,12 @@ public class CommunityEditionModule extends EditionModule
         dependencies.satisfyDependency( createSessionTracker() );
     }
 
-    static Predicate<String> fileWatcherFileNameFilter()
+    protected Predicate<String> fileWatcherFileNameFilter()
+    {
+        return communityFileWatcherFileNameFilter();
+    }
+
+    static Predicate<String> communityFileWatcherFileNameFilter()
     {
         return Predicates.any(
                 fileName -> fileName.startsWith( TransactionLogFiles.DEFAULT_NAME ),

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Neo4jJobScheduler.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/util/Neo4jJobScheduler.java
@@ -113,7 +113,7 @@ public class Neo4jJobScheduler extends LifecycleAdapter implements JobScheduler
             throw new RejectedExecutionException( "Scheduler is not started" );
         }
 
-        return register( new PooledJobHandle( this.globalPool.submit( job ) ) );
+        return register( new PooledJobHandle( globalPool.submit( job ) ) );
     }
 
     private JobHandle register( PooledJobHandle pooledJobHandle )

--- a/community/kernel/src/test/java/org/neo4j/helpers/FormatTest.java
+++ b/community/kernel/src/test/java/org/neo4j/helpers/FormatTest.java
@@ -21,6 +21,10 @@ package org.neo4j.helpers;
 
 import org.junit.Test;
 
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class FormatTest
@@ -121,5 +125,13 @@ public class FormatTest
         // then
         assertTrue( format.startsWith( "4" ) );
         assertTrue( format.endsWith( "T" ) );
+    }
+
+    @Test
+    public void displayDuration()
+    {
+        assertThat( Format.duration( MINUTES.toMillis( 1 ) + SECONDS.toMillis( 2 ) ), is( "1m 2s" ) );
+        assertThat( Format.duration( 42 ), is( "42ms" ) );
+        assertThat( Format.duration( 0 ), is( "0ms" ) );
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/factory/CommunityEditionModuleIntegrationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/factory/CommunityEditionModuleIntegrationTest.java
@@ -71,7 +71,7 @@ public class CommunityEditionModuleIntegrationTest
     @Test
     public void fileWatcherFileNameFilter()
     {
-        Predicate<String> filter = CommunityEditionModule.fileWatcherFileNameFilter();
+        Predicate<String> filter = CommunityEditionModule.communityFileWatcherFileNameFilter();
         assertFalse( filter.test( MetaDataStore.DEFAULT_NAME ) );
         assertFalse( filter.test( StoreFile.NODE_STORE.fileName( StoreFileType.STORE ) ) );
         assertTrue( filter.test( TransactionLogFiles.DEFAULT_NAME + ".1" ) );

--- a/community/kernel/src/test/java/org/neo4j/test/rule/EmbeddedDatabaseRule.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/EmbeddedDatabaseRule.java
@@ -31,7 +31,7 @@ import org.neo4j.test.TestGraphDatabaseFactory;
 
 /**
  * JUnit @Rule for configuring, creating and managing an EmbeddedGraphDatabase instance.
- *
+ * <p>
  * The database instance is created lazily, so configurations can be injected prior to calling
  * {@link #getGraphDatabaseAPI()}.
  */
@@ -78,5 +78,16 @@ public class EmbeddedDatabaseRule extends DatabaseRule
     public Statement apply( Statement base, Description description )
     {
         return testDirectory.apply( super.apply( base, description ), description );
+    }
+
+    /**
+     * Get the inner {@link TestDirectory} instance that is used to prepare the store directory for this database.
+     * <p>
+     * <strong>Note:</strong> There is no need to add a {@link org.junit.Rule} annotation on this {@link TestDirectory}
+     * instance.
+     */
+    public TestDirectory getTestDirectory()
+    {
+        return testDirectory;
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/EnterpriseCoreEditionModule.java
@@ -99,6 +99,7 @@ import org.neo4j.kernel.impl.factory.PlatformModule;
 import org.neo4j.kernel.impl.factory.StatementLocksFactorySelector;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.impl.pagecache.PageCacheWarmer;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdReuseEligibility;
@@ -329,7 +330,9 @@ public class EnterpriseCoreEditionModule extends EditionModule
         return Predicates.any(
                 fileName -> fileName.startsWith( TransactionLogFiles.DEFAULT_NAME ),
                 fileName -> fileName.startsWith( IndexConfigStore.INDEX_DB_FILE_NAME ),
-                filename -> filename.startsWith( StoreUtil.TEMP_COPY_DIRECTORY_NAME )
+                filename -> filename.startsWith( StoreUtil.TEMP_COPY_DIRECTORY_NAME ),
+                filename -> filename.endsWith( PageCacheWarmer.SUFFIX_CACHEPROF ),
+                filename -> filename.endsWith( PageCacheWarmer.SUFFIX_CACHEPROF_TMP )
         );
     }
 

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModule.java
@@ -91,6 +91,7 @@ import org.neo4j.kernel.impl.factory.ReadOnly;
 import org.neo4j.kernel.impl.factory.StatementLocksFactorySelector;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.impl.pagecache.PageCacheWarmer;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.store.id.DefaultIdGeneratorFactory;
 import org.neo4j.kernel.impl.store.id.IdReuseEligibility;
@@ -303,7 +304,9 @@ public class EnterpriseReadReplicaEditionModule extends EditionModule
         return Predicates.any( fileName -> fileName.startsWith( TransactionLogFiles.DEFAULT_NAME ),
                 fileName -> fileName.startsWith( IndexConfigStore.INDEX_DB_FILE_NAME ),
                 filename -> filename.startsWith( StoreUtil.BRANCH_SUBDIRECTORY ),
-                filename -> filename.startsWith( StoreUtil.TEMP_COPY_DIRECTORY_NAME ) );
+                filename -> filename.startsWith( StoreUtil.TEMP_COPY_DIRECTORY_NAME ),
+                filename -> filename.endsWith( PageCacheWarmer.SUFFIX_CACHEPROF ),
+                filename -> filename.endsWith( PageCacheWarmer.SUFFIX_CACHEPROF_TMP ) );
     }
 
     @Override

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModuleTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/readreplica/EnterpriseReadReplicaEditionModuleTest.java
@@ -25,6 +25,7 @@ import java.util.function.Predicate;
 
 import org.neo4j.com.storecopy.StoreUtil;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
+import org.neo4j.kernel.impl.pagecache.PageCacheWarmer;
 import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.StoreFile;
 import org.neo4j.kernel.impl.storemigration.StoreFileType;
@@ -45,5 +46,7 @@ public class EnterpriseReadReplicaEditionModuleTest
         assertTrue( filter.test( IndexConfigStore.INDEX_DB_FILE_NAME + ".any" ) );
         assertTrue( filter.test( StoreUtil.BRANCH_SUBDIRECTORY ) );
         assertTrue( filter.test( StoreUtil.TEMP_COPY_DIRECTORY_NAME ) );
+        assertTrue( filter.test( MetaDataStore.DEFAULT_NAME + PageCacheWarmer.SUFFIX_CACHEPROF ) );
+        assertTrue( filter.test( MetaDataStore.DEFAULT_NAME + PageCacheWarmer.SUFFIX_CACHEPROF_TMP ) );
     }
 }

--- a/enterprise/cluster/LICENSES.txt
+++ b/enterprise/cluster/LICENSES.txt
@@ -4,11 +4,13 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Lucene Core
   Lucene Memory
   Netty
   Netty/All-in-One
+  Objenesis
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/enterprise/cluster/NOTICE.txt
+++ b/enterprise/cluster/NOTICE.txt
@@ -26,11 +26,13 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Lucene Core
   Lucene Memory
   Netty
   Netty/All-in-One
+  Objenesis
 
 Bouncy Castle License
   Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs

--- a/enterprise/com/LICENSES.txt
+++ b/enterprise/com/LICENSES.txt
@@ -4,11 +4,13 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Lucene Core
   Lucene Memory
   Netty
   Netty/All-in-One
+  Objenesis
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/enterprise/com/NOTICE.txt
+++ b/enterprise/com/NOTICE.txt
@@ -26,11 +26,13 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Lucene Core
   Lucene Memory
   Netty
   Netty/All-in-One
+  Objenesis
 
 Bouncy Castle License
   Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs

--- a/enterprise/com/src/main/java/org/neo4j/com/storecopy/ExternallyManagedPageCache.java
+++ b/enterprise/com/src/main/java/org/neo4j/com/storecopy/ExternallyManagedPageCache.java
@@ -111,6 +111,12 @@ public class ExternallyManagedPageCache implements PageCache
         return delegate.getCachedFileSystem();
     }
 
+    @Override
+    public void reportEvents()
+    {
+        delegate.reportEvents();
+    }
+
     /**
      * Create a GraphDatabaseFactory that will build EmbeddedGraphDatabase instances that all use the given page cache.
      */

--- a/enterprise/cypher/acceptance-spec-suite/LICENSES.txt
+++ b/enterprise/cypher/acceptance-spec-suite/LICENSES.txt
@@ -4,6 +4,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   ConcurrentLinkedHashMap
@@ -15,6 +16,7 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
+  Objenesis
   opencsv
   parboiled-core
   parboiled-scala

--- a/enterprise/cypher/acceptance-spec-suite/NOTICE.txt
+++ b/enterprise/cypher/acceptance-spec-suite/NOTICE.txt
@@ -26,6 +26,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   ConcurrentLinkedHashMap
@@ -37,6 +38,7 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
+  Objenesis
   opencsv
   parboiled-core
   parboiled-scala

--- a/enterprise/cypher/compatibility-spec-suite/LICENSES.txt
+++ b/enterprise/cypher/compatibility-spec-suite/LICENSES.txt
@@ -4,6 +4,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   ConcurrentLinkedHashMap
@@ -15,6 +16,7 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
+  Objenesis
   opencsv
   openCypher TCK Features and Graphs
   parboiled-core

--- a/enterprise/cypher/compatibility-spec-suite/NOTICE.txt
+++ b/enterprise/cypher/compatibility-spec-suite/NOTICE.txt
@@ -26,6 +26,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   ConcurrentLinkedHashMap
@@ -37,6 +38,7 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
+  Objenesis
   opencsv
   openCypher TCK Features and Graphs
   parboiled-core

--- a/enterprise/cypher/cypher/LICENSES.txt
+++ b/enterprise/cypher/cypher/LICENSES.txt
@@ -4,6 +4,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   ConcurrentLinkedHashMap
@@ -15,6 +16,7 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
+  Objenesis
   opencsv
   parboiled-core
   parboiled-scala

--- a/enterprise/cypher/cypher/NOTICE.txt
+++ b/enterprise/cypher/cypher/NOTICE.txt
@@ -26,6 +26,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   ConcurrentLinkedHashMap
@@ -37,6 +38,7 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
+  Objenesis
   opencsv
   parboiled-core
   parboiled-scala

--- a/enterprise/cypher/morsel-runtime/LICENSES.txt
+++ b/enterprise/cypher/morsel-runtime/LICENSES.txt
@@ -4,6 +4,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   ConcurrentLinkedHashMap
@@ -13,6 +14,7 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
+  Objenesis
   opencsv
   parboiled-core
   parboiled-scala

--- a/enterprise/cypher/morsel-runtime/NOTICE.txt
+++ b/enterprise/cypher/morsel-runtime/NOTICE.txt
@@ -26,6 +26,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   ConcurrentLinkedHashMap
@@ -35,6 +36,7 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
+  Objenesis
   opencsv
   parboiled-core
   parboiled-scala

--- a/enterprise/cypher/slotted-runtime/LICENSES.txt
+++ b/enterprise/cypher/slotted-runtime/LICENSES.txt
@@ -4,6 +4,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   ConcurrentLinkedHashMap
@@ -13,6 +14,7 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
+  Objenesis
   opencsv
   parboiled-core
   parboiled-scala

--- a/enterprise/cypher/slotted-runtime/NOTICE.txt
+++ b/enterprise/cypher/slotted-runtime/NOTICE.txt
@@ -26,6 +26,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   ConcurrentLinkedHashMap
@@ -35,6 +36,7 @@ Apache Software License, Version 2.0
   Lucene Memory
   Lucene QueryParsers
   Netty/All-in-One
+  Objenesis
   opencsv
   parboiled-core
   parboiled-scala

--- a/enterprise/cypher/spec-suite-tools/LICENSES.txt
+++ b/enterprise/cypher/spec-suite-tools/LICENSES.txt
@@ -4,6 +4,7 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   casbah-commons
@@ -20,6 +21,7 @@ Apache Software License, Version 2.0
   MongoDB Java Driver
   Netty/All-in-One
   nscala-time
+  Objenesis
   openCypher TCK API
   openCypher TCK Features and Graphs
   org.apiguardian:apiguardian-api

--- a/enterprise/cypher/spec-suite-tools/NOTICE.txt
+++ b/enterprise/cypher/spec-suite-tools/NOTICE.txt
@@ -26,6 +26,7 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Caffeine cache
   casbah-commons
@@ -42,6 +43,7 @@ Apache Software License, Version 2.0
   MongoDB Java Driver
   Netty/All-in-One
   nscala-time
+  Objenesis
   openCypher TCK API
   openCypher TCK Features and Graphs
   org.apiguardian:apiguardian-api

--- a/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
+++ b/enterprise/ha/src/main/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModule.java
@@ -152,6 +152,7 @@ import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.StatementLocksFactory;
 import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.impl.pagecache.PageCacheWarmer;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.StoreId;
@@ -576,7 +577,9 @@ public class HighlyAvailableEditionModule
                 fileName -> fileName.startsWith( TransactionLogFiles.DEFAULT_NAME ),
                 fileName -> fileName.startsWith( IndexConfigStore.INDEX_DB_FILE_NAME ),
                 filename -> filename.startsWith( StoreUtil.BRANCH_SUBDIRECTORY ),
-                filename -> filename.startsWith( StoreUtil.TEMP_COPY_DIRECTORY_NAME )
+                filename -> filename.startsWith( StoreUtil.TEMP_COPY_DIRECTORY_NAME ),
+                filename -> filename.endsWith( PageCacheWarmer.SUFFIX_CACHEPROF ),
+                filename -> filename.endsWith( PageCacheWarmer.SUFFIX_CACHEPROF_TMP )
         );
     }
 

--- a/enterprise/ha/src/test/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModuleIT.java
+++ b/enterprise/ha/src/test/java/org/neo4j/kernel/ha/factory/HighlyAvailableEditionModuleIT.java
@@ -28,6 +28,7 @@ import org.neo4j.com.storecopy.StoreUtil;
 import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.kernel.impl.ha.ClusterManager;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
+import org.neo4j.kernel.impl.pagecache.PageCacheWarmer;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.id.BufferedIdController;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.id.IdController;
 import org.neo4j.kernel.impl.store.MetaDataStore;
@@ -71,5 +72,7 @@ public class HighlyAvailableEditionModuleIT
         assertTrue( filter.test( IndexConfigStore.INDEX_DB_FILE_NAME + ".any" ) );
         assertTrue( filter.test( StoreUtil.BRANCH_SUBDIRECTORY ) );
         assertTrue( filter.test( StoreUtil.TEMP_COPY_DIRECTORY_NAME ) );
+        assertTrue( filter.test( MetaDataStore.DEFAULT_NAME + PageCacheWarmer.SUFFIX_CACHEPROF ) );
+        assertTrue( filter.test( MetaDataStore.DEFAULT_NAME + PageCacheWarmer.SUFFIX_CACHEPROF_TMP ) );
     }
 }

--- a/enterprise/kernel/LICENSES.txt
+++ b/enterprise/kernel/LICENSES.txt
@@ -4,10 +4,12 @@ libraries. For an overview of the licenses see the NOTICE.txt file.
 
 ------------------------------------------------------------------------------
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Lucene Core
   Lucene Memory
   Netty/All-in-One
+  Objenesis
 ------------------------------------------------------------------------------
 
                                  Apache License

--- a/enterprise/kernel/NOTICE.txt
+++ b/enterprise/kernel/NOTICE.txt
@@ -26,10 +26,12 @@ Third-party licenses
 --------------------
 
 Apache Software License, Version 2.0
+  Apache Commons Compress
   Apache Commons Lang
   Lucene Core
   Lucene Memory
   Netty/All-in-One
+  Objenesis
 
 Bouncy Castle License
   Bouncy Castle PKIX, CMS, EAC, TSP, PKCS, OCSP, CMP, and CRMF APIs

--- a/enterprise/kernel/pom.xml
+++ b/enterprise/kernel/pom.xml
@@ -69,6 +69,10 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+    </dependency>
 
     <!-- Neo4j test dependencies -->
     <dependency>

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModule.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModule.java
@@ -19,6 +19,9 @@
  */
 package org.neo4j.kernel.impl.enterprise;
 
+import java.util.function.Predicate;
+
+import org.neo4j.function.Predicates;
 import org.neo4j.graphdb.factory.GraphDatabaseSettings;
 import org.neo4j.kernel.api.bolt.BoltConnectionTracker;
 import org.neo4j.internal.kernel.api.exceptions.KernelException;
@@ -34,12 +37,15 @@ import org.neo4j.kernel.impl.factory.CommunityEditionModule;
 import org.neo4j.kernel.impl.factory.EditionModule;
 import org.neo4j.kernel.impl.factory.PlatformModule;
 import org.neo4j.kernel.impl.factory.StatementLocksFactorySelector;
+import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.locking.Locks;
 import org.neo4j.kernel.impl.locking.StatementLocksFactory;
 import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.impl.pagecache.PageCacheWarmer;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.store.id.configuration.IdTypeConfigurationProvider;
 import org.neo4j.kernel.impl.store.stats.IdBasedStoreEntityCounters;
+import org.neo4j.kernel.impl.transaction.log.files.TransactionLogFiles;
 
 /**
  * This implementation of {@link EditionModule} creates the implementations of services
@@ -59,6 +65,22 @@ public class EnterpriseEditionModule extends CommunityEditionModule
         platformModule.dependencies.satisfyDependency( new IdBasedStoreEntityCounters( this.idGeneratorFactory ) );
         ioLimiter = new ConfigurableIOLimiter( platformModule.config );
         platformModule.dependencies.satisfyDependency( createSessionTracker() );
+    }
+
+    @Override
+    protected Predicate<String> fileWatcherFileNameFilter()
+    {
+        return enterpriseNonClusterFileWatcherFileNameFilter();
+    }
+
+    static Predicate<String> enterpriseNonClusterFileWatcherFileNameFilter()
+    {
+        return Predicates.any(
+                fileName -> fileName.startsWith( TransactionLogFiles.DEFAULT_NAME ),
+                fileName -> fileName.startsWith( IndexConfigStore.INDEX_DB_FILE_NAME ),
+                filename -> filename.endsWith( PageCacheWarmer.SUFFIX_CACHEPROF ),
+                filename -> filename.endsWith( PageCacheWarmer.SUFFIX_CACHEPROF_TMP )
+        );
     }
 
     @Override

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmer.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmer.java
@@ -72,6 +72,7 @@ public class PageCacheWarmer implements NeoStoreFileListing.StoreFileProvider
     // where the uncompressed profile is 87.5 KiB. A 35% reduction.
     private static final String COMPRESSION_FORMAT = CompressorStreamFactory.getDeflate();
     private static final int IO_PARALLELISM = Runtime.getRuntime().availableProcessors();
+    private static final CompressorStreamFactory COMPRESSOR_FACTORY = new CompressorStreamFactory( true, 1024 );
 
     private final FileSystemAbstraction fs;
     private final PageCache pageCache;
@@ -278,7 +279,7 @@ public class PageCacheWarmer implements NeoStoreFileListing.StoreFileProvider
         InputStream source = fs.openAsInputStream( input );
         try
         {
-            return compressors().createCompressorInputStream( COMPRESSION_FORMAT, source );
+            return COMPRESSOR_FACTORY.createCompressorInputStream( COMPRESSION_FORMAT, source );
         }
         catch ( CompressorException e )
         {
@@ -292,18 +293,13 @@ public class PageCacheWarmer implements NeoStoreFileListing.StoreFileProvider
         OutputStream sink = fs.openAsOutputStream( output, false );
         try
         {
-            return compressors().createCompressorOutputStream( COMPRESSION_FORMAT, sink );
+            return COMPRESSOR_FACTORY.createCompressorOutputStream( COMPRESSION_FORMAT, sink );
         }
         catch ( CompressorException e )
         {
             IOUtils.closeAllSilently( sink );
             throw new IOException( "Exception when building compressor.", e );
         }
-    }
-
-    private CompressorStreamFactory compressors()
-    {
-        return new CompressorStreamFactory( true, 1024 );
     }
 
     private File profileOutputFileFinal( PagedFile file )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmer.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmer.java
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.pagecache;
+
+import org.apache.commons.compress.compressors.CompressorException;
+import org.apache.commons.compress.compressors.CompressorStreamFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.StandardCopyOption;
+import java.util.List;
+import java.util.OptionalLong;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.neo4j.io.IOUtils;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.scheduler.JobScheduler;
+
+import static org.neo4j.io.pagecache.PagedFile.PF_NO_FAULT;
+import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_READ_LOCK;
+
+/**
+ * The page cache warmer profiles the page cache to figure out what data is in memory and what is not, and uses those
+ * profiles to load probably-desirable data into the page cache during startup.
+ * <p>
+ * The profiling data is stored in sibling files to the mapped files. These siblings have the same name as the mapped
+ * file, except they start with a "." (to hide them on POSIX-like systems) and end with ".cacheprof".
+ * <p>
+ * These cacheprof files are compressed bitmaps where each raised bit indicates that the page identified by the
+ * bit-index was in memory.
+ */
+public class PageCacheWarmer
+{
+    public static final String SUFFIX_CACHEPROF = ".cacheprof";
+    public static final String SUFFIX_CACHEPROF_TMP = ".cacheprof.tmp";
+
+    // We use the deflate algorithm since it has been experimentally shown to be both the fastest,
+    // and the algorithm that produces the smallest output.
+    // For instance, a 5.7 GiB file where 7 out of 8 pages are in memory, produces a 57 KiB profile file,
+    // where the uncompressed profile is 87.5 KiB. A 35% reduction.
+    private static final String COMPRESSION_FORMAT = CompressorStreamFactory.getDeflate();
+    private static final int IO_PARALLELISM = Runtime.getRuntime().availableProcessors();
+
+    private final FileSystemAbstraction fs;
+    private final PageCache pageCache;
+    private final ExecutorService executor;
+    private final PageLoaderFactory pageLoaderFactory;
+    private volatile boolean stopped;
+
+    PageCacheWarmer( FileSystemAbstraction fs, PageCache pageCache, JobScheduler scheduler )
+    {
+        this.fs = fs;
+        this.pageCache = pageCache;
+        this.executor = buildExecutorService( scheduler );
+        this.pageLoaderFactory = new PageLoaderFactory( executor, pageCache );
+    }
+
+    private ExecutorService buildExecutorService( JobScheduler scheduler )
+    {
+        BlockingQueue<Runnable> workQueue = new LinkedBlockingQueue<>( IO_PARALLELISM * 4 );
+        RejectedExecutionHandler rejectionPolicy = new ThreadPoolExecutor.CallerRunsPolicy();
+        ThreadFactory threadFactory = scheduler.threadFactory( JobScheduler.Groups.pageCacheIOHelper );
+        return new ThreadPoolExecutor(
+                0, IO_PARALLELISM, 10, TimeUnit.SECONDS, workQueue,
+                threadFactory, rejectionPolicy );
+    }
+
+    public void stop()
+    {
+        stopped = true;
+        synchronized ( this )
+        {
+            // This synchronised block means we'll wait for any reheat() or profile() to notice our raised stopped flag,
+            // before we return to the caller. This helps avoid races, e.g. if the page cache is closed while this page
+            // cache warmer is still holding on to some mapped pages.
+        }
+        executor.shutdown();
+    }
+
+    /**
+     * Reheat the page cache based on existing profiling data, or do nothing if no profiling data is available.
+     *
+     * @return An {@link OptionalLong} of the number of pages loaded in, or {@link OptionalLong#empty()} if the
+     * reheating was stopped early via {@link #stop()}.
+     * @throws IOException if anything goes wrong while reading the profiled data back in.
+     */
+    public synchronized OptionalLong reheat() throws IOException
+    {
+        long pagesLoaded = 0;
+        List<PagedFile> files = pageCache.listExistingMappings();
+        try
+        {
+            for ( PagedFile file : files )
+            {
+                pagesLoaded += reheat( file );
+            }
+        }
+        finally
+        {
+            IOUtils.closeAll( files );
+        }
+        return stopped ? OptionalLong.empty() : OptionalLong.of( pagesLoaded );
+    }
+
+    private long reheat( PagedFile file ) throws IOException
+    {
+        long pagesLoaded = 0;
+        File savedProfile = profileOutputFileFinal( file );
+
+        if ( !fs.fileExists( savedProfile ) )
+        {
+            return pagesLoaded;
+        }
+
+        try ( InputStream inputStream = compressedInputStream( savedProfile );
+              PageLoader loader = pageLoaderFactory.getLoader( file ) )
+        {
+            long pageId = 0;
+            int b;
+            while ( (b = inputStream.read()) != -1 )
+            {
+                for ( int i = 0; i < 8; i++ )
+                {
+                    if ( stopped )
+                    {
+                        return pagesLoaded;
+                    }
+                    if ( (b & 1) == 1 )
+                    {
+                        loader.load( pageId );
+                        pagesLoaded++;
+                    }
+                    b >>= 1;
+                    pageId++;
+                }
+            }
+        }
+        pageCache.reportEvents();
+        return pagesLoaded;
+    }
+
+    /**
+     * Profile the in-memory data in the page cache, and write it to "cacheprof" file siblings of the mapped files.
+     *
+     * @return An {@link OptionalLong} of the number of pages that were found to be in memory, or
+     * {@link OptionalLong#empty()} if the profiling was stopped early via {@link #stop()}.
+     * @throws IOException If anything goes wrong while accessing the page cache or writing out the profile data.
+     */
+    public synchronized OptionalLong profile() throws IOException
+    {
+        // Note that we could in principle profile the files in parallel. However, producing a profile is usually so
+        // fast, that it rivals the overhead of starting and stopping threads. Because of this, the complexity of
+        // profiling in parallel is just not worth it.
+        long pagesInMemory = 0;
+        List<PagedFile> files = pageCache.listExistingMappings();
+        try
+        {
+            for ( PagedFile file : files )
+            {
+                pagesInMemory += profile( file );
+            }
+        }
+        finally
+        {
+            IOUtils.closeAll( files );
+        }
+        pageCache.reportEvents();
+        return stopped ? OptionalLong.empty() : OptionalLong.of( pagesInMemory );
+    }
+
+    private long profile( PagedFile file ) throws IOException
+    {
+        long pagesInMemory = 0;
+        File outputNext = profileOutputFileNext( file );
+
+        try ( OutputStream outputStream = compressedOutputStream( outputNext );
+              PageCursor cursor = file.io( 0, PF_SHARED_READ_LOCK | PF_NO_FAULT ) )
+        {
+            int stepper = 7;
+            int b = 0;
+            for ( ; ; )
+            {
+                if ( stopped )
+                {
+                    return pagesInMemory;
+                }
+                if ( !cursor.next() )
+                {
+                    break; // Exit the loop if there are no more pages.
+                }
+                b >>= 1;
+                if ( cursor.getCurrentPageId() != PageCursor.UNBOUND_PAGE_ID )
+                {
+                    pagesInMemory++;
+                    b += 0b1000_0000;
+                }
+                if ( stepper == 0 )
+                {
+                    outputStream.write( b );
+                    b = 0;
+                    stepper = 7;
+                }
+                else
+                {
+                    stepper--;
+                }
+            }
+            b >>= stepper + 1;
+            outputStream.write( b );
+            outputStream.flush();
+        }
+
+        File outputFinal = profileOutputFileFinal( file );
+        fs.renameFile( outputNext, outputFinal, StandardCopyOption.REPLACE_EXISTING );
+        return pagesInMemory;
+    }
+
+    private InputStream compressedInputStream( File input ) throws IOException
+    {
+        InputStream source = fs.openAsInputStream( input );
+        try
+        {
+            return compressors().createCompressorInputStream( COMPRESSION_FORMAT, source );
+        }
+        catch ( CompressorException e )
+        {
+            IOUtils.closeAllSilently( source );
+            throw new IOException( "Exception when building decompressor.", e );
+        }
+    }
+
+    private OutputStream compressedOutputStream( File output ) throws IOException
+    {
+        OutputStream sink = fs.openAsOutputStream( output, false );
+        try
+        {
+            return compressors().createCompressorOutputStream( COMPRESSION_FORMAT, sink );
+        }
+        catch ( CompressorException e )
+        {
+            IOUtils.closeAllSilently( sink );
+            throw new IOException( "Exception when building compressor.", e );
+        }
+    }
+
+    private CompressorStreamFactory compressors()
+    {
+        return new CompressorStreamFactory( true, 1024 );
+    }
+
+    private File profileOutputFileFinal( PagedFile file )
+    {
+        File mappedFile = file.file();
+        String profileOutputName = "." + mappedFile.getName() + SUFFIX_CACHEPROF;
+        File parent = mappedFile.getParentFile();
+        return new File( parent, profileOutputName );
+    }
+
+    private File profileOutputFileNext( PagedFile file )
+    {
+        File mappedFile = file.file();
+        String profileOutputName = "." + mappedFile.getName() + SUFFIX_CACHEPROF_TMP;
+        File parent = mappedFile.getParentFile();
+        return new File( parent, profileOutputName );
+    }
+}

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmer.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmer.java
@@ -250,7 +250,7 @@ public class PageCacheWarmer implements NeoStoreFileListing.StoreFileProvider
                 if ( cursor.getCurrentPageId() != PageCursor.UNBOUND_PAGE_ID )
                 {
                     pagesInMemory++;
-                    b |= (1 << stepper);
+                    b |= 1 << stepper;
                 }
                 stepper++;
                 if ( stepper == 8 )

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmer.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmer.java
@@ -235,7 +235,7 @@ public class PageCacheWarmer implements NeoStoreFileListing.StoreFileProvider
         try ( OutputStream outputStream = compressedOutputStream( outputNext );
               PageCursor cursor = file.io( 0, PF_SHARED_READ_LOCK | PF_NO_FAULT ) )
         {
-            int stepper = 7;
+            int stepper = 0;
             int b = 0;
             for ( ; ; )
             {
@@ -247,24 +247,19 @@ public class PageCacheWarmer implements NeoStoreFileListing.StoreFileProvider
                 {
                     break; // Exit the loop if there are no more pages.
                 }
-                b >>= 1;
                 if ( cursor.getCurrentPageId() != PageCursor.UNBOUND_PAGE_ID )
                 {
                     pagesInMemory++;
-                    b += 0b1000_0000;
+                    b |= (1 << stepper);
                 }
-                if ( stepper == 0 )
+                stepper++;
+                if ( stepper == 8 )
                 {
                     outputStream.write( b );
                     b = 0;
-                    stepper = 7;
-                }
-                else
-                {
-                    stepper--;
+                    stepper = 0;
                 }
             }
-            b >>= stepper + 1;
             outputStream.write( b );
             outputStream.flush();
         }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmerKernelExtension.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmerKernelExtension.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.pagecache;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.helpers.Format;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.AvailabilityGuard;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.lifecycle.LifecycleAdapter;
+import org.neo4j.logging.Log;
+import org.neo4j.scheduler.JobScheduler;
+import org.neo4j.util.FeatureToggles;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.neo4j.scheduler.JobScheduler.Groups.pageCacheIOHelper;
+
+class PageCacheWarmerKernelExtension extends LifecycleAdapter
+{
+    private static final boolean ENABLED = FeatureToggles.flag( PageCacheWarmerKernelExtension.class, "enabled", true );
+
+    private final JobScheduler scheduler;
+    private final AvailabilityGuard availabilityGuard;
+    private final Log log;
+    private final PageCacheWarmerMonitor monitor;
+    private final Config config;
+    private final PageCacheWarmer pageCacheWarmer;
+    private final AtomicBoolean profilingStarted;
+    private volatile JobScheduler.JobHandle profileHandle;
+
+    PageCacheWarmerKernelExtension( JobScheduler scheduler, AvailabilityGuard availabilityGuard,
+                                    PageCache pageCache, FileSystemAbstraction fs, Log log,
+                                    PageCacheWarmerMonitor monitor, Config config )
+    {
+        this.scheduler = scheduler;
+        this.availabilityGuard = availabilityGuard;
+        this.log = log;
+        this.monitor = monitor;
+        this.config = config;
+        pageCacheWarmer = new PageCacheWarmer( fs, pageCache, scheduler );
+        profilingStarted = new AtomicBoolean();
+    }
+
+    @Override
+    public void start() throws Throwable
+    {
+        if ( ENABLED )
+        {
+            scheduleTryReheat();
+        }
+    }
+
+    private void scheduleTryReheat()
+    {
+        scheduler.schedule( pageCacheIOHelper, this::tryReheat, 100, TimeUnit.MILLISECONDS );
+    }
+
+    private void tryReheat()
+    {
+        if ( availabilityGuard.isAvailable() )
+        {
+            doReheat();
+            scheduleProfile();
+        }
+        else if ( !availabilityGuard.isShutdown() )
+        {
+            scheduleTryReheat();
+        }
+    }
+
+    private void doReheat()
+    {
+        try
+        {
+            long start = System.nanoTime();
+            pageCacheWarmer.reheat().ifPresent( pagesLoaded ->
+            {
+                long elapsedMillis = NANOSECONDS.toMillis( System.nanoTime() - start );
+                monitor.warmupCompleted( pagesLoaded, elapsedMillis );
+                log.debug( "Active page cache warmup took " + Format.duration( elapsedMillis ) +
+                           " to load " + pagesLoaded + " pages." );
+            } );
+        }
+        catch ( IOException e )
+        {
+            log.debug( "Active page cache warmup failed, " +
+                       "so it may take longer for the cache to be populated with hot data.", e );
+        }
+    }
+
+    private void scheduleProfile()
+    {
+        long frequencyMillis = config.get( GraphDatabaseSettings.pagecache_warmup_profiling_interval ).toMillis();
+        profileHandle = scheduler.schedule(
+                pageCacheIOHelper, this::tryStartProfile, frequencyMillis, TimeUnit.MILLISECONDS );
+    }
+
+    private void tryStartProfile()
+    {
+        if ( profilingStarted.compareAndSet( false, true ) )
+        {
+            // At this point, we are currently executing inside a *scheduled* executor thread. There are, at this time
+            // of writing, only two executor threads. Therefor, we *must* hand off the actual profiling work to another
+            // thread, so we don't cause congestion in the scheduler. Congestion could for instance arise if the
+            // profile gets stuck on some lock in the page cache. We cannot allow this to block a scheduler thread for
+            // an extended period of time, since there are many other services that rely on timely activation from the
+            // scheduler. For instance, catchup in causal cluster is relying the timeliness of the scheduler.
+            scheduler.schedule( pageCacheIOHelper, this::doProfile );
+        }
+    }
+
+    private void doProfile()
+    {
+        try
+        {
+            long start = System.nanoTime();
+            pageCacheWarmer.profile().ifPresent( pagesInMemory ->
+            {
+                long elapsedMillis = NANOSECONDS.toMillis( System.nanoTime() - start );
+                monitor.profileCompleted( elapsedMillis, pagesInMemory );
+                log.debug( "Profiled page cache in " + Format.duration( elapsedMillis ) +
+                           ", and found " + pagesInMemory + " pages in memory." );
+            });
+        }
+        catch ( IOException e )
+        {
+            log.debug( "Page cache profiling failed, so no new profile of what data is hot or not was produced. " +
+                       "This may reduce the effectiveness of a future page cache warmup process.", e );
+        }
+        finally
+        {
+            profilingStarted.set( false );
+            scheduleProfile();
+        }
+    }
+
+    @Override
+    public void stop() throws Throwable
+    {
+        JobScheduler.JobHandle handle = profileHandle;
+        if ( handle != null )
+        {
+            handle.cancel( false );
+        }
+        pageCacheWarmer.stop();
+    }
+}

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmerKernelExtensionFactory.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmerKernelExtensionFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.pagecache;
+
+import org.neo4j.helpers.Service;
+import org.neo4j.io.fs.FileSystemAbstraction;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.kernel.AvailabilityGuard;
+import org.neo4j.kernel.configuration.Config;
+import org.neo4j.kernel.extension.KernelExtensionFactory;
+import org.neo4j.kernel.impl.logging.LogService;
+import org.neo4j.kernel.impl.spi.KernelContext;
+import org.neo4j.kernel.lifecycle.Lifecycle;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.logging.Log;
+import org.neo4j.scheduler.JobScheduler;
+
+@Service.Implementation( KernelExtensionFactory.class )
+public class PageCacheWarmerKernelExtensionFactory
+        extends KernelExtensionFactory<PageCacheWarmerKernelExtensionFactory.Dependencies>
+{
+    public interface Dependencies
+    {
+        JobScheduler jobScheduler();
+
+        AvailabilityGuard availabilityGuard();
+
+        PageCache pageCache();
+
+        FileSystemAbstraction fileSystemAbstraction();
+
+        LogService logService();
+
+        Monitors monitors();
+
+        Config config();
+    }
+
+    public PageCacheWarmerKernelExtensionFactory()
+    {
+        super( "pagecachewarmer" );
+    }
+
+    @Override
+    public Lifecycle newInstance( KernelContext context, Dependencies deps )
+    {
+        JobScheduler scheduler = deps.jobScheduler();
+        AvailabilityGuard availabilityGuard = deps.availabilityGuard();
+        PageCache pageCache = deps.pageCache();
+        FileSystemAbstraction fs = deps.fileSystemAbstraction();
+        LogService logService = deps.logService();
+        Log log = logService.getInternalLog( PageCacheWarmer.class );
+        PageCacheWarmerMonitor monitor = deps.monitors().newMonitor( PageCacheWarmerMonitor.class );
+        Config config = deps.config();
+        return new PageCacheWarmerKernelExtension( scheduler, availabilityGuard, pageCache, fs, log, monitor, config );
+    }
+}

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmerKernelExtensionFactory.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmerKernelExtensionFactory.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.impl.pagecache;
 
+import java.util.function.Supplier;
+
 import org.neo4j.helpers.Service;
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
@@ -27,6 +29,7 @@ import org.neo4j.kernel.configuration.Config;
 import org.neo4j.kernel.extension.KernelExtensionFactory;
 import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.impl.spi.KernelContext;
+import org.neo4j.kernel.impl.transaction.state.NeoStoreFileListing;
 import org.neo4j.kernel.lifecycle.Lifecycle;
 import org.neo4j.kernel.monitoring.Monitors;
 import org.neo4j.logging.Log;
@@ -45,6 +48,8 @@ public class PageCacheWarmerKernelExtensionFactory
         PageCache pageCache();
 
         FileSystemAbstraction fileSystemAbstraction();
+
+        NeoStoreFileListing fileListing();
 
         LogService logService();
 
@@ -65,10 +70,12 @@ public class PageCacheWarmerKernelExtensionFactory
         AvailabilityGuard availabilityGuard = deps.availabilityGuard();
         PageCache pageCache = deps.pageCache();
         FileSystemAbstraction fs = deps.fileSystemAbstraction();
+        Supplier<NeoStoreFileListing> fileListing = deps::fileListing;
         LogService logService = deps.logService();
         Log log = logService.getInternalLog( PageCacheWarmer.class );
         PageCacheWarmerMonitor monitor = deps.monitors().newMonitor( PageCacheWarmerMonitor.class );
         Config config = deps.config();
-        return new PageCacheWarmerKernelExtension( scheduler, availabilityGuard, pageCache, fs, log, monitor, config );
+        return new PageCacheWarmerKernelExtension(
+                scheduler, availabilityGuard, pageCache, fs, fileListing, log, monitor, config );
     }
 }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmerMonitor.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmerMonitor.java
@@ -17,22 +17,10 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.test.rule;
+package org.neo4j.kernel.impl.pagecache;
 
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
-import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
-
-public class EnterpriseDatabaseRule extends EmbeddedDatabaseRule
+public interface PageCacheWarmerMonitor
 {
-    @Override
-    protected GraphDatabaseFactory newFactory()
-    {
-        return new TestEnterpriseGraphDatabaseFactory();
-    }
-
-    @Override
-    public EnterpriseDatabaseRule startLazily()
-    {
-        return (EnterpriseDatabaseRule) super.startLazily();
-    }
+    void warmupCompleted( long elapsedMillis, long pagesLoaded );
+    void profileCompleted( long elapsedMillis, long pagesInMemory );
 }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageLoader.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageLoader.java
@@ -17,22 +17,12 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.test.rule;
+package org.neo4j.kernel.impl.pagecache;
 
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
-import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
+import java.io.Closeable;
+import java.io.IOException;
 
-public class EnterpriseDatabaseRule extends EmbeddedDatabaseRule
+abstract class PageLoader implements Closeable
 {
-    @Override
-    protected GraphDatabaseFactory newFactory()
-    {
-        return new TestEnterpriseGraphDatabaseFactory();
-    }
-
-    @Override
-    public EnterpriseDatabaseRule startLazily()
-    {
-        return (EnterpriseDatabaseRule) super.startLazily();
-    }
+    public abstract void load( long pageId ) throws IOException;
 }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageLoader.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/PageLoader.java
@@ -22,7 +22,7 @@ package org.neo4j.kernel.impl.pagecache;
 import java.io.Closeable;
 import java.io.IOException;
 
-abstract class PageLoader implements Closeable
+interface PageLoader extends Closeable
 {
-    public abstract void load( long pageId ) throws IOException;
+    void load( long pageId ) throws IOException;
 }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ParallelPageLoader.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ParallelPageLoader.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.pagecache;
+
+import java.io.IOException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.io.pagecache.PagedFile;
+
+import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_READ_LOCK;
+
+class ParallelPageLoader extends PageLoader
+{
+    private final PagedFile file;
+    private final Executor executor;
+    private final PageCache pageCache;
+    private final AtomicLong received;
+    private final AtomicLong processed;
+
+    ParallelPageLoader( PagedFile file, Executor executor, PageCache pageCache )
+    {
+        this.file = file;
+        this.executor = executor;
+        this.pageCache = pageCache;
+        received = new AtomicLong();
+        processed = new AtomicLong();
+    }
+
+    @Override
+    public void load( long pageId )
+    {
+        received.getAndIncrement();
+        executor.execute( () ->
+        {
+            try
+            {
+                try ( PageCursor cursor = file.io( pageId, PF_SHARED_READ_LOCK ) )
+                {
+                    cursor.next();
+                }
+                catch ( IOException ignore )
+                {
+                }
+            }
+            finally
+            {
+                processed.getAndIncrement();
+                pageCache.reportEvents();
+            }
+        } );
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        while ( processed.get() < received.get() )
+        {
+            Thread.yield();
+        }
+    }
+}

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ParallelPageLoader.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/ParallelPageLoader.java
@@ -29,7 +29,7 @@ import org.neo4j.io.pagecache.PagedFile;
 
 import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_READ_LOCK;
 
-class ParallelPageLoader extends PageLoader
+class ParallelPageLoader implements PageLoader
 {
     private final PagedFile file;
     private final Executor executor;
@@ -71,7 +71,7 @@ class ParallelPageLoader extends PageLoader
     }
 
     @Override
-    public void close() throws IOException
+    public void close()
     {
         while ( processed.get() < received.get() )
         {

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/SingleCursorPageLoader.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/SingleCursorPageLoader.java
@@ -17,22 +17,33 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.test.rule;
+package org.neo4j.kernel.impl.pagecache;
 
-import org.neo4j.graphdb.factory.GraphDatabaseFactory;
-import org.neo4j.test.TestEnterpriseGraphDatabaseFactory;
+import java.io.IOException;
 
-public class EnterpriseDatabaseRule extends EmbeddedDatabaseRule
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.io.pagecache.PagedFile;
+
+import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_READ_LOCK;
+
+class SingleCursorPageLoader extends PageLoader
 {
-    @Override
-    protected GraphDatabaseFactory newFactory()
+    private final PageCursor cursor;
+
+    SingleCursorPageLoader( PagedFile file ) throws IOException
     {
-        return new TestEnterpriseGraphDatabaseFactory();
+        cursor = file.io( 0, PF_SHARED_READ_LOCK );
     }
 
     @Override
-    public EnterpriseDatabaseRule startLazily()
+    public void load( long pageId ) throws IOException
     {
-        return (EnterpriseDatabaseRule) super.startLazily();
+        cursor.next( pageId );
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        cursor.close();
     }
 }

--- a/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/SingleCursorPageLoader.java
+++ b/enterprise/kernel/src/main/java/org/neo4j/kernel/impl/pagecache/SingleCursorPageLoader.java
@@ -26,7 +26,7 @@ import org.neo4j.io.pagecache.PagedFile;
 
 import static org.neo4j.io.pagecache.PagedFile.PF_SHARED_READ_LOCK;
 
-class SingleCursorPageLoader extends PageLoader
+class SingleCursorPageLoader implements PageLoader
 {
     private final PageCursor cursor;
 
@@ -42,7 +42,7 @@ class SingleCursorPageLoader extends PageLoader
     }
 
     @Override
-    public void close() throws IOException
+    public void close()
     {
         cursor.close();
     }

--- a/enterprise/kernel/src/main/resources/META-INF/services/org.neo4j.kernel.extension.KernelExtensionFactory
+++ b/enterprise/kernel/src/main/resources/META-INF/services/org.neo4j.kernel.extension.KernelExtensionFactory
@@ -1,0 +1,1 @@
+org.neo4j.kernel.impl.pagecache.PageCacheWarmerKernelExtensionFactory

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModuleTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/enterprise/EnterpriseEditionModuleTest.java
@@ -17,62 +17,32 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.causalclustering.core;
+package org.neo4j.kernel.impl.enterprise;
 
-import org.junit.Rule;
 import org.junit.Test;
 
 import java.util.function.Predicate;
 
-import org.neo4j.causalclustering.core.state.machines.id.FreeIdFilteredIdGeneratorFactory;
-import org.neo4j.causalclustering.discovery.Cluster;
-import org.neo4j.causalclustering.discovery.CoreClusterMember;
-import org.neo4j.com.storecopy.StoreUtil;
-import org.neo4j.graphdb.DependencyResolver;
 import org.neo4j.kernel.impl.index.IndexConfigStore;
 import org.neo4j.kernel.impl.pagecache.PageCacheWarmer;
-import org.neo4j.kernel.impl.storageengine.impl.recordstorage.id.BufferedIdController;
-import org.neo4j.kernel.impl.storageengine.impl.recordstorage.id.IdController;
 import org.neo4j.kernel.impl.store.MetaDataStore;
 import org.neo4j.kernel.impl.store.StoreFile;
-import org.neo4j.kernel.impl.store.id.IdGeneratorFactory;
 import org.neo4j.kernel.impl.storemigration.StoreFileType;
 import org.neo4j.kernel.impl.transaction.log.files.TransactionLogFiles;
-import org.neo4j.test.causalclustering.ClusterRule;
 
-import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-public class EnterpriseCoreEditionModuleIntegrationTest
+public class EnterpriseEditionModuleTest
 {
-    @Rule
-    public ClusterRule clusterRule = new ClusterRule();
-
-    @Test
-    public void createBufferedIdComponentsByDefault() throws Exception
-    {
-        Cluster cluster = clusterRule.startCluster();
-        CoreClusterMember leader = cluster.awaitLeader();
-        DependencyResolver dependencyResolver = leader.database().getDependencyResolver();
-
-        IdController idController = dependencyResolver.resolveDependency( IdController.class );
-        IdGeneratorFactory idGeneratorFactory = dependencyResolver.resolveDependency( IdGeneratorFactory.class );
-
-        assertThat( idController, instanceOf( BufferedIdController.class ) );
-        assertThat( idGeneratorFactory, instanceOf( FreeIdFilteredIdGeneratorFactory.class ) );
-    }
-
     @Test
     public void fileWatcherFileNameFilter()
     {
-        Predicate<String> filter = EnterpriseCoreEditionModule.fileWatcherFileNameFilter();
+        Predicate<String> filter = EnterpriseEditionModule.enterpriseNonClusterFileWatcherFileNameFilter();
         assertFalse( filter.test( MetaDataStore.DEFAULT_NAME ) );
         assertFalse( filter.test( StoreFile.NODE_STORE.fileName( StoreFileType.STORE ) ) );
         assertTrue( filter.test( TransactionLogFiles.DEFAULT_NAME + ".1" ) );
         assertTrue( filter.test( IndexConfigStore.INDEX_DB_FILE_NAME + ".any" ) );
-        assertTrue( filter.test( StoreUtil.TEMP_COPY_DIRECTORY_NAME ) );
         assertTrue( filter.test( MetaDataStore.DEFAULT_NAME + PageCacheWarmer.SUFFIX_CACHEPROF ) );
         assertTrue( filter.test( MetaDataStore.DEFAULT_NAME + PageCacheWarmer.SUFFIX_CACHEPROF_TMP ) );
     }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmerTest.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/impl/pagecache/PageCacheWarmerTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.impl.pagecache;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.neo4j.collection.primitive.Primitive;
+import org.neo4j.collection.primitive.PrimitiveIntIterator;
+import org.neo4j.collection.primitive.PrimitiveIntSet;
+import org.neo4j.io.ByteUnit;
+import org.neo4j.io.pagecache.PageCache;
+import org.neo4j.io.pagecache.PageCursor;
+import org.neo4j.io.pagecache.PagedFile;
+import org.neo4j.io.pagecache.tracing.DefaultPageCacheTracer;
+import org.neo4j.io.pagecache.tracing.PageCacheTracer;
+import org.neo4j.io.pagecache.tracing.cursor.DefaultPageCursorTracerSupplier;
+import org.neo4j.kernel.impl.util.Neo4jJobScheduler;
+import org.neo4j.kernel.lifecycle.LifeSupport;
+import org.neo4j.scheduler.JobScheduler;
+import org.neo4j.test.rule.PageCacheRule;
+import org.neo4j.test.rule.TestDirectory;
+import org.neo4j.test.rule.fs.EphemeralFileSystemRule;
+import org.neo4j.test.rule.fs.FileSystemRule;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class PageCacheWarmerTest
+{
+    private FileSystemRule fs = new EphemeralFileSystemRule();
+    private TestDirectory dir = TestDirectory.testDirectory( fs );
+    private PageCacheRule pageCacheRule = new PageCacheRule();
+    @Rule
+    public RuleChain rules = RuleChain.outerRule( fs ).around( dir ).around( pageCacheRule );
+
+    private LifeSupport life;
+    private JobScheduler scheduler;
+    private DefaultPageCacheTracer cacheTracer;
+    private DefaultPageCursorTracerSupplier cursorTracer;
+    private PageCacheRule.PageCacheConfig cfg;
+    private File file;
+
+    @Before
+    public void setUp() throws IOException
+    {
+        life = new LifeSupport();
+        scheduler = life.add( new Neo4jJobScheduler() );
+        life.start();
+        cacheTracer = new DefaultPageCacheTracer();
+        cursorTracer = DefaultPageCursorTracerSupplier.INSTANCE;
+        clearTracerCounts();
+        cfg = PageCacheRule.config().withTracer( cacheTracer ).withCursorTracerSupplier( cursorTracer );
+        file = dir.file( "a" );
+        fs.create( file );
+    }
+
+    @After
+    public void tearDown()
+    {
+        life.shutdown();
+    }
+
+    private void clearTracerCounts()
+    {
+        cursorTracer.get().init( PageCacheTracer.NULL );
+        cursorTracer.get().reportEvents();
+        cursorTracer.get().init( cacheTracer );
+    }
+
+    @Test
+    public void mustDoNothingWhenReheatingUnprofiledPageCache() throws Exception
+    {
+
+        try ( PageCache pageCache = pageCacheRule.getPageCache( fs, cfg );
+              PagedFile ignore = pageCache.map( file, pageCache.pageSize(), StandardOpenOption.CREATE ) )
+        {
+            PageCacheWarmer warmer = new PageCacheWarmer( fs, pageCache, scheduler );
+            warmer.reheat();
+        }
+        cursorTracer.get().reportEvents();
+        assertThat( cacheTracer.faults(), is( 0L ) );
+    }
+
+    @Test
+    public void mustReheatProfiledPageCache() throws Exception
+    {
+        try ( PageCache pageCache = pageCacheRule.getPageCache( fs, cfg );
+              PagedFile pf = pageCache.map( file, pageCache.pageSize(), StandardOpenOption.CREATE ) )
+        {
+            try ( PageCursor writer = pf.io( 0, PagedFile.PF_SHARED_WRITE_LOCK ) )
+            {
+                assertTrue( writer.next( 1 ) );
+                assertTrue( writer.next( 3 ) );
+            }
+            pf.flushAndForce();
+            PageCacheWarmer warmer = new PageCacheWarmer( fs, pageCache, scheduler );
+            warmer.profile();
+        }
+
+        clearTracerCounts();
+        long initialFaults = cacheTracer.faults();
+        try ( PageCache pageCache = pageCacheRule.getPageCache( fs, cfg );
+              PagedFile pf = pageCache.map( file, pageCache.pageSize() ) )
+        {
+            PageCacheWarmer warmer = new PageCacheWarmer( fs, pageCache, scheduler );
+            warmer.reheat();
+
+            pageCache.reportEvents();
+            assertThat( cacheTracer.faults(), is( initialFaults + 2L ) );
+
+            try ( PageCursor reader = pf.io( 0, PagedFile.PF_SHARED_READ_LOCK ) )
+            {
+                assertTrue( reader.next( 1 ) );
+                assertTrue( reader.next( 3 ) );
+            }
+
+            // No additional faults must have been reported.
+            pageCache.reportEvents();
+            assertThat( cacheTracer.faults(), is( initialFaults + 2L ) );
+        }
+    }
+
+    @Test
+    public void reheatingMustWorkOnLargeNumberOfPages() throws Exception
+    {
+        int maxPagesInMemory = 1_000;
+        int[] pageIds = randomSortedPageIds( maxPagesInMemory );
+
+        String pageCacheMemory = String.valueOf( maxPagesInMemory * ByteUnit.kibiBytes( 9 ) );
+        try ( PageCache pageCache = pageCacheRule.getPageCache( fs, cfg.withMemory( pageCacheMemory ) );
+              PagedFile pf = pageCache.map( file, pageCache.pageSize(), StandardOpenOption.CREATE ) )
+        {
+            try ( PageCursor writer = pf.io( 0, PagedFile.PF_SHARED_WRITE_LOCK ) )
+            {
+                for ( int pageId : pageIds )
+                {
+                    assertTrue( writer.next( pageId ) );
+                }
+            }
+            pf.flushAndForce();
+            PageCacheWarmer warmer = new PageCacheWarmer( fs, pageCache, scheduler );
+            warmer.profile();
+        }
+
+        long initialFaults = cacheTracer.faults();
+        clearTracerCounts();
+        try ( PageCache pageCache = pageCacheRule.getPageCache( fs, cfg );
+              PagedFile pf = pageCache.map( file, pageCache.pageSize() ) )
+        {
+            PageCacheWarmer warmer = new PageCacheWarmer( fs, pageCache, scheduler );
+            warmer.reheat();
+
+            pageCache.reportEvents();
+            assertThat( cacheTracer.faults(), is( initialFaults + pageIds.length ) );
+
+            try ( PageCursor reader = pf.io( 0, PagedFile.PF_SHARED_READ_LOCK ) )
+            {
+                for ( int pageId : pageIds )
+                {
+                    assertTrue( reader.next( pageId ) );
+                }
+            }
+
+            // No additional faults must have been reported.
+            pageCache.reportEvents();
+            assertThat( cacheTracer.faults(), is( initialFaults + pageIds.length ) );
+        }
+    }
+
+    private int[] randomSortedPageIds( int maxPagesInMemory )
+    {
+        PrimitiveIntSet setIds = Primitive.intSet();
+        ThreadLocalRandom rng = ThreadLocalRandom.current();
+        for ( int i = 0; i < maxPagesInMemory; i++ )
+        {
+            setIds.add( rng.nextInt( maxPagesInMemory * 7 ) );
+        }
+        int[] pageIds = new int[setIds.size()];
+        PrimitiveIntIterator itr = setIds.iterator();
+        int i = 0;
+        while ( itr.hasNext() )
+        {
+            pageIds[i] = itr.next();
+            i++;
+        }
+        Arrays.sort( pageIds );
+        return pageIds;
+    }
+}

--- a/integrationtests/pom.xml
+++ b/integrationtests/pom.xml
@@ -177,6 +177,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.neo4j</groupId>
+      <artifactId>neo4j-metrics</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.neo4j.test</groupId>
       <artifactId>neo4j-harness</artifactId>
       <version>${project.version}</version>

--- a/integrationtests/src/test/java/org/neo4j/kernel/PageCacheWarmupCcIT.java
+++ b/integrationtests/src/test/java/org/neo4j/kernel/PageCacheWarmupCcIT.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.neo4j.causalclustering.discovery.Cluster;
+import org.neo4j.causalclustering.discovery.ClusterMember;
+import org.neo4j.causalclustering.discovery.CoreClusterMember;
+import org.neo4j.concurrent.BinaryLatch;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.impl.pagecache.PageCacheWarmerMonitor;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.test.causalclustering.ClusterRule;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class PageCacheWarmupCcIT extends PageCacheWarmupTestSupport
+{
+    @Rule
+    public ClusterRule clusterRule = new ClusterRule()
+            .withNumberOfReadReplicas( 0 )
+            .withSharedCoreParam( GraphDatabaseSettings.pagecache_warmup_profiling_interval, "100ms" )
+            .withSharedReadReplicaParam( GraphDatabaseSettings.pagecache_warmup_profiling_interval, "100ms" );
+
+    private Cluster cluster;
+
+    @Before
+    public void setup() throws Exception
+    {
+        cluster = clusterRule.startCluster();
+    }
+
+    private long warmUpCluster() throws TimeoutException
+    {
+        CoreClusterMember leader = cluster.awaitLeader();
+        createTestData( leader.database() );
+        long pagesInMemory = waitForCacheProfile( leader.database() );
+        for ( CoreClusterMember member : cluster.coreMembers() )
+        {
+            waitForCacheProfile( member.database() );
+        }
+        return pagesInMemory;
+    }
+
+    private void verifyWarmupHappensAfterStoreCopy( ClusterMember member, long pagesInMemory )
+    {
+        AtomicLong pagesLoadedInWarmup = new AtomicLong();
+        BinaryLatch warmupLatch = new BinaryLatch();
+        Monitors monitors = member.monitors();
+        monitors.addMonitorListener( new PageCacheWarmerMonitor()
+        {
+            @Override
+            public void warmupCompleted( long elapsedMillis, long pagesLoaded )
+            {
+                pagesLoadedInWarmup.set( pagesInMemory );
+                warmupLatch.release();
+            }
+
+            @Override
+            public void profileCompleted( long elapsedMillis, long pagesInMemory )
+            {
+            }
+        } );
+        member.start();
+        warmupLatch.await();
+        assertThat( pagesLoadedInWarmup.get(), is( pagesInMemory ) );
+    }
+
+    @Test
+    public void cacheProfilesMustBeIncludedInStoreCopyToCore() throws Exception
+    {
+        long pagesInMemory = warmUpCluster();
+        ClusterMember member = cluster.addCoreMemberWithId( 4 );
+        verifyWarmupHappensAfterStoreCopy( member, pagesInMemory );
+    }
+
+    @Test
+    public void cacheProfilesMustBeIncludedInStoreCopyToReadReplica() throws Exception
+    {
+        long pagesInMemory = warmUpCluster();
+        ClusterMember member = cluster.addReadReplicaWithId( 4 );
+        verifyWarmupHappensAfterStoreCopy( member, pagesInMemory );
+    }
+}

--- a/integrationtests/src/test/java/org/neo4j/kernel/PageCacheWarmupEnterpriseEditionIT.java
+++ b/integrationtests/src/test/java/org/neo4j/kernel/PageCacheWarmupEnterpriseEditionIT.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+import java.io.File;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.neo4j.concurrent.BinaryLatch;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.graphdb.factory.GraphDatabaseSettings;
+import org.neo4j.kernel.configuration.Settings;
+import org.neo4j.kernel.impl.enterprise.configuration.OnlineBackupSettings;
+import org.neo4j.kernel.impl.pagecache.PageCacheWarmerMonitor;
+import org.neo4j.kernel.monitoring.Monitors;
+import org.neo4j.metrics.MetricsSettings;
+import org.neo4j.test.rule.EnterpriseDatabaseRule;
+import org.neo4j.test.rule.TestDirectory;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.neo4j.metrics.MetricsTestHelper.metricsCsv;
+import static org.neo4j.metrics.MetricsTestHelper.readLongValue;
+import static org.neo4j.metrics.source.db.PageCacheMetrics.PC_PAGE_FAULTS;
+import static org.neo4j.test.assertion.Assert.assertEventually;
+
+public class PageCacheWarmupEnterpriseEditionIT
+{
+    private TestDirectory dir = TestDirectory.testDirectory();
+    private EnterpriseDatabaseRule db = new EnterpriseDatabaseRule().startLazily();
+    @Rule
+    public RuleChain rules = RuleChain.outerRule( dir ).around( db );
+
+    @Test
+    public void warmupMustReloadHotPagesAfterRestartAndFaultsMustBeVisibleViaMetrics() throws Exception
+    {
+        File metricsDirectory = dir.directory( "metrics" );
+        db.setConfig( MetricsSettings.metricsEnabled, Settings.FALSE )
+          .setConfig( OnlineBackupSettings.online_backup_enabled, Settings.FALSE )
+          .setConfig( GraphDatabaseSettings.pagecache_warmup_profiling_interval, "100ms" );
+        db.ensureStarted();
+
+        try ( Transaction tx = db.beginTx() )
+        {
+            Label label = Label.label( "Label" );
+            RelationshipType relationshipType = RelationshipType.withName( "REL" );
+            long[] largeValue = new long[1024];
+            for ( int i = 0; i < 100; i++ )
+            {
+                Node node = db.createNode( label );
+                node.setProperty( "Niels", "Borh" );
+                node.setProperty( "Albert", largeValue );
+                for ( int j = 0; j < 10; j++ )
+                {
+                    Relationship rel = node.createRelationshipTo( node, relationshipType );
+                    rel.setProperty( "Max", "Planck" );
+                }
+            }
+            tx.success();
+        }
+
+        AtomicLong pageCount = new AtomicLong();
+        BinaryLatch profileLatch = new BinaryLatch();
+        db.resolveDependency( Monitors.class ).addMonitorListener( new PageCacheWarmerMonitor()
+        {
+            @Override
+            public void warmupCompleted( long elapsedMillis, long pagesLoaded )
+            {
+            }
+
+            @Override
+            public void profileCompleted( long elapsedMillis, long pagesInMemory )
+            {
+                pageCount.set( pagesInMemory );
+                profileLatch.release();
+            }
+        } );
+        profileLatch.await();
+
+        db.restartDatabase(
+                MetricsSettings.neoPageCacheEnabled.name(), Settings.TRUE,
+                MetricsSettings.csvEnabled.name(), Settings.TRUE,
+                MetricsSettings.csvInterval.name(), "100ms",
+                MetricsSettings.csvPath.name(), metricsDirectory.getAbsolutePath() );
+
+        long pagesInMemory = pageCount.get();
+        assertEventually( "Metrics report should include page cache page faults",
+                () -> readLongValue( metricsCsv( metricsDirectory, PC_PAGE_FAULTS ) ),
+                greaterThanOrEqualTo( pagesInMemory ), 5, SECONDS );
+    }
+}

--- a/integrationtests/src/test/java/org/neo4j/kernel/PageCacheWarmupTestSupport.java
+++ b/integrationtests/src/test/java/org/neo4j/kernel/PageCacheWarmupTestSupport.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.neo4j.concurrent.BinaryLatch;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.Relationship;
+import org.neo4j.graphdb.RelationshipType;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.kernel.impl.pagecache.PageCacheWarmerMonitor;
+import org.neo4j.kernel.internal.GraphDatabaseAPI;
+import org.neo4j.kernel.monitoring.Monitors;
+
+class PageCacheWarmupTestSupport
+{
+    void createTestData( GraphDatabaseService db )
+    {
+        try ( Transaction tx = db.beginTx() )
+        {
+            Label label = Label.label( "Label" );
+            RelationshipType relationshipType = RelationshipType.withName( "REL" );
+            long[] largeValue = new long[1024];
+            for ( int i = 0; i < 1000; i++ )
+            {
+                Node node = db.createNode( label );
+                node.setProperty( "Niels", "Borh" );
+                node.setProperty( "Albert", largeValue );
+                for ( int j = 0; j < 30; j++ )
+                {
+                    Relationship rel = node.createRelationshipTo( node, relationshipType );
+                    rel.setProperty( "Max", "Planck" );
+                }
+            }
+            tx.success();
+        }
+    }
+
+    long waitForCacheProfile( GraphDatabaseAPI db )
+    {
+        AtomicLong pageCount = new AtomicLong();
+        BinaryLatch profileLatch = new BinaryLatch();
+        PageCacheWarmerMonitor listener = new AwaitProfileMonitor( pageCount, profileLatch );
+        Monitors monitors = db.getDependencyResolver().resolveDependency( Monitors.class );
+        monitors.addMonitorListener( listener );
+        profileLatch.await();
+        monitors.removeMonitorListener( listener );
+        return pageCount.get();
+    }
+
+    private static class AwaitProfileMonitor implements PageCacheWarmerMonitor
+    {
+        private final AtomicLong pageCount;
+        private final BinaryLatch profileLatch;
+
+        AwaitProfileMonitor( AtomicLong pageCount, BinaryLatch profileLatch )
+        {
+            this.pageCount = pageCount;
+            this.profileLatch = profileLatch;
+        }
+
+        @Override
+        public void warmupCompleted( long elapsedMillis, long pagesLoaded )
+        {
+        }
+
+        @Override
+        public void profileCompleted( long elapsedMillis, long pagesInMemory )
+        {
+            pageCount.set( pagesInMemory );
+            profileLatch.release();
+        }
+    }
+}


### PR DESCRIPTION
[cl] Introduces a new _active page cache warmup_ feature in the Enterprise Edition. The memory contents of the Neo4j page cache are periodically profiled, and these profiles will then be used to quickly reheat the cache on startup. This decreases the time-to-performance for restarts or crashes.