### PR TITLE
SeekCursor faster for ranged queries

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/GBPTree.java
@@ -816,7 +816,7 @@ public class GBPTree<KEY,VALUE> implements Closeable
         // Returns cursor which is now initiated with left-most leaf node for the specified range
         return new SeekCursor<>( cursor, bTreeNode, fromInclusive, toExclusive, layout,
                 stableGeneration, unstableGeneration, generationSupplier, rootCatchup, rootGeneration,
-                exceptionDecorator );
+                exceptionDecorator, SeekCursor.DEFAULT_MAX_READ_AHEAD );
     }
 
     /**

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/SeekCursor.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/SeekCursor.java
@@ -523,7 +523,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
                 //   are made only once per batch instead of once per key/value.
                 // - (FAST) there are keys/values read and validated and ready to simply be returned to the user.
 
-                if ( cachedIndex + 1 < cachedLength && !closed && !cursor.shouldRetry() )
+                if ( cachedIndex + 1 < cachedLength && !closed && !(concurrentWriteHappened = cursor.shouldRetry()) )
                 {   // FAST, key/value is readily available
                     cachedIndex++;
                     if ( 0 <= pos && pos < keyCount && insideEndRange( exactMatch ) )

--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/SeekCursor.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/SeekCursor.java
@@ -142,20 +142,39 @@ import static org.neo4j.index.internal.gbptree.TreeNode.Type.LEAF;
  */
 class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hit<KEY,VALUE>
 {
+    static final int DEFAULT_MAX_READ_AHEAD = 20;
+
     /**
      * Cursor for reading from tree nodes and also will be moved around when following pointers.
      */
     private final PageCursor cursor;
 
     /**
-     * Key instance to use for reading keys from current node.
+     * Key instances to use for reading keys from current node.
      */
-    private final KEY mutableKey;
+    private final KEY[] mutableKeys;
 
     /**
      * Value instances to use for reading values from current node.
      */
-    private final VALUE mutableValue;
+    private final VALUE[] mutableValues;
+
+    /**
+     * Index into {@link #mutableKeys}/{@link #mutableValues}, i.e. which key/value to consider as result next.
+     */
+    private int cachedIndex;
+
+    /**
+     * Number of keys/values read into {@link #mutableKeys} and {@link #mutableValues} from the most recently read batch.
+     */
+    private int cachedLength;
+
+    /**
+     * Initially set to {@code false} after a {@link #readAndValidateNextKeyValueBatch()} and will become {@code true}
+     * as soon as coming across a key which is a result key. From that point on and until the next batch read,
+     * having this a {@code true} will allow fewer comparisons to figure out whether or not a key is a result key.
+     */
+    private boolean resultOnTrack;
 
     /**
      * Provided when constructing the {@link SeekCursor}, marks the start (inclusive) of the key range to seek.
@@ -363,9 +382,10 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
      */
     private final Consumer<Throwable> exceptionDecorator;
 
+    @SuppressWarnings( "unchecked" )
     SeekCursor( PageCursor cursor, TreeNode<KEY,VALUE> bTreeNode, KEY fromInclusive, KEY toExclusive,
             Layout<KEY,VALUE> layout, long stableGeneration, long unstableGeneration, LongSupplier generationSupplier,
-            Supplier<Root> rootCatchup, long lastFollowedPointerGeneration, Consumer<Throwable> exceptionDecorator )
+            Supplier<Root> rootCatchup, long lastFollowedPointerGeneration, Consumer<Throwable> exceptionDecorator, int maxReadAhead )
                     throws IOException
     {
         this.cursor = cursor;
@@ -380,8 +400,11 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
         this.bTreeNode = bTreeNode;
         this.rootCatchup = rootCatchup;
         this.lastFollowedPointerGeneration = lastFollowedPointerGeneration;
-        this.mutableKey = layout.newKey();
-        this.mutableValue = layout.newValue();
+        int batchSize = exactMatch ? 1 : maxReadAhead;
+        this.mutableKeys = (KEY[]) new Object[batchSize];
+        this.mutableValues = (VALUE[]) new Object[batchSize];
+        this.mutableKeys[0] = layout.newKey();
+        this.mutableValues[0] = layout.newValue();
         this.prevKey = layout.newKey();
         this.seekForward = layout.compare( fromInclusive, toExclusive ) <= 0;
         this.stride = seekForward ? 1 : -1;
@@ -480,6 +503,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
             // need to trigger search for key in next
             concurrentWriteHappened = true;
         }
+        cachedLength = 0;
     }
 
     @Override
