### PR TITLE
Traversal regressions

### DIFF
--- a/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ResourceManager.scala
+++ b/community/cypher/interpreted-runtime/src/main/scala/org/neo4j/cypher/internal/runtime/interpreted/ResourceManager.scala
@@ -30,10 +30,7 @@ import scala.collection.JavaConverters._
 class ResourceManager extends CloseableResource {
   private val resources: util.Set[AutoCloseable] = newSetFromMap(new util.IdentityHashMap[AutoCloseable, java.lang.Boolean]())
 
-  def trace(resource: AutoCloseable): Unit =
-    if (!resources.add(resource)) {
-      throw new IllegalStateException(s"$resource is already in the resource set $resources")
-    }
+  def trace(resource: AutoCloseable): Unit = resources.add(resource)
 
   def release(resource: AutoCloseable): Unit = {
     resource.close()

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionCursor.java
@@ -65,10 +65,4 @@ public final class RelationshipDenseSelectionCursor extends RelationshipDenseSel
     {
         return relationshipCursor.targetNodeReference();
     }
-
-    @Override
-    protected void setRelationship( long id, long sourceNode, int type, long targetNode )
-    {
-        // nothing to do
-    }
 }

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionIterator.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionIterator.java
@@ -29,26 +29,26 @@ import org.neo4j.graphdb.ResourceIterator;
 public final class RelationshipDenseSelectionIterator<R> extends RelationshipDenseSelection
         implements ResourceIterator<R>
 {
+    private final static long NO_ID = -1L;
+    private final static long NOT_INITIALIZED = -2L;
     private RelationshipFactory<R> factory;
-    private R _next;
-    private boolean initialized;
+    private long _next = NOT_INITIALIZED;
 
-    public RelationshipDenseSelectionIterator( RelationshipFactory<R> factory )
+    RelationshipDenseSelectionIterator( RelationshipFactory<R> factory )
     {
         this.factory = factory;
-        this.initialized = false;
     }
 
     @Override
     public boolean hasNext()
     {
-        if ( !initialized )
+        if ( _next == NOT_INITIALIZED )
         {
             fetchNext();
-            initialized = true;
+            _next = relationshipCursor.relationshipReference();
         }
 
-        if ( _next == null )
+        if ( _next == NO_ID )
         {
             close();
             return false;
@@ -63,18 +63,15 @@ public final class RelationshipDenseSelectionIterator<R> extends RelationshipDen
         {
             throw new NoSuchElementException();
         }
-        R current = _next;
+        R current = factory.relationship( relationshipCursor.relationshipReference(),
+                relationshipCursor.sourceNodeReference(),
+                relationshipCursor.label(), relationshipCursor.targetNodeReference() );
         if ( !fetchNext() )
         {
-            _next = null;
+            _next = NO_ID;
         }
+        _next = relationshipCursor.relationshipReference();
 
         return current;
-    }
-
-    @Override
-    protected void setRelationship( long id, long sourceNode, int type, long targetNode )
-    {
-        _next = factory.relationship( id, sourceNode, type, targetNode );
     }
 }

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionIterator.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipDenseSelectionIterator.java
@@ -23,14 +23,15 @@ import java.util.NoSuchElementException;
 
 import org.neo4j.graphdb.ResourceIterator;
 
+import static org.neo4j.internal.kernel.api.helpers.RelationshipSelections.NOT_INITIALIZED;
+import static org.neo4j.internal.kernel.api.helpers.RelationshipSelections.NO_ID;
+
 /**
  * Helper iterator for traversing specific types and directions of a dense node.
  */
 public final class RelationshipDenseSelectionIterator<R> extends RelationshipDenseSelection
         implements ResourceIterator<R>
 {
-    private final static long NO_ID = -1L;
-    private final static long NOT_INITIALIZED = -2L;
     private RelationshipFactory<R> factory;
     private long _next = NOT_INITIALIZED;
 

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSelections.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSelections.java
@@ -35,6 +35,9 @@ public final class RelationshipSelections
         throw new UnsupportedOperationException( "Do not instantiate" );
     }
 
+    static final long NO_ID = -1L;
+    static final long NOT_INITIALIZED = -2L;
+
     /**
      * Returns an outgoing selection cursor given the provided node cursor and relationship types.
      *

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelection.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelection.java
@@ -46,7 +46,7 @@ abstract class RelationshipSparseSelection
      *
      * @param relationshipCursor Relationship traversal cursor to use. Pre-initialized on node.
      */
-    public void outgoing( RelationshipTraversalCursor relationshipCursor )
+    public final void outgoing( RelationshipTraversalCursor relationshipCursor )
     {
         init( relationshipCursor, null, Dir.OUT );
     }
@@ -57,7 +57,7 @@ abstract class RelationshipSparseSelection
      * @param relationshipCursor Relationship traversal cursor to use. Pre-initialized on node.
      * @param types Relationship types to traverse
      */
-    public void outgoing(
+    public final void outgoing(
             RelationshipTraversalCursor relationshipCursor,
             int[] types )
     {
@@ -69,7 +69,7 @@ abstract class RelationshipSparseSelection
      *
      * @param relationshipCursor Relationship traversal cursor to use. Pre-initialized on node.
      */
-    public void incoming( RelationshipTraversalCursor relationshipCursor )
+    public final void incoming( RelationshipTraversalCursor relationshipCursor )
     {
         init( relationshipCursor, null, Dir.IN );
     }
@@ -80,7 +80,7 @@ abstract class RelationshipSparseSelection
      * @param relationshipCursor Relationship traversal cursor to use. Pre-initialized on node.
      * @param types Relationship types to traverse
      */
-    public void incoming(
+    public final void incoming(
             RelationshipTraversalCursor relationshipCursor,
             int[] types )
     {
@@ -92,7 +92,7 @@ abstract class RelationshipSparseSelection
      *
      * @param relationshipCursor Relationship traversal cursor to use. Pre-initialized on node.
      */
-    public void all( RelationshipTraversalCursor relationshipCursor )
+    public final void all( RelationshipTraversalCursor relationshipCursor )
     {
         init( relationshipCursor, null, Dir.BOTH );
     }
@@ -103,7 +103,7 @@ abstract class RelationshipSparseSelection
      * @param relationshipCursor Relationship traversal cursor to use. Pre-initialized on node.
      * @param types Relationship types to traverse
      */
-    public void all(
+    public final void all(
             RelationshipTraversalCursor relationshipCursor,
             int[] types )
     {
@@ -120,12 +120,11 @@ abstract class RelationshipSparseSelection
     }
 
     /**
-     * Fetch the next valid relationship. If a valid relationship is found, will callback
-     * using {@link #setRelationship(long, long, int, long)}
+     * Fetch the next valid relationship. If a valid relationship is found.
      *
      * @return True is a valid relationship was found
      */
-    protected boolean fetchNext()
+    protected final boolean fetchNext()
     {
         if ( onRelationship || firstNext )
         {
@@ -136,25 +135,8 @@ abstract class RelationshipSparseSelection
             } while ( onRelationship && (!correctDirection() || !correctType()) );
         }
 
-        if ( onRelationship )
-        {
-           setRelationship( cursor.relationshipReference(),
-                            cursor.sourceNodeReference(),
-                            cursor.label(),
-                            cursor.targetNodeReference() );
-        }
         return onRelationship;
     }
-
-    /**
-     * Called when {@link #fetchNext()} finds a valid relationship.
-     *
-     * @param id relationship id
-     * @param sourceNode source node id
-     * @param type relationship type
-     * @param targetNode target node id
-     */
-    protected abstract void setRelationship( long id, long sourceNode, int type, long targetNode );
 
     private boolean correctDirection()
     {

--- a/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionCursor.java
+++ b/community/kernel-api/src/main/java/org/neo4j/internal/kernel/api/helpers/RelationshipSparseSelectionCursor.java
@@ -65,10 +65,4 @@ public final class RelationshipSparseSelectionCursor extends RelationshipSparseS
     {
         return cursor.targetNodeReference();
     }
-
-    @Override
-    protected void setRelationship( long id, long sourceNode, int type, long targetNode )
-    {
-        // nothing to do
-    }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/NeoStoreDataSource.java
@@ -82,8 +82,8 @@ import org.neo4j.kernel.impl.locking.LockService;
 import org.neo4j.kernel.impl.locking.ReentrantLockService;
 import org.neo4j.kernel.impl.locking.StatementLocksFactory;
 import org.neo4j.kernel.impl.logging.LogService;
-import org.neo4j.kernel.impl.newapi.KernelToken;
 import org.neo4j.kernel.impl.newapi.DefaultCursors;
+import org.neo4j.kernel.impl.newapi.KernelToken;
 import org.neo4j.kernel.impl.proc.Procedures;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.RecordStorageEngine;
 import org.neo4j.kernel.impl.storageengine.impl.recordstorage.id.IdController;
@@ -669,7 +669,7 @@ public class NeoStoreDataSource implements Lifecycle, IndexProviders
                 constraintIndexCreator, statementOperationParts, schemaWriteGuard, transactionHeaderInformationFactory,
                 transactionCommitProcess, indexConfigStore, explicitIndexProviderLookup, hooks, transactionMonitor,
                 availabilityGuard, tracers, storageEngine, procedures, transactionIdStore, clock,
-                cpuClockRef, heapAllocationRef, accessCapability, token, new DefaultCursors(), autoIndexing, explicitIndexStore ) );
+                cpuClockRef, heapAllocationRef, accessCapability, token, DefaultCursors::new, autoIndexing, explicitIndexStore ) );
 
         buildTransactionMonitor( kernelTransactions, clock, config );
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/KernelTransaction.java
@@ -21,8 +21,6 @@ package org.neo4j.kernel.api;
 
 import java.util.Optional;
 
-import org.neo4j.internal.kernel.api.NodeCursor;
-import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.Transaction;
 import org.neo4j.internal.kernel.api.security.LoginContext;
 import org.neo4j.internal.kernel.api.security.SecurityContext;
@@ -203,10 +201,6 @@ public interface KernelTransaction extends Transaction
     long getCommitTime();
 
     Revertable overrideWith( SecurityContext context );
-
-    NodeCursor nodeCursor();
-
-    PropertyCursor propertyCursor();
 
     @FunctionalInterface
     interface Revertable extends AutoCloseable

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/KernelTransactions.java
@@ -94,7 +94,7 @@ public class KernelTransactions extends LifecycleAdapter implements Supplier<Ker
     private final SystemNanoClock clock;
     private final ReentrantReadWriteLock newTransactionsLock = new ReentrantReadWriteLock();
     private final MonotonicCounter userTransactionIdCounter = MonotonicCounter.newAtomicMonotonicCounter();
-    private final DefaultCursors cursors;
+    private final Supplier<DefaultCursors> cursors;
     private final KernelToken token;
     private final AutoIndexing autoIndexing;
     private final ExplicitIndexStore explicitIndexStore;
@@ -136,7 +136,7 @@ public class KernelTransactions extends LifecycleAdapter implements Supplier<Ker
             StorageEngine storageEngine, Procedures procedures, TransactionIdStore transactionIdStore,
             SystemNanoClock clock,
             AtomicReference<CpuClock> cpuClockRef, AtomicReference<HeapAllocation> heapAllocationRef, AccessCapability accessCapability,
-            KernelToken token, DefaultCursors cursors,
+            KernelToken token, Supplier<DefaultCursors> cursors,
             AutoIndexing autoIndexing,
             ExplicitIndexStore explicitIndexStore )
     {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/NodeProxy.java
@@ -39,6 +39,7 @@ import org.neo4j.graphdb.RelationshipType;
 import org.neo4j.graphdb.ResourceIterable;
 import org.neo4j.graphdb.ResourceIterator;
 import org.neo4j.graphdb.TransactionTerminatedException;
+import org.neo4j.internal.kernel.api.CursorFactory;
 import org.neo4j.internal.kernel.api.LabelSet;
 import org.neo4j.internal.kernel.api.NodeCursor;
 import org.neo4j.internal.kernel.api.PropertyCursor;
@@ -320,8 +321,9 @@ public class NodeProxy implements Node
             throw new IllegalArgumentException( "(null) property key is not allowed" );
         }
         KernelTransaction transaction = safeAcquireTransaction();
-        NodeCursor nodes = transaction.nodeCursor();
-        PropertyCursor properties = transaction.propertyCursor();
+        CursorFactory cursors = transaction.cursors();
+        NodeCursor nodes = cursors.allocateNodeCursor();
+        PropertyCursor properties = cursors.allocatePropertyCursor();
         int propertyKey = transaction.tokenRead().propertyKey( key );
         if ( propertyKey == KeyReadOperations.NO_SUCH_PROPERTY_KEY )
         {
@@ -347,8 +349,9 @@ public class NodeProxy implements Node
         List<String> keys = new ArrayList<>();
         try
         {
-            NodeCursor nodes = transaction.nodeCursor();
-            PropertyCursor properties = transaction.propertyCursor();
+            CursorFactory cursors = transaction.cursors();
+            NodeCursor nodes = cursors.allocateNodeCursor();
+            PropertyCursor properties = cursors.allocatePropertyCursor();
             singleNode( transaction, nodes );
             TokenRead token = transaction.tokenRead();
             nodes.properties( properties );
@@ -393,8 +396,9 @@ public class NodeProxy implements Node
             propertyIds[i] = token.propertyKey( key );
         }
 
-        NodeCursor nodes = transaction.nodeCursor();
-        PropertyCursor propertyCursor = transaction.propertyCursor();
+        CursorFactory cursors = transaction.cursors();
+        NodeCursor nodes = cursors.allocateNodeCursor();
+        PropertyCursor propertyCursor = cursors.allocatePropertyCursor();
         singleNode( transaction, nodes );
         nodes.properties( propertyCursor );
         int propertiesToFind = itemsToReturn;
@@ -424,8 +428,9 @@ public class NodeProxy implements Node
 
         try
         {
-            NodeCursor nodes = transaction.nodeCursor();
-            PropertyCursor propertyCursor = transaction.propertyCursor();
+            CursorFactory cursors = transaction.cursors();
+            NodeCursor nodes = cursors.allocateNodeCursor();
+            PropertyCursor propertyCursor = cursors.allocatePropertyCursor();
             TokenRead token = transaction.tokenRead();
             singleNode( transaction, nodes );
             nodes.properties( propertyCursor );
@@ -456,8 +461,9 @@ public class NodeProxy implements Node
             throw new NotFoundException( format( "No such property, '%s'.", key ) );
         }
 
-        NodeCursor nodes = transaction.nodeCursor();
-        PropertyCursor properties = transaction.propertyCursor();
+        CursorFactory cursors = transaction.cursors();
+        NodeCursor nodes = cursors.allocateNodeCursor();
+        PropertyCursor properties = cursors.allocatePropertyCursor();
         singleNode( transaction, nodes );
         nodes.properties( properties );
         while ( properties.next() )
@@ -490,8 +496,9 @@ public class NodeProxy implements Node
             return false;
         }
 
-        NodeCursor nodes = transaction.nodeCursor();
-        PropertyCursor properties = transaction.propertyCursor();
+        CursorFactory cursors = transaction.cursors();
+        NodeCursor nodes = cursors.allocateNodeCursor();
+        PropertyCursor properties = cursors.allocatePropertyCursor();
         singleNode( transaction, nodes );
         nodes.properties( properties );
         while ( properties.next() )
@@ -753,7 +760,7 @@ public class NodeProxy implements Node
     private ResourceIterator<Relationship> getRelationshipSelectionIterator( Direction direction, int[] typeIds )
     {
         KernelTransaction transaction = safeAcquireTransaction();
-        NodeCursor node = transaction.nodeCursor();
+        NodeCursor node = transaction.cursors().allocateNodeCursor();
         transaction.dataRead().singleNode( getId(), node );
         if ( !node.next() )
         {

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/core/ThreadToStatementContextBridge.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/core/ThreadToStatementContextBridge.java
@@ -72,11 +72,11 @@ public class ThreadToStatementContextBridge extends LifecycleAdapter implements 
         {
             throw new BridgeNotInTransactionException();
         }
-        Optional<Status> terminationReason = transaction.getReasonIfTerminated();
-        terminationReason.ifPresent( status ->
+        if ( transaction.isTerminated() )
         {
-            throw new TransactionTerminatedException( status );
-        } );
+            Status terminationReason = transaction.getReasonIfTerminated().orElse( Status.Transaction.Terminated );
+            throw new TransactionTerminatedException( terminationReason );
+        }
     }
 
     public void assertInUnterminatedTransaction()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultCursors.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultCursors.java
@@ -20,60 +20,155 @@
 package org.neo4j.kernel.impl.newapi;
 
 import org.neo4j.internal.kernel.api.CursorFactory;
+import org.neo4j.kernel.impl.util.InstanceCache;
 
 public class DefaultCursors implements CursorFactory
 {
+    private final InstanceCache<DefaultNodeCursor> nodeCursor;
+    private final InstanceCache<DefaultRelationshipScanCursor> relationshipScanCursor;
+    private final InstanceCache<DefaultRelationshipTraversalCursor> relationshipTraversalCursor;
+    private final InstanceCache<DefaultPropertyCursor> propertyCursor;
+    private final InstanceCache<DefaultRelationshipGroupCursor> relationshipGroupCursor;
+    private final InstanceCache<DefaultNodeValueIndexCursor> nodeValueIndexCursor;
+    private final InstanceCache<DefaultNodeLabelIndexCursor> nodeLabelIndexCursor;
+    private final InstanceCache<DefaultNodeExplicitIndexCursor> nodeExplicitIndexCursor;
+    private final InstanceCache<DefaultRelationshipExplicitIndexCursor> relationshipExplicitIndexCursor;
+
+    public DefaultCursors()
+    {
+        nodeCursor = new InstanceCache<DefaultNodeCursor>()
+        {
+            @Override
+            protected DefaultNodeCursor create()
+            {
+                return new DefaultNodeCursor( this );
+            }
+        };
+
+        relationshipScanCursor = new InstanceCache<DefaultRelationshipScanCursor>()
+        {
+            @Override
+            protected DefaultRelationshipScanCursor create()
+            {
+                return new DefaultRelationshipScanCursor( this );
+            }
+        };
+
+        relationshipTraversalCursor = new InstanceCache<DefaultRelationshipTraversalCursor>()
+        {
+            @Override
+            protected DefaultRelationshipTraversalCursor create()
+            {
+                return new DefaultRelationshipTraversalCursor( new DefaultRelationshipGroupCursor( null ), this );
+            }
+        };
+
+        propertyCursor = new InstanceCache<DefaultPropertyCursor>()
+        {
+            @Override
+            protected DefaultPropertyCursor create()
+            {
+                return new DefaultPropertyCursor( this );
+            }
+        };
+
+        relationshipGroupCursor = new InstanceCache<DefaultRelationshipGroupCursor>()
+        {
+            @Override
+            protected DefaultRelationshipGroupCursor create()
+            {
+                return new DefaultRelationshipGroupCursor( this );
+            }
+        };
+
+        nodeValueIndexCursor = new InstanceCache<DefaultNodeValueIndexCursor>()
+        {
+            @Override
+            protected DefaultNodeValueIndexCursor create()
+            {
+                return new DefaultNodeValueIndexCursor( this );
+            }
+        };
+
+        nodeLabelIndexCursor = new InstanceCache<DefaultNodeLabelIndexCursor>()
+        {
+            @Override
+            protected DefaultNodeLabelIndexCursor create()
+            {
+                return new DefaultNodeLabelIndexCursor( this );
+            }
+        };
+
+        nodeExplicitIndexCursor = new InstanceCache<DefaultNodeExplicitIndexCursor>()
+        {
+            @Override
+            protected DefaultNodeExplicitIndexCursor create()
+            {
+                return new DefaultNodeExplicitIndexCursor( this );
+            }
+        };
+
+        relationshipExplicitIndexCursor = new InstanceCache<DefaultRelationshipExplicitIndexCursor>()
+        {
+            @Override
+            protected DefaultRelationshipExplicitIndexCursor create()
+            {
+                return new DefaultRelationshipExplicitIndexCursor( this );
+            }
+        };
+    }
+
     @Override
     public DefaultNodeCursor allocateNodeCursor()
     {
-        return new DefaultNodeCursor( );
+        return nodeCursor.get();
     }
 
     @Override
     public DefaultRelationshipScanCursor allocateRelationshipScanCursor()
     {
-        return new DefaultRelationshipScanCursor( );
+        return relationshipScanCursor.get( );
     }
 
     @Override
     public DefaultRelationshipTraversalCursor allocateRelationshipTraversalCursor()
     {
-        return new DefaultRelationshipTraversalCursor( allocateRelationshipGroupCursor() );
+        return relationshipTraversalCursor.get();
     }
 
     @Override
     public DefaultPropertyCursor allocatePropertyCursor()
     {
-        return new DefaultPropertyCursor( );
+        return propertyCursor.get();
     }
 
     @Override
     public DefaultRelationshipGroupCursor allocateRelationshipGroupCursor()
     {
-        return new DefaultRelationshipGroupCursor( );
+        return relationshipGroupCursor.get();
     }
 
     @Override
     public DefaultNodeValueIndexCursor allocateNodeValueIndexCursor()
     {
-        return new DefaultNodeValueIndexCursor( );
+        return nodeValueIndexCursor.get();
     }
 
     @Override
     public DefaultNodeLabelIndexCursor allocateNodeLabelIndexCursor()
     {
-        return new DefaultNodeLabelIndexCursor( );
+        return nodeLabelIndexCursor.get();
     }
 
     @Override
     public DefaultNodeExplicitIndexCursor allocateNodeExplicitIndexCursor()
     {
-        return new DefaultNodeExplicitIndexCursor( );
+        return nodeExplicitIndexCursor.get();
     }
 
     @Override
     public DefaultRelationshipExplicitIndexCursor allocateRelationshipExplicitIndexCursor()
     {
-        return new DefaultRelationshipExplicitIndexCursor( );
+        return relationshipExplicitIndexCursor.get();
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeCursor.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.newapi;
 
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveIntSet;
@@ -47,9 +48,12 @@ class DefaultNodeCursor extends NodeRecord implements NodeCursor
     private HasChanges hasChanges = HasChanges.MAYBE;
     private Set<Long> addedNodes;
 
-    DefaultNodeCursor()
+    private final Consumer<DefaultNodeCursor> pool;
+
+    DefaultNodeCursor( Consumer<DefaultNodeCursor> pool )
     {
         super( NO_ID );
+        this.pool = pool;
     }
 
     void scan( Read read )
@@ -242,21 +246,27 @@ class DefaultNodeCursor extends NodeRecord implements NodeCursor
     @Override
     public void close()
     {
-        if ( pageCursor != null )
-        {
-            pageCursor.close();
-            pageCursor = null;
-        }
         read = null;
+        hasChanges = HasChanges.MAYBE;
+        addedNodes = emptySet();
+        reset();
 
         if ( labelCursor != null )
         {
             labelCursor.close();
             labelCursor = null;
         }
-        hasChanges = HasChanges.MAYBE;
-        addedNodes = emptySet();
-        reset();
+
+        if ( pageCursor != null )
+        {
+            pageCursor.close();
+            pageCursor = null;
+
+            if ( pool != null )
+            {
+                pool.accept( this );
+            }
+        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeLabelIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultNodeLabelIndexCursor.java
@@ -21,6 +21,7 @@ package org.neo4j.kernel.impl.newapi;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
@@ -43,8 +44,11 @@ class DefaultNodeLabelIndexCursor extends IndexCursor<LabelScanValueIndexProgres
     private PrimitiveLongIterator added;
     private Set<Long> removed;
 
-    DefaultNodeLabelIndexCursor()
+    private final Consumer<DefaultNodeLabelIndexCursor> pool;
+
+    DefaultNodeLabelIndexCursor( Consumer<DefaultNodeLabelIndexCursor> pool )
     {
+        this.pool = pool;
         node = NO_ID;
     }
 
@@ -140,11 +144,19 @@ class DefaultNodeLabelIndexCursor extends IndexCursor<LabelScanValueIndexProgres
     @Override
     public void close()
     {
-        super.close();
-        node = NO_ID;
-        labels = null;
-        read = null;
-        removed = null;
+        if ( !isClosed() )
+        {
+            super.close();
+            node = NO_ID;
+            labels = null;
+            read = null;
+            removed = null;
+
+            if ( pool != null )
+            {
+                pool.accept( this );
+            }
+        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipExplicitIndexCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipExplicitIndexCursor.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.impl.newapi;
 
+import java.util.function.Consumer;
+
 import org.neo4j.internal.kernel.api.NodeCursor;
 import org.neo4j.internal.kernel.api.RelationshipExplicitIndexCursor;
 import org.neo4j.internal.kernel.api.RelationshipScanCursor;
@@ -33,6 +35,13 @@ class DefaultRelationshipExplicitIndexCursor extends IndexCursor<ExplicitIndexPr
     private int expectedSize;
     private long relationship;
     private float score;
+
+    private final Consumer<DefaultRelationshipExplicitIndexCursor> pool;
+
+    DefaultRelationshipExplicitIndexCursor( Consumer<DefaultRelationshipExplicitIndexCursor> pool )
+    {
+        this.pool = pool;
+    }
 
     @Override
     public void initialize( ExplicitIndexProgressor progressor, int expectedSize )
@@ -117,11 +126,19 @@ class DefaultRelationshipExplicitIndexCursor extends IndexCursor<ExplicitIndexPr
     @Override
     public void close()
     {
-        super.close();
-        relationship = NO_ID;
-        score = 0;
-        expectedSize = 0;
-        read = null;
+        if ( !isClosed() )
+        {
+            super.close();
+            relationship = NO_ID;
+            score = 0;
+            expectedSize = 0;
+            read = null;
+
+            if ( pool != null )
+            {
+                pool.accept( this );
+            }
+        }
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipGroupCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipGroupCursor.java
@@ -36,7 +36,7 @@ import static org.neo4j.kernel.impl.newapi.RelationshipReferenceEncoding.encodeN
 import static org.neo4j.kernel.impl.newapi.RelationshipReferenceEncoding.encodeNoLoopRels;
 import static org.neo4j.kernel.impl.newapi.RelationshipReferenceEncoding.encodeNoOutgoingRels;
 
-class DefaultRelationshipGroupCursor extends RelationshipGroupRecord implements RelationshipGroupCursor
+final class DefaultRelationshipGroupCursor extends RelationshipGroupRecord implements RelationshipGroupCursor
 {
     private Read read;
     private final RelationshipRecord edge = new RelationshipRecord( NO_ID );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipScanCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipScanCursor.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.impl.newapi;
 
 import java.util.Set;
+import java.util.function.Consumer;
 
 import org.neo4j.internal.kernel.api.RelationshipScanCursor;
 import org.neo4j.io.pagecache.PageCursor;
@@ -33,7 +34,14 @@ class DefaultRelationshipScanCursor extends RelationshipCursor implements Relati
     private long next;
     private long highMark;
     private PageCursor pageCursor;
-    Set<Long> addedRelationships;
+    private Set<Long> addedRelationships;
+
+    private final Consumer<DefaultRelationshipScanCursor> pool;
+
+    DefaultRelationshipScanCursor( Consumer<DefaultRelationshipScanCursor> pool )
+    {
+        this.pool = pool;
+    }
 
     void scan( int label, Read read )
     {
@@ -141,13 +149,19 @@ class DefaultRelationshipScanCursor extends RelationshipCursor implements Relati
     @Override
     public void close()
     {
+        read = null;
+        reset();
+
         if ( pageCursor != null )
         {
             pageCursor.close();
             pageCursor = null;
+
+            if ( pool != null )
+            {
+                pool.accept( this );
+            }
         }
-        read = null;
-        reset();
     }
 
     private void reset()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/DefaultRelationshipTraversalCursor.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.kernel.impl.newapi;
 
+import java.util.function.Consumer;
+
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.internal.kernel.api.NodeCursor;
@@ -117,6 +119,7 @@ class DefaultRelationshipTraversalCursor extends RelationshipCursor
     private Record buffer;
     private PageCursor pageCursor;
     private final DefaultRelationshipGroupCursor group;
+    private final Consumer<DefaultRelationshipTraversalCursor> pool;
     private GroupState groupState;
     private FilterState filterState;
     private boolean filterStore;
@@ -124,9 +127,10 @@ class DefaultRelationshipTraversalCursor extends RelationshipCursor
 
     private PrimitiveLongIterator addedRelationships;
 
-    DefaultRelationshipTraversalCursor( DefaultRelationshipGroupCursor group )
+    DefaultRelationshipTraversalCursor( DefaultRelationshipGroupCursor group, Consumer<DefaultRelationshipTraversalCursor> pool )
     {
         this.group = group;
+        this.pool = pool;
     }
 
     /*
@@ -478,13 +482,19 @@ class DefaultRelationshipTraversalCursor extends RelationshipCursor
     @Override
     public void close()
     {
+        read = null;
+        reset();
+
         if ( pageCursor != null )
         {
             pageCursor.close();
             pageCursor = null;
+
+            if ( pool != null )
+            {
+                pool.accept( this );
+            }
         }
-        read = null;
-        reset();
     }
 
     private void reset()

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Operations.java
@@ -86,7 +86,7 @@ public class Operations implements Write, ExplicitIndexWrite
     private final IndexTxStateUpdater updater;
     private DefaultPropertyCursor propertyCursor;
     private DefaultRelationshipScanCursor relationshipCursor;
-    private final DefaultCursors cursors;
+    private DefaultCursors cursors;
     private final NodeSchemaMatcher schemaMatcher;
 
     public Operations(
@@ -109,8 +109,10 @@ public class Operations implements Write, ExplicitIndexWrite
         this.schemaMatcher = schemaMatcher;
     }
 
-    public void initialize()
+    public void initialize( DefaultCursors cursors )
     {
+        this.cursors = cursors;
+        this.allStoreHolder.initialize( cursors );
         this.nodeCursor = cursors.allocateNodeCursor();
         this.propertyCursor = cursors.allocatePropertyCursor();
         this.relationshipCursor = cursors.allocateRelationshipScanCursor();
@@ -649,15 +651,5 @@ public class Operations implements Write, ExplicitIndexWrite
     public Read dataRead()
     {
         return allStoreHolder;
-    }
-
-    public DefaultNodeCursor nodeCursor()
-    {
-        return nodeCursor;
-    }
-
-    public DefaultPropertyCursor propertyCursor()
-    {
-        return propertyCursor;
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Read.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/Read.java
@@ -74,13 +74,18 @@ abstract class Read implements TxStateHolder,
         org.neo4j.internal.kernel.api.ExplicitIndexRead,
         org.neo4j.internal.kernel.api.SchemaRead
 {
-    private final DefaultCursors cursors;
+    private DefaultCursors cursors;
     final KernelTransactionImplementation ktx;
 
     Read( DefaultCursors cursors, KernelTransactionImplementation ktx )
     {
         this.cursors = cursors;
         this.ktx = ktx;
+    }
+
+    void initialize( DefaultCursors cursors )
+    {
+        this.cursors = cursors;
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/newapi/RelationshipCursor.java
@@ -19,8 +19,6 @@
  */
 package org.neo4j.kernel.impl.newapi;
 
-import java.util.Set;
-
 import org.neo4j.internal.kernel.api.NodeCursor;
 import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.RelationshipDataAccessor;

--- a/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/api/KernelTransactionFactory.java
@@ -102,7 +102,7 @@ public class KernelTransactionFactory
                 Clocks.systemClock(), new AtomicReference<>( CpuClock.NOT_AVAILABLE ), new AtomicReference<>( HeapAllocation.NOT_AVAILABLE ), NULL,
                 LockTracer.NONE,
                 PageCursorTracerSupplier.NULL,
-                storageEngine, new CanWrite(), new KernelToken( storeReadLayer ), new DefaultCursors(), AutoIndexing.UNSUPPORTED, mock(
+                storageEngine, new CanWrite(), new KernelToken( storeReadLayer ), DefaultCursors::new, AutoIndexing.UNSUPPORTED, mock(
                 ExplicitIndexStore.class) );
 
         StatementLocks statementLocks = new SimpleStatementLocks( new NoOpClient() );

--- a/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/StubKernelTransaction.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/builtinprocs/StubKernelTransaction.java
@@ -25,8 +25,6 @@ import org.neo4j.internal.kernel.api.CursorFactory;
 import org.neo4j.internal.kernel.api.ExplicitIndexRead;
 import org.neo4j.internal.kernel.api.ExplicitIndexWrite;
 import org.neo4j.internal.kernel.api.Locks;
-import org.neo4j.internal.kernel.api.NodeCursor;
-import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.Read;
 import org.neo4j.internal.kernel.api.SchemaRead;
 import org.neo4j.internal.kernel.api.SchemaWrite;
@@ -225,18 +223,6 @@ public class StubKernelTransaction implements KernelTransaction
 
     @Override
     public Revertable overrideWith( SecurityContext context )
-    {
-        throw new UnsupportedOperationException( "not implemented" );
-    }
-
-    @Override
-    public NodeCursor nodeCursor()
-    {
-        throw new UnsupportedOperationException( "not implemented" );
-    }
-
-    @Override
-    public PropertyCursor propertyCursor()
     {
         throw new UnsupportedOperationException( "not implemented" );
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTerminationTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTerminationTest.java
@@ -346,7 +346,7 @@ public class KernelTransactionTerminationTest
                     TransactionTracer.NULL,
                     LockTracer.NONE, PageCursorTracerSupplier.NULL,
                     mock( StorageEngine.class, RETURNS_MOCKS ), new CanWrite(), mock( KernelToken.class ),
-                    mock( DefaultCursors.class ), AutoIndexing.UNSUPPORTED, mock( ExplicitIndexStore.class ) );
+                    () -> mock( DefaultCursors.class ), AutoIndexing.UNSUPPORTED, mock( ExplicitIndexStore.class ) );
 
             this.monitor = monitor;
         }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTestBase.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionTestBase.java
@@ -155,7 +155,7 @@ public class KernelTransactionTestBase
         return new KernelTransactionImplementation( statementOperations, schemaWriteGuard, hooks, null, null, headerInformationFactory, commitProcess,
                 transactionMonitor, explicitIndexStateSupplier, txPool, clock, new AtomicReference<>( CpuClock.NOT_AVAILABLE ),
                 new AtomicReference<>( HeapAllocation.NOT_AVAILABLE ), TransactionTracer.NULL, LockTracer.NONE, PageCursorTracerSupplier.NULL, storageEngine,
-                new CanWrite(), mock( KernelToken.class ), new DefaultCursors(), AutoIndexing.UNSUPPORTED, mock( ExplicitIndexStore.class ) );
+                new CanWrite(), mock( KernelToken.class ), DefaultCursors::new, AutoIndexing.UNSUPPORTED, mock( ExplicitIndexStore.class ) );
     }
 
     public class CapturingCommitProcess implements TransactionCommitProcess

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/KernelTransactionsTest.java
@@ -586,7 +586,7 @@ public class KernelTransactionsTest
         return new KernelTransactions( statementLocksFactory, null, statementOperations, null, DEFAULT, commitProcess, null, null, new TransactionHooks(),
                 mock( TransactionMonitor.class ), availabilityGuard, tracers, storageEngine, new Procedures(), transactionIdStore, clock,
                 new AtomicReference<>( CpuClock.NOT_AVAILABLE ), new AtomicReference<>( HeapAllocation.NOT_AVAILABLE ), new CanWrite(),
-                new KernelToken( storageEngine.storeReadLayer() ), new DefaultCursors(), AutoIndexing.UNSUPPORTED, mock( ExplicitIndexStore.class ) );
+                new KernelToken( storageEngine.storeReadLayer() ), DefaultCursors::new, AutoIndexing.UNSUPPORTED, mock( ExplicitIndexStore.class ) );
     }
 
     private static TestKernelTransactions createTestTransactions( StorageEngine storageEngine,
@@ -652,7 +652,7 @@ public class KernelTransactionsTest
             super( statementLocksFactory, constraintIndexCreator, statementOperations, schemaWriteGuard, txHeaderFactory, transactionCommitProcess,
                     indexConfigStore, explicitIndexProviderLookup, hooks, transactionMonitor, availabilityGuard, tracers, storageEngine, procedures,
                     transactionIdStore, clock, new AtomicReference<>( CpuClock.NOT_AVAILABLE ), new AtomicReference<>( HeapAllocation.NOT_AVAILABLE ),
-                    accessCapability, token, cursors, autoIndexing, mock( ExplicitIndexStore.class ) );
+                    accessCapability, token, () -> cursors, autoIndexing, mock( ExplicitIndexStore.class ) );
         }
 
         @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/constraints/ConstraintIndexCreatorTest.java
@@ -30,8 +30,6 @@ import org.neo4j.internal.kernel.api.ExplicitIndexRead;
 import org.neo4j.internal.kernel.api.ExplicitIndexWrite;
 import org.neo4j.internal.kernel.api.Locks;
 import org.neo4j.internal.kernel.api.Modes;
-import org.neo4j.internal.kernel.api.NodeCursor;
-import org.neo4j.internal.kernel.api.PropertyCursor;
 import org.neo4j.internal.kernel.api.Read;
 import org.neo4j.internal.kernel.api.SchemaRead;
 import org.neo4j.internal.kernel.api.SchemaWrite;
@@ -576,17 +574,6 @@ public class ConstraintIndexCreatorTest
                 return timeout;
             }
 
-            @Override
-            public NodeCursor nodeCursor()
-            {
-                throw new UnsupportedOperationException( "not implemented" );
-            }
-
-            @Override
-            public PropertyCursor propertyCursor()
-            {
-                throw new UnsupportedOperationException( "not implemented" );
-            }
         }
     }
 }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueClientFilterTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/NodeValueClientFilterTest.java
