### PR TITLE
Return sets instead of collections in Kernel APIs

### DIFF
--- a/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionCountingStateVisitor.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/api/txstate/TransactionCountingStateVisitor.java
@@ -21,7 +21,6 @@ package org.neo4j.kernel.api.txstate;
 
 import java.util.Set;
 
-import org.neo4j.collection.primitive.PrimitiveIntCollection;
 import org.neo4j.collection.primitive.PrimitiveIntSet;
 import org.neo4j.collection.primitive.PrimitiveIntVisitor;
 import org.neo4j.cursor.Cursor;
@@ -134,7 +133,7 @@ public class TransactionCountingStateVisitor extends TxStateVisitor.Delegator
         super.visitNodeLabelChanges( id, added, removed );
     }
 
-    private void updateRelationshipsCountsFromDegrees( PrimitiveIntCollection labels, int type, long outgoing,
+    private void updateRelationshipsCountsFromDegrees( PrimitiveIntSet labels, int type, long outgoing,
             long incoming )
     {
         labels.visitKeys( label -> updateRelationshipsCountsFromDegrees( type, label, outgoing, incoming ) );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/ConstraintEnforcingEntityOperations.java
@@ -23,7 +23,6 @@ import org.apache.commons.lang3.ArrayUtils;
 
 import java.util.Iterator;
 
-import org.neo4j.collection.primitive.PrimitiveIntCollection;
 import org.neo4j.collection.primitive.PrimitiveIntCollections;
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.collection.primitive.PrimitiveIntSet;
@@ -510,7 +509,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
     }
 
     @Override
-    public PrimitiveIntCollection nodeGetPropertyKeys( KernelStatement statement, NodeItem node )
+    public PrimitiveIntSet nodeGetPropertyKeys( KernelStatement statement, NodeItem node )
     {
         return entityReadOperations.nodeGetPropertyKeys( statement, node );
     }
@@ -535,7 +534,7 @@ public class ConstraintEnforcingEntityOperations implements EntityOperations, Sc
     }
 
     @Override