@@ -487,7 +511,72 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
     {
         try
         {
-            return internalNext();
+            while ( true )
+            {
+                pos += stride;
+
+                // There are two main tracks in this loop:
+                // - (SLOW) no keys/values have been read and will therefore need to be read from the cursor.
+                //   Reading from the cursor means there are a lot of things around the actual keys and values
+                //   that need to be check to validate the read. This is expensive to do since there's so much
+                //   to validate. This is why keys/values are read in batches of N entries. The validations
+                //   are made only once per batch instead of once per key/value.
+                // - (FAST) there are keys/values read and validated and ready to simply be returned to the user.
+
+                if ( cachedIndex + 1 < cachedLength && !closed && !cursor.shouldRetry() )
+                {   // FAST, key/value is readily available
+                    cachedIndex++;
+                    if ( 0 <= pos && pos < keyCount && insideEndRange( exactMatch ) )
+                    {
+                        if ( resultOnTrack || isResultKey() )
+                        {
+                            layout.copyKey( mutableKeys[cachedIndex], prevKey );
+                            resultOnTrack = true;
+                            return true; // which marks this read a hit that user can see
+                        }
+                        continue;
+                    }
+                }
+                else
+                {   // SLOW, next batch of keys/values needs to be read
+                    if ( !readAndValidateNextKeyValueBatch() )
+                    {
+                        // Concurrent changes
+                        cachedLength = 0;
+                        continue;
+                    }
+
+                    // Below, the cached key/value at slot [0] will be used
+                    if ( !seekForward && pos >= keyCount )
+                    {
+                        goTo( prevSiblingId, prevSiblingGeneration, "prev sibling", true );
+                        // Continue in the read loop above so that we can continue reading from previous sibling
+                        // or on next position
+                        continue;
+                    }
+
+                    if ( (seekForward && pos >= keyCount) || (!seekForward && pos <= 0 && !insidePrevKey()) )
+                    {
+                        if ( goToNextSibling() )
+                        {
+                            continue; // in the read loop above so that we can continue reading from next sibling
+                        }
+                    }
+                    else if ( 0 <= pos && pos < keyCount && insideEndRange( exactMatch ) )
+                    {
+                        if ( isResultKey() )
+                        {
+                            layout.copyKey( mutableKeys[cachedIndex], prevKey );
+                            resultOnTrack = true;
+                            return true; // which marks this read a hit that user can see
+                        }
+                        continue;
+                    }
+                }
+
+                // We've come too far and so this means the end of the result set
+                return false;
+            }
         }
         catch ( Throwable e )
         {
@@ -496,118 +585,97 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
         }
     }
 
