### PR TITLE
Add a PageCursor.copyTo(long,ByteBuffer) method.

### DIFF
--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/PageAwareByteArrayCursor.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/PageAwareByteArrayCursor.java
@@ -21,6 +21,7 @@ package org.neo4j.index.internal.gbptree;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -137,6 +138,18 @@ class PageAwareByteArrayCursor extends PageCursor
         for ( int i = 0; i < bytesToCopy; i++ )
         {
             targetCursor.putByte( targetOffset + i, getByte( sourceOffset + i ) );
+        }
+        return bytesToCopy;
+    }
+
+    @Override
+    public int copyTo( int sourceOffset, ByteBuffer buf )
+    {
+        int bytesToCopy = Math.min( buf.limit() - buf.position(), pageSize - sourceOffset );
+        for ( int i = 0; i < bytesToCopy; i++ )
+        {
+            byte b = getByte( sourceOffset + i );
+            buf.put( b );
         }
         return bytesToCopy;
     }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/PageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/PageCursor.java
@@ -21,6 +21,7 @@ package org.neo4j.io.pagecache;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 /**
  * A PageCursor is returned from {@link org.neo4j.io.pagecache.PagedFile#io(long, int)},
@@ -163,6 +164,7 @@ public abstract class PageCursor implements AutoCloseable
      * Set the given number of bytes to the given value, beginning at current offset into the page.
      */
     public abstract void putBytes( int bytes, byte value );
+
     /**
      * Get the signed short at the current page offset, and then increment the offset by one.
      */
