### PR TITLE
Fix the ibm-jdk8 red builds after jetty 9.4 upgrade

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/SecureWebSocketConnection.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/SecureWebSocketConnection.java
@@ -23,12 +23,24 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 
 import java.net.URI;
+import java.util.function.Supplier;
 
 public class SecureWebSocketConnection extends WebSocketConnection
 {
     public SecureWebSocketConnection()
     {
-        super( () -> new WebSocketClient( new SslContextFactory( /* trustall= */ true ) ),
-                address -> URI.create( "wss://" + address.getHost() + ":" + address.getPort() ) );
+        super( createTestClientSupplier(), address -> URI.create( "wss://" + address.getHost() + ":" + address.getPort() ) );
+    }
+
+    private static Supplier<WebSocketClient> createTestClientSupplier()
+    {
+        return () ->
+        {
+            SslContextFactory sslContextFactory = new SslContextFactory( /* trustall= */ true );
+            /* remove all default filters added by jetty on protocol and cipher suites */
+            sslContextFactory.setExcludeCipherSuites();
+            sslContextFactory.setExcludeProtocols();
+            return new WebSocketClient( sslContextFactory );
+        };
     }
 }


### PR DESCRIPTION
Jetty 9.4 only supports TLSv1.2 by default, however ibm-jdk8 only supports TLSv1.0 by default.
As a result, the tests failed to perform ssl handshake.
We fix the bug by removing the jetty TLS requirement in tests and let tests run on a lower TLS version.

For users who require TLS1.2 on ibm-jdk8, they could config jvm option `com.ibm.jsse2.overrideDefaultTLS=true`