-    private boolean internalNext() throws IOException
+    private boolean readAndValidateNextKeyValueBatch() throws IOException
     {
-        while ( true )
+        do
         {
-            pos += stride;
-            // Read
-            do
+            cachedIndex = 0;
+            cachedLength = 0;
+            resultOnTrack = false;
+
+            // Where we are
+            if ( !readHeader() || isInternal )
             {
-                // Where we are
-                if ( !readHeader() || isInternal )
+                continue;
+            }
+
+            if ( verifyExpectedFirstAfterGoToNext )
+            {
+                pos = seekForward ? 0 : keyCount - 1;
+                bTreeNode.keyAt( cursor, firstKeyInNode, pos, LEAF );
+            }
+
+            if ( concurrentWriteHappened )
+            {
+                // Keys could have been moved so we need to make sure we are not missing any keys by
+                // moving position back until we find previously returned key
+                searchResult = searchKey( first ? fromInclusive : prevKey, LEAF );
+                if ( !KeySearch.isSuccess( searchResult ) )
                 {
                     continue;
                 }
+                pos = positionOf( searchResult );
 
-                if ( verifyExpectedFirstAfterGoToNext )
+                if ( !seekForward && pos >= keyCount )
                 {
-                    pos = seekForward ? 0 : keyCount - 1;
-                    bTreeNode.keyAt( cursor,firstKeyInNode, pos, LEAF );
-                }
-
-                if ( concurrentWriteHappened )
-                {
-                    // Keys could have been moved so we need to make sure we are not missing any keys by
-                    // moving position back until we find previously returned key
-                    searchResult = searchKey( first ? fromInclusive : prevKey, LEAF );
-                    if ( !KeySearch.isSuccess( searchResult ) )
-                    {
-                        continue;
-                    }
-                    pos = positionOf( searchResult );
-
-                    if ( !seekForward && pos >= keyCount )
-                    {
-                        // We may need to go to previous sibling to find correct place to start seeking from
-                        prevSiblingId = readPrevSibling();
-                        prevSiblingGeneration = readPointerGenerationOnSuccess( prevSiblingId );
-                    }
-                }
-
-                // Next result
-                if ( (seekForward && pos >= keyCount) || (!seekForward && pos <= 0) )
-                {
-                    // Read right sibling
-                    pointerId = readNextSibling();
-                    pointerGeneration = readPointerGenerationOnSuccess( pointerId );
-                }
-                if ( 0 <= pos && pos < keyCount )
-                {
-                    // Read the next value in this leaf
-                    bTreeNode.keyValueAt( cursor, mutableKey, mutableValue, pos );
+                    // We may need to go to previous sibling to find correct place to start seeking from
+                    prevSiblingId = readPrevSibling();
+                    prevSiblingGeneration = readPointerGenerationOnSuccess( prevSiblingId );
                 }
             }
-            while ( concurrentWriteHappened = cursor.shouldRetry() );
-            checkOutOfBoundsAndClosed();
-            cursor.checkAndClearCursorException();
 
-            // Act
-            if ( !endedUpOnExpectedNode() || isInternal )
+            // Next result
+            if ( (seekForward && pos >= keyCount) || (!seekForward && pos <= 0) )
             {
-                // This node has been reused for something else than a tree node. Restart seek from root.
-                prepareToStartFromRoot();
-                traverseDownToFirstLeaf();
-                continue;
+                // Read right sibling
+                pointerId = readNextSibling();
+                pointerGeneration = readPointerGenerationOnSuccess( pointerId );
             }
-            else if ( !saneRead() )
+            for ( int readPos = pos; cachedLength < mutableKeys.length && 0 <= readPos && readPos < keyCount; readPos += stride, cachedLength++ )
             {
-                throw new TreeInconsistencyException( "Read inconsistent tree node %d%n" +
-                        "  nodeType:%d%n  currentNodeGeneration:%d%n  successor:%d%n  successorGeneration:%d%n" +
-                        "  keyCount:%d%n  searchResult:%d%n  pos:%d%n" +
-                        "  rightSibling:%d%n  rightSiblingGeneration:%d",
-                        cursor.getCurrentPageId(), nodeType, currentNodeGeneration, successor, successorGeneration,
-                        keyCount, searchResult, pos, pointerId, pointerGeneration );
-            }
-
-            if ( !verifyFirstKeyInNodeIsExpectedAfterGoTo() )
-            {
-                continue;
-            }
-
-            if ( goToSuccessor() )
-            {
-                continue;
-            }
-
-            if ( !seekForward && pos >= keyCount )
-            {
-                goTo( prevSiblingId, prevSiblingGeneration, "prev sibling", true );
-                // Continue in the read loop above so that we can continue reading from previous sibling
-                // or on next position
-                continue;
-            }
-
-            if ( (seekForward && pos >= keyCount) || (!seekForward && pos <= 0 && !insidePrevKey()) )
-            {
-                if ( goToNextSibling() )
+                // Read the next value in this leaf
+                if ( mutableKeys[cachedLength] == null )
                 {
-                    continue; // in the read loop above so that we can continue reading from next sibling
+                    // Lazy instantiation of key/value
+                    mutableKeys[cachedLength] = layout.newKey();
+                    mutableValues[cachedLength] = layout.newValue();
                 }
+                bTreeNode.keyValueAt( cursor, mutableKeys[cachedLength], mutableValues[cachedLength], readPos );
             }
-            else if ( 0 <= pos && pos < keyCount && insideEndRange( exactMatch ) )
-            {
-                if ( isResultKey() )
-                {
-                    layout.copyKey( mutableKey, prevKey );
-                    return true; // which marks this read a hit that user can see
-                }
-                continue;
-            }
+        }
+        while ( concurrentWriteHappened = cursor.shouldRetry() );
+        checkOutOfBoundsAndClosed();
+        cursor.checkAndClearCursorException();
 
-            // We've come too far and so this means the end of the result set
+        // Act
+        if ( !endedUpOnExpectedNode() || isInternal )
+        {
+            // This node has been reused for something else than a tree node. Restart seek from root.
+            prepareToStartFromRoot();
+            traverseDownToFirstLeaf();
             return false;
         }
+        else if ( !saneRead() )
+        {
+            throw new TreeInconsistencyException( "Read inconsistent tree node %d%n" +
+                    "  nodeType:%d%n  currentNodeGeneration:%d%n  successor:%d%n  successorGeneration:%d%n" +
+                    "  keyCount:%d%n  searchResult:%d%n  pos:%d%n" +
+                    "  rightSibling:%d%n  rightSiblingGeneration:%d",
+                    cursor.getCurrentPageId(), nodeType, currentNodeGeneration, successor, successorGeneration,
+                    keyCount, searchResult, pos, pointerId, pointerGeneration );
+        }
+
+        if ( !verifyFirstKeyInNodeIsExpectedAfterGoTo() )
+        {
+            return false;
+        }
+
+        if ( goToSuccessor() )
+        {
+            return false;
+        }
+
+        return true;
     }
 
     /**
@@ -632,35 +700,35 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
     }
 
     /**
-     * @return whether or not the read key ({@link #mutableKey}) is "before" the end of the key range
+     * @return whether or not the read key ({@link #mutableKeys}) is "before" the end of the key range
      * ({@link #toExclusive}) of this seek.
      */
     private boolean insideEndRange( boolean exactMatch )
     {
         if ( exactMatch )
         {
-            return seekForward ? layout.compare( mutableKey, toExclusive ) <= 0
-                               : layout.compare( mutableKey, toExclusive ) >= 0;
+            return seekForward ? layout.compare( mutableKeys[cachedIndex], toExclusive ) <= 0
+                               : layout.compare( mutableKeys[cachedIndex], toExclusive ) >= 0;
         }
         else
         {
-            return seekForward ? layout.compare( mutableKey, toExclusive ) < 0
-                               : layout.compare( mutableKey, toExclusive ) > 0;
+            return seekForward ? layout.compare( mutableKeys[cachedIndex], toExclusive ) < 0
+                               : layout.compare( mutableKeys[cachedIndex], toExclusive ) > 0;
         }
     }
 
     /**
-     * @return whether or not the read key ({@link #mutableKey}) is "after" the start of the key range
+     * @return whether or not the read key ({@link #mutableKeys}) is "after" the start of the key range
      * ({@link #fromInclusive}) of this seek.
      */
     private boolean insideStartRange()
     {
-        return seekForward ? layout.compare( mutableKey, fromInclusive ) >= 0
-                           : layout.compare( mutableKey, fromInclusive ) <= 0;
+        return seekForward ? layout.compare( mutableKeys[cachedIndex], fromInclusive ) >= 0
+                           : layout.compare( mutableKeys[cachedIndex], fromInclusive ) <= 0;
     }
 
     /**
-     * @return whether or not the read key ({@link #mutableKey}) is "after" the last returned key of this seek
+     * @return whether or not the read key ({@link #mutableKeys}) is "after" the last returned key of this seek
      * ({@link #prevKey}), or if no result has been returned the start of the key range ({@link #fromInclusive}).
      */
     private boolean insidePrevKey()