@@ -306,10 +308,22 @@ public abstract class PageCursor implements AutoCloseable
     public abstract int copyTo( int sourceOffset, PageCursor targetCursor, int targetOffset, int lengthInBytes );
 
     /**
-     * Shift the specified number of bytes starting from given offset the specified number of bytes to the left or right. The area
+     * Copy bytes from the specified offset in this page, into the given buffer, until either the limit of the buffer
+     * is reached, or the end of the page is reached. The actual number of bytes copied is returned.
+     *
+     * @param sourceOffset The offset into this page to copy from.
+     * @param targetBuffer The buffer the data will be copied to.
+     * @return The number of bytes actually copied.
+     */
+    public abstract int copyTo( int sourceOffset, ByteBuffer targetBuffer );
+
+    /**
+     * Shift the specified number of bytes starting from given offset the specified number of bytes to the left or
+     * right. The area
      * left behind after the shift is not padded and thus is left with garbage.
      * <p>
-     * Out of bounds flag is raised if either start or end of either source range or target range fall outside end of this cursor
+     * Out of bounds flag is raised if either start or end of either source range or target range fall outside end of
+     * this cursor
      * or if length is negative.
      *
      * @param sourceOffset The offset into this page to start moving from.

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/CompositePageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/CompositePageCursor.java
@@ -21,6 +21,7 @@ package org.neo4j.io.pagecache.impl;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import org.neo4j.io.pagecache.CursorException;
 import org.neo4j.io.pagecache.PageCursor;
@@ -444,6 +445,12 @@ public class CompositePageCursor extends PageCursor
 
     @Override
     public int copyTo( int sourceOffset, PageCursor targetCursor, int targetOffset, int lengthInBytes )
+    {
+        throw new UnsupportedOperationException( "Composite cursor does not support copyTo functionality." );
+    }
+
+    @Override
+    public int copyTo( int sourceOffset, ByteBuffer targetBuffer )
     {
         throw new UnsupportedOperationException( "Composite cursor does not support copyTo functionality." );
     }

--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/DelegatingPageCursor.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/DelegatingPageCursor.java
@@ -21,6 +21,7 @@ package org.neo4j.io.pagecache.impl;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 
 import org.neo4j.io.pagecache.CursorException;
 import org.neo4j.io.pagecache.PageCursor;
@@ -42,6 +43,12 @@ public class DelegatingPageCursor extends PageCursor
     public int copyTo( int sourceOffset, PageCursor targetCursor, int targetOffset, int lengthInBytes )
     {
         return delegate.copyTo( sourceOffset, targetCursor, targetOffset, lengthInBytes );
+    }
+
+    @Override
+    public int copyTo( int sourceOffset, ByteBuffer targetBuffer )
+    {
+        return delegate.copyTo( sourceOffset, targetBuffer );
     }
 
     @Override

--- a/community/io/src/test/java/org/neo4j/io/pagecache/ByteArrayPageCursor.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/ByteArrayPageCursor.java
@@ -257,6 +257,12 @@ public class ByteArrayPageCursor extends PageCursor
     }
 
     @Override
+    public int copyTo( int sourceOffset, ByteBuffer targetBuffer )
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void shiftBytes( int sourceOffset, int length, int shift )
     {
         int currentOffset = getOffset();

--- a/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/PageCacheTest.java
@@ -31,12 +31,14 @@ import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.ByteBuffer;
+import java.nio.ReadOnlyBufferException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.OpenOption;
 import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -4313,7 +4315,7 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
     }
 
     @Test
-    public void copyToMustCheckBounds() throws Exception
+    public void copyToPageCursorMustCheckBounds() throws Exception
     {
         configureStandardPageCache();
         int pageSize = 16;
@@ -4364,6 +4366,174 @@ public abstract class PageCacheTest<T extends PageCache> extends PageCacheTestSu
             cursorA.copyTo( 1, cursorB, 1, -1 );
             assertTrue( cursorA.checkAndClearBoundsFlag() );
             assertFalse( cursorB.checkAndClearBoundsFlag() );
+        }
+    }
+
+    @Test
+    public void copyToHeapByteBufferFromReadPageCursorMustCheckBounds() throws Exception
+    {
+        configureStandardPageCache();
+        ByteBuffer buffer = ByteBuffer.allocate( filePageSize );
+        File file = file( "a" );
+        generateFileWithRecords( file, recordsPerFilePage, recordSize );
+        try ( PagedFile pf = pageCache.map( file, filePageSize );
+              PageCursor cursor = pf.io( 0, PF_SHARED_READ_LOCK ) )
+        {
+            assertTrue( cursor.next() );
+            verifyCopyToBufferBounds( cursor, buffer );
+        }
+    }
+
+    @Test
+    public void copyToDirectByteBufferFromReadPageCursorMustCheckBounds() throws Exception
+    {
+        configureStandardPageCache();
+        ByteBuffer buffer = ByteBuffer.allocateDirect( filePageSize );
+        File file = file( "a" );
+        generateFileWithRecords( file, recordsPerFilePage, recordSize );
+        try ( PagedFile pf = pageCache.map( file, filePageSize );
+              PageCursor cursor = pf.io( 0, PF_SHARED_READ_LOCK ) )
+        {
+            assertTrue( cursor.next() );
+            verifyCopyToBufferBounds( cursor, buffer );
+        }
+    }
+
+    @Test
+    public void copyToHeapByteBufferFromWritePageCursorMustCheckBounds() throws Exception
+    {
+        configureStandardPageCache();
+        ByteBuffer buffer = ByteBuffer.allocate( filePageSize );
+        File file = file( "a" );
+        generateFileWithRecords( file, recordsPerFilePage, recordSize );
+        try ( PagedFile pf = pageCache.map( file, filePageSize );
+              PageCursor cursor = pf.io( 0, PF_SHARED_WRITE_LOCK ) )
+        {
+            assertTrue( cursor.next() );
+            verifyCopyToBufferBounds( cursor, buffer );
+        }
+    }
+
+    @Test
+    public void copyToDirectByteBufferFromWritePageCursorMustCheckBounds() throws Exception
+    {
+        configureStandardPageCache();
+        ByteBuffer buffer = ByteBuffer.allocateDirect( filePageSize );
+        File file = file( "a" );
+        generateFileWithRecords( file, recordsPerFilePage, recordSize );
+        try ( PagedFile pf = pageCache.map( file, filePageSize );
+              PageCursor cursor = pf.io( 0, PF_SHARED_WRITE_LOCK ) )
+        {
+            assertTrue( cursor.next() );
+            verifyCopyToBufferBounds( cursor, buffer );
+        }
+    }
+
+    private void verifyCopyToBufferBounds( PageCursor cursor, ByteBuffer buffer ) throws IOException
+    {
+        // Assuming no mistakes, the data must be copied as is.
+        int copied;
+        do
+        {
+            buffer.clear();
+            copied = cursor.copyTo( 0, buffer );
+        }
+        while ( cursor.shouldRetry() );
+        assertThat( copied, is( filePageSize ) );
+        buffer.clear();
+        verifyRecordsMatchExpected( 0, 0, buffer );
+
+        // Source buffer underflow.
+        buffer.clear();
+        cursor.copyTo( -1, buffer );
+        assertTrue( cursor.checkAndClearBoundsFlag() );
+
+        // Target buffer overflow^W truncation.
+        buffer.clear();
+        copied = cursor.copyTo( 1, buffer );
+        assertFalse( cursor.checkAndClearBoundsFlag() );
+        assertThat( copied, is( filePageSize - 1 ) );
+        assertThat( buffer.position(), is( filePageSize - 1 ) );
+        assertThat( buffer.remaining(), is( 1 ) );
+        buffer.clear();
+
+        // Smaller buffer at offset zero.
+        zapBuffer( buffer );
+        do
+        {
+            buffer.clear();
+            buffer.limit( filePageSize - recordSize );
+            copied = cursor.copyTo( 0, buffer );
+        }
+        while ( cursor.shouldRetry() );
+        assertThat( copied, is( filePageSize - recordSize ) );
+        assertThat( buffer.position(), is( filePageSize - recordSize ) );
+        assertThat( buffer.remaining(), is( 0 ) );
+        buffer.clear();
+        buffer.limit( filePageSize - recordSize );
+        verifyRecordsMatchExpected( 0, 0, buffer );
+
+        // Smaller buffer at non-zero offset.
+        zapBuffer( buffer );
+        do
+        {
+            buffer.clear();
+            buffer.limit( filePageSize - recordSize );
+            copied = cursor.copyTo( recordSize, buffer );
+        }
+        while ( cursor.shouldRetry() );
+        assertThat( copied, is( filePageSize - recordSize ) );
+        assertThat( buffer.position(), is( filePageSize - recordSize ) );
+        assertThat( buffer.remaining(), is( 0 ) );
+        buffer.clear();
+        buffer.limit( filePageSize - recordSize );
+        verifyRecordsMatchExpected( 0, recordSize, buffer );
+    }
+
+    private void zapBuffer( ByteBuffer buffer )
+    {
+        byte zero = (byte) 0;
+        if ( buffer.hasArray() )
+        {
+            Arrays.fill( buffer.array(), zero );
+        }
+        else
+        {
+            buffer.clear();
+            while ( buffer.hasRemaining() )
+            {
+                buffer.put( zero );
+            }
+        }
+    }
+
+    @Test
+    public void copyToReadOnlyHeapByteBufferMustThrow() throws Exception
+    {
+        configureStandardPageCache();
+        ByteBuffer buf = ByteBuffer.allocate( filePageSize ).asReadOnlyBuffer();
+        try ( PagedFile pf = pageCache.map( file( "a" ), filePageSize );
+              PageCursor cursor = pf.io( 0, PF_SHARED_WRITE_LOCK ) )
+        {
+            assertTrue( cursor.next() );
+
+            expectedException.expect( ReadOnlyBufferException.class );
+            cursor.copyTo( 0, buf );
+        }
+    }
+
+    @Test
+    public void copyToReadOnlyDirectByteBufferMustThrow() throws Exception
+    {
+        configureStandardPageCache();
+        ByteBuffer buf = ByteBuffer.allocateDirect( filePageSize ).asReadOnlyBuffer();
+        try ( PagedFile pf = pageCache.map( file( "a" ), filePageSize );
+              PageCursor cursor = pf.io( 0, PF_SHARED_WRITE_LOCK ) )
+        {
+            assertTrue( cursor.next() );
+
+            expectedException.expect( ReadOnlyBufferException.class );
+            cursor.copyTo( 0, buf );
         }
     }
 

--- a/community/io/src/test/java/org/neo4j/io/pagecache/StubPageCursor.java
+++ b/community/io/src/test/java/org/neo4j/io/pagecache/StubPageCursor.java
@@ -130,6 +130,12 @@ public class StubPageCursor extends PageCursor
     }
 
     @Override
+    public int copyTo( int sourceOffset, ByteBuffer targetBuffer )
+    {
+        return 0;
+    }
+
+    @Override
     public void shiftBytes( int sourceOffset, int length, int shift )
     {
         throw new UnsupportedOperationException( "Stub cursor does not support this method... yet" );

--- a/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtil.java
+++ b/community/unsafe/src/main/java/org/neo4j/unsafe/impl/internal/dragons/UnsafeUtil.java
@@ -55,8 +55,9 @@ public final class UnsafeUtil
 {
     /**
      * Whether or not to explicitly dirty the allocated memory. This is off by default.
-     * The {@link UnsafeUtil#allocateMemory(long, MemoryAllocationTracker)} method is not guaranteed to allocate zeroed out memory, but might
-     * often do so by pure chance.
+     * The {@link UnsafeUtil#allocateMemory(long, MemoryAllocationTracker)} method is not guaranteed to allocate
+     * zeroed out memory, but might often do so by pure chance.
+     * <p>
      * Enabling this feature will make sure that the allocated memory is full of random data, such that we can test
      * and verify that our code does not assume that memory is clean when allocated.
      */
