### PR TITLE
Fix bug where shortestPath unnecessarily required named nodes

### DIFF
--- a/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/Pattern.scala
+++ b/community/cypher/frontend-3.3/src/main/scala/org/neo4j/cypher/internal/frontend/v3_3/ast/Pattern.scala
@@ -151,7 +151,6 @@ case class ShortestPaths(element: PatternElement, single: Boolean)(val position:
   def semanticCheck(ctx: SemanticContext) =
     checkContext(ctx) chain
       checkContainsSingle chain
-      checkKnownEnds chain
       checkLength chain
       checkRelVariablesUnknown chain
       element.semanticCheck(ctx)
@@ -172,18 +171,6 @@ case class ShortestPaths(element: PatternElement, single: Boolean)(val position:
       }
     case _                                                    =>
       SemanticError(s"$name(...) requires a pattern containing a single relationship", position, element.position)
-  }
-
-  private def checkKnownEnds: SemanticCheck = element match {
-    case RelationshipChain(l: NodePattern, _, r: NodePattern) =>
-      if (l.variable.isEmpty)
-        SemanticError(s"$name(...) requires named nodes", position, l.position)
-      else if (r.variable.isEmpty)
-        SemanticError(s"$name(...) requires named nodes", position, r.position)
-      else
-        None
-    case _                                                    =>
-      None
   }
 
   private def checkLength: SemanticCheck = (state: SemanticState) => element match {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
@@ -747,9 +747,7 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
       """MATCH p=shortestPath( (:Person)-[*1..4]->(:Movie) )
         |RETURN length(p)
       """.stripMargin
-    val result = graph.execute(query)
-
-    println(result.next())
+    graph.execute(query).columnAs[Int]("length(p)").next() should be (1)
   }
 
   private def createLdbc14Model(): Unit = {

--- a/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
+++ b/enterprise/cypher/acceptance-spec-suite/src/test/scala/org/neo4j/internal/cypher/acceptance/ShortestPathAcceptanceTest.scala
@@ -740,6 +740,18 @@ class ShortestPathAcceptanceTest extends ExecutionEngineFunSuite with CypherComp
     result.toList should equal(List(Map("length(path)" -> 2)))
   }
 
+  test("should not require named nodes in shortest path") {
+    graph.execute("CREATE (a:Person)-[:WATCH]->(b:Movie)")
+
+    val query =
+      """MATCH p=shortestPath( (:Person)-[*1..4]->(:Movie) )
+        |RETURN length(p)
+      """.stripMargin
+    val result = graph.execute(query)
+
+    println(result.next())
+  }
+
   private def createLdbc14Model(): Unit = {
     def createPersonNode( id: Int ) = createLabeledNode(Map("id" -> id), "Person")
 


### PR DESCRIPTION
Null forward merge, since we have a corresponding PR for 3.4