@@ -135,7 +135,7 @@ public class NodeValueClientFilterTest implements IndexProgressor, NodeValueClie
     private NodeValueClientFilter initializeFilter( IndexQuery... filters )
     {
         NodeValueClientFilter filter = new NodeValueClientFilter(
-                this, new DefaultNodeCursor(), new DefaultPropertyCursor(), store, filters );
+                this, new DefaultNodeCursor( null ), new DefaultPropertyCursor( null ), store, filters );
         filter.initialize( IndexDescriptorFactory.forLabel( 11), this, null );
         return filter;
     }

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/OperationsLockTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/newapi/OperationsLockTest.java
@@ -118,7 +118,7 @@ public class OperationsLockTest
         operations = new Operations( allStoreHolder, mock( IndexTxStateUpdater.class ),
                 store, transaction, new KernelToken( storeReadLayer ), cursors, autoindexing,
                 mock( NodeSchemaMatcher.class ) );
-        operations.initialize();
+        operations.initialize( cursors );
 
         this.order = inOrder( locks, txState, storeReadLayer );
     }

--- a/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/StubKernelTransaction.java
+++ b/enterprise/kernel/src/test/java/org/neo4j/kernel/enterprise/builtinprocs/StubKernelTransaction.java
@@ -224,15 +224,4 @@ class StubKernelTransaction implements KernelTransaction
         return null;
     }
 
-    @Override
-    public NodeCursor nodeCursor()
-    {
-        throw new UnsupportedOperationException( "not implemented" );
-    }
-
-    @Override
-    public PropertyCursor propertyCursor()
-    {
-        throw new UnsupportedOperationException( "not implemented" );
-    }
 }


### PR DESCRIPTION
We saw some regressions from changing to the new Kernel API for traversals, this fix includes

- pooling cursors
- faster `assertInUnterminatedTransaction`
- Some minor optimizations on the relationship iterators.