### PR TITLE
Rename the Cypher frontend module to openCypher-frontend

### DIFF
--- a/community/cypher/cypher-logical-plans-3.4/pom.xml
+++ b/community/cypher/cypher-logical-plans-3.4/pom.xml
@@ -65,7 +65,7 @@
 
     <dependency>
       <groupId>org.neo4j</groupId>
-      <artifactId>neo4j-cypher-frontend-3.4</artifactId>
+      <artifactId>openCypher-frontend-1</artifactId>
       <version>${project.version}</version>
     </dependency>
 
@@ -79,7 +79,7 @@
 
     <dependency>
       <groupId>org.neo4j</groupId>
-      <artifactId>neo4j-cypher-frontend-3.4</artifactId>
+      <artifactId>openCypher-frontend-1</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/community/cypher/cypher-planner-3.4/pom.xml
+++ b/community/cypher/cypher-planner-3.4/pom.xml
@@ -88,7 +88,7 @@
 
     <dependency>
       <groupId>org.neo4j</groupId>
-      <artifactId>neo4j-cypher-frontend-3.4</artifactId>
+      <artifactId>openCypher-frontend-1</artifactId>
       <version>${project.version}</version>
     </dependency>
 
@@ -137,7 +137,7 @@
 
     <dependency>
       <groupId>org.neo4j</groupId>
-      <artifactId>neo4j-cypher-frontend-3.4</artifactId>
+      <artifactId>openCypher-frontend-1</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/community/cypher/cypher/pom.xml
+++ b/community/cypher/cypher/pom.xml
@@ -296,7 +296,7 @@
 
     <dependency>
       <groupId>org.neo4j</groupId>
-      <artifactId>neo4j-cypher-frontend-3.4</artifactId>
+      <artifactId>openCypher-frontend-1</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/community/cypher/frontend-3.4/pom.xml
+++ b/community/cypher/frontend-3.4/pom.xml
@@ -8,12 +8,24 @@
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>neo4j-cypher-frontend-3.4</artifactId>
+  <artifactId>openCypher-frontend-1</artifactId>
   <packaging>jar</packaging>
   <version>3.4.0-SNAPSHOT</version>
-  <name>Neo4j - Cypher Frontend 3.4</name>
+  <name>openCypher Frontend</name>
 
-  <description>Front end of the Cypher compiler</description>
+  <description>
+    Scala implementation of
+      - parser
+      - abstract syntax tree (AST)
+      - semantic analysis
+      - typing
+      - scoping
+
+    for openCypher queries, resulting in a normalised AST representation of the query string.
+
+    See https://www.opencypher.org for more information on the openCypher project and query language.
+  </description>
+
   <url>http://components.neo4j.org/${project.artifactId}/${project.version}</url>
 
   <scm>

--- a/community/cypher/ir-3.4/pom.xml
+++ b/community/cypher/ir-3.4/pom.xml
@@ -59,7 +59,7 @@
 
     <dependency>
       <groupId>org.neo4j</groupId>
-      <artifactId>neo4j-cypher-frontend-3.4</artifactId>
+      <artifactId>openCypher-frontend-1</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/enterprise/cypher/acceptance-spec-suite/pom.xml
+++ b/enterprise/cypher/acceptance-spec-suite/pom.xml
@@ -187,7 +187,7 @@
 
     <dependency>
       <groupId>org.neo4j</groupId>
-      <artifactId>neo4j-cypher-frontend-3.4</artifactId>
+      <artifactId>openCypher-frontend-1</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/enterprise/cypher/cypher/pom.xml
+++ b/enterprise/cypher/cypher/pom.xml
@@ -175,7 +175,7 @@
 
     <dependency>
       <groupId>org.neo4j</groupId>
-      <artifactId>neo4j-cypher-frontend-3.4</artifactId>
+      <artifactId>openCypher-frontend-1</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/enterprise/cypher/morsel-runtime/pom.xml
+++ b/enterprise/cypher/morsel-runtime/pom.xml
@@ -98,7 +98,7 @@
 
     <dependency>
       <groupId>org.neo4j</groupId>
-      <artifactId>neo4j-cypher-frontend-3.4</artifactId>
+      <artifactId>openCypher-frontend-1</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/enterprise/cypher/physical-planning/pom.xml
+++ b/enterprise/cypher/physical-planning/pom.xml
@@ -143,7 +143,7 @@
 
     <dependency>
       <groupId>org.neo4j</groupId>
-      <artifactId>neo4j-cypher-frontend-3.4</artifactId>
+      <artifactId>openCypher-frontend-1</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/enterprise/cypher/slotted-runtime/pom.xml
+++ b/enterprise/cypher/slotted-runtime/pom.xml
@@ -158,7 +158,7 @@
 
     <dependency>
       <groupId>org.neo4j</groupId>
-      <artifactId>neo4j-cypher-frontend-3.4</artifactId>
+      <artifactId>openCypher-frontend-1</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>


### PR DESCRIPTION
This is a small second step in the process of moving this module to the realm of `openCypher`. (The first step was relicensing the module to Apache 2.0.) 

This renames the module from `neo4j-cypher-frontend-3.4` to `openCypher-frontend-1`. The version stays the same (tied to Neo4j, latest `3.4.0-SNAPSHOT`). The description is also extended.

This would accomplish two things: signal to all users of this module that it belongs in `openCypher` space, and remove the Neo4j version from the name. A subsequent move of this module to another repository with a detached release process could choose a different version scheme, as long as it uses version numbers above `3.4`.

Possibly, we should also change the version, to not occupy the version space for the new `artifactId`. Although this may be a moot point because we expect the `groupId` to change once we make the move.