### PR TITLE
Fixes as issue with applying index updates to unique indexes

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexPopulator.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexPopulator.java
@@ -74,7 +74,7 @@ public abstract class NativeSchemaNumberIndexPopulator<KEY extends SchemaNumberK
         super( pageCache, fs, storeFile, layout, monitor, descriptor, indexId );
         this.treeKey = layout.newKey();
         this.treeValue = layout.newValue();
-        this.conflictDetectingValueMerger = new ConflictDetectingValueMerger<>();
+        this.conflictDetectingValueMerger = new ConflictDetectingValueMerger.Check<>();
     }
 
     @Override

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/ConflictDetectingValueMergerTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/ConflictDetectingValueMergerTest.java
@@ -21,23 +21,28 @@ package org.neo4j.kernel.impl.index.schema;
 
 import org.junit.Test;
 
+import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.values.storable.Value;
 import org.neo4j.values.storable.Values;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.neo4j.helpers.ArrayUtil.array;
+import static org.neo4j.values.storable.Values.stringValue;
 
 public class ConflictDetectingValueMergerTest
 {
-    private final ConflictDetectingValueMerger<SchemaNumberKey,SchemaNumberValue> detector = new ConflictDetectingValueMerger<>();
+    private final ConflictDetectingValueMerger<SchemaNumberKey,SchemaNumberValue> detector = new ConflictDetectingValueMerger.Check<>();
 
     @Test
     public void shouldReportConflictOnSameValueAndDifferentEntityIds() throws Exception
     {
         // given
-        Value value = Values.of( 123);
+        Value value = Values.of( 123 );
         long entityId1 = 10;
         long entityId2 = 20;
 
@@ -50,9 +55,17 @@ public class ConflictDetectingValueMergerTest
 
         // then
         assertNull( merged );
-        assertTrue( detector.wasConflict() );
-        assertEquals( entityId1, detector.existingNodeId() );
-        assertEquals( entityId2, detector.addedNodeId() );
+        try
+        {
+            detector.checkConflict( array( value ) );
+            fail( "Should've detected conflict" );
+        }
+        catch ( IndexEntryConflictException e )
+        {
+            assertEquals( entityId1, e.getExistingNodeId() );
+            assertEquals( entityId2, e.getAddedNodeId() );
+            assertEquals( value, e.getSinglePropertyValue() );
+        }
     }
 
     @Test
@@ -71,7 +84,7 @@ public class ConflictDetectingValueMergerTest
 
         // then
         assertNull( merged );
-        assertFalse( detector.wasConflict() );
+        detector.checkConflict( array() ); // <-- should not throw conflict exception
     }
 
     private static SchemaNumberKey key( long entityId, Value... value )

--- a/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProviderTest.java
+++ b/community/kernel/src/test/java/org/neo4j/kernel/impl/index/schema/NativeSchemaNumberIndexProviderTest.java
@@ -29,7 +29,6 @@ import java.io.IOException;
 
 import org.neo4j.io.fs.FileSystemAbstraction;
 import org.neo4j.io.pagecache.PageCache;
-import org.neo4j.kernel.api.exceptions.index.IndexEntryConflictException;
 import org.neo4j.kernel.api.index.IndexAccessor;
 import org.neo4j.kernel.api.index.IndexEntryUpdate;
 import org.neo4j.kernel.api.index.IndexPopulator;
@@ -124,40 +123,13 @@ public class NativeSchemaNumberIndexProviderTest
     /* getOnlineAccessor */
 
     @Test
