### PR TITLE
Cleanup usage of deprecated and removed methods in TestSecurityManager

### DIFF
--- a/community/kernel/src/test/java/org/neo4j/test/rule/system/TestSecurityManager.java
+++ b/community/kernel/src/test/java/org/neo4j/test/rule/system/TestSecurityManager.java
@@ -28,7 +28,7 @@ public class TestSecurityManager extends SecurityManager
 
     private SecurityManager securityManager;
 
-    public TestSecurityManager( SecurityManager securityManager )
+    TestSecurityManager( SecurityManager securityManager )
     {
         this.securityManager = securityManager;
     }
@@ -37,12 +37,6 @@ public class TestSecurityManager extends SecurityManager
     public void checkExit( int status )
     {
         throw new SystemExitError( status );
-    }
-
-    @Override
-    public boolean getInCheck()
-    {
-        return managerExists() ? securityManager.getInCheck() : super.getInCheck();
     }
 
     @Override


### PR DESCRIPTION
As part of Java 10 security manager deprecations were cleaned up:
https://bugs.openjdk.java.net/browse/JDK-8186535
Since we do not use removed method and to allow
kernel compilation with latest jdk releases, old method in our
implementations also removed.