### PR TITLE
Enforce TLSv1.2 for HTTPS and Bolt server

### DIFF
--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/SecureSocketConnection.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/SecureSocketConnection.java
@@ -41,7 +41,7 @@ public class SecureSocketConnection extends SocketConnection
     {
         try
         {
-            SSLContext context = SSLContext.getInstance( "SSL" );
+            SSLContext context = SSLContext.getInstance( "TLS" );
             context.init( new KeyManager[0], new TrustManager[]{new NaiveTrustManager( serverCertificatesSeen::add )}, new SecureRandom() );
 
             return context.getSocketFactory().createSocket();

--- a/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/SecureWebSocketConnection.java
+++ b/community/bolt/src/test/java/org/neo4j/bolt/v1/transport/socket/client/SecureWebSocketConnection.java
@@ -23,24 +23,12 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.websocket.client.WebSocketClient;
 
 import java.net.URI;
-import java.util.function.Supplier;
 
 public class SecureWebSocketConnection extends WebSocketConnection
 {
     public SecureWebSocketConnection()
     {
-        super( createTestClientSupplier(), address -> URI.create( "wss://" + address.getHost() + ":" + address.getPort() ) );
-    }
-
-    private static Supplier<WebSocketClient> createTestClientSupplier()
-    {
-        return () ->
-        {
-            SslContextFactory sslContextFactory = new SslContextFactory( /* trustall= */ true );
-            /* remove all default filters added by jetty on protocol and cipher suites */
-            sslContextFactory.setExcludeCipherSuites();
-            sslContextFactory.setExcludeProtocols();
-            return new WebSocketClient( sslContextFactory );
-        };
+        super( () -> new WebSocketClient( new SslContextFactory( /* trustall= */ true ) ),
+                address -> URI.create( "wss://" + address.getHost() + ":" + address.getPort() ) );
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/LegacySslPolicyConfig.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/LegacySslPolicyConfig.java
@@ -20,6 +20,7 @@
 package org.neo4j.kernel.configuration.ssl;
 
 import java.io.File;
+import java.util.List;
 
 import org.neo4j.configuration.Description;
 import org.neo4j.configuration.Internal;
@@ -27,8 +28,12 @@ import org.neo4j.configuration.LoadableConfig;
 import org.neo4j.graphdb.config.Setting;
 
 import static org.neo4j.kernel.configuration.Settings.PATH;
+import static org.neo4j.kernel.configuration.Settings.STRING_LIST;
 import static org.neo4j.kernel.configuration.Settings.derivedSetting;
 import static org.neo4j.kernel.configuration.Settings.pathSetting;
+import static org.neo4j.kernel.configuration.Settings.setting;
+import static org.neo4j.kernel.configuration.ssl.SslPolicyConfig.CIPHER_SUITES_DEFAULTS;
+import static org.neo4j.kernel.configuration.ssl.SslPolicyConfig.TLS_VERSION_DEFAULTS;
 
 /**
  * To be removed in favour of {@link SslPolicyConfig}. The settings below are still
@@ -54,4 +59,15 @@ public class LegacySslPolicyConfig implements LoadableConfig
     public static final Setting<File> tls_key_file =
             derivedSetting( "unsupported.dbms.security.tls_key_file", certificates_directory,
                     certificates -> new File( certificates, "neo4j.key" ), PATH );
+
+    @Internal
+    @Description( "Default encryption protocol used for legacy SSl policy." )
+    static final Setting<List<String>> default_security_protocol =
+            setting( "unsupported.dbms.security.protocol", STRING_LIST, TLS_VERSION_DEFAULTS );
+
+    @Internal
+    @Description( "Default encryption protocol used for legacy SSl policy." )
+    static final Setting<List<String>> default_security_cipher_suites =
+            setting( "unsupported.dbms.security.cipher_suites", STRING_LIST, CIPHER_SUITES_DEFAULTS );
+
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/LegacySslPolicyConfig.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/LegacySslPolicyConfig.java
@@ -20,7 +20,6 @@
 package org.neo4j.kernel.configuration.ssl;
 
 import java.io.File;
-import java.util.List;
 
 import org.neo4j.configuration.Description;
 import org.neo4j.configuration.Internal;
@@ -28,12 +27,8 @@ import org.neo4j.configuration.LoadableConfig;
 import org.neo4j.graphdb.config.Setting;
 
 import static org.neo4j.kernel.configuration.Settings.PATH;
-import static org.neo4j.kernel.configuration.Settings.STRING_LIST;
 import static org.neo4j.kernel.configuration.Settings.derivedSetting;
 import static org.neo4j.kernel.configuration.Settings.pathSetting;
-import static org.neo4j.kernel.configuration.Settings.setting;
-import static org.neo4j.kernel.configuration.ssl.SslPolicyConfig.CIPHER_SUITES_DEFAULTS;
-import static org.neo4j.kernel.configuration.ssl.SslPolicyConfig.TLS_VERSION_DEFAULTS;
 
 /**
  * To be removed in favour of {@link SslPolicyConfig}. The settings below are still
@@ -59,15 +54,4 @@ public class LegacySslPolicyConfig implements LoadableConfig
     public static final Setting<File> tls_key_file =
             derivedSetting( "unsupported.dbms.security.tls_key_file", certificates_directory,
                     certificates -> new File( certificates, "neo4j.key" ), PATH );
-
-    @Internal
-    @Description( "Default encryption protocol used for legacy SSl policy." )
-    static final Setting<List<String>> default_security_protocol =
-            setting( "unsupported.dbms.security.protocol", STRING_LIST, TLS_VERSION_DEFAULTS );
-
-    @Internal
-    @Description( "Default encryption protocol used for legacy SSl policy." )
-    static final Setting<List<String>> default_security_cipher_suites =
-            setting( "unsupported.dbms.security.cipher_suites", STRING_LIST, CIPHER_SUITES_DEFAULTS );
-
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyConfig.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyConfig.java
@@ -44,7 +44,8 @@ import static org.neo4j.kernel.configuration.Settings.setting;
 @Group( "dbms.ssl.policy" )
 public class SslPolicyConfig
 {
-    private static final String TLS_VERSION_DEFAULTS = join( ",", new String[]{"TLSv1.2"} );
+    public static final String TLS_VERSION_DEFAULTS = join( ",", new String[]{"TLSv1.2"} );
+    public static final String CIPHER_SUITES_DEFAULTS = NO_DEFAULT;
 
     @Description( "The mandatory base directory for cryptographic objects of this policy." +
                   " It is also possible to override each individual configuration with absolute paths." )
@@ -99,7 +100,7 @@ public class SslPolicyConfig
         this.private_key_password = group.scope( setting( "private_key_password", STRING, NO_DEFAULT ) );
         this.client_auth = group.scope( setting( "client_auth", options( ClientAuth.class, true ), ClientAuth.REQUIRE.name() ) );
         this.tls_versions = group.scope( setting( "tls_versions", STRING_LIST, TLS_VERSION_DEFAULTS ) );
-        this.ciphers = group.scope( setting( "ciphers", STRING_LIST, NO_DEFAULT ) );
+        this.ciphers = group.scope( setting( "ciphers", STRING_LIST, CIPHER_SUITES_DEFAULTS ) );
     }
 
     // TODO: can we make this handle relative paths?

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyConfig.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyConfig.java
@@ -30,6 +30,7 @@ import org.neo4j.kernel.configuration.GroupSettingSupport;
 import org.neo4j.ssl.ClientAuth;
 
 import static java.lang.String.join;
+import static java.util.Arrays.asList;
 import static org.neo4j.kernel.configuration.Settings.BOOLEAN;
 import static org.neo4j.kernel.configuration.Settings.FALSE;
 import static org.neo4j.kernel.configuration.Settings.NO_DEFAULT;
@@ -44,8 +45,8 @@ import static org.neo4j.kernel.configuration.Settings.setting;
 @Group( "dbms.ssl.policy" )
 public class SslPolicyConfig
 {
-    public static final String TLS_VERSION_DEFAULTS = join( ",", new String[]{"TLSv1.2"} );
-    public static final String CIPHER_SUITES_DEFAULTS = NO_DEFAULT;
+    public static final List<String> TLS_VERSION_DEFAULTS = asList( "TLSv1.2" );
+    public static final List<String> CIPHER_SUITES_DEFAULTS = null;
 
     @Description( "The mandatory base directory for cryptographic objects of this policy." +
                   " It is also possible to override each individual configuration with absolute paths." )
@@ -99,13 +100,25 @@ public class SslPolicyConfig
 
         this.private_key_password = group.scope( setting( "private_key_password", STRING, NO_DEFAULT ) );
         this.client_auth = group.scope( setting( "client_auth", options( ClientAuth.class, true ), ClientAuth.REQUIRE.name() ) );
-        this.tls_versions = group.scope( setting( "tls_versions", STRING_LIST, TLS_VERSION_DEFAULTS ) );
-        this.ciphers = group.scope( setting( "ciphers", STRING_LIST, CIPHER_SUITES_DEFAULTS ) );
+        this.tls_versions = group.scope( setting( "tls_versions", STRING_LIST, joinList( TLS_VERSION_DEFAULTS ) ) );
+        this.ciphers = group.scope( setting( "ciphers", STRING_LIST, joinList( CIPHER_SUITES_DEFAULTS ) ) );
     }
 
     // TODO: can we make this handle relative paths?
     private Setting<File> derivedDefault( String settingName, Setting<File> baseDirectory, String defaultFilename )
     {
         return derivedSetting( settingName, baseDirectory, base -> new File( base, defaultFilename ), PATH );
+    }
+
+    private String joinList( List<String> list )
+    {
+        if ( list == null )
+        {
+            return null;
+        }
+        else
+        {
+            return join( ",", list );
+        }
     }
 }

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyLoader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyLoader.java
@@ -57,8 +57,8 @@ import org.neo4j.ssl.SslPolicy;
 import static java.lang.String.format;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.default_advertised_address;
 import static org.neo4j.kernel.configuration.ssl.LegacySslPolicyConfig.LEGACY_POLICY_NAME;
-import static org.neo4j.kernel.configuration.ssl.LegacySslPolicyConfig.default_security_cipher_suites;
-import static org.neo4j.kernel.configuration.ssl.LegacySslPolicyConfig.default_security_protocol;
+import static org.neo4j.kernel.configuration.ssl.SslPolicyConfig.CIPHER_SUITES_DEFAULTS;
+import static org.neo4j.kernel.configuration.ssl.SslPolicyConfig.TLS_VERSION_DEFAULTS;
 
 /**
  * Each component which utilises SSL policies is recommended to provide a component
@@ -159,10 +159,7 @@ public class SslPolicyLoader
         PrivateKey privateKey = loadPrivateKey( privateKeyFile, null );
         X509Certificate[] keyCertChain = loadCertificateChain( certficateFile );
 
-        List<String> ciphers = config.get( default_security_cipher_suites );
-        List<String> tlsVersions = config.get( default_security_protocol );
-
-        return new SslPolicy( privateKey, keyCertChain, tlsVersions, ciphers,
+        return new SslPolicy( privateKey, keyCertChain, TLS_VERSION_DEFAULTS, CIPHER_SUITES_DEFAULTS,
                 ClientAuth.NONE, InsecureTrustManagerFactory.INSTANCE, sslProvider );
     }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyLoader.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/configuration/ssl/SslPolicyLoader.java
@@ -57,6 +57,8 @@ import org.neo4j.ssl.SslPolicy;
 import static java.lang.String.format;
 import static org.neo4j.graphdb.factory.GraphDatabaseSettings.default_advertised_address;
 import static org.neo4j.kernel.configuration.ssl.LegacySslPolicyConfig.LEGACY_POLICY_NAME;
+import static org.neo4j.kernel.configuration.ssl.LegacySslPolicyConfig.default_security_cipher_suites;
+import static org.neo4j.kernel.configuration.ssl.LegacySslPolicyConfig.default_security_protocol;
 
 /**
  * Each component which utilises SSL policies is recommended to provide a component
@@ -157,7 +159,10 @@ public class SslPolicyLoader
         PrivateKey privateKey = loadPrivateKey( privateKeyFile, null );
         X509Certificate[] keyCertChain = loadCertificateChain( certficateFile );
 
-        return new SslPolicy( privateKey, keyCertChain, null, null,
+        List<String> ciphers = config.get( default_security_cipher_suites );
+        List<String> tlsVersions = config.get( default_security_protocol );
+
+        return new SslPolicy( privateKey, keyCertChain, tlsVersions, ciphers,
                 ClientAuth.NONE, InsecureTrustManagerFactory.INSTANCE, sslProvider );
     }
 

--- a/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTestIT.java
+++ b/community/neo4j-harness/src/test/java/org/neo4j/harness/InProcessBuilderTestIT.java
@@ -118,12 +118,13 @@ public class InProcessBuilderTestIT
                 .withConfig( httpsConnector.type, "HTTP" )
                 .withConfig( httpsConnector.enabled, "true" )
                 .withConfig( httpsConnector.encryption, "TLS" )
-                .withConfig( httpsConnector.address, "localhost:" + PortAuthority.allocatePort() )
+                .withConfig( httpsConnector.listen_address, "localhost:" + PortAuthority.allocatePort() )
                 .withConfig( LegacySslPolicyConfig.certificates_directory.name(), testDir.directory( "certificates" ).getAbsolutePath() )
                 .withConfig( GraphDatabaseSettings.dense_node_threshold, "20" )
                 .newServer() )
         {
             // Then
+            assertThat( HTTP.GET( server.httpURI().toString() ).status(), equalTo( 200 ) );
             assertThat( HTTP.GET( server.httpsURI().get().toString() ).status(), equalTo( 200 ) );
             assertDBConfig( server, "20", GraphDatabaseSettings.dense_node_threshold.name() );
         }

--- a/community/server/src/main/java/org/neo4j/server/security/ssl/SslSocketConnectorFactory.java
+++ b/community/server/src/main/java/org/neo4j/server/security/ssl/SslSocketConnectorFactory.java
@@ -74,11 +74,16 @@ public class SslSocketConnectorFactory extends HttpConnectorFactory
         {
             sslContextFactory.setIncludeCipherSuites( ciphers.toArray( new String[ciphers.size()] ) );
         }
+        // regardless whether cipher suites are provided by user or not,
+        // we always remove the cipher filter added in jetty 9.4 to keep the back-compatibility of jetty 9.2
+        sslContextFactory.setExcludeCipherSuites();
 
         List<String> protocols = sslPolicy.getTlsVersions();
         if ( protocols != null )
         {
+            // If a user specified what protocols they want to use, then apply whatever they added by removing extra jetty filter
             sslContextFactory.setIncludeProtocols( protocols.toArray( new String[protocols.size()] ) );
+            sslContextFactory.setExcludeProtocols(); // remove jetty filter
         }
 
         switch ( sslPolicy.getClientAuth() )

--- a/community/server/src/main/java/org/neo4j/server/security/ssl/SslSocketConnectorFactory.java
+++ b/community/server/src/main/java/org/neo4j/server/security/ssl/SslSocketConnectorFactory.java
@@ -73,17 +73,14 @@ public class SslSocketConnectorFactory extends HttpConnectorFactory
         if ( ciphers != null )
         {
             sslContextFactory.setIncludeCipherSuites( ciphers.toArray( new String[ciphers.size()] ) );
+            sslContextFactory.setExcludeCipherSuites();
         }
-        // regardless whether cipher suites are provided by user or not,
-        // we always remove the cipher filter added in jetty 9.4 to keep the back-compatibility of jetty 9.2
-        sslContextFactory.setExcludeCipherSuites();
 
         List<String> protocols = sslPolicy.getTlsVersions();
         if ( protocols != null )
         {
-            // If a user specified what protocols they want to use, then apply whatever they added by removing extra jetty filter
             sslContextFactory.setIncludeProtocols( protocols.toArray( new String[protocols.size()] ) );
-            sslContextFactory.setExcludeProtocols(); // remove jetty filter
+            sslContextFactory.setExcludeProtocols();
         }
 
         switch ( sslPolicy.getClientAuth() )


### PR DESCRIPTION
HTTPS server and Bolt server use legacy ssl policy. This policy does not expose any configuration option for allowed security protocols or cipher suites. As a result, the REST and Bolt server were running with protocol and cipher suites provided by jvm by default. However to provide more secured neo4j service, from this version, we will enforce TLSv1.2 as default for legacy ssl policy.
 
For users who would like to have their own customized protocols or cipher suites, they could migrate their ssl policy for bolt and https to new [`dbms.ssl.policy`](https://neo4j.com/docs/operations-manual/current/security/ssl-framework/#_policy_definition) to have the full control of security settings.

For users whose jdk does not have TLSv1.2 enabled by default (such as **ibm-jdk8**), if they would like to have neo4j HTTPS and Bolt server running normally with TLSv1.2, they should run the server with jvm option `com.ibm.jsse2.overrideDefaultTLS=true`. This could be achieved by adding a line `dbms.jvm.additional=-Dcom.ibm.jsse2.overrideDefaultTLS=true` in `neo4j.config` file.