### PR TITLE
Less indirection

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/AbstractIndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/AbstractIndexReader.java
@@ -45,7 +45,7 @@ public abstract class AbstractIndexReader implements IndexReader
                     String.format( "This reader only have support for index order %s. Provided index order was %s.",
                             IndexOrder.NONE, indexOrder ) );
         }
-        client.initialize( descriptor, new NodeValueIndexProgressor( query( query ), client ), query );
+        client.initialize( descriptor,  query( client, query ), query );
     }
 
 }

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/IndexProgressors.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/IndexProgressors.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.storageengine.api.schema;
+
+import java.util.Iterator;
+
+import org.neo4j.helpers.collection.Iterables;
+import org.neo4j.io.IOUtils;
+
+public final class IndexProgressors
+{
+    private IndexProgressors()
+    {
+        throw new UnsupportedOperationException( "Do not instantiate" );
+    }
+
+    public static IndexProgressor concat( IndexProgressor... progressors )
+    {
+        return new IndexProgressor()
+        {
+            private int current;
+            private volatile boolean closed;
+
+            @Override
+            public boolean next()
+            {
+                while ( !closed && current < progressors.length )
+                {
+                    if ( progressors[current].next() )
+                    {
+                        return true;
+                    }
+                    current++;
+                }
+                return false;
+            }
+
+            @Override
+            public void close()
+            {
+                if ( !closed )
+                {
+                    closed = true;
+                    IOUtils.closeAllSilently( progressors );
+                }
+            }
+        };
+    }
+
+    public static IndexProgressor concat( Iterable<IndexProgressor> progressors )
+    {
+        return new IndexProgressor()
+        {
+            private Iterator<IndexProgressor> iterator = progressors.iterator();
+            private IndexProgressor current;
+            private volatile boolean closed;
+
+            @Override
+            public boolean next()
+            {
+                if ( current == null && !iterator.hasNext() )
+                {
+                    return false;
+                }
+                else if ( current == null )
+                {
+                    current = iterator.next();
+                }
+
+                while ( !closed )
+                {
+                    if ( current.next() )
+                    {
+                        return true;
+                    }
+                    else if ( iterator.hasNext() )
+                    {
+                        current = iterator.next();
+                    }
+                    else
+                    {
+                        return false;
+                    }
+                }
+                return false;
+            }
+
+            @Override
+            public void close()
+            {
+                if ( !closed )
+                {
+                    closed = true;
+                    IOUtils.closeAllSilently( Iterables.asCollection( progressors ) );
+                }
+            }
+        };
+    }
+}

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/IndexReader.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/IndexReader.java
@@ -53,6 +53,16 @@ public interface IndexReader extends Resource
     /**
      * Queries the index for the given {@link IndexQuery} predicates.
      *
+     * @param client the client the progressor should communicate with
+     * @param predicates the predicates to query for.
+     * @return a progressor over the matching entity IDs.
+     */
+    IndexProgressor query( IndexProgressor.NodeValueClient client, IndexQuery... predicates )
+            throws IndexNotApplicableKernelException;
+
+    /**
+     * Queries the index for the given {@link IndexQuery} predicates.
+     *
      * @param client the client which will control the progression though query results.
      * @param query the query so serve.
      */
@@ -90,6 +100,13 @@ public interface IndexReader extends Resource
         public PrimitiveLongResourceIterator query( IndexQuery[] predicates )
         {
             return PrimitiveLongResourceCollections.emptyIterator();
+        }
+
+        @Override
+        public IndexProgressor query( IndexProgressor.NodeValueClient client, IndexQuery... predicates )
+                throws IndexNotApplicableKernelException
+        {
+            return IndexProgressor.EMPTY;
         }
 
         @Override

--- a/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/NodeValueIndexProgressor.java
+++ b/community/kernel/src/main/java/org/neo4j/storageengine/api/schema/NodeValueIndexProgressor.java
@@ -22,12 +22,12 @@ package org.neo4j.storageengine.api.schema;
 import org.neo4j.collection.primitive.PrimitiveLongResourceIterator;
 import org.neo4j.values.storable.Value;
 
