### PR TITLE
Fix bug where shortestPath unnecessarily required named nodes

### DIFF
--- a/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticPatternCheck.scala
+++ b/community/cypher/frontend-3.4/src/main/scala/org/neo4j/cypher/internal/frontend/v3_4/semantics/SemanticPatternCheck.scala
@@ -99,23 +99,6 @@ object SemanticPatternCheck extends SemanticAnalysisTooling {
               }(...) requires a pattern containing a single relationship", x.position, x.element.position)
           }
 
-        def checkKnownEnds: SemanticCheck =
-          x.element match {
-            case RelationshipChain(l: NodePattern, _, r: NodePattern) =>
-              if (l.variable.isEmpty)
-                SemanticError(s"${
-                  x.name
-                }(...) requires named nodes", x.position, l.position)
-              else if (r.variable.isEmpty)
-                SemanticError(s"${
-                  x.name
-                }(...) requires named nodes", x.position, r.position)
-              else
-                None
-            case _ =>
-              None
-          }
-
         def checkLength: SemanticCheck =
           (state: SemanticState) =>
             x.element match {
@@ -155,7 +138,6 @@ object SemanticPatternCheck extends SemanticAnalysisTooling {
 
         checkContext chain
           checkContainsSingle chain
-          checkKnownEnds chain
           checkLength chain
           checkRelVariablesUnknown chain
           check(ctx, x.element)

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
@@ -743,6 +743,18 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
     result.toList should equal(List(Map("length(path)" -> 2)))
   }
 
+  test("should not require named nodes in shortest path") {
+    graph.execute("CREATE (a:Person)-[:WATCH]->(b:Movie)")
+
+    val query =
+      """MATCH p=shortestPath( (:Person)-[*1..4]->(:Movie) )
+        |RETURN length(p)
+      """.stripMargin
+    val result = graph.execute(query)
+
+    println(result.next())
+  }
+
   private def createLdbc14Model(): Unit = {
     def createPersonNode( id: Int ) = createLabeledNode(Map("id" -> id), "Person")
 

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
@@ -750,9 +750,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
       """MATCH p=shortestPath( (:Person)-[*1..4]->(:Movie) )
         |RETURN length(p)
       """.stripMargin
-    val result = graph.execute(query)
-
-    println(result.next())
+    graph.execute(query).columnAs[Int]("length(p)").next() should be (1)
   }
 
   private def createLdbc14Model(): Unit = {


### PR DESCRIPTION
This fixes it for 3.4. I did that first then realized I should be doing it in 3.3 instead. So now there"s 2 PRs.