### PR TITLE
Make use of dynamic keyValueSizeHeader

### DIFF
--- a/community/index/src/main/java/org/neo4j/index/internal/gbptree/DynamicSizeUtil.java
+++ b/community/index/src/main/java/org/neo4j/index/internal/gbptree/DynamicSizeUtil.java
@@ -88,8 +88,8 @@ class DynamicSizeUtil
 
     private static final int FLAG_FIRST_BYTE_TOMBSTONE = 0x80;
     private static final long FLAG_READ_TOMBSTONE = 0x80000000_00000000L;
-    private static final int MASK_ONE_BYTE_KEY_SIZE = 0x1F;
-    private static final int MASK_ONE_BYTE_VALUE_SIZE = 0x7F;
+    static final int MASK_ONE_BYTE_KEY_SIZE = 0x1F;
+    static final int MASK_ONE_BYTE_VALUE_SIZE = 0x7F;
     private static final int FLAG_HAS_VALUE_SIZE = 0x20;
     private static final int FLAG_ADDITIONAL_KEY_SIZE = 0x40;
     private static final int FLAG_ADDITIONAL_VALUE_SIZE = 0x80;
@@ -207,6 +207,11 @@ class DynamicSizeUtil
     static int extractKeySize( long keyValueSize )
     {
         return (int) ((keyValueSize & ~FLAG_READ_TOMBSTONE) >>> Integer.SIZE);
+    }
+
+    static int getOverhead( int keySize, int valueSize )
+    {
+        return 1 + (keySize > MASK_ONE_BYTE_KEY_SIZE ? 1 : 0) + (valueSize > 0 ? 1 : 0) + (valueSize > MASK_ONE_BYTE_VALUE_SIZE ? 1 : 0);
     }
 
     static boolean extractTombstone( long keyValueSize )

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/InternalTreeLogicTestBase.java
@@ -1168,7 +1168,7 @@ public abstract class InternalTreeLogicTestBase<KEY,VALUE>
         long middle = i / 2;
         KEY middleKey = key( middle ); // Should be located in middle leaf
         VALUE oldValue = value( middle );
-        VALUE newValue = value( middle * 100 );
+        VALUE newValue = value( middle * 11 );
         insert( middleKey, newValue );
 
         // THEN

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeDynamicSizeTest.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeDynamicSizeTest.java
@@ -19,6 +19,8 @@
  */
 package org.neo4j.index.internal.gbptree;
 
+import org.junit.Test;
+
 import org.neo4j.io.pagecache.PageCursor;
 
 import static org.junit.Assert.assertEquals;
@@ -34,7 +36,7 @@ public class TreeNodeDynamicSizeTest extends TreeNodeTestBase<RawBytes,RawBytes>
     }
 
     @Override
-    protected TreeNode<RawBytes,RawBytes> getNode( int pageSize, Layout<RawBytes,RawBytes> layout )
+    protected TreeNodeDynamicSize<RawBytes,RawBytes> getNode( int pageSize, Layout<RawBytes,RawBytes> layout )
     {
         return new TreeNodeDynamicSize<>( pageSize, layout );
     }
@@ -47,5 +49,39 @@ public class TreeNodeDynamicSizeTest extends TreeNodeTestBase<RawBytes,RawBytes>
 
         // Then
         assertEquals("allocSpace point to end of page", pageSize, currentAllocSpace );
+    }
+
+    @Test
+    public void mustCompactKeyValueSizeHeader() throws Exception
+    {
+        int oneByteKeyMax = DynamicSizeUtil.MASK_ONE_BYTE_KEY_SIZE;
+        int oneByteValueMax = DynamicSizeUtil.MASK_ONE_BYTE_VALUE_SIZE;
+
+        TreeNodeDynamicSize<RawBytes,RawBytes> node = getNode( PAGE_SIZE, layout );
+
+        verifyOverhead( node, oneByteKeyMax, 0, 1 );
+        verifyOverhead( node, oneByteKeyMax, 1, 2 );
+        verifyOverhead( node, oneByteKeyMax, oneByteValueMax, 2 );
+        verifyOverhead( node, oneByteKeyMax, oneByteValueMax +  1, 3 );
+        verifyOverhead( node, oneByteKeyMax + 1, 0, 2 );
+        verifyOverhead( node, oneByteKeyMax + 1, 1, 3 );
+        verifyOverhead( node, oneByteKeyMax + 1, oneByteValueMax, 3 );
+        verifyOverhead( node, oneByteKeyMax + 1, oneByteValueMax +  1, 4 );
+    }
+
+    private void verifyOverhead( TreeNodeDynamicSize<RawBytes,RawBytes> node, int keySize, int valueSize, int expectedOverhead )
+    {
+        cursor.zapPage();
+        node.initializeLeaf( cursor, STABLE_GENERATION, UNSTABLE_GENERATION );
+
+        RawBytes key = layout.newKey();
+        RawBytes value = layout.newValue();
+        key.bytes = new byte[keySize];
+        value.bytes = new byte[valueSize];
+
+        int allocOffsetBefore = node.getAllocOffset( cursor );
+        node.insertKeyValueAt( cursor, key, value, 0, 0 );
+        int allocOffsetAfter = node.getAllocOffset( cursor );
+        assertEquals( allocOffsetBefore - keySize - valueSize - expectedOverhead, allocOffsetAfter );
     }
 }

--- a/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeTestBase.java
+++ b/community/index/src/test/java/org/neo4j/index/internal/gbptree/TreeNodeTestBase.java
@@ -30,6 +30,7 @@ import java.util.List;
 import org.neo4j.index.internal.gbptree.TreeNode.Overflow;
 import org.neo4j.io.pagecache.PageCursor;
 import org.neo4j.test.rule.RandomRule;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -45,15 +46,15 @@ import static org.neo4j.index.internal.gbptree.TreeNode.Type.LEAF;
 
 public abstract class TreeNodeTestBase<KEY,VALUE>
 {
-    private static final int STABLE_GENERATION = 1;
-    private static final int UNSTABLE_GENERATION = 3;
+    static final int STABLE_GENERATION = 1;
+    static final int UNSTABLE_GENERATION = 3;
     private static final int HIGH_GENERATION = 4;
 
-    private static final int PAGE_SIZE = 512;
+    static final int PAGE_SIZE = 512;
     PageCursor cursor;
 
     private TestLayout<KEY,VALUE> layout;
-    private TreeNode<KEY,VALUE> node;
+    TreeNode<KEY,VALUE> node;
 
     @Rule
     public final RandomRule random = new RandomRule();


### PR DESCRIPTION
Header describing key and value size is dynamic to use as few bytes as possible when storing. This was not used by TreeNodeDynamicSize however. This commit addresses that by calculating overhead before allocating space for key and value.