### PR TITLE
Fix offset bug in periodic commit

### DIFF
--- a/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/PeriodicCommitAcceptanceTest.scala
+++ b/community/cypher/acceptance/src/test/scala/org/neo4j/internal/cypher/acceptance/PeriodicCommitAcceptanceTest.scala
@@ -122,7 +122,7 @@ class PeriodicCommitAcceptanceTest extends ExecutionEngineFunSuite
     val (_, txCounts) = executeAndTrackTxCounts(queryText)
 
     // then
-    txCounts should equal(TxCounts(commits = 3, rollbacks = 0))
+    txCounts should equal(TxCounts(commits = 2, rollbacks = 0))
   }
 
   test("should commit first tx and abort second tx when failing on second batch during periodic commit") {

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/LoadCsvPeriodicCommitObserver.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/LoadCsvPeriodicCommitObserver.scala
@@ -1,4 +1,4 @@
-/*
+ /*
  * Copyright (c) 2002-2018 "Neo Technology,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
@@ -31,9 +31,11 @@ class LoadCsvPeriodicCommitObserver(batchRowCount: Long, resources: ExternalReso
   val updateCounter = new UpdateCounter
   var outerLoadCSVIterator: Option[LoadCsvIterator] = None
 
-  def getCsvIterator(url: URL, fieldTerminator: Option[String] = None): Iterator[Array[String]] = {
-    val innerIterator = resources.getCsvIterator(url, fieldTerminator)
+  def getCsvIterator(url: URL, fieldTerminator: Option[String] = None, headers:Boolean=false): Iterator[Array[String]] = {
+    val innerIterator = resources.getCsvIterator(url, fieldTerminator, headers)
     if (outerLoadCSVIterator.isEmpty) {
+      if (headers)
+        updateCounter.offsetForHeaders()
       val iterator = new LoadCsvIterator(url, innerIterator)(onNext())
       outerLoadCSVIterator = Some(iterator)
       iterator
@@ -43,8 +45,8 @@ class LoadCsvPeriodicCommitObserver(batchRowCount: Long, resources: ExternalReso
   }
 
   private def onNext() {
-    updateCounter += 1
     updateCounter.resetIfPastLimit(batchRowCount)(commitAndRestartTx())
+    updateCounter += 1
   }
 
   private def commitAndRestartTx() {

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/UpdateCounter.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/executionplan/UpdateCounter.scala
@@ -20,6 +20,12 @@
 package org.neo4j.cypher.internal.compiler.v2_3.executionplan
 
 class UpdateCounter {
+  def offsetForHeaders(): Unit = {
+    if (uncommittedRows != 0)
+      throw new IllegalStateException("Header offset must be accounted for at the beginning")
+    uncommittedRows = -1
+  }
+
   private var uncommittedRows = 0L
   private var totalRows = 0L
 

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ExternalResource.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/ExternalResource.scala
@@ -22,5 +22,5 @@ package org.neo4j.cypher.internal.compiler.v2_3.pipes
 import java.net.URL
 
 trait ExternalResource {
-  def getCsvIterator(url: URL, fieldTerminator: Option[String] = None): Iterator[Array[String]]
+  def getCsvIterator(url: URL, fieldTerminator: Option[String] = None, headers:Boolean=false): Iterator[Array[String]]
 }

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/LoadCSVPipe.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/pipes/LoadCSVPipe.scala
@@ -103,7 +103,7 @@ case class LoadCSVPipe(source: Pipe,
       implicit val s = state
       val url = getImportURL(urlExpression(context).asInstanceOf[String], state.query)
 
-      val iterator: Iterator[Array[String]] = state.resources.getCsvIterator(url, fieldTerminator)
+      val iterator: Iterator[Array[String]] = state.resources.getCsvIterator(url, fieldTerminator, format match {case HasHeaders => true; case _ => false})
       format match {
         case HasHeaders =>
           val headers = if (iterator.nonEmpty) iterator.next().toIndexedSeq else IndexedSeq.empty // First row is headers

--- a/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/CSVResources.scala
+++ b/community/cypher/cypher-compiler-2.3/src/main/scala/org/neo4j/cypher/internal/compiler/v2_3/spi/CSVResources.scala
@@ -51,7 +51,7 @@ object CSVResources {
 
 class CSVResources(cleaner: TaskCloser) extends ExternalResource {
 
-  def getCsvIterator(url: URL, fieldTerminator: Option[String] = None): Iterator[Array[String]] = {
+  def getCsvIterator(url: URL, fieldTerminator: Option[String] = None, headers:Boolean=false): Iterator[Array[String]] = {
     val inputStream = openStream(url)
 
     val reader = if (url.getProtocol == "file") {

--- a/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
+++ b/community/cypher/cypher/src/test/scala/org/neo4j/cypher/ProfilerAcceptanceTest.scala
@@ -269,8 +269,7 @@ class ProfilerAcceptanceTest extends ExecutionEngineFunSuite with CreateTempFile
     val result = legacyProfile(query)
 
     // then
-    val expectedTxCount = 1 + // First tx used to compile the query
-                          10  // One per 10 rows of CSV file
+    val expectedTxCount = 10  // One per 10 rows of CSV file
 
     graph.txCounts-initialTxCounts should equal(TxCounts(commits = expectedTxCount))
     result.queryStatistics().containsUpdates should equal(true)


### PR DESCRIPTION
Periodic commit used to commit BEFORE the specified number of CSV rows. For example `USING PERIODIC COMMIT 100` would commit after 99 rows, then after 199 rows, then after 299 rows et.c. After this change it commits after 100 rows, then after 200 rows, then after 300 rows, et.c.

Furthermore `LOAD CSV WITH HEADERS` counted the header row the same as a data row, meaning that `USING PERIODIC COMMIT 100` would actually commit after 98 data rows, then after 298 data rows, et.c. After this change it will commit after 100 data rows, regardless of whether the CSV file has headers or not.

This PR commit targets 2.3 in order to get this fixed even for people who use `CYPHER 2.3 ...` in later versions of Neo4j.