@@ -70,7 +71,7 @@ public final class UnsafeUtil
     private static final String allowUnalignedMemoryAccessProperty =
             "org.neo4j.unsafe.impl.internal.dragons.UnsafeUtil.allowUnalignedMemoryAccess";
 
-    private static final Class<?> directByteBufferClass;
+    public static final Class<?> directByteBufferClass;
     private static final Constructor<?> directByteBufferCtor;
     private static final long directByteBufferMarkOffset;
     private static final long directByteBufferPositionOffset;
@@ -137,8 +138,8 @@ public final class UnsafeUtil
         // See java.nio.Bits.unaligned() and its uses.
         String alignmentProperty = System.getProperty( allowUnalignedMemoryAccessProperty );
         if ( alignmentProperty != null &&
-                (alignmentProperty.equalsIgnoreCase( "true" )
-                        || alignmentProperty.equalsIgnoreCase( "false" )) )
+             (alignmentProperty.equalsIgnoreCase( "true" )
+              || alignmentProperty.equalsIgnoreCase( "false" )) )
         {
             allowUnalignedMemoryAccess = Boolean.parseBoolean( alignmentProperty );
         }
@@ -402,7 +403,7 @@ public final class UnsafeUtil
      * The given pointer should be allocated with at least the requested size + {@code alignBy - 1},
      * where the additional bytes will serve as padding for the worst case where the start of the usable
      * area of the allocated memory will need to be shifted at most {@code alignBy - 1} bytes to the right.