@@ -669,8 +737,8 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
         {
             return insideStartRange();
         }
-        return seekForward ? layout.compare( mutableKey, prevKey ) > 0
-                           : layout.compare( mutableKey, prevKey ) < 0;
+        return seekForward ? layout.compare( mutableKeys[cachedIndex], prevKey ) > 0
+                           : layout.compare( mutableKeys[cachedIndex], prevKey ) < 0;
     }
 
     /**
@@ -769,7 +837,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
      */
     private int searchKey( KEY key, TreeNode.Type type )
     {
-        return KeySearch.search( cursor, bTreeNode, type, key, mutableKey, keyCount );
+        return KeySearch.search( cursor, bTreeNode, type, key, mutableKeys[0], keyCount );
     }
 
     private int positionOf( int searchResult )
@@ -943,7 +1011,7 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
     }
 
     /**
-     * @return whether or not the read {@link #mutableKey} is one that should be included in the result.
+     * @return whether or not the read {@link #mutableKeys} is one that should be included in the result.
      * If this method returns {@code true} then {@link #next()} will return {@code true}.
      * Returns {@code false} if this happened to be a bad read in the middle of a split or merge or so.
      */
@@ -1095,13 +1163,13 @@ class SeekCursor<KEY,VALUE> implements RawCursor<Hit<KEY,VALUE>,IOException>, Hi
     @Override
     public KEY key()
     {
-        return mutableKey;
+        return mutableKeys[cachedIndex];
     }
 
     @Override
     public VALUE value()
     {
-        return mutableValue;
+        return mutableValues[cachedIndex];
     }
 
     @Override

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTestBase.java
@@ -21,6 +21,7 @@ package org.neo4j.index.internal.gbptree;
 
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -35,6 +36,7 @@ import java.util.function.Supplier;
 
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.io.pagecache.impl.DelegatingPageCursor;
+import org.neo4j.test.rule.RandomRule;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
@@ -44,6 +46,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.neo4j.index.internal.gbptree.GenerationSafePointerPair.pointer;
+import static org.neo4j.index.internal.gbptree.SeekCursor.DEFAULT_MAX_READ_AHEAD;
 import static org.neo4j.index.internal.gbptree.TreeNode.Type.INTERNAL;
 import static org.neo4j.index.internal.gbptree.TreeNode.Type.LEAF;
 import static org.neo4j.index.internal.gbptree.ValueMergers.overwrite;
