### PR TITLE
Enable previously disabled page cache tests

### DIFF
--- a/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
+++ b/community/io/src/main/java/org/neo4j/io/pagecache/impl/muninn/MuninnPageCache.java
@@ -907,7 +907,7 @@ public class MuninnPageCache implements PageCache
         return clockArm;
     }
 
-    private void addFreePageToFreelist( long pageRef )
+    void addFreePageToFreelist( long pageRef )
     {
         Object current;
         FreePage freePage = new FreePage( pageRef );


### PR DESCRIPTION
Do not blindly request eviction of all pages, since that most probably
will not gonna be possible since some of them can be already evicted.
Instead try to grab all pages and then release them.
That will make the same effect as evicting each page one by one.