-     *
+     * <p>
      * <pre><code>
      * 0   4   8   12  16  20        ; 4-byte alignments
      * |---|---|---|---|---|         ; memory
@@ -467,7 +468,7 @@ public final class UnsafeUtil
         }
     }
 
-    private static final ConcurrentSkipListMap<Long, Long> pointers = new ConcurrentSkipListMap<>();
+    private static final ConcurrentSkipListMap<Long,Long> pointers = new ConcurrentSkipListMap<>();
     private static final FreeTrace[] freeTraces = CHECK_NATIVE_ACCESS ? new FreeTrace[4096] : null;
     private static final AtomicLong freeTraceCounter = new AtomicLong();
 
@@ -974,6 +975,19 @@ public final class UnsafeUtil
     }
 
     /**
+     * Read the value of the address field in the (assumed to be) DirectByteBuffer.
+     * <p>
+     * <strong>NOTE:</strong> calling this method on a non-direct ByteBuffer is undefined behaviour.
+     *
+     * @param dbb The direct byte buffer to read the address field from.
+     * @return The native memory address in the given direct byte buffer.
+     */
+    public static long getDirectByteBufferAddress( ByteBuffer dbb )
+    {
+        return unsafe.getLong( dbb, directByteBufferAddressOffset );
+    }
+
+    /**
      * Change if native access checking is enabled by setting it to the given new setting, and returning the old
      * setting.
      * <p>
@@ -1006,7 +1020,7 @@ public final class UnsafeUtil
      */
     public static short getShortByteWiseLittleEndian( long p )
     {
-        short a = (short) (UnsafeUtil.getByte( p     ) & 0xFF);
+        short a = (short) (UnsafeUtil.getByte( p ) & 0xFF);
         short b = (short) (UnsafeUtil.getByte( p + 1 ) & 0xFF);
         return (short) ((b << 8) | a);
     }