-    public PrimitiveIntCollection relationshipGetPropertyKeys( KernelStatement statement,
+    public PrimitiveIntSet relationshipGetPropertyKeys( KernelStatement statement,
             RelationshipItem relationship )
     {
         return entityReadOperations.relationshipGetPropertyKeys( statement, relationship );

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/StateHandlingStatementOperations.java
@@ -24,10 +24,8 @@ import java.util.Iterator;
 import java.util.Map;
 
 import org.neo4j.collection.primitive.Primitive;
-import org.neo4j.collection.primitive.PrimitiveIntCollection;
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.collection.primitive.PrimitiveIntSet;
-import org.neo4j.collection.primitive.PrimitiveIntStack;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.collection.primitive.PrimitiveLongResourceIterator;
 import org.neo4j.cursor.Cursor;
@@ -267,14 +265,14 @@ public class StateHandlingStatementOperations implements
     }
 
     @Override
-    public PrimitiveIntCollection nodeGetPropertyKeys( KernelStatement statement, NodeItem node )
+    public PrimitiveIntSet nodeGetPropertyKeys( KernelStatement statement, NodeItem node )
     {
-        PrimitiveIntStack keys = new PrimitiveIntStack();
+        final PrimitiveIntSet keys = Primitive.intSet();
         try ( Cursor<PropertyItem> properties = nodeGetProperties( statement, node ) )
         {
             while ( properties.next() )
             {
-                keys.push( properties.get().propertyKeyId() );
+                keys.add( properties.get().propertyKeyId() );
             }
         }
 
@@ -347,15 +345,15 @@ public class StateHandlingStatementOperations implements
     }
 
     @Override
-    public PrimitiveIntCollection relationshipGetPropertyKeys( KernelStatement statement,
+    public PrimitiveIntSet relationshipGetPropertyKeys( KernelStatement statement,
             RelationshipItem relationship )
     {
-        PrimitiveIntStack keys = new PrimitiveIntStack();
+        final PrimitiveIntSet keys = Primitive.intSet();
         try ( Cursor<PropertyItem> properties = relationshipGetProperties( statement, relationship ) )
         {
             while ( properties.next() )
             {
-                keys.push( properties.get().propertyKeyId() );
+                keys.add( properties.get().propertyKeyId() );
             }
         }
 

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMap.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMap.java
@@ -28,9 +28,9 @@ import java.util.Set;
 import java.util.function.BiConsumer;
 
 import org.neo4j.collection.primitive.Primitive;
-import org.neo4j.collection.primitive.PrimitiveIntCollection;
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.collection.primitive.PrimitiveIntObjectMap;
+import org.neo4j.collection.primitive.PrimitiveIntSet;
 import org.neo4j.collection.primitive.PrimitiveLongCollections;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
 import org.neo4j.collection.primitive.PrimitiveLongObjectMap;
@@ -145,7 +145,7 @@ public final class IndexMap implements Cloneable
      * @return set of LabelSchemaDescriptors describing the potentially affected indexes
      */
     public Set<LabelSchemaDescriptor> getRelatedIndexes(
-            long[] changedLabels, long[] unchangedLabels, PrimitiveIntCollection properties )
+            long[] changedLabels, long[] unchangedLabels, PrimitiveIntSet properties )
     {
         if ( changedLabels.length == 1 && properties.isEmpty() )
         {
@@ -269,7 +269,7 @@ public final class IndexMap implements Cloneable
      */
     private Set<LabelSchemaDescriptor> getDescriptorsByProperties(
             long[] unchangedLabels,
-            PrimitiveIntCollection properties )
+            PrimitiveIntSet properties )
     {
         int nIndexesForLabels = countIndexesByLabels( unchangedLabels );
         int nIndexesForProperties = countIndexesByProperties( properties );
@@ -316,7 +316,7 @@ public final class IndexMap implements Cloneable
         return count;
     }
 
-    private Set<LabelSchemaDescriptor> extractIndexesByProperties( PrimitiveIntCollection properties )
+    private Set<LabelSchemaDescriptor> extractIndexesByProperties( PrimitiveIntSet properties )
     {
         Set<LabelSchemaDescriptor> set = new HashSet<>();
         for ( PrimitiveIntIterator iterator = properties.iterator(); iterator.hasNext(); )
@@ -330,7 +330,7 @@ public final class IndexMap implements Cloneable
         return set;
     }
 
-    private int countIndexesByProperties( PrimitiveIntCollection properties )
+    private int countIndexesByProperties( PrimitiveIntSet properties )
     {
         int count = 0;
         for ( PrimitiveIntIterator iterator = properties.iterator(); iterator.hasNext(); )

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMapReference.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/IndexMapReference.java
@@ -19,7 +19,7 @@
  */
 package org.neo4j.kernel.impl.api.index;
 
-import org.neo4j.collection.primitive.PrimitiveIntCollection;
+import org.neo4j.collection.primitive.PrimitiveIntSet;
 import org.neo4j.function.ThrowingFunction;
 import org.neo4j.internal.kernel.api.schema.LabelSchemaDescriptor;
 import org.neo4j.kernel.api.exceptions.index.IndexNotFoundKernelException;
@@ -100,7 +100,7 @@ public class IndexMapReference implements IndexMapSnapshotProvider
     }
 
     public Iterable<LabelSchemaDescriptor> getRelatedIndexes(
-            long[] changedLabels, long[] unchangedLabels, PrimitiveIntCollection properties )
+            long[] changedLabels, long[] unchangedLabels, PrimitiveIntSet properties )
     {
         return indexMap.getRelatedIndexes( changedLabels, unchangedLabels, properties );
     }

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/NodeUpdates.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/index/NodeUpdates.java
@@ -25,7 +25,6 @@ import java.util.List;
 
 import org.neo4j.collection.primitive.Primitive;
 import org.neo4j.collection.primitive.PrimitiveArrays;
-import org.neo4j.collection.primitive.PrimitiveIntCollection;
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.collection.primitive.PrimitiveIntObjectMap;
 import org.neo4j.collection.primitive.PrimitiveIntSet;
@@ -37,6 +36,7 @@ import org.neo4j.values.storable.Value;
 
 import static java.lang.String.format;
 import static java.util.Arrays.binarySearch;
+import static org.neo4j.collection.primitive.PrimitiveIntCollections.asSet;
 import static org.neo4j.kernel.impl.api.index.NodeUpdates.PropertyValueType.Changed;
 import static org.neo4j.kernel.impl.api.index.NodeUpdates.PropertyValueType.NoValue;
 
@@ -138,11 +138,11 @@ public class NodeUpdates implements PropertyLoader.PropertyLoadSink
         return PrimitiveArrays.intersect( labelsBefore, labelsAfter );
     }
 
-    PrimitiveIntCollection propertiesChanged()
+    PrimitiveIntSet propertiesChanged()
     {
         assert !hasLoadedAdditionalProperties : "Calling propertiesChanged() is not valid after non-changed " +
                                                 "properties have already been loaded.";
-        return knownProperties;
+        return asSet( knownProperties.iterator() );
     }
 
     @Override

--- a/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/EntityReadOperations.java
+++ b/community/kernel/src/main/java/org/neo4j/kernel/impl/api/operations/EntityReadOperations.java
@@ -19,7 +19,6 @@
  */
 package org.neo4j.kernel.impl.api.operations;
 
-import org.neo4j.collection.primitive.PrimitiveIntCollection;
 import org.neo4j.collection.primitive.PrimitiveIntIterator;
 import org.neo4j.collection.primitive.PrimitiveIntSet;
 import org.neo4j.collection.primitive.PrimitiveLongIterator;
@@ -106,7 +105,7 @@ public interface EntityReadOperations
 
     boolean nodeHasProperty( KernelStatement statement, NodeItem node, int propertyKeyId );
 
-    PrimitiveIntCollection nodeGetPropertyKeys( KernelStatement statement, NodeItem node );
+    PrimitiveIntSet nodeGetPropertyKeys( KernelStatement statement, NodeItem node );
 
     Cursor<PropertyItem> relationshipGetProperties( KernelStatement statement, RelationshipItem relationship );
 
@@ -114,7 +113,7 @@ public interface EntityReadOperations
 
     boolean relationshipHasProperty( KernelStatement statement, RelationshipItem relationship, int propertyKeyId );
 
-    PrimitiveIntCollection relationshipGetPropertyKeys( KernelStatement statement, RelationshipItem relationship );
+    PrimitiveIntSet relationshipGetPropertyKeys( KernelStatement statement, RelationshipItem relationship );
 
     long nodesGetCount( KernelStatement statement );
 


### PR DESCRIPTION
Return sets instead of collections in Kernel APIs where uniqueness semantic is implied by design