### PR TITLE
Removed the cipher filter enforced by new jetty

### DIFF
--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTestIT.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTestIT.java
@@ -118,12 +118,13 @@ public class InProcessBuilderTestIT
                 .withConfig( httpsConnector.type, "HTTP" )
                 .withConfig( httpsConnector.enabled, "true" )
                 .withConfig( httpsConnector.encryption, "TLS" )
-                .withConfig( httpsConnector.address, "localhost:" + PortAuthority.allocatePort() )
+                .withConfig( httpsConnector.listen_address, "localhost:" + PortAuthority.allocatePort() )
                 .withConfig( LegacySslPolicyConfig.certificates_directory.name(), testDir.directory( "certificates" ).getAbsolutePath() )
                 .withConfig( GraphDatabaseSettings.dense_node_threshold, "20" )
                 .newServer() )
         {
             // Then
+            assertThat( HTTP.GET( server.httpURI().toString() ).status(), equalTo( 200 ) );
             assertThat( HTTP.GET( server.httpsURI().get().toString() ).status(), equalTo( 200 ) );
             assertDBConfig( server, "20", GraphDatabaseSettings.dense_node_threshold.name() );
         }

--- a/community/server/src/main/java/org/neo4j/server/security/ssl/SslSocketConnectorFactory.java
+++ b/community/server/src/main/java/org/neo4j/server/security/ssl/SslSocketConnectorFactory.java
@@ -74,11 +74,16 @@ public class SslSocketConnectorFactory extends HttpConnectorFactory
         {
             sslContextFactory.setIncludeCipherSuites( ciphers.toArray( new String[ciphers.size()] ) );
         }
+        // regardless whether cipher suites are provided by user or not,
+        // we always remove the cipher filter added in jetty 9.4 to keep the back-compatibility of jetty 9.2
+        sslContextFactory.setExcludeCipherSuites();
 
         List<String> protocols = sslPolicy.getTlsVersions();
         if ( protocols != null )
         {
+            // If a user specified what protocols they want to use, then apply whatever they added by removing extra jetty filter
             sslContextFactory.setIncludeProtocols( protocols.toArray( new String[protocols.size()] ) );
+            sslContextFactory.setExcludeProtocols(); // remove jetty filter
         }
 
         switch ( sslPolicy.getClientAuth() )


### PR DESCRIPTION
If a user configures cipher suites and protocols via configuration ssl policy, then jetty server should pick up whatever the user configured.