@@ -1022,7 +1036,7 @@ public final class UnsafeUtil
      */
     public static int getIntByteWiseLittleEndian( long p )
     {
-        int a = UnsafeUtil.getByte( p     ) & 0xFF;
+        int a = UnsafeUtil.getByte( p ) & 0xFF;
         int b = UnsafeUtil.getByte( p + 1 ) & 0xFF;
         int c = UnsafeUtil.getByte( p + 2 ) & 0xFF;
         int d = UnsafeUtil.getByte( p + 3 ) & 0xFF;
@@ -1040,7 +1054,7 @@ public final class UnsafeUtil
      */
     public static long getLongByteWiseLittleEndian( long p )
     {
-        long a = UnsafeUtil.getByte( p     ) & 0xFF;
+        long a = UnsafeUtil.getByte( p ) & 0xFF;
         long b = UnsafeUtil.getByte( p + 1 ) & 0xFF;
         long c = UnsafeUtil.getByte( p + 2 ) & 0xFF;
         long d = UnsafeUtil.getByte( p + 3 ) & 0xFF;
@@ -1078,9 +1092,9 @@ public final class UnsafeUtil
     public static void putIntByteWiseLittleEndian( long p, int value )
     {
         UnsafeUtil.putByte( p, (byte) value );
-        UnsafeUtil.putByte( p + 1, (byte)( value >> 8  ) );
-        UnsafeUtil.putByte( p + 2, (byte)( value >> 16 ) );
-        UnsafeUtil.putByte( p + 3, (byte)( value >> 24 ) );
+        UnsafeUtil.putByte( p + 1, (byte) (value >> 8) );
+        UnsafeUtil.putByte( p + 2, (byte) (value >> 16) );
+        UnsafeUtil.putByte( p + 3, (byte) (value >> 24) );
     }
 
     /**
@@ -1095,12 +1109,12 @@ public final class UnsafeUtil
     public static void putLongByteWiseLittleEndian( long p, long value )
     {
         UnsafeUtil.putByte( p, (byte) value );
-        UnsafeUtil.putByte( p + 1, (byte)( value >> 8  ) );
-        UnsafeUtil.putByte( p + 2, (byte)( value >> 16 ) );
-        UnsafeUtil.putByte( p + 3, (byte)( value >> 24 ) );
-        UnsafeUtil.putByte( p + 4, (byte)( value >> 32 ) );
-        UnsafeUtil.putByte( p + 5, (byte)( value >> 40 ) );
-        UnsafeUtil.putByte( p + 6, (byte)( value >> 48 ) );
-        UnsafeUtil.putByte( p + 7, (byte)( value >> 56 ) );
+        UnsafeUtil.putByte( p + 1, (byte) (value >> 8) );
+        UnsafeUtil.putByte( p + 2, (byte) (value >> 16) );
+        UnsafeUtil.putByte( p + 3, (byte) (value >> 24) );
+        UnsafeUtil.putByte( p + 4, (byte) (value >> 32) );
+        UnsafeUtil.putByte( p + 5, (byte) (value >> 40) );
+        UnsafeUtil.putByte( p + 6, (byte) (value >> 48) );
+        UnsafeUtil.putByte( p + 7, (byte) (value >> 56) );
     }
 }


### PR DESCRIPTION
Using this method, we can choose to quickly copy memory out of our page cursors for interpretation,
so we can simplify the cases where inconsistent-read-robust record decoding is too difficult to do.