### PR TITLE
Plan pattern comprehension inside unwind correctly.

### DIFF
--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/PlanEventHorizon.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/PlanEventHorizon.scala
@@ -55,7 +55,8 @@ case object PlanEventHorizon
         sortSkipAndLimit(distinctPlan, query)
 
       case UnwindProjection(variable, expression) =>
-        context.logicalPlanProducer.planUnwind(plan, variable, expression)
+        val (inner, projectionsMap) = PatternExpressionSolver()(selectedPlan, Seq(expression))
+        context.logicalPlanProducer.planUnwind(inner, variable, projectionsMap.head, expression)
 
       case ProcedureCallProjection(call) =>
         context.logicalPlanProducer.planCallProcedure(plan, call)

--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/steps/LogicalPlanProducer.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/steps/LogicalPlanProducer.scala
@@ -430,8 +430,8 @@ case class LogicalPlanProducer(cardinalityModel: CardinalityModel) extends ListS
     LoadCSVPlan(inner, url, variableName, format, fieldTerminator.map(_.value), context.legacyCsvQuoteEscaping)(solved)
   }
 
-  def planUnwind(inner: LogicalPlan, name: String, expression: Expression)(implicit context: LogicalPlanningContext): LogicalPlan = {
-    val solved = inner.solved.updateTailOrSelf(_.withHorizon(UnwindProjection(name, expression)))
+  def planUnwind(inner: LogicalPlan, name: String, expression: Expression, reported: Expression)(implicit context: LogicalPlanningContext): LogicalPlan = {
+    val solved = inner.solved.updateTailOrSelf(_.withHorizon(UnwindProjection(name, reported)))
     UnwindCollection(inner, name, expression)(solved)
   }
 

--- a/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/steps/PatternExpressionSolver.scala
+++ b/community/cypher/cypher-compiler-3.3/src/main/scala/org/neo4j/cypher/internal/compiler/v3_3/planner/logical/steps/PatternExpressionSolver.scala
@@ -80,7 +80,7 @@ case class PatternExpressionSolver(pathStepBuilder: EveryPath => PathStep = proj
         newPlan
     }
 
-    (finalPlan, expressionBuild)
+    (finalPlan.updateSolved(source.solved), expressionBuild)
   }
 
   def apply(source: LogicalPlan, projectionsMap: Map[String, Expression])

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-23.txt
@@ -82,3 +82,5 @@ Nested unwind with longs
 Nested unwind with doubles
 Nested unwind with strings
 Nested unwind with mixed types
+Pattern comprehension in unwind with empty db
+Pattern comprehension in unwind with hits

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-31.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-31.txt
@@ -18,3 +18,7 @@ min() over list values
 Shorthand case with filter should work as expected
 equality with boolean lists
 optional equality with boolean lists
+
+//UnwindAcceptance.feature
+Pattern comprehension in unwind with empty db
+Pattern comprehension in unwind with hits

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-32.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/compatibility-32.txt
@@ -3,3 +3,7 @@ max() over mixed values
 min() over mixed values
 max() over list values
 min() over list values
+
+//UnwindAcceptance.feature
+Pattern comprehension in unwind with empty db
+Pattern comprehension in unwind with hits

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-compiled.txt
@@ -207,3 +207,7 @@ Should handle complex IS NOT NULL on node property when node is null
 
 //DeleteAcceptance.feature
 Return properties from deleted node
+
+//UnwindAcceptance.feature
+Pattern comprehension in unwind with empty db
+Pattern comprehension in unwind with hits

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-slotted.txt
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/blacklists/cost-slotted.txt
@@ -119,3 +119,7 @@ Variable length path with both sides already bound
 
 //DeleteAcceptance.feature
 Return properties from deleted node
+
+//UnwindAcceptance.feature
+Pattern comprehension in unwind with empty db
+Pattern comprehension in unwind with hits

--- a/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/UnwindAcceptance.feature
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/resources/cypher/features/UnwindAcceptance.feature
@@ -301,3 +301,33 @@ Feature: UnwindAcceptance
       | 'd'   |
     And no side effects
 
+  Scenario: Pattern comprehension in unwind with empty db
+    Given an empty graph
+    When executing query:
+      """
+        UNWIND [(a)-->(b) | b ] as c
+        RETURN c
+      """
+    Then the result should be empty
+    And no side effects
+
+  Scenario: Pattern comprehension in unwind with hits
+    Given an empty graph
+    And having executed:
+      """
+      CREATE (a:A)
+      CREATE (b:B)
+      CREATE (c:C)
+      CREATE (a)-[:T]->(b),
+             (b)-[:T]->(c)
+      """
+    When executing query:
+      """
+        UNWIND [(a)-->(b) | b ] as c
+        RETURN c
+      """
+    Then the result should be:
+      | c     |
+      | (:B)  |
+      | (:C)  |
+    And no side effects

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/PatternComprehensionAcceptanceTest.scala
@@ -418,4 +418,31 @@ class PatternComprehensionAcceptanceTest extends ExecutionEngineFunSuite with Cy
     ))
   }
 
+  test("pattern comprehension in unwind with empty db") {
+    val query =
+      """
+        | unwind [(a)-->(b) | b ] as c
+        | return c
+      """.stripMargin
+
+    val result = executeWith(Configs.DefaultInterpreted, query)
+    result.toList should equal(List.empty)
+  }
+
+  test("pattern comprehension in unwind with hits") {
+    val node1 = createNode()
+    val node2 = createNode()
+    val node3 = createNode()
+    relate(node1, node2)
+    relate(node2, node3)
+
+    val query =
+      """
+        | unwind [(a)-->(b) | b ] as c
+        | return c
+      """.stripMargin
+
+    val result = executeWith(Configs.DefaultInterpreted, query)
+    result.toList should equal(List(Map("c" -> node2), Map("c" -> node3)))
+  }
 }


### PR DESCRIPTION
Now using `PatternExpressionSolver` instead of `PatternMatcher`. Also makes sure `solveds` knows which expression was solved.