### PR TITLE
Report the actual listening Bolt port in the log

### DIFF
--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
@@ -22,6 +22,7 @@ package org.neo4j.bolt;
 import io.netty.handler.ssl.SslContext;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
+import java.net.InetSocketAddress;
 import java.time.Clock;
 import java.util.Map;
 import java.util.function.Function;
@@ -192,12 +193,11 @@ public class BoltKernelExtension extends KernelExtensionFactory<BoltKernelExtens
 
         if ( !connectors.isEmpty() && !config.get( GraphDatabaseSettings.disconnected ) )
         {
-            life.add( new NettyServer( scheduler.threadFactory( boltNetworkIO ), connectors, connectionRegister ) );
+            NettyServer server = new NettyServer( scheduler.threadFactory( boltNetworkIO ),
+                                                  connectors, connectionRegister,
+                                                  logService.getUserLog( WorkerFactory.class ) );
+            life.add( server );
             log.info( "Bolt Server extension loaded." );
-            for ( ProtocolInitializer connector : connectors.values() )
-            {
-                logService.getUserLog( WorkerFactory.class ).info( "Bolt enabled on %s.", connector.address() );
-            }
         }
 
         return life;

--- a/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/BoltKernelExtension.java
@@ -22,7 +22,6 @@ package org.neo4j.bolt;
 import io.netty.handler.ssl.SslContext;
 import io.netty.util.internal.logging.InternalLoggerFactory;
 
-import java.net.InetSocketAddress;
 import java.time.Clock;
 import java.util.Map;
 import java.util.function.Function;

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/NettyServer.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/NettyServer.java
@@ -28,8 +28,6 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.epoll.Epoll;
 
 import java.net.InetSocketAddress;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadFactory;
 
@@ -40,7 +38,6 @@ import org.neo4j.helpers.ListenSocketAddress;
 import org.neo4j.helpers.PortBindException;
 import org.neo4j.kernel.configuration.BoltConnector;
 import org.neo4j.kernel.configuration.ConnectorPortRegister;
-import org.neo4j.kernel.impl.logging.LogService;
 import org.neo4j.kernel.lifecycle.LifecycleAdapter;
 import org.neo4j.logging.Log;
 import org.neo4j.util.FeatureToggles;

--- a/community/bolt/src/main/java/org/neo4j/bolt/transport/NettyServer.java
+++ b/community/bolt/src/main/java/org/neo4j/bolt/transport/NettyServer.java
@@ -112,9 +112,18 @@ public class NettyServer extends LifecycleAdapter
                                 .bind( protocolInitializer.address().socketAddress() ).sync();
                 InetSocketAddress localAddress = (InetSocketAddress) channelFuture.channel().localAddress();
                 connectionRegister.register( boltConnector.key(), localAddress );
-                ListenSocketAddress listenSocketAddress = new ListenSocketAddress(
-                        protocolInitializer.address().getHostname(), localAddress.getPort() );
-                log.info( "Bolt enabled on %s.", listenSocketAddress );
+                String host = protocolInitializer.address().getHostname();
+                int port = localAddress.getPort();
+                if ( host.contains( ":" ) )
+                {
+                    // IPv6
+                    log.info( "Bolt enabled on [%s]:%s.", host, port );
+                }
+                else
+                {
+                    // IPv4
+                    log.info( "Bolt enabled on %s:%s.", host, port );
+                }
             }
             catch ( Throwable e )
             {

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/NettyServerTest.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/NettyServerTest.java
@@ -35,6 +35,7 @@ import org.neo4j.helpers.NamedThreadFactory;
 import org.neo4j.helpers.PortBindException;
 import org.neo4j.kernel.configuration.BoltConnector;
 import org.neo4j.kernel.configuration.ConnectorPortRegister;
+import org.neo4j.logging.NullLog;
 
 import static org.neo4j.helpers.collection.MapUtil.genericMap;
 
@@ -59,7 +60,7 @@ public class NettyServerTest
             Map<BoltConnector,NettyServer.ProtocolInitializer> initializersMap =
                     genericMap( new BoltConnector( "test" ), protocolOnAddress( address ) );
             new NettyServer( new NamedThreadFactory( "mythreads" ), initializersMap,
-                    new ConnectorPortRegister() ).start();
+                             new ConnectorPortRegister(), NullLog.getInstance() ).start();
 
         }
     }


### PR DESCRIPTION
This change alters the log output to report the actual port(s) on which the Bolt connector(s) is/are listening.

While not commonly used outside testing environments, it is possible to configure the socket to [bind to port zero](https://www.dnorth.net/2012/03/17/the-port-0-trick/), which asks the network stack to select a vacant, high-numbered port. Previously, this was reported in the log as `0` rather than as the actual port number selected:
```
2018-02-06 17:28:50.788+0000 INFO  ======== Neo4j 3.4.0-SNAPSHOT ========
2018-02-06 17:28:50.813+0000 INFO  Starting...
2018-02-06 17:28:51.973+0000 INFO  Bolt enabled on [::]:0.
```

This PR moves the logging to a point when the actual port number is known and simply reports that instead:
```
2018-02-06 17:28:50.788+0000 INFO  ======== Neo4j 3.4.0-SNAPSHOT ========
2018-02-06 17:28:50.813+0000 INFO  Starting...
2018-02-06 17:28:51.973+0000 INFO  Bolt enabled on [::]:41359.
```