### PR TITLE
3.4 modifier protocols

### DIFF
--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Follower.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/core/consensus/roles/Follower.java
@@ -149,7 +149,7 @@ class Follower implements RaftMessageHandler
         }
 
         @Override
-        public Outcome handle( RaftMessages.PruneRequest pruneRequest ) throws IOException
+        public Outcome handle( RaftMessages.PruneRequest pruneRequest )
         {
             Pruning.handlePruneRequest( outcome, pruneRequest );
             return outcome;
@@ -174,7 +174,7 @@ class Follower implements RaftMessageHandler
         }
 
         @Override
-        public Outcome handle( RaftMessages.Timeout.Heartbeat heartbeat ) throws IOException
+        public Outcome handle( RaftMessages.Timeout.Heartbeat heartbeat )
         {
             return outcome;
         }
@@ -242,7 +242,7 @@ class Follower implements RaftMessageHandler
     private static class PreVoteUnsupportedRefusesToLead implements ElectionTimeoutHandler
     {
         @Override
-        public Outcome handle( RaftMessages.Timeout.Election election, Outcome outcome, ReadableRaftState ctx, Log log ) throws IOException
+        public Outcome handle( RaftMessages.Timeout.Election election, Outcome outcome, ReadableRaftState ctx, Log log )
         {
             log.info( "Election timeout triggered but refusing to be leader" );
             return outcome;
@@ -254,7 +254,7 @@ class Follower implements RaftMessageHandler
     private static class PreVoteSupportedRefusesToLeadHandler implements ElectionTimeoutHandler
     {
         @Override
-        public Outcome handle( RaftMessages.Timeout.Election election, Outcome outcome, ReadableRaftState ctx, Log log ) throws IOException
+        public Outcome handle( RaftMessages.Timeout.Election election, Outcome outcome, ReadableRaftState ctx, Log log )
         {
             log.info( "Election timeout triggered but refusing to be leader" );
             Set<MemberId> memberIds = ctx.votingMembers();
@@ -295,7 +295,7 @@ class Follower implements RaftMessageHandler
     private static class PreVoteRequestNoOpHandler implements PreVoteRequestHandler
     {
         @Override
-        public Outcome handle( RaftMessages.PreVote.Request request, Outcome outcome, ReadableRaftState ctx, Log log ) throws IOException
+        public Outcome handle( RaftMessages.PreVote.Request request, Outcome outcome, ReadableRaftState ctx, Log log )
         {
             return outcome;
         }
@@ -343,7 +343,7 @@ class Follower implements RaftMessageHandler
     private static class PreVoteResponseNoOpHandler implements PreVoteResponseHandler
     {
         @Override
-        public Outcome handle( RaftMessages.PreVote.Response response, Outcome outcome, ReadableRaftState ctx, Log log ) throws IOException
+        public Outcome handle( RaftMessages.PreVote.Response response, Outcome outcome, ReadableRaftState ctx, Log log )
         {
             return outcome;
         }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/MessageGate.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/messaging/MessageGate.java
@@ -71,7 +71,7 @@ public class MessageGate extends ChannelDuplexHandler
     }
 
     @Override
-    public void write( ChannelHandlerContext ctx, Object msg, ChannelPromise promise ) throws Exception
+    public void write( ChannelHandlerContext ctx, Object msg, ChannelPromise promise )
     {
         if ( !gated.test( msg ) )
         {

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/ClientNettyPipelineBuilder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/ClientNettyPipelineBuilder.java
@@ -17,22 +17,24 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.causalclustering.protocol.handshake;
+package org.neo4j.causalclustering.protocol;
 
-import static org.neo4j.causalclustering.protocol.handshake.StatusCode.FAILURE;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.LengthFieldPrepender;
 
-public class ApplicationProtocolResponse extends BaseProtocolResponse implements ClientMessage
+import org.neo4j.logging.Log;
+
+public class ClientNettyPipelineBuilder extends NettyPipelineBuilder<ProtocolInstaller.Orientation.Client, ClientNettyPipelineBuilder>
 {
-    public static final ApplicationProtocolResponse NO_PROTOCOL = new ApplicationProtocolResponse( FAILURE, "", 0 );
-
-    ApplicationProtocolResponse( StatusCode statusCode, String protocolName, int version )
+    ClientNettyPipelineBuilder( ChannelPipeline pipeline, Log log )
     {
-        super( statusCode, protocolName, version );
+        super( pipeline, log );
     }
 
     @Override
-    public void dispatch( ClientMessageHandler handler )
+    public ClientNettyPipelineBuilder addFraming()
     {
-        handler.handle( this );
+        add( "frame_encoder", new LengthFieldPrepender( 4 ) );
+        return this;
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/ModifierProtocolInstaller.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/ModifierProtocolInstaller.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.protocol;
+
+import io.netty.handler.codec.compression.SnappyFrameDecoder;
+import io.netty.handler.codec.compression.SnappyFrameEncoder;
+
+import java.util.List;
+
+import org.neo4j.causalclustering.protocol.ProtocolInstaller.Orientation;
+
+import static java.util.Arrays.asList;
+
+public interface ModifierProtocolInstaller<O extends Orientation>
+{
+    Protocol.ModifierProtocol protocol();
+
+    <BUILDER extends NettyPipelineBuilder<O,BUILDER>> void apply( NettyPipelineBuilder<O,BUILDER> nettyPipelineBuilder );
+
+    List<ModifierProtocolInstaller<Orientation.Server>> serverCompressionInstallers = asList( SnappyServer.instance );
+    List<ModifierProtocolInstaller<Orientation.Client>> clientCompressionInstallers = asList( SnappyClient.instance );
+
+    List<ModifierProtocolInstaller<Orientation.Server>> allServerInstallers = serverCompressionInstallers;
+    List<ModifierProtocolInstaller<Orientation.Client>> allClientInstallers = clientCompressionInstallers;
+
+    class SnappyClient implements ModifierProtocolInstaller<Orientation.Client>
+    {
+        public static final SnappyClient instance = new SnappyClient();
+
+        private SnappyClient()
+        {
+        }
+
+        @Override
+        public Protocol.ModifierProtocol protocol()
+        {
+            return Protocol.ModifierProtocols.COMPRESSION_SNAPPY;
+        }
+
+        @Override
+        public <BUILDER extends NettyPipelineBuilder<Orientation.Client,BUILDER>> void apply(
+                NettyPipelineBuilder<Orientation.Client,BUILDER> nettyPipelineBuilder )
+        {
+            nettyPipelineBuilder.add( "snappy_encoder", new SnappyFrameEncoder() );
+        }
+    }
+
+    class SnappyServer implements ModifierProtocolInstaller<Orientation.Server>
+    {
+        private SnappyServer()
+        {
+        }
+
+        public static final SnappyServer instance = new SnappyServer();
+
+        @Override
+        public Protocol.ModifierProtocol protocol()
+        {
+            return Protocol.ModifierProtocols.COMPRESSION_SNAPPY;
+        }
+
+        @Override
+        public <BUILDER extends NettyPipelineBuilder<Orientation.Server,BUILDER>> void apply(
+                NettyPipelineBuilder<Orientation.Server,BUILDER> nettyPipelineBuilder )
+        {
+            nettyPipelineBuilder.add( "snappy_decoder", new SnappyFrameDecoder() );
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/NettyPipelineBuilderFactory.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/NettyPipelineBuilderFactory.java
@@ -21,9 +21,9 @@ package org.neo4j.causalclustering.protocol;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandler;
-import io.netty.channel.ChannelPipeline;
 
 import org.neo4j.causalclustering.handlers.PipelineWrapper;
+import org.neo4j.causalclustering.protocol.ProtocolInstaller.Orientation;
 import org.neo4j.logging.Log;
 
 public class NettyPipelineBuilderFactory
@@ -35,16 +35,25 @@ public class NettyPipelineBuilderFactory
         this.wrapper = wrapper;
     }
 
-    public NettyPipelineBuilder create( Channel channel, Log log ) throws Exception
+    public ClientNettyPipelineBuilder client( Channel channel, Log log ) throws Exception
     {
-        ChannelPipeline pipeline = channel.pipeline();
-        NettyPipelineBuilder builder = NettyPipelineBuilder.with( pipeline, log );
+        return create( channel, NettyPipelineBuilder.client( channel.pipeline(), log ) );
+    }
+
+    public ServerNettyPipelineBuilder server( Channel channel, Log log ) throws Exception
+    {
+        return create( channel, NettyPipelineBuilder.server( channel.pipeline(), log ) );
+    }
+
+    private <O extends Orientation, BUILDER extends NettyPipelineBuilder<O,BUILDER>> BUILDER create(
+            Channel channel, BUILDER nettyPipelineBuilder ) throws Exception
+    {
         int i = 0;
         for ( ChannelHandler handler : wrapper.handlersFor( channel ) )
         {
-            builder.add( String.format( "%s_%d", wrapper.name(), i ), handler );
+            nettyPipelineBuilder.add( String.format( "%s_%d", wrapper.name(), i ), handler );
             i++;
         }
-        return builder;
+        return nettyPipelineBuilder;
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/Protocol.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/Protocol.java
@@ -25,26 +25,36 @@ public interface Protocol
 
     int version();
 
-    enum Identifier
+    interface Identifier<T extends Protocol>
+    {
+        String canonicalName();
+    }
+
+    interface ApplicationProtocol extends Protocol
+    {
+    }
+
+    enum ApplicationProtocolIdentifier implements Identifier<ApplicationProtocol>
     {
         RAFT,
         CATCHUP;
 
+        @Override
         public String canonicalName()
         {
             return name().toLowerCase();
         }
     }
 
-    enum Protocols implements Protocol
+    enum ApplicationProtocols implements ApplicationProtocol
     {
-        RAFT_1( Identifier.RAFT, 1 ),
-        CATCHUP_1( Identifier.CATCHUP, 1 );
+        RAFT_1( ApplicationProtocolIdentifier.RAFT, 1 ),
+        CATCHUP_1( ApplicationProtocolIdentifier.CATCHUP, 1 );
 
         private final int version;
-        private final Identifier identifier;
+        private final ApplicationProtocolIdentifier identifier;
 
-        Protocols( Identifier identifier, int version )
+        ApplicationProtocols( ApplicationProtocolIdentifier identifier, int version )
         {
             this.identifier = identifier;
             this.version = version;
@@ -53,13 +63,67 @@ public interface Protocol
         @Override
         public String identifier()
         {
-            return this.identifier.canonicalName();
+            return identifier.canonicalName();
         }
 
         @Override
         public int version()
         {
             return version;
+        }
+    }
+
+    interface ModifierProtocol extends Protocol
+    {
+        /**
+         * Should be human readable in a comma separated list
+         */
+        String friendlyName();
+    }
+
+    enum ModifierProtocolIdentifier implements Identifier<ModifierProtocol>
+    {
+        COMPRESSION,
+        GRATUITOUS_OBFUSCATION;
+
+        @Override
+        public String canonicalName()
+        {
+            return name().toLowerCase();
+        }
+    }
+
+    enum ModifierProtocols implements ModifierProtocol
+    {
+        COMPRESSION_SNAPPY( ModifierProtocolIdentifier.COMPRESSION, 1, "Snappy" );
+
+        private final int version;
+        private final ModifierProtocolIdentifier identifier;
+        private final String friendlyName;
+
+        ModifierProtocols( ModifierProtocolIdentifier identifier, int version, String friendlyName )
+        {
+            this.version = version;
+            this.identifier = identifier;
+            this.friendlyName = friendlyName;
+        }
+
+        @Override
+        public int version()
+        {
+            return version;
+        }
+
+        @Override
+        public String identifier()
+        {
+            return identifier.canonicalName();
+        }
+
+        @Override
+        public String friendlyName()
+        {
+            return friendlyName;
         }
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/ServerNettyPipelineBuilder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/ServerNettyPipelineBuilder.java
@@ -17,22 +17,24 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.neo4j.causalclustering.protocol.handshake;
+package org.neo4j.causalclustering.protocol;
 
-import static org.neo4j.causalclustering.protocol.handshake.StatusCode.FAILURE;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 
-public class ApplicationProtocolResponse extends BaseProtocolResponse implements ClientMessage
+import org.neo4j.logging.Log;
+
+public class ServerNettyPipelineBuilder extends NettyPipelineBuilder<ProtocolInstaller.Orientation.Server, ServerNettyPipelineBuilder>
 {
-    public static final ApplicationProtocolResponse NO_PROTOCOL = new ApplicationProtocolResponse( FAILURE, "", 0 );
-
-    ApplicationProtocolResponse( StatusCode statusCode, String protocolName, int version )
+    protected ServerNettyPipelineBuilder( ChannelPipeline pipeline, Log log )
     {
-        super( statusCode, protocolName, version );
+        super( pipeline, log );
     }
 
     @Override
-    public void dispatch( ClientMessageHandler handler )
+    public ServerNettyPipelineBuilder addFraming()
     {
-        handler.handle( this );
+        add( "frame_decoder", new LengthFieldBasedFrameDecoder( Integer.MAX_VALUE, 0, 4, 0, 4 ) );
+        return this;
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ApplicationProtocolRequest.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ApplicationProtocolRequest.java
@@ -19,54 +19,18 @@
  */
 package org.neo4j.causalclustering.protocol.handshake;
 
-import java.util.Objects;
 import java.util.Set;
 
-public class ApplicationProtocolRequest implements ServerMessage
+public class ApplicationProtocolRequest extends BaseProtocolRequest implements ServerMessage
 {
-    private final String protocolName;
-    private final Set<Integer> versions;
-
     ApplicationProtocolRequest( String protocolName, Set<Integer> versions )
     {
-        this.protocolName = protocolName;
-        this.versions = versions;
+        super( protocolName, versions );
     }
 
     @Override
     public void dispatch( ServerMessageHandler handler )
     {
         handler.handle( this );
-    }
-
-    String protocolName()
-    {
-        return protocolName;
-    }
-
-    public Set<Integer> versions()
-    {
-        return versions;
-    }
-
-    @Override
-    public boolean equals( Object o )
-    {
-        if ( this == o )
-        {
-            return true;
-        }
-        if ( o == null || getClass() != o.getClass() )
-        {
-            return false;
-        }
-        ApplicationProtocolRequest that = (ApplicationProtocolRequest) o;
-        return Objects.equals( protocolName, that.protocolName ) && Objects.equals( versions, that.versions );
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return Objects.hash( protocolName, versions );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/BaseProtocolRequest.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/BaseProtocolRequest.java
@@ -19,18 +19,48 @@
  */
 package org.neo4j.causalclustering.protocol.handshake;
 
+import java.util.Objects;
 import java.util.Set;
 
-public class ModifierProtocolRequest extends BaseProtocolRequest implements ServerMessage
+public abstract class BaseProtocolRequest
 {
-    ModifierProtocolRequest( String protocolName, Set<Integer> versions )
+    private final String protocolName;
+    private final Set<Integer> versions;
+
+    BaseProtocolRequest( String protocolName, Set<Integer> versions )
     {
-        super( protocolName, versions );
+        this.protocolName = protocolName;
+        this.versions = versions;
+    }
+
+    public String protocolName()
+    {
+        return protocolName;
+    }
+
+    public Set<Integer> versions()
+    {
+        return versions;
     }
 
     @Override
-    public void dispatch( ServerMessageHandler handler )
+    public boolean equals( Object o )
     {
-        handler.handle( this );
+        if ( this == o )
+        {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() )
+        {
+            return false;
+        }
+        BaseProtocolRequest that = (BaseProtocolRequest) o;
+        return Objects.equals( protocolName, that.protocolName ) && Objects.equals( versions, that.versions );
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash( protocolName, versions );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/BaseProtocolResponse.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/BaseProtocolResponse.java
@@ -21,37 +21,17 @@ package org.neo4j.causalclustering.protocol.handshake;
 
 import java.util.Objects;
 
-public class InitialMagicMessage implements ServerMessage, ClientMessage
+public abstract class BaseProtocolResponse
 {
-    // these can never, ever change
-    static final String CORRECT_MAGIC_VALUE = "NEO4J_CLUSTER";
-    static final int MESSAGE_CODE = 0x344F454E; // ASCII/UTF-8 "NEO4"
+    private final StatusCode statusCode;
+    private final String protocolName;
+    private final int version;
 
-    private final String magic;
-    // TODO: clusterId (String?)
-
-    private static final InitialMagicMessage instance = new InitialMagicMessage( CORRECT_MAGIC_VALUE );
-
-    InitialMagicMessage( String magic )
+    BaseProtocolResponse( StatusCode statusCode, String protocolName, int version )
     {
-        this.magic = magic;
-    }
-
-    public static InitialMagicMessage instance()
-    {
-        return instance;
-    }
-
-    @Override
-    public void dispatch( ServerMessageHandler handler )
-    {
-        handler.handle( this );
-    }
-
-    @Override
-    public void dispatch( ClientMessageHandler handler )
-    {
-        handler.handle( this );
+        this.statusCode = statusCode;
+        this.protocolName = protocolName;
+        this.version = version;
     }
 
     @Override
@@ -65,23 +45,28 @@ public class InitialMagicMessage implements ServerMessage, ClientMessage
         {
             return false;
         }
-        InitialMagicMessage that = (InitialMagicMessage) o;
-        return Objects.equals( magic, that.magic );
+        BaseProtocolResponse that = (BaseProtocolResponse) o;
+        return version == that.version && Objects.equals( protocolName, that.protocolName );
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash( magic );
+        return Objects.hash( protocolName, version );
     }
 
-    boolean isCorrectMagic()
+    public StatusCode statusCode()
     {
-        return magic.equals( CORRECT_MAGIC_VALUE );
+        return statusCode;
     }
 
-    public String magic()
+    public String protocolName()
     {
-        return magic;
+        return protocolName;
+    }
+
+    public int version()
+    {
+        return version;
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ClientMessageEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ClientMessageEncoder.java
@@ -56,19 +56,14 @@ public class ClientMessageEncoder extends MessageToByteEncoder<ServerMessage>
         public void handle( ApplicationProtocolRequest applicationProtocolRequest )
         {
             out.writeInt( 1 );
-            StringMarshal.marshal( out, applicationProtocolRequest.protocolName() );
-            out.writeInt( applicationProtocolRequest.versions().size() );
-            for ( int version : applicationProtocolRequest.versions() )
-            {
-                out.writeInt( version );
-            }
+            encodeProtocolRequest( applicationProtocolRequest );
         }
 
         @Override
         public void handle( ModifierProtocolRequest modifierProtocolRequest )
         {
             out.writeInt( 2 );
-            // TODO
+            encodeProtocolRequest( modifierProtocolRequest );
         }
 
         @Override
@@ -77,6 +72,20 @@ public class ClientMessageEncoder extends MessageToByteEncoder<ServerMessage>
             out.writeInt( 3 );
             StringMarshal.marshal( out, switchOverRequest.protocolName() );
             out.writeInt( switchOverRequest.version() );
+            out.writeInt( switchOverRequest.modifierProtocols().size() );
+            switchOverRequest.modifierProtocols().forEach( pair ->
+                    {
+                        StringMarshal.marshal( out, pair.first() );
+                        out.writeInt( pair.other() );
+                    }
+            );
+        }
+
+        private void encodeProtocolRequest( BaseProtocolRequest applicationProtocolRequest )
+        {
+            StringMarshal.marshal( out, applicationProtocolRequest.protocolName() );
+            out.writeInt( applicationProtocolRequest.versions().size() );
+            applicationProtocolRequest.versions().forEach( out::writeInt );
         }
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/HandshakeServer.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/HandshakeServer.java
@@ -19,34 +19,42 @@
  */
 package org.neo4j.causalclustering.protocol.handshake;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import org.neo4j.causalclustering.messaging.Channel;
 import org.neo4j.causalclustering.protocol.Protocol;
+import org.neo4j.causalclustering.protocol.Protocol.ApplicationProtocol;
+import org.neo4j.causalclustering.protocol.Protocol.ModifierProtocol;
+import org.neo4j.stream.Streams;
 
 import static org.neo4j.causalclustering.protocol.handshake.StatusCode.SUCCESS;
 
 public class HandshakeServer implements ServerMessageHandler
 {
     private final Channel channel;
-    private final ProtocolRepository protocolRepository;
-    private final Protocol.Identifier allowedProtocol;
-    private ProtocolStack protocolStack;
+    private final ProtocolRepository<ApplicationProtocol> applicationProtocolRepository;
+    private final ProtocolRepository<ModifierProtocol> modifierProtocolRepository;
+    private final Protocol.ApplicationProtocolIdentifier applicationProtocolIdentifier;
+    private final ProtocolStack.Builder protocolStackBuilder = ProtocolStack.builder();
     private final CompletableFuture<ProtocolStack> protocolStackFuture = new CompletableFuture<>();
     private boolean magicReceived;
     private boolean initialised;
 
-    HandshakeServer( Channel channel, ProtocolRepository protocolRepository, Protocol.Identifier allowedProtocol )
+    HandshakeServer( Channel channel, ProtocolRepository<ApplicationProtocol> applicationProtocolRepository,
+            ProtocolRepository<ModifierProtocol> modifierProtocolRepository, Protocol.ApplicationProtocolIdentifier allowedProtocol )
     {
         this.channel = channel;
-        this.protocolRepository = protocolRepository;
-        this.allowedProtocol = allowedProtocol;
+        this.applicationProtocolRepository = applicationProtocolRepository;
+        this.modifierProtocolRepository = modifierProtocolRepository;
+        this.applicationProtocolIdentifier = allowedProtocol;
     }
 
     public void init()
     {
-        channel.writeAndFlush( new InitialMagicMessage() );
+        channel.writeAndFlush( InitialMagicMessage.instance() );
         initialised = true;
     }
 
@@ -81,28 +89,29 @@ public class HandshakeServer implements ServerMessageHandler
         ensureMagic();
 
         ApplicationProtocolResponse response;
-        if ( !request.protocolName().equals( allowedProtocol.canonicalName() ) )
+        if ( !request.protocolName().equals( applicationProtocolIdentifier.canonicalName() ) )
         {
             response = ApplicationProtocolResponse.NO_PROTOCOL;
             channel.writeAndFlush( response );
             decline( String.format( "Requested protocol %s not supported", request.protocolName() ) );
-            return;
-        }
-
-        Optional<Protocol> selected = protocolRepository.select( request.protocolName(), request.versions() );
-
-        if ( selected.isPresent() )
-        {
-            Protocol selectedProtocol = selected.get();
-            protocolStack = new ProtocolStack( selectedProtocol );
-            response = new ApplicationProtocolResponse( SUCCESS, selectedProtocol.identifier(), selectedProtocol.version() );
-            channel.writeAndFlush( response );
         }
         else
         {
-            response = ApplicationProtocolResponse.NO_PROTOCOL;
-            channel.writeAndFlush( response );
-            decline( String.format( "Do not support requested protocol %s versions %s", request.protocolName(), request.versions() ) );
+            Optional<ApplicationProtocol> selected = applicationProtocolRepository.select( request.protocolName(), request.versions() );
+
+            if ( selected.isPresent() )
+            {
+                ApplicationProtocol selectedProtocol = selected.get();
+                protocolStackBuilder.application( selectedProtocol );
+                response = new ApplicationProtocolResponse( SUCCESS, selectedProtocol.identifier(), selectedProtocol.version() );
+                channel.writeAndFlush( response );
+            }
+            else
+            {
+                response = ApplicationProtocolResponse.NO_PROTOCOL;
+                channel.writeAndFlush( response );
+                decline( String.format( "Do not support requested protocol %s versions %s", request.protocolName(), request.versions() ) );
+            }
         }
     }
 
@@ -110,20 +119,48 @@ public class HandshakeServer implements ServerMessageHandler
     public void handle( ModifierProtocolRequest modifierProtocolRequest )
     {
         ensureMagic();
-        throw new UnsupportedOperationException( "Not implemented" );
+
+        ModifierProtocolResponse response;
+        Optional<ModifierProtocol> selected =
+                modifierProtocolRepository.select( modifierProtocolRequest.protocolName(), modifierProtocolRequest.versions() );
+
+        if ( selected.isPresent() )
+        {
+            ModifierProtocol modifierProtocol = selected.get();
+            protocolStackBuilder.modifier( modifierProtocol );
+            response = new ModifierProtocolResponse( SUCCESS, modifierProtocol.identifier(), modifierProtocol.version() );
+        }
+        else
+        {
+            response = ModifierProtocolResponse.failure( modifierProtocolRequest.protocolName() );
+        }
+
+        channel.writeAndFlush( response );
     }
 
     @Override
     public void handle( SwitchOverRequest switchOverRequest )
     {
         ensureMagic();
-        Optional<Protocol> switchOverProtocol = protocolRepository.select( switchOverRequest.protocolName(), switchOverRequest.version() );
+        ProtocolStack protocolStack = protocolStackBuilder.build();
+        Optional<ApplicationProtocol> switchOverProtocol =
+                applicationProtocolRepository.select( switchOverRequest.protocolName(), switchOverRequest.version() );
+        List<ModifierProtocol> switchOverModifiers = switchOverRequest.modifierProtocols()
+                .stream()
+                .map( pair -> modifierProtocolRepository.select( pair.first(), pair.other() ) )
+                .flatMap( Streams::ofOptional )
+                .collect( Collectors.toList() );
 
         if ( !switchOverProtocol.isPresent() )
         {
             channel.writeAndFlush( SwitchOverResponse.FAILURE );
             decline( String.format( "Cannot switch to protocol %s version %d", switchOverRequest.protocolName(), switchOverRequest.version() ) );
-            return;
+        }
+        else if ( protocolStack.applicationProtocol() == null )
+        {
+            channel.writeAndFlush( SwitchOverResponse.FAILURE );
+            decline( String.format( "Attempted to switch to protocol %s version %d before negotiation complete",
+                    switchOverRequest.protocolName(), switchOverRequest.version() ) );
         }
         else if ( !switchOverProtocol.get().equals( protocolStack.applicationProtocol() ) )
         {
@@ -131,13 +168,20 @@ public class HandshakeServer implements ServerMessageHandler
             decline( String.format( "Switch over mismatch: requested %s version %s but negotiated %s version %s",
                     switchOverRequest.protocolName(), switchOverRequest.version(),
                     protocolStack.applicationProtocol().identifier(), protocolStack.applicationProtocol().version() ) );
-            return;
         }
+        else if ( !switchOverModifiers.equals( protocolStack.modifierProtocols() ) )
+        {
+            channel.writeAndFlush( SwitchOverResponse.FAILURE );
+            decline( String.format( "Switch over mismatch: requested modifiers %s but negotiated %s",
+                    switchOverRequest.modifierProtocols(), protocolStack.modifierProtocols() ) );
+        }
+        else
+        {
+            SwitchOverResponse response = new SwitchOverResponse( SUCCESS );
+            channel.writeAndFlush( response );
 
-        SwitchOverResponse response = new SwitchOverResponse( SUCCESS );
-        channel.writeAndFlush( response );
-
-        protocolStackFuture.complete( protocolStack );
+            protocolStackFuture.complete( protocolStack );
+        }
     }
 
     private void decline( String message )

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ModifierProtocolResponse.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ModifierProtocolResponse.java
@@ -19,34 +19,21 @@
  */
 package org.neo4j.causalclustering.protocol.handshake;
 
-import java.util.Objects;
-
-public class ModifierProtocolResponse implements ClientMessage
+public class ModifierProtocolResponse extends BaseProtocolResponse implements ClientMessage
 {
+    ModifierProtocolResponse( StatusCode statusCode, String protocolName, int version )
+    {
+        super( statusCode, protocolName, version );
+    }
+
+    static ModifierProtocolResponse failure( String protocolName )
+    {
+        return new ModifierProtocolResponse( StatusCode.FAILURE, protocolName, 0 );
+    }
+
     @Override
     public void dispatch( ClientMessageHandler handler )
     {
         handler.handle( this );
-    }
-
-    @Override
-    public boolean equals( Object o )
-    {
-        if ( this == o )
-        {
-            return true;
-        }
-        if ( o == null || getClass() != o.getClass() )
-        {
-            return false;
-        }
-        ModifierProtocolResponse that = (ModifierProtocolResponse) o;
-        return true;
-    }
-
-    @Override
-    public int hashCode()
-    {
-        return Objects.hash( 12 );
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ProtocolSelection.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ProtocolSelection.java
@@ -21,7 +21,9 @@ package org.neo4j.causalclustering.protocol.handshake;
 
 import java.util.Set;
 
-public class ProtocolSelection
+import org.neo4j.causalclustering.protocol.Protocol;
+
+public class ProtocolSelection<T extends Protocol>
 {
     private final String identifier;
     private final Set<Integer> versions;

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ProtocolStack.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ProtocolStack.java
@@ -19,22 +19,33 @@
  */
 package org.neo4j.causalclustering.protocol.handshake;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
-import org.neo4j.causalclustering.protocol.Protocol;
+import static org.neo4j.causalclustering.protocol.Protocol.ApplicationProtocol;
+import static org.neo4j.causalclustering.protocol.Protocol.ModifierProtocol;
 
 public class ProtocolStack
 {
-    private final Protocol applicationProtocol;
+    private final ApplicationProtocol applicationProtocol;
+    private final List<ModifierProtocol> modifierProtocols;
 
-    public ProtocolStack( Protocol applicationProtocol )
+    public ProtocolStack( ApplicationProtocol applicationProtocol, List<ModifierProtocol> modifierProtocols )
     {
         this.applicationProtocol = applicationProtocol;
+        this.modifierProtocols = Collections.unmodifiableList( modifierProtocols );
     }
 
-    public Protocol applicationProtocol()
+    public ApplicationProtocol applicationProtocol()
     {
         return applicationProtocol;
+    }
+
+    public List<ModifierProtocol> modifierProtocols()
+    {
+        return modifierProtocols;
     }
 
     @Override
@@ -49,18 +60,50 @@ public class ProtocolStack
             return false;
         }
         ProtocolStack that = (ProtocolStack) o;
-        return Objects.equals( applicationProtocol, that.applicationProtocol );
+        return Objects.equals( applicationProtocol, that.applicationProtocol ) && Objects.equals( modifierProtocols, that.modifierProtocols );
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash( applicationProtocol );
+        return Objects.hash( applicationProtocol, modifierProtocols );
     }
 
     @Override
     public String toString()
     {
-        return "ProtocolStack{" + "applicationProtocol=" + applicationProtocol + '}';
+        return "ProtocolStack{" + "applicationProtocol=" + applicationProtocol + ", modifierProtocols=" + modifierProtocols + '}';
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static class Builder
+    {
+        private ApplicationProtocol applicationProtocol;
+        private final List<ModifierProtocol> modifierProtocols = new ArrayList<>();
+
+        private Builder()
+        {
+        }
+
+        public Builder modifier( ModifierProtocol modifierProtocol )
+        {
+            modifierProtocols.add( modifierProtocol );
+            return this;
+        }
+
+        public Builder application( ApplicationProtocol applicationProtocol )
+        {
+            this.applicationProtocol = applicationProtocol;
+            return this;
+        }
+
+        ProtocolStack build()
+        {
+            return new ProtocolStack( applicationProtocol, modifierProtocols );
+        }
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ServerMessageEncoder.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/ServerMessageEncoder.java
@@ -56,16 +56,14 @@ public class ServerMessageEncoder extends MessageToByteEncoder<ClientMessage>
         public void handle( ApplicationProtocolResponse applicationProtocolResponse )
         {
             out.writeInt( 0 );
-            out.writeInt( applicationProtocolResponse.statusCode().codeValue() );
-            StringMarshal.marshal( out, applicationProtocolResponse.protocolName() );
-            out.writeInt( applicationProtocolResponse.version() );
+            encodeProtocolResponse( applicationProtocolResponse );
         }
 
         @Override
         public void handle( ModifierProtocolResponse modifierProtocolResponse )
         {
             out.writeInt( 1 );
-            // TODO
+            encodeProtocolResponse( modifierProtocolResponse );
         }
 
         @Override
@@ -73,6 +71,13 @@ public class ServerMessageEncoder extends MessageToByteEncoder<ClientMessage>
         {
             out.writeInt( 2 );
             out.writeInt( switchOverResponse.status().codeValue() );
+        }
+
+        private void encodeProtocolResponse( BaseProtocolResponse protocolResponse )
+        {
+            out.writeInt( protocolResponse.statusCode().codeValue() );
+            StringMarshal.marshal( out, protocolResponse.protocolName() );
+            out.writeInt( protocolResponse.version() );
         }
     }
 }

--- a/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/SwitchOverRequest.java
+++ b/enterprise/causal-clustering/src/main/java/org/neo4j/causalclustering/protocol/handshake/SwitchOverRequest.java
@@ -19,17 +19,22 @@
  */
 package org.neo4j.causalclustering.protocol.handshake;
 
+import java.util.List;
 import java.util.Objects;
+
+import org.neo4j.helpers.collection.Pair;
 
 public class SwitchOverRequest implements ServerMessage
 {
     private final String protocolName;
     private final int version;
+    private final List<Pair<String,Integer>> modifierProtocols;
 
-    public SwitchOverRequest( String protocolName, int version )
+    public SwitchOverRequest( String applicationProtocolName, int applicationProtocolVersion, List<Pair<String,Integer>> modifierProtocols )
     {
-        this.protocolName = protocolName;
-        this.version = version;
+        this.protocolName = applicationProtocolName;
+        this.version = applicationProtocolVersion;
+        this.modifierProtocols = modifierProtocols;
     }
 
     @Override
@@ -41,6 +46,11 @@ public class SwitchOverRequest implements ServerMessage
     public String protocolName()
     {
         return protocolName;
+    }
+
+    public List<Pair<String,Integer>> modifierProtocols()
+    {
+        return modifierProtocols;
     }
 
     public int version()
@@ -60,12 +70,18 @@ public class SwitchOverRequest implements ServerMessage
             return false;
         }
         SwitchOverRequest that = (SwitchOverRequest) o;
-        return version == that.version && Objects.equals( protocolName, that.protocolName );
+        return version == that.version && Objects.equals( protocolName, that.protocolName ) && Objects.equals( modifierProtocols, that.modifierProtocols );
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash( protocolName, version );
+        return Objects.hash( protocolName, version, modifierProtocols );
+    }
+
+    @Override
+    public String toString()
+    {
+        return "SwitchOverRequest{" + "protocolName='" + protocolName + '\'' + ", version=" + version + ", modifierProtocols=" + modifierProtocols + '}';
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/procedures/InstalledProtocolsProcedureTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/discovery/procedures/InstalledProtocolsProcedureTest.java
@@ -24,28 +24,39 @@ import org.junit.Test;
 import java.util.stream.Stream;
 
 import org.neo4j.causalclustering.protocol.handshake.ProtocolStack;
-import org.neo4j.causalclustering.protocol.handshake.TestProtocols;
+import org.neo4j.causalclustering.protocol.handshake.TestProtocols.TestApplicationProtocols;
+import org.neo4j.causalclustering.protocol.handshake.TestProtocols.TestModifierProtocols;
+import org.neo4j.causalclustering.scenarios.InstalledProtocolsProcedureIT;
 import org.neo4j.collection.RawIterator;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.helpers.SocketAddress;
 import org.neo4j.helpers.collection.Pair;
 import org.neo4j.kernel.api.exceptions.ProcedureException;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 
+/**
+ * @see InstalledProtocolsProcedureIT
+ */
 public class InstalledProtocolsProcedureTest
 {
     private Pair<AdvertisedSocketAddress,ProtocolStack> outbound1 =
-            Pair.of( new AdvertisedSocketAddress( "host1", 1 ), new ProtocolStack( TestProtocols.RAFT_1 ) );
+            Pair.of( new AdvertisedSocketAddress( "host1", 1 ),
+                    new ProtocolStack( TestApplicationProtocols.RAFT_1, asList( TestModifierProtocols.SNAPPY ) ) );
     private Pair<AdvertisedSocketAddress,ProtocolStack> outbound2 =
-            Pair.of( new AdvertisedSocketAddress( "host2", 2 ), new ProtocolStack( TestProtocols.RAFT_2 ) );
+            Pair.of( new AdvertisedSocketAddress( "host2", 2 ),
+                    new ProtocolStack( TestApplicationProtocols.RAFT_2, asList( TestModifierProtocols.SNAPPY, TestModifierProtocols.ROT13 ) ) );
 
     private Pair<SocketAddress,ProtocolStack> inbound1 =
-            Pair.of( new SocketAddress( "host3", 3 ), new ProtocolStack( TestProtocols.RAFT_3 ) );
+            Pair.of( new SocketAddress( "host3", 3 ),
+                    new ProtocolStack( TestApplicationProtocols.RAFT_3, asList( TestModifierProtocols.SNAPPY ) ) );
     private Pair<SocketAddress,ProtocolStack> inbound2 =
-            Pair.of( new SocketAddress( "host4", 4 ), new ProtocolStack( TestProtocols.RAFT_4 ) );
+            Pair.of( new SocketAddress( "host4", 4 ),
+                    new ProtocolStack( TestApplicationProtocols.RAFT_4, emptyList() ) );
 
     @Test
     public void shouldHaveEmptyOutputIfNoInstalledProtocols() throws Throwable
@@ -72,8 +83,8 @@ public class InstalledProtocolsProcedureTest
         RawIterator<Object[],ProcedureException> result = installedProtocolsProcedure.apply( null, null, null );
 
         // then
-        assertThat( result.next(), arrayContaining( "outbound", "host1:1", "raft", 1L ) );
-        assertThat( result.next(), arrayContaining( "outbound", "host2:2", "raft", 2L ) );
+        assertThat( result.next(), arrayContaining( "outbound", "host1:1", "raft", 1L, "[TestSnappy]" ) );
+        assertThat( result.next(), arrayContaining( "outbound", "host2:2", "raft", 2L, "[TestSnappy,ROT13]" ) );
         assertFalse( result.hasNext() );
     }
 
@@ -88,8 +99,8 @@ public class InstalledProtocolsProcedureTest
         RawIterator<Object[],ProcedureException> result = installedProtocolsProcedure.apply( null, null, null );
 
         // then
-        assertThat( result.next(), arrayContaining( "inbound", "host3:3", "raft", 3L ) );
-        assertThat( result.next(), arrayContaining( "inbound", "host4:4", "raft", 4L ) );
+        assertThat( result.next(), arrayContaining( "inbound", "host3:3", "raft", 3L, "[TestSnappy]" ) );
+        assertThat( result.next(), arrayContaining( "inbound", "host4:4", "raft", 4L, "[]" ) );
         assertFalse( result.hasNext() );
     }
 
@@ -104,10 +115,10 @@ public class InstalledProtocolsProcedureTest
         RawIterator<Object[],ProcedureException> result = installedProtocolsProcedure.apply( null, null, null );
 
         // then
-        assertThat( result.next(), arrayContaining( "outbound", "host1:1", "raft", 1L ) );
-        assertThat( result.next(), arrayContaining( "outbound", "host2:2", "raft", 2L ) );
-        assertThat( result.next(), arrayContaining( "inbound", "host3:3", "raft", 3L ) );
-        assertThat( result.next(), arrayContaining( "inbound", "host4:4", "raft", 4L ) );
+        assertThat( result.next(), arrayContaining( "outbound", "host1:1", "raft", 1L, "[TestSnappy]" ) );
+        assertThat( result.next(), arrayContaining( "outbound", "host2:2", "raft", 2L, "[TestSnappy,ROT13]" ) );
+        assertThat( result.next(), arrayContaining( "inbound", "host3:3", "raft", 3L, "[TestSnappy]" ) );
+        assertThat( result.next(), arrayContaining( "inbound", "host4:4", "raft", 4L, "[]" ) );
         assertFalse( result.hasNext() );
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/ReconnectingChannelsTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/messaging/ReconnectingChannelsTest.java
@@ -27,12 +27,13 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.neo4j.causalclustering.protocol.handshake.ProtocolStack;
-import org.neo4j.causalclustering.protocol.handshake.TestProtocols;
+import org.neo4j.causalclustering.protocol.handshake.TestProtocols.TestApplicationProtocols;
 import org.neo4j.helpers.AdvertisedSocketAddress;
 import org.neo4j.helpers.collection.Pair;
 
 import static co.unruly.matchers.StreamMatchers.contains;
 import static co.unruly.matchers.StreamMatchers.empty;
+import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertThat;
 
 public class ReconnectingChannelsTest
@@ -44,7 +45,7 @@ public class ReconnectingChannelsTest
     private ReconnectingChannel channel2 = Mockito.mock( ReconnectingChannel.class );
 
     @Test
-    public void shouldReturnEmptyStreamOfInstalledProtocolsIfNoChannels() throws Throwable
+    public void shouldReturnEmptyStreamOfInstalledProtocolsIfNoChannels()
     {
         // when
         Stream<Pair<AdvertisedSocketAddress,ProtocolStack>> installedProtocols = reconnectingChannels.installedProtocols();
@@ -54,13 +55,13 @@ public class ReconnectingChannelsTest
     }
 
     @Test
-    public void shouldReturnStreamOfInstalledProtocolsForChannelsThatHaveCompletedHandshake() throws Throwable
+    public void shouldReturnStreamOfInstalledProtocolsForChannelsThatHaveCompletedHandshake()
     {
         // given
         reconnectingChannels.putIfAbsent( to1, channel1 );
         reconnectingChannels.putIfAbsent( to2, channel2 );
-        ProtocolStack protocolStack1 = new ProtocolStack( TestProtocols.RAFT_3 );
-        ProtocolStack protocolStack2 = new ProtocolStack( TestProtocols.RAFT_2 );
+        ProtocolStack protocolStack1 = new ProtocolStack( TestApplicationProtocols.RAFT_3, emptyList() );
+        ProtocolStack protocolStack2 = new ProtocolStack( TestApplicationProtocols.RAFT_2, emptyList() );
         Mockito.when( channel1.installedProtocolStack() ).thenReturn( Optional.of( protocolStack1 ) );
         Mockito.when( channel2.installedProtocolStack() ).thenReturn( Optional.of( protocolStack2 ) );
 
@@ -73,12 +74,12 @@ public class ReconnectingChannelsTest
     }
 
     @Test
-    public void shouldExcludeChannelsWithoutInstalledProtocol() throws Throwable
+    public void shouldExcludeChannelsWithoutInstalledProtocol()
     {
         // given
         reconnectingChannels.putIfAbsent( to1, channel1 );
         reconnectingChannels.putIfAbsent( to2, channel2 );
-        ProtocolStack protocolStack1 = new ProtocolStack( TestProtocols.RAFT_3 );
+        ProtocolStack protocolStack1 = new ProtocolStack( TestApplicationProtocols.RAFT_3, emptyList() );
         Mockito.when( channel1.installedProtocolStack() ).thenReturn( Optional.of( protocolStack1 ) );
         Mockito.when( channel2.installedProtocolStack() ).thenReturn( Optional.empty() );
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/NettyPipelineBuilderTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/NettyPipelineBuilderTest.java
@@ -56,7 +56,7 @@ public class NettyPipelineBuilderTest
     {
         // given
         RuntimeException ex = new RuntimeException();
-        NettyPipelineBuilder.with( channel.pipeline(), log ).add( "read_handler", new ChannelInboundHandlerAdapter()
+        NettyPipelineBuilder.server( channel.pipeline(), log ).add( "read_handler", new ChannelInboundHandlerAdapter()
         {
             @Override
             public void channelRead( ChannelHandlerContext ctx, Object msg )
@@ -77,7 +77,7 @@ public class NettyPipelineBuilderTest
     {
         // given
         Object msg = new Object();
-        NettyPipelineBuilder.with( channel.pipeline(), log ).install();
+        NettyPipelineBuilder.server( channel.pipeline(), log ).install();
 
         // when
         channel.writeOneInbound( msg );
@@ -91,7 +91,7 @@ public class NettyPipelineBuilderTest
     {
         // given
         Object msg = new Object();
-        NettyPipelineBuilder.with( channel.pipeline(), log ).install();
+        NettyPipelineBuilder.server( channel.pipeline(), log ).install();
 
         // when
         channel.writeAndFlush( msg );
@@ -104,7 +104,7 @@ public class NettyPipelineBuilderTest
     public void shouldLogExceptionOutbound()
     {
         RuntimeException ex = new RuntimeException();
-        NettyPipelineBuilder.with( channel.pipeline(), log ).add( "write_handler", new ChannelOutboundHandlerAdapter()
+        NettyPipelineBuilder.server( channel.pipeline(), log ).add( "write_handler", new ChannelOutboundHandlerAdapter()
         {
             @Override
             public void write( ChannelHandlerContext ctx, Object msg, ChannelPromise promise )
@@ -124,7 +124,7 @@ public class NettyPipelineBuilderTest
     public void shouldLogExceptionOutboundWithVoidPromise()
     {
         RuntimeException ex = new RuntimeException();
-        NettyPipelineBuilder.with( channel.pipeline(), log ).add( "write_handler", new ChannelOutboundHandlerAdapter()
+        NettyPipelineBuilder.server( channel.pipeline(), log ).add( "write_handler", new ChannelOutboundHandlerAdapter()
         {
             @Override
             public void write( ChannelHandlerContext ctx, Object msg, ChannelPromise promise )
@@ -153,7 +153,7 @@ public class NettyPipelineBuilderTest
                 // handled
             }
         };
-        NettyPipelineBuilder.with( channel.pipeline(), log ).add( "read_handler", handler ).install();
+        NettyPipelineBuilder.server( channel.pipeline(), log ).add( "read_handler", handler ).install();
 
         // when
         channel.writeOneInbound( msg );
@@ -175,7 +175,7 @@ public class NettyPipelineBuilderTest
                 ctx.write( ctx.alloc().buffer() );
             }
         };
-        NettyPipelineBuilder.with( channel.pipeline(), log ).add( "write_handler", encoder ).install();
+        NettyPipelineBuilder.server( channel.pipeline(), log ).add( "write_handler", encoder ).install();
 
         // when
         channel.writeAndFlush( msg );
@@ -185,12 +185,12 @@ public class NettyPipelineBuilderTest
     }
 
     @Test
-    public void shouldReInstallWithPreviousGate() throws Exception
+    public void shouldReInstallWithPreviousGate()
     {
         // given
         Object gatedMessage = new Object();
 
-        NettyPipelineBuilder builderA = NettyPipelineBuilder.with( channel.pipeline(), log );
+        ServerNettyPipelineBuilder builderA = NettyPipelineBuilder.server( channel.pipeline(), log );
         builderA.addGate( p -> p == gatedMessage );
         builderA.install();
 
@@ -199,7 +199,7 @@ public class NettyPipelineBuilderTest
                 hasItems( "error_handler_head", NettyPipelineBuilder.MESSAGE_GATE_NAME, "error_handler_tail" ) );
 
         // when
-        NettyPipelineBuilder builderB = NettyPipelineBuilder.with( channel.pipeline(), log );
+        ServerNettyPipelineBuilder builderB = NettyPipelineBuilder.server( channel.pipeline(), log );
         builderB.add( "my_handler", EMPTY_HANDLER );
         builderB.install();
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/ProtocolInstallerRepositoryTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/ProtocolInstallerRepositoryTest.java
@@ -19,63 +19,242 @@
  */
 package org.neo4j.causalclustering.protocol;
 
+import org.hamcrest.Matchers;
 import org.junit.Test;
+
+import java.util.List;
 
 import org.neo4j.causalclustering.core.consensus.RaftProtocolClientInstaller;
 import org.neo4j.causalclustering.core.consensus.RaftProtocolServerInstaller;
 import org.neo4j.causalclustering.handlers.VoidPipelineWrapperFactory;
-import org.neo4j.causalclustering.protocol.handshake.TestProtocols;
+import org.neo4j.causalclustering.protocol.Protocol.ApplicationProtocols;
+import org.neo4j.causalclustering.protocol.Protocol.ModifierProtocols;
+import org.neo4j.causalclustering.protocol.ProtocolInstaller.Orientation;
+import org.neo4j.causalclustering.protocol.handshake.ProtocolStack;
+import org.neo4j.causalclustering.protocol.handshake.TestProtocols.TestApplicationProtocols;
+import org.neo4j.causalclustering.protocol.handshake.TestProtocols.TestModifierProtocols;
 import org.neo4j.logging.NullLogProvider;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 public class ProtocolInstallerRepositoryTest
 {
-    private final NettyPipelineBuilderFactory pipelineBuilderFactory = new NettyPipelineBuilderFactory( VoidPipelineWrapperFactory.VOID_WRAPPER );
-    private final RaftProtocolClientInstaller raftProtocolClientInstaller =
-            new RaftProtocolClientInstaller( NullLogProvider.getInstance(), pipelineBuilderFactory );
-    private final RaftProtocolServerInstaller raftProtocolServerInstaller =
-            new RaftProtocolServerInstaller( null, pipelineBuilderFactory, NullLogProvider.getInstance() );
+    private List<ModifierProtocolInstaller<Orientation.Client>> clientModifiers =
+            asList( new SnappyClientInstaller(), new LZHClientInstaller(), new Rot13ClientInstaller() );
+    private List<ModifierProtocolInstaller<Orientation.Server>> serverModifiers =
+            asList( new SnappyServerInstaller(), new LZHServerInstaller(), new Rot13ServerInstaller() );
 
-    private final ProtocolInstallerRepository<ProtocolInstaller.Orientation.Client> clientRepository =
-            new ProtocolInstallerRepository<>( asList( raftProtocolClientInstaller ) );
-    private final ProtocolInstallerRepository<ProtocolInstaller.Orientation.Server> serverRepository =
-            new ProtocolInstallerRepository<>( asList( raftProtocolServerInstaller ) );
+    private final NettyPipelineBuilderFactory pipelineBuilderFactory =
+            new NettyPipelineBuilderFactory( VoidPipelineWrapperFactory.VOID_WRAPPER );
+    private final RaftProtocolClientInstaller.Factory raftProtocolClientInstaller =
+            new RaftProtocolClientInstaller.Factory( pipelineBuilderFactory, NullLogProvider.getInstance() );
+    private final RaftProtocolServerInstaller.Factory raftProtocolServerInstaller =
+            new RaftProtocolServerInstaller.Factory( null, pipelineBuilderFactory, NullLogProvider.getInstance() );
+
+    private final ProtocolInstallerRepository<Orientation.Client> clientRepository =
+            new ProtocolInstallerRepository<>( asList( raftProtocolClientInstaller ), clientModifiers );
+    private final ProtocolInstallerRepository<Orientation.Server> serverRepository =
+            new ProtocolInstallerRepository<>( asList( raftProtocolServerInstaller ), serverModifiers );
 
     @Test
     public void shouldReturnRaftServerInstaller()
     {
-        assertEquals( raftProtocolServerInstaller, serverRepository.installerFor( Protocol.Protocols.RAFT_1 ) );
+        assertEquals(
+                raftProtocolServerInstaller.applicationProtocol(),
+                serverRepository.installerFor( new ProtocolStack( ApplicationProtocols.RAFT_1, emptyList() ) ).applicationProtocol() );
     }
 
     @Test
     public void shouldReturnRaftClientInstaller()
     {
-        assertEquals( raftProtocolClientInstaller, clientRepository.installerFor( Protocol.Protocols.RAFT_1 ) );
+        assertEquals(
+                raftProtocolClientInstaller.applicationProtocol(),
+                clientRepository.installerFor( new ProtocolStack( ApplicationProtocols.RAFT_1, emptyList() ) ).applicationProtocol() );
+    }
+
+    @Test
+    public void shouldReturnModifierProtocolsForServer()
+    {
+        // given
+        Protocol.ModifierProtocol expected = TestModifierProtocols.SNAPPY;
+        ProtocolStack protocolStack = new ProtocolStack( ApplicationProtocols.RAFT_1, asList( expected ) );
+
+        // when
+        List<Protocol.ModifierProtocol> actual = clientRepository.installerFor( protocolStack ).modifiers();
+
+        // then
+        assertThat(
+                expected,
+                Matchers.isIn( actual )
+        );
+    }
+
+    @Test
+    public void shouldUseDifferentInstancesOfProtocolInstaller()
+    {
+        // given
+        ProtocolStack protocolStack1 = new ProtocolStack( ApplicationProtocols.RAFT_1, asList( TestModifierProtocols.SNAPPY ) );
+        ProtocolStack protocolStack2 = new ProtocolStack( ApplicationProtocols.RAFT_1, asList( TestModifierProtocols.LZH ) );
+
+        // when
+        ProtocolInstaller protocolInstaller1 = clientRepository.installerFor( protocolStack1 );
+        ProtocolInstaller protocolInstaller2 = clientRepository.installerFor( protocolStack2 );
+
+        // then
+        assertThat( protocolInstaller1, not( sameInstance( protocolInstaller2 ) ) );
+    }
+
+    @Test( expected = IllegalArgumentException.class )
+    public void shouldThrowIfAttemptingToCreateInstallerForMultipleModifiersWithSameIdentifier()
+    {
+        // given
+        ProtocolStack protocolStack = new ProtocolStack(
+                ApplicationProtocols.RAFT_1,
+                asList( TestModifierProtocols.SNAPPY, TestModifierProtocols.LZH ) );
+
+        // when
+        clientRepository.installerFor( protocolStack );
+
+        // then throw
     }
 
     @Test( expected = IllegalArgumentException.class )
     public void shouldNotInitialiseIfMultipleInstallersForSameProtocolForServer()
     {
-        new ProtocolInstallerRepository<>( asList( raftProtocolServerInstaller, raftProtocolServerInstaller ) );
+        new ProtocolInstallerRepository<>( asList( raftProtocolServerInstaller, raftProtocolServerInstaller ), emptyList() );
     }
 
     @Test( expected = IllegalArgumentException.class )
     public void shouldNotInitialiseIfMultipleInstallersForSameProtocolForClient()
     {
-        new ProtocolInstallerRepository<>( asList( raftProtocolClientInstaller, raftProtocolClientInstaller ) );
+        new ProtocolInstallerRepository<>( asList( raftProtocolClientInstaller, raftProtocolClientInstaller ), emptyList() );
     }
 
     @Test( expected = IllegalStateException.class )
     public void shouldThrowIfUnknownProtocolForServer()
     {
-        serverRepository.installerFor( TestProtocols.RAFT_3 );
+        serverRepository.installerFor( new ProtocolStack( TestApplicationProtocols.RAFT_3, emptyList() ) );
     }
 
     @Test( expected = IllegalStateException.class )
     public void shouldThrowIfUnknownProtocolForClient()
     {
-        clientRepository.installerFor( TestProtocols.RAFT_3 );
+        clientRepository.installerFor( new ProtocolStack( TestApplicationProtocols.RAFT_3, emptyList() ) );
+    }
+
+    @Test( expected = IllegalStateException.class )
+    public void shouldThrowIfUnknownModifierProtocol()
+    {
+        // given
+        // setup used TestModifierProtocols, doesn't know about production protocols
+        Protocol.ModifierProtocol unknownProtocol = ModifierProtocols.COMPRESSION_SNAPPY;
+
+        // when
+        serverRepository.installerFor( new ProtocolStack( ApplicationProtocols.RAFT_1, asList( unknownProtocol ) ) );
+
+        // then throw
+    }
+
+    // Dummy installers
+
+    private static class SnappyClientInstaller implements ModifierProtocolInstaller<Orientation.Client>
+    {
+        @Override
+        public Protocol.ModifierProtocol protocol()
+        {
+            return TestModifierProtocols.SNAPPY;
+        }
+
+        @Override
+        public <BUILDER extends NettyPipelineBuilder<Orientation.Client,BUILDER>> void apply(
+                NettyPipelineBuilder<Orientation.Client,BUILDER> nettyPipelineBuilder )
+        {
+
+        }
+    }
+
+    private static class LZHClientInstaller implements ModifierProtocolInstaller<Orientation.Client>
+    {
+        @Override
+        public Protocol.ModifierProtocol protocol()
+        {
+            return TestModifierProtocols.LZH;
+        }
+
+        @Override
+        public <BUILDER extends NettyPipelineBuilder<Orientation.Client,BUILDER>> void apply(
+                NettyPipelineBuilder<Orientation.Client,BUILDER> nettyPipelineBuilder )
+        {
+
+        }
+    }
+
+    private class Rot13ClientInstaller implements ModifierProtocolInstaller<Orientation.Client>
+    {
+        @Override
+        public Protocol.ModifierProtocol protocol()
+        {
+            return TestModifierProtocols.ROT13;
+        }
+
+        @Override
+        public <BUILDER extends NettyPipelineBuilder<Orientation.Client,BUILDER>> void apply(
+                NettyPipelineBuilder<Orientation.Client,BUILDER> nettyPipelineBuilder )
+        {
+
+        }
+    }
+
+    private static class SnappyServerInstaller implements ModifierProtocolInstaller<Orientation.Server>
+    {
+        @Override
+        public Protocol.ModifierProtocol protocol()
+        {
+            return TestModifierProtocols.SNAPPY;
+        }
+
+        @Override
+        public <BUILDER extends NettyPipelineBuilder<Orientation.Server,BUILDER>> void apply(
+                NettyPipelineBuilder<Orientation.Server,BUILDER> nettyPipelineBuilder )
+        {
+
+        }
+    }
+
+    private static class LZHServerInstaller implements ModifierProtocolInstaller<Orientation.Server>
+    {
+        @Override
+        public Protocol.ModifierProtocol protocol()
+        {
+            return TestModifierProtocols.LZH;
+        }
+
+        @Override
+        public <BUILDER extends NettyPipelineBuilder<Orientation.Server,BUILDER>> void apply(
+                NettyPipelineBuilder<Orientation.Server,BUILDER> nettyPipelineBuilder )
+        {
+
+        }
+    }
+
+    private class Rot13ServerInstaller implements ModifierProtocolInstaller<Orientation.Server>
+    {
+        @Override
+        public Protocol.ModifierProtocol protocol()
+        {
+            return TestModifierProtocols.ROT13;
+        }
+
+        @Override
+        public <BUILDER extends NettyPipelineBuilder<Orientation.Server,BUILDER>> void apply(
+                NettyPipelineBuilder<Orientation.Server,BUILDER> nettyPipelineBuilder )
+        {
+
+        }
     }
 }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/ClientMessageEncodingTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/ClientMessageEncodingTest.java
@@ -41,7 +41,7 @@ public class ClientMessageEncodingTest
     private final ServerMessageEncoder encoder = new ServerMessageEncoder();
     private final ClientMessageDecoder decoder = new ClientMessageDecoder();
 
-    private List<Object> encodeDecode( ClientMessage message )
+    private List<Object> encodeDecode( ClientMessage message ) throws ClientHandshakeException
     {
         ByteBuf byteBuf = Unpooled.directBuffer();
         List<Object> output = new ArrayList<>();
@@ -57,7 +57,7 @@ public class ClientMessageEncodingTest
     {
         return Arrays.asList(
                 new ApplicationProtocolResponse( StatusCode.FAILURE, "protocol", 13 ),
-                new ModifierProtocolResponse(),
+                new ModifierProtocolResponse( StatusCode.SUCCESS, "modifier", 7 ),
                 new SwitchOverResponse( StatusCode.FAILURE )
                 );
     }
@@ -68,7 +68,7 @@ public class ClientMessageEncodingTest
     }
 
     @Test
-    public void shouldCompleteEncodingRoundTrip()
+    public void shouldCompleteEncodingRoundTrip() throws ClientHandshakeException
     {
         //when
         List<Object> output = encodeDecode( message );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/HandshakeClientEnsureMagicTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/HandshakeClientEnsureMagicTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.protocol.handshake;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+import org.neo4j.causalclustering.messaging.Channel;
+import org.neo4j.causalclustering.protocol.Protocol;
+import org.neo4j.causalclustering.protocol.handshake.TestProtocols.TestApplicationProtocols;
+import org.neo4j.causalclustering.protocol.handshake.TestProtocols.TestModifierProtocols;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptySet;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+@RunWith( Parameterized.class )
+public class HandshakeClientEnsureMagicTest
+{
+    private CompletableFuture<ProtocolStack> protocolStackCompletableFuture;
+
+    @Parameterized.Parameters( name = "{0}" )
+    public static Collection<ClientMessage> data()
+    {
+        return asList(
+                new ApplicationProtocolResponse( StatusCode.SUCCESS, "protocol", 2 ),
+                new ModifierProtocolResponse( StatusCode.SUCCESS, "modifier", 4 ),
+                new SwitchOverResponse( StatusCode.SUCCESS )
+        );
+    }
+
+    @Parameterized.Parameter
+    public ClientMessage message;
+
+    private Channel channel = mock( Channel.class );
+    private ProtocolRepository<Protocol.ApplicationProtocol> applicationProtocolRepository = new ProtocolRepository<>( TestApplicationProtocols.values() );
+    private ProtocolRepository<Protocol.ModifierProtocol> modifierProtocolRepository = new ProtocolRepository<>( TestModifierProtocols.values() );
+
+    private HandshakeClient client = new HandshakeClient();
+
+    @Before
+    public void setUp()
+    {
+        protocolStackCompletableFuture =
+                client.initiate( channel, applicationProtocolRepository, Protocol.ApplicationProtocolIdentifier.RAFT, modifierProtocolRepository, emptySet() );
+    }
+
+    @Test( expected = IllegalStateException.class )
+    public void shouldThrowIfMagicHasNotBeenSent()
+    {
+        message.dispatch( client );
+    }
+
+    @Test( expected = ClientHandshakeException.class )
+    public void shouldCompleteExceptionallyIfMagicHasNotBeenSent() throws Throwable
+    {
+        try
+        {
+            message.dispatch( client );
+        }
+        catch ( Exception ignored )
+        {
+            // swallow
+        }
+
+        try
+        {
+            protocolStackCompletableFuture.getNow( null );
+        }
+        catch ( CompletionException ex )
+        {
+            throw ex.getCause();
+        }
+    }
+
+    @Test
+    public void shouldNotThrowIfMagicHasBeenSent()
+    {
+        // given
+        InitialMagicMessage.instance().dispatch( client );
+
+        // when
+        message.dispatch( client );
+
+        // then pass
+    }
+
+    @Test
+    public void shouldNotCompleteExceptionallyIfMagicHasBeenSent()
+    {
+        // given
+        InitialMagicMessage.instance().dispatch( client );
+
+        // when
+        message.dispatch( client );
+
+        // then future should either not complete exceptionally or do so for non-magic reasons
+        try
+        {
+            protocolStackCompletableFuture.getNow( null );
+        }
+        catch ( CompletionException ex )
+        {
+            assertThat( ex.getMessage().toLowerCase(), not( containsString( "magic" ) ) );
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/HandshakeClientTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/HandshakeClientTest.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.protocol.handshake;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.stream.Stream;
+
+import org.neo4j.causalclustering.messaging.Channel;
+import org.neo4j.causalclustering.protocol.handshake.TestProtocols.TestApplicationProtocols;
+import org.neo4j.causalclustering.protocol.handshake.TestProtocols.TestModifierProtocols;
+import org.neo4j.helpers.collection.Pair;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.Matchers.any;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.neo4j.causalclustering.protocol.Protocol.ApplicationProtocol;
+import static org.neo4j.causalclustering.protocol.Protocol.ApplicationProtocolIdentifier;
+import static org.neo4j.causalclustering.protocol.Protocol.ModifierProtocol;
+import static org.neo4j.causalclustering.protocol.Protocol.ModifierProtocolIdentifier;
+import static org.neo4j.helpers.collection.Iterators.asSet;
+
+/**
+ * @see HandshakeClientEnsureMagicTest
+ */
+public class HandshakeClientTest
+{
+    private HandshakeClient client = new HandshakeClient();
+    private Channel channel = mock( Channel.class );
+    private ProtocolRepository<ApplicationProtocol> applicationProtocolRepository = new ProtocolRepository<>( TestApplicationProtocols.values() );
+    private ProtocolRepository<ModifierProtocol> modifierProtocolRepository = new ProtocolRepository<>( TestModifierProtocols.values() );
+    private ApplicationProtocolIdentifier applicationProtocolIdentifier = ApplicationProtocolIdentifier.RAFT;
+    private int raftVersion = TestApplicationProtocols.latest( ApplicationProtocolIdentifier.RAFT ).version();
+    private ApplicationProtocol expectedApplicationProtocol =
+            applicationProtocolRepository.select( applicationProtocolIdentifier.canonicalName(), raftVersion ).get();
+
+    @Test
+    public void shouldSendInitialMagicOnInitiation()
+    {
+        client.initiate( channel, applicationProtocolRepository, applicationProtocolIdentifier, modifierProtocolRepository, emptySet() );
+
+        verify( channel ).write( InitialMagicMessage.instance() );
+    }
+
+    @Test
+    public void shouldSendApplicationProtocolRequestOnInitiation()
+    {
+        client.initiate( channel, applicationProtocolRepository, applicationProtocolIdentifier, modifierProtocolRepository, emptySet() );
+
+        ApplicationProtocolRequest expectedMessage = new ApplicationProtocolRequest(
+                applicationProtocolIdentifier.canonicalName(),
+                applicationProtocolRepository.getAll( applicationProtocolIdentifier ).versions()
+        );
+
+        verify( channel ).writeAndFlush( expectedMessage );
+    }
+
+    @Test
+    public void shouldSendModifierProtocolRequestsOnInitiation()
+    {
+        // when
+        client.initiate( channel, applicationProtocolRepository, applicationProtocolIdentifier, modifierProtocolRepository,
+                asSet( ModifierProtocolIdentifier.values() ) );
+
+        // then
+        Stream.of( ModifierProtocolIdentifier.values() ).forEach( modifierProtocolIdentifier ->
+                {
+                    Set<Integer> versions = modifierProtocolRepository.getAll( modifierProtocolIdentifier ).versions();
+                    verify( channel ).write( new ModifierProtocolRequest( modifierProtocolIdentifier.canonicalName(), versions ) );
+                } );
+    }
+
+    @Test
+    public void shouldExceptionallyCompleteProtocolStackOnReceivingIncorrectMagic()
+    {
+        // given
+        CompletableFuture<ProtocolStack> protocolStackCompletableFuture =
+                client.initiate( channel, applicationProtocolRepository, applicationProtocolIdentifier, modifierProtocolRepository, emptySet() );
+
+        // when
+        client.handle( new InitialMagicMessage( "totally legit" ) );
+
+        // then
+        assertCompletedExceptionally( protocolStackCompletableFuture );
+    }
+
+    @Test
+    public void shouldAcceptCorrectMagic()
+    {
+        // given
+        CompletableFuture<ProtocolStack> protocolStackCompletableFuture =
+                client.initiate( channel, applicationProtocolRepository, applicationProtocolIdentifier, modifierProtocolRepository, emptySet() );
+
+        // when
+        client.handle( InitialMagicMessage.instance() );
+
+        // then
+        assertFalse( protocolStackCompletableFuture.isDone() );
+    }
+
+    @Test
+    public void shouldExceptionallyCompleteProtocolStackWhenApplicationProtocolResponseNotSuccessful()
+    {
+        // given
+        CompletableFuture<ProtocolStack> protocolStackCompletableFuture =
+                client.initiate( channel, applicationProtocolRepository, applicationProtocolIdentifier, modifierProtocolRepository, emptySet() );
+        client.handle( InitialMagicMessage.instance() );
+
+        // when
+        client.handle( new ApplicationProtocolResponse( StatusCode.FAILURE, applicationProtocolIdentifier.canonicalName(), raftVersion ) );
+
+        // then
+        assertCompletedExceptionally( protocolStackCompletableFuture );
+    }
+
+    @Test
+    public void shouldExceptionallyCompleteProtocolStackWhenApplicationProtocolResponseForIncorrectProtocol()
+    {
+        // given
+        CompletableFuture<ProtocolStack> protocolStackCompletableFuture =
+                client.initiate( channel, applicationProtocolRepository, applicationProtocolIdentifier, modifierProtocolRepository, emptySet() );
+        client.handle( InitialMagicMessage.instance() );
+
+        // when
+        client.handle( new ApplicationProtocolResponse( StatusCode.SUCCESS, "zab", raftVersion ) );
+
+        // then
+        assertCompletedExceptionally( protocolStackCompletableFuture );
+    }
+
+    @Test
+    public void shouldExceptionallyCompleteProtocolStackWhenApplicationProtocolResponseForUnsupportedVersion()
+    {
+        // given
+        CompletableFuture<ProtocolStack> protocolStackCompletableFuture =
+                client.initiate( channel, applicationProtocolRepository, applicationProtocolIdentifier, modifierProtocolRepository, emptySet() );
+        client.handle( InitialMagicMessage.instance() );
+
+        // when
+        client.handle( new ApplicationProtocolResponse( StatusCode.SUCCESS, applicationProtocolIdentifier.canonicalName(), Integer.MAX_VALUE ) );
+
+        // then
+        assertCompletedExceptionally( protocolStackCompletableFuture );
+    }
+
+    @Test
+    public void shouldSendSwitchOverRequestIfNoModifierProtocolsToRequestOnApplicationProtocolResponse()
+    {
+        // given
+        CompletableFuture<ProtocolStack> protocolStackCompletableFuture =
+                client.initiate( channel, applicationProtocolRepository, applicationProtocolIdentifier, modifierProtocolRepository, emptySet() );
+        client.handle( InitialMagicMessage.instance() );
+
+        // when
+        client.handle( new ApplicationProtocolResponse( StatusCode.SUCCESS, applicationProtocolIdentifier.canonicalName(), raftVersion ) );
+
+        // then
+        verify( channel ).writeAndFlush( new SwitchOverRequest( applicationProtocolIdentifier.canonicalName(), raftVersion, emptyList() ) );
+        assertFalse( protocolStackCompletableFuture.isDone() );
+    }
+
+    @Test
+    public void shouldNotSendSwitchOverRequestOnModifierProtocolResponseIfNotAllModifierProtocolResponsesReceived()
+    {
+        // given
+        CompletableFuture<ProtocolStack> protocolStackCompletableFuture =
+                client.initiate( channel, applicationProtocolRepository, applicationProtocolIdentifier, modifierProtocolRepository,
+                        asSet( ModifierProtocolIdentifier.COMPRESSION, ModifierProtocolIdentifier.GRATUITOUS_OBFUSCATION ) );
+        client.handle( InitialMagicMessage.instance() );
+        client.handle( new ApplicationProtocolResponse( StatusCode.SUCCESS, applicationProtocolIdentifier.canonicalName(), raftVersion ) );
+
+        // when
+        client.handle( new ModifierProtocolResponse( StatusCode.SUCCESS, ModifierProtocolIdentifier.COMPRESSION.canonicalName(), 1 ) );
+
+        // then
+        verify( channel, never() ).writeAndFlush( any( SwitchOverRequest.class ) );
+        assertFalse( protocolStackCompletableFuture.isDone() );
+    }
+
+    @Test
+    public void shouldNotSendSwitchOverRequestIfApplicationProtocolResponseNotReceivedOnModifierProtocolResponseReceive()
+    {
+        // given
+        CompletableFuture<ProtocolStack> protocolStackCompletableFuture =
+                client.initiate( channel, applicationProtocolRepository, applicationProtocolIdentifier, modifierProtocolRepository,
+                        asSet( ModifierProtocolIdentifier.COMPRESSION ) );
+        client.handle( InitialMagicMessage.instance() );
+
+        // when
+        client.handle( new ModifierProtocolResponse( StatusCode.SUCCESS, ModifierProtocolIdentifier.COMPRESSION.canonicalName(), 1 ) );
+
+        // then
+        verify( channel, never() ).writeAndFlush( any( SwitchOverRequest.class ) );
+        assertFalse( protocolStackCompletableFuture.isDone() );
+    }
+
+    @Test
+    public void shouldSendSwitchOverRequestOnModifierProtocolResponseIfAllModifierProtocolResponsesReceived()
+    {
+        // given
+        CompletableFuture<ProtocolStack> protocolStackCompletableFuture =
+                client.initiate( channel, applicationProtocolRepository, applicationProtocolIdentifier, modifierProtocolRepository,
+                        asSet( ModifierProtocolIdentifier.COMPRESSION, ModifierProtocolIdentifier.GRATUITOUS_OBFUSCATION ) );
+        client.handle( InitialMagicMessage.instance() );
+        client.handle( new ApplicationProtocolResponse( StatusCode.SUCCESS, applicationProtocolIdentifier.canonicalName(), raftVersion ) );
+
+        // when
+        client.handle( new ModifierProtocolResponse( StatusCode.SUCCESS, ModifierProtocolIdentifier.COMPRESSION.canonicalName(), 1 ) );
+        client.handle( new ModifierProtocolResponse( StatusCode.SUCCESS, ModifierProtocolIdentifier.GRATUITOUS_OBFUSCATION.canonicalName(), 1 ) );
+
+        // then
+        List<Pair<String,Integer>> switchOverModifierProtocols = asList( Pair.of( ModifierProtocolIdentifier.GRATUITOUS_OBFUSCATION.canonicalName(), 1 ),
+                Pair.of( ModifierProtocolIdentifier.COMPRESSION.canonicalName(), 1 ) );
+        verify( channel ).writeAndFlush( new SwitchOverRequest( applicationProtocolIdentifier.canonicalName(), raftVersion, switchOverModifierProtocols ) );
+        assertFalse( protocolStackCompletableFuture.isDone() );
+    }
+
+    @Test
+    public void shouldNotIncludeModifierProtocolInSwitchOverRequestIfNotSuccessful()
+    {
+        // given
+        CompletableFuture<ProtocolStack> protocolStackCompletableFuture =
+                client.initiate( channel, applicationProtocolRepository, applicationProtocolIdentifier, modifierProtocolRepository,
+                        asSet( ModifierProtocolIdentifier.COMPRESSION, ModifierProtocolIdentifier.GRATUITOUS_OBFUSCATION ) );
+        client.handle( InitialMagicMessage.instance() );
+        client.handle( new ApplicationProtocolResponse( StatusCode.SUCCESS, applicationProtocolIdentifier.canonicalName(), raftVersion ) );
+
+        // when
+        client.handle( new ModifierProtocolResponse( StatusCode.SUCCESS, ModifierProtocolIdentifier.COMPRESSION.canonicalName(), 1 ) );
+        client.handle( new ModifierProtocolResponse( StatusCode.FAILURE, ModifierProtocolIdentifier.GRATUITOUS_OBFUSCATION.canonicalName(), 1 ) );
+
+        // then
+        List<Pair<String,Integer>> switchOverModifierProtocols = asList( Pair.of( ModifierProtocolIdentifier.COMPRESSION.canonicalName(), 1 ) );
+        verify( channel ).writeAndFlush( new SwitchOverRequest( applicationProtocolIdentifier.canonicalName(), raftVersion, switchOverModifierProtocols ) );
+        assertFalse( protocolStackCompletableFuture.isDone() );
+    }
+
+    @Test
+    public void shouldNotIncludeModifierProtocolInSwitchOverRequestIfUnsupportedProtocol()
+    {
+        // given
+        CompletableFuture<ProtocolStack> protocolStackCompletableFuture =
+                client.initiate( channel, applicationProtocolRepository, applicationProtocolIdentifier, modifierProtocolRepository,
+                        asSet( ModifierProtocolIdentifier.COMPRESSION, ModifierProtocolIdentifier.GRATUITOUS_OBFUSCATION ) );
+        client.handle( InitialMagicMessage.instance() );
+        client.handle( new ApplicationProtocolResponse( StatusCode.SUCCESS, applicationProtocolIdentifier.canonicalName(), raftVersion ) );
+
+        // when
+        client.handle( new ModifierProtocolResponse( StatusCode.SUCCESS, ModifierProtocolIdentifier.COMPRESSION.canonicalName(), 1 ) );
+        client.handle( new ModifierProtocolResponse( StatusCode.SUCCESS, "not a protocol", 1 ) );
+
+        // then
+        List<Pair<String,Integer>> switchOverModifierProtocols = asList( Pair.of( ModifierProtocolIdentifier.COMPRESSION.canonicalName(), 1 ) );
+        verify( channel ).writeAndFlush( new SwitchOverRequest( applicationProtocolIdentifier.canonicalName(), raftVersion, switchOverModifierProtocols ) );
+        assertFalse( protocolStackCompletableFuture.isDone() );
+    }
+
+    @Test
+    public void shouldNotIncludeModifierProtocolInSwitchOverRequestIfUnsupportedVersion()
+    {
+        // given
+        CompletableFuture<ProtocolStack> protocolStackCompletableFuture =
+                client.initiate( channel, applicationProtocolRepository, applicationProtocolIdentifier, modifierProtocolRepository,
+                        asSet( ModifierProtocolIdentifier.COMPRESSION, ModifierProtocolIdentifier.GRATUITOUS_OBFUSCATION ) );
+        client.handle( InitialMagicMessage.instance() );
+        client.handle( new ApplicationProtocolResponse( StatusCode.SUCCESS, applicationProtocolIdentifier.canonicalName(), raftVersion ) );
+
+        // when
+        client.handle(
+                new ModifierProtocolResponse( StatusCode.SUCCESS, ModifierProtocolIdentifier.COMPRESSION.canonicalName(), 1 ) );
+        client.handle(
+                new ModifierProtocolResponse( StatusCode.SUCCESS, ModifierProtocolIdentifier.GRATUITOUS_OBFUSCATION.canonicalName(), Integer.MAX_VALUE ) );
+
+        // then
+        List<Pair<String,Integer>> switchOverModifierProtocols = asList( Pair.of( ModifierProtocolIdentifier.COMPRESSION.canonicalName(), 1 ) );
+        verify( channel ).writeAndFlush( new SwitchOverRequest( applicationProtocolIdentifier.canonicalName(), raftVersion, switchOverModifierProtocols ) );
+        assertFalse( protocolStackCompletableFuture.isDone() );
+    }
+
+    @Test
+    public void shouldExceptionallyCompleteProtocolStackWhenSwitchOverResponseNotSuccess()
+    {
+        // given
+        CompletableFuture<ProtocolStack> protocolStackCompletableFuture =
+                client.initiate( channel, applicationProtocolRepository, applicationProtocolIdentifier, modifierProtocolRepository, emptySet() );
+        client.handle( InitialMagicMessage.instance() );
+        client.handle( new ApplicationProtocolResponse( StatusCode.SUCCESS, applicationProtocolIdentifier.canonicalName(), raftVersion ) );
+
+        // when
+        client.handle( new SwitchOverResponse( StatusCode.FAILURE ) );
+
+        // then
+        assertCompletedExceptionally( protocolStackCompletableFuture );
+    }
+
+    @Test
+    public void shouldExceptionallyCompleteProtocolStackWhenProtocolStackNotSet()
+    {
+        // given
+        CompletableFuture<ProtocolStack> protocolStackCompletableFuture =
+                client.initiate( channel, applicationProtocolRepository, applicationProtocolIdentifier, modifierProtocolRepository, emptySet() );
+        client.handle( InitialMagicMessage.instance() );
+
+        // when
+        client.handle( new SwitchOverResponse( StatusCode.SUCCESS ) );
+
+        // then
+        assertCompletedExceptionally( protocolStackCompletableFuture );
+    }
+
+    @Test
+    public void shouldCompleteProtocolStackOnSwitchoverResponse()
+    {
+        // given
+        CompletableFuture<ProtocolStack> protocolStackCompletableFuture =
+                client.initiate( channel, applicationProtocolRepository, applicationProtocolIdentifier,
+                        modifierProtocolRepository, asSet( ModifierProtocolIdentifier.COMPRESSION ) );
+        client.handle( InitialMagicMessage.instance() );
+        client.handle( new ApplicationProtocolResponse( StatusCode.SUCCESS, applicationProtocolIdentifier.canonicalName(), raftVersion ) );
+        client.handle(
+                new ModifierProtocolResponse( StatusCode.SUCCESS, TestModifierProtocols.SNAPPY.identifier(), TestModifierProtocols.SNAPPY.version() ) );
+
+        // when
+        client.handle( new SwitchOverResponse( StatusCode.SUCCESS ) );
+
+        // then
+        ProtocolStack protocolStack = protocolStackCompletableFuture.getNow( null );
+        assertThat( protocolStack, equalTo( new ProtocolStack( expectedApplicationProtocol, singletonList( TestModifierProtocols.SNAPPY ) ) ) );
+    }
+
+    private void assertCompletedExceptionally( CompletableFuture<ProtocolStack> protocolStackCompletableFuture )
+    {
+        assertTrue( protocolStackCompletableFuture.isCompletedExceptionally() );
+        try
+        {
+            protocolStackCompletableFuture.getNow( null );
+        }
+        catch ( CompletionException ex )
+        {
+            assertThat( ex.getCause(), instanceOf( ClientHandshakeException.class ) );
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/HandshakeServerEnsureMagicTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/HandshakeServerEnsureMagicTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.causalclustering.protocol.handshake;
+
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Collection;
+import java.util.concurrent.CompletionException;
+
+import org.neo4j.causalclustering.messaging.Channel;
+import org.neo4j.causalclustering.protocol.Protocol;
+import org.neo4j.causalclustering.protocol.handshake.TestProtocols.TestApplicationProtocols;
+import org.neo4j.causalclustering.protocol.handshake.TestProtocols.TestModifierProtocols;
+import org.neo4j.helpers.collection.Iterators;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static org.mockito.Mockito.mock;
+
+@RunWith( Parameterized.class )
+public class HandshakeServerEnsureMagicTest
+{
+    @Parameterized.Parameters( name = "{0}" )
+    public static Collection<ServerMessage> data()
+    {
+        return asList(
+                new ApplicationProtocolRequest( Protocol.ApplicationProtocolIdentifier.RAFT.canonicalName(), Iterators.asSet( 1, 2 ) ),
+                new ModifierProtocolRequest( Protocol.ModifierProtocolIdentifier.COMPRESSION.canonicalName(), Iterators.asSet( 3, 4 ) ),
+                new SwitchOverRequest( Protocol.ApplicationProtocolIdentifier.RAFT.canonicalName(), 2, emptyList() )
+        );
+    }
+
+    @Parameterized.Parameter
+    public ServerMessage message;
+
+    private Channel channel = mock( Channel.class );
+    private ProtocolRepository<Protocol.ApplicationProtocol> applicationProtocolRepository = new ProtocolRepository<>( TestApplicationProtocols.values() );
+    private ProtocolRepository<Protocol.ModifierProtocol> modifierProtocolRepository = new ProtocolRepository<>( TestModifierProtocols.values() );
+
+    private HandshakeServer server =
+            new HandshakeServer( channel, applicationProtocolRepository, modifierProtocolRepository, Protocol.ApplicationProtocolIdentifier.RAFT );
+
+    @Test( expected = IllegalStateException.class )
+    public void shouldThrowIfMagicHasNotBeenSent()
+    {
+        message.dispatch( server );
+    }
+
+    @Test( expected = ServerHandshakeException.class )
+    public void shouldCompleteExceptionallyIfMagicHasNotBeenSent() throws Throwable
+    {
+        // when
+        try
+        {
+            message.dispatch( server );
+        }
+        catch ( Exception ignored )
+        {
+            // swallow, tested elsewhere
+        }
+
+        // then future is completed exceptionally
+        try
+        {
+            server.protocolStackFuture().getNow( null );
+        }
+        catch ( CompletionException completion )
+        {
+            throw completion.getCause();
+        }
+    }
+
+    @Test
+    public void shouldNotThrowIfMagicHasBeenSent()
+    {
+        // given
+        InitialMagicMessage.instance().dispatch( server );
+
+        // when
+        message.dispatch( server );
+
+        // then pass
+    }
+
+    @Test
+    public void shouldNotCompleteExceptionallyIfMagicHasBeenSent()
+    {
+        // given
+        InitialMagicMessage.instance().dispatch( server );
+
+        // when
+        message.dispatch( server );
+
+        // then future should either not complete exceptionally or do so for non-magic reasons
+        try
+        {
+            server.protocolStackFuture().getNow( null );
+        }
+        catch ( CompletionException ex )
+        {
+            Assert.assertThat( ex.getMessage().toLowerCase(), Matchers.not( Matchers.containsString( "magic" ) ) );
+        }
+    }
+}

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/InitialMagicMessageTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/InitialMagicMessageTest.java
@@ -30,7 +30,7 @@ public class InitialMagicMessageTest
     public void shouldCreateWithCorrectMagicValue()
     {
         // given
-        InitialMagicMessage magicMessage = new InitialMagicMessage();
+        InitialMagicMessage magicMessage = InitialMagicMessage.instance();
 
         // then
         assertTrue( magicMessage.isCorrectMagic() );

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/ProtocolRepositoryTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/ProtocolRepositoryTest.java
@@ -22,10 +22,10 @@ package org.neo4j.causalclustering.protocol.handshake;
 import co.unruly.matchers.OptionalMatchers;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.Optional;
 
 import org.neo4j.causalclustering.protocol.Protocol;
+import org.neo4j.causalclustering.protocol.handshake.TestProtocols.TestApplicationProtocols;
 
 import static java.util.Collections.emptySet;
 import static org.junit.Assert.assertThat;
@@ -33,13 +33,14 @@ import static org.neo4j.helpers.collection.Iterators.asSet;
 
 public class ProtocolRepositoryTest
 {
-    private ProtocolRepository protocolRepository = new ProtocolRepository( TestProtocols.values() );
+    private ProtocolRepository<Protocol.ApplicationProtocol> protocolRepository = new ProtocolRepository<>( TestApplicationProtocols.values() );
 
     @Test
     public void shouldReturnEmptyIfUnknownVersion()
     {
         // when
-        Optional<Protocol> applicationProtocol = protocolRepository.select( TestProtocols.Identifier.RAFT.canonicalName(), -1 );
+        Optional<Protocol.ApplicationProtocol> applicationProtocol =
+                protocolRepository.select( Protocol.ApplicationProtocolIdentifier.RAFT.canonicalName(), -1 );
 
         // then
         assertThat( applicationProtocol, OptionalMatchers.empty() );
@@ -49,7 +50,7 @@ public class ProtocolRepositoryTest
     public void shouldReturnEmptyIfUnknownName()
     {
         // when
-        Optional<Protocol> applicationProtocol = protocolRepository.select( "not a real protocol", 1 );
+        Optional<Protocol.ApplicationProtocol> applicationProtocol = protocolRepository.select( "not a real protocol", 1 );
 
         // then
         assertThat( applicationProtocol, OptionalMatchers.empty() );
@@ -59,7 +60,8 @@ public class ProtocolRepositoryTest
     public void shouldReturnEmptyIfNoVersions()
     {
         // when
-        Optional<Protocol> applicationProtocol = protocolRepository.select( TestProtocols.Identifier.RAFT.canonicalName(), emptySet());
+        Optional<Protocol.ApplicationProtocol> applicationProtocol =
+                protocolRepository.select( Protocol.ApplicationProtocolIdentifier.RAFT.canonicalName(), emptySet() );
 
         // then
         assertThat( applicationProtocol, OptionalMatchers.empty() );
@@ -69,39 +71,41 @@ public class ProtocolRepositoryTest
     public void shouldReturnProtocolIfKnownNameAndVersion()
     {
         // when
-        Optional<Protocol> applicationProtocol = protocolRepository.select( TestProtocols.Identifier.RAFT.canonicalName(), 1 );
+        Optional<Protocol.ApplicationProtocol> applicationProtocol =
+                protocolRepository.select( Protocol.ApplicationProtocolIdentifier.RAFT.canonicalName(), 1 );
 
         // then
-        assertThat( applicationProtocol, OptionalMatchers.contains( TestProtocols.RAFT_1 ) );
+        assertThat( applicationProtocol, OptionalMatchers.contains( TestApplicationProtocols.RAFT_1 ) );
     }
 
     @Test
     public void shouldReturnKnownProtocolVersionWhenFirstGivenVersionNotKnown()
     {
         // when
-        Optional<Protocol> applicationProtocol = protocolRepository.select( TestProtocols.Identifier.RAFT.canonicalName(), asSet( -1, 1 ));
+        Optional<Protocol.ApplicationProtocol> applicationProtocol =
+                protocolRepository.select( Protocol.ApplicationProtocolIdentifier.RAFT.canonicalName(), asSet( -1, 1 ) );
 
         // then
-        assertThat( applicationProtocol, OptionalMatchers.contains( TestProtocols.RAFT_1 ) );
+        assertThat( applicationProtocol, OptionalMatchers.contains( TestApplicationProtocols.RAFT_1 ) );
     }
 
     @Test
     public void shouldReturnProtocolOfHighestVersionRequestedAndSupported()
     {
         // when
-        Optional<Protocol> applicationProtocol = protocolRepository.select( TestProtocols.Identifier.RAFT.canonicalName(), asSet( 9, 1, 3, 2, 7 ) );
+        Optional<Protocol.ApplicationProtocol> applicationProtocol =
+                protocolRepository.select( Protocol.ApplicationProtocolIdentifier.RAFT.canonicalName(), asSet( 9, 1, 3, 2, 7 ) );
 
         // then
-        assertThat( applicationProtocol, OptionalMatchers.contains( TestProtocols.RAFT_3 ) );
+        assertThat( applicationProtocol, OptionalMatchers.contains( TestApplicationProtocols.RAFT_3 ) );
     }
 
     @Test( expected = IllegalArgumentException.class )
     public void shouldNotInstantiateIfDuplicateProtocolsSupplied()
     {
         // given
-        Protocol protocol = new Protocol()
+        Protocol.ApplicationProtocol protocol = new Protocol.ApplicationProtocol()
         {
-
             @Override
             public String identifier()
             {
@@ -114,10 +118,10 @@ public class ProtocolRepositoryTest
                 return 1;
             }
         };
-        Protocol[] protocols = {protocol, protocol};
+        Protocol.ApplicationProtocol[] protocols = {protocol, protocol};
 
         // when
-        new ProtocolRepository( protocols );
+        new ProtocolRepository<>( protocols );
 
         // then throw
     }

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/ServerMessageEncodingTest.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/ServerMessageEncodingTest.java
@@ -27,10 +27,13 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import org.neo4j.helpers.collection.Pair;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.neo4j.helpers.collection.Iterators.asSet;
@@ -56,11 +59,13 @@ public class ServerMessageEncodingTest
     @Parameterized.Parameters( name = "ResponseMessage-{0}" )
     public static Collection<ServerMessage> data()
     {
-        return Arrays.asList(
+        return asList(
                 new ApplicationProtocolRequest( "protocol", asSet( 3,7,13 ) ),
                 new InitialMagicMessage( "Magic string" ),
-                new ModifierProtocolRequest(),
-                new SwitchOverRequest( "protocol", 38 )
+                new ModifierProtocolRequest( "modifierProtocol", asSet( 1,4,7) ),
+                new SwitchOverRequest( "protocol", 38, emptyList() ),
+                new SwitchOverRequest( "protocol", 38,
+                        asList( Pair.of( "mod1", 1 ), Pair.of( "mod2" , 2) ) )
                 );
     }
 

--- a/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/TestProtocols.java
+++ b/enterprise/causal-clustering/src/test/java/org/neo4j/causalclustering/protocol/handshake/TestProtocols.java
@@ -24,40 +24,92 @@ import java.util.stream.Stream;
 
 import org.neo4j.causalclustering.protocol.Protocol;
 
-public enum TestProtocols implements Protocol
+public interface TestProtocols
 {
-    RAFT_1( Identifier.RAFT, 1 ),
-    RAFT_2( Identifier.RAFT, 2 ),
-    RAFT_3( Identifier.RAFT, 3 ),
-    RAFT_4( Identifier.RAFT, 4 ),
-    CATCHUP_1( Identifier.CATCHUP, 1 ),
-    CATCHUP_2( Identifier.CATCHUP, 2 ),
-    CATCHUP_3( Identifier.CATCHUP, 3 ),
-    CATCHUP_4( Identifier.CATCHUP, 4 );
-
-    static Protocol RAFT_LATEST = Stream.of( values() )
-            .filter( protocol -> protocol.identifier().equals( Identifier.RAFT.canonicalName() ) )
-            .max( Comparator.comparing( Protocol::version ) )
-            .get();
-
-    private final int version;
-    private final Identifier identifier;
-
-    TestProtocols( Identifier identifier, int version )
+    static <T extends Protocol> T latest( Protocol.Identifier<T> identifier, T[] values )
     {
-        this.identifier = identifier;
-        this.version = version;
+        return Stream.of( values )
+                .filter( protocol -> protocol.identifier().equals( identifier.canonicalName() ) )
+                .max( Comparator.comparing( T::version ) )
+                .get();
     }
 
-    @Override
-    public String identifier()
+    enum TestApplicationProtocols implements Protocol.ApplicationProtocol
     {
-        return this.identifier.canonicalName();
+        RAFT_1( ApplicationProtocolIdentifier.RAFT, 1 ),
+        RAFT_2( ApplicationProtocolIdentifier.RAFT, 2 ),
+        RAFT_3( ApplicationProtocolIdentifier.RAFT, 3 ),
+        RAFT_4( ApplicationProtocolIdentifier.RAFT, 4 ),
+        CATCHUP_1( ApplicationProtocolIdentifier.CATCHUP, 1 ),
+        CATCHUP_2( ApplicationProtocolIdentifier.CATCHUP, 2 ),
+        CATCHUP_3( ApplicationProtocolIdentifier.CATCHUP, 3 ),
+        CATCHUP_4( ApplicationProtocolIdentifier.CATCHUP, 4 );
+
+        private final int version;
+
+        private final ApplicationProtocolIdentifier identifier;
+        TestApplicationProtocols( ApplicationProtocolIdentifier identifier, int version )
+        {
+            this.identifier = identifier;
+            this.version = version;
+        }
+
+        @Override
+        public String identifier()
+        {
+            return this.identifier.canonicalName();
+        }
+
+        @Override
+        public int version()
+        {
+            return version;
+        }
+
+        static ApplicationProtocol latest( ApplicationProtocolIdentifier identifier )
+        {
+            return TestProtocols.latest( identifier, values() );
+        }
     }
 
-    @Override
-    public int version()
+    enum TestModifierProtocols implements Protocol.ModifierProtocol
     {
-        return version;
+        SNAPPY( ModifierProtocolIdentifier.COMPRESSION, 1, "TestSnappy" ),
+        LZH( ModifierProtocolIdentifier.COMPRESSION, 2, "TestLZH" ),
+        ROT13( ModifierProtocolIdentifier.GRATUITOUS_OBFUSCATION, 1, "ROT13" );
+
+        private final int version;
+        private final ModifierProtocolIdentifier identifier;
+        private final String friendlyName;
+
+        TestModifierProtocols( ModifierProtocolIdentifier identifier, int version, String friendlyName )
+        {
+            this.version = version;
+            this.identifier = identifier;
+            this.friendlyName = friendlyName;
+        }
+
+        @Override
+        public String identifier()
+        {
+            return identifier.canonicalName();
+        }
+
+        @Override
+        public int version()
+        {
+            return version;
+        }
+
+        @Override
+        public String friendlyName()
+        {
+            return friendlyName;
+        }
+
+        static ModifierProtocol latest( ModifierProtocolIdentifier identifier )
+        {
+            return TestProtocols.latest( identifier, values() );
+        }
     }
 }


### PR DESCRIPTION
Handshake modifier protocols.

Does not include installers for protocols, or much thought into what they might be.

Modifier protocol type (name + identifier) may require some thought.

May refactor to have handshake client send modifier protocol requests without waiting for an application protocol response.