@@ -67,6 +70,9 @@ public abstract class SeekCursorTestBase<KEY, VALUE>
     private static final Consumer<Throwable> exceptionDecorator = t ->
     {
     };
+
+    @Rule
+    public final RandomRule random = new RandomRule();
 
     private TestLayout<KEY,VALUE> layout;
     private TreeNode<KEY,VALUE> node;
@@ -2191,7 +2197,7 @@ public abstract class SeekCursorTestBase<KEY, VALUE>
             PageCursor pageCursor, long stableGeneration, long unstableGeneration ) throws IOException
     {
         return new SeekCursor<>( pageCursor, node, key( fromInclusive ), key( toExclusive ), layout, stableGeneration, unstableGeneration,
-                generationSupplier, failingRootCatchup, unstableGeneration , exceptionDecorator, 1 );
+                generationSupplier, failingRootCatchup, unstableGeneration , exceptionDecorator, random.nextInt( 1, DEFAULT_MAX_READ_AHEAD ) );
     }
 
     /**

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/SeekCursorTestBase.java
@@ -1199,7 +1199,7 @@ public abstract class SeekCursorTestBase<KEY, VALUE>
         // WHEN
         try ( SeekCursor<KEY,VALUE> cursor = new SeekCursor<>( this.cursor,
                 node, from, to, layout, stableGeneration, unstableGeneration, () -> 0L, failingRootCatchup,
-                unstableGeneration, exceptionDecorator ) )
+                unstableGeneration, exceptionDecorator, 1 ) )
         {
             // reading a couple of keys
             assertTrue( cursor.next() );
@@ -1869,7 +1869,7 @@ public abstract class SeekCursorTestBase<KEY, VALUE>
         //noinspection EmptyTryBlock
         try ( SeekCursor<KEY,VALUE> ignored = new SeekCursor<>( cursor, node, key( 0 ), key( 1 ), layout,
                 stableGeneration, unstableGeneration, generationSupplier, rootCatchup, generation - 1,
-                exceptionDecorator ) )
+                exceptionDecorator, 1 ) )
         {
             // do nothing
         }
@@ -1920,7 +1920,7 @@ public abstract class SeekCursorTestBase<KEY, VALUE>
         //noinspection EmptyTryBlock
         try ( SeekCursor<KEY,VALUE> ignored = new SeekCursor<>( cursor, node, from, to, layout,
                 stableGeneration, unstableGeneration, generationSupplier, rootCatchup, unstableGeneration,
-                exceptionDecorator ) )
+                exceptionDecorator, 1 ) )
         {
             // do nothing
         }
@@ -1969,7 +1969,7 @@ public abstract class SeekCursorTestBase<KEY, VALUE>
         KEY to = key( 20L );
         try ( SeekCursor<KEY,VALUE> seek = new SeekCursor<>( cursor, node, from, to, layout,
                 stableGeneration - 1, unstableGeneration - 1, generationSupplier, rootCatchup, unstableGeneration,
-                exceptionDecorator ) )
+                exceptionDecorator, 1 ) )
         {
             while ( seek.next() )
             {
@@ -2191,7 +2191,7 @@ public abstract class SeekCursorTestBase<KEY, VALUE>
             PageCursor pageCursor, long stableGeneration, long unstableGeneration ) throws IOException
     {
         return new SeekCursor<>( pageCursor, node, key( fromInclusive ), key( toExclusive ), layout, stableGeneration, unstableGeneration,
-                generationSupplier, failingRootCatchup, unstableGeneration , exceptionDecorator );
+                generationSupplier, failingRootCatchup, unstableGeneration , exceptionDecorator, 1 );
     }
 
     /**


### PR DESCRIPTION
SeekCursor reads keys/values off of tree nodes while they are potentially
concurrently changing, getting deleted, getting reused and what not.
Therefore there's rigorous validation made after reading a key/value pair.
This validation is expensive and slows down ranged queries because every result
goes through this validation.

What this commit does is to read more key/value pairs while it's reading anyway,
and does validation of the read once per such batch. With a default batch size
of 20 this means that the expensive validation is made for basically every
20th result, instead of for every result.

The batch size can be experimented with, but having too big a batch size
may hurt by means of creating too many KEY/VALUE instances. Also interesting
coupled with this type of change is to consider SeekCursor pooling or to
let user explicitly allocate these SeekCursors and close when done.