### PR TITLE
Support injection of initial variables in SemanticState

### DIFF
--- a/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/phases/LogicalPlanState.scala
+++ b/community/cypher/cypher-planner-3.4/src/main/scala/org/neo4j/cypher/internal/compiler/v3_4/phases/LogicalPlanState.scala
@@ -62,23 +62,6 @@ case class LogicalPlanState(queryText: String,
   def withMaybeLogicalPlan(p: Option[LogicalPlan]): LogicalPlanState = copy(maybeLogicalPlan = p)
 }
 
-case class InitialState(queryText: String,
-                        startPosition: Option[InputPosition],
-                        plannerName: PlannerName,
-                        maybeStatement: Option[Statement] = None,
-                        maybeSemantics: Option[SemanticState] = None,
-                        maybeExtractedParams: Option[Map[String, Any]] = None,
-                        maybeSemanticTable: Option[SemanticTable] = None,
-                        accumulatedConditions: Set[Condition] = Set.empty) extends BaseState {
-  override def withStatement(s: Statement): InitialState = copy(maybeStatement = Some(s))
-
-  override def withSemanticTable(s: SemanticTable): InitialState = copy(maybeSemanticTable = Some(s))
-
-  override def withSemanticState(s: SemanticState): InitialState = copy(maybeSemantics = Some(s))
-
-  override def withParams(p: Map[String, Any]): InitialState = copy(maybeExtractedParams = Some(p))
-}
-
 object LogicalPlanState {
   def apply(state: BaseState): LogicalPlanState =
     LogicalPlanState(queryText = state.queryText,

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/BaseState.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/BaseState.scala
@@ -51,3 +51,21 @@ trait BaseState {
   def withSemanticState(s: SemanticState): BaseState
   def withParams(p: Map[String, Any]): BaseState
 }
+
+case class InitialState(queryText: String,
+  startPosition: Option[InputPosition],
+  plannerName: PlannerName,
+  maybeStatement: Option[Statement] = None,
+  maybeSemantics: Option[SemanticState] = None,
+  maybeExtractedParams: Option[Map[String, Any]] = None,
+  maybeSemanticTable: Option[SemanticTable] = None,
+  accumulatedConditions: Set[Condition] = Set.empty) extends BaseState {
+
+  override def withStatement(s: Statement): InitialState = copy(maybeStatement = Some(s))
+
+  override def withSemanticTable(s: SemanticTable): InitialState = copy(maybeSemanticTable = Some(s))
+
+  override def withSemanticState(s: SemanticState): InitialState = copy(maybeSemantics = Some(s))
+
+  override def withParams(p: Map[String, Any]): InitialState = copy(maybeExtractedParams = Some(p))
+}

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/SemanticAnalysis.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/phases/SemanticAnalysis.scala
@@ -25,7 +25,9 @@ case class SemanticAnalysis(warn: Boolean, features: SemanticFeature*)
   extends Phase[BaseContext, BaseState, BaseState] {
 
   override def process(from: BaseState, context: BaseContext): BaseState = {
-    val SemanticCheckResult(state, errors) = SemanticChecker.check(from.statement(), features: _*)
+    val startState = from.maybeSemantics.getOrElse(SemanticState.clean).withFeatures(features: _*)
+
+    val SemanticCheckResult(state, errors) = SemanticChecker.check(from.statement(), startState)
     if (warn) state.notifications.foreach(context.notificationLogger.log)
 
     context.errorHandler(errors)

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticChecker.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticChecker.scala
@@ -21,8 +21,8 @@ import org.neo4j.cypher.internal.frontend.v3_4.ScopeTreeVerifier
 import org.neo4j.cypher.internal.frontend.v3_4.ast.Statement
 
 object SemanticChecker {
-  def check(statement: Statement, features: SemanticFeature*): SemanticCheckResult = {
-    val result = statement.semanticCheck(SemanticState.clean.withFeatures(features: _*))
+  def check(statement: Statement, startState: SemanticState = SemanticState.clean): SemanticCheckResult = {
+    val result = statement.semanticCheck(startState)
     val scopeTreeIssues = ScopeTreeVerifier.verify(result.state.scopeTree)
     if (scopeTreeIssues.nonEmpty)
       throw new InternalException(scopeTreeIssues.mkString(s"\n"))

--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticState.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticState.scala
@@ -16,7 +16,7 @@
  */
 package org.neo4j.cypher.internal.frontend.v3_4.semantics
 
-import org.neo4j.cypher.internal.util.v3_4.symbols.{CTGraphRef, TypeSpec}
+import org.neo4j.cypher.internal.util.v3_4.symbols.{CTGraphRef, CypherType, TypeSpec}
 import org.neo4j.cypher.internal.util.v3_4.{ASTNode, InputPosition, InternalException, Ref}
 import org.neo4j.cypher.internal.frontend.v3_4.SemanticCheck
 import org.neo4j.cypher.internal.frontend.v3_4.ast.ASTAnnotationMap
@@ -240,6 +240,16 @@ final case class Scope(symbolTable: Map[String, Symbol],
 
 object SemanticState {
   implicit object ScopeZipper extends TreeZipper[Scope]
+
+  def withStartingVariables(variables: (String, CypherType)*) =
+    SemanticState(
+      Scope.empty.copy(variables.toMap.map {
+        case (name, t) =>
+          name -> Symbol(name, Set(InputPosition.NONE), TypeSpec.exact(t))
+      }).location,
+      ASTAnnotationMap.empty,
+      ASTAnnotationMap.empty
+    )
 
   val clean = SemanticState(Scope.empty.location, ASTAnnotationMap.empty, ASTAnnotationMap.empty)
 

--- a/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/SemanticAnalysisTest.scala
+++ b/community/cypher/frontend-3.4/src/test/scala/org/neo4j/cypher/internal/frontend/v3_4/SemanticAnalysisTest.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.neo4j.cypher.internal.frontend.v3_4
+
+import org.neo4j.cypher.internal.frontend.v3_4.ast.AstConstructionTestSupport
+import org.neo4j.cypher.internal.frontend.v3_4.ast.rewriters.Never
+import org.neo4j.cypher.internal.frontend.v3_4.phases._
+import org.neo4j.cypher.internal.frontend.v3_4.semantics.{SemanticErrorDef, SemanticState}
+import org.neo4j.cypher.internal.util.v3_4.symbols._
+import org.neo4j.cypher.internal.util.v3_4.test_helpers.CypherFunSuite
+
+class SemanticAnalysisTest extends CypherFunSuite with AstConstructionTestSupport {
+
+  val pipeline = Parsing andThen SemanticAnalysis(warn = false)
+
+  test("can inject starting semantic state") {
+    val query = "RETURN name AS name"
+    val startState = initStartState(query, SemanticState.withStartingVariables("name" -> CTString))
+
+    pipeline.transform(startState, ErrorCollectingContext)
+
+    ErrorCollectingContext.errors shouldBe empty
+  }
+
+  test("can inject starting semantic state for larger query") {
+    val query = "MATCH (n:Label {name: name}) WHERE n.age > age RETURN n.name AS name"
+
+    val startState = initStartState(query, SemanticState.withStartingVariables("name" -> CTString, "age" -> CTInteger))
+
+    pipeline.transform(startState, ErrorCollectingContext)
+
+    ErrorCollectingContext.errors shouldBe empty
+  }
+
+  private def initStartState(query: String, state: SemanticState) =
+    InitialState(query, None, NoPlannerName, maybeSemantics = Some(state))
+}
+
+object ErrorCollectingContext extends BaseContext {
+
+  var errors: Seq[SemanticErrorDef] = Seq.empty
+
+  override def tracer = CompilationPhaseTracer.NO_TRACING
+  override def notificationLogger = devNullLogger
+  override def exceptionCreator = ???
+  override def monitors = ???
+  override def errorHandler = (errs: Seq[SemanticErrorDef]) =>
+    errors = errs
+}
+
+object NoPlannerName extends PlannerName {
+  override def name = "no planner"
+  override def toTextOutput = "no planner"
+  override def version = "no version"
+}


### PR DESCRIPTION
This allows Cypher queries to reference variables that come from an outside scope, such as a _driving table_. The default driving table has always been the _unit table_ of a single row with zero fields. This change is in support for a general driving table with many fields.