### PR TITLE
Elector identification now happens more reliably

### DIFF
--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ClusterContextImpl.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/atomicbroadcast/multipaxos/context/ClusterContextImpl.java
@@ -172,6 +172,12 @@ class ClusterContextImpl
     }
 
     @Override
+    public Set<InstanceId> getFailedInstances()
+    {
+        return heartbeatContext.getFailed();
+    }
+
+    @Override
     public InstanceId getLastElector()
     {
         return lastElector;
@@ -214,10 +220,19 @@ class ClusterContextImpl
     }
 
     @Override
-    public void acquiredConfiguration( final Map<InstanceId, URI> memberList, final Map<String, InstanceId> roles )
+    public void acquiredConfiguration( final Map<InstanceId, URI> memberList, final Map<String, InstanceId> roles,
+                                       final Set<InstanceId> failedInstances )
     {
         commonState.configuration().setMembers( memberList );
         commonState.configuration().setRoles( roles );
+        for ( InstanceId failedInstance : failedInstances )
+        {
+            if ( !failedInstance.equals( me  ) )
+            {
+                logProvider.getLog( ClusterContextImpl.class ).debug( "Adding instance " + failedInstance + " as failed from the start" );
+                heartbeatContext.failed( failedInstance );
+            }
+        }
     }
 
     @Override

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterContext.java
@@ -22,6 +22,7 @@ package org.neo4j.cluster.protocol.cluster;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.protocol.ConfigurationContext;
@@ -53,7 +54,8 @@ public interface ClusterContext
 
     void joining( String name, Iterable<URI> instanceList );
 
-    void acquiredConfiguration( Map<InstanceId, URI> memberList, Map<String, InstanceId> roles );
+    void acquiredConfiguration( Map<InstanceId, URI> memberList, Map<String, InstanceId> roles,
+                                Set<InstanceId> failedInstances );
 
     void joined();
 
@@ -124,4 +126,11 @@ public interface ClusterContext
     void setLastElectorVersion( long lastElectorVersion );
 
     boolean shouldFilterContactingInstances();
+
+    /**
+     * @return The set of instances present in the failed set. This is not the same as the instances which are
+     * determined to be failed based on suspicions, as failed instance information can also come from the cluster
+     * configuration response at join time.
+     */
+    Set<InstanceId> getFailedInstances();
 }

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterMessage.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterMessage.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.com.message.MessageType;
@@ -125,14 +126,16 @@ public enum ClusterMessage
         private org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.InstanceId latestReceivedInstanceId;
         private Map<String, InstanceId> roles;
         private String clusterName;
+        private Set<InstanceId> failedMembers;
 
         public ConfigurationResponseState( Map<String, InstanceId> roles, Map<InstanceId, URI> nodes,
                                            org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.InstanceId latestReceivedInstanceId,
-                                          String clusterName )
+                                           Set<InstanceId> failedMembers, String clusterName )
         {
             this.roles = roles;
             this.nodes = nodes;
             this.latestReceivedInstanceId = latestReceivedInstanceId;
+            this.failedMembers = failedMembers;
             this.clusterName = clusterName;
         }
 
@@ -156,10 +159,15 @@ public enum ClusterMessage
             return clusterName;
         }
 
+        public Set<InstanceId> getFailedMembers()
+        {
+            return failedMembers;
+        }
+
         public ConfigurationResponseState snapshot()
         {
-            return new ConfigurationResponseState( new HashMap<>(roles), new HashMap<>(nodes),
-                    latestReceivedInstanceId, clusterName );
+            return new ConfigurationResponseState( new HashMap<>( roles ), new HashMap<>( nodes ),
+                    latestReceivedInstanceId, failedMembers, clusterName );
         }
 
         @Override
@@ -169,6 +177,7 @@ public enum ClusterMessage
                     "nodes=" + nodes +
                     ", latestReceivedInstanceId=" + latestReceivedInstanceId +
                     ", roles=" + roles +
+                    ", failed=" + failedMembers +
                     ", clusterName='" + clusterName + '\'' +
                     '}';
         }
@@ -197,6 +206,10 @@ public enum ClusterMessage
                 return false;
             }
             if ( nodes != null ? !nodes.equals( that.nodes ) : that.nodes != null )
