### PR TITLE
Fixed bug in rendering inequality expressions and improved readability.

### DIFF
--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planDescription/PlanDescriptionArgumentSerializer.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planDescription/PlanDescriptionArgumentSerializer.scala
@@ -41,7 +41,7 @@ object PlanDescriptionArgumentSerializer {
       case LegacyIndex(index) => index
       case Index(label, properties) => s":$label(${properties.mkString(",")})"
       case PrefixIndex(label, property, prefix) => s":$label($property STARTS WITH $prefix)"
-      case InequalityIndex(label, property, bounds) => s":$label($property) ${bounds.mkString(", ")}"
+      case InequalityIndex(label, property, bounds) => bounds.map(bound => s":$label($property) $bound").mkString(" AND ")
       case LabelName(label) => s":$label"
       case KeyNames(keys) => keys.map(removeGeneratedNames).mkString(SEPARATOR)
       case KeyExpressions(expressions) => expressions.mkString(SEPARATOR)

--- a/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/LogicalPlan2PlanDescription.scala
+++ b/community/cypher/cypher-compiler-3.2/src/main/scala/org/neo4j/cypher/internal/compiler/v3_2/planner/logical/LogicalPlan2PlanDescription.scala
@@ -380,14 +380,18 @@ case class LogicalPlan2PlanDescription(idMap: Map[LogicalPlan, Id], readOnly: Bo
                 PrefixIndex(label.name, propertyKey, prefix)
 
               case InequalitySeekRangeExpression(RangeLessThan(bounds)) =>
-                InequalityIndex(label.name, propertyKey, bounds.map(bound => s"<${bound.inequalitySignSuffix} ${bound.endPoint}").toIndexedSeq)
+                InequalityIndex(label.name, propertyKey,
+                  bounds.map(bound => s"<${bound.inequalitySignSuffix} ${bound.endPoint}").toIndexedSeq)
 
               case InequalitySeekRangeExpression(RangeGreaterThan(bounds)) =>
-                InequalityIndex(label.name, propertyKey, bounds.map(bound => s">${bound.inequalitySignSuffix} ${bound.endPoint}").toIndexedSeq)
+                InequalityIndex(label.name, propertyKey,
+                  bounds.map(bound => s">${bound.inequalitySignSuffix} ${bound.endPoint}").toIndexedSeq)
 
               case InequalitySeekRangeExpression(RangeBetween(greaterThanBounds, lessThanBounds)) =>
-                val greaterThanBoundsText = greaterThanBounds.bounds.map(bound => s">${bound.inequalitySignSuffix} ${bound.endPoint}").toIndexedSeq
-                val lessThanBoundsText = lessThanBounds.bounds.map(bound => s"<${bound.inequalitySignSuffix} ${bound.endPoint}").toIndexedSeq
+                val greaterThanBoundsText = greaterThanBounds.bounds.map(bound =>
+                  s">${bound.inequalitySignSuffix} ${bound.endPoint}").toIndexedSeq
+                val lessThanBoundsText = lessThanBounds.bounds.map(bound =>
+                  s"<${bound.inequalitySignSuffix} ${bound.endPoint}").toIndexedSeq
                 InequalityIndex(label.name, propertyKey, greaterThanBoundsText ++ lessThanBoundsText)
             }
 


### PR DESCRIPTION
This fix is already included in the spatial index PR for 3.4 (https://github.com/OliviaYtterbrink/neo4j/commit/649568a4e1f630677d5e4e957d1d8fe6af10b16e).
So it should be forward merged to 3.3 and **null forward merged** to 3.4