-    public void getOnlineAccessorMustCreateUniqueAccessorForTypeUnique() throws Exception
+    public void shouldNotCheckConflictsWhenApplyingUpdatesInOnlineAccessor() throws Exception
     {
         // given
         provider = newProvider();
 
         // when
         IndexDescriptor descriptor = descriptorUnique();
-        try ( IndexAccessor accessor = provider.getOnlineAccessor( indexId, descriptor, samplingConfig() );
-              IndexUpdater indexUpdater = accessor.newUpdater( IndexUpdateMode.ONLINE ) )
-        {
-            Value value = Values.intValue( 1 );
-            indexUpdater.process( IndexEntryUpdate.add( 1, descriptor.schema(), value ) );
-
-            // then
-            try
-            {
-                indexUpdater.process( IndexEntryUpdate.add( 2, descriptor.schema(), value ) );
-                fail( "Should have failed" );
-            }
-            catch ( IndexEntryConflictException e )
-            {
-                // good
-            }
-        }
-    }
-
-    @Test
-    public void getOnlineAccessorMustCreateNonUniqueAccessorForTypeGeneral() throws Exception
-    {
-        // given
-        provider = newProvider();
-
-        // when
-        IndexDescriptor descriptor = descriptor();
         try ( IndexAccessor accessor = provider.getOnlineAccessor( indexId, descriptor, samplingConfig() );
               IndexUpdater indexUpdater = accessor.newUpdater( IndexUpdateMode.ONLINE ) )
         {

--- a/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/AccidentalUniquenessConstraintViolationIT.java
+++ b/community/lucene-index/src/test/java/org/neo4j/kernel/api/impl/index/AccidentalUniquenessConstraintViolationIT.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2002-2018 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.neo4j.kernel.api.impl.index;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.util.Map;
+
+import org.neo4j.graphdb.Label;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.NotFoundException;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.test.rule.DatabaseRule;
+import org.neo4j.test.rule.ImpermanentDatabaseRule;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+public class AccidentalUniquenessConstraintViolationIT
+{
+    private static final Label Foo = Label.label( "Foo" );
+    private static final String BAR = "bar";
+
+    @Rule
+    public final DatabaseRule db = new ImpermanentDatabaseRule();
+
+    @Test
+    public void shouldApplyChangesWithIntermediateConstraintViolations() throws Exception
+    {
+        // given
+        try ( Transaction tx = db.beginTx() )
+        {
+            db.schema().constraintFor( Foo ).assertPropertyIsUnique( BAR ).create();
+            tx.success();
+        }
+        Node fourtyTwo;
+        Node fourtyOne;
+        try ( Transaction tx = db.beginTx() )
+        {
+            fourtyTwo = db.createNode( Foo );
+            fourtyTwo.setProperty( BAR, 42 );
+            fourtyOne = db.createNode( Foo );
+            fourtyOne.setProperty( BAR, 41 );
+            tx.success();
+        }
+
+        // when
+        try ( Transaction tx = db.beginTx() )
+        {
+            Map<String,Object> props = fourtyOne.getAllProperties();
+            fourtyOne.delete();
+            fourtyTwo.setProperty( BAR, props.get( BAR ) );
+            tx.success();
+        }
+
+        // then
+        try ( Transaction tx = db.beginTx() )
+        {
+            assertEquals( 41, fourtyTwo.getProperty( BAR ) );
+            try
+            {
+                fourtyOne.getProperty( BAR );
+                fail( "Should be deleted" );
+            }
+            catch ( NotFoundException e )
+            {
+                // good
+            }
+            tx.success();
+        }
+    }
+}


### PR DESCRIPTION
Given a uniqueness contraint on Foo:bar. If a transaction make changes
such that in the end, the constraint is not violated but some intermediate
individual step violates the constraint the index would still throw an
exception.

The reason this happens is that native index validates the uniqueness
constraint on every insert (since doing so is for free).

Although actually doing so when applying online updates has never been done
in the lucene indexes because all that is handled in the kernel layer
before committing a transaction anyway. Detecting a conflict while applying
updates to a unique index means that there's a bug inside the kernel layer
and would result in a kernel panic.

Therefore we avoid this problem and do what we do for lucene indexes,
namely by not checking conclicts when applying online updates.