+            {
+                return false;
+            }
+            if ( failedMembers != null ? !failedMembers.equals( that.failedMembers ) : that.failedMembers != null )
             {
                 return false;
             }

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/cluster/ClusterState.java
@@ -55,20 +55,20 @@ public enum ClusterState
             {
                 @Override
                 public State<?, ?> handle( ClusterContext context, Message<ClusterMessage> message,
-                                           MessageHolder outgoing ) throws Throwable
+                                           MessageHolder outgoing )
                 {
                     switch ( message.getMessageType() )
                     {
                         case addClusterListener:
                         {
-                            context.addClusterListener( message.<ClusterListener>getPayload() );
+                            context.addClusterListener( message.getPayload() );
 
                             break;
                         }
 
                         case removeClusterListener:
                         {
-                            context.removeClusterListener( message.<ClusterListener>getPayload() );
+                            context.removeClusterListener( message.getPayload() );
 
                             break;
                         }
@@ -84,10 +84,10 @@ public enum ClusterState
                         case join:
                         {
                             // Send configuration request to all instances
-                            Object[] args = message.<Object[]>getPayload();
+                            Object[] args = message.getPayload();
                             String name = (String) args[0];
                             URI[] clusterInstanceUris = (URI[]) args[1];
-                            context.joining( name, Iterables.<URI,URI>iterable( clusterInstanceUris ) );
+                            context.joining( name, Iterables.iterable( clusterInstanceUris ) );
                             context.getLog( getClass() ).info( "Trying to join with DISCOVERY header " + context.generateDiscoveryHeader() );
 
                             for ( URI potentialClusterInstanceUri : clusterInstanceUris )
@@ -154,10 +154,10 @@ public enum ClusterState
                                         ", got " + state.getClusterName() + "." );
                             }
 
-                            HashMap<InstanceId, URI> memberList = new HashMap<InstanceId, URI>( state.getMembers() );
+                            HashMap<InstanceId, URI> memberList = new HashMap<>( state.getMembers() );
                             context.discoveredLastReceivedInstanceId( state.getLatestReceivedInstanceId().getId() );
 
-                            context.acquiredConfiguration( memberList, state.getRoles() );
+                            context.acquiredConfiguration( memberList, state.getRoles(), state.getFailedMembers() );
 
                             if ( !memberList.containsKey( context.getMyId() ) ||
                                     !memberList.get( context.getMyId() ).equals( context.boundAt() ) )
@@ -379,7 +379,6 @@ public enum ClusterState
                                            Message<ClusterMessage> message,
                                            MessageHolder outgoing
                 )
-                        throws Throwable
                 {
                     switch ( message.getMessageType() )
                     {
@@ -448,20 +447,20 @@ public enum ClusterState
             {
                 @Override
                 public State<?, ?> handle( ClusterContext context, Message<ClusterMessage> message,
-                                           MessageHolder outgoing ) throws Throwable
+                                           MessageHolder outgoing )
                 {
                     switch ( message.getMessageType() )
                     {
                         case addClusterListener:
                         {
-                            context.addClusterListener( message.<ClusterListener>getPayload() );
+                            context.addClusterListener( message.getPayload() );
 
                             break;
                         }
 
                         case removeClusterListener:
                         {
-                            context.removeClusterListener( message.<ClusterListener>getPayload() );
+                            context.removeClusterListener( message.getPayload() );
 
                             break;
                         }
@@ -504,6 +503,7 @@ public enum ClusterState
                                                 .getRoles(), context.getConfiguration().getMembers(),
                                                 new org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.InstanceId(
                                                         context.getLastDeliveredInstanceId() ),
+                                                context.getFailedInstances(),
                                                 context.getConfiguration().getName() ) ) ) );
                             }
                             else
@@ -515,6 +515,7 @@ public enum ClusterState
                                                 .getRoles(), context.getConfiguration().getMembers(),
                                                 new org.neo4j.cluster.protocol.atomicbroadcast.multipaxos.InstanceId(
                                                         context.getLastDeliveredInstanceId() ),
+                                                context.getFailedInstances(),
                                                 context.getConfiguration().getName() ) ) ) );
                             }
                             break;