-class NodeValueIndexProgressor implements IndexProgressor
+public class NodeValueIndexProgressor implements IndexProgressor
 {
     private final PrimitiveLongResourceIterator ids;
     private final NodeValueClient client;
 
-    NodeValueIndexProgressor( PrimitiveLongResourceIterator ids, NodeValueClient client )
+    public NodeValueIndexProgressor( PrimitiveLongResourceIterator ids, NodeValueClient client )
     {
         this.ids = ids;
         this.client = client;

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/HashBasedIndex.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/api/index/inmemory/HashBasedIndex.java
@@ -32,8 +32,11 @@ import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.collection.primitive.PrimitiveLongResourceIterator;
 import org.neo4j.helpers.collection.Iterables;
 import org.neo4j.internal.kernel.api.IndexQuery;
+import org.neo4j.kernel.api.exceptions.index.IndexNotApplicableKernelException;
 import org.neo4j.kernel.api.schema.index.IndexDescriptor;
+import org.neo4j.storageengine.api.schema.IndexProgressor;
 import org.neo4j.storageengine.api.schema.IndexSampler;
+import org.neo4j.storageengine.api.schema.NodeValueIndexProgressor;
 import org.neo4j.values.storable.Value;
 
 import static org.neo4j.collection.primitive.PrimitiveLongCollections.emptyIterator;
@@ -291,6 +294,13 @@ class HashBasedIndex extends InMemoryIndexImplementation
         default:
             throw new RuntimeException( "Unsupported query: " + Arrays.toString( predicates ) );
         }
+    }
+
+    @Override
+    public IndexProgressor query( IndexProgressor.NodeValueClient client, IndexQuery... predicates )
+            throws IndexNotApplicableKernelException
+    {
+        return new NodeValueIndexProgressor( query( predicates ), client );
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/storageengine/api/schema/DefaultIndexReaderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/storageengine/api/schema/DefaultIndexReaderTest.java
@@ -72,6 +72,13 @@ public class DefaultIndexReaderTest
             }
 
             @Override
+            public IndexProgressor query( IndexProgressor.NodeValueClient client, IndexQuery... predicates )
+                    throws IndexNotApplicableKernelException
+            {
+                return null;
+            }
+
+            @Override
             public boolean hasFullNumberPrecision( IndexQuery... predicates )
             {
                 return false;

--- a/community/kernel/src/test/java/org/neo4j/storageengine/api/schema/IndexProgressorsTest.java
+++ b/community/kernel/src/test/java/org/neo4j/storageengine/api/schema/IndexProgressorsTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.storageengine.api.schema;
+
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.neo4j.storageengine.api.schema.IndexProgressors.concat;
+
+public class IndexProgressorsTest
+{
+    @Test
+    public void shouldConcatTwoIndexProgressors()
+    {
+        //Given
+        IndexProgressor a = progressor( 1, 2, 3 );
+        IndexProgressor b = progressor( 3, 4, 5, 6 );
+
+        //When
+        IndexProgressor concat = concat( a, b );
+
+        //Then
+        assertThat( count( concat ), equalTo( 7 ) );
+    }
+
+    @Test
+    public void shouldConcatMultipleIndexProgressors()
+    {
+        //Given
+        List<IndexProgressor> progressors =
+                asList( progressor( 1, 2, 3 ), progressor( 3, 4, 5, 6 ), progressor( 3 ) );
+
+        //When
+        IndexProgressor concat = concat( progressors );
+
+        //Then
+        assertThat( count( concat ), equalTo( 8 ) );
+    }
+
+    private int count( IndexProgressor progressor )
+    {
+        int count = 0;
+        while ( progressor.next() )
+        {
+            count++;
+        }
+        return count;
+    }
+
+    private IndexProgressor progressor( int... values )
+    {
+        return new StubProgressor( values );
+    }
+
+    private static class StubProgressor implements IndexProgressor
+    {
+        private final int[] values;
+        private int current = -1;
+
+        StubProgressor( int... values )
+        {
+            this.values = values;
+        }
+
+        @Override
+        public boolean next()
+        {
+            return ++current < values.length;
+        }
+
+        public int value()
+        {
+            return values[current];
+        }
+
+        @Override
+        public void close()
+        {
+            //nothing to close
+        }
+    }
+}


### PR DESCRIPTION
Instead of first creating iterator and then wrap them in progressors we
create progressors directly. This PR introduce some duplication but in a future not too distant we should be able to get rid of some of the iterator variants