@@ -529,7 +530,7 @@ public enum ClusterState
 
                         case leave:
                         {
-                            List<URI> nodeList = new ArrayList<URI>( context.getConfiguration().getMemberURIs() );
+                            List<URI> nodeList = new ArrayList<>( context.getConfiguration().getMemberURIs() );
                             if ( nodeList.size() == 1 )
                             {
                                 context.getLog( ClusterState.class ).info( format( "Shutting down cluster: %s",
@@ -570,7 +571,6 @@ public enum ClusterState
                                            Message<ClusterMessage> message,
                                            MessageHolder outgoing
                 )
-                        throws Throwable
                 {
                     switch ( message.getMessageType() )
                     {

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ElectionState.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/election/ElectionState.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.com.message.Message;
@@ -49,7 +50,6 @@ public enum ElectionState
                                            Message<ElectionMessage> message,
                                            MessageHolder outgoing
                 )
-                        throws Throwable
                 {
                     if ( message.getMessageType() == ElectionMessage.created )
                     {
@@ -72,7 +72,6 @@ public enum ElectionState
                                            Message<ElectionMessage> message,
                                            MessageHolder outgoing
                 )
-                        throws Throwable
                 {
                     Log log = context.getLog( ElectionState.class );
                     switch ( message.getMessageType() )
@@ -154,6 +153,7 @@ public enum ElectionState
 
                                 if ( isElector )
                                 {
+                                    context.getLog( ElectionState.class ).info( "I am the elector, doing election..." );
                                     // Start election process for all roles
                                     Iterable<ElectionRole> rolesRequiringElection = context.getPossibleRoles();
                                     for ( ElectionRole role : rolesRequiringElection )
@@ -212,10 +212,23 @@ public enum ElectionState
                                 }
                                 else
                                 {
-                                    List<InstanceId> aliveInstances = Iterables.asList( context.getAlive() );
-                                    Collections.sort( aliveInstances );
+                                    /*
+                                     * We take alive instances as determined by suspicions and remove those that are
+                                     * marked as failed in the failed set. This is done so that an instance which
+                                     * just joined can use the failed set provided in the configuration response to
+                                     * correctly determine the instances that are failed and skip them.
+                                     * Basically, this is to solve an issue where if an instance joins and is the
+                                     * lowest numbered alive but not overall will not try to get the failed lower
+                                     * numbered one to do elections.
+                                     */
+                                    Set<InstanceId> aliveInstances = Iterables.asSet( context.getAlive() );
+                                    aliveInstances.removeAll( context.getFailed() );
+                                    List<InstanceId> adjustedAlive = Iterables.asList( aliveInstances );
+                                    Collections.sort( adjustedAlive );
+
+                                    context.getLog( ElectionState.class ).info( "I am NOT the elector, sending to " + adjustedAlive );
                                     outgoing.offer( message.setHeader( Message.TO,
-                                            context.getUriForId( firstOrNull( aliveInstances ) ).toString() ) );
+                                            context.getUriForId( firstOrNull( adjustedAlive ) ).toString() ) );
                                 }
                             }
                             break;

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatContext.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatContext.java
@@ -54,7 +54,7 @@ public interface HeartbeatContext
 
     void serverLeftCluster( InstanceId node );
 
-    boolean isFailed( InstanceId node );
+    boolean isFailedBasedOnSuspicions( InstanceId node );
 
     List<InstanceId> getSuspicionsOf( InstanceId server );
 
@@ -65,4 +65,10 @@ public interface HeartbeatContext
     long getLastKnownLearnedInstanceInCluster();
 
     long getLastLearnedInstanceId();
+
+    /**
+     * Adds an instance in the failed set. Note that the {@link #isFailedBasedOnSuspicions(InstanceId)} method does not consult this set
+     * or adds to it, instead deriving failed status from suspicions.
+     */
+    void failed( InstanceId instanceId );
 }

--- a/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatLeftListener.java
+++ b/enterprise/cluster/src/main/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatLeftListener.java
@@ -40,7 +40,7 @@ public class HeartbeatLeftListener extends ClusterListener.Adapter
     @Override
     public void leftCluster( InstanceId instanceId, URI member )
     {
-        if ( heartbeatContext.isFailed( instanceId ) )
+        if ( heartbeatContext.isFailedBasedOnSuspicions( instanceId ) )
         {
             log.warn( "Instance " + instanceId + " (" + member + ") has left the cluster " +
                     "but is still treated as failed by HeartbeatContext" );

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterStateTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/cluster/ClusterStateTest.java
@@ -19,15 +19,15 @@
  */
 package org.neo4j.cluster.protocol.cluster;
 
-import org.junit.Test;
-import org.mockito.ArgumentMatcher;
-
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+
+import org.junit.Test;
+import org.mockito.ArgumentMatcher;
 
 import org.neo4j.cluster.InstanceId;
 import org.neo4j.cluster.com.message.Message;
@@ -246,7 +246,7 @@ public class ClusterStateTest
     private ConfigurationResponseState configurationResponseState( Map<InstanceId, URI> existingMembers )
     {
         return new ConfigurationResponseState( Collections.<String,InstanceId>emptyMap(),
-                existingMembers, null, "ClusterStateTest" );
+                existingMembers, null, Collections.emptySet(),  "ClusterStateTest" );
     }
 
     private ClusterConfiguration clusterConfiguration( Map<InstanceId, URI> members )

--- a/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatContextTest.java
+++ b/enterprise/cluster/src/test/java/org/neo4j/cluster/protocol/heartbeat/HeartbeatContextTest.java
@@ -119,7 +119,7 @@ public class HeartbeatContextTest
 
         for ( InstanceId initialHost : instanceIds )
         {
-            assertFalse( toTest.isFailed( initialHost ) );
+            assertFalse( toTest.isFailedBasedOnSuspicions( initialHost ) );
         }
     }
 
@@ -131,7 +131,7 @@ public class HeartbeatContextTest
         assertEquals( Collections.singleton( suspect ), toTest.getSuspicionsFor( context.getMyId() ) );
         assertEquals( Collections.singletonList( context.getMyId() ), toTest.getSuspicionsOf( suspect ) );
         // Being suspected by just one (us) is not enough
-        assertFalse( toTest.isFailed( suspect ) );
+        assertFalse( toTest.isFailedBasedOnSuspicions( suspect ) );
         assertTrue( toTest.alive( suspect ) ); // This resets the suspicion above
 
         // If we suspect an instance twice in a row, it shouldn't change its status in any way.
@@ -139,7 +139,7 @@ public class HeartbeatContextTest
         toTest.suspect( suspect );
         assertEquals( Collections.singleton( suspect ), toTest.getSuspicionsFor( context.getMyId() ) );
         assertEquals( Collections.singletonList( context.getMyId() ), toTest.getSuspicionsOf( suspect ) );
-        assertFalse( toTest.isFailed( suspect ) );
+        assertFalse( toTest.isFailedBasedOnSuspicions( suspect ) );
         assertTrue( toTest.alive( suspect ) );
 
         // The other one sends suspicions too
@@ -153,7 +153,7 @@ public class HeartbeatContextTest
         suspiciousBastards.add( context.getMyId() );
         suspiciousBastards.add( newSuspiciousBastard );
         assertEquals( suspiciousBastards, toTest.getSuspicionsOf( suspect ) );
-        assertTrue( toTest.isFailed( suspect ) );
+        assertTrue( toTest.isFailedBasedOnSuspicions( suspect ) );
         assertTrue( toTest.alive( suspect ) );
     }
 
@@ -166,7 +166,7 @@ public class HeartbeatContextTest
         toTest.suspect( suspect );
 
         // Just make sure
-        assertTrue( toTest.isFailed( suspect ) );
+        assertTrue( toTest.isFailedBasedOnSuspicions( suspect ) );
 
         // Suspicions of a failed instance should be ignored
         toTest.suspicions( suspect, Collections.singleton( newSuspiciousBastard ) );
@@ -182,20 +182,20 @@ public class HeartbeatContextTest
         toTest.suspect( suspect );
 
         // Just make sure
-        assertTrue( toTest.isFailed( suspect ) );
+        assertTrue( toTest.isFailedBasedOnSuspicions( suspect ) );
 
         // Ok, here it is. We received a heartbeat, so it is alive.
         toTest.alive( suspect );
         // It must no longer be failed
-        assertFalse( toTest.isFailed( suspect ) );
+        assertFalse( toTest.isFailedBasedOnSuspicions( suspect ) );
 
         // Simulate us stopping receiving heartbeats again
         toTest.suspect( suspect );
-        assertTrue( toTest.isFailed( suspect ) );
+        assertTrue( toTest.isFailedBasedOnSuspicions( suspect ) );
 
         // Assume the other guy started receiving heartbeats first
         toTest.suspicions( newSuspiciousBastard, Collections.<InstanceId>emptySet() );
-        assertFalse( toTest.isFailed( suspect ) );
+        assertFalse( toTest.isFailedBasedOnSuspicions( suspect ) );
     }
 
     /**
@@ -214,16 +214,16 @@ public class HeartbeatContextTest
         // Both A and B consider C down
         toTest.suspect( instanceC );
         toTest.suspicions( instanceB, Collections.singleton( instanceC ) );
-        assertTrue( toTest.isFailed( instanceC ) );
+        assertTrue( toTest.isFailedBasedOnSuspicions( instanceC ) );
 
         // A sees B as down
         toTest.suspect( instanceB );
-        assertTrue( toTest.isFailed( instanceB ) );
+        assertTrue( toTest.isFailedBasedOnSuspicions( instanceB ) );
 
         // C starts responding again
         assertTrue( toTest.alive( instanceC ) );
 
-        assertFalse( toTest.isFailed( instanceC ) );
+        assertFalse( toTest.isFailedBasedOnSuspicions( instanceC ) );
     }
     @Test
     public void shouldConsultSuspicionsOnlyFromCurrentClusterMembers() throws Exception


### PR DESCRIPTION
When an instance joins an HA cluster, it assumes all other
 members, as they are received in the configuration response,
 are alive. This means that, if the newly joining instance, is the
 lowest numbered alive one but there are others, lower numbered, but
 which are failed, it will choose not to trigger elections. Updating
 liveness state afterwards, through suspicion gossip, will not
 alter that since marking a member as failed does not result in
 elections if that member does not hold any roles.
This patch addresses this issue by making liveness information
 part of the configuration response and consulting that list on
 the first election request. By getting all alive instances and
 removing what the cluster says is currently failed, we end up with
 a reliable list of alive members which then we can check and see
 who the elector is.